### PR TITLE
swipl: 8.1.4 -> 8.1.15

### DIFF
--- a/pkgs/development/compilers/pakcs/default.nix
+++ b/pkgs/development/compilers/pakcs/default.nix
@@ -4,13 +4,13 @@
 , curl, git, unzip, gnutar, coreutils, sqlite }:
 
 let
-  name = "pakcs-2.1.1";
+  name = "pakcs-2.1.2";
 
   # Don't switch to development release without a reason, because its
   # source updates without version bump. Prefer current release instead.
   src = fetchurl {
     url = "https://www.informatik.uni-kiel.de/~pakcs/download/${name}-src.tar.gz";
-    sha256 = "112v9ynqfbbm4x770mcfrai9v5bh7c3zn7jka80pv6v4y65r778c";
+    sha256 = "0i0nprli3knc7zlp5qkqkpiq3ny36v52hnvgph376l3ajjds7wf6";
   };
 
   curry-frontend = (haskellPackages.override {
@@ -43,9 +43,14 @@ in stdenv.mkDerivation {
     # Since we can't expand $out in `makeFlags`
     #makeFlags="$makeFlags PAKCSINSTALLDIR=$out/pakcs"
 
-    substituteInPlace currytools/cpm/src/CPM/Repository.curry \
-      --replace "/bin/rm" "rm"
-  '';
+    for file in currytools/cpm/src/CPM/Repository.curry \
+                currytools/cpm/src/CPM/Repository/CacheDB.curry \
+                scripts/compile-all-libs.sh \
+                scripts/cleancurry.sh \
+                examples/test.sh testsuite/test.sh lib/test.sh; do
+        substituteInPlace $file --replace "/bin/rm" "rm"
+    done
+  '' ;
 
   # cypm new: EXISTENCE ERROR: source_sink
   # "/tmp/nix-build-pakcs-2.0.2.drv-0/pakcs-2.0.2/currytools/cpm/templates/LICENSE"

--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "8.1.4";
+  version = "8.1.15";
   packInstall = swiplPath: pack:
     ''${swiplPath}/bin/swipl -g "pack_install(${pack}, [package_directory(\"${swiplPath}/lib/swipl/pack\"), silent(true), interactive(false)])." -t "halt."
     '';
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   src = fetchgit {
     url = "https://github.com/SWI-Prolog/swipl-devel";
     rev = "V${version}";
-    sha256 = "0qxa6f5dypwczxajlf0l736adbjb17cbak3qsh5g04hpv2bxm6dh";
+    sha256 = "0czbrscx2s4079nmwvipp9cnwfny16m3fpnp823llm7wyljchgvq";
   };
 
   buildInputs = [ cacert git cmake gmp readline openssl


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

8.1.4 can no longer download SWI-Prolog packages (pack_list,
pack_install, etc), rendering it much less useful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @meditans
