### PR TITLE
prettyping: works on unix platforms

### DIFF
--- a/pkgs/tools/networking/prettyping/default.nix
+++ b/pkgs/tools/networking/prettyping/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/denilsonsa/prettyping;
     description = "A wrapper around the standard ping tool with the objective of making the output prettier, more colorful, more compact, and easier to read";
     license = with licenses; [ mit ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ qoelet ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
prettyping is not linux-specific.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @qoelet 
