### PR TITLE
Squeezelite updates and refactor

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6251,6 +6251,12 @@
     githubId = 766350;
     name = "Richard Zetterberg";
   };
+  samdoshi = {
+    email = "sam@metal-fish.co.uk";
+    github = "samdoshi";
+    githubId = 112490;
+    name = "Sam Doshi";
+  };
   samdroid-apps = {
     email = "sam@sam.today";
     github = "samdroid-apps";

--- a/pkgs/applications/audio/squeezelite/default.nix
+++ b/pkgs/applications/audio/squeezelite/default.nix
@@ -1,22 +1,55 @@
-{ stdenv, fetchFromGitHub, alsaLib, faad2, flac, libmad, libvorbis, makeWrapper, mpg123 }:
+{ stdenv, fetchFromGitHub
+, alsaLib, flac, libmad, libvorbis, mpg123
+, dsdSupport ? true
+, faad2Support ? true, faad2
+, ffmpegSupport ? true, ffmpeg
+, opusSupport ? true, opusfile
+, resampleSupport ? true, soxr
+, sslSupport ? true, openssl
+}:
 
 let
-  runtimeDeps  = [ faad2 flac libmad libvorbis mpg123 ];
-  rpath = stdenv.lib.makeLibraryPath runtimeDeps;
+  concatStringsSep = stdenv.lib.concatStringsSep;
+  optional = stdenv.lib.optional;
+  opts = [ "-DLINKALL" ]
+    ++ optional dsdSupport "-DDSD"
+    ++ optional (!faad2Support) "-DNO_FAAD"
+    ++ optional ffmpegSupport "-DFFMPEG"
+    ++ optional opusSupport "-DOPUS"
+    ++ optional resampleSupport "-DRESAMPLE"
+    ++ optional sslSupport "-DUSE_SSL";
+
 in stdenv.mkDerivation {
-  name = "squeezelite-git-2018-08-14";
+  pname = "squeezelite";
+
+  # versions are specified in `squeezelite.h`
+  # see https://github.com/ralph-irving/squeezelite/issues/29
+  version = "1.9.6.1196";
 
   src = fetchFromGitHub {
     owner  = "ralph-irving";
     repo   = "squeezelite";
-    rev    = "ecb6e3696a42113994640e5345d0b5ca2e77d28b";
-    sha256 = "0di3d5qy8fhawijq6bxy524fgffvzl08dprrws0fs2j1a70fs0fh";
+    rev    = "2b508464dce2cbdb2a3089c58df2a6fbc36328c0";
+    sha256 = "024ypr1da2r079k3hgiifzd3d3wcfprhbl5zdm40zm0c7frzmr8i";
   };
 
-  buildInputs = [ alsaLib ] ++ runtimeDeps;
-  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ alsaLib flac libmad libvorbis mpg123 ]
+    ++ optional faad2Support faad2
+    ++ optional ffmpegSupport ffmpeg
+    ++ optional opusSupport opusfile
+    ++ optional resampleSupport soxr
+    ++ optional sslSupport openssl;
 
   enableParallelBuilding = true;
+
+  postPatch = ''
+    substituteInPlace opus.c \
+      --replace "<opusfile.h>" "<opus/opusfile.h>"
+  '';
+
+  preBuild = ''
+    export OPTS="${concatStringsSep " " opts}"
+  '';
 
   installPhase = ''
     runHook preInstall
@@ -24,15 +57,14 @@ in stdenv.mkDerivation {
     install -Dm755 -t $out/bin                   squeezelite
     install -Dm644 -t $out/share/doc/squeezelite *.txt *.md
 
-    wrapProgram $out/bin/squeezelite --set LD_LIBRARY_PATH $RPATH
     runHook postInstall
   '';
 
   meta = with stdenv.lib; {
     description = "Lightweight headless squeezebox client emulator";
     homepage = https://github.com/ralph-irving/squeezelite;
-    license = licenses.gpl3;
+    license = with licenses; [ gpl3 ] ++ optional dsdSupport bsd2;
+    maintainers = with maintainers; [ samdoshi ];
     platforms = platforms.linux;
   };
-  RPATH = rpath;
 }


### PR DESCRIPTION
###### Motivation for this change

**Version change**: upstream is using an `svn2git` setup, and whilst there has _never_ been an official release, version numbers are indicated in `squeezelite.h` (see https://github.com/ralph-irving/squeezelite/issues/29).

**Broken `mp3`, `ogg` and `aac` support:** current build doesn't find libraries at runtime (fixed by added `-DLINKALL`):


Outout from current build:
```
[15:27:56.936888] load_faad:593 dlerror: libfaad.so.2: cannot open shared object file: No such file or directory
[15:27:56.936924] alsa_open:351 opening device at: 44100
[15:27:56.936956] load_vorbis:289 dlerror: libvorbisidec.so.1: cannot open shared object file: No such file or directory
[15:27:56.936978] load_flac:266 loaded libFLAC.so.8
[15:27:56.936986] register_flac:294 using flac to decode flc
[15:27:56.936991] register_pcm:433 using pcm to decode aif,pcm
[15:27:56.937012] load_mad:366 dlerror: libmad.so.0: cannot open shared object file: No such file or directory
...
[15:27:57.064437] sendHELO:132 cap: Model=squeezelite,AccuratePlayPoints=1,HasDigitalOut=1,HasPolarityInversion=1,Firmware=v1.9.0-1113,ModelName=SqueezeLite,MaxSampleRate=384000,flc,aif,pcm
```

**Added extra codecs, and features**:

Added support for DSD, ALAC, WMA and Opus. Added resampling support and SSL.

Output from new build:
```
[15:29:24.790298] sendHELO:144 cap: CanHTTPS=1,Model=squeezelite,AccuratePlayPoints=1,HasDigitalOut=1,HasPolarityInversion=1,Firmware=v1.9.6-1196,ModelName=SqueezeLite,MaxSampleRate=384000,dsf,dff,alc,wma,wmap,aac,ogg,ops,ogf,flc,aif,pcm,mp3
```

The downside is that the closure size increases from 30,132,336 to 149,554,504. I could disable `ffmpeg` support by default (and with it ALAC & WMA) to reduce the size to 44,408,752 which is a much smaller increase.

**Added myself as a maintainer**.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc (I know you're not listed as a package maintainer, but pinging @peterhoeg)