### PR TITLE
truvari: init at 1.3.2

### DIFF
--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -1,6 +1,6 @@
 { lib
 , fetchFromGitHub
-, pythonPackages
+, buildPythonPackage
 , pyvcf
 , python-Levenshtein
 , progressbar2
@@ -9,7 +9,7 @@
 , intervaltree
 }:
 
-pythonPackages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "truvari";
   version = "1.3.2";
 

--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitHub
-, python
 , pythonPackages
 , pyvcf
 , python-Levenshtein
@@ -9,8 +8,8 @@
 , pyfaidx
 , intervaltree
 }:
-pythonPackages.buildPythonPackage rec {
 
+pythonPackages.buildPythonPackage rec {
   pname = "truvari";
   version = "1.3.2";
 
@@ -32,8 +31,8 @@ pythonPackages.buildPythonPackage rec {
 
   prePatch = ''
     substituteInPlace ./setup.py \
-      --replace "pysam==0.15.2" "pysam==0.15.3" \
-      --replace "progressbar2==3.41.0" "progressbar2==3.42.0"
+      --replace '"progressbar2==3.41.0",' "" \
+      --replace '"pysam==0.15.2",' ""
   '';
 
   meta = with lib; {
@@ -47,5 +46,4 @@ pythonPackages.buildPythonPackage rec {
       is created by Spiral Genetics.
     '';
   };
-
 }

--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, fetchFromGitHub
+, python
+, pythonPackages
+, pyvcf
+, python-Levenshtein
+, progressbar2
+, pysam
+, pyfaidx
+, intervaltree
+}:
+
+pythonPackages.buildPythonPackage rec {
+
+  pname = "truvari";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "spiralgenetics";
+    repo = "truvari";
+    rev = "v${version}";
+    sha256 = "0wmjz8nzibvj0ixky1m0qi7iyd204prk7glbvig1cvaab33k19f1";
+  };
+
+  propagatedBuildInputs = [
+    pyvcf
+    python-Levenshtein
+    progressbar2
+    pysam
+    pyfaidx
+    intervaltree
+  ];
+
+  prePatch = ''
+    substituteInPlace ./setup.py \
+      --replace "pysam==0.15.2" "pysam==0.15.3" \
+      --replace "progressbar2==3.41.0" "progressbar2==3.42.0"
+  '';
+
+  meta = with lib; {
+    description = "Structural variant comparison tool for VCFs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ scalavision ];
+    longDescription = ''
+      Truvari is a benchmarking tool for comparison sets of SVs.
+      It can calculate the recall, precision, and f-measure of a
+      vcf from a given structural variant caller. The tool
+      is created by Spiral Genetics.
+    '';
+  };
+
+}

--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -1,15 +1,9 @@
 { lib
 , fetchFromGitHub
-, buildPythonPackage
-, pyvcf
-, python-Levenshtein
-, progressbar2
-, pysam
-, pyfaidx
-, intervaltree
+, python3Packages
 }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   pname = "truvari";
   version = "1.3.2";
 
@@ -20,7 +14,7 @@ buildPythonPackage rec {
     sha256 = "0wmjz8nzibvj0ixky1m0qi7iyd204prk7glbvig1cvaab33k19f1";
   };
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python3Packages; [
     pyvcf
     python-Levenshtein
     progressbar2

--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -3,7 +3,7 @@
 , python3Packages
 }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "truvari";
   version = "1.3.2";
 

--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -9,7 +9,6 @@
 , pyfaidx
 , intervaltree
 }:
-
 pythonPackages.buildPythonPackage rec {
 
   pname = "truvari";

--- a/pkgs/development/python-modules/pyvcf/default.nix
+++ b/pkgs/development/python-modules/pyvcf/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+}:
+
+buildPythonPackage rec {
+
+  pname = "PyVCF";
+  version = "0.6.8";
+
+  src = fetchFromGitHub {
+    owner = "jamescasbon";
+    repo = "PyVCF";
+    rev = "476169cd457ba0caa6b998b301a4d91e975251d9";
+    sha256 = "0qf9lwj7r2hjjp4bd4vc7nayrhblfm4qcqs4dbd43a6p4bj2jv5p";
+  };
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    homepage = "https://pyvcf.readthedocs.io/en/latest/index.html";
+    description = "A VCF (Variant Call Format) Parser for Python, supporting version 4.0 and 4.1";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ scalavision ];
+    longDescription = ''
+      The intent of this module is to mimic the csv module in the Python stdlib, 
+      as opposed to more flexible serialization formats like JSON or YAML. 
+      vcf will attempt to parse the content of each record based on the data 
+      types specified in the meta-information lines
+    '';
+  };
+
+}

--- a/pkgs/development/python-modules/pyvcf/default.nix
+++ b/pkgs/development/python-modules/pyvcf/default.nix
@@ -3,8 +3,8 @@
 , fetchFromGitHub
 , pytest
 }:
-buildPythonPackage rec {
 
+buildPythonPackage rec {
   pname = "PyVCF";
   version = "0.6.8";
 
@@ -29,5 +29,4 @@ buildPythonPackage rec {
       types specified in the meta-information lines
     '';
   };
-
 }

--- a/pkgs/development/python-modules/pyvcf/default.nix
+++ b/pkgs/development/python-modules/pyvcf/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , pytest
 }:
-
 buildPythonPackage rec {
 
   pname = "PyVCF";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23124,7 +23124,7 @@ in
 
   trimal = callPackage ../applications/science/biology/trimal { };
 
-  truvari = python3Packages.callPackage ../applications/science/biology/truvari { };
+  truvari = callPackage ../applications/science/biology/truvari { };
 
   varscan = callPackage ../applications/science/biology/varscan { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23124,6 +23124,8 @@ in
 
   trimal = callPackage ../applications/science/biology/trimal { };
 
+  truvari = python3Packages.callPackage ../applications/science/biology/truvari { };
+
   varscan = callPackage ../applications/science/biology/varscan { };
 
   hmmer = callPackage ../applications/science/biology/hmmer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1152,6 +1152,8 @@ in {
 
   pyvcd = callPackage ../development/python-modules/pyvcd { };
 
+  pyvcf = callPackage ../development/python-modules/pyvcf { };
+
   pyvoro = callPackage ../development/python-modules/pyvoro { };
 
   relatorio = callPackage ../development/python-modules/relatorio { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x] Ensured that relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

The pyvcf license doesn't exclusively say MIT, but the text is identical as far as I can see.

I've created a specific version of the progressbar, don't know if any of the existing ones could be upgraded.

I upgraded the pysam library version to 0.15.3 to avoid creating a specific version for truvari. The differences of the versions seems to not have any compatibility issues.

Truvari is a much used tools for benchmarking within bioinformatics.
