### PR TITLE
perlPackages.DeviceMAC: init at 1.00

### DIFF
--- a/pkgs/development/perl-modules/Device-OUI-1.04-hash.patch
+++ b/pkgs/development/perl-modules/Device-OUI-1.04-hash.patch
@@ -1,0 +1,11 @@
+--- Device-OUI-1.04/lib/Device/OUI.pm.orig	2009-03-07 02:23:17.000000000 +0000
++++ Device-OUI-1.04/lib/Device/OUI.pm	2016-08-09 08:19:00.642799675 +0100
+@@ -54,7 +54,7 @@
+         for my $x ( keys %hash ) {
+             if ( not defined $hash{ $x } ) { $hash{ $x } = '' }
+         }
+-        return $handle->{ $oui } = join( "\0", %hash );
++        return $handle->{ $oui } = join( "\0", map {$_,$hash{$_}} sort keys %hash );
+     } elsif ( my $x = $handle->{ $oui } ) {
+         return { split( "\0", $x ) };
+     }

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4544,6 +4544,39 @@ let
     };
   };
 
+  DeviceMAC = buildPerlPackage {
+    pname = "Device-MAC";
+    version = "1.00";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JA/JASONK/Device-MAC-1.00.tar.gz";
+      sha256 = "c42182a9a8489a314cbfe6e1c8452f32b3b626aa6c89fee1d8925e6dfb64fad5";
+    };
+    buildInputs = [ TestMost TestDifferences TestException TestWarn TestDeep ];
+    propagatedBuildInputs = [ DeviceOUI Moose ];
+    meta = {
+      description = "Handle hardware MAC Addresses (EUI-48 and EUI-64)";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.sgo ];
+    };
+  };
+
+  DeviceOUI = buildPerlPackage {
+    pname = "Device-OUI";
+    version = "1.04";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JA/JASONK/Device-OUI-1.04.tar.gz";
+      sha256 = "4b367e61b1fadde77fb6fb729f3cd5acd1d46e71218d96f406bcba38d43b4bef";
+    };
+    buildInputs = [ TestException ];
+    patches = [ ../development/perl-modules/Device-OUI-1.04-hash.patch ];
+    propagatedBuildInputs = [ ClassAccessorGrouped SubExporter LWP ];
+    meta = {
+      description = "Resolve an Organizationally Unique Identifier";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.sgo ];
+    };
+  };
+
   DBDMock = buildPerlModule {
     pname = "DBD-Mock";
     version = "1.45";


### PR DESCRIPTION
###### Motivation for this change

This is the Device::MAC module for handling hardware addresses in Perl.

dependencies:
- perlPackages.DeviceOUI: init at 1.04

Patch to prevent random test failures in Device::OUI is included:
  https://rt.cpan.org/Public/Bug/Display.html?id=109209
  https://rt.cpan.org/Ticket/Attachment/1657288/889472/Device-OUI-1.04-hash.patch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @volth 
