### PR TITLE
Added package libvmaf.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1115,6 +1115,12 @@
     githubId = 5771456;
     name = "Chaddaï Fouché";
   };
+  cfsmp3 = {
+    email = "carlos@sanz.dev";
+    github = "cfsmp3";
+    githubId = 5949913;
+    name = "Carlos Fernandez Sanz";
+  };
   chaduffy = {
     email = "charles@dyfis.net";
     github = "charles-dyfis-net";

--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -3,7 +3,7 @@
  *  Licensing options (yes some are listed twice, filters and such are not listed)
  */
 , gplLicensing ? true # GPL: fdkaac,openssl,frei0r,cdio,samba,utvideo,vidstab,x265,x265,xavs,avid,zvbi,x11grab
-, version3Licensing ? true # (L)GPL3: opencore-amrnb,opencore-amrwb,samba,vo-aacenc,vo-amrwbenc
+, version3Licensing ? true # (L)GPL3: libvmaf,opencore-amrnb,opencore-amrwb,samba,vo-aacenc,vo-amrwbenc
 , nonfreeLicensing ? false # NONFREE: openssl,fdkaac,blackmagic-design-desktop-video
 /*
  *  Build options
@@ -87,6 +87,7 @@
 , libv4l ? null # Video 4 Linux support
 , libva ? null # Vaapi hardware acceleration
 , libvdpau ? null # Vdpau hardware acceleration
+, libvmaf ? null # Netflix's VMAF (Video Multi-Method Assessment Fusion)
 , libvorbis ? null # Vorbis de/encoding, native encoder exists
 , libvpx ? null # VP8 & VP9 de/encoding
 , libwebp ? null # WebP encoder
@@ -364,6 +365,7 @@ stdenv.mkDerivation rec {
     (enableFeature ((isLinux || isFreeBSD) && libva != null) "vaapi")
     (enableFeature (libvdpau != null) "vdpau")
     (enableFeature (libvorbis != null) "libvorbis")
+    (enableFeature (libvmaf != null && version3Licensing) "libvmaf")
     (enableFeature (libvpx != null) "libvpx")
     (enableFeature (libwebp != null) "libwebp")
     (enableFeature (libX11 != null && libXv != null && libXext != null) "xlib")
@@ -425,6 +427,7 @@ stdenv.mkDerivation rec {
   ] ++ optional openglExtlib libGLU_combined
     ++ optionals nonfreeLicensing [ fdk_aac openssl ]
     ++ optional ((isLinux || isFreeBSD) && libva != null) libva
+    ++ optional (libvmaf != null  && version3Licensing ) libvmaf
     ++ optionals isLinux [ alsaLib libraw1394 libv4l ]
     ++ optional (isLinux && !isAarch64 && libmfx != null) libmfx
     ++ optional nvenc nv-codec-headers

--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -1,11 +1,13 @@
 { stdenv, fetchurl, autoconf, automake, intltool, libtool, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "libvmaf";
+  pname = "libvmaf";
   version = "1.3.15";
 
-  src = fetchurl {
-    url="https://github.com/Netflix/vmaf/archive/v1.3.15.tar.gz";
+  src = fetchFromGitHub {
+    owner = "netflix";
+    repo = "vmaf";
+    rev = "v${version}";
     sha256="13ajbcidngjvgl0rr7l0mb43h651p5pqj3d1linrfk9c222b9fs3";
   };
 

--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, autoconf, automake, intltool, libtool, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "libvmaf";
+  version = "1.3.15";
+
+  src = fetchurl {
+    url="https://github.com/Netflix/vmaf/archive/v1.3.15.tar.gz";
+    sha256="13ajbcidngjvgl0rr7l0mb43h651p5pqj3d1linrfk9c222b9fs3";
+  };
+
+  buildInputs = [ autoconf automake intltool libtool pkgconfig ];
+  doCheck = true;
+
+  installPhase = ''
+    make INSTALL_PREFIX=$out install
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Netflix/vmaf";
+    description = "Perceptual video quality assessment based on multi-method fusion (VMAF).";
+    platforms = stdenv.lib.platforms.linux;
+    license = licenses.asl20;
+    maintainers = [ maintainers.cfsmp3 ];
+  };
+
+}

--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake, intltool, libtool, pkgconfig }:
+{ stdenv, fetchFromGitHub, autoconf, automake, intltool, libtool, pkgconfig }:
 
 stdenv.mkDerivation rec {
   pname = "libvmaf";

--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, intltool, libtool, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "libvmaf";
+  version = "1.3.15";
+
+  src = fetchFromGitHub {
+    owner = "netflix";
+    repo = "vmaf";
+    rev = "v${version}";
+    sha256="13ajbcidngjvgl0rr7l0mb43h651p5pqj3d1linrfk9c222b9fs3";
+  };
+
+  nativeBuildInputs = [ autoconf automake intltool libtool pkgconfig ];
+  doCheck = true;
+
+  installPhase = ''
+    make INSTALL_PREFIX=$out install
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Netflix/vmaf";
+    description = "Perceptual video quality assessment based on multi-method fusion (VMAF).";
+    platforms = platforms.linux;
+    license = licenses.asl20;
+    maintainers = [ maintainers.cfsmp3 ];
+  };
+
+}

--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://github.com/Netflix/vmaf";
     description = "Perceptual video quality assessment based on multi-method fusion (VMAF).";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = platforms.linux;
     license = licenses.asl20;
     maintainers = [ maintainers.cfsmp3 ];
   };

--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256="13ajbcidngjvgl0rr7l0mb43h651p5pqj3d1linrfk9c222b9fs3";
   };
 
-  buildInputs = [ autoconf automake intltool libtool pkgconfig ];
+  nativeBuildInputs = [ autoconf automake intltool libtool pkgconfig ];
   doCheck = true;
 
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12560,6 +12560,8 @@ in
 
   libvisual = callPackage ../development/libraries/libvisual { };
 
+  libvmaf = callPackage ../development/libraries/libvmaf { };
+
   libvncserver = callPackage ../development/libraries/libvncserver {};
 
   libviper = callPackage ../development/libraries/libviper { };


### PR DESCRIPTION
###### Motivation for this change

VMAF is netflix's video quality scoring library. 
FFmpeg supports it as a build option. This is the first of two PR - the 2nd being of course for FFmpeg itself.

###### Things done

Created package file. Tested on Linux (Ubuntu). It's a standard build though, nothing fancy here.

Nothing pre-existing depends on this package, but I've tested of course that FFmpeg builds with it when the relevant option is enabled.

Added myself as a maintainer.

Followed the contribution guide as best as I could.

