### PR TITLE
qt5: 5.12.4 -> 5.12.5

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -65,6 +65,7 @@ let
         ./qtbase.patch.d/0009-qtbase-tzdir.patch
         ./qtbase.patch.d/0010-qtbase-qtpluginpath.patch
         ./qtbase.patch.d/0011-qtbase-assert.patch
+        ./qtbase.patch.d/0012-fix-header-module.patch
       ];
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -65,7 +65,7 @@ let
         ./qtbase.patch.d/0009-qtbase-tzdir.patch
         ./qtbase.patch.d/0010-qtbase-qtpluginpath.patch
         ./qtbase.patch.d/0011-qtbase-assert.patch
-        ./qtbase.patch.d/0012-fix-header-module.patch
+        ./qtbase.patch.d/0012-fix-header_module.patch
       ];
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];

--- a/pkgs/development/libraries/qt-5/5.12/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.12/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.12/5.12.4/submodules/ )
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.12/5.12.5/submodules/ )

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
@@ -1,7 +1,7 @@
 From 361a9395704ca1ee170a8bb3823ba860293eecee Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:34:00 -0500
-Subject: [PATCH 01/11] qtbase-mkspecs-mac
+Subject: [PATCH 01/12] qtbase-mkspecs-mac
 
 ---
  mkspecs/common/mac.conf               |   2 +-

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0001-qtbase-mkspecs-mac.patch
@@ -1,18 +1,18 @@
-From 58d98b66da5d748d610f053053bd12e42c97d9e6 Mon Sep 17 00:00:00 2001
+From 361a9395704ca1ee170a8bb3823ba860293eecee Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:34:00 -0500
 Subject: [PATCH 01/11] qtbase-mkspecs-mac
 
 ---
  mkspecs/common/mac.conf               |   2 +-
- mkspecs/features/mac/default_post.prf | 196 --------------------------
+ mkspecs/features/mac/default_post.prf | 201 --------------------------
  mkspecs/features/mac/default_pre.prf  |  58 --------
  mkspecs/features/mac/sdk.mk           |  25 ----
  mkspecs/features/mac/sdk.prf          |  61 --------
- 5 files changed, 1 insertion(+), 341 deletions(-)
+ 5 files changed, 1 insertion(+), 346 deletions(-)
 
 diff --git a/mkspecs/common/mac.conf b/mkspecs/common/mac.conf
-index b77494ec..470c38e7 100644
+index b77494ec9b..470c38e772 100644
 --- a/mkspecs/common/mac.conf
 +++ b/mkspecs/common/mac.conf
 @@ -24,7 +24,7 @@ QMAKE_INCDIR_OPENGL     = \
@@ -25,10 +25,10 @@ index b77494ec..470c38e7 100644
  
  QMAKE_LFLAGS_REL_RPATH  =
 diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/default_post.prf
-index c46222de..18dcfbce 100644
+index 26bd3e2e98..b80ec1e801 100644
 --- a/mkspecs/features/mac/default_post.prf
 +++ b/mkspecs/features/mac/default_post.prf
-@@ -64,202 +64,6 @@ qt {
+@@ -68,207 +68,6 @@ qt {
      }
  }
  
@@ -212,6 +212,11 @@ index c46222de..18dcfbce 100644
 -    QMAKE_PCH_OUTPUT_EXT = _${QMAKE_PCH_ARCH}$${QMAKE_PCH_OUTPUT_EXT}
 -}
 -
+-!equals(sdk_version, $$QMAKE_MAC_SDK_VERSION) {
+-    # Explicit SDK version has been set, respect that
+-    QMAKE_LFLAGS += -Wl,-sdk_version -Wl,$$sdk_version
+-}
+-
 -cache(QMAKE_XCODE_DEVELOPER_PATH, stash)
 -!isEmpty(QMAKE_XCODE_VERSION): \
 -    cache(QMAKE_XCODE_VERSION, stash)
@@ -229,10 +234,10 @@ index c46222de..18dcfbce 100644
 -QMAKE_MAC_XCODE_SETTINGS += xcode_product_bundle_identifier_setting
 -
  !macx-xcode {
-     generate_xcode_project.commands = @$(QMAKE) -spec macx-xcode $(EXPORT__PRO_FILE_)
+     generate_xcode_project.commands = @$(QMAKE) -spec macx-xcode \"$(EXPORT__PRO_FILE_)\" $$QMAKE_ARGS
      generate_xcode_project.target = xcodeproj
 diff --git a/mkspecs/features/mac/default_pre.prf b/mkspecs/features/mac/default_pre.prf
-index e3534561..3b01424e 100644
+index e3534561a5..3b01424e67 100644
 --- a/mkspecs/features/mac/default_pre.prf
 +++ b/mkspecs/features/mac/default_pre.prf
 @@ -1,60 +1,2 @@
@@ -297,7 +302,7 @@ index e3534561..3b01424e 100644
 -xcode_copy_phase_strip_setting.value = NO
 -QMAKE_MAC_XCODE_SETTINGS += xcode_copy_phase_strip_setting
 diff --git a/mkspecs/features/mac/sdk.mk b/mkspecs/features/mac/sdk.mk
-index c40f58c9..e69de29b 100644
+index c40f58c987..e69de29bb2 100644
 --- a/mkspecs/features/mac/sdk.mk
 +++ b/mkspecs/features/mac/sdk.mk
 @@ -1,25 +0,0 @@
@@ -327,7 +332,7 @@ index c40f58c9..e69de29b 100644
 -    endif
 -endif
 diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
-index 3a9c2778..e69de29b 100644
+index 3a9c2778bb..e69de29bb2 100644
 --- a/mkspecs/features/mac/sdk.prf
 +++ b/mkspecs/features/mac/sdk.prf
 @@ -1,61 +0,0 @@
@@ -393,5 +398,5 @@ index 3a9c2778..e69de29b 100644
 -    cache($$tool_variable, set stash, $$tool)
 -}
 -- 
-2.22.1
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0002-qtbase-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0002-qtbase-mac.patch
@@ -1,7 +1,7 @@
 From 203c9338dc92c2c36007cfe6633387348976637e Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:37:15 -0500
-Subject: [PATCH 02/11] qtbase-mac
+Subject: [PATCH 02/12] qtbase-mac
 
 ---
  src/corelib/kernel/qcore_mac_p.h | 16 ++++++++++++++--

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0002-qtbase-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0002-qtbase-mac.patch
@@ -1,4 +1,4 @@
-From 203c9338dc92c2c36007cfe6633387348976637e Mon Sep 17 00:00:00 2001
+From c8ca2cd3ebd870f52a25ea7d1962df993767be5b Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:37:15 -0500
 Subject: [PATCH 02/11] qtbase-mac
@@ -13,10 +13,10 @@ Subject: [PATCH 02/11] qtbase-mac
  6 files changed, 19 insertions(+), 7 deletions(-)
 
 diff --git a/src/corelib/kernel/qcore_mac_p.h b/src/corelib/kernel/qcore_mac_p.h
-index f96e7358..650946b7 100644
+index 168e0418e4..32542c332c 100644
 --- a/src/corelib/kernel/qcore_mac_p.h
 +++ b/src/corelib/kernel/qcore_mac_p.h
-@@ -212,7 +212,7 @@ private:
+@@ -213,7 +213,7 @@ private:
  
  // --------------------------------------------------------------------------
  
@@ -25,7 +25,7 @@ index f96e7358..650946b7 100644
  
  QT_END_NAMESPACE
  #include <os/activity.h>
-@@ -290,7 +290,19 @@ QT_MAC_WEAK_IMPORT(_os_activity_current);
+@@ -291,7 +291,19 @@ QT_MAC_WEAK_IMPORT(_os_activity_current);
  
  #define QT_APPLE_SCOPED_LOG_ACTIVITY(...) QAppleLogActivity scopedLogActivity = QT_APPLE_LOG_ACTIVITY(__VA_ARGS__).enter();
  
@@ -112,5 +112,5 @@ index e63e89a7..213b6945 100644
  #endif
  #if defined(HAVE_XCTEST)
 -- 
-2.23.0
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0002-qtbase-mac.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0002-qtbase-mac.patch
@@ -1,4 +1,4 @@
-From c8ca2cd3ebd870f52a25ea7d1962df993767be5b Mon Sep 17 00:00:00 2001
+From 203c9338dc92c2c36007cfe6633387348976637e Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:37:15 -0500
 Subject: [PATCH 02/11] qtbase-mac
@@ -13,10 +13,10 @@ Subject: [PATCH 02/11] qtbase-mac
  6 files changed, 19 insertions(+), 7 deletions(-)
 
 diff --git a/src/corelib/kernel/qcore_mac_p.h b/src/corelib/kernel/qcore_mac_p.h
-index 168e0418e4..32542c332c 100644
+index f96e7358..650946b7 100644
 --- a/src/corelib/kernel/qcore_mac_p.h
 +++ b/src/corelib/kernel/qcore_mac_p.h
-@@ -213,7 +213,7 @@ private:
+@@ -212,7 +212,7 @@ private:
  
  // --------------------------------------------------------------------------
  
@@ -25,7 +25,7 @@ index 168e0418e4..32542c332c 100644
  
  QT_END_NAMESPACE
  #include <os/activity.h>
-@@ -291,7 +291,19 @@ QT_MAC_WEAK_IMPORT(_os_activity_current);
+@@ -290,7 +290,19 @@ QT_MAC_WEAK_IMPORT(_os_activity_current);
  
  #define QT_APPLE_SCOPED_LOG_ACTIVITY(...) QAppleLogActivity scopedLogActivity = QT_APPLE_LOG_ACTIVITY(__VA_ARGS__).enter();
  
@@ -112,5 +112,5 @@ index e63e89a7..213b6945 100644
  #endif
  #if defined(HAVE_XCTEST)
 -- 
-2.23.GIT
+2.23.0
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0003-qtbase-mkspecs.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0003-qtbase-mkspecs.patch
@@ -1,4 +1,4 @@
-From 5ff996d9028c0f54939ca7c54d358cd7503ab1ae Mon Sep 17 00:00:00 2001
+From 8bdbddc2e5fef1553b1ba0297d3c03b38e9b947b Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Wed, 18 Sep 2019 05:39:39 -0500
 Subject: [PATCH 03/11] qtbase-mkspecs
@@ -18,7 +18,7 @@ Subject: [PATCH 03/11] qtbase-mkspecs
  11 files changed, 39 insertions(+), 142 deletions(-)
 
 diff --git a/mkspecs/features/create_cmake.prf b/mkspecs/features/create_cmake.prf
-index c9910dda..e9bc8076 100644
+index 00da9bd33f..bd166fbfea 100644
 --- a/mkspecs/features/create_cmake.prf
 +++ b/mkspecs/features/create_cmake.prf
 @@ -21,7 +21,7 @@ load(cmake_functions)
@@ -30,7 +30,7 @@ index c9910dda..e9bc8076 100644
  contains(CMAKE_INSTALL_LIBS_DIR, ^(/usr)?/lib(64)?.*): CMAKE_USR_MOVE_WORKAROUND = $$CMAKE_INSTALL_LIBS_DIR
  
  CMAKE_OUT_DIR = $$MODULE_BASE_OUTDIR/lib/cmake
-@@ -60,45 +60,20 @@ split_incpath {
+@@ -70,45 +70,20 @@ split_incpath {
          $$cmake_extra_source_includes.output
  }
  
@@ -87,7 +87,7 @@ index c9910dda..e9bc8076 100644
  
  static|staticlib:CMAKE_STATIC_TYPE = true
  
-@@ -178,7 +153,7 @@ contains(CONFIG, plugin) {
+@@ -188,7 +163,7 @@ contains(CONFIG, plugin) {
        cmake_target_file
  
      cmake_qt5_plugin_file.files = $$cmake_target_file.output
@@ -96,7 +96,7 @@ index c9910dda..e9bc8076 100644
      INSTALLS += cmake_qt5_plugin_file
  
      return()
-@@ -323,7 +298,7 @@ exists($$cmake_macros_file.input) {
+@@ -333,7 +308,7 @@ exists($$cmake_macros_file.input) {
      cmake_qt5_module_files.files += $$cmake_macros_file.output
  }
  
@@ -106,7 +106,7 @@ index c9910dda..e9bc8076 100644
  # We are generating cmake files. Most developers of Qt are not aware of cmake,
  # so we require automatic tests to be available. The only module which should
 diff --git a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-index c7298928..c60ef16e 100644
+index c729892889..c60ef16e64 100644
 --- a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 +++ b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 @@ -3,30 +3,6 @@ if (CMAKE_VERSION VERSION_LESS 3.1.0)
@@ -266,7 +266,7 @@ index c7298928..c60ef16e 100644
          set_target_properties(Qt5::${Plugin} PROPERTIES
              \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
 diff --git a/mkspecs/features/qml_module.prf b/mkspecs/features/qml_module.prf
-index 57cfec78..5cbd7c52 100644
+index 57cfec78b3..5cbd7c52ef 100644
 --- a/mkspecs/features/qml_module.prf
 +++ b/mkspecs/features/qml_module.prf
 @@ -51,7 +51,7 @@ builtin_resources {
@@ -279,7 +279,7 @@ index 57cfec78..5cbd7c52 100644
  
  qmlfiles.base = $$_PRO_FILE_PWD_
 diff --git a/mkspecs/features/qml_plugin.prf b/mkspecs/features/qml_plugin.prf
-index ad8ecdf5..804634b2 100644
+index ad8ecdf5f1..804634b22e 100644
 --- a/mkspecs/features/qml_plugin.prf
 +++ b/mkspecs/features/qml_plugin.prf
 @@ -50,7 +50,7 @@ load(qt_build_paths)
@@ -292,7 +292,7 @@ index ad8ecdf5..804634b2 100644
  
  # Some final setup
 diff --git a/mkspecs/features/qt_app.prf b/mkspecs/features/qt_app.prf
-index 8354f30e..62028fef 100644
+index 8354f30eea..62028fef8e 100644
 --- a/mkspecs/features/qt_app.prf
 +++ b/mkspecs/features/qt_app.prf
 @@ -30,7 +30,7 @@ host_build:force_bootstrap {
@@ -305,7 +305,7 @@ index 8354f30e..62028fef 100644
  }
  INSTALLS += target
 diff --git a/mkspecs/features/qt_build_paths.prf b/mkspecs/features/qt_build_paths.prf
-index 3bb3823a..655b7b7d 100644
+index 3bb3823a8e..655b7b7db8 100644
 --- a/mkspecs/features/qt_build_paths.prf
 +++ b/mkspecs/features/qt_build_paths.prf
 @@ -24,6 +24,6 @@ exists($$MODULE_BASE_INDIR/.git): \
@@ -318,7 +318,7 @@ index 3bb3823a..655b7b7d 100644
 +    MODULE_QMAKE_OUTDIR = $$NIX_OUTPUT_OUT
  }
 diff --git a/mkspecs/features/qt_docs.prf b/mkspecs/features/qt_docs.prf
-index 3b74cd4d..6bfbbe6e 100644
+index 3b74cd4dd5..6bfbbe6e2d 100644
 --- a/mkspecs/features/qt_docs.prf
 +++ b/mkspecs/features/qt_docs.prf
 @@ -45,7 +45,7 @@ QMAKE_DOCS_OUTPUTDIR = $$QMAKE_DOCS_BASE_OUTDIR/$$QMAKE_DOCS_TARGETDIR
@@ -357,7 +357,7 @@ index 3b74cd4d..6bfbbe6e 100644
      INSTALLS += inst_qch_docs
  
 diff --git a/mkspecs/features/qt_example_installs.prf b/mkspecs/features/qt_example_installs.prf
-index 43b58817..e635b8f6 100644
+index 43b58817fe..e635b8f67a 100644
 --- a/mkspecs/features/qt_example_installs.prf
 +++ b/mkspecs/features/qt_example_installs.prf
 @@ -88,7 +88,7 @@ sourcefiles += \
@@ -370,7 +370,7 @@ index 43b58817..e635b8f6 100644
  
  check_examples {
 diff --git a/mkspecs/features/qt_functions.prf b/mkspecs/features/qt_functions.prf
-index 1903e509..ae7b5859 100644
+index 1903e509c8..ae7b585989 100644
 --- a/mkspecs/features/qt_functions.prf
 +++ b/mkspecs/features/qt_functions.prf
 @@ -69,7 +69,7 @@ defineTest(qtHaveModule) {
@@ -383,7 +383,7 @@ index 1903e509..ae7b5859 100644
              $${1}_EXE = $${cmd}.pl
              cmd = perl -w $$system_path($${cmd}.pl)
 diff --git a/mkspecs/features/qt_installs.prf b/mkspecs/features/qt_installs.prf
-index 1ebca173..b784441d 100644
+index 1ebca17366..b784441da0 100644
 --- a/mkspecs/features/qt_installs.prf
 +++ b/mkspecs/features/qt_installs.prf
 @@ -12,16 +12,10 @@
@@ -448,7 +448,7 @@ index 1ebca173..b784441d 100644
          INSTALLS += privpritarget
      }
 diff --git a/mkspecs/features/qt_plugin.prf b/mkspecs/features/qt_plugin.prf
-index 40528a65..903f7952 100644
+index 40528a65e2..903f795284 100644
 --- a/mkspecs/features/qt_plugin.prf
 +++ b/mkspecs/features/qt_plugin.prf
 @@ -88,7 +88,7 @@ CONFIG(static, static|shared)|prefix_build {
@@ -461,5 +461,5 @@ index 40528a65..903f7952 100644
  
  TARGET = $$qt5LibraryTarget($$TARGET)
 -- 
-2.22.1
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0003-qtbase-mkspecs.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0003-qtbase-mkspecs.patch
@@ -1,7 +1,7 @@
 From 8bdbddc2e5fef1553b1ba0297d3c03b38e9b947b Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Wed, 18 Sep 2019 05:39:39 -0500
-Subject: [PATCH 03/11] qtbase-mkspecs
+Subject: [PATCH 03/12] qtbase-mkspecs
 
 ---
  mkspecs/features/create_cmake.prf             | 53 ++++--------

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0004-qtbase-replace-libdir.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0004-qtbase-replace-libdir.patch
@@ -1,7 +1,7 @@
 From 492f6555bb09f207c83387441f0f23ba4602dfff Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Wed, 18 Sep 2019 05:39:50 -0500
-Subject: [PATCH 04/11] qtbase-replace-libdir
+Subject: [PATCH 04/12] qtbase-replace-libdir
 
 ---
  mkspecs/features/qt_common.prf | 20 ++------------------

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0004-qtbase-replace-libdir.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0004-qtbase-replace-libdir.patch
@@ -1,4 +1,4 @@
-From d126db8f5c2c1f6d6738de1a53040c93fdf6ff73 Mon Sep 17 00:00:00 2001
+From 492f6555bb09f207c83387441f0f23ba4602dfff Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Wed, 18 Sep 2019 05:39:50 -0500
 Subject: [PATCH 04/11] qtbase-replace-libdir
@@ -9,7 +9,7 @@ Subject: [PATCH 04/11] qtbase-replace-libdir
  2 files changed, 3 insertions(+), 22 deletions(-)
 
 diff --git a/mkspecs/features/qt_common.prf b/mkspecs/features/qt_common.prf
-index caecb68a..d3aa3ba5 100644
+index caecb68a84..d3aa3ba570 100644
 --- a/mkspecs/features/qt_common.prf
 +++ b/mkspecs/features/qt_common.prf
 @@ -30,32 +30,16 @@ contains(TEMPLATE, .*lib) {
@@ -48,10 +48,10 @@ index caecb68a..d3aa3ba5 100644
  
  # The remainder of this file must not apply to host tools/libraries,
 diff --git a/mkspecs/features/qt_module.prf b/mkspecs/features/qt_module.prf
-index 51b5bde6..82e2907c 100644
+index ee7de22059..9015b30d73 100644
 --- a/mkspecs/features/qt_module.prf
 +++ b/mkspecs/features/qt_module.prf
-@@ -292,10 +292,7 @@ load(qt_targets)
+@@ -303,10 +303,7 @@ load(qt_targets)
  }
  !lib_bundle:unix {
      CONFIG += create_libtool
@@ -60,9 +60,9 @@ index 51b5bde6..82e2907c 100644
 -    else: \
 -        QMAKE_LIBTOOL_LIBDIR = "=$$[QT_INSTALL_LIBS/raw]"
 +    QMAKE_LIBTOOL_LIBDIR = $$NIX_OUTPUT_OUT/lib
-     ltlib_replace.match = $$lib_replace.match
-     !isEmpty(lib_replace.replace): \
-         ltlib_replace.replace = $$QMAKE_LIBTOOL_LIBDIR
+     !isEmpty(lib_replace0.match) {
+         ltlib_replace0.match = $$lib_replace0.match
+         ltlib_replace0.replace = $$QMAKE_LIBTOOL_LIBDIR/
 -- 
-2.22.1
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0005-qtbase-cmake.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0005-qtbase-cmake.patch
@@ -1,4 +1,4 @@
-From 0ea804da2eb1d0cfbbfc15fbc33a3d7dd5de36ed Mon Sep 17 00:00:00 2001
+From 6f53835deae80b28ec5c1c9a5c0294bbcc87f91b Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:34:28 -0500
 Subject: [PATCH 05/11] qtbase-cmake
@@ -15,7 +15,7 @@ Subject: [PATCH 05/11] qtbase-cmake
  8 files changed, 16 insertions(+), 24 deletions(-)
 
 diff --git a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
-index c60ef16e..e354ab91 100644
+index c60ef16e64..e354ab9156 100644
 --- a/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 +++ b/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 @@ -278,7 +278,7 @@ if (NOT TARGET Qt5::$${CMAKE_MODULE_NAME})
@@ -28,7 +28,7 @@ index c60ef16e..e354ab91 100644
          set_target_properties(Qt5::${Plugin} PROPERTIES
              \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
 diff --git a/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in b/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
-index 5baf0fdb..3583745a 100644
+index 5baf0fdb10..3583745aea 100644
 --- a/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
 +++ b/mkspecs/features/data/cmake/Qt5PluginTarget.cmake.in
 @@ -2,10 +2,10 @@
@@ -45,7 +45,7 @@ index 5baf0fdb..3583745a 100644
  
  list(APPEND Qt5$${CMAKE_MODULE_NAME}_PLUGINS Qt5::$$CMAKE_PLUGIN_NAME)
 diff --git a/src/corelib/Qt5CoreConfigExtras.cmake.in b/src/corelib/Qt5CoreConfigExtras.cmake.in
-index e0652fdc..450b2a2d 100644
+index e0652fdcf9..450b2a2d28 100644
 --- a/src/corelib/Qt5CoreConfigExtras.cmake.in
 +++ b/src/corelib/Qt5CoreConfigExtras.cmake.in
 @@ -3,7 +3,7 @@ if (NOT TARGET Qt5::qmake)
@@ -94,7 +94,7 @@ index e0652fdc..450b2a2d 100644
      set(imported_location \"$${CMAKE_LIB_DIR}$${CMAKE_WINMAIN_FILE_LOCATION_DEBUG}\")
  !!ENDIF
 diff --git a/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in b/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
-index c357237d..6f0c75de 100644
+index c357237d0e..6f0c75de3c 100644
 --- a/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
 +++ b/src/corelib/Qt5CoreConfigExtrasMkspecDir.cmake.in
 @@ -1,6 +1,6 @@
@@ -106,7 +106,7 @@ index c357237d..6f0c75de 100644
  set(_qt5_corelib_extra_includes \"$${CMAKE_HOST_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
  !!ENDIF
 diff --git a/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in b/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
-index 706304cf..546420f6 100644
+index 706304cf34..546420f6ad 100644
 --- a/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
 +++ b/src/corelib/Qt5CoreConfigExtrasMkspecDirForInstall.cmake.in
 @@ -1,6 +1,6 @@
@@ -118,7 +118,7 @@ index 706304cf..546420f6 100644
  set(_qt5_corelib_extra_includes \"$${CMAKE_INSTALL_DATA_DIR}mkspecs/$${CMAKE_MKSPEC}\")
  !!ENDIF
 diff --git a/src/dbus/Qt5DBusConfigExtras.cmake.in b/src/dbus/Qt5DBusConfigExtras.cmake.in
-index 1d947159..b36865fc 100644
+index 1d947159e2..b36865fc48 100644
 --- a/src/dbus/Qt5DBusConfigExtras.cmake.in
 +++ b/src/dbus/Qt5DBusConfigExtras.cmake.in
 @@ -2,11 +2,7 @@
@@ -148,7 +148,7 @@ index 1d947159..b36865fc 100644
  
      set_target_properties(Qt5::qdbusxml2cpp PROPERTIES
 diff --git a/src/gui/Qt5GuiConfigExtras.cmake.in b/src/gui/Qt5GuiConfigExtras.cmake.in
-index 84dbbfeb..8ad0720c 100644
+index 84dbbfebd4..8ad0720c5c 100644
 --- a/src/gui/Qt5GuiConfigExtras.cmake.in
 +++ b/src/gui/Qt5GuiConfigExtras.cmake.in
 @@ -2,7 +2,7 @@
@@ -177,7 +177,7 @@ index 84dbbfeb..8ad0720c 100644
      set(imported_implib \"$${CMAKE_LIB_DIR}${IMPLIB_LOCATION}\")
  !!ENDIF
 diff --git a/src/widgets/Qt5WidgetsConfigExtras.cmake.in b/src/widgets/Qt5WidgetsConfigExtras.cmake.in
-index 99d87e2e..a4eab2aa 100644
+index 99d87e2e46..a4eab2aa72 100644
 --- a/src/widgets/Qt5WidgetsConfigExtras.cmake.in
 +++ b/src/widgets/Qt5WidgetsConfigExtras.cmake.in
 @@ -3,7 +3,7 @@ if (NOT TARGET Qt5::uic)
@@ -190,5 +190,5 @@ index 99d87e2e..a4eab2aa 100644
      set(imported_location \"$${CMAKE_BIN_DIR}uic$$CMAKE_BIN_SUFFIX\")
  !!ENDIF
 -- 
-2.22.1
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0005-qtbase-cmake.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0005-qtbase-cmake.patch
@@ -1,7 +1,7 @@
 From 6f53835deae80b28ec5c1c9a5c0294bbcc87f91b Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:34:28 -0500
-Subject: [PATCH 05/11] qtbase-cmake
+Subject: [PATCH 05/12] qtbase-cmake
 
 ---
  mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in  |  2 +-

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0006-qtbase-gtk3.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0006-qtbase-gtk3.patch
@@ -1,4 +1,4 @@
-From 8fa184fb70a62cbe9ee160bceddaf5d7c21cb85c Mon Sep 17 00:00:00 2001
+From 5bf1785809baf6be7fb5904ce6cefdb761f2c278 Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:35:33 -0500
 Subject: [PATCH 06/11] qtbase-gtk3
@@ -8,7 +8,7 @@ Subject: [PATCH 06/11] qtbase-gtk3
  1 file changed, 16 insertions(+), 1 deletion(-)
 
 diff --git a/src/plugins/platformthemes/gtk3/main.cpp b/src/plugins/platformthemes/gtk3/main.cpp
-index fb1c425d..bb8bab97 100644
+index fb1c425d8e..bb8bab9795 100644
 --- a/src/plugins/platformthemes/gtk3/main.cpp
 +++ b/src/plugins/platformthemes/gtk3/main.cpp
 @@ -39,6 +39,7 @@
@@ -44,5 +44,5 @@ index fb1c425d..bb8bab97 100644
      return 0;
  }
 -- 
-2.22.1
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0006-qtbase-gtk3.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0006-qtbase-gtk3.patch
@@ -1,7 +1,7 @@
 From 5bf1785809baf6be7fb5904ce6cefdb761f2c278 Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:35:33 -0500
-Subject: [PATCH 06/11] qtbase-gtk3
+Subject: [PATCH 06/12] qtbase-gtk3
 
 ---
  src/plugins/platformthemes/gtk3/main.cpp | 17 ++++++++++++++++-

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0007-qtbase-xcursor.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0007-qtbase-xcursor.patch
@@ -1,7 +1,7 @@
 From 35e80f303ae6a6c4c53ba8eb3d84574cc03d68d8 Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:35:58 -0500
-Subject: [PATCH 07/11] qtbase-xcursor
+Subject: [PATCH 07/12] qtbase-xcursor
 
 ---
  src/plugins/platforms/xcb/qxcbcursor.cpp | 4 ++--

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0007-qtbase-xcursor.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0007-qtbase-xcursor.patch
@@ -1,4 +1,4 @@
-From b4fe78eb31f30ef499970b2ca7e7947c025588af Mon Sep 17 00:00:00 2001
+From 35e80f303ae6a6c4c53ba8eb3d84574cc03d68d8 Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:35:58 -0500
 Subject: [PATCH 07/11] qtbase-xcursor
@@ -8,7 +8,7 @@ Subject: [PATCH 07/11] qtbase-xcursor
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/plugins/platforms/xcb/qxcbcursor.cpp b/src/plugins/platforms/xcb/qxcbcursor.cpp
-index fbadab4d..c83ce0af 100644
+index fbadab4d50..c83ce0af5b 100644
 --- a/src/plugins/platforms/xcb/qxcbcursor.cpp
 +++ b/src/plugins/platforms/xcb/qxcbcursor.cpp
 @@ -317,10 +317,10 @@ QXcbCursor::QXcbCursor(QXcbConnection *conn, QXcbScreen *screen)
@@ -25,5 +25,5 @@ index fbadab4d..c83ce0af 100644
          }
          if (xcursorFound) {
 -- 
-2.22.1
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0008-qtbase-xcompose.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0008-qtbase-xcompose.patch
@@ -1,4 +1,4 @@
-From 47b2bed58224bda2267480604707a580dc17dd1f Mon Sep 17 00:00:00 2001
+From b7c1c103ba04e76ae498f87ca9ef2c4e09e36d7e Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:36:10 -0500
 Subject: [PATCH 08/11] qtbase-xcompose
@@ -8,7 +8,7 @@ Subject: [PATCH 08/11] qtbase-xcompose
  1 file changed, 1 insertion(+), 4 deletions(-)
 
 diff --git a/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp b/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
-index b5a0a5bb..6c20305f 100644
+index b5a0a5bbeb..6c20305f4d 100644
 --- a/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
 +++ b/src/plugins/platforminputcontexts/compose/generator/qtablegenerator.cpp
 @@ -265,12 +265,9 @@ void TableGenerator::initPossibleLocations()
@@ -26,5 +26,5 @@ index b5a0a5bb..6c20305f 100644
  
  QString TableGenerator::findComposeFile()
 -- 
-2.22.1
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0008-qtbase-xcompose.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0008-qtbase-xcompose.patch
@@ -1,7 +1,7 @@
 From b7c1c103ba04e76ae498f87ca9ef2c4e09e36d7e Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:36:10 -0500
-Subject: [PATCH 08/11] qtbase-xcompose
+Subject: [PATCH 08/12] qtbase-xcompose
 
 ---
  .../compose/generator/qtablegenerator.cpp                    | 5 +----

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0009-qtbase-tzdir.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0009-qtbase-tzdir.patch
@@ -1,7 +1,7 @@
 From db9686362ae34e02538e449e0edfe3d61065b2e9 Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:36:25 -0500
-Subject: [PATCH 09/11] qtbase-tzdir
+Subject: [PATCH 09/12] qtbase-tzdir
 
 ---
  src/corelib/tools/qtimezoneprivate_tz.cpp | 20 ++++++++++++++------

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0009-qtbase-tzdir.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0009-qtbase-tzdir.patch
@@ -1,4 +1,4 @@
-From 354713a61005b9a4743b9db0d76c72514c4579f8 Mon Sep 17 00:00:00 2001
+From db9686362ae34e02538e449e0edfe3d61065b2e9 Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:36:25 -0500
 Subject: [PATCH 09/11] qtbase-tzdir
@@ -8,10 +8,10 @@ Subject: [PATCH 09/11] qtbase-tzdir
  1 file changed, 14 insertions(+), 6 deletions(-)
 
 diff --git a/src/corelib/tools/qtimezoneprivate_tz.cpp b/src/corelib/tools/qtimezoneprivate_tz.cpp
-index 7d85bc07..c13d99b8 100644
+index 57bc000af5..d7d8119682 100644
 --- a/src/corelib/tools/qtimezoneprivate_tz.cpp
 +++ b/src/corelib/tools/qtimezoneprivate_tz.cpp
-@@ -71,7 +71,11 @@ typedef QHash<QByteArray, QTzTimeZone> QTzTimeZoneHash;
+@@ -77,7 +77,11 @@ typedef QHash<QByteArray, QTzTimeZone> QTzTimeZoneHash;
  // Parse zone.tab table, assume lists all installed zones, if not will need to read directories
  static QTzTimeZoneHash loadTzTimeZones()
  {
@@ -24,7 +24,7 @@ index 7d85bc07..c13d99b8 100644
      if (!QFile::exists(path))
          path = QStringLiteral("/usr/lib/zoneinfo/zone.tab");
  
-@@ -650,12 +654,16 @@ void QTzTimeZonePrivate::init(const QByteArray &ianaId)
+@@ -656,12 +660,16 @@ void QTzTimeZonePrivate::init(const QByteArray &ianaId)
          if (!tzif.open(QIODevice::ReadOnly))
              return;
      } else {
@@ -47,5 +47,5 @@ index 7d85bc07..c13d99b8 100644
      }
  
 -- 
-2.22.1
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0010-qtbase-qtpluginpath.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0010-qtbase-qtpluginpath.patch
@@ -1,7 +1,7 @@
 From a3aaebda6d4b302cd202c21e306c55d3715e9b0d Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:36:41 -0500
-Subject: [PATCH 10/11] qtbase-qtpluginpath
+Subject: [PATCH 10/12] qtbase-qtpluginpath
 
 ---
  src/corelib/kernel/qcoreapplication.cpp | 9 +++++++++

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0010-qtbase-qtpluginpath.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0010-qtbase-qtpluginpath.patch
@@ -1,4 +1,4 @@
-From 571060c0e1dca29554cc97cfb33087c9b41114a5 Mon Sep 17 00:00:00 2001
+From a3aaebda6d4b302cd202c21e306c55d3715e9b0d Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:36:41 -0500
 Subject: [PATCH 10/11] qtbase-qtpluginpath
@@ -8,10 +8,10 @@ Subject: [PATCH 10/11] qtbase-qtpluginpath
  1 file changed, 9 insertions(+)
 
 diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
-index 8652c456..74562272 100644
+index db6546028a..cc97c46004 100644
 --- a/src/corelib/kernel/qcoreapplication.cpp
 +++ b/src/corelib/kernel/qcoreapplication.cpp
-@@ -2690,6 +2690,15 @@ QStringList QCoreApplication::libraryPaths()
+@@ -2694,6 +2694,15 @@ QStringList QCoreApplication::libraryPaths()
          QStringList *app_libpaths = new QStringList;
          coreappdata()->app_libpaths.reset(app_libpaths);
  
@@ -28,5 +28,5 @@ index 8652c456..74562272 100644
          if (!libPathEnv.isEmpty()) {
              QStringList paths = libPathEnv.split(QDir::listSeparator(), QString::SkipEmptyParts);
 -- 
-2.22.1
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0011-qtbase-assert.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0011-qtbase-assert.patch
@@ -1,7 +1,7 @@
 From 4f93027de0e9b825c4b7853d583e9b02a0443c6b Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:37:04 -0500
-Subject: [PATCH 11/11] qtbase-assert
+Subject: [PATCH 11/12] qtbase-assert
 
 ---
  src/testlib/qtestassert.h | 7 +++++--

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0011-qtbase-assert.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0011-qtbase-assert.patch
@@ -1,4 +1,4 @@
-From 545e696e270a3879dd59f71d145e31a7d93ab8f4 Mon Sep 17 00:00:00 2001
+From 4f93027de0e9b825c4b7853d583e9b02a0443c6b Mon Sep 17 00:00:00 2001
 From: Thomas Tuegel <ttuegel@mailbox.org>
 Date: Tue, 17 Sep 2019 05:37:04 -0500
 Subject: [PATCH 11/11] qtbase-assert
@@ -8,7 +8,7 @@ Subject: [PATCH 11/11] qtbase-assert
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/src/testlib/qtestassert.h b/src/testlib/qtestassert.h
-index 6498ea84..d821ced7 100644
+index 6498ea84ef..d821ced7fc 100644
 --- a/src/testlib/qtestassert.h
 +++ b/src/testlib/qtestassert.h
 @@ -44,10 +44,13 @@
@@ -28,5 +28,5 @@ index 6498ea84..d821ced7 100644
  QT_END_NAMESPACE
  
 -- 
-2.22.1
+2.23.GIT
 

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0012-fix-header_module.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0012-fix-header_module.patch
@@ -1,0 +1,25 @@
+From 7abf00d01ed0a3099cb2f5950c7ebc57a3960094 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Mon, 30 Sep 2019 20:15:40 -0500
+Subject: [PATCH 12/12] fix header_module
+
+---
+ mkspecs/features/qt_module.prf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mkspecs/features/qt_module.prf b/mkspecs/features/qt_module.prf
+index 9015b30d73..351a46227f 100644
+--- a/mkspecs/features/qt_module.prf
++++ b/mkspecs/features/qt_module.prf
+@@ -84,7 +84,7 @@ header_module {
+         CONFIG  += qt_no_install_library
+ 
+     # Allow creation of .prl, .la and .pc files.
+-    target.path = $$[QT_INSTALL_LIBS]
++    target.path = $$NIXOS_OUTPUT_OUT/lib
+     target.CONFIG += dummy_install
+     INSTALLS    += target
+ } else {
+-- 
+2.23.GIT
+

--- a/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0012-fix-header_module.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase.patch.d/0012-fix-header_module.patch
@@ -1,4 +1,4 @@
-From 7abf00d01ed0a3099cb2f5950c7ebc57a3960094 Mon Sep 17 00:00:00 2001
+From 821db0c3056a813e2d0d36fbb2c7361df5559b05 Mon Sep 17 00:00:00 2001
 From: Will Dietz <w@wdtz.org>
 Date: Mon, 30 Sep 2019 20:15:40 -0500
 Subject: [PATCH 12/12] fix header_module
@@ -8,7 +8,7 @@ Subject: [PATCH 12/12] fix header_module
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/mkspecs/features/qt_module.prf b/mkspecs/features/qt_module.prf
-index 9015b30d73..351a46227f 100644
+index 9015b30d73..7347c791b4 100644
 --- a/mkspecs/features/qt_module.prf
 +++ b/mkspecs/features/qt_module.prf
 @@ -84,7 +84,7 @@ header_module {
@@ -16,7 +16,7 @@ index 9015b30d73..351a46227f 100644
  
      # Allow creation of .prl, .la and .pc files.
 -    target.path = $$[QT_INSTALL_LIBS]
-+    target.path = $$NIXOS_OUTPUT_OUT/lib
++    target.path = $$NIX_OUTPUT_OUT/lib
      target.CONFIG += dummy_install
      INSTALLS    += target
  } else {

--- a/pkgs/development/libraries/qt-5/5.12/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.12/srcs.nix
@@ -3,323 +3,323 @@
 
 {
   qt3d = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qt3d-everywhere-src-5.12.4.tar.xz";
-      sha256 = "cfad2e16f40fa07f8be59fa29c0c246743ee67db417ca29772a92f36fa322af3";
-      name = "qt3d-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qt3d-everywhere-src-5.12.5.tar.xz";
+      sha256 = "2a35b144768c7ad8a9265d16a04f038d9bc51016bd2c4b2b516e374f81ff29c4";
+      name = "qt3d-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtactiveqt-everywhere-src-5.12.4.tar.xz";
-      sha256 = "d3c78e6c2a75b9d4f9685d4eea6e84f44f97034a54aed7a159c53cfd4ec4eac7";
-      name = "qtactiveqt-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtactiveqt-everywhere-src-5.12.5.tar.xz";
+      sha256 = "d673a1269dd900c78dbfe88eb16e086e36d236571722712a64401cdec7b73a40";
+      name = "qtactiveqt-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtandroidextras-everywhere-src-5.12.4.tar.xz";
-      sha256 = "18e0dbd82920b0ca51b29172fc0ed1f2a923cb7c4fa8fb574595abc16ec3245e";
-      name = "qtandroidextras-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtandroidextras-everywhere-src-5.12.5.tar.xz";
+      sha256 = "f115ccef1e808da7c5d0348f3e245952a2973966f34d18b935f9e3eb16062eab";
+      name = "qtandroidextras-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtbase = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtbase-everywhere-src-5.12.4.tar.xz";
-      sha256 = "20fbc7efa54ff7db9552a7a2cdf9047b80253c1933c834f35b0bc5c1ae021195";
-      name = "qtbase-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtbase-everywhere-src-5.12.5.tar.xz";
+      sha256 = "fc8abffbbda9da3e593d8d62b56bc17dbaab13ff71b72915ddda11dabde4d625";
+      name = "qtbase-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtcanvas3d = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtcanvas3d-everywhere-src-5.12.4.tar.xz";
-      sha256 = "d7e0e8aa542d077a929fb7700411ca9de1f65ae4748d64168d2e7533facd7869";
-      name = "qtcanvas3d-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtcanvas3d-everywhere-src-5.12.5.tar.xz";
+      sha256 = "1553e06ce3cc5afb36aed3698b85c00e734eac07f7f41895426bebd84216d80c";
+      name = "qtcanvas3d-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtcharts = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtcharts-everywhere-src-5.12.4.tar.xz";
-      sha256 = "06ff68a80dc377847429cdd87d4e46465e1d6fbc417d52700a0a59d197669c9e";
-      name = "qtcharts-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtcharts-everywhere-src-5.12.5.tar.xz";
+      sha256 = "4c7c30a916ba0100a1635b89f48bc5a8af4cdedac79c3fc18456af54dc0a6608";
+      name = "qtcharts-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtconnectivity-everywhere-src-5.12.4.tar.xz";
-      sha256 = "749d05242b9fae12e80f569fb6b918dc011cb191eeb05147cbde474ca6b173ef";
-      name = "qtconnectivity-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtconnectivity-everywhere-src-5.12.5.tar.xz";
+      sha256 = "bdf62c72d689f47c4d17ecdde934d9f85a1164091e58fce02873de259e8de88b";
+      name = "qtconnectivity-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtdatavis3d-everywhere-src-5.12.4.tar.xz";
-      sha256 = "1c160eeb430c8602aaee8ae4faa55bc62f880dae642be5fd1ac019f7886eb15a";
-      name = "qtdatavis3d-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtdatavis3d-everywhere-src-5.12.5.tar.xz";
+      sha256 = "1de165bf5330c7fb18c6fbb8c0e5cda47fa19c2eaba657b3792fd75e653444f3";
+      name = "qtdatavis3d-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtdeclarative-everywhere-src-5.12.4.tar.xz";
-      sha256 = "614105ed73079d67d81b34fef31c9934c5e751342e4b2e0297128c8c301acda7";
-      name = "qtdeclarative-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtdeclarative-everywhere-src-5.12.5.tar.xz";
+      sha256 = "22c5323d4b01259e6e352eef1b54129d6dfee00a406f0312905fa7db322b9190";
+      name = "qtdeclarative-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtdoc = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtdoc-everywhere-src-5.12.4.tar.xz";
-      sha256 = "93e6cb6abc0dad3a831a6e2c46d950bd7a99b59d60ce2d2b81c2ce893bfb41bb";
-      name = "qtdoc-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtdoc-everywhere-src-5.12.5.tar.xz";
+      sha256 = "f1de30227b8854c284e9c23e9c0c44d9fe768880aef826b0f880a44dd7c7538d";
+      name = "qtdoc-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtgamepad = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtgamepad-everywhere-src-5.12.4.tar.xz";
-      sha256 = "25de6f10fb18f2484d1e569688bf33deb90ecbfb97ce41c2b5fb3521146e4c45";
-      name = "qtgamepad-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtgamepad-everywhere-src-5.12.5.tar.xz";
+      sha256 = "de88f01d47f7cc5d54a1af783c5fae9f2b0101948ff33b8290f71b2657aded33";
+      name = "qtgamepad-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtgraphicaleffects = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtgraphicaleffects-everywhere-src-5.12.4.tar.xz";
-      sha256 = "0bc38b168fa724411984525173d667aa47076c8cbd4eeb791d0da7fe4b9bdf73";
-      name = "qtgraphicaleffects-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtgraphicaleffects-everywhere-src-5.12.5.tar.xz";
+      sha256 = "bdbddba7e0e0d041809a98d97c07da8be8936ec48537335cbaea9b0049c646ad";
+      name = "qtgraphicaleffects-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtimageformats = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtimageformats-everywhere-src-5.12.4.tar.xz";
-      sha256 = "2dee25c3eea90d172cbd40f41450153322b902da1daa7d2370a55124b2307bb3";
-      name = "qtimageformats-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtimageformats-everywhere-src-5.12.5.tar.xz";
+      sha256 = "9f19394830542fb9e6bde6806b6216b7207f96bff674b91e8e8a8f89699e1f0a";
+      name = "qtimageformats-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtlocation = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtlocation-everywhere-src-5.12.4.tar.xz";
-      sha256 = "127b40bd7679fead3fb98f4c9c1d71dde9d6d416e90a6000129b61a5f128b3a0";
-      name = "qtlocation-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtlocation-everywhere-src-5.12.5.tar.xz";
+      sha256 = "12c8b59755abc4ca56e135e8ae3db7c6ba1bd95c779060f10a01393ae1040122";
+      name = "qtlocation-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtmacextras = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtmacextras-everywhere-src-5.12.4.tar.xz";
-      sha256 = "3ea0b94f9b63e801f2ddafa2a908002d9529a3c65021d261627d21e07454acde";
-      name = "qtmacextras-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtmacextras-everywhere-src-5.12.5.tar.xz";
+      sha256 = "984c3c95834aaa6fd85234ab1987a79662911c510e419611ce88fb4756313194";
+      name = "qtmacextras-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtmultimedia-everywhere-src-5.12.4.tar.xz";
-      sha256 = "7c0759ab6fca2480b10b71a35beeffe0b847adeff5af94eacd1a4531d033423d";
-      name = "qtmultimedia-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtmultimedia-everywhere-src-5.12.5.tar.xz";
+      sha256 = "d5a0a4fddc5ef14d641160a1fc0011b190ff8d9f19009498d586516b8ee3479c";
+      name = "qtmultimedia-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtnetworkauth-everywhere-src-5.12.4.tar.xz";
-      sha256 = "e501eb46b8405a2b7db9fe90a1c224cf6676a07dc22c0662317ffe3dee1dbf55";
-      name = "qtnetworkauth-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtnetworkauth-everywhere-src-5.12.5.tar.xz";
+      sha256 = "0933475a2d30550c70ce4026c72678cbfdac73211593c78d442e038ef531a9f1";
+      name = "qtnetworkauth-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtpurchasing = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtpurchasing-everywhere-src-5.12.4.tar.xz";
-      sha256 = "7804a111043d0e8d6d81a0d0ae465ce2c36eca73f2774ccb5fa7be8670211672";
-      name = "qtpurchasing-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtpurchasing-everywhere-src-5.12.5.tar.xz";
+      sha256 = "7bcebc4985d387f3fa4ffcc19eada1f4f0f000ed0fd3e1d1dc37eb1db0be615b";
+      name = "qtpurchasing-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtquickcontrols-everywhere-src-5.12.4.tar.xz";
-      sha256 = "32d4c2505337c67b0bac26d7f565ec8fabdc616e61247e98674820769dda9858";
-      name = "qtquickcontrols-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtquickcontrols-everywhere-src-5.12.5.tar.xz";
+      sha256 = "46deaefbdac3daa576c748e807956f5f82b2318923b1a36e434a3ff32d1d2559";
+      name = "qtquickcontrols-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtquickcontrols2 = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtquickcontrols2-everywhere-src-5.12.4.tar.xz";
-      sha256 = "9a447eed38bc8c7d7be7bc407317f58940377c077ddca74c9a641b1ee6200331";
-      name = "qtquickcontrols2-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtquickcontrols2-everywhere-src-5.12.5.tar.xz";
+      sha256 = "d744bdc492486db6cb521b1d4891e2358719399825ca1cf2a50968a80f6acb8f";
+      name = "qtquickcontrols2-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtremoteobjects-everywhere-src-5.12.4.tar.xz";
-      sha256 = "54dd0c782abff90bf0608771c2e90b36073d9bd8d6c61706a2873bb7c317f413";
-      name = "qtremoteobjects-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtremoteobjects-everywhere-src-5.12.5.tar.xz";
+      sha256 = "acf131af93dd1fefbf30c7e03e29b8a1da3180e00c49f95c14a1cb6158cfeacd";
+      name = "qtremoteobjects-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtscript = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtscript-everywhere-src-5.12.4.tar.xz";
-      sha256 = "7adb3fe77638c7a6f2a26bca850b0ff54f5fb7e5561d2e4141d14a84305c2b6a";
-      name = "qtscript-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtscript-everywhere-src-5.12.5.tar.xz";
+      sha256 = "0083734ae827840334b774decb15de37f1b4ea5c88e442e2f485c530f24f1df4";
+      name = "qtscript-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtscxml = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtscxml-everywhere-src-5.12.4.tar.xz";
-      sha256 = "696fb72a62018151275fe589fc80cb160d2becab9a3254321d40e2e11a0ad4f8";
-      name = "qtscxml-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtscxml-everywhere-src-5.12.5.tar.xz";
+      sha256 = "6f1ec74100cdb2e7dfc3535e09d356fc53ba42e61b32fc3b93d5a7efed49960c";
+      name = "qtscxml-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtsensors = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtsensors-everywhere-src-5.12.4.tar.xz";
-      sha256 = "95873c7ea5960008d6eb41368ca64d68fbd05594ca8c2cd848b1612fc4aec0a9";
-      name = "qtsensors-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtsensors-everywhere-src-5.12.5.tar.xz";
+      sha256 = "e3a86a706f475bb23fc874de56026482de223ebd24f8cb4e94a28d1985ca0b85";
+      name = "qtsensors-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtserialbus = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtserialbus-everywhere-src-5.12.4.tar.xz";
-      sha256 = "69d56905f43ee13e670750e8f46d373835fae81d6343baa7c4004d2a2c6311fc";
-      name = "qtserialbus-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtserialbus-everywhere-src-5.12.5.tar.xz";
+      sha256 = "8474ae61a703c56e327ae0755c27643f2eafe0d915e8c6afb21728548dc02c22";
+      name = "qtserialbus-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtserialport = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtserialport-everywhere-src-5.12.4.tar.xz";
-      sha256 = "bf487df8a9fb2eddf103842b57a75b17ef4c498ee40306ae9997017c82b0ad39";
-      name = "qtserialport-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtserialport-everywhere-src-5.12.5.tar.xz";
+      sha256 = "f8ef0321a59ecfe2c72adc2ee220e0047403439a3c7b9efb719b1476af1fb862";
+      name = "qtserialport-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtspeech = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtspeech-everywhere-src-5.12.4.tar.xz";
-      sha256 = "2ff9660fb3f5663c9161f491d1a304db62691720136ae22c145ef6a1c94b90ec";
-      name = "qtspeech-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtspeech-everywhere-src-5.12.5.tar.xz";
+      sha256 = "f94c0cd7236d1a20d97d314d2c17c45c967cd7f24b869c43f5f46253f436f25b";
+      name = "qtspeech-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtsvg = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtsvg-everywhere-src-5.12.4.tar.xz";
-      sha256 = "110812515a73c650e5ebc41305d9a243dadeb21f485aaed773e394dd84ce0d04";
-      name = "qtsvg-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtsvg-everywhere-src-5.12.5.tar.xz";
+      sha256 = "75a791cf749f671d7ea9090b403ca513f745795018db512e7eecbf418b679840";
+      name = "qtsvg-everywhere-src-5.12.5.tar.xz";
     };
   };
   qttools = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qttools-everywhere-src-5.12.4.tar.xz";
-      sha256 = "3b0e353860a9c0cd4db9eeae5f94fef8811ed7d107e3e5e97e4a557f61bd6eb6";
-      name = "qttools-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qttools-everywhere-src-5.12.5.tar.xz";
+      sha256 = "28e095047b4985437dd66120cbcb49ac091bf4f12576ecad7ebc781b7dd44025";
+      name = "qttools-everywhere-src-5.12.5.tar.xz";
     };
   };
   qttranslations = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qttranslations-everywhere-src-5.12.4.tar.xz";
-      sha256 = "ab8dd55f5ca869cab51c3a6ce0888f854b96dc03c7f25d2bd3d2c50314ab60fb";
-      name = "qttranslations-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qttranslations-everywhere-src-5.12.5.tar.xz";
+      sha256 = "72eb6317190fdcc3f8de37996adc646ab8772988766bacaab60a5bcc7d6a3f2a";
+      name = "qttranslations-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtvirtualkeyboard-everywhere-src-5.12.4.tar.xz";
-      sha256 = "33ac0356f916995fe5a91582e12b4c4f730c705808ea3c14e75c6e350e8131e6";
-      name = "qtvirtualkeyboard-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtvirtualkeyboard-everywhere-src-5.12.5.tar.xz";
+      sha256 = "786d745b34b1f145073488d492325e98bcde81b07ab984032ea5eb2fb52e6e5e";
+      name = "qtvirtualkeyboard-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtwayland = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtwayland-everywhere-src-5.12.4.tar.xz";
-      sha256 = "2fade959c3927687134c597d85c12ba1af22129a60ab326c2dc77a648e74e6b7";
-      name = "qtwayland-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtwayland-everywhere-src-5.12.5.tar.xz";
+      sha256 = "29fd31267149451f93faa15f031e0a14506e704086033f70d51479522c6f3846";
+      name = "qtwayland-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtwebchannel-everywhere-src-5.12.4.tar.xz";
-      sha256 = "ab571a1b699e61a86be1a6b8d6ffd998d431c4850cc27e9a21f81fa5923bfdb7";
-      name = "qtwebchannel-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtwebchannel-everywhere-src-5.12.5.tar.xz";
+      sha256 = "9f1d1ac20722ee053ecf071d4ec0070a45a765cb67b6e31add61004fb4b3c5e8";
+      name = "qtwebchannel-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtwebengine = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtwebengine-everywhere-src-5.12.4.tar.xz";
-      sha256 = "fccf5c945412c19c3805323211b504ac8becbf191c638a2dc85ec91abfb1b331";
-      name = "qtwebengine-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtwebengine-everywhere-src-5.12.5.tar.xz";
+      sha256 = "31881130e69eb8336e9480f9f33cd5a93e86de8d7323c0ae1893e1a72ce70743";
+      name = "qtwebengine-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtwebglplugin = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtwebglplugin-everywhere-src-5.12.4.tar.xz";
-      sha256 = "756fa09893618029bb56605be3ac5756a1834255fb223f8e4b7de205846d3266";
-      name = "qtwebglplugin-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtwebglplugin-everywhere-src-5.12.5.tar.xz";
+      sha256 = "aac3b2b2e5b6f26dd7abba6eab616777fecbb4d06de05ddab68c1296652bc4f7";
+      name = "qtwebglplugin-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtwebsockets-everywhere-src-5.12.4.tar.xz";
-      sha256 = "b471eda2f486d21c51fc3bc53bb8844022117e746d5f15c5eabb82cd37eb2abe";
-      name = "qtwebsockets-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtwebsockets-everywhere-src-5.12.5.tar.xz";
+      sha256 = "5d58e697c49c0ea19a8299deba84b5360dca8c336a1636d38de0351757293262";
+      name = "qtwebsockets-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtwebview = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtwebview-everywhere-src-5.12.4.tar.xz";
-      sha256 = "1f244c6b774dd9d03d3c5cafe877381900b50a2775cef6487c8bb66e32ab5a5d";
-      name = "qtwebview-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtwebview-everywhere-src-5.12.5.tar.xz";
+      sha256 = "a6d4d8c335cd6838f4638874fcd67655e80db569ed567a774a84f6bf7d332f26";
+      name = "qtwebview-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtwinextras = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtwinextras-everywhere-src-5.12.4.tar.xz";
-      sha256 = "f6e0172582a499d5e50c51877552d1a3bff66546d9a02e5754100a51b192973f";
-      name = "qtwinextras-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtwinextras-everywhere-src-5.12.5.tar.xz";
+      sha256 = "7ee2fc73bc95c5e36e8ed2d02fc89822d56c406c540fbfa52bb0e3929ff2f93d";
+      name = "qtwinextras-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtx11extras-everywhere-src-5.12.4.tar.xz";
-      sha256 = "49cc009eaf4a01ca7dbe12651ef39de9a43860acb674aec372e70b209f9bae1e";
-      name = "qtx11extras-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtx11extras-everywhere-src-5.12.5.tar.xz";
+      sha256 = "89425af3e48b040878c6a64ace58c17a83b87c9330e6366b09a41d6797062a68";
+      name = "qtx11extras-everywhere-src-5.12.5.tar.xz";
     };
   };
   qtxmlpatterns = {
-    version = "5.12.4";
+    version = "5.12.5";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.12/5.12.4/submodules/qtxmlpatterns-everywhere-src-5.12.4.tar.xz";
-      sha256 = "0bea1719bb948f65cbed4375cc3e997a6464f35d25b631bafbd7a3161f8f5666";
-      name = "qtxmlpatterns-everywhere-src-5.12.4.tar.xz";
+      url = "${mirror}/official_releases/qt/5.12/5.12.5/submodules/qtxmlpatterns-everywhere-src-5.12.5.tar.xz";
+      sha256 = "b905d9107f87798ef0f142942fc45c0f63fc113522ab041e791d3cb744a8babd";
+      name = "qtxmlpatterns-everywhere-src-5.12.5.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Changes to Darwin patch occurred after I originally put this together,
so optimistically reset to what the latest change was -- which may not
apply or make sense for 5.12.5, but we'll see.

Rest I've been using for about a week now, seems good here!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @