### PR TITLE
unit: 1.11.0 -> 1.12.0

### DIFF
--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -14,14 +14,14 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.11.0";
+  version = "1.12.0";
   pname = "unit";
 
   src = fetchFromGitHub {
     owner = "nginx";
     repo = "unit";
     rev = version;
-    sha256 = "05qplbwki8kcj0xy9d39gf8lhwwg2cx24waxd1q5cb0fq9a5hprm";
+    sha256 = "1ylzfsajjfaxzn7mycjs69ms4x58r4szpk07kqrmbf03dp2cmxkq";
   };
 
   nativeBuildInputs = [ which ];


### PR DESCRIPTION
###### Motivation for this change
Update package to version 1.12.0
Chengelog:
 - Feature: compatibility with PHP 7.4.
 - Bugfix: descriptors leak on process creation; the bug had appeared in 1.11.0.
 - Bugfix: TLS connection might be closed prematurely while sending response.
 - Bugfix: segmentation fault might have occurred if an irregular file was requested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
