### PR TITLE
[19.09] libguestfs: unmark as broken

### DIFF
--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -85,6 +85,5 @@ stdenv.mkDerivation rec {
     homepage = http://libguestfs.org/;
     maintainers = with maintainers; [offline];
     platforms = platforms.linux;
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This doesn't [look broken](https://hydra.nixos.org/job/nixos/release-19.09/nixpkgs.libguestfs.x86_64-linux)?

This was marked broken in https://github.com/NixOS/nixpkgs/commit/e6754980264fe927320d5ff2dbd24ca4fac9a160

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @offlinehacker
and @lheckemann @disassembler 