### PR TITLE
diceware: add missing 'setuptools' to propagatedBuildInputs

### DIFF
--- a/pkgs/tools/security/diceware/default.nix
+++ b/pkgs/tools/security/diceware/default.nix
@@ -15,6 +15,8 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [ pytestrunner ];
 
+  propagatedBuildInputs = [ setuptools ];
+
   checkInputs = [ coverage pytest ];
 
   # see https://github.com/ulif/diceware/commit/a7d844df76cd4b95a717f21ef5aa6167477b6733


### PR DESCRIPTION
(cherry picked from commit f641fca688c8be93bcb1c0f54920ce16e9b0e631)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Currently fails with:

```
[grahamc@Petunia:~]$ nix-shell -p diceware --run diceware
Traceback (most recent call last):
  File "/nix/store/izqgibxvwydd4yg29p2hym1zsfq4sxfy-diceware-0.9.6/bin/.diceware-wrapped", line 7, in <module>
    from diceware import main
  File "/nix/store/izqgibxvwydd4yg29p2hym1zsfq4sxfy-diceware-0.9.6/lib/python2.7/site-packages/diceware/__init__.py", line 19, in <module>
    import pkg_resources
ImportError: No module named pkg_resources
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
