### PR TITLE
add documentation for booting ISO image via grub

### DIFF
--- a/nixos/doc/manual/installation/installing-loopback.xml
+++ b/nixos/doc/manual/installation/installing-loopback.xml
@@ -1,0 +1,25 @@
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-booting-iso-from-grub">
+ <title>Booting from ISO on disk via grub</title>
+
+ <para>
+  For systems without CD drive, the NixOS live CD can be booted directly via grub. 
+  Place the ISO image on your boot partition in a <literal>iso</literal> sub-directory, e.g. <literal>/boot/iso</literal>.
+  Source the <literal>autoiso.cfg</literal> from <literal>/docs</literal> of the <literal>grub</literal> package.
+  You can also get it from <link xlink:href="https://git.savannah.gnu.org/gitweb/?p=grub.git;a=blob_plain;f=docs/autoiso.cfg;hb=HEAD">https://git.savannah.gnu.org/gitweb/?p=grub.git;a=blob_plain;f=docs/autoiso.cfg;hb=HEAD</link>.
+  and it will be detected by https://github.com/rhboot/grub2/blob/master/docs/autoiso.cfg, when you source it in your <literal>grub.cfg</literal> or <literal>custom.cfg</literal>.
+
+<screen>
+<prompt>$ </prompt>cd /boot
+<prompt>$ </prompt>mkdir -p iso && cd iso
+<prompt>$ </prompt>wget https://releases.nixos.org/nixos/unstable/nixos-20.03pre196201.07d4df59626/nixos-graphical-20.03pre196201.07d4df59626-x86_64-linux.iso
+<prompt>$ </prompt>cd ../grub
+<prompt>$ </prompt>wget "https://git.savannah.gnu.org/gitweb/?p=grub.git;a=blob_plain;f=docs/autoiso.cfg;hb=HEAD"
+<prompt>$ </prompt>echo "source autoiso.cfg" >>custom.cfg
+</screen>
+
+ </para>
+</section>

--- a/nixos/doc/manual/installation/installing-loopback.xml
+++ b/nixos/doc/manual/installation/installing-loopback.xml
@@ -14,7 +14,7 @@
 
 <screen>
 <prompt>$ </prompt>cd /boot
-<prompt>$ </prompt>mkdir -p iso && cd iso
+<prompt>$ </prompt>mkdir -p iso; cd iso
 <prompt>$ </prompt>wget https://releases.nixos.org/nixos/unstable/nixos-20.03pre196201.07d4df59626/nixos-graphical-20.03pre196201.07d4df59626-x86_64-linux.iso
 <prompt>$ </prompt>cd ../grub
 <prompt>$ </prompt>wget "https://git.savannah.gnu.org/gitweb/?p=grub.git;a=blob_plain;f=docs/autoiso.cfg;hb=HEAD"

--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -554,6 +554,8 @@ Retype new UNIX password: ***</screen>
  <section xml:id="sec-installation-additional-notes">
   <title>Additional installation notes</title>
 
+  <xi:include href="installing-loopback.xml" />
+
   <xi:include href="installing-usb.xml" />
 
   <xi:include href="installing-pxe.xml" />


### PR DESCRIPTION
###### Motivation for this change
documentation for #67627

###### Things done
was not able to check how these changes compile, since the process core-dumped on my system.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
