### PR TITLE
pythonPackages.nixpkgs-pytools: 1.0.1 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/nixpkgs-pytools/default.nix
+++ b/pkgs/development/python-modules/nixpkgs-pytools/default.nix
@@ -3,22 +3,24 @@
 , fetchPypi
 , jinja2
 , setuptools
+, rope
 , isPy27
 }:
 
 buildPythonPackage rec {
   pname = "nixpkgs-pytools";
-  version = "1.0.1";
+  version = "1.3.0";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0796c6e95daeb3d7e61c9c53126d95ba6a48f84b995b12b60f45619caf28a574";
+    sha256 = "11skcbi1lf9qcv9j5ikifb4pakhbbygqpcmv3390j7gxsa85cn19";
   };
 
   propagatedBuildInputs = [
     jinja2
     setuptools
+    rope
   ];
 
   # tests require network ..


### PR DESCRIPTION
###### Motivation for this change

Update to latest nixpkgs-pytools. Requires new dependency `rope`, that is why it probably was not caught by @r-ryantm :)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc 
