### PR TITLE
nixos/doc: fix manpage format

### DIFF
--- a/nixos/doc/manual/man-configuration.xml
+++ b/nixos/doc/manual/man-configuration.xml
@@ -8,8 +8,8 @@
 <!-- <refmiscinfo class="version"><xi:include href="version.txt" parse="text"/></refmiscinfo> -->
  </refmeta>
  <refnamediv>
-  <refname><filename>configuration.nix</filename>
-  </refname><refpurpose>NixOS system configuration specification</refpurpose>
+  <refname><filename>configuration.nix</filename></refname>
+  <refpurpose>NixOS system configuration specification</refpurpose>
  </refnamediv>
  <refsection>
   <title>Description</title>

--- a/nixos/doc/manual/man-nixos-build-vms.xml
+++ b/nixos/doc/manual/man-nixos-build-vms.xml
@@ -8,8 +8,8 @@
 <!-- <refmiscinfo class="version"><xi:include href="version.txt" parse="text"/></refmiscinfo> -->
  </refmeta>
  <refnamediv>
-  <refname><command>nixos-build-vms</command>
-  </refname><refpurpose>build a network of virtual machines from a network of NixOS configurations</refpurpose>
+  <refname><command>nixos-build-vms</command></refname>
+  <refpurpose>build a network of virtual machines from a network of NixOS configurations</refpurpose>
  </refnamediv>
  <refsynopsisdiv>
   <cmdsynopsis>

--- a/nixos/doc/manual/man-nixos-enter.xml
+++ b/nixos/doc/manual/man-nixos-enter.xml
@@ -8,8 +8,8 @@
 <!-- <refmiscinfo class="version"><xi:include href="version.txt" parse="text"/></refmiscinfo> -->
  </refmeta>
  <refnamediv>
-  <refname><command>nixos-enter</command>
-  </refname><refpurpose>run a command in a NixOS chroot environment</refpurpose>
+  <refname><command>nixos-enter</command></refname>
+  <refpurpose>run a command in a NixOS chroot environment</refpurpose>
  </refnamediv>
  <refsynopsisdiv>
   <cmdsynopsis>

--- a/nixos/doc/manual/man-nixos-generate-config.xml
+++ b/nixos/doc/manual/man-nixos-generate-config.xml
@@ -8,8 +8,8 @@
 <!-- <refmiscinfo class="version"><xi:include href="version.txt" parse="text"/></refmiscinfo> -->
  </refmeta>
  <refnamediv>
-  <refname><command>nixos-generate-config</command>
-  </refname><refpurpose>generate NixOS configuration modules</refpurpose>
+  <refname><command>nixos-generate-config</command></refname>
+  <refpurpose>generate NixOS configuration modules</refpurpose>
  </refnamediv>
  <refsynopsisdiv>
   <cmdsynopsis>

--- a/nixos/doc/manual/man-nixos-install.xml
+++ b/nixos/doc/manual/man-nixos-install.xml
@@ -8,8 +8,8 @@
 <!-- <refmiscinfo class="version"><xi:include href="version.txt" parse="text"/></refmiscinfo> -->
  </refmeta>
  <refnamediv>
-  <refname><command>nixos-install</command>
-  </refname><refpurpose>install bootloader and NixOS</refpurpose>
+  <refname><command>nixos-install</command></refname>
+  <refpurpose>install bootloader and NixOS</refpurpose>
  </refnamediv>
  <refsynopsisdiv>
   <cmdsynopsis>

--- a/nixos/doc/manual/man-nixos-option.xml
+++ b/nixos/doc/manual/man-nixos-option.xml
@@ -8,8 +8,8 @@
 <!-- <refmiscinfo class="version"><xi:include href="version.txt" parse="text"/></refmiscinfo> -->
  </refmeta>
  <refnamediv>
-  <refname><command>nixos-option</command>
-  </refname><refpurpose>inspect a NixOS configuration</refpurpose>
+  <refname><command>nixos-option</command></refname>
+  <refpurpose>inspect a NixOS configuration</refpurpose>
  </refnamediv>
  <refsynopsisdiv>
   <cmdsynopsis>

--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -9,8 +9,8 @@
  </refmeta>
 
  <refnamediv>
-  <refname><command>nixos-rebuild</command>
-  </refname><refpurpose>reconfigure a NixOS machine</refpurpose>
+  <refname><command>nixos-rebuild</command></refname>
+  <refpurpose>reconfigure a NixOS machine</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>

--- a/nixos/doc/manual/man-nixos-version.xml
+++ b/nixos/doc/manual/man-nixos-version.xml
@@ -7,8 +7,8 @@
   <refmiscinfo class="source">NixOS</refmiscinfo>
  </refmeta>
  <refnamediv>
-  <refname><command>nixos-version</command>
-  </refname><refpurpose>show the NixOS version</refpurpose>
+  <refname><command>nixos-version</command></refname>
+  <refpurpose>show the NixOS version</refpurpose>
  </refnamediv>
  <refsynopsisdiv>
   <cmdsynopsis>


### PR DESCRIPTION
###### Motivation for this change

Spaces inside `<refname>` cause stray double underscore in generated manual pages.

Fixes #70468

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
