### PR TITLE
pantheon: use latest vala

### DIFF
--- a/pkgs/applications/audio/vocal/default.nix
+++ b/pkgs/applications/audio/vocal/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , cmake
 , ninja
+, vala
 , pkgconfig
 , pantheon
 , gtk3
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
     cmake
     libxml2
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     wrapGAppsHook
   ];

--- a/pkgs/applications/editors/quilter/default.nix
+++ b/pkgs/applications/editors/quilter/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, meson, ninja, python3
+{ stdenv, fetchFromGitHub, pkgconfig, meson, ninja, python3, vala
 , gtk3, desktop-file-utils, gtksourceview, webkitgtk, gtkspell3, pantheon
 , libgee, discount, wrapGAppsHook }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     desktop-file-utils
     meson
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     python3
     wrapGAppsHook

--- a/pkgs/applications/graphics/fondo/default.nix
+++ b/pkgs/applications/graphics/fondo/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , fetchpatch
 , pantheon
+, vala
 , pkgconfig
 , meson
 , ninja
@@ -31,7 +32,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     python3
     wrapGAppsHook

--- a/pkgs/applications/graphics/ideogram/default.nix
+++ b/pkgs/applications/graphics/ideogram/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchFromGitHub
 , fetchpatch
+, vala
 , pkgconfig
 , python3
 , glib
@@ -31,7 +32,7 @@ stdenv.mkDerivation rec {
     hicolor-icon-theme # for setup-hook
     meson
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     python3
     wrapGAppsHook

--- a/pkgs/applications/misc/appeditor/default.nix
+++ b/pkgs/applications/misc/appeditor/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, vala
 , meson
 , ninja
 , pkgconfig
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
     gettext
     meson
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     python3
     wrapGAppsHook

--- a/pkgs/applications/misc/cipher/default.nix
+++ b/pkgs/applications/misc/cipher/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , meson
 , ninja
+, vala
 , pkgconfig
 , pantheon
 , python3
@@ -27,7 +28,7 @@ stdenv.mkDerivation rec {
     gettext
     meson
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     python3
     wrapGAppsHook

--- a/pkgs/applications/misc/formatter/default.nix
+++ b/pkgs/applications/misc/formatter/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , meson
 , ninja
+, vala
 , pkgconfig
 , pantheon
 , python3
@@ -42,7 +43,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     python3
     wrapGAppsHook

--- a/pkgs/applications/misc/notejot/default.nix
+++ b/pkgs/applications/misc/notejot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, meson, ninja, python3, pantheon
+{ stdenv, fetchFromGitHub, vala, pkgconfig, meson, ninja, python3, pantheon
 , gtk3, gtksourceview, json-glib, libgee, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     python3
     wrapGAppsHook

--- a/pkgs/applications/misc/regextester/default.nix
+++ b/pkgs/applications/misc/regextester/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, vala
 , gettext
 , libxml2
 , pkgconfig
@@ -25,7 +26,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pantheon.vala
+    vala
     gettext
     gobject-introspection
     libxml2

--- a/pkgs/applications/misc/sequeler/default.nix
+++ b/pkgs/applications/misc/sequeler/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, meson, ninja, pkgconfig, pantheon, gettext, wrapGAppsHook, python3, desktop-file-utils
+, vala, meson, ninja, pkgconfig, pantheon, gettext, wrapGAppsHook, python3, desktop-file-utils
 , gtk3, glib, libgee, libgda, gtksourceview, libxml2, libsecret, libssh2 }:
 
 
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
     sha256 = "16vc3v9qls9fxg9h8fsi67z68s4acl5hj14gbcrnqm7mf3kmk3aw";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig pantheon.vala gettext wrapGAppsHook python3 desktop-file-utils ];
+  nativeBuildInputs = [ meson ninja pkgconfig vala gettext wrapGAppsHook python3 desktop-file-utils ];
 
   buildInputs = [ gtk3 glib pantheon.granite libgee sqlGda gtksourceview libxml2 libsecret libssh2 ];
 

--- a/pkgs/applications/misc/tootle/default.nix
+++ b/pkgs/applications/misc/tootle/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, meson, ninja, pkgconfig, python3, libgee, gsettings-desktop-schemas
+, vala, meson, ninja, pkgconfig, python3, libgee, gsettings-desktop-schemas
 , gnome3, pantheon, gobject-introspection, wrapGAppsHook
 , gtk3, json-glib, glib, glib-networking, hicolor-icon-theme
 }:
@@ -23,7 +23,7 @@ in stdenv.mkDerivation {
     ninja
     pkgconfig
     python3
-    pantheon.vala
+    vala
     wrapGAppsHook
   ];
   buildInputs = [

--- a/pkgs/applications/networking/browsers/ephemeral/default.nix
+++ b/pkgs/applications/networking/browsers/ephemeral/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchFromGitHub
 , desktop-file-utils
+, vala
 , gettext
 , glib
 , gtk3
@@ -33,7 +34,7 @@ stdenv.mkDerivation rec {
     gettext
     meson
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     python3
     wrapGAppsHook

--- a/pkgs/applications/networking/ftp/taxi/default.nix
+++ b/pkgs/applications/networking/ftp/taxi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pantheon, pkgconfig, meson, ninja, python3
+{ stdenv, fetchFromGitHub, pantheon, pkgconfig, meson, ninja, python3, vala
 , gtk3, libgee, libsoup, libsecret, gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pantheon.vala
+    vala
     gobject-introspection
     meson
     ninja

--- a/pkgs/applications/networking/p2p/torrential/default.nix
+++ b/pkgs/applications/networking/p2p/torrential/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , cmake
 , pkgconfig
+, vala
 , pantheon
 , curl
 , glib
@@ -14,7 +15,8 @@
 , libunity
 , miniupnpc
 , openssl
-, wrapGAppsHook }:
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "torrential";
@@ -30,7 +32,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    pantheon.vala
+    vala
     pkgconfig
     wrapGAppsHook
   ];

--- a/pkgs/applications/networking/ping/default.nix
+++ b/pkgs/applications/networking/ping/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , meson
 , ninja
+, vala
 , pkgconfig
 , pantheon
 , python3
@@ -28,7 +29,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     python3
     wrapGAppsHook

--- a/pkgs/applications/networking/transporter/default.nix
+++ b/pkgs/applications/networking/transporter/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , meson
 , ninja
+, vala
 , pkgconfig
 , gtk3
 , python3
@@ -31,7 +32,7 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [
     appstream-glib
     desktop-file-utils
-    pantheon.vala
+    vala
     gettext
     gobject-introspection # For setup hook
     libxml2

--- a/pkgs/applications/office/aesop/default.nix
+++ b/pkgs/applications/office/aesop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pantheon, pkgconfig, meson, ninja, python3, gtk3
+{ stdenv, vala, fetchFromGitHub, pantheon, pkgconfig, meson, ninja, python3, gtk3
 , desktop-file-utils, json-glib, libsoup, libgee, poppler, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     ninja
     pkgconfig
     python3
-    pantheon.vala
+    vala
     wrapGAppsHook
   ];
 

--- a/pkgs/applications/office/bookworm/default.nix
+++ b/pkgs/applications/office/bookworm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pantheon, python3, python2, pkgconfig, libxml2, meson, ninja, gtk3, gnome3, glib, webkitgtk
+{ stdenv, fetchFromGitHub, pantheon, vala, python3, python2, pkgconfig, libxml2, meson, ninja, gtk3, gnome3, glib, webkitgtk
 , gobject-introspection, sqlite, poppler, poppler_utils, html2text, curl, gnugrep, coreutils, bash, unzip, unar, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     ninja
     pkgconfig
     python3
-    pantheon.vala
+    vala
     wrapGAppsHook
   ];
 

--- a/pkgs/applications/office/notes-up/default.nix
+++ b/pkgs/applications/office/notes-up/default.nix
@@ -1,4 +1,19 @@
-{ stdenv, fetchFromGitHub, pantheon, pkgconfig, cmake, ninja, gtk3, gtksourceview3, webkitgtk, gtkspell3, glib, libgee, sqlite, discount, wrapGAppsHook
+{ stdenv
+, fetchFromGitHub
+, pantheon
+, pkgconfig
+, vala
+, cmake
+, ninja
+, gtk3
+, gtksourceview3
+, webkitgtk
+, gtkspell3
+, glib
+, libgee
+, sqlite
+, discount
+, wrapGAppsHook
 , withPantheon ? false }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +30,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     wrapGAppsHook
   ];

--- a/pkgs/applications/office/spice-up/default.nix
+++ b/pkgs/applications/office/spice-up/default.nix
@@ -3,6 +3,7 @@
 , cmake
 , gdk-pixbuf
 , gtk3
+, vala
 , gettext
 , ninja
 , pantheon
@@ -12,7 +13,8 @@
 , libevdev
 , libgee
 , libsoup
-, wrapGAppsHook }:
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "spice-up";
@@ -32,7 +34,7 @@ stdenv.mkDerivation rec {
     gettext
     ninja
     pkgconfig
-    pantheon.vala
+    vala
     wrapGAppsHook
   ];
   buildInputs = [

--- a/pkgs/applications/office/timetable/default.nix
+++ b/pkgs/applications/office/timetable/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , glib
 , gtk3
+, vala
 , hicolor-icon-theme
 , json-glib
 , libgee
@@ -29,7 +30,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkgconfig
-    pantheon.vala
+    vala
     python3
     wrapGAppsHook
   ];

--- a/pkgs/applications/science/math/nasc/default.nix
+++ b/pkgs/applications/science/math/nasc/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchFromGitHub
 , pkgconfig
+, vala
 , gtk3
 , glib
 , pantheon
@@ -26,7 +27,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    pantheon.vala
+    vala
     pkgconfig
     wrapGAppsHook
   ];

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchFromGitHub
 , pantheon
+, fetchpatch
 , substituteAll
 , meson
 , ninja
@@ -54,6 +55,11 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./xkb.patch;
       config = "${xorg.xkeyboardconfig}/share/X11/xkb/rules/evdev.xml";
+    })
+    # Fix build with latest vala.
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-keyboard/commit/28fa960f607f0b1d67f2864965a079bdfc23e3a8.patch";
+      sha256 = "0121qcg8n7gkz7gpwrxc1cx0nnypj02zy2jmp3cks5r9sc0yi0hw";
     })
   ];
 

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , pantheon
 , meson
 , ninja
@@ -52,6 +53,14 @@ stdenv.mkDerivation rec {
     librest
     switchboard
     webkitgtk
+  ];
+
+  patches = [
+    # Fix build with latest vala
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-onlineaccounts/commit/5fa2882f765076d20c6ef4886198a34a05159f8a.patch";
+      sha256 = "1szryyy7shdmbvx9yhpi0bhzaayg7hl6pq2c456j1qf9kfv0m4hf";
+    })
   ];
 
   PKG_CONFIG_LIBACCOUNTS_GLIB_PROVIDERFILESDIR = "${placeholder "out"}/share/accounts/providers";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , pantheon
 , meson
 , ninja
@@ -42,6 +43,14 @@ stdenv.mkDerivation rec {
     gtk3
     libgee
     switchboard
+  ];
+
+  patches = [
+    # Fix build with latest vala.
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-printers/commit/3175c2ebf106145a95355d2571e0a2aa4834e884.patch";
+      sha256 = "1b2q48a1284037nz79vjcrz8g2qpsyg7s5rag6bfp03a1ijb7gw3";
+    })
   ];
 
   PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , pantheon
 , meson
 , ninja
@@ -40,6 +41,14 @@ stdenv.mkDerivation rec {
     gtk3
     libgee
     switchboard
+  ];
+
+  patches = [
+    # Fix build with latest vala
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-sharing/commit/22c9d52577a2e8c36c840a99009420266a39e1fe.patch";
+      sha256 = "0rbf1yxhc7k44cwikd45mv2g6slzw0rkwn5s38q3yxai9jnpvqch";
+    })
   ];
 
   PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder "out"}/lib/switchboard";

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -59,7 +59,6 @@ lib.makeScope pkgs.newScope (self: with self; {
   maintainers = with pkgs.stdenv.lib.maintainers; [ worldofpeace ];
 
   mutter = pkgs.gnome3.mutter328;
-  vala = pkgs.vala_0_40;
 
   elementary-gsettings-schemas = callPackage ./desktop/elementary-gsettings-schemas { };
 

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -219,4 +219,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   elementary-wallpapers = callPackage ./artwork/elementary-wallpapers { };
 
+  ### ALIASES
+
+  vala = pkgs.vala; # added 2019-10-10
+
 })

--- a/pkgs/desktops/pantheon/granite/default.nix
+++ b/pkgs/desktops/pantheon/granite/default.nix
@@ -34,6 +34,12 @@ stdenv.mkDerivation rec {
       url = "https://src.fedoraproject.org/rpms/granite/raw/0550b44ed6400c9b1ff7e70871913747df2ff323/f/00-datetime-clock-format-gsettings.patch";
       sha256 = "0i9yvdmn77x5fjdwd1raw6ym8js8yxa7w6ydc7syx7hcyls00dmq";
     })
+
+    # Fix build latest vala.
+    (fetchpatch {
+      url = "https://github.com/elementary/granite/commit/fd26013c84afdeb6300ae2f4a574856753fc2b58.patch";
+      sha256 = "01nxqhj8gr61n6wx6ccrqdn25nmbrhhk437k21g4mxqx0gnih265";
+    })
   ];
 
   passthru = {

--- a/pkgs/tools/misc/hashit/default.nix
+++ b/pkgs/tools/misc/hashit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, pantheon, python3, libgee, gtk3, desktop-file-utils, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, vala, pantheon, python3, libgee, gtk3, desktop-file-utils, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "hashit";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     desktop-file-utils
     meson
     ninja
-    pantheon.vala
+    vala
     pkgconfig
     python3
     wrapGAppsHook


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
elementary OS's ecosystem is curated around Ubuntu's LTS releases.
This means the development platform for their curated applications
always includes a LTS version of vala (in 18.04 it's 0.40).
Because of how vala development works I suspect some of these
applications to have serious issues if complied with the latest vala.
However in the past year or so, for Pantheon at least, I don't think
their applications will have much issues with latest vala, and if there
is I don't think they'd be difficult to fix. In this single regard they've
become more responsive since their preferred language is vala.

As for the curated applications I have less of this confidence in.
So I'd have to be accept less applications, but that's something
I'm willing to compromise on. And this is easily reversible or
could be done on a per-application basis. And nix already makes
this trivial.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
