### PR TITLE
alot: fix hardcoded Python in Zsh completion

### DIFF
--- a/pkgs/development/python-modules/alot/default.nix
+++ b/pkgs/development/python-modules/alot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPythonPackage, fetchFromGitHub, isPy3k
+{ stdenv, lib, buildPythonPackage, python, fetchFromGitHub, isPy3k
 , notmuch, urwid, urwidtrees, twisted, python_magic, configobj, mock, file, gpgme
 , service-identity
 , gnupg ? null, sphinx, awk ? null, procps ? null, future ? null
@@ -39,7 +39,9 @@ buildPythonPackage rec {
 
   checkInputs =  [ awk future mock gnupg procps ];
 
-  postInstall = lib.optionalString withManpage ''
+  postInstall = let
+    completionPython = python.withPackages (ps: [ ps.configobj ]);
+  in lib.optionalString withManpage ''
     mkdir -p $out/man
     cp -r docs/build/man $out/man
   ''
@@ -47,6 +49,8 @@ buildPythonPackage rec {
     mkdir -p $out/share/{applications,alot}
     cp -r extra/themes $out/share/alot
 
+    substituteInPlace extra/completion/alot-completion.zsh \
+      --replace "python3" "${completionPython.interpreter}"
     install -D extra/completion/alot-completion.zsh $out/share/zsh/site-functions/_alot
 
     sed "s,/usr/bin,$out/bin,g" extra/alot.desktop > $out/share/applications/alot.desktop


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This allows completing `alot compose --sender <Tab>`

I would have liked to have a solution similar to `wrapPython` instead of having a python with custom env (this adds another derivation to the mix), but I couldn't see how to extract the [preamble](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/interpreters/python/wrap-python.nix#L35).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nix-review` [1](https://github.com/Mic92/nix-review)
<details>
  <summary>1 package were build:</summary>

  - alot
</details>


###### Notify maintainers

cc @geistesk 
