### PR TITLE
chromaprint: 1.3.2 -> 1.4.3

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -28,6 +28,11 @@ let
       url = "https://github.com/clementine-player/Clementine/pull/5630.patch";
       sha256 = "0px7xp1m4nvrncx8sga1qlxppk562wrk2qqk19iiry84nxg20mk4";
     })
+    (fetchpatch {
+      # Fixes compilation with chromaprint >= 1.4
+      url = "https://github.com/clementine-player/Clementine/commit/d3ea0c8482dfd3f6264a30cfceb456076d76e6cd.patch";
+      sha256 = "1ifrs5aqdzw16jbnf0z1ilir20chdnr9k5n21r99miq9hzjpbh12";
+    })
   ];
 
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "chromaprint";
-  version = "1.3.2";
+  version = "1.4.3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/acoustid/chromaprint/downloads/${pname}-${version}.tar.gz";
-    sha256 = "0lln8dh33gslb9cbmd1hcv33pr6jxdwipd8m8gbsyhksiq6r1by3";
+    url = "https://github.com/acoustid/chromaprint/releases/download/v${version}/${pname}-${version}.tar.gz";
+    sha256 = "10kz8lncal4s2rp2rqpgc6xyjp0jzcrihgkx7chf127vfs5n067a";
   };
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ boost ffmpeg ];
 
-  cmakeFlags = [ "-DBUILD_EXAMPLES=ON" ];
+  cmakeFlags = [ "-DBUILD_EXAMPLES=ON" "-DBUILD_TOOLS=ON" ];
 
   meta = with stdenv.lib; {
     homepage = https://acoustid.org/chromaprint;


### PR DESCRIPTION
Changed upstream URL to GitHub. The latest release is not on BitBucket
and the web site points to GitHub.

###### Motivation for this change
Upstream version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ehmry 
