### PR TITLE
argbash: init at 2.8.1

### DIFF
--- a/pkgs/development/tools/misc/argbash/default.nix
+++ b/pkgs/development/tools/misc/argbash/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoconf }:
 
 stdenv.mkDerivation rec {
-  name = "argbash";
+  pname = "argbash";
 
   version = "2.8.1";
 

--- a/pkgs/development/tools/misc/argbash/default.nix
+++ b/pkgs/development/tools/misc/argbash/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, autoconf }:
+
+stdenv.mkDerivation rec {
+  name = "argbash";
+
+  version = "2.8.1";
+
+  src = fetchFromGitHub {
+    owner = "matejak";
+    repo = "argbash";
+    rev = "${version}";
+    sha256 = "0jzfr2w5pza33mvw6hq6rm1vjgrfy95dp4421403jnji3ziwgf0w";
+  };
+
+  sourceRoot = "${src}/resources";
+
+  nativeBuildInputs = [ autoconf ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Bash argument parsing code generator";
+    homepage = "https://argbash.io/";
+    license = licenses.free; # custom license.  See LICENSE in source repo.
+    maintainers = with maintainers; [ rencire ];
+  };
+}

--- a/pkgs/development/tools/misc/argbash/default.nix
+++ b/pkgs/development/tools/misc/argbash/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "matejak";
     repo = "argbash";
     rev = "${version}";
-    sha256 = "0jzfr2w5pza33mvw6hq6rm1vjgrfy95dp4421403jnji3ziwgf0w";
+    sha256 = "0zara7v3pnwiwkpb0x0g37pxhmim4425q4gba712f6djj115r1mr";
   };
 
   sourceRoot = "${src}/resources";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9145,6 +9145,8 @@ in
 
   kt = callPackage ../tools/misc/kt {};
 
+  argbash = callPackage ../development/tools/misc/argbash {};
+
   arpa2cm = callPackage ../development/tools/build-managers/arpa2cm { };
 
   asn2quickder = python2Packages.callPackage ../development/tools/asn2quickder {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add new package: [argbash](https://github.com/matejak/argbash)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
