### PR TITLE
amber-theme: init at 3.34-1

### DIFF
--- a/pkgs/data/themes/amber/default.nix
+++ b/pkgs/data/themes/amber/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, meson, ninja, sassc, gdk-pixbuf, librsvg, gtk_engines, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  pname = "amber-theme";
+  version = "3.34-1";
+
+  src = fetchFromGitHub {
+    owner = "lassekongo83";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1fmsjhaxlw2znlbjys3ggmsr7zlfk1wlng7bh54g6b0vjgdbik3r";
+  };
+
+  nativeBuildInputs = [ meson ninja sassc ];
+
+  buildInputs = [ gdk-pixbuf librsvg gtk_engines ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  meta = with stdenv.lib; {
+    description = "GTK, gnome-shell and Xfce theme based on Ubuntu Ambiance";
+    homepage = https://github.com/lassekongo83/amber-theme;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16681,6 +16681,8 @@ in
 
   aileron = callPackage ../data/fonts/aileron { };
 
+  amber-theme = callPackage ../data/themes/amber { };
+
   amiri = callPackage ../data/fonts/amiri { };
 
   andagii = callPackage ../data/fonts/andagii { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [amber theme](https://github.com/lassekongo83/amber-theme), a theme for GTK, gnome-shell and Xfce based on the Ubuntu Ambiance theme.


![amber2](https://user-images.githubusercontent.com/1217934/66582533-58254e00-eb58-11e9-9965-04f34c6adf6f.png)

![amber](https://user-images.githubusercontent.com/1217934/66582532-58254e00-eb58-11e9-915d-60a4dceb5259.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
