### PR TITLE
ocamlPackages.lru: 0.2.0 → 0.3.0; ocamlPackages.psq: 0.1.0 → 0.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/lru/default.nix
+++ b/pkgs/development/ocaml-modules/lru/default.nix
@@ -1,25 +1,20 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, psq }:
+{ lib, fetchurl, buildDunePackage, psq }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-lru-${version}";
-  version = "0.2.0";
+buildDunePackage rec {
+  pname = "lru";
+  version = "0.3.0";
 
   src = fetchurl {
-    url = "https://github.com/pqwy/lru/releases/download/v${version}/lru-${version}.tbz";
-    sha256 = "0bd7js9rrma1fjjjjc3fgr9l5fjbhgihx2nsaf96g2b35iiaimd0";
+    url = "https://github.com/pqwy/lru/releases/download/v${version}/lru-v${version}.tbz";
+    sha256 = "1ab9rd7cq15ml8x0wjl44wy99h5z7x4g9vkkz4i2d7n84ghy7vw4";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
-
   propagatedBuildInputs = [ psq ];
-
-  inherit (topkg) buildPhase installPhase;
 
   meta = {
     homepage = "https://github.com/pqwy/lru";
     description = "Scalable LRU caches for OCaml";
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
-    license = stdenv.lib.licenses.isc;
-    inherit (ocaml.meta) platforms;
+    maintainers = [ lib.maintainers.vbgl ];
+    license = lib.licenses.isc;
   };
 }

--- a/pkgs/development/ocaml-modules/psq/default.nix
+++ b/pkgs/development/ocaml-modules/psq/default.nix
@@ -1,27 +1,21 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
+{ lib, buildDunePackage, fetchurl, seq }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
-then throw "psq is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-psq-${version}";
-  version = "0.1.0";
+buildDunePackage rec {
+  minimumOCamlVersion = "4.03";
+  pname = "psq";
+  version = "0.2.0";
 
   src = fetchurl {
-    url = "https://github.com/pqwy/psq/releases/download/v${version}/psq-${version}.tbz";
-    sha256 = "08ghgdivbjrxnaqc3hsb69mr9s2ql5ds0fb97b7z6zimzqibz6lp";
+    url = "https://github.com/pqwy/psq/releases/download/v${version}/psq-v${version}.tbz";
+    sha256 = "1j4lqkq17rskhgcrpgr4n1m1a2b1x35mlxj6f9g05rhpmgvgvknk";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
-
-  inherit (topkg) buildPhase installPhase;
+  propagatedBuildInputs = [ seq ];
 
   meta = {
     description = "Functional Priority Search Queues for OCaml";
     homepage = "https://github.com/pqwy/psq";
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
-    license = stdenv.lib.licenses.isc;
-    inherit (ocaml.meta) platforms;
+    maintainers = [ lib.maintainers.vbgl ];
+    license = lib.licenses.isc;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

API changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
