### PR TITLE
build libinput to look for local quirks in /etc

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     (mkFlag documentationSupport "documentation")
     (mkFlag eventGUISupport "debug-gui")
     (mkFlag testsSupport "tests")
+    "--sysconfdir=/etc"
     "--libexecdir=${placeholder "bin"}/libexec"
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

If the user wants to configure libinput locally (e.g. to tune
touchpad sensitivity) the advertised[*] mechanism to do this
upstream is by adding a file `/etc/libinput/local-overrides.quirks`

This doesn't work in NixOS, which is instead looking at (e.g) `/nix/store/9lwm03xqd8pkbxc3hgq9iiginddiyha3-libinput-1.12.6/etc/libinput/local-overrides.quirks`

[*] can't quite claim it as "supported", but it's certainly the
mechanism that's publically described.  See
https://wayland.freedesktop.org/libinput/doc/latest/device-quirks.html

###### Things done

Add --sysconfdir option to the libinput configurePhase so that we
build libinput to look for the file there instead of in libinput's
store path

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested on my laptop using an overlay to override the libinput derivation [https://ww.telent.net/2019/10/2/light_touch_regulation]

- [ ] building the virtualbox image `nix-build nixos/release-combined.nix -A nixos.ova` as I write, will update this when finished

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [n/a] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
