### PR TITLE
linuxPackages.blcr: mark as broken

### DIFF
--- a/pkgs/os-specific/linux/blcr/default.nix
+++ b/pkgs/os-specific/linux/blcr/default.nix
@@ -1,9 +1,5 @@
 { stdenv, fetchurl, kernel, perl, makeWrapper }:
 
-# BLCR version 0.8.6 should works with linux kernel up to version 3.17.x
-
-assert stdenv.lib.versionOlder "3.18" kernel.version;
-
 stdenv.mkDerivation {
   name = "blcr_${kernel.version}-0.8.6pre4";
 
@@ -36,6 +32,7 @@ stdenv.mkDerivation {
     homepage = https://ftg.lbl.gov/projects/CheckpointRestart/;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
+    broken = stdenv.lib.versionOlder "3.18" kernel.version;
     maintainers = with stdenv.lib.maintainers; [
       z77z
     ];


### PR DESCRIPTION
The build currently fails[1] because the kernel version check only accounts for
2.* and 3.*.

This package has been broken for a while, however, so rather than attempt to
figure out if it can be made to work with 4.* and older, just mark it broken
for now.

For ZHF[2]

[1]: https://hydra.nixos.org/build/102520936
[2]: https://github.com/NixOS/nixpkgs/issues/68361
