### PR TITLE
asciidoctorj init at 2.1.0

### DIFF
--- a/pkgs/tools/typesetting/asciidoctorj/default.nix
+++ b/pkgs/tools/typesetting/asciidoctorj/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchzip, jdk, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "asciidoctorj";
+  version = "2.1.0";
+
+  src = fetchzip {
+    url = "http://dl.bintray.com/asciidoctor/maven/org/asciidoctor/${pname}/${version}/${pname}-${version}-bin.zip";
+    sha256 = "19fl4y3xlkmmgf5vyyb3k9p6nyglck9l53r6x12zil01q49g0zba";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    rm bin/asciidoctorj.bat
+    cp -r . $out
+    wrapProgram $out/bin/asciidoctorj \
+      --prefix JAVA_HOME : ${jdk}
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      AsciidoctorJ is the official library for running Asciidoctor on the JVM.
+    '';
+    longDescription = ''
+      AsciidoctorJ is the official library for running Asciidoctor on the JVM. 
+      Using AsciidoctorJ, you can convert AsciiDoc content or analyze the 
+      structure of a parsed AsciiDoc document from Java and other JVM 
+      languages.
+    '';
+    homepage = https://asciidoctor.org/docs/asciidoctorj/;
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ moaxcp ];
+  };
+} 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2060,6 +2060,8 @@ in
     epubcheck = null;
   };
 
+  asciidoctorj = callPackage ../tools/typesetting/asciidoctorj { };
+
   asunder = callPackage ../applications/audio/asunder { };
 
   autossh = callPackage ../tools/networking/autossh { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add asciidoctorj package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
