### PR TITLE
cargo-edit: 0.3.3 -> 0.4.0

### DIFF
--- a/pkgs/tools/package-management/cargo-edit/default.nix
+++ b/pkgs/tools/package-management/cargo-edit/default.nix
@@ -4,16 +4,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-edit";
-  version = "0.3.3";
+  version = "v0.4.0";
 
   src = fetchFromGitHub {
     owner = "killercup";
     repo = pname;
     rev = "v${version}";
-    sha256 = "05b64bm9441crw74xlywjg2y3psljk2kf9xsrixaqwbnnahi0mm5";
+    sha256 = "07n8h2shjjwgsxww91hcgjgigsz6s81xv6i6xv1hc6lxzmsgkhdr";
   };
 
-  cargoSha256 = "1hjjw3i35vqr6nxsv2m3izq4x8c2a6wvl5c2kjlpg6shy9j2mjaa";
+  cargoSha256 = "04gyjfhw5s0ig928hfa7h586jgi73xzjbsbjbhz8aim71wd7d60p";
 
   nativeBuildInputs = lib.optional (!stdenv.isDarwin) pkgconfig;
   buildInputs = lib.optional (!stdenv.isDarwin) openssl;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I'm trying to update `cargo-edit` to the latest version, however the tests do not compile. I cloned the repo locally and ran the tests from there with `cargo test`, which worked fine. I get a ton of errors in `nixpkgs` when I try to build it. See the log below. cc @killercup, do you have any idea what gives?

```text
failures:

---- adds_dependency stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_dependency' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

---- adds_dependency_with_custom_target stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_dependency_with_custom_target' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- add_prints_message_for_dev_deps stdout ----
thread 'add_prints_message_for_dev_deps' panicked at 'Assertion failed for `target/debug/cargo-add add docopt --dev --vers 0.8.0 --manifest-path=/build/cargo-edit-test.oxN6yZ6fUOQ9/Cargo.toml`
with: Unexpected return status: failure
stdout=``````
stderr=```Command failed due to unhandled error: Invalid cargo config

```', /build/cargo-edit-v0.4.0-vendor/assert_cli/src/assert.rs:441:13

---- add_prints_message_with_section stdout ----
thread 'add_prints_message_with_section' panicked at 'Assertion failed for `target/debug/cargo-add add clap --optional --target=mytarget --vers=0.1.0 --manifest-path=/build/cargo-edit-test.YIy1Ievk9IUs/Cargo.toml`
with: Unexpected return status: failure
stdout=``````
stderr=```Command failed due to unhandled error: Invalid cargo config

```', /build/cargo-edit-v0.4.0-vendor/assert_cli/src/assert.rs:441:13

---- add_prints_message stdout ----
thread 'add_prints_message' panicked at 'Assertion failed for `target/debug/cargo-add add docopt --vers=0.6.0 --manifest-path=/build/cargo-edit-test.HuoKC47NWz2z/Cargo.toml`
with: Unexpected return status: failure
stdout=``````
stderr=```Command failed due to unhandled error: Invalid cargo config

```', /build/cargo-edit-v0.4.0-vendor/assert_cli/src/assert.rs:441:13

---- adds_dependency_with_upgrade_none stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_dependency_with_upgrade_none' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_dependency_with_upgrade_minor stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_dependency_with_upgrade_minor' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_dependency_with_upgrade_all stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_dependency_with_upgrade_all' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- add_prints_message_for_build_deps stdout ----
thread 'add_prints_message_for_build_deps' panicked at 'Assertion failed for `target/debug/cargo-add add hello-world --build --vers 0.1.0 --manifest-path=/build/cargo-edit-test.CvSmu7adtrwU/Cargo.toml`
with: Unexpected return status: failure
stdout=``````
stderr=```Command failed due to unhandled error: Invalid cargo config

```', /build/cargo-edit-v0.4.0-vendor/assert_cli/src/assert.rs:441:13

---- adds_dependency_with_target_triple stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_dependency_with_target_triple' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_dependency_with_upgrade_patch stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_dependency_with_upgrade_patch' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_local_source_using_flag stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_local_source_using_flag' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_dependency_with_target_cfg stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_dependency_with_target_cfg' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_dev_build_dependency stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_dev_build_dependency' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_git_source_using_flag stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_git_source_using_flag' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_local_source_without_flag stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_local_source_without_flag' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_local_source_with_version_flag_and_semver_metadata stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_local_source_with_version_flag_and_semver_metadata' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_multiple_dependencies stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_multiple_dependencies' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_local_source_with_inline_version_notation stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_local_source_with_inline_version_notation' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_multiple_dependencies_with_some_versions stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_multiple_dependencies_with_some_versions' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_multiple_dependencies_with_versions stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_multiple_dependencies_with_versions' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_local_source_with_version_flag stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_local_source_with_version_flag' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_multiple_dev_build_dependencies stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_multiple_dev_build_dependencies' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_multiple_no_default_features_dependencies stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_multiple_no_default_features_dependencies' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_specified_version stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_specified_version' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_prerelease_dependency stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_prerelease_dependency' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_optional_dependency stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_optional_dependency' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_no_default_features_dependency stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_no_default_features_dependency' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_multiple_optional_dependencies stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_multiple_optional_dependencies' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_specified_version_with_inline_notation stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_specified_version_with_inline_notation' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- adds_sorted_dependencies stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'adds_sorted_dependencies' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- overwrite_version_with_path stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'overwrite_version_with_path' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- overwrite_git_with_path stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'overwrite_git_with_path' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- overwrite_version_with_git stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'overwrite_version_with_git' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- overwrite_path_with_version stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'overwrite_path_with_version' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9

---- overwrite_version_with_version stdout ----
Status code: ExitStatus(ExitStatus(256))
STDOUT:
STDERR: Command failed due to unhandled error: Invalid cargo config


thread 'overwrite_version_with_version' panicked at 'cargo-add failed to execute', tests/utils.rs:65:9


failures:
    add_prints_message
    add_prints_message_for_build_deps
    add_prints_message_for_dev_deps
    add_prints_message_with_section
    adds_dependency
    adds_dependency_with_custom_target
    adds_dependency_with_target_cfg
    adds_dependency_with_target_triple
    adds_dependency_with_upgrade_all
    adds_dependency_with_upgrade_minor
    adds_dependency_with_upgrade_none
    adds_dependency_with_upgrade_patch
    adds_dev_build_dependency
    adds_git_source_using_flag
    adds_local_source_using_flag
    adds_local_source_with_inline_version_notation
    adds_local_source_with_version_flag
    adds_local_source_with_version_flag_and_semver_metadata
    adds_local_source_without_flag
    adds_multiple_dependencies
    adds_multiple_dependencies_with_some_versions
    adds_multiple_dependencies_with_versions
    adds_multiple_dev_build_dependencies
    adds_multiple_no_default_features_dependencies
    adds_multiple_optional_dependencies
    adds_no_default_features_dependency
    adds_optional_dependency
    adds_prerelease_dependency
    adds_sorted_dependencies
    adds_specified_version
    adds_specified_version_with_inline_notation
    overwrite_git_with_path
    overwrite_path_with_version
    overwrite_version_with_git
    overwrite_version_with_path
    overwrite_version_with_version

test result: FAILED. 11 passed; 36 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '--test cargo-add'
builder for '/nix/store/0mchn429s5pxhj4g6j0i905rwjc0zqsb-cargo-edit-v0.4.0.drv' failed with exit code 101
error: build of '/nix/store/0mchn429s5pxhj4g6j0i905rwjc0zqsb-cargo-edit-v0.4.0.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Gerschtli @jb55 
