### PR TITLE
pythonPackages.lazy_import: init at 0.2.2

### DIFF
--- a/pkgs/development/python-modules/lazy_import/default.nix
+++ b/pkgs/development/python-modules/lazy_import/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, isPy3k
+, pytest
+, pytest_xdist
+, six }:
+
+buildPythonPackage rec {
+  pname = "lazy_import";
+  version = "0.2.2";
+
+  disabled = pythonOlder "2.7" || (isPy3k && pythonOlder "3.4");
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gca9xj60qr3aprj9qdc66crr4r7hl8wzv6gc9y40nclazwawj91";
+  };
+
+  checkInputs = [
+    pytest
+    pytest_xdist
+  ];
+
+  propagatedBuildInputs = [
+    six
+  ];
+
+  meta = with stdenv.lib; {
+    description = "lazy_import provides a set of functions that load modules, and related attributes, in a lazy fashion.";
+    homepage = https://github.com/mnmelo/lazy_import;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.marenz ];
+  };
+}

--- a/pkgs/development/python-modules/lazy_import/default.nix
+++ b/pkgs/development/python-modules/lazy_import/default.nix
@@ -7,8 +7,6 @@ buildPythonPackage rec {
   pname = "lazy_import";
   version = "0.2.2";
 
-  disabled = pythonOlder "2.7" || (isPy3k && pythonOlder "3.4");
-
   src = fetchPypi {
     inherit pname version;
     sha256 = "0gca9xj60qr3aprj9qdc66crr4r7hl8wzv6gc9y40nclazwawj91";
@@ -22,6 +20,11 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     six
   ];
+
+  checkPhase = ''
+    cd lazy_import
+    pytest --boxed
+  '';
 
   meta = with stdenv.lib; {
     description = "lazy_import provides a set of functions that load modules, and related attributes, in a lazy fashion.";

--- a/pkgs/development/python-modules/lazy_import/default.nix
+++ b/pkgs/development/python-modules/lazy_import/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, isPy3k
+{ stdenv, buildPythonPackage, fetchPypi,
 , pytest
 , pytest_xdist
 , six }:

--- a/pkgs/development/python-modules/lazy_import/default.nix
+++ b/pkgs/development/python-modules/lazy_import/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi,
+{ stdenv, buildPythonPackage, fetchPypi
 , pytest
 , pytest_xdist
 , six }:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3601,6 +3601,8 @@ in {
     inherit (pkgs) kerberos;
   };
 
+  lazy_import = callPackage ../development/python-modules/lazy_import { };
+
   lazy-object-proxy = callPackage ../development/python-modules/lazy-object-proxy { };
 
   ldaptor = callPackage ../development/python-modules/ldaptor { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Mic92 
