### PR TITLE
devpi-client: 4.1.0 -> 5.0.0

### DIFF
--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -1,40 +1,65 @@
 { stdenv
-, pythonPackages
+, buildPythonApplication
+, fetchPypi
+# buildInputs
 , glibcLocales
+, pkginfo
+, check-manifest
+# propagatedBuildInputs
+, py
+, devpi-common
+, pluggy
+, setuptools
+# CheckInputs
+, pytest
+, pytest-flake8
+, webtest
+, mock
 , devpi-server
+, tox
+, sphinx
+, wheel
 , git
 , mercurial
 } :
 
-pythonPackages.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "devpi-client";
-  version = "4.1.0";
+  version = "5.0.0";
 
-  src = pythonPackages.fetchPypi {
+  src = fetchPypi {
     inherit pname version;
-    sha256 = "0f5jkvxx9fl8v5vwbwmplqhjsdfgiib7j3zvn0zxd8krvi2s38fq";
+    sha256 = "0hyj3xc5c6658slk5wgcr9rh7hwi5r3hzxk1p6by61sqx5r38v3q";
   };
 
-  checkInputs = with pythonPackages; [
-                    pytest pytest-flakes webtest mock
-                    devpi-server tox
-                    sphinx wheel git mercurial detox
-                    setuptools
-                    ];
+  buildInputs = [ glibcLocales pkginfo check-manifest ];
+
+  propagatedBuildInputs = [ py devpi-common pluggy setuptools ];
+
+  checkInputs = [
+    pytest pytest-flake8 webtest mock
+    devpi-server tox
+    sphinx wheel git mercurial
+  ];
+
   checkPhase = ''
     export PATH=$PATH:$out/bin
     export HOME=$TMPDIR # fix tests failing in sandbox due to "/homeless-shelter"
 
-    # setuptools do not get propagated into the tox call (cannot import setuptools)
-    rm testing/test_test.py
+    # test_pypi_index_attributes: tries to connect to upstream pypi
+    # test_test: setuptools does not get propagated into the tox call (cannot import setuptools), also no detox
+    # test_index: hangs forever
+    # test_upload: fails multiple times with
+    # > assert args[0], args
+    # F AssertionError: [None, local('/build/pytest-of-nixbld/pytest-0/test_export_attributes_git_set0/repo2/setupdir/setup.py'), '--name']
 
-    # test_pypi_index_attributes tries to connect to upstream pypi
-    py.test -k 'not test_pypi_index_attributes' testing
+    py.test -k 'not test_pypi_index_attributes \
+                and not test_test \
+                and not test_index \
+                and not test_upload' testing
   '';
 
   LC_ALL = "en_US.UTF-8";
-  buildInputs = with pythonPackages; [ glibcLocales pkginfo check-manifest ];
-  propagatedBuildInputs = with pythonPackages; [ py devpi-common pluggy setuptools ];
 
   meta = with stdenv.lib; {
     homepage = http://doc.devpi.net;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7519,7 +7519,7 @@ in
 
   dbmate = callPackage ../development/tools/database/dbmate { };
 
-  devpi-client = callPackage ../development/tools/devpi-client {};
+  devpi-client = python3Packages.callPackage ../development/tools/devpi-client {};
 
   devpi-server = callPackage ../development/tools/devpi-server {};
 


### PR DESCRIPTION


###### Motivation for this change
devpi-client was broken for quite some time, this PR:
* unbreaks the package
* cleans up dependencies
* and makes deps overridable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nlewo 
