### PR TITLE
tdesktop: 1.8.9 -> 1.8.13, range-v3: 0.5.0 -> 0.9.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/default.nix
@@ -8,7 +8,7 @@ with lib;
 
 mkDerivation rec {
   pname = "telegram-desktop";
-  version = "1.8.9";
+  version = "1.8.13";
   # Note: Due to our strong dependency on the Arch patches it's probably best
   # to also wait for the Arch update (especially if the patches don't apply).
 
@@ -17,7 +17,7 @@ mkDerivation rec {
     owner = "telegramdesktop";
     repo = "tdesktop";
     rev = "v${version}";
-    sha256 = "0b1c903ah3fhxr9qjg23p8x9k895k3cxkzz5ckcr7r4pmmbnnvkp";
+    sha256 = "19p4cjzk7jyhrd4sd8dq1r1zksff23zyg5rh5vlr3kqd372bffzz";
     fetchSubmodules = true;
   };
 
@@ -25,8 +25,8 @@ mkDerivation rec {
   archPatches = fetchsvn {
     url = "svn://svn.archlinux.org/community/telegram-desktop/trunk";
     # svn log svn://svn.archlinux.org/community/telegram-desktop/trunk
-    rev = "509240";
-    sha256 = "1sf4mspbsqsnjzp9ys9l0asrx1bhj273d163i2bv1zhl4mmgpl3k";
+    rev = "512849";
+    sha256 = "1hl7znvv6qr4cwpkj8wlplpa63i1lhk2iax7hb4l1s1a4mijx9ls";
   };
   privateHeadersPatch = fetchpatch {
     url = "https://github.com/telegramdesktop/tdesktop/commit/b9d3ba621eb8af638af46c6b3cfd7a8330bf0dd5.patch";
@@ -38,8 +38,10 @@ mkDerivation rec {
   patches = [
     "${archPatches}/tdesktop.patch"
     "${archPatches}/no-gtk2.patch"
-    # "${archPatches}/Use-system-wide-font.patch"
+    "${archPatches}/Revert-Disable-DemiBold-fallback-for-Semibold.patch"
     "${archPatches}/tdesktop_lottie_animation_qtdebug.patch"
+    # "${archPatches}/Revert-Change-some-private-header-includes.patch"
+    # "${archPatches}/Use-system-wide-font.patch"
   ];
 
   postPatch = ''
@@ -87,7 +89,6 @@ mkDerivation rec {
 
   preConfigure = ''
     # Patches to revert:
-    patch -R -Np1 -i "${archPatches}/demibold.patch"
     patch -R -Np1 -i "${privateHeadersPatch}"
 
     # Patches to apply:
@@ -98,17 +99,17 @@ mkDerivation rec {
     # disable static-qt for rlottie
     sed "/RLOTTIE_WITH_STATIC_QT/d" -i "Telegram/gyp/lib_rlottie.gyp"
 
-    sed -i Telegram/gyp/telegram_linux.gypi \
+    sed -i Telegram/gyp/telegram/linux.gypi \
       -e 's,/usr,/does-not-exist,g' \
       -e 's,appindicator-0.1,appindicator3-0.1,g' \
       -e 's,-flto,,g'
 
-    sed -i Telegram/gyp/qt.gypi \
+    sed -i Telegram/gyp/modules/qt.gypi \
       -e "s,/usr/include/qt/QtCore/,${qtbase.dev}/include/QtCore/,g" \
       -e 's,\d+",\d+" | head -n1,g'
-    sed -i Telegram/gyp/qt_moc.gypi \
+    sed -i Telegram/gyp/modules/qt_moc.gypi \
       -e "s,/usr/bin/moc,moc,g"
-    sed -i Telegram/gyp/qt_rcc.gypi \
+    sed -i Telegram/gyp/modules/qt_rcc.gypi \
       -e "s,/usr/bin/rcc,rcc,g"
 
     # Build system assumes x86, but it works fine on non-x86 if we patch this one flag out

--- a/pkgs/development/libraries/range-v3/default.nix
+++ b/pkgs/development/libraries/range-v3/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "range-v3";
-  version = "0.5.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "ericniebler";
     repo = "range-v3";
     rev = version;
-    sha256 = "0fzbpaa4vwlivi417zxm1d6v4lkp5c9f5bd706nn2fmw3zxjj815";
+    sha256 = "0qga2fnfrlrzrvnnk1z1plpmvcr8b4c75g5xz0jv0sav0kmq5zwn";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/ericniebler/range-v3;
     license = licenses.boost;
     platforms = platforms.all;
-    maintainers = with maintainers; [ xwvvvvwx ];
+    maintainers = with maintainers; [ primeos xwvvvvwx ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
