### PR TITLE
mdcat: init at 0.13.0

### DIFF
--- a/pkgs/development/python-modules/ansi2html/default.nix
+++ b/pkgs/development/python-modules/ansi2html/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k, six, mock, nose, setuptools }:
+
+buildPythonPackage rec {
+  pname = "ansi2html";
+  version = "1.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1a9vihsvd03hb0a4dbiklyy686adp9q2ipl79mkxmdr6gfp8bbln";
+  };
+
+  propagatedBuildInputs = [ six setuptools ];
+
+  checkInputs = [ mock nose ];
+
+  meta = with lib; {
+    description = "Convert text with ANSI color codes to HTML";
+    homepage = http://github.com/ralphbean/ansi2html;
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ davidtwco ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/text/mdcat/default.nix
+++ b/pkgs/tools/text/mdcat/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl, Security, ansi2html }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mdcat";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "lunaryorn";
+    repo = pname;
+    rev = "mdcat-${version}";
+    sha256 = "0xlcpyfmil7sszv4008v4ipqswz49as4nzac0kzmzsb86np191q0";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ (stdenv.lib.optional stdenv.isDarwin Security) openssl ];
+
+  cargoSha256 = "16q17gm59lpjqa18q289cjmjlf2jicag12jz529x5kh11x6bjl8v";
+
+  checkInputs = [ ansi2html ];
+  checkPhase = ''
+    # Skip tests that use the network.
+    cargo test -- --skip terminal::iterm2
+  '';
+
+  meta = with stdenv.lib; {
+    description = "cat for markdown";
+    homepage = https://github.com/lunaryorn/mdcat;
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ davidtwco ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4343,6 +4343,11 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  mdcat = callPackage ../tools/text/mdcat {
+    inherit (darwin.apple_sdk.frameworks) Security;
+    inherit (pythonPackages) ansi2html;
+  };
+
   medfile = callPackage ../development/libraries/medfile { };
 
   memtester = callPackage ../tools/system/memtester { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -165,6 +165,8 @@ in {
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
+  ansi2html = callPackage ../development/python-modules/ansi2html { };
+
   anytree = callPackage ../development/python-modules/anytree {
     inherit (pkgs) graphviz;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adds a package for [mdcat](https://github.com/lunaryorn/mdcat) (and [ansi2html](https://pypi.org/project/ansi2html/) for mdcat's testing).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

me!
