### PR TITLE
ocamlPackages.digestif: 0.5 → 0.8.0

### DIFF
--- a/pkgs/development/ocaml-modules/digestif/default.nix
+++ b/pkgs/development/ocaml-modules/digestif/default.nix
@@ -1,27 +1,26 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
+{ lib, fetchurl, buildDunePackage
+, bigarray-compat, eqaf, stdlib-shims
+, alcotest
+}:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.3"
-then throw "digestif is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-digestif-${version}";
-  version = "0.5";
+buildDunePackage rec {
+  pname = "digestif";
+  version = "0.8.0";
 
   src = fetchurl {
-    url = "https://github.com/mirage/digestif/releases/download/v${version}/digestif-${version}.tbz";
-    sha256 = "0fsyfi5ps17j3wjav5176gf6z3a5xcw9aqhcr1gml9n9ayfbkhrd";
+    url = "https://github.com/mirage/digestif/releases/download/v${version}/digestif-v${version}.tbz";
+    sha256 = "09g4zngqiw97cljv8ds4m063wcxz3y7c7vzaprsbpjzi0ja5jdcy";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = lib.optional doCheck alcotest;
+  propagatedBuildInputs = [ bigarray-compat eqaf stdlib-shims ];
 
-  inherit (topkg) buildPhase installPhase;
+  doCheck = true;
 
   meta = {
     description = "Simple hash algorithms in OCaml";
     homepage = "https://github.com/mirage/digestif";
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/eqaf/default.nix
+++ b/pkgs/development/ocaml-modules/eqaf/default.nix
@@ -1,0 +1,20 @@
+{ lib, fetchurl, buildDunePackage }:
+
+buildDunePackage rec {
+  minimumOCamlVersion = "4.03";
+  pname = "eqaf";
+  version = "0.5";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/eqaf/releases/download/v${version}/eqaf-v${version}.tbz";
+    sha256 = "1wkkmw8q2ml7ifpg0g06y0sclq0zvjf6dpsi36dnci7f230q3vsq";
+  };
+
+  meta = {
+    description = "Constant time equal function to avoid timing attacks in OCaml";
+    homepage = "https://github.com/mirage/eqaf";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -239,6 +239,8 @@ let
 
     enumerate = callPackage ../development/ocaml-modules/enumerate { };
 
+    eqaf = callPackage ../development/ocaml-modules/eqaf { };
+
     erm_xml = callPackage ../development/ocaml-modules/erm_xml { };
 
     erm_xmpp = callPackage ../development/ocaml-modules/erm_xmpp { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/mirage/digestif/blob/master/CHANGES.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

