### PR TITLE
android-studio: add new emulator dependencies

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -1,8 +1,11 @@
 { channel, pname, version, build, sha256Hash }:
 
-{ bash
+{ alsaLib
+, bash
 , buildFHSUserEnv
 , coreutils
+, dbus
+, expat
 , fetchurl
 , findutils
 , file
@@ -19,16 +22,24 @@
 , libpulseaudio
 , libGL
 , libX11
+, libxcb
+, libXcomposite
+, libXcursor
+, libXdamage
 , libXext
+, libXfixes
 , libXi
 , libXrandr
 , libXrender
 , libXtst
 , makeWrapper
+, nspr
+, nss
 , pciutils
 , pkgsi686Linux
 , setxkbmap
 , stdenv
+, systemd
 , unzip
 , which
 , runCommand
@@ -99,9 +110,20 @@ let
           libXrandr
 
           # For Android emulator
+          alsaLib
+          dbus
+          expat
           libpulseaudio
           libX11
+          libxcb
+          libXcomposite
+          libXcursor
+          libXdamage
+          libXfixes
           libGL
+          nspr
+          nss
+          systemd
 
           # For GTKLookAndFeel
           gtk2


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Android emulator has gotten a few new dependencies. Without those present, it won't start.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @primeos
