### PR TITLE
qtpbfimageplugin: 1.4 -> 2.0

### DIFF
--- a/pkgs/development/libraries/qtpbfimageplugin/default.nix
+++ b/pkgs/development/libraries/qtpbfimageplugin/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qtpbfimageplugin";
-  version = "1.4";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "tumic0";
     repo = "QtPBFImagePlugin";
     rev = version;
-    sha256 = "0d39i7rmhrmm2df49gd47zm37gnz3fmyr6hfc6hhzvk08jb6956r";
+    sha256 = "16qsax1p09gldbg83df77ixaz7bkxl8wm806lc55y19pwnid9m7p";
   };
 
   nativeBuildInputs = [ qmake ];
@@ -31,9 +31,9 @@ stdenv.mkDerivation rec {
       displaying raster MBTiles maps or raster XYZ online maps to also display PBF
       vector tiles without (almost) any application modifications.
     '';
-    homepage = https://github.com/tumic0/QtPBFImagePlugin;
+    homepage = "https://github.com/tumic0/QtPBFImagePlugin";
     license = licenses.lgpl3;
-    maintainers = [ maintainers.sikmir ];
+    maintainers = with maintainers; [ sikmir ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:QtPBFImagePlugin/QtPBFImagePlugin/libqt5-qtpbfimageformat.changes)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/lvgr9s7ywyhvrybrnic5q27m1fx5wy1n-qtpbfimageplugin-1.4
/nix/store/lvgr9s7ywyhvrybrnic5q27m1fx5wy1n-qtpbfimageplugin-1.4	 193.4M
$ nix path-info -Sh /nix/store/b8ykb9mpzn6jg62w4g1gsmc18vg3iy1w-qtpbfimageplugin-2.0
/nix/store/b8ykb9mpzn6jg62w4g1gsmc18vg3iy1w-qtpbfimageplugin-2.0	 193.5M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
