### PR TITLE
Fix dead anonscm links

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -42,7 +42,7 @@ edk2.mkDerivation projectDscPath {
     mv -v $out/FV/QEMU_{EFI,VARS}.fd $fd/FV
 
     # Uses Fedora dir layout: https://src.fedoraproject.org/cgit/rpms/edk2.git/tree/edk2.spec
-    # FIXME: why is it different from Debian dir layout? https://anonscm.debian.org/cgit/pkg-qemu/edk2.git/tree/debian/rules
+    # FIXME: why is it different from Debian dir layout? https://salsa.debian.org/qemu-team/edk2/blob/debian/debian/rules
     dd of=$fd/AAVMF/QEMU_EFI-pflash.raw       if=/dev/zero bs=1M    count=64
     dd of=$fd/AAVMF/QEMU_EFI-pflash.raw       if=$fd/FV/QEMU_EFI.fd conv=notrunc
     dd of=$fd/AAVMF/vars-template-pflash.raw if=/dev/zero bs=1M    count=64

--- a/pkgs/misc/drivers/foomatic-filters/default.nix
+++ b/pkgs/misc/drivers/foomatic-filters/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   patches = [
     # for CVE-2015-8327 & CVE-2015-8560
     (fetchpatch {
-      url = "https://anonscm.debian.org/cgit/collab-maint/foomatic-filters.git/plain/debian/patches/0500-r7406_also_consider_the_back_tick_as_an_illegal_shell_escape_character.patch";
+      url = "https://salsa.debian.org/debian/foomatic-filters/raw/a3abbef2d2f8c7e62d2fe64f64afe294563fdf8f/debian/patches/0500-r7406_also_consider_the_back_tick_as_an_illegal_shell_escape_character.patch";
       sha256 = "055nwi3sjf578nk40bqsch3wx8m2h65hdih0wmxflb6l0hwkq4p4";
     })
   ];

--- a/pkgs/misc/emulators/desmume/01_use_system_tinyxml.patch
+++ b/pkgs/misc/emulators/desmume/01_use_system_tinyxml.patch
@@ -1,0 +1,231 @@
+From: Evgeni Golov <evgeni@debian.org>
+Subject: use the system tinyxml instead of the embedded copy
+Last-Update: 2015-08-09
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 7b9e263..bc7ba8c 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -81,12 +81,6 @@ libdesmume_a_SOURCES = \
+ 	utils/libfat/mem_allocate.h \
+ 	utils/libfat/partition.cpp \
+ 	utils/libfat/partition.h \
+-	utils/tinyxml/tinystr.cpp \
+-	utils/tinyxml/tinystr.h \
+-	utils/tinyxml/tinyxml.cpp \
+-	utils/tinyxml/tinyxml.h \
+-	utils/tinyxml/tinyxmlerror.cpp \
+-	utils/tinyxml/tinyxmlparser.cpp \
+ 	utils/glcorearb.h \
+ 	addons/slot2_auto.cpp addons/slot2_mpcf.cpp addons/slot2_paddle.cpp addons/slot2_gbagame.cpp addons/slot2_none.cpp addons/slot2_rumblepak.cpp addons/slot2_guitarGrip.cpp addons/slot2_expMemory.cpp addons/slot2_piano.cpp addons/slot2_passme.cpp addons/slot1_none.cpp addons/slot1_r4.cpp addons/slot1_retail_nand.cpp addons/slot1_retail_auto.cpp addons/slot1_retail_mcrom.cpp addons/slot1_retail_mcrom_debug.cpp addons/slot1comp_mc.cpp addons/slot1comp_mc.h addons/slot1comp_rom.h addons/slot1comp_rom.cpp addons/slot1comp_protocol.h addons/slot1comp_protocol.cpp \
+ 	cheatSystem.cpp cheatSystem.h \
+@@ -204,3 +198,4 @@ if HAVE_GDB_STUB
+ libdesmume_a_SOURCES += gdbstub.h
+ endif
+ libdesmume_a_LIBADD = fs-$(desmume_arch).$(OBJEXT)
++LIBS += -ltinyxml
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 9cf26a3..d9ff7b2 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -184,9 +184,6 @@ am__libdesmume_a_SOURCES_DIST = armcpu.cpp armcpu.h \
+ 	utils/libfat/libfat_public_api.h utils/libfat/lock.cpp \
+ 	utils/libfat/lock.h utils/libfat/mem_allocate.h \
+ 	utils/libfat/partition.cpp utils/libfat/partition.h \
+-	utils/tinyxml/tinystr.cpp utils/tinyxml/tinystr.h \
+-	utils/tinyxml/tinyxml.cpp utils/tinyxml/tinyxml.h \
+-	utils/tinyxml/tinyxmlerror.cpp utils/tinyxml/tinyxmlparser.cpp \
+ 	utils/glcorearb.h addons/slot2_auto.cpp addons/slot2_mpcf.cpp \
+ 	addons/slot2_paddle.cpp addons/slot2_gbagame.cpp \
+ 	addons/slot2_none.cpp addons/slot2_rumblepak.cpp \
+@@ -324,10 +321,6 @@ am_libdesmume_a_OBJECTS = armcpu.$(OBJEXT) arm_instructions.$(OBJEXT) \
+ 	utils/libfat/libfat.$(OBJEXT) \
+ 	utils/libfat/libfat_public_api.$(OBJEXT) \
+ 	utils/libfat/lock.$(OBJEXT) utils/libfat/partition.$(OBJEXT) \
+-	utils/tinyxml/tinystr.$(OBJEXT) \
+-	utils/tinyxml/tinyxml.$(OBJEXT) \
+-	utils/tinyxml/tinyxmlerror.$(OBJEXT) \
+-	utils/tinyxml/tinyxmlparser.$(OBJEXT) \
+ 	addons/slot2_auto.$(OBJEXT) addons/slot2_mpcf.$(OBJEXT) \
+ 	addons/slot2_paddle.$(OBJEXT) addons/slot2_gbagame.$(OBJEXT) \
+ 	addons/slot2_none.$(OBJEXT) addons/slot2_rumblepak.$(OBJEXT) \
+@@ -475,7 +468,7 @@ LIBAGG_LIBS = @LIBAGG_LIBS@
+ LIBGLADE_CFLAGS = @LIBGLADE_CFLAGS@
+ LIBGLADE_LIBS = @LIBGLADE_LIBS@
+ LIBOBJS = @LIBOBJS@
+-LIBS = @LIBS@
++LIBS = @LIBS@ -ltinyxml
+ LIBSOUNDTOUCH_CFLAGS = @LIBSOUNDTOUCH_CFLAGS@
+ LIBSOUNDTOUCH_LIBS = @LIBSOUNDTOUCH_LIBS@
+ LTLIBOBJS = @LTLIBOBJS@
+@@ -625,9 +618,6 @@ libdesmume_a_SOURCES = armcpu.cpp armcpu.h arm_instructions.cpp \
+ 	utils/libfat/libfat_public_api.h utils/libfat/lock.cpp \
+ 	utils/libfat/lock.h utils/libfat/mem_allocate.h \
+ 	utils/libfat/partition.cpp utils/libfat/partition.h \
+-	utils/tinyxml/tinystr.cpp utils/tinyxml/tinystr.h \
+-	utils/tinyxml/tinyxml.cpp utils/tinyxml/tinyxml.h \
+-	utils/tinyxml/tinyxmlerror.cpp utils/tinyxml/tinyxmlparser.cpp \
+ 	utils/glcorearb.h addons/slot2_auto.cpp addons/slot2_mpcf.cpp \
+ 	addons/slot2_paddle.cpp addons/slot2_gbagame.cpp \
+ 	addons/slot2_none.cpp addons/slot2_rumblepak.cpp \
+@@ -760,20 +750,6 @@ utils/libfat/lock.$(OBJEXT): utils/libfat/$(am__dirstamp) \
+ 	utils/libfat/$(DEPDIR)/$(am__dirstamp)
+ utils/libfat/partition.$(OBJEXT): utils/libfat/$(am__dirstamp) \
+ 	utils/libfat/$(DEPDIR)/$(am__dirstamp)
+-utils/tinyxml/$(am__dirstamp):
+-	@$(MKDIR_P) utils/tinyxml
+-	@: > utils/tinyxml/$(am__dirstamp)
+-utils/tinyxml/$(DEPDIR)/$(am__dirstamp):
+-	@$(MKDIR_P) utils/tinyxml/$(DEPDIR)
+-	@: > utils/tinyxml/$(DEPDIR)/$(am__dirstamp)
+-utils/tinyxml/tinystr.$(OBJEXT): utils/tinyxml/$(am__dirstamp) \
+-	utils/tinyxml/$(DEPDIR)/$(am__dirstamp)
+-utils/tinyxml/tinyxml.$(OBJEXT): utils/tinyxml/$(am__dirstamp) \
+-	utils/tinyxml/$(DEPDIR)/$(am__dirstamp)
+-utils/tinyxml/tinyxmlerror.$(OBJEXT): utils/tinyxml/$(am__dirstamp) \
+-	utils/tinyxml/$(DEPDIR)/$(am__dirstamp)
+-utils/tinyxml/tinyxmlparser.$(OBJEXT): utils/tinyxml/$(am__dirstamp) \
+-	utils/tinyxml/$(DEPDIR)/$(am__dirstamp)
+ addons/$(am__dirstamp):
+ 	@$(MKDIR_P) addons
+ 	@: > addons/$(am__dirstamp)
+@@ -1035,10 +1011,6 @@ mostlyclean-compile:
+ 	-rm -f utils/libfat/partition.$(OBJEXT)
+ 	-rm -f utils/md5.$(OBJEXT)
+ 	-rm -f utils/task.$(OBJEXT)
+-	-rm -f utils/tinyxml/tinystr.$(OBJEXT)
+-	-rm -f utils/tinyxml/tinyxml.$(OBJEXT)
+-	-rm -f utils/tinyxml/tinyxmlerror.$(OBJEXT)
+-	-rm -f utils/tinyxml/tinyxmlparser.$(OBJEXT)
+ 	-rm -f utils/vfat.$(OBJEXT)
+ 	-rm -f utils/xstring.$(OBJEXT)
+ 
+@@ -1175,10 +1147,6 @@ distclean-compile:
+ @AMDEP_TRUE@@am__include@ @am__quote@utils/libfat/$(DEPDIR)/libfat_public_api.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@utils/libfat/$(DEPDIR)/lock.Po@am__quote@
+ @AMDEP_TRUE@@am__include@ @am__quote@utils/libfat/$(DEPDIR)/partition.Po@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@utils/tinyxml/$(DEPDIR)/tinystr.Po@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@utils/tinyxml/$(DEPDIR)/tinyxml.Po@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@utils/tinyxml/$(DEPDIR)/tinyxmlerror.Po@am__quote@
+-@AMDEP_TRUE@@am__include@ @am__quote@utils/tinyxml/$(DEPDIR)/tinyxmlparser.Po@am__quote@
+ 
+ .c.o:
+ @am__fastdepCC_TRUE@	depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.o$$||'`;\
+@@ -1449,8 +1417,6 @@ distclean-generic:
+ 	-rm -f utils/decrypt/$(am__dirstamp)
+ 	-rm -f utils/libfat/$(DEPDIR)/$(am__dirstamp)
+ 	-rm -f utils/libfat/$(am__dirstamp)
+-	-rm -f utils/tinyxml/$(DEPDIR)/$(am__dirstamp)
+-	-rm -f utils/tinyxml/$(am__dirstamp)
+ 
+ maintainer-clean-generic:
+ 	@echo "This command is intended for maintainers to use"
+@@ -1460,7 +1426,7 @@ clean: clean-recursive
+ clean-am: clean-generic clean-noinstLIBRARIES mostlyclean-am
+ 
+ distclean: distclean-recursive
+-	-rm -rf ./$(DEPDIR) addons/$(DEPDIR) filter/$(DEPDIR) metaspu/$(DEPDIR) utils/$(DEPDIR) utils/AsmJit/core/$(DEPDIR) utils/AsmJit/x86/$(DEPDIR) utils/decrypt/$(DEPDIR) utils/libfat/$(DEPDIR) utils/tinyxml/$(DEPDIR)
++	-rm -rf ./$(DEPDIR) addons/$(DEPDIR) filter/$(DEPDIR) metaspu/$(DEPDIR) utils/$(DEPDIR) utils/AsmJit/core/$(DEPDIR) utils/AsmJit/x86/$(DEPDIR) utils/decrypt/$(DEPDIR) utils/libfat/$(DEPDIR)
+ 	-rm -f Makefile
+ distclean-am: clean-am distclean-compile distclean-generic \
+ 	distclean-tags
+@@ -1506,7 +1472,7 @@ install-ps-am:
+ installcheck-am:
+ 
+ maintainer-clean: maintainer-clean-recursive
+-	-rm -rf ./$(DEPDIR) addons/$(DEPDIR) filter/$(DEPDIR) metaspu/$(DEPDIR) utils/$(DEPDIR) utils/AsmJit/core/$(DEPDIR) utils/AsmJit/x86/$(DEPDIR) utils/decrypt/$(DEPDIR) utils/libfat/$(DEPDIR) utils/tinyxml/$(DEPDIR)
++	-rm -rf ./$(DEPDIR) addons/$(DEPDIR) filter/$(DEPDIR) metaspu/$(DEPDIR) utils/$(DEPDIR) utils/AsmJit/core/$(DEPDIR) utils/AsmJit/x86/$(DEPDIR) utils/decrypt/$(DEPDIR) utils/libfat/$(DEPDIR)
+ 	-rm -f Makefile
+ maintainer-clean-am: distclean-am maintainer-clean-generic
+ 
+diff --git a/src/cli/Makefile.am b/src/cli/Makefile.am
+index 1985209..d958323 100755
+--- a/src/cli/Makefile.am
++++ b/src/cli/Makefile.am
+@@ -5,7 +5,7 @@ AM_CPPFLAGS += $(SDL_CFLAGS) $(ALSA_CFLAGS) $(LIBAGG_CFLAGS) $(GLIB_CFLAGS) $(GT
+ 
+ bin_PROGRAMS = desmume-cli
+ desmume_cli_SOURCES = main.cpp ../sndsdl.cpp ../ctrlssdl.h ../ctrlssdl.cpp ../driver.h ../driver.cpp
+-desmume_cli_LDADD = ../libdesmume.a $(SDL_LIBS) $(ALSA_LIBS) $(LIBAGG_LIBS) $(GLIB_LIBS) $(GTHREAD_LIBS) $(LIBSOUNDTOUCH_LIBS)
++desmume_cli_LDADD = ../libdesmume.a $(SDL_LIBS) $(ALSA_LIBS) $(LIBAGG_LIBS) $(GLIB_LIBS) $(GTHREAD_LIBS) $(LIBSOUNDTOUCH_LIBS) -ltinyxml
+ if HAVE_GDB_STUB
+ desmume_cli_LDADD += ../gdbstub/libgdbstub.a
+ endif
+diff --git a/src/cli/Makefile.in b/src/cli/Makefile.in
+index 14efd77..f04ab7d 100644
+--- a/src/cli/Makefile.in
++++ b/src/cli/Makefile.in
+@@ -311,7 +311,7 @@ AM_LDFLAGS =
+ desmume_cli_SOURCES = main.cpp ../sndsdl.cpp ../ctrlssdl.h ../ctrlssdl.cpp ../driver.h ../driver.cpp
+ desmume_cli_LDADD = ../libdesmume.a $(SDL_LIBS) $(ALSA_LIBS) \
+ 	$(LIBAGG_LIBS) $(GLIB_LIBS) $(GTHREAD_LIBS) \
+-	$(LIBSOUNDTOUCH_LIBS) $(am__append_1)
++	$(LIBSOUNDTOUCH_LIBS) -ltinyxml $(am__append_1)
+ all: all-recursive
+ 
+ .SUFFIXES:
+diff --git a/src/gtk-glade/Makefile.am b/src/gtk-glade/Makefile.am
+index b667fca..c79fdac 100755
+--- a/src/gtk-glade/Makefile.am
++++ b/src/gtk-glade/Makefile.am
+@@ -33,7 +33,7 @@ desmume_glade_SOURCES =  \
+ desmume_glade_LDADD = ../libdesmume.a \
+ 			$(SDL_LIBS) $(GTKGLEXT_LIBS) $(LIBGLADE_LIBS) \
+ 			$(GTHREAD_LIBS) $(ALSA_LIBS) $(LIBAGG_LIBS) \
+-			$(LIBSOUNDTOUCH_LIBS)
++			$(LIBSOUNDTOUCH_LIBS) -ltinyxml
+ if HAVE_GDB_STUB
+ desmume_glade_LDADD += ../gdbstub/libgdbstub.a
+ endif
+diff --git a/src/gtk-glade/Makefile.in b/src/gtk-glade/Makefile.in
+index 5f77ec5..012aa72 100644
+--- a/src/gtk-glade/Makefile.in
++++ b/src/gtk-glade/Makefile.in
+@@ -367,7 +367,7 @@ desmume_glade_SOURCES = \
+ 
+ desmume_glade_LDADD = ../libdesmume.a $(SDL_LIBS) $(GTKGLEXT_LIBS) \
+ 	$(LIBGLADE_LIBS) $(GTHREAD_LIBS) $(ALSA_LIBS) $(LIBAGG_LIBS) \
+-	$(LIBSOUNDTOUCH_LIBS) $(am__append_1)
++	$(LIBSOUNDTOUCH_LIBS) -ltinyxml $(am__append_1)
+ all: all-recursive
+ 
+ .SUFFIXES:
+diff --git a/src/gtk/Makefile.am b/src/gtk/Makefile.am
+index 59cb1f2..e451102 100755
+--- a/src/gtk/Makefile.am
++++ b/src/gtk/Makefile.am
+@@ -32,7 +32,7 @@ desmume_SOURCES = \
+ 	../filter/videofilter.cpp ../filter/videofilter.h \
+ 	main.cpp main.h
+ desmume_LDADD = ../libdesmume.a \
+-	$(SDL_LIBS) $(GTK_LIBS) $(GTHREAD_LIBS) $(ALSA_LIBS) $(LIBAGG_LIBS) $(LIBSOUNDTOUCH_LIBS)
++	$(SDL_LIBS) $(GTK_LIBS) $(GTHREAD_LIBS) $(ALSA_LIBS) $(LIBAGG_LIBS) $(LIBSOUNDTOUCH_LIBS) -ltinyxml
+ if HAVE_GDB_STUB
+ desmume_LDADD += ../gdbstub/libgdbstub.a
+ endif
+diff --git a/src/gtk/Makefile.in b/src/gtk/Makefile.in
+index e1a2c37..75f392f 100644
+--- a/src/gtk/Makefile.in
++++ b/src/gtk/Makefile.in
+@@ -382,7 +382,7 @@ desmume_SOURCES = \
+ 
+ desmume_LDADD = ../libdesmume.a $(SDL_LIBS) $(GTK_LIBS) \
+ 	$(GTHREAD_LIBS) $(ALSA_LIBS) $(LIBAGG_LIBS) \
+-	$(LIBSOUNDTOUCH_LIBS) $(am__append_1) $(am__append_2) \
++	$(LIBSOUNDTOUCH_LIBS) -ltinyxml $(am__append_1) $(am__append_2) \
+ 	$(am__append_3)
+ UPDATE_DESKTOP = \
+   appsdir=$(DESTDIR)$(datadir)/applications ; \
+diff --git a/src/utils/advanscene.cpp b/src/utils/advanscene.cpp
+index 8d8f370..09c35bb 100755
+--- a/src/utils/advanscene.cpp
++++ b/src/utils/advanscene.cpp
+@@ -19,7 +19,7 @@
+ #include <time.h>
+ 
+ #define TIXML_USE_STL
+-#include "tinyxml/tinyxml.h"
++#include <tinyxml.h>
+ 
+ #include "advanscene.h"
+ #include "../common.h"

--- a/pkgs/misc/emulators/desmume/default.nix
+++ b/pkgs/misc/emulators/desmume/default.nix
@@ -2,6 +2,7 @@
 , pkgconfig, libtool, intltool
 , libXmu
 , lua
+, tinyxml
 , agg, alsaLib, soundtouch, openal
 , desktop-file-utils
 , gtk2, gtkglext, libglade, pangox_compat
@@ -19,11 +20,9 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (fetchpatch {
-      name = "gcc6_fixes.patch";
-      url = "https://anonscm.debian.org/viewvc/pkg-games/packages/trunk/desmume/debian/patches/gcc6_fixes.patch?revision=15925";
-      sha256 = "0j3fmxz0mfb3f4biks03pyz8f9hy958ks6qplisl60rzq9v9qpks";
-     })
+    ./gcc6_fixes.patch
+    ./gcc7_fixes.patch
+    ./01_use_system_tinyxml.patch
   ];
 
   CXXFLAGS = "-fpermissive";
@@ -31,7 +30,7 @@ stdenv.mkDerivation rec {
   buildInputs =
   [ pkgconfig libtool intltool libXmu lua agg alsaLib soundtouch
     openal desktop-file-utils gtk2 gtkglext libglade pangox_compat
-    libGLU libpcap SDL zziplib ];
+    libGLU libpcap SDL zziplib tinyxml ];
 
   configureFlags = [
     "--disable-glade"  # Failing on compile step

--- a/pkgs/misc/emulators/desmume/gcc6_fixes.patch
+++ b/pkgs/misc/emulators/desmume/gcc6_fixes.patch
@@ -1,0 +1,59 @@
+From: zeromus
+Origin: upstream, https://sourceforge.net/p/desmume/code/5514, https://sourceforge.net/p/desmume/code/5517, https://sourceforge.net/p/desmume/code/5430
+Subject: fix GCC6 issues
+Bug: https://sourceforge.net/p/desmume/bugs/1570/
+Bug-Debian: http://bugs.debian.org/811691
+
+Index: desmume/src/MMU_timing.h
+===================================================================
+--- desmume/src/MMU_timing.h	(revision 5513)
++++ desmume/src/MMU_timing.h	(revision 5517)
+@@ -155,8 +155,8 @@
+ 	enum { ASSOCIATIVITY = 1 << ASSOCIATIVESHIFT };
+ 	enum { BLOCKSIZE = 1 << BLOCKSIZESHIFT };
+ 	enum { TAGSHIFT = SIZESHIFT - ASSOCIATIVESHIFT };
+-	enum { TAGMASK = (u32)(~0 << TAGSHIFT) };
+-	enum { BLOCKMASK = ((u32)~0 >> (32 - TAGSHIFT)) & (u32)(~0 << BLOCKSIZESHIFT) };
++	enum { TAGMASK = (u32)(~0U << TAGSHIFT) };
++	enum { BLOCKMASK = ((u32)~0U >> (32 - TAGSHIFT)) & (u32)(~0U << BLOCKSIZESHIFT) };
+ 	enum { WORDSIZE = sizeof(u32) };
+ 	enum { WORDSPERBLOCK = (1 << BLOCKSIZESHIFT) / WORDSIZE };
+ 	enum { DATAPERWORD = WORDSIZE * ASSOCIATIVITY };
+Index: desmume/src/ctrlssdl.cpp
+===================================================================
+--- desmume/src/ctrlssdl.cpp	(revision 5513)
++++ desmume/src/ctrlssdl.cpp	(revision 5517)
+@@ -200,7 +200,7 @@
+           break;
+         case SDL_JOYAXISMOTION:
+           /* Dead zone of 50% */
+-          if( (abs(event.jaxis.value) >> 14) != 0 )
++          if( ((u32)abs(event.jaxis.value) >> 14) != 0 )
+             {
+               key = ((event.jaxis.which & 15) << 12) | JOY_AXIS << 8 | ((event.jaxis.axis & 127) << 1);
+               if (event.jaxis.value > 0) {
+@@ -370,7 +370,7 @@
+          Note: button constants have a 1bit offset. */
+     case SDL_JOYAXISMOTION:
+       key_code = ((event->jaxis.which & 15) << 12) | JOY_AXIS << 8 | ((event->jaxis.axis & 127) << 1);
+-      if( (abs(event->jaxis.value) >> 14) != 0 )
++      if( ((u32)abs(event->jaxis.value) >> 14) != 0 )
+         {
+           if (event->jaxis.value > 0)
+             key_code |= 1;
+Index: desmume/src/wifi.cpp
+===================================================================
+--- desmume/src/wifi.cpp	(revision 5429)
++++ desmume/src/wifi.cpp	(revision 5430)
+@@ -320,9 +320,9 @@
+ 
+ #if (WIFI_LOGGING_LEVEL >= 1)
+ 	#if WIFI_LOG_USE_LOGC
+-		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) LOGC(8, "WIFI: "__VA_ARGS__);
++		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) LOGC(8, "WIFI: " __VA_ARGS__);
+ 	#else
+-		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) printf("WIFI: "__VA_ARGS__);
++		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) printf("WIFI: " __VA_ARGS__);
+ 	#endif
+ #else
+ #define WIFI_LOG(level, ...) {}

--- a/pkgs/misc/emulators/desmume/gcc7_fixes.patch
+++ b/pkgs/misc/emulators/desmume/gcc7_fixes.patch
@@ -1,0 +1,18 @@
+From e1f7039f1b06add4fb75b2f8774000b8f05574af Mon Sep 17 00:00:00 2001
+From: rogerman <rogerman@users.sf.net>
+Date: Mon, 17 Aug 2015 21:15:04 +0000
+Subject: Fix bug with libfat string handling.
+
+diff --git a/src/utils/libfat/directory.cpp b/src/utils/libfat/directory.cpp
+index 765d7ae5..b6d7f01f 100644
+--- a/src/utils/libfat/directory.cpp
++++ b/src/utils/libfat/directory.cpp
+@@ -139,7 +139,7 @@ static size_t _FAT_directory_mbstoucs2 (ucs2_t* dst, const char* src, size_t len
+ 	int bytes;
+ 	size_t count = 0;
+ 
+-	while (count < len-1 && src != '\0') {
++	while (count < len-1 && *src != '\0') {
+ 		bytes = mbrtowc (&tempChar, src, MB_CUR_MAX, &ps);
+ 		if (bytes > 0) {
+ 			*dst = (ucs2_t)tempChar;

--- a/pkgs/misc/emulators/pcsxr/default.nix
+++ b/pkgs/misc/emulators/pcsxr/default.nix
@@ -14,35 +14,35 @@ stdenv.mkDerivation rec {
 
   patches = [
     ( fetchpatch {
-      url = "https://anonscm.debian.org/cgit/pkg-games/pcsxr.git/plain/debian/patches/01_fix-i386-exec-stack.patch?h=debian/1.9.94-2";
+      url = "https://salsa.debian.org/games-team/pcsxr/raw/315e56d16e36ef3011f72d0fe86190728d2ba596/debian/patches/01_fix-i386-exec-stack.patch";
       sha256 = "17497wjxd6b92bj458s2769d9bpp68ydbvmfs9gp51yhnq4zl81x";
     })
     ( fetchpatch {
-      url = "https://anonscm.debian.org/cgit/pkg-games/pcsxr.git/plain/debian/patches/02_disable-ppc-auto-dynarec.patch?h=debian/1.9.94-2";
+      url = "https://salsa.debian.org/games-team/pcsxr/raw/315e56d16e36ef3011f72d0fe86190728d2ba596/debian/patches/02_disable-ppc-auto-dynarec.patch";
       sha256 = "0v8n79z034w6cqdrzhgd9fkdpri42mzvkdjm19x4asz94gg2i2kf";
     })
     ( fetchpatch {
-      url = "https://anonscm.debian.org/cgit/pkg-games/pcsxr.git/plain/debian/patches/03_fix-plugin-dir.patch?h=debian/1.9.94-2";
+      url = "https://salsa.debian.org/games-team/pcsxr/raw/315e56d16e36ef3011f72d0fe86190728d2ba596/debian/patches/03_fix-plugin-dir.patch";
       sha256 = "0vkl0mv6whqaz79kvvvlmlmjpynyq4lh352j3bbxcr0vjqffxvsy";
     })
     ( fetchpatch {
-      url = "https://anonscm.debian.org/cgit/pkg-games/pcsxr.git/plain/debian/patches/04_update-homedir-symlinks.patch?h=debian/1.9.94-2";
+      url = "https://salsa.debian.org/games-team/pcsxr/raw/315e56d16e36ef3011f72d0fe86190728d2ba596/debian/patches/04_update-homedir-symlinks.patch";
       sha256 = "18r6n025ybr8fljfsaqm4ap31wp8838j73lrsffi49fkis60dp4j";
     })
     ( fetchpatch {
-      url = "https://anonscm.debian.org/cgit/pkg-games/pcsxr.git/plain/debian/patches/05_format-security.patch?h=debian/1.9.94-2";
+      url = "https://salsa.debian.org/games-team/pcsxr/raw/315e56d16e36ef3011f72d0fe86190728d2ba596/debian/patches/05_format-security.patch";
       sha256 = "03m4kfc9bk5669hf7ji1anild08diliapx634f9cigyxh72jcvni";
     })
     ( fetchpatch {
-      url = "https://anonscm.debian.org/cgit/pkg-games/pcsxr.git/plain/debian/patches/06_warnings.patch?h=debian/1.9.94-2";
+      url = "https://salsa.debian.org/games-team/pcsxr/raw/315e56d16e36ef3011f72d0fe86190728d2ba596/debian/patches/06_warnings.patch";
       sha256 = "0iz3g9ihnhisfgrzma9l74y4lhh57na9h41bmiam1millb796g71";
     })
     ( fetchpatch {
-      url = "https://anonscm.debian.org/cgit/pkg-games/pcsxr.git/plain/debian/patches/07_non-linux-ip-addr.patch?h=debian/1.9.94-2";
+      url = "https://salsa.debian.org/games-team/pcsxr/raw/315e56d16e36ef3011f72d0fe86190728d2ba596/debian/patches/07_non-linux-ip-addr.patch";
       sha256 = "14vb9l0l4nzxcymhjjs4q57nmsncmby9qpdr7c19rly5wavm4k77";
     })
     ( fetchpatch {
-      url = "https://anonscm.debian.org/cgit/pkg-games/pcsxr.git/plain/debian/patches/08_reproducible.patch?h=debian/1.9.94-2";
+      url = "https://salsa.debian.org/games-team/pcsxr/raw/315e56d16e36ef3011f72d0fe86190728d2ba596/debian/patches/08_reproducible.patch";
       sha256 = "1cx9q59drsk9h6l31097lg4aanaj93ysdz5p88pg9c7wvxk1qz06";
     })
 

--- a/pkgs/os-specific/linux/acpitool/default.nix
+++ b/pkgs/os-specific/linux/acpitool/default.nix
@@ -3,7 +3,7 @@
 let
    acpitool-patch-051-4 = params: fetchpatch rec {
      inherit (params) name sha256;
-     url = "https://anonscm.debian.org/cgit/pkg-acpi/acpitool.git/plain/debian/patches/${name}?h=debian/0.5.1-4&id=3fd9f396f12ec9c1cae3337a2a25026b7faad2ae";
+     url = "https://salsa.debian.org/debian/acpitool/raw/33e2ef42a663de820457b212ea2925e506df3b88/debian/patches/${name}";
    };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/os-specific/linux/ipsec-tools/CVE-2016-10396.patch
+++ b/pkgs/os-specific/linux/ipsec-tools/CVE-2016-10396.patch
@@ -1,0 +1,193 @@
+From: Antoine_Beaupre <anarcat@orangeseeds.org>
+Acked-by: Jiri Bohac <jbohac@suse.cz>
+Subject: PR/51682: Avoid DoS with fragment out of order insertion; keep fragments sorted in the list.
+References: bsc#1047443, CVE-2016-10396
+
+
+
+Index: a/src/racoon/handler.h
+===================================================================
+--- a/src/racoon/handler.h.orig	2018-01-26 18:05:21.114764376 +0100
++++ a/src/racoon/handler.h	2018-01-26 18:05:33.986741103 +0100
+@@ -141,6 +141,7 @@ struct ph1handle {
+ #endif
+ #ifdef ENABLE_FRAG
+ 	int frag;			/* IKE phase 1 fragmentation */
++	int frag_last_index;
+ 	struct isakmp_frag_item *frag_chain;	/* Received fragments */
+ #endif
+ 
+Index: a/src/racoon/isakmp.c
+===================================================================
+--- a/src/racoon/isakmp.c.orig	2018-01-26 18:05:21.118764369 +0100
++++ a/src/racoon/isakmp.c	2018-01-26 18:05:33.986741103 +0100
+@@ -1069,6 +1069,7 @@ isakmp_ph1begin_i(rmconf, remote, local)
+ 		iph1->frag = 1;
+ 	else
+ 		iph1->frag = 0;
++	iph1->frag_last_index = 0;
+ 	iph1->frag_chain = NULL;
+ #endif
+ 	iph1->approval = NULL;
+@@ -1173,6 +1174,7 @@ isakmp_ph1begin_r(msg, remote, local, et
+ #endif
+ #ifdef ENABLE_FRAG
+ 	iph1->frag = 0;
++	iph1->frag_last_index = 0;
+ 	iph1->frag_chain = NULL;
+ #endif
+ 	iph1->approval = NULL;
+Index: a/src/racoon/isakmp_frag.c
+===================================================================
+--- a/src/racoon/isakmp_frag.c.orig	2018-01-26 18:05:21.118764369 +0100
++++ a/src/racoon/isakmp_frag.c	2018-01-26 18:05:33.986741103 +0100
+@@ -173,6 +173,43 @@ vendorid_frag_cap(gen)
+ 	return ntohl(hp[MD5_DIGEST_LENGTH / sizeof(*hp)]);
+ }
+ 
++static int 
++isakmp_frag_insert(struct ph1handle *iph1, struct isakmp_frag_item *item)
++{
++	struct isakmp_frag_item *pitem = NULL;
++	struct isakmp_frag_item *citem = iph1->frag_chain;
++
++	/* no frag yet, just insert at beginning of list */
++	if (iph1->frag_chain == NULL) {
++		iph1->frag_chain = item;
++		return 0;
++	}
++
++	do {
++		/* duplicate fragment number, abort (CVE-2016-10396) */
++		if (citem->frag_num == item->frag_num)
++			return -1;
++
++		/* need to insert before current item */
++		if (citem->frag_num > item->frag_num) {
++			if (pitem != NULL)
++				pitem->frag_next = item;
++			else
++				/* insert at the beginning of the list  */
++				iph1->frag_chain = item;
++			item->frag_next = citem;
++			return 0;
++		}
++
++		pitem = citem;
++		citem = citem->frag_next;
++	} while (citem != NULL);
++
++	/* we reached the end of the list, insert */
++	pitem->frag_next = item;
++	return 0;
++}
++
+ int 
+ isakmp_frag_extract(iph1, msg)
+ 	struct ph1handle *iph1;
+@@ -224,39 +261,43 @@ isakmp_frag_extract(iph1, msg)
+ 	item->frag_next = NULL;
+ 	item->frag_packet = buf;
+ 
+-	/* Look for the last frag while inserting the new item in the chain */
+-	if (item->frag_last)
+-		last_frag = item->frag_num;
++	/* Check for the last frag before inserting the new item in the chain */
++	if (item->frag_last) {
++		/* if we have the last fragment, indices must match */
++		if (iph1->frag_last_index != 0 &&
++		    item->frag_last != iph1->frag_last_index) {
++			plog(LLV_ERROR, LOCATION, NULL,
++			     "Repeated last fragment index mismatch\n");
++			racoon_free(item);
++			vfree(buf);
++			return -1;
++		}
+ 
+-	if (iph1->frag_chain == NULL) {
+-		iph1->frag_chain = item;
+-	} else {
+-		struct isakmp_frag_item *current;
++		last_frag = iph1->frag_last_index = item->frag_num;
++	}
+ 
+-		current = iph1->frag_chain;
+-		while (current->frag_next) {
+-			if (current->frag_last)
+-				last_frag = item->frag_num;
+-			current = current->frag_next;
+-		}
+-		current->frag_next = item;
++	/* insert fragment into chain */
++	if (isakmp_frag_insert(iph1, item) == -1) {
++		plog(LLV_ERROR, LOCATION, NULL,
++		    "Repeated fragment index mismatch\n");
++		racoon_free(item);
++		vfree(buf);
++		return -1;
+ 	}
+ 
+-	/* If we saw the last frag, check if the chain is complete */
++	/* If we saw the last frag, check if the chain is complete
++	 * we have a sorted list now, so just walk through */
+ 	if (last_frag != 0) {
++		item = iph1->frag_chain;
+ 		for (i = 1; i <= last_frag; i++) {
+-			item = iph1->frag_chain;
+-			do {
+-				if (item->frag_num == i)
+-					break;
+-				item = item->frag_next;
+-			} while (item != NULL);
+-
++			if (item->frag_num != i)
++				break;
++			item = item->frag_next;
+ 			if (item == NULL) /* Not found */
+ 				break;
+ 		}
+ 
+-		if (item != NULL) /* It is complete */
++		if (i > last_frag) /* It is complete */
+ 			return 1;
+ 	}
+ 		
+@@ -291,15 +332,9 @@ isakmp_frag_reassembly(iph1)
+ 	}
+ 	data = buf->v;
+ 
++	item = iph1->frag_chain;
+ 	for (i = 1; i <= frag_count; i++) {
+-		item = iph1->frag_chain;
+-		do {
+-			if (item->frag_num == i)
+-				break;
+-			item = item->frag_next;
+-		} while (item != NULL);
+-
+-		if (item == NULL) {
++		if (item->frag_num != i) {
+ 			plog(LLV_ERROR, LOCATION, NULL, 
+ 			    "Missing fragment #%d\n", i);
+ 			vfree(buf);
+@@ -308,6 +343,7 @@ isakmp_frag_reassembly(iph1)
+ 		}
+ 		memcpy(data, item->frag_packet->v, item->frag_packet->l);
+ 		data += item->frag_packet->l;
++		item = item->frag_next;
+ 	}
+ 
+ out:
+
+
+diff -u -p -r1.50 -r1.51
+--- a/src/racoon/isakmp_inf.c	2013/04/12 09:53:10	1.50
++++ a/src/racoon/isakmp_inf.c	2017/01/24 19:23:56	1.51
+@@ -720,6 +720,7 @@ isakmp_info_send_nx(isakmp, remote, loca
+ #endif
+ #ifdef ENABLE_FRAG
+ 	iph1->frag = 0;
++	iph1->frag_last_index = 0;
+ 	iph1->frag_chain = NULL;
+ #endif
+ 

--- a/pkgs/os-specific/linux/ipsec-tools/default.nix
+++ b/pkgs/os-specific/linux/ipsec-tools/default.nix
@@ -19,10 +19,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./dont-create-localstatedir-during-install.patch
     ./CVE-2015-4047.patch
-    (fetchpatch {
-      url = "https://anonscm.debian.org/cgit/pkg-ipsec-tools/pkg-ipsec-tools.git/plain/debian/patches/CVE-2016-10396.patch?id=62ac12648a4eb7c5ba5dba0f81998d1acf310d8b";
-      sha256 = "1kf7j2pf1blni52z7q41n0yisqb7gvk01lvldr319zaxxg7rm84a";
-    })
+    ./CVE-2016-10396.patch
   ];
 
   # fix build with newer gcc versions

--- a/pkgs/os-specific/linux/molly-guard/default.nix
+++ b/pkgs/os-specific/linux/molly-guard/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Attempts to prevent you from accidentally shutting down or rebooting machines";
-    homepage    = https://anonscm.debian.org/git/collab-maint/molly-guard.git/;
+    homepage    = https://salsa.debian.org/debian/molly-guard;
     license     = licenses.artistic2;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ DerTim1 ];

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, python3Packages, docutils, help2man
+{ lib, stdenv, fetchurl, python3Packages, docutils, help2man
 , acl, apktool, binutils-unwrapped, bzip2, cbfstool, cdrkit, colord, colordiff, coreutils, cpio, db, diffutils, dtc
 , e2fsprogs, file, findutils, fontforge-fonttools, fpc, gettext, ghc, ghostscriptX, giflib, gnumeric, gnupg, gnutar
 , gzip, imagemagick, jdk, libarchive, libcaca, llvm, lz4, mono, openssh, pdftk, pgpdump, poppler_utils, sng, sqlite
@@ -8,13 +8,12 @@
 
 # Note: when upgrading this package, please run the list-missing-tools.sh script as described below!
 python3Packages.buildPythonApplication rec {
-  name = "diffoscope-${version}";
-  version = "110";
+  pname = "diffoscope";
+  version = "125";
 
-  src = fetchgit {
-    url    = "https://anonscm.debian.org/git/reproducible/diffoscope.git";
-    rev    = "refs/tags/${version}";
-    sha256 = "0rhjxigwxbqbqk7xv7n4m4rh693rg3cbp4x565jv68iy423mf2fb";
+  src = fetchurl {
+    url    = "https://diffoscope.org/archive/diffoscope-${version}.tar.bz2";
+    sha256 = "0qwib44f43hinidbdjqnr2zanj678mgckx34x48jyywppvbj8yq4";
   };
 
   patches = [
@@ -34,7 +33,7 @@ python3Packages.buildPythonApplication rec {
   # Most of the non-Python dependencies here are optional command-line tools for various file-format parsers.
   # To help figuring out what's missing from the list, run: ./pkgs/tools/misc/diffoscope/list-missing-tools.sh
   #
-  # Still missing these tools: abootimg docx2txt dumpxsb enjarify js-beautify lipo oggDump otool procyon-decompiler Rscript
+  # Still missing these tools: abootimg docx2txt dumpxsb enjarify js-beautify lipo oggDump otool procyon-decompiler Rscript wasm2wat zipnode
   # Also these libraries: python3-guestfs
   pythonPath = with python3Packages; [ debian libarchive-c python_magic tlsh rpm ] ++ [
       acl binutils-unwrapped bzip2 cdrkit colordiff coreutils cpio db diffutils

--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -20,11 +20,11 @@ stdenv.mkDerivation rec {
       ./nonpriv.patch
       (fetchurl {
         name = "CVE-2015-3310.patch";
-        url = "https://anonscm.debian.org/git/collab-maint/pkg-ppp.git/plain/debian/patches/rc_mksid-no-buffer-overflow?h=debian/2.4.7-1%2b4";
+        url = "https://salsa.debian.org/roam/ppp/raw/ef5d585aca6b1200a52c7109caa66ef97964d76e/debian/patches/rc_mksid-no-buffer-overflow";
         sha256 = "1dk00j7bg9nfgskw39fagnwv1xgsmyv0xnkd6n1v5gy0psw0lvqh";
       })
       (fetchurl {
-        url = "https://anonscm.debian.org/git/collab-maint/pkg-ppp.git/plain/debian/patches/0016-pppoe-include-netinet-in.h-before-linux-in.h.patch";
+        url = "https://salsa.debian.org/roam/ppp/raw/ef5d585aca6b1200a52c7109caa66ef97964d76e/debian/patches/0016-pppoe-include-netinet-in.h-before-linux-in.h.patch";
         sha256 = "1xnmqn02kc6g5y84xynjwnpv9cvrfn3nyv7h7r8j8xi7qf2aj4q8";
       })
       (fetchurl {

--- a/pkgs/tools/networking/uwimap/default.nix
+++ b/pkgs/tools/networking/uwimap/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation ({
     ++ stdenv.lib.optional (!stdenv.isDarwin) pam;
 
   patches = [ (fetchpatch {
-    url = "https://anonscm.debian.org/cgit/collab-maint/uw-imap.git/plain/debian/patches/1006_openssl1.1_autoverify.patch?id=b4df81d246a6cdbfd035c21f43e844effda3582b";
+    url = "https://salsa.debian.org/holmgren/uw-imap/raw/dcb42981201ea14c2d71c01ebb4a61691b6f68b3/debian/patches/1006_openssl1.1_autoverify.patch";
     sha256 = "09xb58awvkhzmmjhrkqgijzgv7ia381ablf0y7i1rvhcqkb5wga7";
   }) ];
 

--- a/pkgs/tools/text/catdoc/default.nix
+++ b/pkgs/tools/text/catdoc/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://anonscm.debian.org/git/collab-maint/catdoc.git/diff/debian/patches/05-CVE-2017-11110.patch?id=21dd5b29b11be04149587657dd90253f52dfef0b";
-      sha256 = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
+      url = "https://sources.debian.org/data/main/c/catdoc/1:0.95-4.1/debian/patches/05-CVE-2017-11110.patch";
+      sha256 = "1ljnwvssvzig94hwx8843b88p252ww2lbxh8zybcwr3kwwlcymx7";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change
Fixes #39927

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
