### PR TITLE
Quast: init at 5.0.2

### DIFF
--- a/pkgs/applications/science/biology/quast/default.nix
+++ b/pkgs/applications/science/biology/quast/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchurl, python3Packages, zlib, bash, coreutils }:
+
+let
+  pythonPackages = python3Packages;
+  inherit (pythonPackages) python;
+in
+
+pythonPackages.buildPythonApplication rec {
+  pname = "quast";
+  version = "5.0.2";
+
+  src = fetchurl {
+    url = "https://github.com/ablab/quast/releases/download/${pname}_${version}/${pname}-${version}.tar.gz";
+    sha256 = "13ml8qywbb4cc7wf2x7z5mz1rjqg51ab8wkizwcg4f6c40zgif6d";
+  };
+
+  pythonPath = with pythonPackages; [ simplejson joblib setuptools matplotlib ];
+
+  nativeBuildInputs = [ coreutils ];
+
+  buildInputs = [ zlib ] ++ pythonPath;
+
+  dontConfigure = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    substituteInPlace quast_libs/bedtools/Makefile \
+      --replace "/bin/bash" "${bash}/bin/bash"
+    mkdir -p "$out/${python.sitePackages}"
+    export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
+    ${python.interpreter} setup.py install \
+      --install-lib=$out/${python.sitePackages} \
+      --prefix="$out"
+  '';
+
+   postFixup = ''
+   for file in $(find $out -type f -type f -perm /0111); do
+       old_rpath=$(patchelf --print-rpath $file) && \
+       patchelf --set-rpath $old_rpath:${stdenv.cc.cc.lib}/lib $file || true
+   done
+   # Link to the master program
+   ln -s $out/bin/quast.py $out/bin/quast
+  '';
+
+  dontPatchELF = true;
+
+  # Tests need to download data files, so manual run after packaging is needed
+  doCheck = false;
+
+  meta = with stdenv.lib ; {
+    description = "Evaluates genome assemblies by computing various metrics";
+    homepage = "https://github.com/ablab/quast";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.bzizou ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23058,6 +23058,8 @@ in
 
   prodigal = callPackage ../applications/science/biology/prodigal { };
 
+  quast = callPackage ../applications/science/biology/quast { };
+
   raxml = callPackage ../applications/science/biology/raxml { };
 
   raxml-mpi = appendToName "mpi" (raxml.override {


### PR DESCRIPTION

###### Motivation for this change
This tools is used into my laboratory

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
