### PR TITLE
xflr5: init at 6.47

### DIFF
--- a/pkgs/applications/science/physics/xflr5/default.nix
+++ b/pkgs/applications/science/physics/xflr5/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchurl, wrapQtAppsHook, qmake }:
+
+stdenv.mkDerivation rec {
+  pname = "xflr5";
+  version = "6.47";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/xflr5/${pname}_v${version}_src.tar.gz";
+    sha256 = "02x3r9iv3ndwxa65mxn9m5dlhcrnjiq7cffi6rmb456gs3v3dnav";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+
+  meta = with stdenv.lib; {
+    description = "An analysis tool for airfoils, wings and planes";
+    homepage = https://sourceforge.net/projects/xflr5/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.esclear ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24040,6 +24040,8 @@ in
 
   xfitter = callPackage ../applications/science/physics/xfitter {};
 
+  xflr5 = libsForQt5.callPackage ../applications/science/physics/xflr5 { };
+
   ### SCIENCE/PROGRAMMING
 
   dafny = dotnetPackages.Dafny;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
xFLR5 is an analysis tool for airfoils, wings and planes operating at low Reynolds Numbers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
  (No dependent packages)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  (Aerofoil creation and analysis works as expected)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  (+ 262.08 MB)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
