### PR TITLE
qtcreator 4.9.1 -> 4.10.0

### DIFF
--- a/pkgs/development/tools/qtcreator/0001-Fix-clang-libcpp-regexp.patch
+++ b/pkgs/development/tools/qtcreator/0001-Fix-clang-libcpp-regexp.patch
@@ -1,8 +1,8 @@
 diff --git a/src/plugins/cpptools/headerpathfilter.cpp b/src/plugins/cpptools/headerpathfilter.cpp
-index b514c46..5f96358 100644
+index e2d1e6a..1a1d839 100644
 --- a/src/plugins/cpptools/headerpathfilter.cpp
 +++ b/src/plugins/cpptools/headerpathfilter.cpp
-@@ -92,8 +92,8 @@ HeaderPaths::iterator resourceIterator(HeaderPaths &headerPaths, bool isMacOs)
+@@ -96,8 +96,8 @@ HeaderPaths::iterator resourceIterator(HeaderPaths &headerPaths, bool isMacOs)
  {
      // include/c++, include/g++, libc++\include and libc++abi\include
      static const QString cppIncludes = R"((.*\/include\/.*(g\+\+|c\+\+).*))"

--- a/pkgs/development/tools/qtcreator/0002-Dont-remove-clang-header-paths.patch
+++ b/pkgs/development/tools/qtcreator/0002-Dont-remove-clang-header-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/src/plugins/cpptools/headerpathfilter.cpp b/src/plugins/cpptools/headerpathfilter.cpp
+index e2d1e6a..1a1d839 100644
+--- a/src/plugins/cpptools/headerpathfilter.cpp
++++ b/src/plugins/cpptools/headerpathfilter.cpp
+@@ -134,8 +134,6 @@ void removeClangSystemHeaderPaths(HeaderPaths &headerPaths)
+ 
+ void HeaderPathFilter::tweakHeaderPaths()
+ {
+-    removeClangSystemHeaderPaths(builtInHeaderPaths);
+-
+     auto split = resourceIterator(builtInHeaderPaths,
+                                   projectPart.toolChainTargetTriple.contains("darwin"));
+ 

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -1,14 +1,11 @@
 { mkDerivation, lib, fetchurl, fetchgit, fetchpatch
 , qtbase, qtquickcontrols, qtscript, qtdeclarative, qmake, llvmPackages_8
-, withDocumentation ? false
+, withDocumentation ? false, withClangPlugins ? true 
 }:
 
 with lib;
 
 let
-  baseVersion = "4.9";
-  revision = "1";
-
   # Fetch clang from qt vendor, this contains submodules like this:
   # clang<-clang-tools-extra<-clazy.
   clang_qt_vendor = llvmPackages_8.clang-unwrapped.overrideAttrs (oldAttrs: {
@@ -23,35 +20,28 @@ in
 
 mkDerivation rec {
   pname = "qtcreator";
-  version = "${baseVersion}.${revision}";
+  version = "4.10.0";
+  baseVersion = builtins.concatStringsSep "." (lib.take 2 (builtins.splitVersion version));
 
   src = fetchurl {
     url = "http://download.qt-project.org/official_releases/${pname}/${baseVersion}/${version}/qt-creator-opensource-src-${version}.tar.xz";
-    sha256 = "10ddp1365rf0z4bs7yzc9hajisp3j6mzjshyd0vpi4ki126j5f3r";
+    sha256 = "12hgxdghz05ms4zl8prz2w8l66vmgw1qw2gsmmwqi2rdaay3lpcg";
   };
 
-  buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative llvmPackages_8.libclang clang_qt_vendor llvmPackages_8.llvm ];
+  buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative ] ++ 
+    optionals withClangPlugins [ llvmPackages_8.libclang 
+                                 clang_qt_vendor 
+                                 llvmPackages_8.llvm ];
 
   nativeBuildInputs = [ qmake ];
 
   # 0001-Fix-clang-libcpp-regexp.patch is for fixing regexp that is used to
   # find clang libc++ library include paths. By default it's not covering paths
   # like libc++-version, which is default name for libc++ folder in nixos.
+  # ./0002-Dont-remove-clang-header-paths.patch is for forcing qtcreator to not 
+  # remove system clang include paths.
   patches = [ ./0001-Fix-clang-libcpp-regexp.patch
-
-    # Fix clazy plugin name. This plugin was renamed with clang8
-    # release, and patch didn't make it into 4.9.1 release. Should be removed
-    # on qtcreator update, if this problem is fixed.
-    (fetchpatch {
-      url = "https://code.qt.io/cgit/qt-creator/qt-creator.git/patch/src/plugins/clangcodemodel/clangeditordocumentprocessor.cpp?id=53c407bc0c87e0b65b537bf26836ddd8e00ead82";
-      sha256 = "1lanp7jg0x8jffajb852q8p4r34facg41l410xsz6s1k91jskbi9";
-    })
-
-    (fetchpatch {
-      url = "https://code.qt.io/cgit/qt-creator/qt-creator.git/patch/src/plugins/clangtools/clangtidyclazyrunner.cpp?id=53c407bc0c87e0b65b537bf26836ddd8e00ead82";
-      sha256 = "1rl0rc2l297lpfhhawvkkmj77zb081hhp0bbi7nnykf3q9ch0clh";
-    })
-  ];
+              ./0002-Dont-remove-clang-header-paths.patch ];
 
   doCheck = true;
 
@@ -63,8 +53,8 @@ mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace src/plugins/plugins.pro \
-      --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls'
-
+      --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls' 
+    '' + optionalString withClangPlugins ''
     # Fix paths for llvm/clang includes directories.
     substituteInPlace src/shared/clang/clang_defines.pri \
       --replace '$$clean_path($${LLVM_LIBDIR}/clang/$${LLVM_VERSION}/include)' '${clang_qt_vendor}/lib/clang/8.0.0/include' \
@@ -77,7 +67,9 @@ mkDerivation rec {
     # Fix paths to libclang library.
     substituteInPlace src/shared/clang/clang_installation.pri \
       --replace 'LIBCLANG_LIBS = -L$${LLVM_LIBDIR}' 'LIBCLANG_LIBS = -L${llvmPackages_8.libclang}/lib' \
-      --replace 'LIBCLANG_LIBS += $${CLANG_LIB}' 'LIBCLANG_LIBS += -lclang'
+      --replace 'LIBCLANG_LIBS += $${CLANG_LIB}' 'LIBCLANG_LIBS += -lclang' \
+      --replace 'LIBTOOLING_LIBS = -L$${LLVM_LIBDIR}' 'LIBTOOLING_LIBS = -L${clang_qt_vendor}/lib' \
+      --replace 'LLVM_CXXFLAGS ~= s,-gsplit-dwarf,' '${lib.concatStringsSep "\n" ["LLVM_CXXFLAGS ~= s,-gsplit-dwarf," "    LLVM_CXXFLAGS += -fno-rtti"]}'
   '';
 
   preBuild = optional withDocumentation ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
There was discussion with @SRGOM  about upgrade on
https://github.com/NixOS/nixpkgs/pull/61348

###### Things done
- [X] Removed patches that was accepted into upstream.
- [X] Fixed linkage error: all modules that is linking with clang tooling libraries should have `-fno-rtti` flag as clang tooling libraries is built with static linkage.
- [X] Updated patch to find clang libc++ includes.
- [X] Added `withClangPlugins` option to make it possible to compile qtc without vendor clang dependency.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

- [X] Additionally tested that clang code model works on test project as i described in https://github.com/NixOS/nixpkgs/pull/61348

###### Notify maintainers

cc @akaWolf 
