### PR TITLE
pythonPackages.mpld3: init at 0.3

### DIFF
--- a/pkgs/development/python-modules/mpld3/default.nix
+++ b/pkgs/development/python-modules/mpld3/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchPypi, python, buildPythonPackage
+, matplotlib, jinja2
+}:
+
+buildPythonPackage rec {
+  version = "0.3";
+  pname = "mpld3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4d455884a211bf99b37ecc760759435c7bb6a5955de47d8daf4967e301878ab7";
+  };
+
+  propagatedBuildInputs = [ matplotlib jinja2 ];
+  # Tests disabled as they need a working X display
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "D3 Viewer for Matplotlib";
+    homepage = "http://mpld3.github.io";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ unode ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3784,6 +3784,8 @@ in {
 
   mozterm = callPackage ../development/python-modules/mozterm { };
 
+  mpld3 = callPackage ../development/python-modules/mpld3 { };
+
   mplleaflet = callPackage ../development/python-modules/mplleaflet { };
 
   multidict = callPackage ../development/python-modules/multidict { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tests are currently disabled as they require access to an X display.