### PR TITLE
torchtext: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6885,6 +6885,12 @@
     githubId = 1771332;
     name = "László Vaskó";
   };
+  vladmaraev = {
+    email = "vlad@maraev.me";
+    github = "vladmaraev";
+    githubId = 920783;
+    name = "Vladislav Maraev";
+  };
   vlstill = {
     email = "xstill@fi.muni.cz";
     github = "vlstill";

--- a/pkgs/development/python-modules/torchtext/default.nix
+++ b/pkgs/development/python-modules/torchtext/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, fetchPypi
+, tqdm    
+, requests
+, pytorch   
+, numpy   
+, six     
+, lib
+}:
+
+buildPythonPackage rec {
+  version = "0.4.0";
+  pname = "torchtext";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e04ca965fb1d74161fd1f4b5222ee4fa1ad6c02f1e7df213495883384f2fa408";
+  };
+
+  propagatedBuildInputs = [ tqdm requests pytorch numpy six ];
+
+  meta = {
+    homepage = https://pytorch.org;
+    description = "Data loaders and abstractions for text and NLP";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ vladmaraev ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5767,6 +5767,8 @@ in {
 
   pypeg2 = callPackage ../development/python-modules/pypeg2 { };
 
+  torchtext = callPackage ../development/python-modules/torchtext { };
+
   torchvision = callPackage ../development/python-modules/torchvision { };
 
   jenkinsapi = callPackage ../development/python-modules/jenkinsapi { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add torchtext: https://torchtext.readthedocs.io/en/latest/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jyp 
