### PR TITLE
perlPackages.CSSMinifierXS: rename from perlPackages.CSSMinifierXP

### DIFF
--- a/pkgs/servers/rt/default.nix
+++ b/pkgs/servers/rt/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       name = "rt-perl-deps";
       paths = (with perlPackages; [
         ApacheSession BusinessHours CGIEmulatePSGI CGIPSGI
-        CSSMinifierXP CSSSquish ConvertColor CryptEksblowfish
+        CSSMinifierXS CSSSquish ConvertColor CryptEksblowfish
         CryptSSLeay DBDSQLite DBDmysql DBIxSearchBuilder DataGUID
         DataICal DataPagePageset DateExtract DateManip
         DateTimeFormatNatural DevelGlobalDestruction EmailAddress

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3517,7 +3517,7 @@ let
     propagatedBuildInputs = [ Clone ];
   };
 
-  CSSMinifierXP = buildPerlModule {
+  CSSMinifierXS = buildPerlModule {
     pname = "CSS-Minifier-XS";
     version = "0.09";
     src = fetchurl {


### PR DESCRIPTION
The attribute for the `CSS::Minifier::XS` module was likely misnamed, this commit changes
the attribute name from `CSSMinifierXP` to `CSSMinifierXS`.

One dependency was affected by this change, it has been updated.

Affected dependencies: 
- servers/rt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @volth 
