### PR TITLE
ultrastar-creator/ultrastar-manager: wrapQtAppsHook

### DIFF
--- a/pkgs/tools/misc/ultrastar-creator/default.nix
+++ b/pkgs/tools/misc/ultrastar-creator/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ lib, mkDerivation, fetchFromGitHub
 , qmake, qtbase, pkgconfig, taglib, libbass, libbass_fx }:
 
 # TODO: get rid of (unfree) libbass
@@ -6,7 +6,7 @@
 # there’s a WIP branch here:
 # https://github.com/UltraStar-Deluxe/UltraStar-Creator/commits/BASS_removed
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "ultrastar-creator";
   version = "2019-04-23";
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     sha256 = "1rzz04l7s7pxj74xam0cxlq569lfpgig35kpbsplq531d4007pc9";
   };
 
-  postPatch = with stdenv.lib; ''
+  postPatch = with lib; ''
     # we don’t want prebuild binaries checked into version control!
     rm -rf lib include
     sed -e "s|DESTDIR =.*$|DESTDIR = $out/bin|" \
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ qmake pkgconfig ];
   buildInputs = [ qtbase taglib libbass libbass_fx ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Ultrastar karaoke song creation tool";
     homepage = https://github.com/UltraStar-Deluxe/UltraStar-Creator;
     license = licenses.gpl2;

--- a/pkgs/tools/misc/ultrastar-manager/default.nix
+++ b/pkgs/tools/misc/ultrastar-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, symlinkJoin, qmake, diffPlugins
+{ lib, mkDerivation, fetchFromGitHub, pkgconfig, symlinkJoin, qmake, diffPlugins
 , qtbase, qtmultimedia, taglib, libmediainfo, libzen, libbass }:
 
 let
@@ -24,12 +24,12 @@ let
       repo = "UltraStar-Manager";
       inherit rev sha256;
     };
-    in stdenv.mkDerivation {
+    in mkDerivation {
       name = "${src.name}-patched";
       inherit src;
       phases = [ "unpackPhase" "patchPhase" ];
 
-      patchPhase = with stdenv.lib; ''
+      patchPhase = with lib; ''
         # we don’t want prebuild binaries checked into version control!
         rm -rf lib include
 
@@ -55,7 +55,7 @@ let
     sed -e "s|QCore.*applicationDirPath()|QString(\"${path}\")|" -i "${file}"
   '';
 
-  buildPlugin = name: stdenv.mkDerivation {
+  buildPlugin = name: mkDerivation {
     name = "ultrastar-manager-${name}-plugin-${version}";
     src = patchedSrc;
 
@@ -82,7 +82,7 @@ let
       paths = map buildPlugin plugins;
     };
 
-in stdenv.mkDerivation {
+in mkDerivation {
   pname = "ultrastar-manager";
   inherit version;
   src = patchedSrc;
@@ -112,7 +112,7 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   inherit buildInputs;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Ultrastar karaoke song manager";
     homepage = https://github.com/UltraStar-Deluxe/UltraStar-Manager;
     license = licenses.gpl2;


### PR DESCRIPTION
It was impossible to start them from a nix shell because they were not
wrapped.
