### PR TITLE
ocamlPackages.spelll: init at 0.3

### DIFF
--- a/pkgs/development/ocaml-modules/spelll/default.nix
+++ b/pkgs/development/ocaml-modules/spelll/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, seq
+}:
+
+buildDunePackage rec {
+  pname = "spelll";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "c-cube";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "03adqisgsazsxdkrypp05k3g91hydfgcif2014il63gdbd9nhzlh";
+  };
+
+  propagatedBuildInputs = [ seq ];
+
+  meta = {
+    inherit (src.meta) homepage;
+    description = "Fuzzy string searching, using Levenshtein automaton";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -745,6 +745,8 @@ let
 
     sedlex = callPackage ../development/ocaml-modules/sedlex { };
 
+    spelll = callPackage ../development/ocaml-modules/spelll { };
+
     sqlite3EZ = callPackage ../development/ocaml-modules/sqlite3EZ { };
 
     ssl = callPackage ../development/ocaml-modules/ssl { };


### PR DESCRIPTION
Fuzzy string searching, using Levenshtein automaton. Can be used for
spell-checking.

Homepage: https://github.com/c-cube/spelll

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
