### PR TITLE
sqlite: 3.28.0 -> 3.30.0, sqlite-analyzer: 3.28.0 -> 3.30.0, resolves #70127 and #68583

### DIFF
--- a/pkgs/development/libraries/sqlite/analyzer.nix
+++ b/pkgs/development/libraries/sqlite/analyzer.nix
@@ -6,11 +6,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sqlite-analyzer";
-  version = "3.28.0";
+  version = "3.30.0";
 
   src = assert version == sqlite.version; fetchurl {
     url = "https://sqlite.org/2019/sqlite-src-${archiveVersion version}.zip";
-    sha256 = "15v57b113bpgcshfsx5jw93szar3da94rr03i053xhl15la7jllh";
+    sha256 = "0d4i87q0f618pmrgax0mr5x7m8bywikrwjvixag3biyhgl5rx7fd";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -10,12 +10,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sqlite";
-  version = "3.28.0";
+  version = "3.30.0";
 
   # NB! Make sure to update analyzer.nix src (in the same directory).
   src = fetchurl {
     url = "https://sqlite.org/2019/sqlite-autoconf-${archiveVersion version}.tar.gz";
-    sha256 = "1hxpi45crbqp6lacl7z611lna02k956m9bsy2bjzrbb2y23546yn";
+    sha256 = "0n7w839y55dc3qqf2zv8xk6238cc6mpx24q4w5amwic7g96cza70";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
replaces #65402

###### Motivation for this change
* sqlite 3.28.0 has a security vulnerability regarding a a division by zero  which is fixed in 3.30.0. See #70127, #68583 and https://nvd.nist.gov/vuln/detail/CVE-2019-16168 for details
* Changelog: https://www.sqlite.org/changes.html

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @eelco @np