### PR TITLE
Scylladb: fix build under sandboxing

### DIFF
--- a/pkgs/servers/scylladb/configure-etc-osrelease.patch
+++ b/pkgs/servers/scylladb/configure-etc-osrelease.patch
@@ -1,0 +1,28 @@
+diff --git a/configure.py b/configure.py
+index 25ca951ac..454140420 100755
+--- a/configure.py
++++ b/configure.py
+@@ -36,13 +36,16 @@ tempfile.tempdir = "./build/tmp"
+
+ configure_args = str.join(' ', [shlex.quote(x) for x in sys.argv[1:]])
+
+-for line in open('/etc/os-release'):
+-    key, _, value = line.partition('=')
+-    value = value.strip().strip('"')
+-    if key == 'ID':
+-        os_ids = [value]
+-    if key == 'ID_LIKE':
+-        os_ids += value.split(' ')
++try:
++    for line in open('/etc/os-release'):
++        key, _, value = line.partition('=')
++        value = value.strip().strip('"')
++        if key == 'ID':
++            os_ids = [value]
++        if key == 'ID_LIKE':
++            os_ids += value.split(' ')
++except FileNotFoundError:
++    os_ids = ["linux"]
+
+
+ # distribution "internationalization", converting package names.

--- a/pkgs/servers/scylladb/default.nix
+++ b/pkgs/servers/scylladb/default.nix
@@ -83,10 +83,12 @@ gcc8Stdenv.mkDerivation {
   configurePhase = ''
     ./configure.py --mode=release
   '';
+
   installPhase = ''
     mkdir $out
     cp -r * $out/
   '';
+
   meta = with stdenv.lib; {
     description = "NoSQL data store using the seastar framework, compatible with Apache Cassandra";
     homepage = "https://scylladb.com";

--- a/pkgs/servers/scylladb/default.nix
+++ b/pkgs/servers/scylladb/default.nix
@@ -77,6 +77,7 @@ gcc8Stdenv.mkDerivation {
 
   postPatch = ''
     patchShebangs ./configure.py
+    patchShebangs seastar/json/json2code.py
   '';
 
   configurePhase = ''

--- a/pkgs/servers/scylladb/default.nix
+++ b/pkgs/servers/scylladb/default.nix
@@ -41,7 +41,7 @@ gcc8Stdenv.mkDerivation {
     fetchSubmodules = true;
   };
 
-  patches = [ ./seastar-configure-script-paths.patch ];
+  patches = [ ./seastar-configure-script-paths.patch ./configure-etc-osrelease.patch ];
 
   nativeBuildInputs = [
    pkgconfig


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Build was broken under sandboxing.
This fixes two build nondeterminisms

CC: @clojurians-org @erictapen 

Resolves #70049 

Also ticks one of the boxes in #68361 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).