### PR TITLE
 doc: Add documentation for the new option to the Automatic Upgrades section

### DIFF
--- a/nixos/doc/manual/installation/upgrading.xml
+++ b/nixos/doc/manual/installation/upgrading.xml
@@ -120,12 +120,17 @@ nixos https://nixos.org/channels/nixos-unstable
    to <filename>configuration.nix</filename>:
 <programlisting>
 <xref linkend="opt-system.autoUpgrade.enable"/> = true;
+<xref linkend="opt-system.autoUpgrade.allowReboot"/> = true;
 </programlisting>
    This enables a periodically executed systemd service named
-   <literal>nixos-upgrade.service</literal>. It runs <command>nixos-rebuild
-   switch --upgrade</command> to upgrade NixOS to the latest version in the
-   current channel. (To see when the service runs, see <command>systemctl
-   list-timers</command>.) You can also specify a channel explicitly, e.g.
+   <literal>nixos-upgrade.service</literal>. If the <literal>allowReboot</literal>
+   option is <literal>false</literal>, it runs <command>nixos-rebuild switch
+   --upgrade</command> to upgrade NixOS to the latest version in the current
+   channel. (To see when the service runs, see <command>systemctl list-timers</command>.)
+   If <literal>allowReboot</literal> is <literal>true</literal>, then the
+   system will automatically reboot if the new generation contains a different
+   kernel, initrd or kernel modules.
+   You can also specify a channel explicitly, e.g.
 <programlisting>
 <xref linkend="opt-system.autoUpgrade.channel"/> = https://nixos.org/channels/nixos-19.09;
 </programlisting>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add information to the release notes for 19.09
Backport to 19.09: #71056

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
