### PR TITLE
mariadb-client: create symlinks for libmariadb

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -144,6 +144,7 @@ client = stdenv.mkDerivation (common // {
     rm "$out"/lib/{libmariadb${libExt},libmysqlclient${libExt},libmysqlclient_r${libExt}}
     mv "$libmysqlclient_path" "$out"/lib/libmysqlclient${libExt}
     ln -sv libmysqlclient${libExt} "$out"/lib/libmysqlclient_r${libExt}
+    ln -sv libmysqlclient${libExt} "$out"/lib/libmariadb${libExt}
   '';
 });
 


### PR DESCRIPTION
Fixes #67144

⚠️ This won't build on macOS until #70841 gets merged. With that patch included, it passes nix-review: 

<details><summary>nix-review output on darwin</summary>

```
$ nix build --no-link --keep-going --max-jobs 8 --option build-use-sandbox true -f /Users/dan/.cache/nix-review/rev-4073dddb87c600b52e967b0f695a65aa2d445ded/build.nix
warning: ignoring the user-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
[7 built, 12 copied (627.1 MiB), 197.7 MiB DL]
8 package were build:
diesel-cli lua51Packages.luadbi-mysql lua52Packages.luadbi-mysql lua53Packages.luadbi-mysql luajitPackages.luadbi-mysql mariadb mysql-client shmig
```
</details>

###### Motivation for this change
I can't build things that link to mariadb's client libraries.

I ran into this issue trying to install Python's mysqlclient module. Other folks ran into issues installing OCaml bindings to mysql (#67144).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice @Izorkin @matthewbauer