### PR TITLE
openmpi: 4.0.1 -> 4.0.2

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "4.0.1";
+  version = "4.0.2";
 
 in stdenv.mkDerivation rec {
   pname = "openmpi";
@@ -17,16 +17,8 @@ in stdenv.mkDerivation rec {
 
   src = with stdenv.lib.versions; fetchurl {
     url = "https://www.open-mpi.org/software/ompi/v${major version}.${minor version}/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "02cpzcp113gj5hb0j2xc0cqma2fn04i2i0bzf80r71120p9bdryc";
+    sha256 = "0ms0zvyxyy3pnx9qwib6zaljyp2b3ixny64xvq3czv3jpr8zf2wh";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "openmpi-mca_btl_vader_component_close-segfault.patch";
-      url = "https://github.com/open-mpi/ompi/pull/6526.patch";
-      sha256 = "0s7ac9rkcj3fi6ampkvy76njlj478yyr4zvypjc7licy6dgr595x";
-    })
-  ];
 
   postPatch = ''
     patchShebangs ./


### PR DESCRIPTION
###### Motivation for this change
https://raw.githubusercontent.com/open-mpi/ompi/v4.0.x/NEWS

###### Things done
* Removed upstream patch

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### nix-review
Failures seem to be unrelated to openmpi
```
cntk ethminer python27Packages.cntk python27Packages.tensorflowWithCuda
python37Packages.datashader python37Packages.tensorflowWithCuda

56 package were build:
dl-poly-classic-mpi ethash freecad getdp globalarrays gromacsDoubleMpi
gromacsMpi hdf5-mpi hpl ior lammps-mpi libtensorflow migrate netcdf-mpi
neuron-full neuron-mpi openmolcas openmpi parmetis python27Packages.baselines
python27Packages.dm-sonnet python27Packages.edward python27Packages.fipy
python27Packages.graph_nets python27Packages.h5py-mpi python27Packages.mpi4py 
python27Packages.neurotools python27Packages.tensorflow
python27Packages.tensorflow-probability python27Packages.tflearn python37Packages.baselines
python37Packages.dask-jobqueue python37Packages.dask-mpi python37Packages.dask-xgboost
python37Packages.dftfit python37Packages.distributed python37Packages.dm-sonnet
python37Packages.edward python37Packages.fipy python37Packages.graph_nets
python37Packages.h5py-mpi python37Packages.lammps-cython python37Packages.mpi4py
python37Packages.neuron-mpi python37Packages.optuna python37Packages.rl-coach
python37Packages.streamz python37Packages.stumpy python37Packages.tensorflow
python37Packages.tensorflow-probability python37Packages.tflearn
quantum-espresso-mpi raxml-mpi scalapack scotch siesta-mpi
```
