### PR TITLE
zathura 0.4.3 > 0.4.4 (and girara 0.3.2 -> 0.3.3)

### DIFF
--- a/pkgs/applications/misc/girara/default.nix
+++ b/pkgs/applications/misc/girara/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "girara";
-  version = "0.3.2";
+  version = "0.3.3";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
-    url = "https://pwmt.org/projects/girara/download/${pname}-${version}.tar.xz";
-    sha256 = "1kc6n1mxjxa7wvwnqy94qfg8l9jvx9qrvrr2kc7m4g0z20x3a00p";
+    url = "https://git.pwmt.org/pwmt/${pname}/-/archive/${version}/${pname}-${version}.tar.gz";
+    sha256 = "13vr62kkkqs2xsrmsn114n6c6084ix1qyjksczqsc3s2y3bdsmj4";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext check dbus xvfb_run ];
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://pwmt.org/projects/girara/;
+    homepage = "https://git.pwmt.org/pwmt/girara";
     description = "User interface library";
     longDescription = ''
       girara is a library that implements a GTK based VIM-like user interface

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -10,11 +10,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "zathura-core";
-  version = "0.4.3";
+  version = "0.4.4";
 
   src = fetchurl {
-    url = "https://pwmt.org/projects/zathura/download/zathura-${version}.tar.xz";
-    sha256 = "0hgx5x09i6d0z45llzdmh4l348fxh1y102sb1w76f2fp4r21j4ky";
+    url = "https://git.pwmt.org/pwmt/zathura/-/archive/${version}/zathura-${version}.tar.gz";
+    sha256 = "0v5klgr009rsxi41h73k0398jbgmgh37asvwz2w15i4fzmw89jgb";
   };
 
   outputs = [ "bin" "man" "dev" "out" ];
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = https://pwmt.org/projects/zathura/;
+    homepage = "https://git.pwmt.org/pwmt/zathura";
     description = "A core component for zathura PDF viewer";
     license = licenses.zlib;
     platforms = platforms.unix;


### PR DESCRIPTION
##### Motivation for this change

Update `zathura` to 0.4.4 as well `girara` to 0.3.3 (it's a required update for `zathura`).

Updated the source URLs and homepages to use https://git.pwmt.org/pwmt as https://pwmt.org is down (and AFAIK has been for a while).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @globin 
