### PR TITLE
google-cloud-cpp: 0.11.0 -> 0.14.0

### DIFF
--- a/pkgs/development/libraries/google-cloud-cpp/default.nix
+++ b/pkgs/development/libraries/google-cloud-cpp/default.nix
@@ -1,65 +1,62 @@
-{ stdenv, grpc, curl, cmake, pkgconfig, fetchFromGitHub, doxygen, protobuf, crc32c, c-ares, nlohmann_json, fetchurl }:
+{ stdenv, clang-tools, grpc, curl, cmake, pkgconfig, fetchFromGitHub, doxygen, protobuf, crc32c, c-ares, fetchurl, openssl, zlib }:
 let
-  googleapis_rev = "a8ee1416f4c588f2ab92da72e7c1f588c784d3e6";
-  googleapis = fetchurl {
-    name = "${googleapis_rev}.tar.gz";
-    url = "https://github.com/googleapis/googleapis/archive/${googleapis_rev}.tar.gz";
-    sha256 = "1kxi27r034p7jfldhvgpbn6rqqqddycnja47m6jyjxj4rcmrp2kb";
+  googleapis = fetchFromGitHub {
+    owner = "googleapis";
+    repo = "googleapis";
+    rev = "9c9f778aedde02f9826d2ae5d0f9c96409ba0f25";
+    sha256 = "1gd3nwv8qf503wy6km0ad6akdvss9w5b1k3jqizy5gah1fkirkpi";
+  };
+  googleapis-cpp-cmakefiles = stdenv.mkDerivation rec {
+    pname = "googleapis-cpp-cmakefiles";
+    version = "0.1.5";
+    src = fetchFromGitHub {
+      owner = "googleapis";
+      repo = "cpp-cmakefiles";
+      rev = "v${version}";
+      sha256 = "02zkcq2wl831ayd9qy009xvfx7q80pgycx7mzz9vknwd0nn6dd0n";
+    };
+
+    nativeBuildInputs = [ cmake pkgconfig ];
+    buildInputs = [ c-ares c-ares.cmake-config grpc openssl protobuf zlib ];
+
+    postPatch = ''
+      sed -e 's,https://github.com/googleapis/googleapis/archive/9c9f778aedde02f9826d2ae5d0f9c96409ba0f25.tar.gz,file://${googleapis},' \
+      -i CMakeLists.txt
+    '';
+  };
+  _nlohmann_json = fetchurl {
+    url = "https://github.com/nlohmann/json/releases/download/v3.4.0/json.hpp";
+    sha256 = "0pw3jpi572irbp2dqclmyhgic6k9rxav5mpp9ygbp9xj48gnvnk3";
   };
 in stdenv.mkDerivation rec {
   pname = "google-cloud-cpp";
-  version = "0.11.0";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-cloud-cpp";
     rev = "v${version}";
-    sha256 = "1w942gzyv01ym1cv2a417x92zxra9s2v3xz5crcv84j919f616f8";
+    sha256 = "15wci4m8h6py7fqfziq8mp5m6pxp2h1cbh5rp2k90mk5js4jb9pa";
   };
 
-  buildInputs = [ curl grpc protobuf nlohmann_json crc32c c-ares c-ares.cmake-config ];
-  nativeBuildInputs = [ cmake pkgconfig doxygen ];
+  buildInputs = [ curl crc32c c-ares c-ares.cmake-config googleapis-cpp-cmakefiles grpc protobuf ];
+  nativeBuildInputs = [ clang-tools cmake pkgconfig doxygen ];
 
   outputs = [ "out" "dev" ];
 
   postPatch = ''
-    NLOHMANN_SHA256=$(sha256sum ${nlohmann_json}/include/nlohmann/json.hpp | cut -f1 -d' ')
-    sed -e 's,https://github.com/nlohmann/json/releases/download/.*,file://${nlohmann_json}/include/nlohmann/json.hpp"),' \
-        -e "s,JSON_SHA256 .*,JSON_SHA256 ''${NLOHMANN_SHA256}," \
-        -i cmake/DownloadNlohmannJson.cmake
-
-    sed -e 's,https://github.com/googleapis/googleapis/archive/${googleapis_rev}.tar.gz,file://${googleapis},' \
-        -i cmake/external/googleapis.cmake
-
-    # Fixup the library path. It would build a path like /build/external//nix/store/…-foo/lib/foo.so for each library instead of /build/external/lib64/foo.so
-    sed -e 's,''${CMAKE_INSTALL_LIBDIR},lib64,g' \
-        -e 's,;lib64,lib,g' \
-        -i cmake/ExternalProjectHelper.cmake
-  '';
-
-  preFixup = ''
-    mv --no-clobber $out/lib64/cmake/* $out/lib/cmake
-    mv --no-clobber $out/lib64/pkgconfig/* $out/lib/pkgconfig
-    rmdir $out/lib64/cmake $out/lib64/pkgconfig
-    find $out/lib64
-
-    for file in $out/lib/pkgconfig/*; do
-      sed -e 's,\''${prefix}//,/,g' -i $file
-    done
+    sed -e 's,https://github.com/nlohmann/json/releases/download/v3.4.0/json.hpp,file://${_nlohmann_json},' \
+    -i cmake/DownloadNlohmannJson.cmake
   '';
 
   cmakeFlags = [
-    "-DGOOGLE_CLOUD_CPP_BIGTABLE_ENABLE_INSTALL=no"
-    "-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package"
-    "-DGOOGLE_CLOUD_CPP_GOOGLEAPIS_PROVIDER=external"
     "-DBUILD_SHARED_LIBS:BOOL=ON"
-    "-DGOOGLE_CLOUD_CPP_INSTALL_RPATH=$(out)/lib"
   ];
 
   meta = with stdenv.lib; {
     license = with licenses; [ asl20 ];
     homepage = https://github.com/googleapis/google-cloud-cpp;
     description = "C++ Idiomatic Clients for Google Cloud Platform services";
-    maintainers = with maintainers; [ andir ];
+    maintainers = with maintainers; [ andir flokli ];
   };
 }


### PR DESCRIPTION
This bumps google-cloud-cpp to 0.14.0, which switched to using pkgconfig
for more of the dependencies. On top of that, the installation looks
much better (we don't need to fixup library paths and move files around)

On top of that, upstream introduced another intermediate dependency
(googleapis-cpp-cmakefiles).

Obsoletes #67769.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Debugging recent google-cloud-cpp bindings improvements which might fix https://github.com/googleapis/google-cloud-cpp/issues/3029, and enable https://github.com/NixOS/nix/pull/3021.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andir @tazjin 
