### PR TITLE
kssd: init at 1.0

### DIFF
--- a/pkgs/applications/science/biology/kssd/default.nix
+++ b/pkgs/applications/science/biology/kssd/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, zlib, automake, autoconf, libtool }:
+
+stdenv.mkDerivation rec {
+  pname = "kssd";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "https://github.com/yhg926/public_${pname}/archive/v${version}.tar.gz";
+    sha256 = "a5dcaf520049a962bef625cb59a567ea2b4252d4dc9be28dd06123d340e03919";
+  };
+
+  buildInputs = [ zlib automake autoconf libtool ];
+
+  installPhase = ''
+      install -vD kssd $out/bin/kssd
+  '';
+
+  meta = with stdenv.lib; {
+    description = "K-mer substring space decomposition";
+    license     = licenses.asl20;
+    homepage    = "https://github.com/yhg926/public_kssd";
+    maintainers = with maintainers; [ unode ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23011,6 +23011,8 @@ in
 
   kallisto = callPackage ../applications/science/biology/kallisto { };
 
+  kssd = callPackage ../applications/science/biology/kssd { };
+
   macse = callPackage ../applications/science/biology/macse { };
 
   migrate = callPackage ../applications/science/biology/migrate { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
