### PR TITLE
bat: update dependencies

### DIFF
--- a/pkgs/tools/misc/bat/default.nix
+++ b/pkgs/tools/misc/bat/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, rustPlatform, fetchFromGitHub, llvmPackages, pkgconfig, zlib
-, Security, libiconv
+{ stdenv, rustPlatform, fetchFromGitHub, llvmPackages, pkgconfig
+, Security, libiconv, installShellFiles
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -16,15 +16,15 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0d7h0kn41w6wm4w63vjy2i7r19jkansfvfjn7vgh2gqh5m60kal2";
 
-  nativeBuildInputs = [ pkgconfig llvmPackages.libclang zlib ];
+  nativeBuildInputs = [ pkgconfig llvmPackages.libclang installShellFiles ];
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security libiconv ];
 
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
   postInstall = ''
-    install -m 444 -Dt $out/share/man/man1 doc/bat.1
-    install -m 444 -Dt $out/share/fish/vendor_completions.d assets/completions/bat.fish
+    installManPage doc/bat.1
+    installShellCompletion assets/completions/bat.fish
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Remove `zlib`, this is no longer a dependency as of at least 0.12.0.

While we're at it, switch to using `installShellFiles` to install the manpage/completion.

###### Motivation for this change
https://github.com/sharkdp/bat/pull/678 removed the instructions saying bat required `cmake` and `zlib`. We already dropped the `cmake` requirement earlier but were still declaring the `zlib` dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
