### PR TITLE
mariadb: fix builds on darwin

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -41,9 +41,6 @@ common = rec { # attributes common to both builds
 
   prePatch = ''
     sed -i 's,[^"]*/var/log,/var/log,g' storage/mroonga/vendor/groonga/CMakeLists.txt
-  '' + optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace cmake/build_configurations/mysql_release.cmake \
-      --replace "SET(PLUGIN_AUTH_PAM YES)" ""
   '';
 
   patches = [
@@ -163,6 +160,8 @@ server = stdenv.mkDerivation (common // {
 
   patches = common.patches ++ [
     ./cmake-without-client.patch
+  ] ++ optionals stdenv.isDarwin [
+    ./cmake-without-plugin-auth-pam.patch
   ];
 
   cmakeFlags = common.cmakeFlags ++ [


### PR DESCRIPTION
Fixes #70835

We want to disable `PLUGIN_AUTH_PAM` when building:

1. `mariadb` on macOS.
2. `mariadb-client` on any platform

Unfortunately, the interaction of these two commits, 6c97b0486c97481dfdb82036de5382921269a771 and 7e43b4d0aee408c3742b84e89749c2c494f16cfe, created a situation where we disable it *twice* when building on macOS: Once in a darwin-specific `prePatch` script, and again in the `patches` section for client builds.

(See [L42-47](https://github.com/NixOS/nixpkgs/blob/6dc7f20f85b584410d171b71cd074b60ac65307e/pkgs/servers/sql/mariadb/default.nix#L42-L47) and [L124-127](https://github.com/NixOS/nixpkgs/blob/6dc7f20f85b584410d171b71cd074b60ac65307e/pkgs/servers/sql/mariadb/default.nix#L124-L127) in the [parent commit](https://github.com/NixOS/nixpkgs/blob/6dc7f20f85b584410d171b71cd074b60ac65307e/pkgs/servers/sql/mariadb/default.nix))

This removes the redundant `prePatch` script and conditionally applies the patch to `mariadb` server builds on darwin.

###### Motivation for this change

- Both mariadb and mariadb-client stopped building on macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice 
