### PR TITLE
gnome3.gnome-session: always run /etc/set-environment on startup

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-session/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-session/fix-paths.patch
@@ -1,6 +1,6 @@
 --- a/gnome-session/gnome-session.in
 +++ b/gnome-session/gnome-session.in
-@@ -3,11 +3,11 @@
+@@ -3,11 +3,13 @@
  if [ "x$XDG_SESSION_TYPE" = "xwayland" ] &&
     [ "x$XDG_SESSION_CLASS" != "xgreeter" ] &&
     [  -n "$SHELL" ] &&
@@ -12,6 +12,8 @@
 +   ! (echo "$SHELL" | @grep@ -q "nologin"); then
    if [ "$1" != '-l' ]; then
 -    exec bash -c "exec -l '$SHELL' -c '$0 -l $*'"
++    # Make sure the shell actually sets up the environment
++    unset __NIXOS_SET_ENVIRONMENT_DONE
 +    exec @bash@ -c "exec -l '$SHELL' -c '$0 -l $*'"
    else
      shift


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

gnomes-session sources its environment from a login shell. But if the systemd
user environment already contains `__NIXOS_SET_ENVIRONMENT_DONE` the environment
setup won't happen correctly. Simply unset this variable to ensure a fresh
environment.

This was previously handled by a GDM patch, but it no longer works reliably with
gnome-sessions systemd session.

~This means we can drop the not so reliable patch in gdm.~ We still need the patch to handle plasma et. al.

See https://github.com/NixOS/nixpkgs/issues/48255 for more info on the
underlying issue.

With the newly added pam environment (and #70430) this shouldn't be strictly necessary, but it does clean up a now broken fix. No idea why I didn't just fix it like this in the first place :laughing: (did it in GDM to handle other sessions obviously).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
