### PR TITLE
cherry: 1.3 -> 1.4, pcf -> otb, mkfontdir for X11

### DIFF
--- a/pkgs/data/fonts/cherry/default.nix
+++ b/pkgs/data/fonts/cherry/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchFromGitHub, bdftopcf }:
+{ stdenv, fetchFromGitHub, fonttosfnt, mkfontdir }:
 
 stdenv.mkDerivation rec {
   pname = "cherry";
-  version = "1.3";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "turquoise-hexagon";
     repo = pname;
     rev = version;
-    sha256 = "1zaiqspf6y0hpszhihdsvsyw33d3ffdap4dym7w45wfrhdpvpi0p";
+    sha256 = "13zkxwp6r6kcxv4x459vwscr0n0sik4a3kcz5xnmlpvcdnbxi586";
   };
 
-  nativeBuildInputs = [ bdftopcf ];
+  nativeBuildInputs = [ fonttosfnt mkfontdir ];
 
   buildPhase = ''
     patchShebangs make.sh
@@ -20,7 +20,10 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/share/fonts/misc
-    cp *.pcf $out/share/fonts/misc
+    cp *.otb $out/share/fonts/misc
+
+    # create fonts.dir so NixOS xorg module adds to fp
+    mkfontdir $out/share/fonts/misc
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16729,7 +16729,7 @@ in
 
   charis-sil = callPackage ../data/fonts/charis-sil { };
 
-  cherry = callPackage ../data/fonts/cherry { };
+  cherry = callPackage ../data/fonts/cherry { inherit (xorg) fonttosfnt mkfontdir; };
 
   cnstrokeorder = callPackage ../data/fonts/cnstrokeorder {};
 


### PR DESCRIPTION
###### Motivation for this change

* 1.3 -> 1.4
* pcf -> otb
* mkfontdir for X11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @