### PR TITLE
ghc modules: use specific commit to fetch patches

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -115,11 +115,11 @@ self: super: {
     broken = false;
   });
   haskell-src-meta = appendPatch (dontCheck (doJailbreak super.haskell-src-meta)) (pkgs.fetchpatch {
-    url = "https://gitlab.haskell.org/ghc/head.hackage/raw/master/patches/haskell-src-meta-0.8.3.patch";
+    url = "https://gitlab.haskell.org/ghc/head.hackage/raw/82d0fd9967af0699f0ccb5b38f2f0cbef6ed22de/patches/haskell-src-meta-0.8.3.patch";
     sha256 = "1asl932mibr5y057xx8v1a7n3qy87lcnclsfh8pbxq1m3iwjkxy8";
   });
   asn1-encoding = appendPatch (dontCheck (doJailbreak super.asn1-encoding)) (pkgs.fetchpatch {
-    url = "https://gitlab.haskell.org/ghc/head.hackage/raw/master/patches/asn1-encoding-0.9.5.patch";
+    url = "https://gitlab.haskell.org/ghc/head.hackage/raw/82d0fd9967af0699f0ccb5b38f2f0cbef6ed22de/patches/asn1-encoding-0.9.5.patch";
     sha256 = "0a3159rnaw6shjzdm46799crd4pxh33s23qy51xa7z6nv5q8wsb5";
   });
   vault = dontHaddock super.vault;
@@ -139,7 +139,7 @@ self: super: {
 
   # https://github.com/sol/hpack/issues/371
   hpack = appendPatch super.hpack (pkgs.fetchpatch {
-    url = "https://gitlab.haskell.org/ghc/head.hackage/raw/master/patches/hpack-0.32.0.patch";
+    url = "https://gitlab.haskell.org/ghc/head.hackage/raw/82d0fd9967af0699f0ccb5b38f2f0cbef6ed22de/patches/hpack-0.32.0.patch";
     sha256 = "11ccl9f7vwbf5cpzknlyvrwgkzpajk4vq9jk9yb5f9la9ggwb244";
   });
 


### PR DESCRIPTION
rather than master to retrieve patches, some of which have gone stale

###### Motivation for this change

URLs for a few module patches used for building ghc 8.8 have gone stale since they refer to the master branch, which has since moved on and removed 8.8 stuff.  This pins them at the last commit where they existed.

Note that there are other patches in this same file pulling from hvr/head.hackage master as well, which need fixing. However, those even refer to an old repo (github.com/hvr/head.hackage, which has moved to gitlab.haskell.org), and are still working for the moment, so I've left them alone. I can take a stab at updating them if that'd be helpful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti 
