### PR TITLE
act: init at 0.1.3

### DIFF
--- a/pkgs/tools/admin/act/default.nix
+++ b/pkgs/tools/admin/act/default.nix
@@ -1,0 +1,26 @@
+{lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "act";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "nektos";
+    repo = "act";
+    rev = "v0.1.3";
+    sha256 = "1y1bvk93dzsxwjakmgpb5qyy3lqng7cdabi64b555c1z6b42mf58";
+  };
+
+  modSha256 = "0g7j9ysvsh7k8sg5nkxmkqnsa0xl824hynfg6cbmdydmb4lvv9rq";
+
+  subPackages = [ "." ];
+
+  buildFlags = [ "-tags netgo" "-tags release" ];
+
+  meta = with lib; {
+    description = "Run your GitHub Actions locally!";
+    homepage = "https://github.com/nektos/act";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/admin/act/default.nix
+++ b/pkgs/tools/admin/act/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "1y1bvk93dzsxwjakmgpb5qyy3lqng7cdabi64b555c1z6b42mf58";
   };
 
-  modSha256 = "0g7j9ysvsh7k8sg5nkxmkqnsa0xl824hynfg6cbmdydmb4lvv9rq";
+  modSha256 = "1c8bx9jb14f70aihnjbzk1js110s9r4nkdfps27kphn65bw2pxn0";
 
   subPackages = [ "." ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -480,6 +480,8 @@ in
 
   abduco = callPackage ../tools/misc/abduco { };
 
+  act = callPackage ../tools/admin/act { };
+
   acct = callPackage ../tools/system/acct { };
 
   accuraterip-checksum = callPackage ../tools/audio/accuraterip-checksum { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add act tool https://github.com/nektos/act .
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

P.S. This is my first package build and first pr to nixpkgs, sorry if something wrong.