### PR TITLE
qscintilla: Fix qt4 build

### DIFF
--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -32,7 +32,8 @@ in stdenv.mkDerivation rec {
     ++ (if withQt5 then [ qmake ] else [ qmake4Hook ])
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  patches = lib.optional (stdenv.isDarwin && withQt5) [ xcodePatch ];
+  patches = (lib.optional (stdenv.isDarwin && withQt5) xcodePatch) ++
+            (lib.optional (!withQt5) ./fix-qt4-build.patch );
 
   # Make sure that libqscintilla2.so is available in $out/lib since it is expected
   # by some packages such as sqlitebrowser
@@ -72,6 +73,5 @@ in stdenv.mkDerivation rec {
     license = with licenses; [ gpl2 gpl3 ]; # and commercial
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;
-    broken = !withQt5;
   };
 }

--- a/pkgs/development/libraries/qscintilla/fix-qt4-build.patch
+++ b/pkgs/development/libraries/qscintilla/fix-qt4-build.patch
@@ -1,0 +1,11 @@
+diff -ur QScintilla_gpl-2.11.2/Qt4Qt5/Qsci/qsciscintillabase.h QScintilla_gpl-2.11.2-fix/Qt4Qt5/Qsci/qsciscintillabase.h
+--- Qt4Qt5/Qsci/qsciscintillabase.h	2019-06-25 14:49:27.000000000 +0200
++++ Qt4Qt5-fix/Qsci/qsciscintillabase.h	2019-10-04 10:22:26.337474261 +0200
+@@ -27,6 +27,7 @@
+ #include <QByteArray>
+ #include <QPoint>
+ #include <QTimer>
++#include <QUrl>
+ 
+ #include <Qsci/qsciglobal.h>
+ 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

qscintilla (with qt4) is marked as broken, but is required for octave.

This PR fixes that to make octave build again.

cc @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
