### PR TITLE
Renoise version 3.2.0

### DIFF
--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -4,8 +4,7 @@
 with stdenv.lib;
 
 # To use the full release version:
-# 1) Sign into https://backstage.renoise.com and download the appropriate (x86 or x86_64) version
-#    for your machine to some stable location.
+# 1) Sign into https://backstage.renoise.com and download the release version to some stable location.
 # 2) Override the releasePath attribute to point to the location of the newly downloaded bundle.
 # Note: Renoise creates an individual build for each license which screws somewhat with the
 # use of functions like requireFile as the hash will be different for every user.
@@ -15,25 +14,20 @@ in
 
 stdenv.mkDerivation rec {
   pname = "renoise";
-  version = "3.1.0";
+  version = "3.2.0";
 
   src =
     if stdenv.hostPlatform.system == "x86_64-linux" then
         if releasePath == null then
-        fetchurl {
-          url = "https://files.renoise.com/demo/Renoise_${urlVersion version}_Demo_x86_64.tar.bz2";
-          sha256 = "0pan68fr22xbj7a930y29527vpry3f07q3i9ya4fp6g7aawffsga";
-        }
+		    fetchurl {
+		      urls = [
+		          "https://files.renoise.com/demo/Renoise_${urlVersion version}_Demo_Linux.tar.gz"
+		          "https://web.archive.org/web/https://files.renoise.com/demo/Renoise_${urlVersion version}_Demo_Linux.tar.gz"
+		      ];
+		      sha256 = "0cfczzpk1ddz61nk4d72fydbm5nbgxqp95v81by2n87s1wffjjhi";
+		    }
         else
-        releasePath
-    else if stdenv.hostPlatform.system == "i686-linux" then
-        if releasePath == null then
-        fetchurl {
-          url = "http://files.renoise.com/demo/Renoise_${urlVersion version}_Demo_x86.tar.bz2";
-          sha256 = "1lccjj4k8hpqqxxham5v01v2rdwmx3c5kgy1p9lqvzqma88k4769";
-        }
-        else
-        releasePath
+        	releasePath
     else throw "Platform is not supported by Renoise";
 
   buildInputs = [ alsaLib libjack2 libX11 libXcursor libXext libXrandr ];
@@ -69,6 +63,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.renoise.com/;
     license = licenses.unfree;
     maintainers = [];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
renoise: 3.1.0 -> 3.2.0

###### Motivation for this change

New version of Renoise. Previous version is not even downloadable anymore, which makes this derivation fail (until now). Also, 32-bits platform is not supported by Renoise anymore.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of the Demo version.
- [ ] Tested execution of the Full version (I don't own the Full version). However nothing should have changed since 3.1.0.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

There are no maintainers, and I don't intend to become one until I buy the full version of Renoise.
