### PR TITLE
plasma-chili: init at 0.5.5

### DIFF
--- a/pkgs/data/themes/chili/plasma-chili.nix
+++ b/pkgs/data/themes/chili/plasma-chili.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "plasma-chili";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "MarianArlt";
+    repo = "kde-plasma-chili";
+    rev = "${version}";
+    sha256 = "17pkxpk4lfgm14yfwg6rw6zrkdpxilzv90s48s2hsicgl3vmyr3x";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/sddm/themes/plasma-chili
+    mv * $out/share/sddm/themes/plasma-chili/
+  '';
+
+  meta = with stdenv.lib; {
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ illegalprime ];
+    homepage = https://github.com/MarianArlt/sddm-chili;
+    description = "The chili login theme for SDDM";
+    longDescription = ''
+      Chili is hot, just like a real chili!
+      Spice up the login experience for your users, your family and yourself.
+      Chili reduces all the clutter and leaves you with a clean,
+      easy to use, login interface with a modern yet classy touch.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17101,6 +17101,8 @@ in
 
   plano-theme = callPackage ../data/themes/plano { };
 
+  plasma-chili-theme = callPackage ../data/themes/chili/plasma-chili.nix {};
+
   plata-theme = callPackage ../data/themes/plata {
     inherit (mate) marco;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add an SDDM theme similar to the one in #59016 but this one is specifically made to work with a plasma desktop (according to the maintainer). That along with the other few SDDM PRs (#70492 #70494) makes SDDM configuration much clearer (IMO). Here's a picture of a VirtualBox instance with everything working:

![Screenshot_20191005_173609](https://user-images.githubusercontent.com/4401220/66261162-a3c1ab80-e796-11e9-8bc4-ff0c2131695f.png)

```nix
{
  services.xserver.displayManager.sddm.themePackages = with pkgs; [
    (callPackage ./sddm-theme-plasma-chili.nix {})
  ];
  services.xserver.displayManager.sddm.theme = "plasma-chili";

  services.xserver.displayManager.sddm.faces.michael = "${./face.icon}";
}
```

One question I have is with naming, the package is called `plasma-chili-theme`, but where should l document that a user should set `sddm.theme` to `"plasma-chili"` if they want to correctly use the theme?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
