### PR TITLE
ocamlPackages.ocsigen_server: 2.11.0 → 2.15.0; ocamlPackages.ssl: 0.5.5 → 0.5.9

### DIFF
--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -13,14 +13,14 @@ let mkpath = p: n:
 in
 
 stdenv.mkDerivation rec {
-  version = "2.11.0";
+  version = "2.15.0";
   pname = "ocsigenserver";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "ocsigenserver";
     rev = version;
-    sha256 = "0y1ngki7w9s10ip7nj9qb7254bd5sp01xxz16sxyj7l7qz603hy2";
+    sha256 = "15qdkxcbl9c1bbn0fh9awjw0hjn7r6awcn288a9vyxln7icdbifw";
   };
 
   buildInputs = [ which makeWrapper ocaml findlib

--- a/pkgs/development/ocaml-modules/ssl/default.nix
+++ b/pkgs/development/ocaml-modules/ssl/default.nix
@@ -1,29 +1,25 @@
-{ stdenv, fetchzip, which, openssl, ocaml, findlib }:
+{ lib, buildDunePackage, fetchFromGitHub, pkg-config, openssl }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ssl-${version}";
-  version = "0.5.5";
+buildDunePackage rec {
+  pname = "ssl";
+  version = "0.5.9";
 
-  src = fetchzip {
-    url = "https://github.com/savonet/ocaml-ssl/releases/download/${version}/ocaml-ssl-${version}.tar.gz";
-    sha256 = "0j5zvsx51dg5r7sli7bakv7gfd29z890h0xzi876pg9vywwz9w7l";
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-ssl";
+    rev = version;
+    sha256 = "04h02rvzrwp886n5hsx84rnc9b150iggy38g5v1x1rwz3pkdnmf0";
   };
 
-  buildInputs = [which ocaml findlib];
-
+  nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [openssl];
-
-  dontAddPrefix = true;
-
-  createFindlibDestdir = true;
 
   meta = {
     homepage = http://savonet.rastageeks.org/;
     description = "OCaml bindings for libssl ";
     license = "LGPL+link exception";
-    platforms = ocaml.meta.platforms or [];
     maintainers = [
-      stdenv.lib.maintainers.z77z
+      lib.maintainers.z77z
     ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.08.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @maggesi (ssl) @FlorentBecker (ocsigen_server)
