### PR TITLE
gnomeExtensions.mpris-indicator-button: init at 2019-09-29

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/mpris-indicator-button/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/mpris-indicator-button/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchFromGitHub
+, gnome3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-mpris-indicator-button-unstable";
+  version = "2019-09-29";
+
+  src = fetchFromGitHub {
+    owner = "JasonLG1979";
+    repo = "gnome-shell-extension-mpris-indicator-button";
+    rev = "6cdc28a8bde98f25618b27ee48280996e2b4a0f8";
+    sha256 = "1n3sh3phpa75y3vpc09wnzhis0m92zli1m46amzsdbvmk6gkifif";
+  };
+
+  uuid = "mprisindicatorbutton@JasonLG1979.github.io";
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions
+    cp -r ${uuid} $out/share/gnome-shell/extensions
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A simple MPRIS indicator button for GNOME Shell";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = gnome3.gnome-shell.meta.platforms;
+    homepage = "https://github.com/JasonLG1979/gnome-shell-extension-mpris-indicator-button";
+    broken = versionOlder gnome3.gnome-shell.version "3.34";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22787,8 +22787,9 @@ in
     gsconnect = callPackage ../desktops/gnome-3/extensions/gsconnect { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
     impatience = callPackage ../desktops/gnome-3/extensions/impatience.nix { };
-    nohotcorner = callPackage ../desktops/gnome-3/extensions/nohotcorner { };
+    mpris-indicator-button = callPackage ../desktops/gnome-3/extensions/mpris-indicator-button { };
     no-title-bar = callPackage ../desktops/gnome-3/extensions/no-title-bar { };
+    nohotcorner = callPackage ../desktops/gnome-3/extensions/nohotcorner { };
     pidgin-im-integration = callPackage ../desktops/gnome-3/extensions/pidgin-im-integration { };
     remove-dropdown-arrows = callPackage ../desktops/gnome-3/extensions/remove-dropdown-arrows { };
     sound-output-device-chooser = callPackage ../desktops/gnome-3/extensions/sound-output-device-chooser { };


### PR DESCRIPTION
This is essentially the replacement for gnomeExtensions.mediaplayer.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done
Works in the shell.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
