### PR TITLE
spleen: 1.3.0 -> 1.5.0, mkfontdir

### DIFF
--- a/pkgs/data/fonts/spleen/default.nix
+++ b/pkgs/data/fonts/spleen/default.nix
@@ -1,8 +1,8 @@
-{ lib, fetchurl }:
+{ lib, fetchurl, mkfontdir }:
 
 let
   pname = "spleen";
-  version = "1.3.0";
+  version = "1.5.0";
 in fetchurl {
   name = "${pname}-${version}";
   url = "https://github.com/fcambus/spleen/releases/download/${version}/spleen-${version}.tar.gz";
@@ -12,11 +12,13 @@ in fetchurl {
   postFetch = ''
     tar xvf $downloadedFile --strip=1
     d="$out/share/fonts/X11/misc/spleen"
-    gzip -n9 *.pcf
     install -Dm644 *.{pcf.gz,psfu,bdf} -t $d
     install -m644 fonts.alias-spleen $d/fonts.alias
+
+    # create fonts.dir so NixOS xorg module adds to fp
+    ${mkfontdir}/bin/mkfontdir $d
   '';
-  sha256 = "1l1ksl8xnz1yh7jl8h2g25a7wfm9xgj3lay8ddqzlxzydkkm110q";
+  sha256 = "13ndyw1m6c778k7jr7qwbfg28gqmpcgksprn2mjgsv75wvy51z19";
 
   meta = with lib; {
     description = "Monospaced bitmap fonts";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17244,7 +17244,7 @@ in
   source-han-serif-simplified-chinese = sourceHanSerifPackages.simplified-chinese;
   source-han-serif-traditional-chinese = sourceHanSerifPackages.traditional-chinese;
 
-  spleen = callPackage ../data/fonts/spleen { };
+  spleen = callPackage ../data/fonts/spleen { inherit (xorg) mkfontdir; };
 
   stilo-themes = callPackage ../data/themes/stilo { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).