### PR TITLE
gnomeExtensions.arc-menu: 33.2 -> 33

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/arc-menu/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/arc-menu/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-arc-menu";
-  version = "33.2";
+  version = "33";
 
   src = fetchFromGitLab {
     owner = "LinxGem33";
     repo = "Arc-Menu";
-    rev = "v${version}-dev";
-    sha256 = "1dd9ysiyza6drwdv4qcxyijy7yijirjf2fd1aq5jv8s4bqajcqf4";
+    rev = "v${version}-Stable";
+    sha256 = "0ncb19jlwy2y9jcj8g6cdbasdv6n7hm96qv9l251z6qgrmg28x4z";
   };
 
   patches = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Despite the 33.3 -> 33 this doesn't appear to be a downgrade.
An actual stable release, where before it was a development version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

