### PR TITLE
chez-scmutils: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3037,6 +3037,11 @@
     githubId = 184898;
     name = "Jirka Marsik";
   };
+  jitwit = {
+    email = "jrn@bluefarm.ca";
+    github = "jitwit";
+    name = "jitwit";
+  };
   jlesquembre = {
     email = "jl@lafuente.me";
     github = "jlesquembre";

--- a/pkgs/development/chez-modules/chez-mit/default.nix
+++ b/pkgs/development/chez-modules/chez-mit/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, chez, chez-srfi }:
+
+stdenv.mkDerivation {
+  pname = "chez-mit";
+  version = "1.0";
+
+  src = fetchgit {
+    url = "https://github.com/fedeinthemix/chez-mit.git";
+    rev = "68f3d7562e77f694847dc74dabb5ecbd106cd6be";
+    sha256 = "0c7i3b6i90xk96nmxn1pc9272a4yal4v40dm1a4ybdi87x53zkk0";
+  };
+
+  buildInputs = [ chez chez-srfi ];
+
+  buildPhase = ''
+    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv9.5-site
+    make PREFIX=$out CHEZ=${chez}/bin/scheme
+  '';
+
+  installPhase = ''
+    make install PREFIX=$out CHEZ=${chez}/bin/scheme
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "This is a MIT/GNU Scheme compatibility library for Chez Scheme";
+    homepage = https://github.com/fedeinthemix/chez-mit/;
+    maintainers = [ stdenv.lib.maintainers.jitwit ];
+    license = stdenv.lib.licenses.free;
+  };
+
+}

--- a/pkgs/development/chez-modules/chez-scmutils/default.nix
+++ b/pkgs/development/chez-modules/chez-scmutils/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, chez, chez-srfi, chez-mit }:
+
+stdenv.mkDerivation {
+  pname = "chez-scmutils";
+  version = "1.0";
+
+  src = fetchgit {
+    url = "https://github.com/fedeinthemix/chez-scmutils.git";
+    rev = "5eaeea6289fd239358d7eed99cc9588528fb52b2";
+    sha256 = "0lb05wlf8qpgg8y0gdsyaxg1nbfx1qbaqdjvygrp64ndn8fnhq7l";
+  };
+
+  buildInputs = [ chez chez-srfi chez-mit ];
+
+  buildPhase = ''
+    export CHEZSCHEMELIBDIRS=${chez-srfi}/lib/csv9.5-site:${chez-mit}/lib/csv9.5-site
+    make PREFIX=$out CHEZ=${chez}/bin/scheme
+  '';
+
+  installPhase = ''
+    make install PREFIX=$out CHEZ=${chez}/bin/scheme
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "This is a port of the ‘MIT Scmutils’ library to Chez Scheme";
+    homepage = https://github.com/fedeinthemix/chez-scmutils/;
+    maintainers = [ stdenv.lib.maintainers.jitwit ];
+    license = stdenv.lib.licenses.gpl3;
+  };
+
+}

--- a/pkgs/development/chez-modules/chez-srfi/default.nix
+++ b/pkgs/development/chez-modules/chez-srfi/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit, chez }:
+
+stdenv.mkDerivation {
+  pname = "chez-srfi";
+  version = "1.0";
+
+  src = fetchgit {
+    url = "https://github.com/fedeinthemix/chez-srfi.git";
+    rev = "5770486c2a85d0e3dd4ac62a97918e7c394ea507";
+    sha256 = "1s47v7b7w0ycd2g6gyv8qbzmh4jjln5iday8n9l3m996ns8is9zj";
+  };
+
+  buildInputs = [ chez ];
+
+  buildPhase = ''
+    make PREFIX=$out CHEZ=${chez}/bin/scheme
+  '';
+
+  installPhase = ''
+    make install PREFIX=$out CHEZ=${chez}/bin/scheme
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "This package provides a collection of SRFI libraries for Chez Scheme";
+    homepage = https://github.com/fedeinthemix/chez-srfi/;
+    maintainers = [ stdenv.lib.maintainers.jitwit ];
+    license = stdenv.lib.licenses.free;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7450,6 +7450,12 @@ in
     inherit (darwin) cctools;
   };
 
+  chez-srfi = callPackage ../development/chez-modules/chez-srfi { };
+
+  chez-mit = callPackage ../development/chez-modules/chez-mit { };
+
+  chez-scmutils = callPackage ../development/chez-modules/chez-scmutils { };
+
   clang = llvmPackages.clang;
   clang-manpages = llvmPackages.clang-manpages;
 


### PR DESCRIPTION
#### Motivation for this change

scmutils is a wonderful generic and symbolic computational library in scheme. This is a packaging for nixpkgs of a port of this software to ChezScheme.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
