### PR TITLE
nixos-rebuild: Fix target-host using fish

### DIFF
--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -111,7 +111,7 @@ buildHostCmd() {
     if [ -z "$buildHost" ]; then
         "$@"
     elif [ -n "$remoteNix" ]; then
-        ssh $SSHOPTS "$buildHost" PATH="$remoteNix:$PATH" "$@"
+        ssh $SSHOPTS "$buildHost" env PATH="$remoteNix:$PATH" "$@"
     else
         ssh $SSHOPTS "$buildHost" "$@"
     fi


### PR DESCRIPTION
I have `users.defaultUserShell = pkgs.fish;` set on my server and when I ran `nixos-rebuild switch --target-host …`, the command failed with the following error:

    fish: Unsupported use of '='. To run 'nix-store' with a modified environment, please use 'env PATH=… nix-store…'

That is because fish requires env to set environment variables for a program. It should also work on other shells.