### PR TITLE
atom, atom-beta: 1.36.1 -> 1.40.0, 1.37.0-beta0 -> 1.41.0-beta0

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -3,14 +3,14 @@
 let
   versions = {
     atom = {
-      version = "1.36.1";
-      sha256 = "1m7q2r3zx463k7kpqb364piqrr69wrhs033ibzxdx9y7r4204qp4";
+      version = "1.40.0";
+      sha256 = "0m66f4ja6nmq854hmx5fcc5zy100qmdnv9db8s26vj30anx73c3l";
     };
 
     atom-beta = {
-      version = "1.37.0";
+      version = "1.41.0";
       beta = 0;
-      sha256 = "0aq8r5vfgq7r31qajjgcg4n5a57a2m8fvq6fzy9vq5gawkvmaxxx";
+      sha256 = "11y6ci84cfm3yl17jxvb38rj89yj7099bzgwnyjjnb07cj95cchy";
     };
   };
 

--- a/pkgs/applications/editors/atom/env.nix
+++ b/pkgs/applications/editors/atom/env.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, zlib, glib, alsaLib, dbus, gtk3, atk, pango, freetype, fontconfig
 , libgnome-keyring3, gdk-pixbuf, cairo, cups, expat, libgpgerror, nspr
-, gconf, nss, xorg, libcap, systemd, libnotify, libsecret
+, gconf, nss, xorg, libcap, systemd, libnotify, libsecret, at-spi2-atk, libuuid
 }:
 
 let
@@ -10,7 +10,7 @@ let
     xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
     xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
     xorg.libXcursor xorg.libxkbfile xorg.libXScrnSaver libcap systemd libnotify
-    xorg.libxcb libsecret
+    xorg.libxcb libsecret at-spi2-atk libuuid
   ];
 
   libPathNative = lib.makeLibraryPath packages;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @offlinehacker @NeQuissimus @ysndr 
