### PR TITLE
python.pkgs.google_cloud_storage: propagate setuptools

### DIFF
--- a/pkgs/development/python-modules/google_api_core/default.nix
+++ b/pkgs/development/python-modules/google_api_core/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, pythonOlder
-, google_auth, protobuf, googleapis_common_protos, requests, grpcio, futures, mock, pytest }:
+, google_auth, protobuf, googleapis_common_protos, requests, setuptools, grpcio, futures, mock, pytest }:
 
 buildPythonPackage rec {
   pname = "google-api-core";
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     googleapis_common_protos protobuf
-    google_auth requests grpcio
+    google_auth requests setuptools grpcio
   ] ++ lib.optional (pythonOlder "3.2") futures;
   checkInputs = [ mock pytest ];
 

--- a/pkgs/development/python-modules/google_auth/default.nix
+++ b/pkgs/development/python-modules/google_auth/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchpatch, fetchPypi
-, pytest, mock, oauth2client, flask, requests, urllib3, pytest-localserver, six, pyasn1-modules, cachetools, rsa }:
+, pytest, mock, oauth2client, flask, requests, setuptools, urllib3, pytest-localserver, six, pyasn1-modules, cachetools, rsa }:
 
 buildPythonPackage rec {
   pname = "google-auth";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [ pytest mock oauth2client flask requests urllib3 pytest-localserver ];
-  propagatedBuildInputs = [ six pyasn1-modules cachetools rsa ];
+  propagatedBuildInputs = [ six pyasn1-modules cachetools rsa setuptools ];
 
   # The removed test tests the working together of google_auth and google's https://pypi.python.org/pypi/oauth2client
   # but the latter is deprecated. Since it is not currently part of the nixpkgs collection and deprecated it will

--- a/pkgs/development/python-modules/google_cloud_core/default.nix
+++ b/pkgs/development/python-modules/google_cloud_core/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, google_api_core, grpcio, pytest, mock }:
+, google_api_core, grpcio, pytest, mock, setuptools }:
 
 buildPythonPackage rec {
   pname = "google-cloud-core";
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "d85b1aaaf3bad9415ad1d8ee5eadce96d7007a82f13ce0a0629a003a11e83f29";
   };
 
-  propagatedBuildInputs = [ google_api_core grpcio ];
+  propagatedBuildInputs = [ google_api_core grpcio setuptools ];
   checkInputs = [ pytest mock ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/google_cloud_storage/default.nix
+++ b/pkgs/development/python-modules/google_cloud_storage/default.nix
@@ -6,6 +6,7 @@
 , google_cloud_core
 , pytest
 , mock
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -17,8 +18,13 @@ buildPythonPackage rec {
     sha256 = "8032e576e2f91a1d3de2355118040c3bcd9916e0453a6b3f64c1b42ed151690a";
   };
 
+  propagatedBuildInputs = [
+    google_resumable_media
+    google_api_core
+    google_cloud_core
+    setuptools
+  ];
   checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ google_resumable_media google_api_core google_cloud_core ];
 
   checkPhase = ''
    pytest tests/unit

--- a/pkgs/development/python-modules/google_resumable_media/default.nix
+++ b/pkgs/development/python-modules/google_resumable_media/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , six
 , requests
+, setuptools
 , pytest
 , mock
 }:
@@ -17,7 +18,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ six requests ];
+  propagatedBuildInputs = [ requests setuptools six ];
 
   checkPhase = ''
     py.test tests/unit

--- a/pkgs/development/python-modules/googleapis_common_protos/default.nix
+++ b/pkgs/development/python-modules/googleapis_common_protos/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, protobuf, pytest }:
+, protobuf, pytest, setuptools }:
 
 buildPythonPackage rec {
   pname = "googleapis-common-protos";
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "d564872083af40bbcc7091340f17db778a316525c7c76497d58d11b98ca2aa74";
   };
 
-  propagatedBuildInputs = [ protobuf ];
+  propagatedBuildInputs = [ protobuf setuptools ];
   checkInputs = [ pytest ];
 
   doCheck = false;  # there are no tests


### PR DESCRIPTION
This is used during runtime.

cc #68314

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`python.pkgs.google_cloud_storage` requires setuptools at runtime.
This looks like a pattern used in other parts of the google bindings aswell, so we might want to fix those too / cc @costrouc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc