### PR TITLE
WoeUSB: Remove writeback buffering workaround

### DIFF
--- a/pkgs/tools/misc/woeusb/default.nix
+++ b/pkgs/tools/misc/woeusb/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1w3m3qbjn0igydsbpf22w29lzf1pkxv7dlny5mbyrb6j0q6wlx0b";
   };
 
+  patches = [ ./remove-workaround.patch ];
+
   nativeBuildInputs = [ autoreconfHook makeWrapper ];
   buildInputs = [ wxGTK30 ];
 

--- a/pkgs/tools/misc/woeusb/remove-workaround.patch
+++ b/pkgs/tools/misc/woeusb/remove-workaround.patch
@@ -1,0 +1,82 @@
+From 3cf93fd595bd3fca98c98a0bdc8fc86b36ee1403 Mon Sep 17 00:00:00 2001
+From: Michael Hoang <enzime@users.noreply.github.com>
+Date: Wed, 9 Oct 2019 12:42:53 +1100
+Subject: [PATCH] Remove writeback buffering workaround
+
+---
+ src/woeusb | 45 ---------------------------------------------
+ 1 file changed, 45 deletions(-)
+
+diff --git a/src/woeusb b/src/woeusb
+index 3284259..0d3ea20 100755
+--- a/src/woeusb
++++ b/src/woeusb
+@@ -308,9 +308,6 @@ init(){
+ 
+ 	current_state=copying-filesystem
+ 
+-	workaround_linux_make_writeback_buffering_not_suck \
+-		apply
+-
+ 	copy_filesystem_files \
+ 		"${source_fs_mountpoint}" \
+ 		"${target_fs_mountpoint}" \
+@@ -1650,41 +1647,6 @@ workaround_support_windows_7_uefi_boot(){
+ 		> "${efi_boot_directory}/bootx64.efi"
+ }; declare -fr workaround_support_windows_7_uefi_boot
+ 
+-## Currently WoeUSB indirectly causes severely unresponsive system on 64-bit architecture with large primary memory during file copy process due to a flaw of the writeback buffer size handling in Linux kernel, workaround it before it is fixed
+-## Refer: 
+-## - System lagging while copying data · Issue #113 · slacka/WoeUSB <https://github.com/slacka/WoeUSB/issues/113>
+-## - The pernicious USB-stick stall problem [LWN.net] <https://lwn.net/Articles/572911/>
+-workaround_linux_make_writeback_buffering_not_suck(){
+-	util_check_function_parameters_quantity 1 "${#}"
+-	local -r mode="${1}"
+-
+-	local -ir VM_DIRTY_BACKGROUND_BYTES=$((16*1024*1024)) # 16MiB
+-	local -ir VM_DIRTY_BYTES=$((48*1024*1024)) # 48MiB
+-
+-	case "${mode}" in
+-		apply)
+-			echo_with_color \
+-				yellow \
+-				'Applying workaround to prevent 64-bit systems with big primary memory from being unresponsive during copying files.'
+-			echo "${VM_DIRTY_BACKGROUND_BYTES}" > /proc/sys/vm/dirty_background_bytes
+-			echo "${VM_DIRTY_BYTES}" > /proc/sys/vm/dirty_bytes
+-		;;
+-		reset)
+-			echo_with_color \
+-				yellow \
+-				'Resetting workaround to prevent 64-bit systems with big primary memory from being unresponsive during copying files.'
+-			echo 0 > /proc/sys/vm/dirty_background_bytes
+-			echo 0 > /proc/sys/vm/dirty_bytes
+-		;;
+-		*)
+-			printf_with_color \
+-				red \
+-				'Fatal: %s: Unexpected *mode* encountered, please report bug.\n' \
+-				"${FUNCNAME[0]}"
+-		;;
+-	esac
+-}; declare -fr workaround_linux_make_writeback_buffering_not_suck
+-
+ install_legacy_pc_bootloader_grub(){
+ 	util_check_function_parameters_quantity 3 "${#}"
+ 	local -r target_fs_mountpoint="${1}"; shift 1
+@@ -1836,13 +1798,6 @@ trap_exit(){
+ 		off \
+ 		"${global_only_for_gui}"
+ 
+-	case "${current_state}" in
+-		copying-filesystem|finished)
+-			workaround_linux_make_writeback_buffering_not_suck \
+-				reset
+-		;;
+-	esac
+-
+ 	if util_is_parameter_set_and_not_empty \
+ 		source_fs_mountpoint; then
+ 		if ! cleanup_mountpoint  \
+-- 
+2.23.0
+


### PR DESCRIPTION
###### Motivation for this change
WoeUSB contains a writeback buffering workaround for 64-bit Linux systems, however this workaround relies on setting /proc/sys/vm/dirty_background_bytes which no longer works on newer
versions of the Linux kernel. The issue is being tracked at slacka/WoeUSB#267, this is a workaround posted in that GitHub issue thread.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bjornfor @gnidorah 
