### PR TITLE
wstunnel: init at unstable-2019-01-28

### DIFF
--- a/pkgs/tools/networking/wstunnel/default.nix
+++ b/pkgs/tools/networking/wstunnel/default.nix
@@ -1,0 +1,47 @@
+{ mkDerivation, async, base, base64-bytestring, binary, bytestring
+, classy-prelude, cmdargs, connection, hslogger, mtl, network
+, network-conduit-tls, stdenv, streaming-commons, text
+, unordered-containers, websockets
+, lib, fetchFromGitHub, fetchpatch
+}:
+
+mkDerivation rec {
+  pname = "wstunnel";
+  version = "unstable-2019-01-28";
+
+  src = fetchFromGitHub {
+    owner = "erebe";
+    repo = pname;
+    rev = "78cc5a5f1aa4dbcb25fa9b0efc9cfef3640672e4";
+    sha256 = "17y3yn7qg1h7jx9xs041sw63g51vyns236f60d2m2mghi49lm9i2";
+  };
+
+  patches = [
+    # Support GHC 8.6   https://github.com/erebe/wstunnel/pull/18
+    (fetchpatch {
+      url = "https://github.com/erebe/wstunnel/commit/8f348fea4dbf75874d5d930334377843763335ab.patch";
+      sha256 = "0a66jx7k97j3iyr7j5npbyq1lkhzz74r81mkas4nig7z3hny1gn9";
+    })
+  ];
+
+  isLibrary = false;
+  isExecutable = true;
+
+  libraryHaskellDepends = [
+    async base base64-bytestring binary bytestring classy-prelude
+    connection hslogger mtl network network-conduit-tls
+    streaming-commons text unordered-containers websockets
+  ];
+
+  executableHaskellDepends = [
+    base bytestring classy-prelude cmdargs hslogger text
+  ];
+
+  testHaskellDepends = [ base text ];
+
+  homepage = "https://github.com/erebe/wstunnel";
+  description = "UDP and TCP tunnelling over WebSocket";
+  maintainers = with lib.maintainers; [ gebner ];
+  license = lib.licenses.bsd3;
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6865,6 +6865,9 @@ in
 
   wsmancli = callPackage ../tools/system/wsmancli {};
 
+  wstunnel = haskell.lib.justStaticExecutables
+    (haskellPackages.callPackage ../tools/networking/wstunnel {});
+
   wolfebin = callPackage ../tools/networking/wolfebin {
     python = python2;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[wstunnel](https://github.com/erebe/wstunnel) is a tools that allows you tunnel UDP or TCP traffic over WebSocket (e.g. using nginx as a reverse proxy).  This is a nice way to tunnel wireguard over tcp: https://kirill888.github.io/notes/wireguard-via-websocket/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
