### PR TITLE
sage: add pager to environment

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -930,11 +930,6 @@
        Please use the fork <literal>cawbird</literal> instead which has been adapted to the API changes and is still maintained.
      </para>
    </listitem>
-   <listitem>
-     <para>
-      The <literal>nodejs-11_x</literal> package has been removed as it's EOLed by upstream.
-     </para>
-   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/applications/science/math/sage/sage-env.nix
+++ b/pkgs/applications/science/math/sage/sage-env.nix
@@ -44,6 +44,7 @@
 , gsl
 , ntl
 , jdk
+, less
 }:
 
 # This generates a `sage-env` shell file that will be sourced by sage on startup.
@@ -92,6 +93,7 @@ let
     rubiks
     flintqs
     jdk # only needed for `jmol` which may be replaced in the future
+    less # needed to prevent transient test errors until https://github.com/ipython/ipython/pull/11864 is resolved
   ]
   ));
 in

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, fetchNodeModules, buildPythonPackage
 , pgpy, flask, bleach, misaka, humanize, markdown, psycopg2, pygments, requests
 , sqlalchemy, flask_login, beautifulsoup4, sqlalchemy-utils, celery, alembic
-, sassc, nodejs
+, sassc, nodejs-11_x
 , writeText }:
 
 buildPythonPackage rec {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   node_modules = fetchNodeModules {
     src = "${src}/srht";
-    nodejs = nodejs;
+    nodejs = nodejs-11_x;
     sha256 = "0axl50swhcw8llq8z2icwr4nkr5qsw2riih0a040f9wx4xiw4p6p";
   };
 
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     sassc
-    nodejs
+    nodejs-11_x
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/web/nodejs/v11.nix
+++ b/pkgs/development/web/nodejs/v11.nix
@@ -1,0 +1,10 @@
+{ callPackage, openssl, enableNpm ? true }:
+
+let
+  buildNodejs = callPackage ./nodejs.nix { inherit openssl; };
+in
+  buildNodejs {
+    inherit enableNpm;
+    version = "11.15.0";
+    sha256 = "68a776c5d8b8b91a8f2adac2ca4ce4390ae1804883ec7ec9c0d6a6a64d306a76";
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4412,6 +4412,10 @@ in
   nodejs-slim-10_x = callPackage ../development/web/nodejs/v10.nix {
     enableNpm = false;
   };
+  nodejs-11_x = callPackage ../development/web/nodejs/v11.nix { };
+  nodejs-slim-11_x = callPackage ../development/web/nodejs/v11.nix {
+    enableNpm = false;
+  };
   nodejs-12_x = callPackage ../development/web/nodejs/v12.nix { };
   nodejs-slim-12_x = callPackage ../development/web/nodejs/v12.nix {
     enableNpm = false;


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/69294 since I've seen the error that prompted it on the release branch as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
