### PR TITLE
kio-gdrive: init at version 1.2.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4074,6 +4074,12 @@
     githubId = 15692230;
     name = "Muhammad Herdiansyah";
   };
+  konstantsky = {
+    email = "konstantin@konstantsky.pw";
+    github = "konstantinous";
+    githubId = 4301666;
+    name = "Konstantin Khokhlov";
+  };
   koral = {
     email = "koral@mailoo.org";
     github = "k0ral";

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -355,6 +355,7 @@ in
        kdeApplications.kaccounts-providers
        kdeApplications.kaccounts-integration
        kdeApplications.signon-kwallet-extension
+       libsForQt5.accounts-qml-module
        pkgs.kio-gdrive
        pkgs.telepathy-mission-control
        pkgs.telepathy-haze

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -158,6 +158,8 @@ in
         example = "vlc";
         description = "Phonon audio backend to install.";
       };
+
+      enableOnlineAccounts = mkEnableOption "Enable integration with online services";
     };
 
   };
@@ -340,6 +342,26 @@ in
       # Update the start menu for each user that is currently logged in
       system.userActivationScripts.plasmaSetup = activationScript;
     })
+
+   # Online acoounts integration
+   (mkIf cfg.enableOnlineAccounts {
+     environment.variables.SSO_PLUGINS_DIR = ["/run/current-system/sw/lib/signon"];
+     environment.variables.SSO_EXTENSIONS_DIR = ["/run/current-system/sw/lib/signon/extensions"];
+     environment.systemPackages = [
+       libsForQt5.signond
+       libsForQt5.signon-ui
+       libsForQt5.signon-plugin-oauth2
+       kdeApplications.ktp-accounts-kcm
+       kdeApplications.kaccounts-providers
+       kdeApplications.kaccounts-integration
+       kdeApplications.signon-kwallet-extension
+       pkgs.kio-gdrive
+       pkgs.telepathy-mission-control
+       pkgs.telepathy-haze
+       pkgs.telepathy-gabble
+       pkgs.telepathy-idle
+     ];
+   })
   ];
 
 }

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -180,6 +180,7 @@ let
       pim-sieve-editor = callPackage ./pim-sieve-editor.nix {};
       print-manager = callPackage ./print-manager.nix {};
       rocs = callPackage ./rocs.nix {};
+      signon-kwallet-extension = callPackage ./signon-kwallet-extension.nix {};
       spectacle = callPackage ./spectacle.nix {};
       yakuake = callPackage ./yakuake.nix {};
       # Okteta was removed from kde applications and will now be released independently

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -144,6 +144,7 @@ let
       kpat = callPackage ./kpat.nix {};
       kpimtextedit = callPackage ./kpimtextedit.nix {};
       ksmtp = callPackage ./ksmtp {};
+      ktp-accounts-kcm = callPackage ./ktp-accounts-kcm.nix {};
       kqtquickcharts = callPackage ./kqtquickcharts.nix {};
       kpkpass = callPackage ./kpkpass.nix {};
       krdc = callPackage ./krdc.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -87,6 +87,7 @@ let
       incidenceeditor = callPackage ./incidenceeditor.nix {};
       k3b = callPackage ./k3b.nix {};
       kaddressbook = callPackage ./kaddressbook.nix {};
+      kaccounts-providers = callPackage ./kaccounts-providers.nix {};
       kaccounts-integration = callPackage ./kaccounts-integration.nix {};
       kalarm = callPackage ./kalarm.nix {};
       kalarmcal = callPackage ./kalarmcal.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -87,6 +87,7 @@ let
       incidenceeditor = callPackage ./incidenceeditor.nix {};
       k3b = callPackage ./k3b.nix {};
       kaddressbook = callPackage ./kaddressbook.nix {};
+      kaccounts-integration = callPackage ./kaccounts-integration.nix {};
       kalarm = callPackage ./kalarm.nix {};
       kalarmcal = callPackage ./kalarmcal.nix {};
       kate = callPackage ./kate.nix {};

--- a/pkgs/applications/kde/kaccounts-integration.nix
+++ b/pkgs/applications/kde/kaccounts-integration.nix
@@ -8,7 +8,8 @@
   accounts-qt,
   signond,
   signon-plugin-oauth2,
-  signon-ui
+  signon-ui,
+  accounts-qml-module
 }:
 
 mkDerivation {
@@ -27,6 +28,7 @@ mkDerivation {
     signond
     signon-plugin-oauth2
     signon-ui
+    accounts-qml-module
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/kde/kaccounts-integration.nix
+++ b/pkgs/applications/kde/kaccounts-integration.nix
@@ -1,0 +1,45 @@
+{
+  mkDerivation,
+  stdenv,
+  extra-cmake-modules,
+  kcmutils,
+  kdoctools,
+  libaccounts-glib,
+  accounts-qt,
+  signond,
+  signon-plugin-oauth2,
+  signon-ui
+}:
+
+mkDerivation {
+
+  name = "kaccounts-integration";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+  ];
+
+  buildInputs = [
+    kcmutils
+    libaccounts-glib
+    accounts-qt
+    signond
+    signon-plugin-oauth2
+    signon-ui
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Small system to administer web accounts for the sites and services across the KDE desktop";
+    homepage = https://github.com/KDE/kaccounts-integration;
+    platforms = platforms.linux;
+
+    license = with licenses; [
+      gpl2
+      lgpl2.1
+    ];
+
+    maintainers = [ maintainers.konstantsky ];
+  };
+
+}

--- a/pkgs/applications/kde/kaccounts-providers.nix
+++ b/pkgs/applications/kde/kaccounts-providers.nix
@@ -1,0 +1,53 @@
+{
+  mkDerivation,
+  stdenv,
+  extra-cmake-modules,
+  kaccounts-integration,
+  intltool,
+  accounts-qt,
+  signond,
+  signon-plugin-oauth2,
+  libaccounts-glib,
+  kconfigwidgets,
+  kiconthemes,
+  kdeclarative,
+  qtdeclarative,
+  kdoctools,
+  kio
+}:
+
+mkDerivation {
+
+  name = "kaccounts-providers";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    intltool
+  ];
+
+  buildInputs = [
+    kaccounts-integration
+    accounts-qt
+    signond
+    signon-plugin-oauth2
+    libaccounts-glib
+    kconfigwidgets
+    kiconthemes
+    qtdeclarative
+    kdoctools
+    kio
+    kdeclarative
+  ];
+
+  meta = with stdenv.lib; {
+    description = "KDE providers for integration with online services and sites";
+    homepage = https://github.com/KDE/kaccounts-providers;
+    platforms = platforms.linux;
+
+    license = with licenses; [
+      gpl2
+    ];
+    maintainers = [ maintainers.konstantsky ];
+  };
+
+}

--- a/pkgs/applications/kde/ktp-accounts-kcm.nix
+++ b/pkgs/applications/kde/ktp-accounts-kcm.nix
@@ -1,0 +1,50 @@
+{
+  mkDerivation,
+  stdenv,
+  extra-cmake-modules,
+  kcmutils,
+  kdoctools,
+  kaccounts-integration,
+  kaccounts-providers,
+  accounts-qt,
+  signond,
+  signon-plugin-oauth2,
+  libaccounts-glib,
+  intltool,
+  telepathy
+}:
+
+mkDerivation {
+
+  name = "ktp-accounts-kcm";
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kdoctools
+    kcmutils
+    telepathy
+    kaccounts-integration
+    kaccounts-providers
+    accounts-qt
+    signond
+    signon-plugin-oauth2
+    libaccounts-glib
+    intltool
+  ];
+
+  meta = with stdenv.lib; {
+    description = "KDE providers for integration with online services and sites.";
+    homepage = https://github.com/KDE/kaccounts-providers;
+    platforms = platforms.linux;
+
+    license = with licenses; [
+      gpl2
+    ];
+
+    maintainers = [ maintainers.konstantsky ];
+  };
+
+}

--- a/pkgs/applications/kde/signon-kwallet-extension.nix
+++ b/pkgs/applications/kde/signon-kwallet-extension.nix
@@ -1,0 +1,47 @@
+{
+  stdenv,
+  mkDerivation,
+  extra-cmake-modules,
+  symlinkJoin,
+  kwallet,
+  signond
+}:
+
+mkDerivation rec {
+
+  name = "signon-kwallet-extension";
+
+  preConfigure = ''
+    # mock signond plugins dir
+    substituteInPlace cmake/modules/FindSignOnExtension.cmake --replace \
+      'set(SIGNONEXTENSION_PLUGINDIR ''${_pkgconfig_invoke_result})' \
+      'set(SIGNONEXTENSION_PLUGINDIR lib/signon/extensions)'
+  '';
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kwallet
+    signond
+  ];
+
+  extension = symlinkJoin {
+    name = "kwallet-extension";
+    paths = [ signond ];
+  };
+
+  meta = with stdenv.lib; {
+    description = "KWallet integration for signon framework";
+    homepage = https://github.com/KDE/signon-kwallet-extension;
+    platforms = platforms.linux;
+
+    license = with licenses; [
+      gpl2
+    ];
+
+    maintainers = [ maintainers.konstantsky ];
+  };
+
+}

--- a/pkgs/applications/misc/kio-gdrive/default.nix
+++ b/pkgs/applications/misc/kio-gdrive/default.nix
@@ -1,0 +1,69 @@
+{
+  mkDerivation,
+  stdenv,
+  fetchurl,
+  extra-cmake-modules,
+  kdoctools,
+  shared-mime-info,
+  libkgapi,
+  accounts-qt,
+  kaccounts-integration,
+  kaccounts-providers,
+  intltool,
+  kcontacts,
+  kio,
+  kcalendarcore,
+  qtkeychain,
+  signon-ui,
+  signond,
+  libaccounts-glib,
+  libsecret
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "kio-gdrive";
+
+  version = "1.2.7";
+  src = fetchurl {
+    url = "mirror://kde/stable/kio-gdrive/${version}/src/kio-gdrive-${version}.tar.xz";
+    sha256 = "1b59e4d9940deb290cc4d7441d4ae8762ccb1de8d14dbd0bdbd3bc9a5fc266a4";
+    name = "kio-gdrive-${version}.tar.xz";
+  };
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    kdoctools
+    shared-mime-info
+    libsecret
+    libaccounts-glib
+  ];
+
+  buildInputs = [
+    libkgapi
+    kaccounts-integration
+    kaccounts-providers
+    accounts-qt
+    intltool
+    kcontacts
+    qtkeychain
+    kio
+    signon-ui
+    signond
+    kcalendarcore
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A KIO slave that enables KIO-aware applications to access and edit Google Drive files on the cloud";
+    homepage = https://community.kde.org/KIO_GDrive;
+    platforms = platforms.linux;
+
+    license = with licenses; [
+      gpl2
+      gpl3
+    ];
+
+    maintainers = [ maintainers.konstantsky ];
+  };
+
+}

--- a/pkgs/development/libraries/accounts-qml-module/default.nix
+++ b/pkgs/development/libraries/accounts-qml-module/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, mkDerivation, fetchFromGitLab, pkgconfig, qmake, accounts-qt, qttools, signond, qtdeclarative, qtbase }:
+
+mkDerivation rec {
+  pname = "accounts-qml-module";
+  version = "0.7";
+
+  src = fetchFromGitLab {
+    sha256 = "0m9zvhx5vkbixxlqy8fszgbkx6cvxa82cfxz23x068ikl33hm941";
+    rev = "VERSION_${version}";
+    repo = "accounts-qml-module";
+    owner = "accounts-sso";
+  };
+
+  buildInputs = [ accounts-qt qtdeclarative qttools signond qtbase ];
+  nativeBuildInputs = [ pkgconfig qmake ];
+
+  qmakeFlags = [
+    "CONFIG+=no_docs"
+  ];
+
+  preConfigure = ''
+    export QT_PLUGIN_PATH="${qtbase.bin}/${qtbase.qtPluginPrefix}"
+    substituteInPlace common-project-config.pri --replace '-Werror' ' '
+    substituteInPlace accounts-qml-module.pro --replace 'tests' ' '
+  '';
+
+  installPhase = ''
+    mkdir -p $out/${qtbase.qtQmlPrefix}
+    mv src/Ubuntu  $out/${qtbase.qtQmlPrefix}
+  '';
+
+
+  meta = with stdenv.lib; {
+    description = "This QML module provides an API to manage the user's online accounts and get their authentication data.";
+    homepage = https://gitlab.com/accounts-sso;
+    license = licenses.lgpl21;
+    platforms = with platforms; linux;
+    maintainers = [ maintainers.konstantsky ];
+  };
+}

--- a/pkgs/development/libraries/accounts-qt/default.nix
+++ b/pkgs/development/libraries/accounts-qt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, doxygen, glib, libaccounts-glib, pkgconfig, qtbase, qmake }:
+{ stdenv, fetchFromGitLab, doxygen, glib, libaccounts-glib, pkgconfig, qtbase, qmake, graphviz }:
 
 stdenv.mkDerivation rec {
   pname = "accounts-qt";
@@ -12,11 +12,13 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ glib libaccounts-glib qtbase ];
-  nativeBuildInputs = [ doxygen pkgconfig qmake ];
+  nativeBuildInputs = [ doxygen pkgconfig qmake graphviz ];
 
-  preConfigure = ''
-    qmakeFlags="$qmakeFlags LIBDIR=$out/lib CMAKE_CONFIG_PATH=$out/lib/cmake"
-  '';
+# Commented due to error 'accounts-qt5 development package not found' when tried to build oauth2 plugin for signon
+# It seems like this options do something wrong
+#  preConfigure = ''
+#    qmakeFlags="$qmakeFlags LIBDIR=$out/lib CMAKE_CONFIG_PATH=$out/lib/cmake"
+#  '';
 
   # Hack to avoid TMPDIR in RPATHs.
   preFixup = ''rm -rf "$(pwd)" '';

--- a/pkgs/development/libraries/signon-ui/default.nix
+++ b/pkgs/development/libraries/signon-ui/default.nix
@@ -1,0 +1,68 @@
+{
+  stdenv,
+  qt5,
+  lib,
+  fetchFromGitLab,
+  libnotify,
+  pkgconfig,
+  qtbase,
+  qmake,
+  signond,
+  qtwebkit-plugins,
+  qtwebkit,
+  qtwebengine,
+  accounts-qt,
+  libproxy,
+  gdk-pixbuf
+}:
+
+
+qt5.mkDerivation rec {
+  name = "signon-ui";
+  version = "0.17.02";
+
+  src = fetchFromGitLab {
+    repo = "${name}";
+    owner = "accounts-sso";
+    rev = "3acb6541";
+    sha256 = "1821k48mz99pajv0iv97k80b7g4j8g1xc1xqpqdvb1ijn33yy12g";
+  };
+
+  PKG_CONFIG_PATH="${accounts-qt}/lib/pkgconfig";
+
+  preConfigure = ''
+    # Do not install tests
+    echo 'INSTALLS =' >>tests/unit/tst_inactivity_timer.pro
+    echo 'INSTALLS =' >>tests/unit/tst_signon_ui.pro
+  '';
+
+  nativeBuildInputs = [
+    qmake
+    pkgconfig
+  ];
+
+  buildInputs = [
+    qtbase
+    signond
+    qtwebkit-plugins
+    qtwebkit
+    accounts-qt
+    qtwebengine
+    libnotify
+    libproxy
+    gdk-pixbuf
+  ];
+
+  meta = with stdenv.lib; {
+    description = "UI component responsible for handling the user interactions which can happen during the login process of an online account";
+    homepage = https://gitlab.com/accounts-sso/signon-ui;
+    platforms = platforms.linux;
+
+    license = with licenses; [
+      lgpl21
+    ];
+
+    maintainers = [ maintainers.konstantsky ];
+  };
+
+}

--- a/pkgs/development/libraries/signond/default.nix
+++ b/pkgs/development/libraries/signond/default.nix
@@ -1,0 +1,56 @@
+{
+  stdenv,
+  qt5,
+  fetchFromGitLab,
+  pkgconfig,
+  qtbase,
+  qttools,
+  libproxy,
+  libsignon-glib,
+  qmake,
+  doxygen,
+  graphviz
+}:
+
+qt5.mkDerivation rec {
+
+  pname = "signond";
+  version = "8.60";
+
+  src = fetchFromGitLab {
+    repo = "signond";
+    owner = "accounts-sso";
+    rev = "VERSION_${version}";
+    sha256 = "0bpjcpp3qsf44m5bd4zz8p78pgb0mdsxzmky7wl93dzfblkmwnm4";
+  };
+
+  nativeBuildInputs = [
+    doxygen
+    pkgconfig
+    qmake
+  ];
+
+  buildInputs = [
+    qtbase
+    qttools
+    graphviz
+    libproxy
+    libsignon-glib
+  ];
+
+  preConfigure = ''
+    # don't install example plugin
+    sed -e "/example/d" -i src/plugins/plugins.pro
+    #disable tests
+    sed -i -e '/^SUBDIRS/s/tests//' signon.pro
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A D-Bus service which performs user authentication on behalf of its clients.";
+    homepage = "https://gitlab.com/accounts-sso/signond";
+    platforms = platforms.linux;
+    license = with licenses; [ lgpl21 ];
+
+    maintainers = [ maintainers.konstantsky ];
+  };
+}

--- a/pkgs/development/libraries/signond/extensions/oauth2.nix
+++ b/pkgs/development/libraries/signond/extensions/oauth2.nix
@@ -1,0 +1,67 @@
+{
+  stdenv,
+  fetchFromGitLab,
+  pkgconfig,
+  symlinkJoin,
+  qtbase,
+  qmake,
+  doxygen,
+  signond
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "signon-plugin-oauth2";
+  version = "0.24";
+
+  src = fetchFromGitLab {
+    repo = "signon-plugin-oauth2";
+    owner = "accounts-sso";
+    rev = "VERSION_${version}";
+    sha256 = "1iqq5jbd9inx10n491lgrhv3rkr3iykjyh7ilf0v21zfl4vc6lzl";
+  };
+
+  PKG_CONFIG_PATH="${signond}/lib/pkgconfig";
+
+  preConfigure = ''
+      # Do not install tests and example
+    echo 'INSTALLS =' >> tests/tests.pro
+    echo 'INSTALLS =' >> example/example.pro
+  '';
+  plugin = symlinkJoin {
+    name = "oauth2";
+    paths = [ signond ];
+  };
+
+  nativeBuildInputs = [
+    doxygen
+    pkgconfig
+    qmake
+  ];
+
+  BuildInputs = [
+    signond
+    qtbase
+  ];
+
+  postFixup = ''
+    install -D ./src/lib/signon/liboauth2plugin.so $out/lib/signon/liboauth2plugin.so
+  '';
+
+  outputs = [ "out" "dev" ];
+
+  meta = with stdenv.lib; {
+    description = "This plugin for the Accounts-SSO SignOn daemon handles the OAuth 1.0 and 2.0 authentication protocols";
+    homepage = https://gitlab.com/accounts-sso/signon-plugin-oauth2;
+    platforms = platforms.linux;
+
+    license = with licenses; [
+      lgpl21
+    ];
+
+    maintainers = [ maintainers.konstantsky ];
+  };
+
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20221,6 +20221,11 @@ in
 
   kid3 = libsForQt5.callPackage ../applications/audio/kid3 { };
 
+  kio-gdrive = libsForQt5.callPackage ../applications/misc/kio-gdrive {
+    inherit (kdeApplications) libkgapi kaccounts-integration kaccounts-providers;
+    inherit (kdeFrameworks) kcalendarcore;
+  };
+
   kile = libsForQt5.callPackage ../applications/editors/kile { };
 
   kino = callPackage ../applications/video/kino {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14078,6 +14078,8 @@ in
 
     accounts-qt = callPackage ../development/libraries/accounts-qt { };
 
+    accounts-qml-module = libsForQt5.callPackage ../development/libraries/accounts-qml-module { };
+
     alkimia = callPackage ../development/libraries/alkimia { };
 
     fcitx-qt5 = callPackage ../tools/inputmethods/fcitx/fcitx-qt5.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14138,6 +14138,8 @@ in
 
     signon-ui = libsForQt5.callPackage ../development/libraries/signon-ui { };
 
+    signon-plugin-oauth2 = libsForQt5.callPackage ../development/libraries/signond/extensions/oauth2.nix { };
+
     qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
     qmltermwidget = callPackage ../development/libraries/qmltermwidget {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14136,6 +14136,8 @@ in
 
     signond = libsForQt5.callPackage ../development/libraries/signond { };
 
+    signon-ui = libsForQt5.callPackage ../development/libraries/signon-ui { };
+
     qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
     qmltermwidget = callPackage ../development/libraries/qmltermwidget {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14134,6 +14134,8 @@ in
       suffix = "qt5";
     };
 
+    signond = libsForQt5.callPackage ../development/libraries/signond { };
+
     qca-qt5 = callPackage ../development/libraries/qca-qt5 { };
 
     qmltermwidget = callPackage ../development/libraries/qmltermwidget {


### PR DESCRIPTION
I had to add signon, signon-ui, kaccounts-integration and providers
packages to be able to build kio-gdrive ( one of the packages from #62168 )

Package works well on my laptop. Signond daemon is probably not able to find it's plugins installed into user profile. However, it doesn't affect kio-gdrive itself.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add google drive integration to KDE dolphin and other kio aware apps.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
