### PR TITLE
pythonPackages.ciso8601: init at 2.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3661,6 +3661,12 @@
     githubId = 307589;
     name = "Nathaniel Baxter";
   };
+  liamdiprose = {
+    email = "liam@liamdiprose.com";
+    github = "liamdiprose";
+    githubId = 1769386;
+    name = "Liam Diprose";
+  };
   liff = {
     email = "liff@iki.fi";
     github = "liff";

--- a/pkgs/development/python-modules/ciso8601/default.nix
+++ b/pkgs/development/python-modules/ciso8601/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, pytz
+, unittest2
+}:
+
+buildPythonPackage rec {
+  pname = "ciso8601";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "closeio";
+    repo = "ciso8601";
+    rev = "v${version}";
+    sha256 = "143b6mqhjnggvcd0wwbaj6k5g9820whx2q94145cb5bqgwq1lc5m";
+  };
+
+  propagatedBuildInputs = [ pytz ];
+
+  checkInputs = [ pytz ]
+   ++ lib.optional isPy27 unittest2;
+
+  meta = with lib; {
+    description = "Fast ISO8601 date time parser for Python written in C";
+    homepage = https://github.com/closeio/ciso8601;
+    license = licenses.mit;
+    maintainers = with maintainers; [ liamdiprose ];
+  };
+
+}

--- a/pkgs/development/python-modules/ciso8601/default.nix
+++ b/pkgs/development/python-modules/ciso8601/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, pytz
+, unittest2
+}:
+
+buildPythonPackage rec {
+  pname = "ciso8601";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "closeio";
+    repo = "ciso8601";
+    rev = "v${version}";
+    sha256 = "143b6mqhjnggvcd0wwbaj6k5g9820whx2q94145cb5bqgwq1lc5m";
+  };
+
+  propagatedBuildInputs = [ pytz ];
+
+  checkInputs = [ pytz ]
+   ++ lib.optional isPy27 unittest2;
+
+  meta = with lib; {
+    description = "Fast ISO8601 date time parser for Python written in C";
+    homepage = https://github.com/closeio/ciso8601
+    license = licenses.mit;
+    maintainers = with maintainers; [ liamdiprose ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1610,6 +1610,8 @@ in {
 
   circus = callPackage ../development/python-modules/circus {};
 
+  ciso8601 = callPackage ../development/python-modules/ciso8601 { };
+
   colorcet = callPackage ../development/python-modules/colorcet { };
 
   coloredlogs = callPackage ../development/python-modules/coloredlogs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Ubuntu 18.04
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) **not applicable?**
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).