### PR TITLE
Fix typos in the Nixpkgs Manual.

### DIFF
--- a/doc/configuration.xml
+++ b/doc/configuration.xml
@@ -45,7 +45,7 @@
   However, this does not allow unfree software for individual users. Their configurations are managed separately.
  </para>
  <para>
-  A user's of nixpkgs configuration is stored in a user-specific configuration file located at <filename>~/.config/nixpkgs/config.nix</filename>. For example:
+  A user's nixpkgs configuration is stored in a user-specific configuration file located at <filename>~/.config/nixpkgs/config.nix</filename>. For example:
 <programlisting>
 {
   allowUnfree = true;

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1692,7 +1692,7 @@ someVar=$(stripHash $name)
     </term>
     <listitem>
      <para>
-      Convenience function for <literal>makeWrapper</literal> that automatically creates a sane wrapper file It takes all the same arguments as <literal>makeWrapper</literal>, except for <literal>--argv0</literal>.
+      Convenience function for <literal>makeWrapper</literal> that automatically creates a sane wrapper file. It takes all the same arguments as <literal>makeWrapper</literal>, except for <literal>--argv0</literal>.
      </para>
      <para>
       It cannot be applied multiple times, since it will overwrite the wrapper file.
@@ -1869,7 +1869,7 @@ addEnvHooks "$hostOffset" myBashFunction
   </para>
 
   <para>
-   Here are some more packages that provide a setup hook. Since the list of hooks is extensible, this is not an exhaustive list the mechanism is only to be used as a last resort, it might cover most uses.
+   Here are some more packages that provide a setup hook. Since the list of hooks is extensible, this is not an exhaustive list. The mechanism is only to be used as a last resort, so it might cover most uses.
    <variablelist>
     <varlistentry>
      <term>


### PR DESCRIPTION
### Motivation for this change
Found a few typos while reading through the Nixpkgs Manual.

###### Things done
Fixed said typos.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
