### PR TITLE
sshoogr init at 0.9.26

### DIFF
--- a/pkgs/tools/networking/sshoogr/default.nix
+++ b/pkgs/tools/networking/sshoogr/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchzip, jdk, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "sshoogr";
+  version = "0.9.26";
+
+  src = fetchzip {
+    url = "https://repo1.maven.org/maven2/com/aestasit/infrastructure/${pname}/${pname}/${version}/${pname}-${version}.zip";
+    sha256 = "134qlx90y82g1rfxhyn12z9r2imm1l3fz09hrrn3pgcdcq5jz2s1";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    rm bin/sshoogr.bat
+    cp -r . $out
+    wrapProgram $out/bin/sshoogr \
+      --prefix JAVA_HOME : ${jdk}
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      A Groovy-based DSL for working with remote SSH servers
+    '';
+    longDescription = ''
+      The sshoogr (pronounced [ʃʊgə]) is a Groovy-based DSL library for working
+      with remote servers through SSH. The DSL allows: connecting, executing 
+      remote commands, copying files and directories, creating tunnels in a 
+      simple and concise way.
+    '';
+    homepage = "https://github.com/aestasit/sshoogr";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ moaxcp ];
+  };
+} 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6328,6 +6328,8 @@ in
 
   sslmate = callPackage ../development/tools/sslmate { };
 
+  sshoogr = callPackage ../tools/networking/sshoogr { };
+
   ssmtp = callPackage ../tools/networking/ssmtp { };
 
   ssocr = callPackage ../applications/misc/ssocr { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add sshoogr groovy dsl to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
