### PR TITLE
git-annex-utils: init at 0.04-3-g531bb33

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -74,6 +74,8 @@ let
 
   git-annex-remote-rclone = callPackage ./git-annex-remote-rclone { };
 
+  git-annex-utils = callPackage ./git-annex-utils { };
+
   git-bug = callPackage ./git-bug { };
 
   # support for bugzilla

--- a/pkgs/applications/version-management/git-and-tools/git-annex-utils/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-annex-utils/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchgit, autoconf, automake, libtool, gmp }:
+
+stdenv.mkDerivation rec {
+  pname = "git-annex-utils";
+  version = "0.04-3-g531bb33";
+  src = fetchgit {
+    url = http://git.mysteryvortex.com/repositories/git-annex-utils.git;
+    rev = "531bb33";
+    sha256 = "1sv7s2ykc840cjwbfn7ayy743643x9i1lvk4cd55w9l052xvzj65";
+  };
+  buildInputs = [ autoconf automake libtool gmp ];
+  preConfigure = "./autogen.sh";
+
+  meta = {
+    description = "gadu, a du like utility for annexed files";
+    longDescription = ''
+      This is a set of utilities that are handy to use with git-annex repositories.
+      Currently there is only one utility gadu, a du like utility for annexed files.
+    '';
+    homepage = http://git-annex.mysteryvortex.com/git-annex-utils.html;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ woffs ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
provide gadu, a git-annex-aware du-lke utility

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
