### PR TITLE
pythonPackages.devpi-common: 3.3.2 -> 3.4.0

### DIFF
--- a/pkgs/development/python-modules/devpi-common/default.nix
+++ b/pkgs/development/python-modules/devpi-common/default.nix
@@ -1,16 +1,21 @@
-{ lib, buildPythonPackage, fetchPypi, requests, py, pytest, pytest-flakes }:
+{ lib, buildPythonPackage, fetchPypi
+, requests
+, py
+, pytest
+, pytest-flake8
+}:
 
 buildPythonPackage rec {
   pname = "devpi-common";
-  version = "3.3.2";
+  version = "3.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2c7a6471c0f5b07ac9257adec3b3c3a89193ee672fdeb0a6f29487dc9d675e0c";
+    sha256 = "1pfl29pnfn120rqv3zwxc22i1hyywwg60rcck9hzxsllbhmfbjqh";
   };
 
   propagatedBuildInputs = [ requests py ];
-  checkInputs = [ pytest pytest-flakes ];
+  checkInputs = [ pytest pytest-flake8 ];
 
   checkPhase = ''
     py.test


### PR DESCRIPTION
##### Motivation for this change

In preparation for bumping `devpi-client` to 5.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
