### PR TITLE
ocamlPackages.ocaml-monadic: init at 0.4.1

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-monadic/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-monadic/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, ocaml-migrate-parsetree, ppx_tools_versioned
+}:
+
+buildDunePackage rec {
+  pname = "ocaml-monadic";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "zepalmer";
+    repo = pname;
+    rev = version;
+    sha256 = "1zcwydypk5vwfn1g7srnl5076scwwq5a5y8xwcjl70pc4cpzszll";
+  };
+
+  buildInputs = [ ppx_tools_versioned ];
+  propagatedBuildInputs = [ ocaml-migrate-parsetree ];
+
+  meta = {
+    inherit (src.meta) homepage;
+    description = "A PPX extension to provide an OCaml-friendly monadic syntax";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -519,6 +519,8 @@ let
 
     ocamlmod = callPackage ../development/tools/ocaml/ocamlmod { };
 
+    ocaml-monadic = callPackage ../development/ocaml-modules/ocaml-monadic { };
+
     ocaml_mysql = callPackage ../development/ocaml-modules/mysql { };
 
     ocamlnet = callPackage ../development/ocaml-modules/ocamlnet { };


### PR DESCRIPTION
###### Motivation for this change

Lightweight PPX extension for OCaml to support natural monadic syntax.
Homepage: https://github.com/zepalmer/ocaml-monadic

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
