### PR TITLE
qt5.{qtwebengine, qtwebkit}: fix -Wno-class-memaccess warning for clang

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -103,7 +103,7 @@ EOF
       --replace 'libs = [ "sandbox" ]' 'libs = [ "/usr/lib/libsandbox.1.dylib" ]'
     '');
 
-  NIX_CFLAGS_COMPILE = [
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [
     # with gcc8, -Wclass-memaccess became part of -Wall and this exceeds the logging limit
     "-Wno-class-memaccess"
   ] ++ lib.optionals (stdenv.hostPlatform.platform.gcc.arch or "" == "sandybridge") [

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -50,13 +50,12 @@ qtModule {
     export qmakeFlags="$qmakeFlags CONFIG+=silent"
   '';
 
-  NIX_CFLAGS_COMPILE =
-    [
+  NIX_CFLAGS_COMPILE = [
       # with gcc7 this warning blows the log over Hydra's limit
       "-Wno-expansion-to-defined"
-      # with gcc8, -Wclass-memaccess became part of -Wall and this too exceeds the logging limit
-      "-Wno-class-memaccess"
     ]
+    # with gcc8, -Wclass-memaccess became part of -Wall and this too exceeds the logging limit
+    ++ optional stdenv.cc.isGNU "-Wno-class-memaccess"
     # with clang this warning blows the log over Hydra's limit
     ++ optional stdenv.isDarwin "-Wno-inconsistent-missing-override"
     ++ optionals flashplayerFix


### PR DESCRIPTION
###### Motivation for this change

~~With a previous fix for log size issues due to GCC 8
a gcc specific `-W` flag was added that clang does
not gracefully ignore~~.

See comment https://github.com/NixOS/nixpkgs/pull/70544#issuecomment-538814414
This does not break the build, it just logs unneeded warnings and the breakage is somewhere else.

This was done in https://github.com/NixOS/nixpkgs/pull/68434 and https://github.com/NixOS/nixpkgs/pull/68869

We forgot to test this with clang and/or on darwin.

cc @worldofpeace

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ 
