### PR TITLE
snzip: init at 1.0.4

### DIFF
--- a/pkgs/tools/archivers/snzip/default.nix
+++ b/pkgs/tools/archivers/snzip/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, snappy
+}:
+
+stdenv.mkDerivation rec {
+  pname = "snzip";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "kubo";
+    repo = "snzip";
+    rev = version;
+    sha256 = "1v8li1zv9f2g31iyi9y9zx42rjvwkaw221g60pmkbv53y667i325";
+  };
+
+  buildInputs = [ snappy ];
+  # We don't use a release tarball so we don't have a `./configure` script to
+  # run. That's why we generate it.
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "A compression/decompression tool based on snappy";
+    homepage = "https://github.com/kubo/snzip";
+    maintainers = with maintainers; [ doronbehar ];
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10169,6 +10169,8 @@ in
 
   snore = callPackage ../tools/misc/snore { };
 
+  snzip = callPackage ../tools/archivers/snzip { };
+
   snowman = qt5.callPackage ../development/tools/analysis/snowman { };
 
   sparse = callPackage ../development/tools/analysis/sparse { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A [snappy](https://github.com/google/snappy) (a newish compression algorithm) command line frontend.

https://github.com/kubo/snzip

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
