### PR TITLE
zziplib: apply patches for CVE-2018-16548

### DIFF
--- a/pkgs/development/libraries/zziplib/default.nix
+++ b/pkgs/development/libraries/zziplib/default.nix
@@ -15,6 +15,22 @@ stdenv.mkDerivation rec {
       url = "https://github.com/gdraheim/zziplib/commit/f609ae8971f3c0ce6.diff";
       sha256 = "0jhiz4fgr93wzh6q03avn95b2nsf6402jaki6hxirxyhs5v9ahry";
     })
+
+    (fetchpatch {
+      name = "CVE-2018-16548-part1.patch";
+      url = "https://github.com/gdraheim/zziplib/commit/9411bde3e4a70a81ff3ffd256b71927b2d90dcbb.patch";
+      sha256 = "0cy8i182zbvcqzs5z2j13d5sl7hbh59pkgw4xkyg5yz739q4fp9b";
+    })
+    (fetchpatch {
+      name = "CVE-2018-16548-part2.patch";
+      url = "https://github.com/gdraheim/zziplib/commit/d2e5d5c53212e54a97ad64b793a4389193fec687.patch";
+      sha256 = "153wd4vab8xqj9avcpx8g2zw9qsp9nkaqi7yc65pz3r7xfcxwdla";
+    })
+    (fetchpatch {
+      name = "CVE-2018-16548-part3.patch";
+      url = "https://github.com/gdraheim/zziplib/commit/0e1dadb05c1473b9df2d7b8f298dab801778ef99.patch";
+      sha256 = "0fs6dns8l7dz5a900397g8b7x62z72b0pbpdmwk1hnx6vb7z5rz5";
+    })
   ];
   postPatch = ''
     sed -i -e s,--export-dynamic,, configure


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#70135 (security bug)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).