### PR TITLE
surf: add run-time dependencies to PATH

### DIFF
--- a/pkgs/applications/networking/browsers/surf/default.nix
+++ b/pkgs/applications/networking/browsers/surf/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, fetchurl
+{ lib, stdenv, fetchurl
 , pkgconfig, wrapGAppsHook
 , glib, glib-networking, gsettings-desktop-schemas, gtk, libsoup, webkitgtk
+, xorg, dmenu, findutils, gnused, coreutils
 , patches ? null
 }:
 
@@ -19,6 +20,16 @@ stdenv.mkDerivation rec {
   inherit patches;
 
   installFlags = [ "PREFIX=$(out)" ];
+
+  # Add run-time dependencies to PATH. Append them to PATH so the user can
+  # override the dependencies with their own PATH.
+  preFixup = let
+    depsPath = lib.makeBinPath [ xorg.xprop dmenu findutils gnused coreutils ];
+  in ''
+    gappsWrapperArgs+=(
+      --suffix PATH : ${depsPath}
+    )
+  '';
 
   meta = with stdenv.lib; {
     description = "A simple web browser based on WebKit/GTK";


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix #70410

Surf didn't work if it was run in a pure nix shell because then some of its run-time dependencies weren't found. To be even more extreme, I tested surf as follows:

```
PATH="" `which surf`
```

If I noticed any complaints about commands that couldn't be found, I added them to `PATH` in the wrapper. Not sure if this is common practice, but as far as I understand, this is how applications should be wrapped.

There might still be more run-time dependencies that are missing. I just tested some basic browsing. On the other hand, surf is so minimal that it has basically no other features than entering URL and following links. I tested both.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
