### PR TITLE
nixos/hardened: blacklist old filesystems

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -52,6 +52,27 @@ with lib;
     "ax25"
     "netrom"
     "rose"
+
+    # Old filesystems
+    "adfs"
+    "affs"
+    "bfs"
+    "befs"
+    "cramfs"
+    "efs"
+    "erofs"
+    "exofs"
+    "freevxfs"
+    "f2fs"
+    "hfs"
+    "hpfs"
+    "jfs"
+    "minix"
+    "nilfs2"
+    "qnx4"
+    "qnx6"
+    "sysv"
+    "ufs"
   ];
 
   # Restrict ptrace() usage to processes with a pre-defined relationship

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -53,7 +53,7 @@ with lib;
     "netrom"
     "rose"
 
-    # Old filesystems
+    # Old or rare or insufficiently audited filesystems
     "adfs"
     "affs"
     "bfs"


### PR DESCRIPTION
The rationale for this is that old filesystems have recieved little scrutiny
wrt. security relevant bugs.

Lifted from OpenSUSE[1].

[1]: https://github.com/openSUSE/suse-module-tools/pull/5/commits/8cb42fb6658f210cb8c955d584a65f7b041c0575
