### PR TITLE
criterion: init at version 2.3.3

### DIFF
--- a/pkgs/development/libraries/boxfort/default.nix
+++ b/pkgs/development/libraries/boxfort/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, coreutils, fetchFromGitHub, cmake, meson, ninja, pkg-config, python3, git }:
+
+stdenv.mkDerivation rec {
+  pname = "boxfort-unstable";
+  version = "2019-09-19";
+
+  src = fetchFromGitHub
+    { owner = "Snaipe";
+      repo  = "BoxFort";
+      rev   = "38fe63046fbabcae34ebc2ee9867d990ac28c4c5";
+      sha256 = "03zy982d1frpk9fr4hbp1ql1ah06s0v6dy7a56d1zl3jjjljhrhn";
+    };
+
+  buildInputs =
+    [ coreutils
+      python3
+    ];
+
+  nativeBuildInputs =
+    [ meson
+      ninja
+      cmake
+      pkg-config
+      git
+    ];
+
+  prePatch = ''
+    patchShebangs ci/isdir.py
+  '';
+
+  meta = with stdenv.lib;
+    { description = "Convenient & cross-platform sandboxing C library";
+      homepage    = "https://github.com/Snaipe/BoxFort";
+      license     = licenses.mit;
+      platforms   = platforms.all;
+      maintainers = with maintainers; [ thesola10 ];
+    };
+}

--- a/pkgs/development/libraries/criterion/default.nix
+++ b/pkgs/development/libraries/criterion/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, cmake, pkg-config, boxfort, libcsptr, dyncall, nanomsg }:
+
+stdenv.mkDerivation rec {
+  pname = "criterion";
+  version = "2.3.3";
+
+  src = fetchFromGitHub
+    { owner = "Snaipe";
+      repo = "Criterion";
+      rev = "v${version}";
+      fetchSubmodules = true;
+      sha256 = "0y1ay8is54k3y82vagdy0jsa3nfkczpvnqfcjm5n9iarayaxaq8p";
+    };
+
+  buildInputs =
+    [ boxfort
+      libcsptr
+      dyncall
+      nanomsg
+    ];
+
+  nativeBuildInputs =
+    [ cmake
+      pkg-config
+    ];
+
+  # CMake needs a little help to find BoxFort and pkg-config
+  preConfigure = ''
+    mkdir -p .third-party
+    ln -s ${boxfort} .third-party/boxfort
+    ln -s ${pkg-config} .third-party/pkg-config
+  '';
+
+  meta = with stdenv.lib;
+    { description = "A cross-platform C and C++ unit testing framework for the 21st century.";
+      homepage    = "https://criterion.readthedocs.io";
+      license     = licenses.mit;
+      platforms   = platforms.all;
+      maintainers = with maintainers; [ thesola10 ];
+    };
+  }

--- a/pkgs/shells/oil/default.nix
+++ b/pkgs/shells/oil/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchpatch }:
+{ stdenv, lib, fetchurl, fetchpatch, readline }:
 
 stdenv.mkDerivation rec {
   pname = "oil";
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
   preInstall = ''
     mkdir -p $out/bin
   '';
+
+  buildInputs = [ readline ];
+  configureFlags = [ "--with-readline" ];
 
   # Stripping breaks the bundles by removing the zip file from the end.
   dontStrip = true;

--- a/pkgs/shells/oil/default.nix
+++ b/pkgs/shells/oil/default.nix
@@ -43,4 +43,8 @@ stdenv.mkDerivation rec {
 
     maintainers = with lib.maintainers; [ lheckemann ];
   };
+
+  passthru = {
+      shellPath = "/bin/osh";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -799,6 +799,8 @@ in
 
   boxfort = callPackage ../development/libraries/boxfort { };
 
+  criterion = callPackage ../development/libraries/criterion { };
+
   crc32c = callPackage ../development/libraries/crc32c { };
 
   cue = callPackage ../development/tools/cue { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -797,6 +797,8 @@ in
 
   crumbs = callPackage ../applications/misc/crumbs { };
 
+  boxfort = callPackage ../development/libraries/boxfort { };
+
   crc32c = callPackage ../development/libraries/crc32c { };
 
   cue = callPackage ../development/tools/cue { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

There is currently no true distro-agnostic way to install the `criterion` library on Linux, and I thought Nix was a good choice.

Note: `boxfort` does not have official tagging/versioning, so I set the version attribute to be the commit hash (like GitHub does).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) _(does not apply, but generated libraries work properly.)_
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aanderse 