### PR TITLE
ocamlPackages.llvm: propagate needed libs, fix url to patch

### DIFF
--- a/pkgs/development/ocaml-modules/llvm/default.nix
+++ b/pkgs/development/ocaml-modules/llvm/default.nix
@@ -8,10 +8,11 @@ stdenv.mkDerivation {
 
   inherit (llvm) src;
 
-  buildInputs = [ python cmake llvm ocaml findlib ctypes ];
+  buildInputs = [ python cmake ocaml findlib ctypes ];
+  propagatedBuildInputs = [ llvm ];
 
   patches = [ (fetchpatch {
-    url = https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/llvm/llvm.3.9/files/cmake.patch;
+    url = https://raw.githubusercontent.com/ocaml/opam-repository/604f1b24af6c426e0ff3a296daae3fff38ff9e95/packages/llvm/llvm.3.9/files/cmake.patch;
     sha256 = "1fcc6ylfiw1npdhx7mrsj7h0dx7cym7i9664kpr76zqazb52ikm9";
   })];
 
@@ -27,6 +28,10 @@ stdenv.mkDerivation {
     mv $out/ocaml $OCAMLFIND_DESTDIR/llvm
     mv $OCAMLFIND_DESTDIR/llvm/META{.llvm,}
   '';
+
+  passthru = {
+    inherit llvm;
+  };
 
   meta = {
     inherit (llvm.meta) license homepage;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Strange link errors happen when the wrong llvm version is used. When ocamlPackages.llvm is a direct dependency, we can propagate the right llvm and when it is only a transitive dependency, we can use ocamlPackages.llvm.llvm to get the right version.

This fixes the build of a project of mine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vbgl
