### PR TITLE
leap-motion: init at 2.3.1

### DIFF
--- a/nixos/modules/hardware/leap-motion.nix
+++ b/nixos/modules/hardware/leap-motion.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.leap-motion;
+in {
+  options.hardware.leap-motion = {
+    enable = mkEnableOption "Core software for the Leap Motion as well as udev rules for the device";
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.leap-motion ];
+    services.udev.packages = [ pkgs.leap-motion ];
+
+    systemd.services.leapd = {
+      description = "Leap Motion Daemon";
+      after = [ "systemd-udev-settle.service" ];
+      wantedBy = [ "default.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        ExecStart = "${pkgs.leap-motion}/bin/leapd";
+        KillSignal = "SIGKILL";
+      };
+    };
+  };
+}
+

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -51,6 +51,7 @@
   ./hardware/device-tree.nix
   ./hardware/sensor/iio.nix
   ./hardware/ksm.nix
+  ./hardware/leap-motion.nix
   ./hardware/ledger.nix
   ./hardware/logitech.nix
   ./hardware/mcelog.nix

--- a/pkgs/misc/leap-motion/default.nix
+++ b/pkgs/misc/leap-motion/default.nix
@@ -1,0 +1,90 @@
+{ stdenv, lib, fetchurl, dpkg, autoPatchelfHook
+, glib, dbus, libX11, libGL, alsaLib, zlib, xorg, libxslt  
+, libxml2, sqlite, libxcb, fontconfig, freetype, libGLU
+, gtk2-x11, atk, gtk2, gdk-pixbuf, pango, cairo }:
+
+stdenv.mkDerivation rec {
+  pname = "leap-motion";
+  version = "2.3.1";
+
+  # non-free binaries
+  src = fetchurl {
+    url = "https://warehouse.leapmotion.com/apps/4186/download";
+    sha256 = "1m3b029734yzhqbi78q36fi59xm9qrf05djshf059hq6ky9qahz0";
+  };
+
+  buildInputs = [
+    glib
+    dbus
+    libGL
+    libGLU
+    alsaLib
+    zlib
+    stdenv.cc.cc.lib
+    xorg.libXrender
+    xorg.libXext
+    xorg.libXi
+    xorg.libSM
+    xorg.libICE
+    libX11
+    libxslt
+    libxml2
+    sqlite
+    libxcb
+    fontconfig
+    gtk2-x11
+    atk
+    gtk2
+    gdk-pixbuf
+    pango
+    cairo
+  ]; 
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  unpackPhase = ''
+    tar xvf $src 
+    dpkg-deb -x Leap_Motion_Installer_Packages_release_public_linux/Leap-*-x64.deb .
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share
+    mkdir -p $out/bin/platforms
+    mkdir -p $out/lib
+
+    cp ./usr/lib/Leap/*       $out/lib
+    cp ./usr/bin/*.so         $out/lib
+
+    cp    ./usr/sbin/leapd           $out/bin
+    cp    ./usr/bin/platforms/*      $out/bin/platforms
+    cp    ./usr/bin/LeapControlPanel $out/bin
+    cp    ./usr/bin/Recalibrate      $out/bin
+    cp    ./usr/bin/Visualizer       $out/bin
+
+    cp    ./usr/bin/Playground       $out/
+    cp -r ./usr/bin/Playground_Data  $out/
+    ln -s $out/Playground $out/bin/Playground
+
+    addAutoPatchelfSearchPath $out/lib
+    addAutoPatchelfSearchPath $out/bin
+    autoPatchelf $out/
+
+    cp -r ./usr/share/Leap $out/share/Leap
+    cp -r ./lib/udev $out/lib/udev
+  '';
+
+  dontAutoPatchelf = true;
+  dontStrip = true;
+
+  meta = {
+    homepage = https://www.leapmotion.com/;
+    description = "Core software for the Leap Motion";
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.noneucat ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24044,6 +24044,8 @@ in
     ;
   kops = kops_1_14;
 
+  leap-motion = callPackage ../misc/leap-motion { };
+
   lguf-brightness = callPackage ../misc/lguf-brightness { };
 
   lilypond = callPackage ../misc/lilypond { guile = guile_1_8; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adds support for the Leap Motion controller.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
