### PR TITLE
envelope: init at 0.0.4

### DIFF
--- a/pkgs/applications/office/envelope/default.nix
+++ b/pkgs/applications/office/envelope/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, meson
+, ninja
+, pkgconfig
+, pantheon
+, python3
+, vala
+, appstream-glib
+, desktop-file-utils
+, gettext
+, glib
+, gtk3
+, libgee
+, sqlite
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "envelope";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "cjfloss";
+    repo = pname;
+    rev = version;
+    sha256 = "111lq1gijcm7qwpac09q11ymwiw2x3m12a28ki52f28fb1amvffc";
+  };
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    gettext
+    meson
+    ninja
+    vala
+    pkgconfig
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libgee
+    pantheon.granite
+    sqlite
+  ];
+
+  doCheck = true;
+
+  patches = [
+    # Fix AppData Validation.
+    # https://github.com/cjfloss/envelope/pull/59
+    (fetchpatch {
+      url = "https://github.com/cjfloss/envelope/commit/b6a28eced89b8f944479fcc695aebfb9aae0c691.patch";
+      sha256 = "11znc8z52kl893n3gmmdpnp3y4vpzmb263m5gp0qxbl3xykq2wzr";
+    })
+  ];
+
+  postPatch = ''
+    chmod +x data/post_install.py
+    patchShebangs data/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Personal finance manager for elementary OS";
+    homepage = "https://github.com/cjfloss/envelope";
+    maintainers = with maintainers; [ kjuvi ] ++ pantheon.maintainers;
+    platforms = platforms.linux;
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18222,6 +18222,8 @@ in
 
   enhanced-ctorrent = callPackage ../applications/networking/enhanced-ctorrent { };
 
+  envelope = callPackage ../applications/office/envelope { };
+
   eolie = callPackage ../applications/networking/browsers/eolie { };
 
   epdfview = callPackage ../applications/misc/epdfview { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add more curated apps from Elementary OS app store for Pantheon Desktop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
