### PR TITLE
graphene-hardened-malloc: constrain platforms to x64 linux

### DIFF
--- a/pkgs/development/libraries/graphene-hardened-malloc/default.nix
+++ b/pkgs/development/libraries/graphene-hardened-malloc/default.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [ ris ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
Build error on i686:

> util.h:39:18: error: '__int128' is not supported on this target
  typedef unsigned __int128 u128;
