### PR TITLE
khronos-ocl-icd-loader: init at 6c03f8b

### DIFF
--- a/pkgs/development/libraries/khronos-ocl-icd-loader/default.nix
+++ b/pkgs/development/libraries/khronos-ocl-icd-loader/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, opencl-clhpp, cmake, withTracing ? false }:
+
+stdenv.mkDerivation rec {
+  name = "khronos-ocl-icd-loader-${version}";
+  version = "6c03f8b";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "OpenCL-ICD-Loader";
+    rev = "6c03f8b58fafd9dd693eaac826749a5cfad515f8";
+    sha256 = "00icrlc00dpc87prbd2j1350igi9pbgkz27hc3rf73s5994yn86a";
+  };
+
+  patches = stdenv.lib.lists.optional withTracing ./tracing.patch;
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ opencl-clhpp ];
+
+  meta = with stdenv.lib; {
+    description = "Offical Khronos OpenCL ICD Loader";
+    homepage = https://github.com/KhronosGroup/OpenCL-ICD-Loader;
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ davidtwco ];
+  };
+}

--- a/pkgs/development/libraries/khronos-ocl-icd-loader/tracing.patch
+++ b/pkgs/development/libraries/khronos-ocl-icd-loader/tracing.patch
@@ -1,0 +1,13 @@
+diff --git a/loader/icd.h b/loader/icd.h
+index a1b6969..cf4e272 100644
+--- a/loader/icd.h
++++ b/loader/icd.h
+@@ -122,7 +122,7 @@ void khrIcdContextPropertiesGetPlatform(
+     cl_platform_id *outPlatform);
+
+ // internal tracing macros
+-#if 0
++#if 1
+     #include <stdio.h>
+     #define KHR_ICD_TRACE(...) \
+     do \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9787,6 +9787,8 @@ in
 
   kind = callPackage ../development/tools/kind {  };
 
+  khronos-ocl-icd-loader = callPackage ../development/libraries/khronos-ocl-icd-loader {  };
+
   kube-aws = callPackage ../development/tools/kube-aws { };
 
   kubectx = callPackage ../development/tools/kubectx { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This PR adds a package for an alternative OpenCL ICD loader. Nix currently has a `ocl-icd` package ([OCL-dev/ocl-icd](https://github.com/OCL-dev/ocl-icd)), which provides the same functionality. Having this package available allows people to choose between the "official" ICD loader by Khronos, and `ocl-icd` which has some helpful environment variables which are useful in debugging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

me!
