### PR TITLE
projectm: adopt, Qt{4->5}, {2->3}1.0, patch rpath, clean-up closure

### DIFF
--- a/pkgs/applications/audio/projectm/default.nix
+++ b/pkgs/applications/audio/projectm/default.nix
@@ -8,6 +8,8 @@
 , qtdeclarative
 , libpulseaudio
 , glm
+
+, wrapQtAppsHook
 }:
 
 mkDerivation rec {
@@ -33,6 +35,8 @@ mkDerivation rec {
     qtdeclarative
     libpulseaudio
     glm
+
+    wrapQtAppsHook
   ];
 
   configureFlags = [

--- a/pkgs/applications/audio/projectm/default.nix
+++ b/pkgs/applications/audio/projectm/default.nix
@@ -1,57 +1,62 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, cmake
-, glew, ftgl, ttf_bitstream_vera
-, withQt ? true, qt4
-, withLibvisual ? false, libvisual, SDL
-, withJack ? false, libjack2
-, withPulseAudio ? true, libpulseaudio
+{ mkDerivation
+, lib
+, fetchFromGitHub
+
+, autoreconfHook
+, pkgconfig
+, SDL2
+, qtdeclarative
+, libpulseaudio
+, glm
 }:
 
-assert withJack       -> withQt;
-assert withPulseAudio -> withQt;
+mkDerivation rec {
+  pname = "projectm";
+  version = "3.1.0";
 
-stdenv.mkDerivation {
-  name = "projectm-2.1.0";
+  src = fetchFromGitHub {
+    owner = "projectM-visualizer";
+    repo = "projectM";
+    rev = "v${version}";
+    sha256 = "0xxwjr8gb38rg73cyrdlnlzqyn10qdrn0fk5icd28q6mg3497gwb";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    autoreconfHook
+  ];
+
+  outputs = [ "bin" "dev" "out" ]; # NOTE: 2019-10-05: libprojectM in "lib" creates a cyclic dependency on the "out"
+
+  buildInputs = [
+    SDL2
+    qtdeclarative
+    libpulseaudio
+    glm
+  ];
+
+  configureFlags = [
+    "--enable-qt"
+    "--enable-sdl"
+  ];
+
+  fixupPhase = ''
+    # NOTE: 2019-10-05: Upstream inserts the src path buring build into ELF rpath, so must delete it out
+    # upstream report: https://github.com/projectM-visualizer/projectm/issues/245
+    for entry in $out/bin/* ; do
+      patchelf --set-rpath "$(patchelf --print-rpath $entry | tr ':' '\n' | grep -v 'src/libprojectM' | tr '\n' ':')" "$entry"
+    done
+  '';
 
   meta = {
-    description = "Music Visualizer";
-    homepage = http://projectm.sourceforge.net/;
-    license = stdenv.lib.licenses.lgpl21Plus;
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "https://github.com/projectM-visualizer/projectm";
+    description = "Cross-platform Milkdrop-compatible music visualizer.";
+    license = lib.licenses.lgpl21;
+    platforms = lib.platforms.unix;
+    longDescription = ''
+      The open-source project that reimplements the esteemed Winamp Milkdrop by Geiss in a more modern, cross-platform reusable library.
+      Read an audio input and produces mesmerizing visuals, detecting tempo, and rendering advanced equations into a limitless array of user-contributed visualizations.
+    '';
   };
 
-  src = fetchurl {
-    url = "mirror://sourceforge/projectm/2.1.0/projectM-complete-2.1.0-Source.tar.gz";
-    sha256 = "1vh6jk68a0jdb6qwppb6f8cbgmhnv2ba3bcavzfd6sq06gq08cji";
-  };
-
-  patch_gcc6 = fetchpatch {
-    url = https://raw.githubusercontent.com/gentoo/gentoo/45abd63abc6644b6e177c057b5b42d894dbf8e29/media-libs/libprojectm/files/libprojectm-2.1.0-fix-c++14.patch;
-    sha256 = "1i50scxv1jlqvb3jm3sql89a7wqckxhlpvnhz20vvmm1kii6lrsn";
-  };
-
-  patchPhase = ''
-    patch -d src/libprojectM -p1 -i "$patch_gcc6"
-    sed -i 's:''${LIBVISUAL_PLUGINSDIR}:''${CMAKE_INSTALL_PREFIX}/lib/libvisual-0.4:' \
-      src/projectM-libvisual/CMakeLists.txt
-  '';
-
-  nativeBuildInputs = [ pkgconfig cmake ];
-
-  cmakeFlags = ''
-    -DprojectM_FONT_MENU=${ttf_bitstream_vera}/share/fonts/truetype/VeraMono.ttf
-    -DprojectM_FONT_TITLE=${ttf_bitstream_vera}/share/fonts/truetype/Vera.ttf
-    -DINCLUDE-PROJECTM-TEST=OFF
-    -DINCLUDE-PROJECTM-QT=${if withQt then "ON" else "OFF"}
-    -DINCLUDE-PROJECTM-LIBVISUAL=${if withLibvisual then "ON" else "OFF"}
-    -DINCLUDE-PROJECTM-JACK=${if withJack then "ON" else "OFF"}
-    -DINCLUDE-PROJECTM-PULSEAUDIO=${if withPulseAudio then "ON" else "OFF"}
-  '';
-
-  buildInputs = with stdenv.lib;
-    [ glew ftgl ]
-    ++ optional withQt qt4
-    ++ optionals withLibvisual [ libvisual SDL ]
-    ++ optional withJack libjack2
-    ++ optional withPulseAudio libpulseaudio
-    ;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5618,7 +5618,7 @@ in
 
   projectlibre = callPackage ../applications/misc/projectlibre { };
 
-  projectm = callPackage ../applications/audio/projectm { };
+  projectm = libsForQt5.callPackage ../applications/audio/projectm { };
 
   proot = callPackage ../tools/system/proot { };
 


### PR DESCRIPTION
###### Motivation for this change

The package was abandoned in `nixpkgs` for some time, but upstream is very active.

Now it is in a good state.

Also patching upstream, waiting on issue resolved or not - patch would roll on versions:
Upstream inserts the `src` path reference during build into ELF `rpath`, so we must delete it out.
upstream report: https://github.com/projectM-visualizer/projectm/issues/245


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).