### PR TITLE
cipher: init at 2.0.0

### DIFF
--- a/pkgs/applications/misc/cipher/default.nix
+++ b/pkgs/applications/misc/cipher/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkgconfig
+, pantheon
+, python3
+, gettext
+, glib
+, gtk3
+, libgee
+, xdg_utils
+, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "cipher";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "arshubham";
+    repo = "cipher";
+    rev = version;
+    sha256 = "0n5aigcyxnl4k52mdmavbxx6afc1ixymn3k3l2ryhyzi5q31x0x3";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pantheon.vala
+    pkgconfig
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    pantheon.granite
+    libgee
+  ];
+
+  postPatch = ''
+  	substituteInPlace data/com.github.arshubham.cipher.desktop.in \
+  		--replace xdg-open ${xdg_utils}/bin/xdg-open
+    chmod +x post_install.py
+    patchShebangs post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple application for encoding and decoding text, designed for elementary OS";
+    homepage = "https://github.com/arshubham/cipher";
+    maintainers = with maintainers; [ kjuvi ] ++ pantheon.maintainers;
+    platforms = platforms.linux;
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17729,6 +17729,8 @@ in
 
   cinelerra = callPackage ../applications/video/cinelerra { };
 
+  cipher = callPackage ../applications/misc/cipher { };
+
   claws-mail = callPackage ../applications/networking/mailreaders/claws-mail {
     inherit (xorg) libSM;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add more curated apps from Elementary OS app store for Pantheon Desktop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
