### PR TITLE
sddm: add a themePackages module option so themes are not installed globally

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -221,6 +221,7 @@ in
 
       services.xserver.displayManager.sddm = {
         theme = mkDefault "breeze";
+        themePackages = with pkgs; [ plasma-workspace ];
       };
 
       security.pam.services.kde = { allowNullPassword = true; };

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -28,6 +28,11 @@ let
     ${cfg.stopScript}
   '';
 
+  themesEnv = pkgs.buildEnv {
+    name = "sddm-themes";
+    paths = [ sddm ] ++ cfg.themePackages;
+  };
+
   cfgFile = pkgs.writeText "sddm.conf" ''
     [General]
     HaltCommand=${pkgs.systemd}/bin/systemctl poweroff
@@ -38,7 +43,7 @@ let
 
     [Theme]
     Current=${cfg.theme}
-    ThemeDir=/run/current-system/sw/share/sddm/themes
+    ThemeDir=${themesEnv}/share/sddm/themes
     FacesDir=/run/current-system/sw/share/sddm/faces
 
     [Users]
@@ -119,6 +124,16 @@ in
         default = "";
         description = ''
           Greeter theme to use.
+        '';
+      };
+
+      themePackages = mkOption {
+        default = [];
+        type = types.listOf types.package;
+        description = ''
+          Extra theme packages for sddm.
+          Add your themes here and then set the `theme` option
+          to the name of the theme you want to display.
         '';
       };
 

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -32,7 +32,7 @@ import ./make-test.nix ({ pkgs, ...} :
     };
     hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     virtualisation.memorySize = 1024;
-    environment.systemPackages = [ sddm_theme ];
+    services.xserver.displayManager.sddm.themePackages = [ sddm_theme ];
   };
 
   testScript = { nodes, ... }: let


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This allows users to keep SDDM theme packages separated from the system environment by adding a NixOS module option to store all the theme packages in. The user is still required to select the theme to use with the `theme` option, but they now don't need to put it in `environment.systemPackages`.

This is an implementation of what's discussed in #59016 .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
