### PR TITLE
Add missing descriptions

### DIFF
--- a/pkgs/applications/editors/nedit/default.nix
+++ b/pkgs/applications/editors/nedit/default.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://sourceforge.net/projects/nedit;
+    homepage = "https://sourceforge.net/projects/nedit";
+    description = "A fast, compact Motif/X11 plain text editor";
     platforms = with platforms; linux ++ darwin;
     license = licenses.gpl2;
   };

--- a/pkgs/applications/editors/okteta/default.nix
+++ b/pkgs/applications/editors/okteta/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     license = licenses.gpl2;
+    description = "A hex editor";
     maintainers = with maintainers; [ peterhoeg bkchr ];
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/wego/default.nix
+++ b/pkgs/applications/misc/wego/default.nix
@@ -17,5 +17,7 @@ buildGoPackage rec {
 
   meta = {
     license = stdenv.lib.licenses.isc;
+    homepage = "https://github.com/schachmat/wego";
+    description = "Weather app for the terminal";
   };
 }

--- a/pkgs/development/tools/parsing/peg/default.nix
+++ b/pkgs/development/tools/parsing/peg/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
   preBuild="makeFlagsArray+=( PREFIX=$out )";
 
   meta = with stdenv.lib; {
-    homepage = http://piumarta.com/software/peg/;
+    homepage = "http://piumarta.com/software/peg/";
+    description = "Tools for generating recursive-descent parsers: programs that perform pattern matching on text";
     platforms = platforms.all;
     license = licenses.mit;
   };

--- a/pkgs/tools/misc/gawp/default.nix
+++ b/pkgs/tools/misc/gawp/default.nix
@@ -16,4 +16,10 @@ buildGoPackage rec {
   };
 
   goDeps = ./deps.nix;
+
+  meta = {
+    homepage = "https://github.com/martingallagher/gawp";
+    description = "A simple, configurable, file watching, job execution tool";
+    license = stdenv.lib.licenses.asl20;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change
A lot of packages have incomplete meta information. This PR adds a few missing descriptions and homepages.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
