### PR TITLE
Reliable epson

### DIFF
--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -30,7 +30,15 @@ let plugins = {
     version = "2.30.4";
 
     src = fetchurl {
-      url = "https://download2.ebz.epson.net/iscan/plugin/perfection-v330/rpm/x64/iscan-perfection-v330-bundle-${version}.x64.rpm.tar.gz";
+      # To find new versions, visit
+      # http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX and search for
+      # some printer like for instance "WF-7210" to get to the most recent
+      # version.  
+      # NOTE: Don't forget to update the webarchive link too!
+      urls = [
+        "https://download2.ebz.epson.net/iscan/plugin/perfection-v330/rpm/x64/iscan-perfection-v330-bundle-${version}.x64.rpm.tar.gz"
+        "https://web.archive.org/web/https://download2.ebz.epson.net/iscan/plugin/perfection-v330/rpm/x64/iscan-perfection-v330-bundle-${version}.x64.rpm.tar.gz"
+      ];
       sha256 = "16iq5gmfcgkvcx5hixggxgb8lwin5gjdhnq0zabgpfqg11n2w21q";
     };
 
@@ -57,7 +65,10 @@ let plugins = {
 
     nativeBuildInputs = [ autoPatchelfHook rpm ];
     src = fetchurl {
-      url = "https://download2.ebz.epson.net/iscan/plugin/gt-x770/rpm/x64/iscan-gt-x770-bundle-${version}.x64.rpm.tar.gz";
+      urls = [
+        "https://download2.ebz.epson.net/iscan/plugin/gt-x770/rpm/x64/iscan-gt-x770-bundle-${version}.x64.rpm.tar.gz"
+        "https://web.archive.org/web/https://download2.ebz.epson.net/iscan/plugin/gt-x770/rpm/x64/iscan-gt-x770-bundle-${version}.x64.rpm.tar.gz"
+      ];
       sha256 = "1cz4z3wz216s77z185m665jcgdslil5gn4dsi118nv1fm17z3jik";
     };
     installPhase = ''
@@ -84,7 +95,10 @@ let plugins = {
     nativeBuildInputs= [ autoPatchelfHook ];
     buildInputs = [ gcc.cc.lib ];
     src = fetchurl {
-      url = "https://download2.ebz.epson.net/iscan/plugin/gt-f720/rpm/x64/iscan-gt-f720-bundle-${version}.x64.rpm.tar.gz";
+      urls = [
+        "https://download2.ebz.epson.net/iscan/plugin/gt-f720/rpm/x64/iscan-gt-f720-bundle-${version}.x64.rpm.tar.gz"
+        "https://web.archive.org/web/https://download2.ebz.epson.net/iscan/plugin/gt-f720/rpm/x64/iscan-gt-f720-bundle-${version}.x64.rpm.tar.gz"
+      ];
       sha256 = "12rivh00n9mhagy5yjl1m0bv7ypbig6brqkxm0a12xy0mjq7yv8y";
     };
     installPhase = ''
@@ -111,7 +125,10 @@ let plugins = {
     nativeBuildInputs = [ autoPatchelfHook ];
     buildInputs = [ gcc.cc.lib libtool ];
     src = fetchurl {
-      url = "https://download2.ebz.epson.net/iscan/plugin/gt-s80/rpm/x64/iscan-gt-s80-bundle-${version}.x64.rpm.tar.gz";
+      urls = [
+        "https://download2.ebz.epson.net/iscan/plugin/gt-s80/rpm/x64/iscan-gt-s80-bundle-${version}.x64.rpm.tar.gz"
+        "https://web.archive.org/web/https://download2.ebz.epson.net/iscan/plugin/gt-s80/rpm/x64/iscan-gt-s80-bundle-${version}.x64.rpm.tar.gz"
+      ];
       sha256 = "1ran75zsxcdci00jakngkz6p9lj4q483hjapmf80p68rzhpmdr5y";
     };
     installPhase = ''
@@ -145,7 +162,10 @@ let plugins = {
     nativeBuildInputs = [ autoPatchelfHook ];
 
     src = fetchurl {
-      url = "https://download2.ebz.epson.net/iscan/general/rpm/x64/iscan-bundle-${version}.x64.rpm.tar.gz";
+      urls = [
+        "https://download2.ebz.epson.net/iscan/general/rpm/x64/iscan-bundle-${version}.x64.rpm.tar.gz"
+        "https://web.archive.org/web/https://download2.ebz.epson.net/iscan/general/rpm/x64/iscan-bundle-${version}.x64.rpm.tar.gz"
+      ];
       sha256 = "1l0y4dy88y91jdq66pxrxqmiwsxwy0rd7x4bh0cw08r4iyhjqprz";
     };
     installPhase = ''
@@ -179,7 +199,10 @@ let iscan-data = stdenv.mkDerivation rec {
   version = "1.39.1-2";
 
   src = fetchurl {
-    url = "http://support.epson.net/linux/src/scanner/iscan/iscan-data_${version}.tar.gz";
+    urls = [
+      "http://support.epson.net/linux/src/scanner/iscan/iscan-data_${version}.tar.gz"
+      "https://web.archive.org/web/http://support.epson.net/linux/src/scanner/iscan/iscan-data_${version}.tar.gz"
+    ];
     sha256 = "04zrvbnxf1k6zinrd13hwnbzscc3qhmwlvx3k2jhjys2lginw7w4";
   };
 
@@ -195,7 +218,10 @@ stdenv.mkDerivation rec {
   version = "2.30.4-2";
 
   src = fetchurl {
-    url = "http://support.epson.net/linux/src/scanner/iscan/iscan_${version}.tar.gz";
+    urls = [
+      "http://support.epson.net/linux/src/scanner/iscan/iscan_${version}.tar.gz"
+      "https://web.archive.org/web/http://support.epson.net/linux/src/scanner/iscan/iscan_${version}.tar.gz"
+    ];
     sha256 = "1ma76jj0k3bz0fy06fiyl4di4y77rcryb0mwjmzs5ms2vq9rjysr";
   };
 
@@ -211,7 +237,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/iscan/files/iscan-2.28.1.3+libpng-1.5.patch?h=b6e4c805d53b49da79a0f64ef16bb82d6d800fcf";
+      urls = [
+        "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/iscan/files/iscan-2.28.1.3+libpng-1.5.patch?h=b6e4c805d53b49da79a0f64ef16bb82d6d800fcf"
+        "https://web.archive.org/web/https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/iscan/files/iscan-2.28.1.3+libpng-1.5.patch?h=b6e4c805d53b49da79a0f64ef16bb82d6d800fcf"
+      ];
       sha256 = "04y70qjd220dpyh771fiq50lha16pms98mfigwjczdfmx6kpj1jd";
     })
     ./firmware_location.patch

--- a/pkgs/misc/drivers/epson-201106w/default.nix
+++ b/pkgs/misc/drivers/epson-201106w/default.nix
@@ -10,7 +10,12 @@ in
     inherit version;
 
     src = fetchurl {
-      url = "https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-201106w-${version}-1lsb3.2.src.rpm";
+      # NOTE: Don't forget to update the webarchive link too!
+      urls = [
+        "https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-201106w-${version}-1lsb3.2.src.rpm"
+        "https://web.archive.org/web/https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-201106w-${version}-1lsb3.2.src.rpm"     
+      ];
+
       sha256 = "1yig1xrh1ikblbp7sx706n5nnc237wy4mbch23ymy6akbgqg4aig";
     };
 

--- a/pkgs/misc/drivers/epson-escpr/cups-filter-ppd-dirs.patch
+++ b/pkgs/misc/drivers/epson-escpr/cups-filter-ppd-dirs.patch
@@ -1,8 +1,8 @@
 diff --git a/configure b/configure_new
-index 699bcb5..89a1832 100755
+index 12b4662..6ec641c 100755
 --- a/configure
 +++ b/configure_new
-@@ -11585,55 +11585,8 @@ else
+@@ -12162,55 +12162,8 @@ else
  $as_echo "no" >&6; }
  fi
  
@@ -44,7 +44,7 @@ index 699bcb5..89a1832 100755
 -   if test -d "${cups_default_prefix}/share/ppd" ; then
 -      CUPS_PPD_DIR="${cups_default_prefix}/share/ppd"
 -   elif test "xyes" = "x$have_cups_config" ; then
--            CUPS_PPD_DIR="${cups_default_prefix}/`cups-config --datadir | sed -e 's,^/[^/][^/]*,,'`/model"
+-            CUPS_PPD_DIR="${cups_default_prefix}`cups-config --datadir | sed -e 's,^/[^/][^/]*,,'`/model"
 -   else
 -      CUPS_PPD_DIR="${cups_default_prefix}/share/cups/model"
 -   fi
@@ -58,5 +58,5 @@ index 699bcb5..89a1832 100755
 +CUPS_FILTER_DIR="${prefix}/lib/cups/filter"
 +CUPS_PPD_DIR="${prefix}/share/cups/model"
  
- { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ANSI C header files" >&5
- $as_echo_n "checking for ANSI C header files... " >&6; }
+ # Check whether --enable-lsb was given.
+ if test "${enable_lsb+set}" = set; then :

--- a/pkgs/misc/drivers/epson-escpr/default.nix
+++ b/pkgs/misc/drivers/epson-escpr/default.nix
@@ -2,11 +2,19 @@
 
 stdenv.mkDerivation {
   pname = "epson-escpr";
-  version = "1.6.16";
+  version = "1.7.3";
 
   src = fetchurl {
-    url = "https://download3.ebz.epson.net/dsc/f/03/00/06/41/54/29588ed107f800e5bc3f91706661567efb369c1c/epson-inkjet-printer-escpr-1.6.16-1lsb3.2.tar.gz";
-    sha256 = "0v9mcih3dg3ws18hdcgm014k97hv6imga39hy2a84gnc6badp6n6";
+    # To find new versions, visit
+    # http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX and search for
+    # some printer like for instance "WF-7110" to get to the most recent
+    # version.  
+    # NOTE: Don't forget to update the webarchive link too!
+    urls = [
+      "https://download3.ebz.epson.net/dsc/f/03/00/09/83/26/f90d0f70b33a9d7d77a2408364c47fba1ccbf943/epson-inkjet-printer-escpr-1.7.3-1lsb3.2.tar.gz"
+      "https://web.archive.org/web/https://download3.ebz.epson.net/dsc/f/03/00/09/83/26/f90d0f70b33a9d7d77a2408364c47fba1ccbf943/epson-inkjet-printer-escpr-1.7.3-1lsb3.2.tar.gz"
+    ];
+    sha256 = "0r3jkdfk33irha9gpyvhha056ans59p7dq9i153i292ifjsd8458";
   };
 
   patches = [ ./cups-filter-ppd-dirs.patch ];

--- a/pkgs/misc/drivers/epson-escpr2/default.nix
+++ b/pkgs/misc/drivers/epson-escpr2/default.nix
@@ -5,10 +5,15 @@ stdenv.mkDerivation rec {
   version = "1.1.1";
 
   src = fetchurl {
-    # To find new versions, visit http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX
-    # and search for some printer like for instance "WF-7210" to get to the most recent version.
-    # NOTE: keep in mind that many parts of the URL change and not just version.
-    url = "https://download3.ebz.epson.net/dsc/f/03/00/09/72/04/c6d928e83e558c4ba1e7e8bcb5c1fe080b8095eb/${pname}-${version}-1lsb3.2.src.rpm";
+    # To find new versions, visit
+    # http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX and search for
+    # some printer like for instance "WF-7210" to get to the most recent
+    # version.  
+    # NOTE: Don't forget to update the webarchive link too!
+    urls = [ 
+      "https://download3.ebz.epson.net/dsc/f/03/00/09/72/04/c6d928e83e558c4ba1e7e8bcb5c1fe080b8095eb/epson-inkjet-printer-escpr2-1.1.1-1lsb3.2.src.rpm"
+      "https://web.archive.org/web/https://download3.ebz.epson.net/dsc/f/03/00/09/72/04/c6d928e83e558c4ba1e7e8bcb5c1fe080b8095eb/epson-inkjet-printer-escpr2-1.1.1-1lsb3.2.src.rpm"
+    ];
     sha256 = "02vdlhvinsx6vsjq172b2c1vrfzkg0w9j5lbsnjvj6yq3yqz5b5q";
   };
 

--- a/pkgs/misc/drivers/epson-workforce-635-nx625-series/default.nix
+++ b/pkgs/misc/drivers/epson-workforce-635-nx625-series/default.nix
@@ -13,7 +13,11 @@ in stdenv.mkDerivation rec {
   version = "1.0.1";
 
   src = fetchurl {
-    url = "https://download.ebz.epson.net/dsc/op/stable/SRPMS/${name}-${version}-1lsb3.2.src.rpm";
+    # NOTE: Don't forget to update the webarchive link too!
+    urls = [
+      "https://download.ebz.epson.net/dsc/op/stable/SRPMS/${name}-${version}-1lsb3.2.src.rpm"
+      "https://web.archive.org/web/https://download.ebz.epson.net/dsc/op/stable/SRPMS/${name}-${version}-1lsb3.2.src.rpm"
+    ];
     sha256 = "19nb2h0y9rvv6rg7j262f8sqap9kjvz8kmisxnjg1w0v19zb9zf2";
   };
   sourceRoot = srcdirs.filter;

--- a/pkgs/misc/drivers/epson_201207w/default.nix
+++ b/pkgs/misc/drivers/epson_201207w/default.nix
@@ -9,7 +9,11 @@ in
     inherit version;
 
     src = fetchurl {
-      url = "https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-201207w-${version}-1lsb3.2.src.rpm";
+      # NOTE: Don't forget to update the webarchive link too!
+      urls = [
+        "https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-201207w-${version}-1lsb3.2.src.rpm"
+        "https://web.archive.org/web/https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-201207w-${version}-1lsb3.2.src.rpm"
+      ];
       sha256 = "1ixnhn2dk83nh9v8sdivzgc2bm9z2phvsbx8bc6ainbjq6vn7lns";
     };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Resolves https://github.com/NixOS/nixpkgs/issues/70155

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @symphorien @artuuge @furrycatherder @nphilou @emanueleperuffo @romildo @jorsn
