### PR TITLE
leo-editor: 5.7.3 -> 6.0, add Qt wrapping

### DIFF
--- a/pkgs/applications/editors/leo-editor/default.nix
+++ b/pkgs/applications/editors/leo-editor/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, python3, fetchFromGitHub, makeWrapper, makeDesktopItem }:
+{ stdenv, python3, fetchFromGitHub, makeWrapper, makeDesktopItem
+, wrapQtAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "leo-editor";
-  version = "5.7.3";
+  version = "6.0";
 
   src = fetchFromGitHub {
     owner = "leo-editor";
     repo = "leo-editor";
-    rev = version;
-    sha256 = "0ri6l6cxwva450l05af5vs1lsgrz6ciwd02njdgphs9pm1vwxbl9";
+    rev = "v${version}";
+    sha256 = "16hfhqxzkkzrv7mza24dypvm4zcarir6kw6fxvib2icrd12jyr6m";
   };
 
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper python3 ];
+  nativeBuildInputs = [ makeWrapper wrapQtAppsHook python3 ];
   propagatedBuildInputs = with python3.pkgs; [ pyqt5 docutils ];
 
   desktopItem = makeDesktopItem {
@@ -53,13 +54,15 @@ stdenv.mkDerivation rec {
     makeWrapper ${python3.interpreter} $out/bin/leo \
       --set PYTHONPATH "$PYTHONPATH:$out/share/leo-editor" \
       --add-flags "-O $out/share/leo-editor/launchLeo.py"
+
+    wrapQtApp $out/bin/leo
   '';
 
   meta = with stdenv.lib; {
     homepage = http://leoeditor.com;
     description = "A powerful folding editor";
     longDescription = "Leo is a PIM, IDE and outliner that accelerates the work flow of programmers, authors and web designers.";
-    license = licenses.mit;
+    license = with licenses; [ mit bsd3 ];
     maintainers = with maintainers; [ leonardoce ramkromberg ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19242,7 +19242,7 @@ in
 
   lemonbar-xft = callPackage ../applications/window-managers/lemonbar/xft.nix { };
 
-  leo-editor = callPackage ../applications/editors/leo-editor { };
+  leo-editor = libsForQt5.callPackage ../applications/editors/leo-editor { };
 
   libowfat = callPackage ../development/libraries/libowfat { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Bump version to 6.0 and fix a crash on startup due to #65399.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @leonardoce @RamKromberg 
