### PR TITLE
evdevremapkeys: init at 0.1.0

### DIFF
--- a/pkgs/tools/inputmethods/evdevremapkeys/default.nix
+++ b/pkgs/tools/inputmethods/evdevremapkeys/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, python3Packages }:
+
+let
+  pythonPackages = python3Packages;
+
+in pythonPackages.buildPythonPackage rec {
+  name = "${pname}-0.1.0";
+  pname = "evdevremapkeys";
+
+  src = fetchFromGitHub {
+    owner = "philipl";
+    repo = pname;
+    rev = "68fb618b8142e1b45d7a1e19ea9a5a9bbb206144";
+    sha256 = "0c9slflakm5jqd8s1zpxm7gmrrk0335m040d7m70hnsak42jvs2f";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ 
+    pyyaml
+    pyxdg
+    python-daemon
+    evdev
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/philipl/evdevremapkeys";
+    description = "Daemon to remap events on linux input devices";
+    license = licenses.mit;
+    maintainers = [ maintainers.q3k ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2331,6 +2331,8 @@ in
 
   anthy = callPackage ../tools/inputmethods/anthy { };
 
+  evdevremapkeys = callPackage ../tools/inputmethods/evdevremapkeys { };
+
   libpinyin = callPackage ../development/libraries/libpinyin { };
 
   libskk = callPackage ../development/libraries/libskk {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Init evdevremapkeys, a tool to remap evdev based inputs at a lower level than X11 or Wayland.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
