### PR TITLE
di: fix homepage

### DIFF
--- a/pkgs/tools/system/di/default.nix
+++ b/pkgs/tools/system/di/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "4.47.1";
 
   src = fetchurl {
-    url = "http://gentoo.com/di/${pname}-${version}.tar.gz";
+    url = "https://gentoo.com/${pname}/${pname}-${version}.tar.gz";
     sha256 = "1bdbl9k3gqf4h6g21difqc0w17pjid6r587y19wi37vx36aava7f";
   };
 
@@ -13,8 +13,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Disk information utility; displays everything 'df' does and more";
-    homepage = http://www.gentoo.com/di/;
+    homepage = https://gentoo.com/di/;
     license = licenses.zlib;
+    updateWalker = true;
     maintainers = with maintainers; [ manveru ndowens ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Was pointing to a broken URL

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
