### PR TITLE
tengine: 2.3.1 -> 2.3.2

### DIFF
--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -105,6 +105,5 @@ stdenv.mkDerivation rec {
     license     = licenses.bsd2;
     platforms   = platforms.all;
     maintainers = with maintainers; [ izorkin ];
-    broken = true;
   };
 }

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, openssl, zlib, pcre, libxml2, libxslt
+{ stdenv, fetchFromGitHub, openssl, zlib, pcre, libxml2, libxslt
 , gd, geoip, gperftools, jemalloc
 , withDebug ? false
 , withMail ? false
@@ -10,12 +10,14 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "2.3.1";
+  version = "2.3.2";
   pname = "tengine";
 
-  src = fetchurl {
-    url = "https://github.com/alibaba/tengine/archive/${version}.tar.gz";
-    sha256 = "075blm2d62a0bdixc3vngrxpgr7ngl1s4y8hm20pbvc07f0kzn9x";
+  src = fetchFromGitHub {
+    owner = "alibaba";
+    repo = pname;
+    rev = version;
+    sha256 = "04xfnbc0qlk8vi6bb8sl38nxnx9naxh550xsgrb4hql6jdi0wv7l";
   };
 
   buildInputs =
@@ -84,6 +86,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [
     "-I${libxml2.dev}/include/libxml2"
+    "-Wno-error=implicit-fallthrough"
   ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations";
 
   preConfigure = (concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/alibaba/tengine/releases/tag/2.3.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
