### PR TITLE
notion: 3-2019050101 -> 4.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5963,6 +5963,11 @@
       fingerprint = "7573 56D7 79BB B888 773E  415E 736C CDF9 EF51 BD97";
     }];
   };
+  raboof = {
+    email = "arnout@bzzt.net";
+    github = "raboof";
+    name = "Arnout Engelen";
+  };
   rafaelgg = {
     email = "rafael.garcia.gallego@gmail.com";
     github = "rafaelgg";

--- a/pkgs/applications/window-managers/notion/default.nix
+++ b/pkgs/applications/window-managers/notion/default.nix
@@ -7,22 +7,22 @@
 
 stdenv.mkDerivation rec{
   pname = "notion";
-  version = "3-2019050101";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "raboof";
     repo = pname;
     rev = version;
-    sha256 = "09kvgqyw0gnj3jhz9gmwq81ak8qy32vyanx1hw79r6m181aysspz";
+    sha256 = "0rqfvwkj0j862hf6i4wsmb6185xibsskfj9kwy896qcpcg8w4kk7";
   };
 
   nativeBuildInputs = [ pkgconfig makeWrapper groff ];
   buildInputs = [ lua gettext which readline fontconfig libX11 libXext libSM
                   libXinerama libXrandr libXft xlibsWrapper ];
 
-  buildFlags = [ "CC=cc" "LUA_DIR=${lua}" "X11_PREFIX=/no-such-path" ];
+  buildFlags = [ "LUA_DIR=${lua}" "X11_PREFIX=/no-such-path" ];
 
-  makeFlags = [ "PREFIX=\${out}" ];
+  makeFlags = [ "NOTION_RELEASE=${version}" "PREFIX=\${out}" ];
 
   postInstall = ''
     wrapProgram $out/bin/notion \
@@ -30,10 +30,10 @@ stdenv.mkDerivation rec{
   '';
 
   meta = with stdenv.lib; {
-    description = "Tiling tabbed window manager, follow-on to the Ion";
-    homepage = "https://notionwm.net/";
+    description = "Tiling tabbed window manager";
+    homepage = "https://notionwm.net";
     license   = licenses.lgpl21;
-    maintainers = with maintainers; [ jfb AndersonTorres ];
+    maintainers = with maintainers; [ jfb AndersonTorres raboof ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Notion 4 isn't released yet, but this prepares for that ;)

###### Motivation for this change

Update to the latest major version of Notion, which is proper LGPL again, has XFT support built-in without needing an external patch, a new set of keybindings, a greatly improved 'notionflux' REPL interface and many more improvements.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s) 
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tftio
