### PR TITLE
mumble/murmur: Fix .override not working

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, pkgconfig, mkDerivation
-, qtbase, qttools, qtsvg, qmake, avahi, boost, libopus, libsndfile, protobuf, speex, libcap
+{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, pkgconfig, qt5
+, avahi, boost, libopus, libsndfile, protobuf, speex, libcap
 , alsaLib, python
 , jackSupport ? false, libjack2 ? null
 , speechdSupport ? false, speechd ? null
@@ -14,12 +14,12 @@ assert iceSupport -> zeroc-ice != null;
 
 with stdenv.lib;
 let
-  generic = overrides: source: mkDerivation (source // overrides // {
+  generic = overrides: source: qt5.mkDerivation (source // overrides // {
     name = "${overrides.type}-${source.version}";
 
     patches = (source.patches or []) ++ optional jackSupport ./mumble-jack-support.patch;
 
-    nativeBuildInputs = [ pkgconfig python qmake ]
+    nativeBuildInputs = [ pkgconfig python qt5.qmake ]
       ++ (overrides.nativeBuildInputs or [ ]);
 
     buildInputs = [ boost protobuf avahi ]
@@ -72,8 +72,8 @@ let
   client = source: generic {
     type = "mumble";
 
-    nativeBuildInputs = [ qttools ];
-    buildInputs = [ libopus libsndfile speex qtsvg ]
+    nativeBuildInputs = [ qt5.qttools ];
+    buildInputs = [ libopus libsndfile speex qt5.qtsvg ]
       ++ optional stdenv.isLinux alsaLib
       ++ optional jackSupport libjack2
       ++ optional speechdSupport speechd

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19672,13 +19672,13 @@ in
 
   multimon-ng = callPackage ../applications/radio/multimon-ng { };
 
-  murmur = (libsForQt5.callPackage ../applications/networking/mumble {
+  murmur = (callPackages ../applications/networking/mumble {
       avahi = avahi-compat;
       pulseSupport = config.pulseaudio or false;
       iceSupport = config.murmur.iceSupport or true;
     }).murmur;
 
-  mumble = (libsForQt5.callPackage ../applications/networking/mumble {
+  mumble = (callPackages ../applications/networking/mumble {
       avahi = avahi-compat;
       jackSupport = config.mumble.jackSupport or false;
       speechdSupport = config.mumble.speechdSupport or false;


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/pull/68800#issuecomment-539229596

Unfortunately there's no `pkgs.libsForQt5.callPackages`, which we need here to
get `.override` attributes on all derivation attributes. It's also
non-trivial to add it without duplicating code.

So instead just use standard `pkgs.callPackages` and pass refer to qt libs
through `pkgs.qt5`

Ping @ajs124 @greizgh 

###### Things done

- [x] Made sure that mumble and murmur evaluate to the same thing as before
- [x] Made sure `.override` works again on mumble and murmur