### PR TITLE
ocamlPackages.labltk: init at 8.06.7 for OCaml ≥ 4.08

### DIFF
--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -1,26 +1,43 @@
-{ stdenv, fetchurl, ocaml, findlib, tcl, tk }:
+{ stdenv, fetchurl, fetchzip, ocaml, findlib, tcl, tk }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.04"
+let OCamlVersionAtLeast = stdenv.lib.versionAtLeast ocaml.version; in
+
+if !OCamlVersionAtLeast "4.04"
 then throw "labltk is not available for OCaml ${ocaml.version}"
 else
 
-let param = {
-  "4.04" = {
+let param =
+if OCamlVersionAtLeast "4.08" then rec {
+  version = "8.06.7";
+  src = fetchzip {
+    url = "https://github.com/garrigue/labltk/archive/${version}.tar.gz";
+    sha256 = "1cqnxjv2dvw9csiz4iqqyx6rck04jgylpglk8f69kgybf7k7xk2h";
+  };
+} else
+  let mkOldParam = { version, key, sha256 }: {
+    src = fetchurl {
+      url = "https://forge.ocamlcore.org/frs/download.php/${key}/labltk-${version}.tar.gz";
+      inherit sha256;
+    };
+    inherit version;
+  }; in
+ {
+  "4.04" = mkOldParam {
     version = "8.06.2";
     key = "1628";
     sha256 = "1p97j9s33axkb4yyl0byhmhlyczqarb886ajpyggizy2br3a0bmk";
   };
-  "4.05" = {
+  "4.05" = mkOldParam {
     version = "8.06.3";
     key = "1701";
     sha256 = "1rka9jpg3kxqn7dmgfsa7pmsdwm16x7cn4sh15ijyyrad9phgdxn";
   };
-  "4.06" = {
+  "4.06" = mkOldParam {
     version = "8.06.4";
     key = "1727";
     sha256 = "0j3rz0zz4r993wa3ssnk5s416b1jhj58l6z2jk8238a86y7xqcii";
   };
-  "4.07" = {
+  "4.07" = mkOldParam {
     version = "8.06.5";
     key = "1764";
     sha256 = "0wgx65y1wkgf22ihpqmspqfp95fqbj3pldhp1p3b1mi8rmc37zwj";
@@ -29,13 +46,8 @@ let param = {
 in
 
 stdenv.mkDerivation rec {
-  inherit (param) version;
+  inherit (param) version src;
   name = "ocaml${ocaml.version}-labltk-${version}";
-
-  src = fetchurl {
-    url = "https://forge.ocamlcore.org/frs/download.php/${param.key}/labltk-${param.version}.tar.gz";
-    inherit (param) sha256;
-  };
 
   buildInputs = [ ocaml findlib tcl tk ];
 


### PR DESCRIPTION
###### Motivation for this change

Ensure that this derivation *evaluates* for OCaml ≥ 4.08

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
