### PR TITLE
add some missing descriptions and homepages

### DIFF
--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -53,7 +53,8 @@ in buildGoPackage rec {
   outputs = [ "bin" "out" "ruby" ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.gitlab.com/;
+    homepage = https://gitlab.com/gitlab-org/gitaly;
+    description = "A Git RPC service for handling all the git calls made by GitLab";
     platforms = platforms.unix;
     maintainers = with maintainers; [ roblabla globin fpletz ];
     license = licenses.mit;

--- a/pkgs/tools/misc/getopt/default.nix
+++ b/pkgs/tools/misc/getopt/default.nix
@@ -17,5 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     platforms = stdenv.lib.platforms.unix;
+    homepage = http://frodo.looijaard.name/project/getopt;
+    description = "Parses command-line arguments from shell scripts";
   };
 }

--- a/pkgs/tools/networking/eggdrop/default.nix
+++ b/pkgs/tools/networking/eggdrop/default.nix
@@ -32,5 +32,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     license = licenses.gpl2;
     platforms = platforms.unix;
+    homepage = http://www.eggheads.org;
+    description = "An Internet Relay Chat (IRC) bot";
   };
 }

--- a/pkgs/tools/networking/weighttp/default.nix
+++ b/pkgs/tools/networking/weighttp/default.nix
@@ -14,5 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     platforms = stdenv.lib.platforms.unix;
+    homepage = https://redmine.lighttpd.net/projects/weighttp/wiki;
+    description = "A lightweight and simple webserver benchmarking tool";
   };
 }

--- a/pkgs/tools/system/which/default.nix
+++ b/pkgs/tools/system/which/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://www.gnu.org/software/which/;
+    description = "Shows the full path of (shell) commands";
     platforms = platforms.all;
     license = licenses.gpl3;
   };


### PR DESCRIPTION
###### Motivation for this change 
A lot of packages have incomplete meta information. This PR adds a few missing descriptions and homepages.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

