### PR TITLE
Gnome Shell 3.34.1

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -15,11 +15,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "gnome-shell";
-  version = "3.34.0";
+  version = "3.34.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0vdx4mfj46cpvzn6mhxc1ivg138437f5m4n3k4vb54pk45w4s00x";
+    sha256 = "07kd7wdk12nba33jfr44xqdlryiy86wgvsyjs8cw55y8p5cnbn6c";
   };
 
   LANG = "en_US.UTF-8";

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mutter";
-  version = "3.34.0";
+  version = "3.34.1";
 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0qdpw0fya8kr5737jf635455qb714wvhszkk82rlw48fqj8nk8ss";
+    sha256 = "13kmmgg2zizr0522clwc2zn3bkwbir503b1wjiiixf5xi37jc65s";
   };
 
   mesonFlags = [
@@ -54,38 +54,6 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    (fetchpatch {
-      name = "ensure-emit-x11-display-opened.patch";
-      url = "https://gitlab.gnome.org/GNOME/mutter/commit/850ef518795dcc20d3b9a4f661f70ff8d0ddacb2.patch";
-      sha256 = "0cxdbrbcc8kfkvw7ryxjm2v1vk15jki7bawn128385r5hasabhxf";
-    })
-    # fix animation related crashes: https://gitlab.gnome.org/GNOME/mutter/merge_requests/805
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/commit/63a0b702c94af013b94ad3f32a8c5ba86bf6dfba.patch";
-      sha256 = "13hvz3n275crvpankj1b47nds71c42nnbq1yx2xhhvk60qc72vh4";
-    })
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/commit/1e637bd7e1b2a4316d1cf6da80966d43819a10df.patch";
-      sha256 = "0jcx33j2sw7hva0gs0svqg69habxxmgdi0kcb07nqq2df6pb62qf";
-    })
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/commit/c9c53cb55fd6e782c50f36da1e2adbf28111a660.patch";
-      sha256 = "0iwjlbr8j0icigmilpghlkcyg4hll9dm0mcaj8lvi7qxrgjrmczr";
-    })
-    # Fix crash when pressing ctrl-super: https://gitlab.gnome.org/GNOME/mutter/issues/823
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/commit/0706e021f5bd82cf4c9b2c0d2916d272f3cba406.patch";
-      sha256 = "0i4ixr419jggrd17gxxs45jnx131lnp8wkkhhygqsrpq8941sdw6";
-    })
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/commit/76f2579e442d8ad0a3b8b644daab7c72a585506b.patch";
-      sha256 = "0c3ls624k9f4mqrrbv8ng0slvm31l0li6ciqn04qd4yi18plnldy";
-    })
-    # Avoid crashing any apps on X11 when restarting: https://gitlab.gnome.org/GNOME/mutter/merge_requests/808
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/mutter/commit/f352c3d79da99e961341c1d2b5dd334dcade0271.patch";
-      sha256 = "1drn8wjbkj903jxay5wxq163i9ahp558sjl2bc3fi1qs90xj6cn2";
-    })
    # TODO: submit upstream
    ./0001-build-use-get_pkgconfig_variable-for-sysprof-dbusdir.patch
     (substituteAll {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

gnome-shell released 3.34.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
