### PR TITLE
sidequest: 0.3.1 -> 0.7.2

### DIFF
--- a/pkgs/applications/misc/sidequest/default.nix
+++ b/pkgs/applications/misc/sidequest/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchurl, buildFHSUserEnv, makeDesktopItem, makeWrapper, atomEnv, libuuid, at-spi2-atk, icu, openssl, zlib }:
 	let
 		pname = "sidequest";
-		version = "0.3.1";
-		
+		version = "0.7.2";
+
 		desktopItem = makeDesktopItem rec {
 			name = "SideQuest";
 			exec = "SideQuest";
@@ -15,17 +15,17 @@
 			inherit pname version;
 
 			src = fetchurl {
-				url = "https://github.com/the-expanse/SideQuest/releases/download/${version}/SideQuest-linux-x64.tar.gz";
-				sha256 = "1hj398zzp1x74zhp9rlhqzm9a0ck6zh9bj39g6fpvc38zab5dj1p";
+				url = "https://github.com/the-expanse/SideQuest/releases/download/v${version}/SideQuest-${version}.tar.xz";
+				sha256 = "035grhzqm3qdfcq5vn4a85lgb188rg60wlgc02r44cnj4sbsyyzj";
 			};
 
 			buildInputs = [ makeWrapper ];
 
 			buildCommand = ''
 				mkdir -p "$out/lib/SideQuest" "$out/bin"
-				tar -xzf "$src" -C "$out/lib/SideQuest" --strip-components 1
+				tar -xJf "$src" -C "$out/lib/SideQuest" --strip-components 1
 
-				ln -s "$out/lib/SideQuest/SideQuest" "$out/bin"
+				ln -s "$out/lib/SideQuest/sidequest" "$out/bin"
 
 				fixupPhase
 
@@ -35,7 +35,7 @@
 				patchelf \
 					--set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
 					--set-rpath "${atomEnv.libPath}/lib:${lib.makeLibraryPath [libuuid at-spi2-atk]}:$out/lib/SideQuest" \
-					"$out/lib/SideQuest/SideQuest"
+					"$out/lib/SideQuest/sidequest"
 			'';
 		};
 	in buildFHSUserEnv {
@@ -49,11 +49,11 @@
 				homepage = "https://github.com/the-expanse/SideQuest";
 				downloadPage = "https://github.com/the-expanse/SideQuest/releases";
 				license = licenses.mit;
-				maintainers = [ maintainers.joepie91 ];
+				maintainers = with maintainers; [ joepie91 rvolosatovs ];
 				platforms = [ "x86_64-linux" ];
 			};
 		};
-		
+
 		targetPkgs = pkgs: [
 			sidequest
 			# Needed in the environment on runtime, to make QuestSaberPatch work
@@ -62,8 +62,8 @@
 
 		extraInstallCommands = ''
 			mkdir -p "$out/share/applications"
-			ln -s "${desktopItem}/share/applications/*" "$out/share/applications"
+			ln -s ${desktopItem}/share/applications/* "$out/share/applications"
 		'';
 
-		runScript = "SideQuest";
+		runScript = "sidequest";
 	}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @joepie91
