### PR TITLE
Abort Qt builds that do not use a supported deriver

### DIFF
--- a/doc/languages-frameworks/qt.xml
+++ b/doc/languages-frameworks/qt.xml
@@ -85,18 +85,6 @@ mkDerivation {
   </para>
  </note>
 
- <para>
-  Libraries are built with every available version of Qt. Use the <literal>meta.broken</literal> attribute to disable the package for unsupported Qt versions:
-<programlisting>
-mkDerivation {
-  # ...
-
-  # Disable this library with Qt &lt; 5.9.0
-  meta.broken = builtins.compareVersions qtbase.version "5.9.0" &lt; 0;
-}
-</programlisting>
- </para>
-
  <formalpara>
   <title>Adding a library to Nixpkgs</title>
   <para>
@@ -119,6 +107,18 @@ mkDerivation {
    </example>
   </para>
  </formalpara>
+
+ <para>
+  Libraries are built with every available version of Qt. Use the <literal>meta.broken</literal> attribute to disable the package for unsupported Qt versions:
+<programlisting>
+mkDerivation {
+  # ...
+
+  # Disable this library with Qt &lt; 5.9.0
+  meta.broken = builtins.compareVersions qtbase.version "5.9.0" &lt; 0;
+}
+</programlisting>
+ </para>
 
  <formalpara>
   <title>Adding an application to Nixpkgs</title>

--- a/doc/languages-frameworks/qt.xml
+++ b/doc/languages-frameworks/qt.xml
@@ -24,7 +24,7 @@ mkDerivation { <co xml:id='qt-default-nix-co-2' />
  <calloutlist>
   <callout arearefs='qt-default-nix-co-1'>
    <para>
-    Import <literal>mkDerivation</literal> and Qt (such as <literal>qtbase</literal> modules directly. <emphasis>Do not</emphasis> import Qt package sets; the Qt versions of dependencies may not be coherent, causing build and runtime failures.
+    Import <literal>mkDerivation</literal> and Qt modules (such as <literal>qtbase</literal>) directly. <emphasis>Do not</emphasis> import Qt package sets; the Qt versions of dependencies may not be coherent, causing build and runtime failures.
    </para>
   </callout>
   <callout arearefs='qt-default-nix-co-2'>

--- a/doc/languages-frameworks/qt.xml
+++ b/doc/languages-frameworks/qt.xml
@@ -38,7 +38,6 @@ mkDerivationWith myDeriver {
   # ...
 }
 </programlisting>
-    If you cannot use <literal>mkDerivationWith</literal>, please refer to <xref linkend='qt-runtime-dependencies' />.
    </para>
   </callout>
   <callout arearefs='qt-default-nix-co-3'>
@@ -51,14 +50,7 @@ mkDerivationWith myDeriver {
  <formalpara xml:id='qt-runtime-dependencies'>
   <title>Locating runtime dependencies</title>
   <para>
-   Qt applications need to be wrapped to find runtime dependencies. If you cannot use <literal>mkDerivation</literal> or <literal>mkDerivationWith</literal> above, include <literal>wrapQtAppsHook</literal> in <literal>nativeBuildInputs</literal>:
-<programlisting>
-stdenv.mkDerivation {
-  # ...
-
-  nativeBuildInputs = [ wrapQtAppsHook ];
-}
-</programlisting>
+   Qt applications need to be wrapped to find runtime dependencies. A hook <literal>wrapQtAppsHook</literal> is provided by <literal>mkDerivation</literal> and <literal>mkDerivationWith</literal> to produce the wrappers. In most cases, the hook works automatically, but for the remaining cases, its settings are described below.
   </para>
  </formalpara>
 

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -1,3 +1,13 @@
+if [ -z "$_qt_mkDerivation" ]
+then
+    cat >&2 <<EOF
+Did not detect supported mkDerivation. Build aborted!
+
+Please refer to the Nixpkgs manual section 'Support for specific programming languages and frameworks/Qt'.
+EOF
+    exit 1
+fi
+
 qtPluginPrefix=@qtPluginPrefix@
 qtQmlPrefix=@qtQmlPrefix@
 qtDocPrefix=@qtDocPrefix@

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -1,9 +1,12 @@
 if [ -z "$_qt_mkDerivation" ]
 then
     cat >&2 <<EOF
-Did not detect supported mkDerivation. Build aborted!
+Did not detect supported 'mkDerivation'. Build aborted!
 
-Please refer to the Nixpkgs manual section 'Support for specific programming languages and frameworks/Qt'.
+Please refer to the Nixpkgs manual for help with Qt packaging:
+https://nixos.org/nixpkgs/manual/#sec-language-qt
+
+In particular, see the notes about 'mkDerivation' and 'mkDerivationWith'.
 EOF
     exit 1
 fi

--- a/pkgs/development/libraries/qt-5/mkDerivation.nix
+++ b/pkgs/development/libraries/qt-5/mkDerivation.nix
@@ -9,6 +9,9 @@ args:
 let
   args_ = {
 
+    # Satisfy the mkDerivation check in the setup hook of qtbase.
+    _qt_mkDerivation = true;
+
     qmakeFlags = [ ("CONFIG+=" + (if debug then "debug" else "release")) ]
               ++ (args.qmakeFlags or []);
 

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -17,6 +17,9 @@ mkDerivation (args // {
   inherit src;
   patches = args.patches or patches.${name} or [];
 
+  # Satisfy the mkDerivation check in the setup hook of qtbase.
+  _qt_mkDerivation = true;
+
   nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ perl self.qmake ];
   propagatedBuildInputs = args.qtInputs ++ (args.propagatedBuildInputs or []);
 


### PR DESCRIPTION

###### Motivation for this change

This will give package maintainers faster feedback to potential build and runtime problems.

See also: https://github.com/NixOS/nixpkgs/issues/65399#issuecomment-538001109

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
