### PR TITLE
scc: init at 2.8.0

### DIFF
--- a/pkgs/development/tools/misc/scc/default.nix
+++ b/pkgs/development/tools/misc/scc/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "scc";
+  version = "2.8.0";
+
+  src = fetchFromGitHub {
+    owner = "boyter";
+    repo = "scc";
+    rev = "v${version}";
+    sha256 = "1g55aahr8j93jc1k2zgpnyxgp7ddn5137vjf8dafsmqp4m2qjq6g";
+  };
+
+  goPackagePath = "github.com/boyter/scc";
+
+  # scc has a scripts/ sub-package that's for testing.
+  subPackages = [ "./" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/boyter/scc;
+    description = "A very fast accurate code counter with complexity calculations and COCOMO estimates written in pure Go";
+    maintainers = with maintainers; [ sigma ];
+    license = with licenses; [ unlicense /* or */ mit ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10071,6 +10071,8 @@ in
 
   sbt-extras = callPackage ../development/tools/build-managers/sbt-extras { };
 
+  scc = callPackage ../development/tools/misc/scc { };
+
   scss-lint = callPackage ../development/tools/scss-lint { };
 
   shadowenv = callPackage ../tools/misc/shadowenv {


### PR DESCRIPTION
###### Motivation for this change
Adding a fast LOC counter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

