### PR TITLE
srt-vtt: init at 2019-01-03

### DIFF
--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ ericdallo ];
     homepage = https://github.com/nwoltman/srt-to-vtt-cl;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, which, substituteAll }:
+{ stdenv, fetchFromGitHub, substituteAll }:
 
 stdenv.mkDerivation rec {
   pname = "srt-to-vtt-cl";
@@ -11,14 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "0qxysj08gjr6npyvg148llmwmjl2n9cyqjllfnf3gxb841dy370n";
   };
 
-  buildInputs = [
-    which
-  ];
-
   patches = [
     (substituteAll {
-      src = ./fix-which-command.patch;
-      inherit which;
+      src = ./fix-validation.patch;
     })
   ];
 

--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, which, substituteAll }:
+
+stdenv.mkDerivation rec {
+  pname = "srt-to-vtt-cl";
+  version = "2019-01-03";
+
+  src = fetchFromGitHub {
+    owner = "nwoltman";
+    repo = pname;
+    rev = "ce3d0776906eb847c129d99a85077b5082f74724";
+    sha256 = "0qxysj08gjr6npyvg148llmwmjl2n9cyqjllfnf3gxb841dy370n";
+  };
+
+  buildInputs = [
+    which
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./fix-which-command.patch;
+      inherit which;
+    })
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/$(uname -s)/$(uname -m)/srt-vtt $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Convert SRT files to VTT";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ericdallo ];
+    homepage = https://github.com/nwoltman/srt-to-vtt-cl;
+  };
+}

--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, which, substituteAll }:
 
 stdenv.mkDerivation rec {
-  pname = "srt-to-vtt-cl";
+  pname = "srt-to-vtt-cl-unstable";
   version = "2019-01-03";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, which, substituteAll }:
 
 stdenv.mkDerivation rec {
-  pname = "srt-to-vtt-cl-unstable";
-  version = "2019-01-03";
+  pname = "srt-to-vtt-cl";
+  version = "unstable-2019-01-03";
 
   src = fetchFromGitHub {
     owner = "nwoltman";

--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/fix-validation.patch
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/fix-validation.patch
@@ -1,0 +1,13 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1,9 +1,4 @@
+-ERR = $(shell which clang++ >/dev/null; echo $$?)
+-ifeq "$(ERR)" "0"
+-	CXX ?= clang++
+-else
+-	CXX ?= g++
+-endif
++CXX ?= g++
+ CXXFLAGS = -std=c++11 -O2 -MMD -I ./deps
+ OBJECTS := src/text_encoding_detect.o src/Utils.o src/Converter.o src/main.o
+ DEPENDS := $(OBJECTS:.o=.d)

--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/fix-which-command.patch
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/fix-which-command.patch
@@ -1,8 +1,0 @@
---- a/Makefile
-+++ b/Makefile
-@@ -1,4 +1,4 @@
--ERR = $(shell which clang++ >/dev/null; echo $$?)
-+ERR = $(shell @which@/bin/which clang++ >/dev/null; echo $$?)
- ifeq "$(ERR)" "0"
- 	CXX ?= clang++
- else

--- a/pkgs/tools/cd-dvd/srt-to-vtt-cl/fix-which-command.patch
+++ b/pkgs/tools/cd-dvd/srt-to-vtt-cl/fix-which-command.patch
@@ -1,0 +1,8 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1,4 +1,4 @@
+-ERR = $(shell which clang++ >/dev/null; echo $$?)
++ERR = $(shell @which@/bin/which clang++ >/dev/null; echo $$?)
+ ifeq "$(ERR)" "0"
+ 	CXX ?= clang++
+ else

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6232,6 +6232,8 @@ in
 
   srcml = callPackage ../applications/version-management/srcml { };
 
+  srt-to-vtt-cl = callPackage ../tools/cd-dvd/srt-to-vtt-cl { };
+
   sourcehut = callPackage ../applications/version-management/sourcehut { };
 
   sshfs-fuse = callPackage ../tools/filesystems/sshfs-fuse { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add `srt-vtt` command

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
