### PR TITLE
chromaprint: 1.3.2 -> 1.4.3

### DIFF
--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchurl, cmake, boost, ffmpeg }:
+{ stdenv, fetchFromGitHub, cmake, boost, ffmpeg }:
 
 stdenv.mkDerivation rec {
   pname = "chromaprint";
-  version = "1.3.2";
+  version = "1.4.3";
 
-  src = fetchurl {
-    url = "https://bitbucket.org/acoustid/chromaprint/downloads/${pname}-${version}.tar.gz";
-    sha256 = "0lln8dh33gslb9cbmd1hcv33pr6jxdwipd8m8gbsyhksiq6r1by3";
+  src = fetchFromGitHub {
+    owner = "acoustid";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "110js8gspaamqpy6wqshr6vjc55xbgiqy4bqni5jr8ljsialll26";
   };
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ boost ffmpeg ];
 
-  cmakeFlags = [ "-DBUILD_EXAMPLES=ON" ];
+  cmakeFlags = [ "-DBUILD_TOOLS=ON" ];
 
   meta = with stdenv.lib; {
     homepage = https://acoustid.org/chromaprint;


### PR DESCRIPTION

###### Motivation for this change

Upgrade `chromaprint` 1.3.2 to 1.4.3. This fixes an issue with Picard and `fpcalc`, though Picard itself has an annoying habit of saving the absolute path to `fpcalc` (i.e. in the store) in the user configuration, and thus updates to `fpcalc` are not picked up automatically. I'm planning on submitting a patch to remove that behaviour from Picard.

`nix-review` wanted to build _a lot_... so I've left it running for a bit...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ehmry 
