### PR TITLE
nixos/matomo: fix phpfpm config, add test

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -692,6 +692,12 @@
     githubId = 135230;
     name = "Aycan iRiCAN";
   };
+  b42 = {
+    email = "martin@martinmilata.cz";
+    github = "mmilata";
+    githubId = 85857;
+    name = "Martin Milata";
+  };
   babariviere = {
     email = "babathriviere@gmail.com";
     github = "babariviere";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -155,6 +155,7 @@ in
   #logstash = handleTest ./logstash.nix {};
   mailcatcher = handleTest ./mailcatcher.nix {};
   mathics = handleTest ./mathics.nix {};
+  matomo = handleTest ./matomo.nix {};
   matrix-synapse = handleTest ./matrix-synapse.nix {};
   mediawiki = handleTest ./mediawiki.nix {};
   memcached = handleTest ./memcached.nix {};

--- a/nixos/tests/matomo.nix
+++ b/nixos/tests/matomo.nix
@@ -1,0 +1,31 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "matomo";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ b42 ];
+  };
+
+  nodes = {
+    matomo = { config, pkgs, ... }: {
+      services.matomo = {
+        enable = true;
+        nginx = {
+          forceSSL = false;
+          enableACME = false;
+        };
+      };
+      services.mysql = {
+        enable = true;
+        package = pkgs.mysql;
+      };
+      services.nginx.enable = true;
+    };
+  };
+
+  testScript = ''
+    $matomo->start;
+    $matomo->waitForUnit("mysql.service");
+    $matomo->waitForUnit("phpfpm-matomo.service");
+    $matomo->waitForUnit("nginx.service");
+    $matomo->succeed("curl -sSfL http://matomo/ | grep '<title>Matomo[^<]*Installation'");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

The module was broken since (probably) a30a1e27:

```
The option `services.phpfpm.pools.matomo.user' is used but not defined.
```

This commit also switches the module to `socket` and `settings` options introduced in 62b774a7 and 400c6aac.

Test is added to avoid future breakages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @florianjacob @aanderse @mmahut 
