### PR TITLE
criterion: init at 2.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7152,6 +7152,16 @@
     githubId = 1866448;
     name = "Eric Bailey";
   };
+  Yumasi = {
+    email = "gpagnoux@gmail.com";
+    github = "Yumasi";
+    githubId = 24368641;
+    name = "Guillaume Pagnoux";
+    keys = [{
+      longkeyid = "rsa4096/0xEC5065899AEAAF4C";
+      fingerprint = "85F8 E850 F8F2 F823 F934  535B EC50 6589 9AEA AF4C";
+    }];
+  };
   yvt = {
     email = "i@yvt.jp";
     github = "yvt";

--- a/pkgs/development/libraries/boxfort/default.nix
+++ b/pkgs/development/libraries/boxfort/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, cmake, pkg-config, gettext, libcsptr, dyncall
+, nanomsg, python37Packages }:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2019-09-19";
+  pname = "boxfort";
+
+  src = fetchFromGitHub {
+    owner = "Snaipe";
+    repo = "BoxFort";
+    rev = "926bd4ce968592dbbba97ec1bb9aeca3edf29b0d";
+    sha256 = "0mzy4f8qij6ckn5578y3l4rni2470pdkjy5xww7ak99l1kh3p3v6";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    dyncall
+    gettext
+    libcsptr
+    nanomsg
+  ];
+
+  checkInputs = with python37Packages; [ cram ];
+
+  cmakeFlags = [ "-DBXF_FORK_RESILIENCE=OFF" ];
+
+  doCheck = true;
+  preCheck = ''
+    export LD_LIBRARY_PATH=`pwd`:$LD_LIBRARY_PATH
+  '';
+
+  outputs = [ "dev" "out" ];
+
+  meta = with stdenv.lib; {
+    description = "Convenient & cross-platform sandboxing C library";
+    homepage = "https://github.com/Snaipe/BoxFort";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      thesola10
+      Yumasi
+    ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/criterion/default.nix
+++ b/pkgs/development/libraries/criterion/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, boxfort, cmake, libcsptr, pkg-config, gettext
+, dyncall , nanomsg, python37Packages }:
+
+stdenv.mkDerivation rec {
+  version = "2.3.3";
+  pname = "criterion";
+
+  src = fetchFromGitHub {
+    owner = "Snaipe";
+    repo = "Criterion";
+    rev = "v${version}";
+    sha256 = "0y1ay8is54k3y82vagdy0jsa3nfkczpvnqfcjm5n9iarayaxaq8p";
+    fetchSubmodules = true;
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    boxfort.dev
+    dyncall
+    gettext
+    libcsptr
+    nanomsg
+  ];
+
+  checkInputs = with python37Packages; [ cram ];
+
+  cmakeFlags = [ "-DCTESTS=ON" ];
+  doCheck = true;
+  preCheck = ''
+    export LD_LIBRARY_PATH=`pwd`:$LD_LIBRARY_PATH
+  '';
+  checkTarget = "criterion_tests test";
+
+  outputs = [ "dev" "out" ];
+
+  meta = with stdenv.lib; {
+    description = "A cross-platform C and C++ unit testing framework for the 21th century";
+    homepage = "https://github.com/Snaipe/Criterion";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      thesola10
+      Yumasi
+    ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10600,6 +10600,8 @@ in
 
   cre2 = callPackage ../development/libraries/cre2 { };
 
+  criterion = callPackage ../development/libraries/criterion { };
+
   croaring = callPackage ../development/libraries/croaring { };
 
   cryptopp = callPackage ../development/libraries/crypto++ { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10455,6 +10455,8 @@ in
 
   box2d = callPackage ../development/libraries/box2d { };
 
+  boxfort = callPackage ../development/libraries/boxfort { };
+
   buddy = callPackage ../development/libraries/buddy { };
 
   bulletml = callPackage ../development/libraries/bulletml { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`Criterion` was not packaged for NixOS, so here is a derivation for it. Alongside it is a derivation for `BoxFort`, which is a library specifically created to implement `Criterion`. Since `BoxFort` is a very nice project, it does not have any release and is built by Criterion's build system against `BoxFort`'s master branch. Since this behavior is not Nix-friendly, I packaged it using the commit hash as a version number. This also guarantees me to have a working Criterion derivation. This PR also adds me in the maintainer list for those packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).