### PR TITLE
aws-sdk-cpp: fixing hydra build

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   # FIXME: might be nice to put different APIs in different outputs
   # (e.g. libaws-cpp-sdk-s3.so in output "s3").
   outputs = [ "out" "dev" ];
-  separateDebugInfo = stdenv.isLinux;
 
   nativeBuildInputs = [ cmake curl ];
 


### PR DESCRIPTION
###### Motivation for this change

Making debug info conditional to fix hydra build.
The debug symbols alone are around ~1.8GB in size, which
makes the closure combined with the other two outputs
too large.

Failing hydra build: https://hydra.nixos.org/build/101616680#tabs-details
Hydra build from 19.03: https://hydra.nixos.org/build/101616680#tabs-details

Related: https://github.com/NixOS/nixpkgs/issues/68361

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edolstra @orivej 
