### PR TITLE
libcouchbase: fix build

### DIFF
--- a/pkgs/development/libraries/libcouchbase/0001-Fix-timeouts-in-libcouchbase-testsuite.patch
+++ b/pkgs/development/libraries/libcouchbase/0001-Fix-timeouts-in-libcouchbase-testsuite.patch
@@ -1,0 +1,36 @@
+From 58237e64fa77ec5cdec658b3295f71ec899175fa Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Sat, 5 Oct 2019 13:47:59 +0200
+Subject: [PATCH] Fix timeouts in libcouchbase testsuite
+
+Nix-specific patch. Basically
+https://github.com/couchbase/libcouchbase/commit/b272f6ab88be523bbcf9d5c4252d07fccb023fe5, but
+rebased onto 2.10.4.
+---
+ src/ssl/ssl_e.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/ssl/ssl_e.c b/src/ssl/ssl_e.c
+index f4506cf..734a3e6 100644
+--- a/src/ssl/ssl_e.c
++++ b/src/ssl/ssl_e.c
+@@ -210,10 +210,16 @@ flush_ssl_data(lcbio_ESSL *es)
+      * calls. While we could have done this inline with the send() call this
+      * would make future optimization more difficult. */
+     GT_WRITE_DONE:
++#if !LCB_CAN_OPTIMIZE_SSL_BIO
++    BIO_get_mem_ptr(es->wbio, &wmb);
++#endif
+     while (wmb->length > (size_t)tmp_len) {
+         char dummy[4096];
+         unsigned to_read = MINIMUM(wmb->length-tmp_len, sizeof dummy);
+         BIO_read(es->wbio, dummy, to_read);
++#if !LCB_CAN_OPTIMIZE_SSL_BIO
++        BIO_get_mem_ptr(es->wbio, &wmb);
++#endif
+     }
+     BIO_clear_retry_flags(es->wbio);
+     return 0;
+-- 
+2.23.0
+

--- a/pkgs/development/libraries/libcouchbase/default.nix
+++ b/pkgs/development/libraries/libcouchbase/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
   # Running tests in parallel does not work
   enableParallelChecking = false;
 
+  patches = [ ./0001-Fix-timeouts-in-libcouchbase-testsuite.patch ];
+
   doCheck = !stdenv.isDarwin;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This applies an upstream fix from libcouchbase to fix a timeout issue
with openssl 1.1.

See also https://hydra.nixos.org/build/102495724

ZHF #68361


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
