### PR TITLE
nixos/containers: explicitly load kernel modules for networking

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -824,5 +824,12 @@ in
     '';
 
     environment.systemPackages = [ pkgs.nixos-container ];
+
+    boot.kernelModules = [
+      "bridge"
+      "macvlan"
+      "tap"
+      "tun"
+    ];
   });
 }


### PR DESCRIPTION
List all modules that *may* be required depending on individual container
configurations; don't expect that further modules can be loaded after boot.

Fixes https://github.com/NixOS/nixpkgs/issues/38676
