### PR TITLE
oxidized: fix git-crypt dependency

### DIFF
--- a/pkgs/tools/admin/oxidized/Gemfile.lock
+++ b/pkgs/tools/admin/oxidized/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
     emk-sinatra-url-for (0.2.1)
       sinatra (>= 0.9.1.1)
     ffi (1.10.0)
+    git (1.5.0)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -17,6 +18,7 @@ GEM
     net-telnet (0.1.1)
     oxidized (0.26.3)
       asetus (~> 0.1)
+      git (~> 1)
       net-ssh (~> 5)
       net-telnet (~> 0.1.1)
       rugged (~> 0.21, >= 0.21.4)

--- a/pkgs/tools/admin/oxidized/gemset.nix
+++ b/pkgs/tools/admin/oxidized/gemset.nix
@@ -50,6 +50,16 @@
     };
     version = "1.10.0";
   };
+  git = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bf83icwypi3p3pd97vlqbnp3hvf31ncd440m9kh9y7x6yk74wyh";
+      type = "gem";
+    };
+    version = "1.5.0";
+  };
   haml = {
     dependencies = ["temple" "tilt"];
     groups = ["default"];
@@ -112,7 +122,7 @@
     version = "0.1.1";
   };
   oxidized = {
-    dependencies = ["asetus" "net-ssh" "net-telnet" "rugged" "slop"];
+    dependencies = ["asetus" "git" "net-ssh" "net-telnet" "rugged" "slop"];
     groups = ["default"];
     platforms = [];
     source = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix dependency (add git) so it will be possible to use git-crypt. Fixes https://github.com/NixOS/nixpkgs/issues/70838

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @WilliButz @nicknovitski 
