### PR TITLE
obs-wlrobs: init at 20191008

### DIFF
--- a/pkgs/applications/video/obs-studio/wlrobs.nix
+++ b/pkgs/applications/video/obs-studio/wlrobs.nix
@@ -1,0 +1,37 @@
+# (the following is somewhat lifted from ./linuxbrowser.nix)
+# We don't have a wrapper which can supply obs-studio plugins so you have to
+# somewhat manually install this:
+
+# nix-env -f . -iA obs-wlrobs
+# mkdir -p ~/.config/obs-studio/plugins/wlrobs/bin/64bit
+# ln -s ~/.nix-profile/share/obs/obs-plugins/wlrobs/bin/64bit/libwlrobs.so ~/.config/obs-studio/plugins/wlrobs/bin/64bit
+{ stdenv, fetchhg, wayland, obs-studio }:
+stdenv.mkDerivation {
+  pname = "obs-wlrobs";
+  version = "20191008";
+
+  src = fetchhg {
+    url = "https://hg.sr.ht/~scoopta/wlrobs";
+    rev = "82e2b93c6f662dfd9d69f7826c0096bef585c3ae";
+    sha256 = "1d2mlybkwyr0jw6paamazla2a1cyj60bs10i0lk9jclxnp780fy6";
+  };
+
+  buildInputs = [ wayland obs-studio ];
+
+  preBuild = ''
+    cd Release
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/obs/obs-plugins/wlrobs/bin/64bit
+    cp ./libwlrobs.so $out/share/obs/obs-plugins/wlrobs/bin/64bit/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An obs-studio plugin that allows you to screen capture on wlroots based wayland compositors";
+    homepage = https://hg.sr.ht/~scoopta/wlrobs;
+    maintainers = with maintainers; [ grahamc ];
+    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19931,6 +19931,8 @@ in
 
   obs-studio = libsForQt5.callPackage ../applications/video/obs-studio { };
 
+  obs-wlrobs = callPackage ../applications/video/obs-studio/wlrobs.nix { };
+
   octoprint = callPackage ../applications/misc/octoprint { };
 
   octoprint-plugins = callPackage ../applications/misc/octoprint/plugins.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
