### PR TITLE
sonobuoy: 0.15.0 -> 0.16.1

### DIFF
--- a/pkgs/applications/networking/cluster/sonobuoy/default.nix
+++ b/pkgs/applications/networking/cluster/sonobuoy/default.nix
@@ -1,11 +1,11 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
 # SHA of ${version} for the tool's help output
-let rev = "7ad367535a6710802085d41e0dbb53df359b9882";
+let rev = "c9c2a461cd3397909fe6e45ff71836347ef89fd8";
 in
 buildGoPackage rec {
   pname = "sonobuoy";
-  version = "0.15.0";
+  version = "0.16.1";
 
   goPackagePath = "github.com/heptio/sonobuoy";
 
@@ -19,10 +19,10 @@ buildGoPackage rec {
     '';
 
   src = fetchFromGitHub {
-    sha256 = "0dkmhmr7calk8mkdxfpy3yjzk10ja4gz1jq8pgk3v8rh04f4h1x5";
+    sha256 = "14qc5a7jbr403wjpk6pgpb94i72yx647sg9srz07q6drq650kyfv";
     rev = "v${version}";
     repo = "sonobuoy";
-    owner = "heptio";
+    owner = "vmware-tanzu";
   };
 
   meta = with lib; {
@@ -36,8 +36,8 @@ buildGoPackage rec {
       accessible and non-destructive manner.
     '';
 
-    homepage = "https://github.com/heptio/sonobuoy";
+    homepage = "https://sonobuoy.io";
     license = licenses.asl20;
-    maintainers = with maintainers; [ carlosdagos ];
+    maintainers = with maintainers; [ carlosdagos saschagrunert ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update sonobuoy to the latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
