### PR TITLE
pythonPackages.cloudpickle: 0.8.1 -> 1.2.2

### DIFF
--- a/pkgs/development/python-modules/datashader/default.nix
+++ b/pkgs/development/python-modules/datashader/default.nix
@@ -81,5 +81,7 @@ buildPythonPackage rec {
     homepage = https://datashader.org;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
+    # numpy is much stricter on types, this package is no longer valid
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/odo/default.nix
+++ b/pkgs/development/python-modules/odo/default.nix
@@ -24,10 +24,10 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytest
-    dask
   ];
 
   propagatedBuildInputs = [
+    dask
     datashape
     numpy
     pandas
@@ -39,6 +39,14 @@ buildPythonPackage rec {
   postConfigure = ''
     substituteInPlace setup.py \
       --replace "versioneer.get_version()" "'0.5.1'"
+  '';
+
+  # inspect.getargspec can't handle type hints,
+  # this should be upstreamed, but the blaze community
+  # is depressingly inactive.
+  postPatch = ''
+    substituteInPlace odo/utils.py \
+      --replace "getargspec" "getfullargspec"
   '';
 
   # disable 6/315 tests

--- a/pkgs/development/python-modules/sunpy/default.nix
+++ b/pkgs/development/python-modules/sunpy/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "sunpy";
-  version = "1.0.2";
+  version = "1.0.3";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "sunpy";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0dmfzxxsjjax9wf2ljyl4z07pxbshrj828zi5qnsa9rgk4148q9x";
+    sha256 = "0z5j9b7sa4cw3hikhg9ng0w6z8vr3xshpq5s9f36wdg8lx6zaha0";
   };
 
   propagatedBuildInputs = [
@@ -68,7 +68,7 @@ buildPythonPackage rec {
   '';
 
   checkPhase = ''
-    pytest sunpy -k "not test_rotation"
+    pytest sunpy -k "not test_rotation and not README"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
##### Motivation for this change
noticed cloudpickle was out-of-date, then fixed all the broken builds in the nix-review

Actions:
 - fixed odo build (which also fixed blaze)
 - bumped sunpy while fixing tests
 - marked datashader broken as it's no longer compatible with the latest numpy


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/70684
53 package were build:
doit maestral maestral-gui python27Packages.Pyro4 python27Packages.baselines python27Packages.celery python27Packages.cloudpickle python27Packages.djmail python27Packages.dm-sonnet python27Packages.graph_nets python27Packages.kombu python27Packages.pygmo python27Packages.spyder-kernels python27Packages.tensorflow-probability python37Packages.Nikola python37Packages.Pyro4 python37Packages.aplpy python37Packages.baselines python37Packages.blaze python37Packages.caffe python37Packages.celery python37Packages.cloudpickle python37Packages.dask python37Packages.dask-glm python37Packages.dask-image python37Packages.dask-jobqueue python37Packages.dask-ml python37Packages.dask-mpi python37Packages.dask-xgboost python37Packages.dftfit python37Packages.distributed python37Packages.djmail python37Packages.dm-sonnet python37Packages.glymur python37Packages.graph_nets python37Packages.image-match python37Packages.intake python37Packages.kombu python37Packages.odo python37Packages.pims python37Packages.pyfftw python37Packages.pygmo python37Packages.rl-coach python37Packages.scikitimage python37Packages.sentry-sdk python37Packages.slicedimage spyder python37Packages.spyder-kernels python37Packages.starfish python37Packages.streamz python37Packages.stumpy python37Packages.sunpy python37Packages.tensorflow-probability
```