### PR TITLE
wmc-mpris: unstable-2019-07-24 -> 0.1.0

### DIFF
--- a/pkgs/applications/misc/web-media-controller/default.nix
+++ b/pkgs/applications/misc/web-media-controller/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wmc-mpris";
-  version = "unstable-2019-07-24";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "f1u77y";
     repo = pname;
-    rev = "3b92847c576662732984ad791d6c7899a39f7787";
-    sha256 = "0q19z0zx53pd237x529rif21kliklwzjrdddx8jfr9hgghjv9giq";
+    rev = "v${version}";
+    sha256 = "1zcnaf9g55cbj9d2zlsr0i15qh0w9gp5jmxkm6dcp1j6yd7j3ymc";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

The web extension doesn't play along with the old version of the executable and finally upstream provides releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @