### PR TITLE
bbtools: init at 38.69

### DIFF
--- a/pkgs/applications/science/biology/bbtools/builder.sh
+++ b/pkgs/applications/science/biology/bbtools/builder.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+source $stdenv/setup
+
+checkPhase() {
+    echo "Testing bbtools - wrappers"
+    echo "> Testing bbmap"
+    $out/bin/bbmap.sh --version 2>&1
+    $out/bin/bbmap.sh --version 2>&1 | grep "BBMap"
+    echo "> Testing bbmerge"
+    $out/bin/bbmerge.sh --version 2>&1
+    $out/bin/bbmerge.sh --version 2>&1 | grep "BBMerge"
+    echo "> Testing bbduk"
+    $out/bin/bbduk.sh --version 2>&1
+    $out/bin/bbduk.sh --version 2>&1 | grep "BBDuk"
+    echo "> Testing bbmask"
+    $out/bin/bbmask.sh --version 2>&1
+    $out/bin/bbmask.sh --version 2>&1 | grep "BBMask"
+    echo "> Testing bbnorm"
+    $out/bin/bbnorm.sh --version 2>&1
+    $out/bin/bbnorm.sh --version 2>&1 | grep "Norm"
+
+    echo "Testing java usability"
+    $out/bin/bbmerge.sh in=$out/bin/resources/sample1.fq.gz out=/dev/null
+
+    echo "Testing python usability"
+    echo "... skipped"
+    # FIXME Disabled as this code depends on mpld3 which is not yet available in nixpkgs
+    #$out/bin/readqc.sh in=$out/bin/resources/sample1.fq.gz  out=/dev/null
+
+}
+
+installPhase() {
+    mkdir -p $out/bin
+    cp -r * $out/bin
+}
+
+fixupPhase() {
+    patchShebangs *.sh
+
+    # Check phase is skipped due to lack of a makefile but we still want to run the tests anyway
+    checkPhase
+}
+
+genericBuild

--- a/pkgs/applications/science/biology/bbtools/default.nix
+++ b/pkgs/applications/science/biology/bbtools/default.nix
@@ -1,0 +1,24 @@
+{stdenv, fetchurl, python, jre, python27Packages }:
+
+stdenv.mkDerivation rec {
+  version = "38.69";
+  name = "bbtools-${version}";
+  src = fetchurl {
+    url = "mirror://sourceforge/bbmap/BBMap_${version}.tar.gz";
+    sha256 = "00gzilb82rhgmwagcqp84d2kqqzm5lc15952xifzm82vszw4zkbj";
+  };
+  propagatedBuildInputs = with python27Packages; [ python jre matplotlib ]; # missing mpld3
+
+  builder = ./builder.sh;
+
+  meta = with stdenv.lib; {
+    description     = "Various bioinformatic tools including BBMap a short-read mapper";
+    longDescription = ''
+      BBTools is a series of Java programs, which includes BBMap a short-read mapper for DNA and RNA-seq data.
+    '';
+    license   = licenses.bsd3;
+    homepage  = "https://jgi.doe.gov/data-and-tools/bbtools/";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ unode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22958,6 +22958,8 @@ in
     stdenv = gcc49Stdenv;
   };
 
+  bbtools = callPackage ../applications/science/biology/bbtools { };
+
   bedtools = callPackage ../applications/science/biology/bedtools { };
 
   bcftools = callPackage ../applications/science/biology/bcftools { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

Tested some of the shell scripts manually.
A few scripts depend on python libraries not yet available in nixpkgs such as `mpld3`.
Pull request #70457 currently tracks that dependency.