### PR TITLE
sddm: add module option to set users profile picture

### DIFF
--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -28,6 +28,14 @@ let
     ${cfg.stopScript}
   '';
 
+  facesEnv = pkgs.linkFarm "sddm-faces" (mapAttrsToList (user: face: {
+    name = "${user}.face.icon";
+    path = face;
+  }) ({
+    root = "${sddm}/share/sddm/faces/root.face.icon";
+    "" = "${sddm}/share/sddm/faces/.face.icon";
+  } // cfg.faces));
+
   cfgFile = pkgs.writeText "sddm.conf" ''
     [General]
     HaltCommand=${pkgs.systemd}/bin/systemctl poweroff
@@ -39,7 +47,7 @@ let
     [Theme]
     Current=${cfg.theme}
     ThemeDir=/run/current-system/sw/share/sddm/themes
-    FacesDir=/run/current-system/sw/share/sddm/faces
+    FacesDir=${facesEnv}
 
     [Users]
     MaximumUid=${toString config.ids.uids.nixbld}
@@ -120,6 +128,15 @@ in
         description = ''
           Greeter theme to use.
         '';
+      };
+
+      faces = mkOption {
+        default = {};
+        example = { alice = "/path/to/picture"; };
+        description = ''
+          the picture to set as a user's profile photo in SDDM
+        '';
+        type = types.attrsOf types.path;
       };
 
       autoNumlock = mkOption {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Currently setting a profile picture in SDDM can be done either by placing a file in the home directory or by install a package into the system environment with a special path that SDDM knows about (`/share/sddm/faces`). This allows explicitly setting user pictures through a NixOS module option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
