### PR TITLE
kakounePlugins: fix license names

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/kak-auto-pairs.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-auto-pairs.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib;
   { description = "Kakoune extension to enable automatic closing of pairs";
     homepage = "https://github.com/alexherbo2/auto-pairs.kak";
-    license = licenses.publicDoman;
+    license = licenses.unlicense;
     maintainers = with maintainers; [ nrdxp ];
     platform = platforms.all;
   };

--- a/pkgs/applications/editors/kakoune/plugins/kak-buffers.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-buffers.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib;
   { description = "Ease navigation between opened buffers in Kakoune";
     homepage = "https://github.com/Delapouite/kakoune-buffers";
-    license = licenses.publicDoman;
+    license = licenses.mit;
     maintainers = with maintainers; [ nrdxp ];
     platform = platforms.all;
   };

--- a/pkgs/applications/editors/kakoune/plugins/kak-fzf.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-fzf.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib;
   { description = "Kakoune plugin that brings integration with fzf";
     homepage = "https://github.com/andreyorst/fzf.kak";
-    license = licenses.publicDoman;
+    license = licenses.mit;
     maintainers = with maintainers; [ nrdxp ];
     platform = platforms.all;
   };

--- a/pkgs/applications/editors/kakoune/plugins/kak-powerline.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-powerline.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib;
   { description = "Kakoune modeline, but with passion";
     homepage = "https://github.com/andreyorst/powerline.kak";
-    license = licenses.publicDoman;
+    license = licenses.mit;
     maintainers = with maintainers; [ nrdxp ];
     platform = platforms.all;
   };

--- a/pkgs/applications/editors/kakoune/plugins/kak-vertical-selection.nix
+++ b/pkgs/applications/editors/kakoune/plugins/kak-vertical-selection.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib;
   { description = "Select up and down lines that match the same pattern in Kakoune";
     homepage = "https://github.com/occivink/kakoune-vertical-selection";
-    license = licenses.publicDoman;
+    license = licenses.unlicense;
     maintainers = with maintainers; [ nrdxp ];
     platform = platforms.all;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The license names seemed to be incorrect according to the upstream repos.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nrdxp 
