### PR TITLE
openscad: remove useless preBuild phase

### DIFF
--- a/pkgs/applications/graphics/openscad/default.nix
+++ b/pkgs/applications/graphics/openscad/default.nix
@@ -53,10 +53,6 @@ mkDerivation rec {
   # src/lexer.l:36:10: fatal error: parser.hxx: No such file or directory
   enableParallelBuilding = false; # true by default due to qmake
 
-  preBuild = ''
-    sed -re 's/qscintilla2_qt5/qscintilla2/g' -i Makefile
-  '';
-
   postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     mkdir $out/Applications
     mv $out/bin/*.app $out/Applications


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The preBuild phase was introduced to follow a modification in qscintilla
build (76ad2796be28c5fbe8f8fe2b9bada12c3e1360e2) that forced the library
libqscintilla2_qt5.so to be called libqscintilla2.so. This has been
inproved in 4bf49d94179ad2378f50ba54138343fecb75e446 so the preBuild
trick is not necessary anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c 
