### PR TITLE
python3Packages.aioinflux: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3778,6 +3778,12 @@
     githubId = 307589;
     name = "Nathaniel Baxter";
   };
+  liamdiprose = {
+    email = "liam@liamdiprose.com";
+    github = "liamdiprose";
+    githubId = 1769386;
+    name = "Liam Diprose";
+  };
   liff = {
     email = "liff@iki.fi";
     github = "liff";

--- a/pkgs/development/python-modules/aioinflux/default.nix
+++ b/pkgs/development/python-modules/aioinflux/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, pytz
+, aiohttp
+, ciso8601
+, pandas
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "aioinflux";
+  version = "0.9.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "gusutabopb";
+    repo = "aioinflux";
+    rev = "v${version}";
+    sha256 = "0cvzkd05i8bzh76m75s7na2gb0kh5msyyz60ajxpj2by9x6qkxmc";
+  };
+
+  propagatedBuildInputs = [ aiohttp pytz ciso8601 pandas ];
+
+  # Tests require local networking so won't run in the sandbox
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Asynchronous Python client for InfluxDB";
+    homepage = https://github.com/gusutabopb/aioinflux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ liamdiprose ];
+  };
+}

--- a/pkgs/development/python-modules/ciso8601/default.nix
+++ b/pkgs/development/python-modules/ciso8601/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, isPy27
+, fetchFromGitHub
+, pytz
+, unittest2
+}:
+
+buildPythonPackage rec {
+  pname = "ciso8601";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "closeio";
+    repo = "ciso8601";
+    rev = "v${version}";
+    sha256 = "143b6mqhjnggvcd0wwbaj6k5g9820whx2q94145cb5bqgwq1lc5m";
+  };
+
+  propagatedBuildInputs = [ pytz ];
+
+  checkInputs = [ pytz ]
+   ++ lib.optional isPy27 unittest2;
+
+  meta = with lib; {
+    description = "Fast ISO8601 date time parser for Python written in C";
+    homepage = https://github.com/closeio/ciso8601;
+    license = licenses.mit;
+    maintainers = with maintainers; [ liamdiprose ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1643,6 +1643,10 @@ in {
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };
 
+  circus = callPackage ../development/python-modules/circus {};
+
+  ciso8601 = callPackage ../development/python-modules/ciso8601 { };
+
   colorcet = callPackage ../development/python-modules/colorcet { };
 
   coloredlogs = callPackage ../development/python-modules/coloredlogs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -157,6 +157,8 @@ in {
 
   aioimaplib = callPackage ../development/python-modules/aioimaplib { };
 
+  aioinflux = callPackage ../development/python-modules/aioinflux { };
+
   aiolifx = callPackage ../development/python-modules/aiolifx { };
 
   aiolifx-effects = callPackage ../development/python-modules/aiolifx-effects { };
@@ -1642,8 +1644,6 @@ in {
   cli-helpers = callPackage ../development/python-modules/cli-helpers {};
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };
-
-  circus = callPackage ../development/python-modules/circus {};
 
   ciso8601 = callPackage ../development/python-modules/ciso8601 { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] Ubuntu 18.04
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
