### PR TITLE
[r19.09] varnish6: 6.2.0 -> 6.2.1, fixing CVE-2019-15892

### DIFF
--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -51,8 +51,8 @@ in
     python = python2;
   };
   varnish6 = common {
-    version = "6.2.0";
-    sha256 = "0lwfk2gq99c653h5f51fs3j37r0gh2pf0p4w5z986nm2mi9z6yn3";
+    version = "6.2.1";
+    sha256 = "15qfvw3fp05bgyspcm6gbsnxhs430p4z3fwz5kkd1z68jb90b3pj";
     python = python3;
     extraNativeBuildInputs = [ python3.pkgs.sphinx ];
   };


### PR DESCRIPTION
###### Motivation for this change
Fixes CVE-2019-15892 https://nvd.nist.gov/vuln/detail/CVE-2019-15892

For `master`, we should be merging #69973 instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
