### PR TITLE
[Docs] Add a hint on Virtualbox machine setup

### DIFF
--- a/nixos/doc/manual/installation/installing-virtualbox-guest.xml
+++ b/nixos/doc/manual/installation/installing-virtualbox-guest.xml
@@ -49,6 +49,11 @@
   </listitem>
   <listitem>
    <para>
+    Click on Settings / Display / Screen and select VBoxVGA as Graphics Controller
+   </para>
+  </listitem>
+  <listitem>
+   <para>
     Save the settings, start the virtual machine, and continue installation
     like normal
    </para>


### PR DESCRIPTION
By default VMSVGA is set, which causes failure upon X startup.

###### Motivation for this change
I've wasted too much time on this while trying out NixOS on Virtualbox. Hope no one else will.

###### Things done
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
