### PR TITLE
[WIP] beets: use new essentia package for absubmit plugin

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -170,7 +170,7 @@ in pythonPackages.buildPythonApplication rec {
     rarfile
     responses
     # The following are plugin's deps but there are tests for them so we add them
-    # to our input no matter what the user may override in his overlays.
+    # to our input no matter what users may override in their overlays.
     pyxdg
     pylast
     discogs_client

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -203,7 +203,7 @@ in pythonPackages.buildPythonApplication rec {
       test/test_replaygain.py
   '' + optionalString enableAcousticbrainzSubmit ''
     # Replace the extractor's executable name searched in $PATH with the absolute path of the executable from the store
-    sed -i -e s,streaming_extractor_music,${essentia}/bin/essentia_streaming_extractor_music,g beetsplug/absubmit.py
+    sed -i -e 's,streaming_extractor_music,${essentia}/bin/essentia_streaming_extractor_music,g' beetsplug/absubmit.py
   '';
 
   postInstall = ''

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -164,6 +164,11 @@ in pythonPackages.buildPythonApplication rec {
     nose
     rarfile
     responses
+    # The following are plugin's deps but there are tests for them so we add them
+    # to our input no matter what the user may override in his overlays.
+    pyxdg
+    pylast
+    discogs_client
   ];
 
   patches = [

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -6,49 +6,49 @@
 # Attributes needed for tests of the external plugins
 , callPackage, beets
 
-, enableAcousticbrainz ? true
+, enableAcousticbrainz        ? true
 # The closure size will grow rather big if this'll be enabled
 , enableAcousticbrainzSubmit  ? false, essentia ? null
-, enableAcoustid       ? true
-, enableBadfiles       ? true, flac ? null, mp3val ? null
-, enableConvert        ? true, ffmpeg ? null
-, enableDiscogs        ? true
-, enableEmbyupdate     ? true
-, enableFetchart       ? true
-, enableGmusic         ? true
-, enableKeyfinder      ? true, keyfinder-cli ? null
-, enableKodiupdate     ? true
-, enableLastfm         ? true
-, enableLoadext        ? true
-, enableMpd            ? true
-, enablePlaylist       ? true
-, enableReplaygain     ? true, bs1770gain ? null
-, enableSonosUpdate    ? true
-, enableSubsonicupdate ? true
-, enableThumbnails     ? true
-, enableWeb            ? true
+, enableAcoustid              ? true
+, enableBadfiles              ? true, flac ? null, mp3val ? null
+, enableConvert               ? true, ffmpeg ? null
+, enableDiscogs               ? true
+, enableEmbyupdate            ? true
+, enableFetchart              ? true
+, enableGmusic                ? true
+, enableKeyfinder             ? true, keyfinder-cli ? null
+, enableKodiupdate            ? true
+, enableLastfm                ? true
+, enableLoadext               ? true
+, enableMpd                   ? true
+, enablePlaylist              ? true
+, enableReplaygain            ? true, bs1770gain ? null
+, enableSonosUpdate           ? true
+, enableSubsonicupdate        ? true
+, enableThumbnails            ? true
+, enableWeb                   ? true
 
 # External plugins
-, enableAlternatives   ? false
-, enableCopyArtifacts  ? false
+, enableAlternatives          ? false
+, enableCopyArtifacts         ? false
 
 , bashInteractive, bash-completion
 }:
 
-assert enableAcoustid    -> pythonPackages.pyacoustid     != null;
+assert enableAcoustid             -> pythonPackages.pyacoustid     != null;
 assert enableAcousticbrainzSubmit -> essentia != null;
-assert enableBadfiles    -> flac != null && mp3val != null;
-assert enableConvert     -> ffmpeg != null;
-assert enableDiscogs     -> pythonPackages.discogs_client != null;
-assert enableFetchart    -> pythonPackages.responses      != null;
-assert enableGmusic      -> pythonPackages.gmusicapi      != null;
-assert enableKeyfinder   -> keyfinder-cli != null;
-assert enableLastfm      -> pythonPackages.pylast         != null;
-assert enableMpd         -> pythonPackages.mpd2           != null;
-assert enableReplaygain  -> bs1770gain                    != null;
-assert enableSonosUpdate -> pythonPackages.soco           != null;
-assert enableThumbnails  -> pythonPackages.pyxdg          != null;
-assert enableWeb         -> pythonPackages.flask          != null;
+assert enableBadfiles             -> flac != null && mp3val != null;
+assert enableConvert              -> ffmpeg != null;
+assert enableDiscogs              -> pythonPackages.discogs_client != null;
+assert enableFetchart             -> pythonPackages.responses      != null;
+assert enableGmusic               -> pythonPackages.gmusicapi      != null;
+assert enableKeyfinder            -> keyfinder-cli != null;
+assert enableLastfm               -> pythonPackages.pylast         != null;
+assert enableMpd                  -> pythonPackages.mpd2           != null;
+assert enableReplaygain           -> bs1770gain                    != null;
+assert enableSonosUpdate          -> pythonPackages.soco           != null;
+assert enableThumbnails           -> pythonPackages.pyxdg          != null;
+assert enableWeb                  -> pythonPackages.flask          != null;
 
 with stdenv.lib;
 
@@ -133,7 +133,7 @@ in pythonPackages.buildPythonApplication rec {
     pythonPackages.gst-python
     pythonPackages.pygobject3
     gobject-introspection
-  ] ++ optional enableAcoustid      pythonPackages.pyacoustid
+  ] ++ optional enableAcoustid              pythonPackages.pyacoustid
     ++ optional enableAcousticbrainzSubmit  essentia
     ++ optional (enableFetchart
               || enableEmbyupdate
@@ -142,18 +142,18 @@ in pythonPackages.buildPythonApplication rec {
               || enablePlaylist
               || enableSubsonicupdate
               || enableAcousticbrainz)
-                                    pythonPackages.requests
-    ++ optional enableConvert       ffmpeg
-    ++ optional enableDiscogs       pythonPackages.discogs_client
-    ++ optional enableGmusic        pythonPackages.gmusicapi
-    ++ optional enableKeyfinder     keyfinder-cli
-    ++ optional enableLastfm        pythonPackages.pylast
-    ++ optional enableMpd           pythonPackages.mpd2
-    ++ optional enableSonosUpdate   pythonPackages.soco
-    ++ optional enableThumbnails    pythonPackages.pyxdg
-    ++ optional enableWeb           pythonPackages.flask
-    ++ optional enableAlternatives  plugins.alternatives
-    ++ optional enableCopyArtifacts plugins.copyartifacts;
+                                            pythonPackages.requests
+    ++ optional enableConvert               ffmpeg
+    ++ optional enableDiscogs               pythonPackages.discogs_client
+    ++ optional enableGmusic                pythonPackages.gmusicapi
+    ++ optional enableKeyfinder             keyfinder-cli
+    ++ optional enableLastfm                pythonPackages.pylast
+    ++ optional enableMpd                   pythonPackages.mpd2
+    ++ optional enableSonosUpdate           pythonPackages.soco
+    ++ optional enableThumbnails            pythonPackages.pyxdg
+    ++ optional enableWeb                   pythonPackages.flask
+    ++ optional enableAlternatives          plugins.alternatives
+    ++ optional enableCopyArtifacts         plugins.copyartifacts;
 
   buildInputs = [
     imagemagick


### PR DESCRIPTION
###### Motivation for this change

Add support for the absubmit plugin which depends on a new package
essentia added in #70389 . Merging this depends upon #70389 which in
turn depends upon #70372.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aszlig @domenkozar @pjones 