### PR TITLE
[WIP] zemeroth: init at 0.6.0

### DIFF
--- a/pkgs/games/zemeroth/default.nix
+++ b/pkgs/games/zemeroth/default.nix
@@ -1,0 +1,136 @@
+{ stdenv
+, fetchFromGitHub
+, runCommand
+, rustPlatform
+, pkgconfig
+, makeWrapper
+, makeDesktopItem
+, alsaLib
+, libGL
+, libGLU
+, libglvnd
+, libpthreadstubs
+, libSM
+, udev
+, libX11
+, libXaw
+, libxcb
+, libXcomposite
+, libXcursor
+, libXdmcp
+, libXext
+, libXi
+, libXinerama
+, libXmu
+, libXrandr
+, libXrender
+, libXv
+, libXxf86vm
+, addOpenGLRunpath
+, patchelf
+, xorg
+, fontconfig
+, dbus
+}:
+
+let
+  pname = "zemeroth";
+  version = "0.6.0";
+  source = fetchFromGitHub {
+    owner = "ozkriff";
+    repo = "zemeroth";
+    rev = "v${version}";
+    sha256 = "0w0g8pv43m9w0plwiwjf3lwz01qisag6apqf9b87x5mgg41a33wi";
+  };
+  assets = fetchFromGitHub {
+    owner = "ozkriff";
+    repo = "zemeroth_assets";
+    rev = "56b620664a25c8747b33d20f3b91433a0717bcf2";
+    sha256 = "0japybbfrdxi3l3xmr1mv3d0jlbnf8461pvhnwb9g9mh9npl5zis";
+  };
+  desktopFile = makeDesktopItem {
+    name = "zemeroth";
+    exec = "%out%/bin/zemeroth";
+    comment = "A 2d turn-based tactical game";
+    desktopName = "Zemeroth";
+    categories = "Game;";
+  };
+  ld_library_path = builtins.concatStringsSep ":" [
+    "${stdenv.cc.cc.lib}/lib64"
+    (stdenv.lib.makeLibraryPath [
+      addOpenGLRunpath.driverLink
+    ])
+  ];
+in
+
+rustPlatform.buildRustPackage rec {
+  inherit pname;
+  inherit version;
+
+  src =
+    runCommand "${pname}-${version}-src" {} ''
+      cp -R ${source} $out
+      chmod +w $out
+      mkdir -p $out/assets
+      cp -R ${assets}/* $out/assets/
+      cp -R ${assets}/.checksum* $out/assets/
+    '';
+
+  cargoBuildFlags = [ "-vv" ];
+  # "--cfg feature=\"cargo:rustc-link-search=native=${ld_library_path}\"" ];
+  cargoSha256 = "1731cnpwk8108c3vk8c789mb2bvz0wgk1dvl5a3r2v11q35172b4";
+
+  nativeBuildInputs = [
+    pkgconfig
+    addOpenGLRunpath
+    makeWrapper
+    patchelf
+  ];
+  buildInputs = [
+    alsaLib
+    libGL
+    libGLU
+    libglvnd
+    libpthreadstubs
+    libSM
+    udev
+    libX11
+    libXaw
+    libxcb
+    libXcomposite
+    libXcursor
+    libXdmcp
+    libXext
+    libXi
+    libXinerama
+    libXmu
+    libXrandr
+    libXrender
+    libXv
+    libXxf86vm
+  ];
+  propagatedBuildInputs = [
+    libGL
+    libGLU
+    libglvnd
+  ];
+  #LD_LIBRARY_PATH = "${ld_library_path}";
+
+  postInstall = ''
+    mkdir -p $out/assets
+    cp -r ${assets}/* $out/assets/
+    wrapProgram $out/bin/zemeroth --set ASSET_DIR_NAME $out/assets
+    mkdir -p $out/share/applications
+    substituteAll ${desktopFile}/share/applications/zemeroth.desktop $out/share/applications/zemeroth.desktop
+    mkdir -p $out/lib
+    ln -s /run/opengl-driver/lib/libGLX_mesa.so $out/lib/libGLX.so
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A 2D turn-based tactical game in Rust";
+    homepage = "https://github.com/ozkriff/zemeroth";
+    license = with licenses; [ asl20 mit ];
+    maintainers = with maintainers; [ "0x4A6F" ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23341,6 +23341,8 @@ in
 
   zdoom = callPackage ../games/zdoom { };
 
+  zemeroth = callPackage ../games/zemeroth { };
+
   zod = callPackage ../games/zod { };
 
   zoom = callPackage ../games/zoom { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[0.6.0 released](https://ozkriff.games/2019-09-21--devlog-zemeroth-v0-6/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
