### PR TITLE
init pyhaversion (3.1.0) for home-assistant

### DIFF
--- a/pkgs/development/python-modules/aresponses/default.nix
+++ b/pkgs/development/python-modules/aresponses/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+# propagatedBuildInputs
+, aiohttp
+# buildInputs
+, pytest
+, pytest-asyncio
+}:
+
+buildPythonPackage rec {
+  pname = "aresponses";
+  version = "1.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d1d6ef52b9a97142d106688cf9b112602ef3dc66f6368de8f91f47241d8cfc9c";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  buildInputs = [
+    pytest
+    pytest-asyncio
+  ];
+
+  # tests only distributed via git repository, not pypi
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Asyncio testing server";
+    homepage = "https://github.com/circleup/aresponses";
+    license = licenses.mit;
+    maintainers = [ maintainers.makefu ];
+  };
+}

--- a/pkgs/development/python-modules/pyhaversion/default.nix
+++ b/pkgs/development/python-modules/pyhaversion/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+# propagatedBuildInputs
+, aiohttp
+, async-timeout
+# buildInputs
+, pytestrunner
+# checkInputs
+, pytest
+, pytest-asyncio
+, aresponses
+}:
+buildPythonPackage rec {
+  pname = "pyhaversion";
+  version = "3.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1d4smpzlaw0sqfgkgvhxsn8h7bmwj8h9gj98sdzvkzhp5vhd96b2";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    async-timeout
+  ];
+
+  buildInputs = [
+    pytestrunner
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-asyncio
+    aresponses
+  ];
+
+  meta = with lib; {
+    description = "A python module to the newest version number of Home Assistant";
+    homepage = https://github.com/ludeeus/pyhaversion;
+    maintainers = [ maintainers.makefu ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -807,7 +807,7 @@
     "venstar" = ps: with ps; [  ];
     "vera" = ps: with ps; [  ];
     "verisure" = ps: with ps; [  ];
-    "version" = ps: with ps; [  ];
+    "version" = ps: with ps; [ pyhaversion ];
     "vesync" = ps: with ps; [  ];
     "viaggiatreno" = ps: with ps; [  ];
     "vicare" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6161,6 +6161,8 @@ in {
 
   pyhamcrest = callPackage ../development/python-modules/pyhamcrest { };
 
+  pyhaversion = callPackage ../development/python-modules/pyhaversion { };
+
   parse = callPackage ../development/python-modules/parse { };
 
   parse-type = callPackage ../development/python-modules/parse-type { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -175,6 +175,8 @@ in {
 
   apprise = callPackage ../development/python-modules/apprise { };
 
+  aresponses = callPackage ../development/python-modules/aresponses { };
+
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
 
   asana = callPackage ../development/python-modules/asana { };


### PR DESCRIPTION
###### Motivation for this change

Add support for `version` module in `home-assistant`

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
