### PR TITLE
pythonPackages.openrazer-daemon: python3 only

### DIFF
--- a/pkgs/development/python-modules/openrazer/daemon.nix
+++ b/pkgs/development/python-modules/openrazer/daemon.nix
@@ -1,4 +1,5 @@
 { buildPythonApplication
+, isPy3k
 , daemonize
 , dbus-python
 , fetchFromGitHub
@@ -20,6 +21,8 @@ buildPythonApplication (common // rec {
   pname = "openrazer_daemon";
 
   sourceRoot = "source/daemon";
+
+  disabled = !isPy3k;
 
   outputs = [ "out" "man" ];
 


### PR DESCRIPTION
The build [fails](https://hydra.nixos.org/build/102502339) due to not finding
the python3 interpreter; as far as I can tell, all scripts in the package
refer to python3.

For [ZHF](https://github.com/NixOS/nixpkgs/issues/68361)
