### PR TITLE
pythonPackages.slither-analyzer: add setuptools

### DIFF
--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -1,4 +1,8 @@
-{ lib, buildPythonPackage, fetchPypi, makeWrapper, prettytable, pythonOlder, solc }:
+{ lib, buildPythonPackage, fetchPypi, makeWrapper, pythonOlder
+, prettytable
+, setuptools
+, solc
+}:
 
 buildPythonPackage rec {
   pname = "slither-analyzer";
@@ -15,7 +19,7 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  propagatedBuildInputs = [ prettytable ];
+  propagatedBuildInputs = [ prettytable setuptools ];
 
   postFixup = ''
     wrapProgram $out/bin/slither \


### PR DESCRIPTION
##### Motivation for this change
noticed it was broken while reviewing #70779

before:
```
slither --help
Traceback (most recent call last):
  File "/nix/store/avcqq2i4qxrq0q88lcfjcqwp5kwncsc0-python3.7-slither-analyzer-0.3.0/bin/.slither-wrapped", line 7, in <module>
    from slither.__main__ import main
  File "/nix/store/avcqq2i4qxrq0q88lcfjcqwp5kwncsc0-python3.7-slither-analyzer-0.3.0/lib/python3.7/site-packages/slither/__main__.py", line 12, in <module>
    from pkg_resources import iter_entry_points, require
ModuleNotFoundError: No module named 'pkg_resources'
```
after:
```
$ slither --help
usage: slither.py contract.sol [flag]

Slither

positional arguments:
....
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
