### PR TITLE
arrow-cpp: 0.14.1 -> 0.15.0

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, fetchFromGitHub, fixDarwinDylibNames, autoconf, boost, brotli, cmake, double-conversion, flatbuffers, gflags, glog, gtest, lz4, perl, python, rapidjson, snappy, thrift, uriparser, which, zlib, zstd }:
+{ stdenv, fetchurl, fetchFromGitHub, fixDarwinDylibNames, autoconf, boost
+, brotli, cmake, double-conversion, flatbuffers, gflags, glog, gtest, lz4, perl
+, python, rapidjson, snappy, thrift, uriparser, which, zlib, zstd }:
 
 let
   parquet-testing = fetchFromGitHub {
@@ -7,14 +9,14 @@ let
     rev = "a277dc4e55ded3e3ea27dab1e4faf98c112442df";
     sha256 = "1yh5a8l4ship36hwmgmp2kl72s5ac9r8ly1qcs650xv2g9q7yhnq";
   };
-in
 
-stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   pname = "arrow-cpp";
   version = "0.15.0";
 
   src = fetchurl {
-    url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
+    url =
+      "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
     sha256 = "0n7xrn5490r2snjl45pm2a4pr2x8a29sh8mpyi4nj5pr9f62s1yi";
   };
 
@@ -24,20 +26,38 @@ stdenv.mkDerivation rec {
     # From
     # ./cpp/cmake_modules/ThirdpartyToolchain.cmake
     # ./cpp/thirdparty/versions.txt
-    url = "https://github.com/jemalloc/jemalloc/releases/download/5.2.0/jemalloc-5.2.0.tar.bz2";
+    url =
+      "https://github.com/jemalloc/jemalloc/releases/download/5.2.0/jemalloc-5.2.0.tar.bz2";
     sha256 = "1d73a5c5qdrwck0fa5pxz0myizaf3s9alsvhiqwrjahdlr29zgkl";
   };
 
   patches = [
     # patch to fix python-test
     ./darwin.patch
-    ];
+  ];
 
-  nativeBuildInputs = [ cmake autoconf /* for vendored jemalloc */ flatbuffers ]
-    ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs = [
+    cmake
+    autoconf # for vendored jemalloc
+    flatbuffers
+  ] ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
   buildInputs = [
-    boost brotli double-conversion flatbuffers gflags glog gtest lz4 rapidjson
-    snappy thrift uriparser zlib zstd python.pkgs.python python.pkgs.numpy
+    boost
+    brotli
+    double-conversion
+    flatbuffers
+    gflags
+    glog
+    gtest
+    lz4
+    rapidjson
+    snappy
+    thrift
+    uriparser
+    zlib
+    zstd
+    python.pkgs.python
+    python.pkgs.numpy
   ];
 
   preConfigure = ''
@@ -56,7 +76,8 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF";
 
   doInstallCheck = true;
-  PARQUET_TEST_DATA = if doInstallCheck then "${parquet-testing}/data" else null;
+  PARQUET_TEST_DATA =
+    if doInstallCheck then "${parquet-testing}/data" else null;
   installCheckInputs = [ perl which ];
   installCheckPhase = (stdenv.lib.optionalString stdenv.isDarwin ''
     for f in release/*test; do
@@ -68,7 +89,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A  cross-language development platform for in-memory data";
-    homepage = https://arrow.apache.org/;
+    homepage = "https://arrow.apache.org/";
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ tobim veprbl ];

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -11,11 +11,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "arrow-cpp";
-  version = "0.14.1";
+  version = "0.15.0";
 
   src = fetchurl {
     url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "0a0xrsbr7dd1yp34yw82jw7psfkfvm935jhd5mam32vrsjvdsj4r";
+    sha256 = "0n7xrn5490r2snjl45pm2a4pr2x8a29sh8mpyi4nj5pr9f62s1yi";
   };
 
   sourceRoot = "apache-arrow-${version}/cpp";
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     ./darwin.patch
     ];
 
-  nativeBuildInputs = [ cmake autoconf /* for vendored jemalloc */ ]
+  nativeBuildInputs = [ cmake autoconf /* for vendored jemalloc */ flatbuffers ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
   buildInputs = [
     boost brotli double-conversion flatbuffers gflags glog gtest lz4 rapidjson
@@ -44,17 +44,13 @@ stdenv.mkDerivation rec {
     substituteInPlace cmake_modules/FindLz4.cmake --replace CMAKE_STATIC_LIBRARY CMAKE_SHARED_LIBRARY
 
     patchShebangs build-support/
-
-    # Fix build for ARROW_USE_SIMD=OFF
-    # https://jira.apache.org/jira/browse/ARROW-5007
-    sed -i src/arrow/util/sse-util.h -e '1i#include "arrow/util/logging.h"'
-    sed -i src/arrow/util/neon-util.h -e '1i#include "arrow/util/logging.h"'
   '';
 
   cmakeFlags = [
     "-DARROW_BUILD_TESTS=ON"
     "-DARROW_DEPENDENCY_SOURCE=SYSTEM"
     "-DARROW_PARQUET=ON"
+    "-DARROW_PLASMA=ON"
     "-DARROW_PYTHON=ON"
     "-Duriparser_SOURCE=SYSTEM"
   ] ++ stdenv.lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF";
@@ -75,6 +71,6 @@ stdenv.mkDerivation rec {
     homepage = https://arrow.apache.org/;
     license = stdenv.lib.licenses.asl20;
     platforms = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ veprbl ];
+    maintainers = with stdenv.lib.maintainers; [ tobim veprbl ];
   };
 }

--- a/pkgs/development/python-modules/awkward/default.nix
+++ b/pkgs/development/python-modules/awkward/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "awkward";
-  version = "0.12.12";
+  version = "0.12.13";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "316abd04dd049d56567082670ae8800c265dc3f06b699cf2a953ea6aea7696ce";
+    sha256 = "0jciasfmayk3xs8lprrdjd6brvy614yd2ngpgyzlszis5sa6nr18";
   };
 
   nativeBuildInputs = [ pytestrunner ];


### PR DESCRIPTION
Release page: https://arrow.apache.org/release/0.15.0.html
Blog post: https://arrow.apache.org/blog/2019/10/06/0.15.0-release/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @veprbl 
