### PR TITLE
system-config-printer: 1.5.11 -> 1.5.12

### DIFF
--- a/nixos/modules/services/desktops/system-config-printer.nix
+++ b/nixos/modules/services/desktops/system-config-printer.nix
@@ -33,6 +33,9 @@ with lib;
       pkgs.system-config-printer
     ];
 
+    # for $out/bin/install-printer-driver
+    services.packagekit.enable = true;
+
   };
 
 }

--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -1,47 +1,56 @@
-{ stdenv, fetchurl, udev, intltool, pkgconfig, glib, xmlto, wrapGAppsHook
+{ stdenv, fetchFromGitHub, udev, intltool, pkgconfig, glib, xmlto, wrapGAppsHook
 , docbook_xml_dtd_412, docbook_xsl
 , libxml2, desktop-file-utils, libusb1, cups, gdk-pixbuf, pango, atk, libnotify
-, gobject-introspection, libsecret
+, gobject-introspection, libsecret, packagekit
 , cups-filters
-, pythonPackages
+, python3Packages, autoreconfHook, bash
 }:
 
 stdenv.mkDerivation rec {
   pname = "system-config-printer";
-  version = "1.5.11";
+  version = "1.5.12";
 
-  src = fetchurl {
-    url = "https://github.com/zdohnal/system-config-printer/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "1lq0q51bhanirpjjvvh4xiafi8hgpk8r32h0dj6dn3f32z8pib9q";
+  src = fetchFromGitHub {
+    owner = "openPrinting";
+    repo = pname;
+    rev = version;
+    sha256 = "1a812jsd9pb02jbz9bq16qj5j6k2kw44g7s1xdqqkg7061rd7mwf";
   };
+
+  prePatch = ''
+    # for automake
+    touch README ChangeLog
+    # for tests
+    substituteInPlace Makefile.am --replace /bin/bash ${bash}/bin/bash
+  '';
 
   patches = [ ./detect_serverbindir.patch ];
 
   buildInputs = [
     glib udev libusb1 cups
-    pythonPackages.python
-    libnotify gobject-introspection gdk-pixbuf pango atk
+    python3Packages.python
+    libnotify gobject-introspection gdk-pixbuf pango atk packagekit
     libsecret
   ];
 
   nativeBuildInputs = [
     intltool pkgconfig
     xmlto libxml2 docbook_xml_dtd_412 docbook_xsl desktop-file-utils
-    pythonPackages.wrapPython
-    wrapGAppsHook
+    python3Packages.wrapPython
+    wrapGAppsHook autoreconfHook
   ];
 
-  pythonPath = with pythonPackages; requiredPythonModules [ pycups pycurl dbus-python pygobject3 requests pycairo pysmbc ];
+  pythonPath = with python3Packages; requiredPythonModules [ pycups pycurl dbus-python pygobject3 requests pycairo pysmbc ];
 
   configureFlags = [
     "--with-udev-rules"
-    "--with-udevdir=$(out)/etc/udev"
-    "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
+    "--with-udevdir=${placeholder "out"}/etc/udev"
+    "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
   ];
 
   stripDebugList = [ "bin" "lib" "etc/udev" ];
 
-  doCheck = false; # generates shebangs in check phase, too lazy to fix
+  doCheck = true;
 
   postInstall =
     ''
@@ -54,20 +63,14 @@ stdenv.mkDerivation rec {
       find $out/share/system-config-printer -name \*.py -type f -perm -0100 -print0 | while read -d "" f; do
         patchPythonScript "$f"
       done
-
-      # The below line will be unneeded when the next upstream release arrives.
-      sed -i -e "s|/usr/local/bin|$out/bin|" "$out/share/dbus-1/services/org.fedoraproject.Config.Printing.service"
-
-      # Manually expand literal "$(out)", which have failed to expand
-      sed -e "s|ExecStart=\$(out)|ExecStart=$out|" \
-          -i "$out/etc/systemd/system/configure-printer@.service"
+      patchPythonScript $out/etc/udev/udev-add-printer
 
       substituteInPlace $out/etc/udev/rules.d/70-printers.rules \
         --replace "udev-configure-printer" "$out/etc/udev/udev-configure-printer"
     '';
 
   meta = {
-    homepage = http://cyberelk.net/tim/software/system-config-printer/;
+    homepage = "https://github.com/openprinting/system-config-printer";
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6367,7 +6367,6 @@ in
 
   system-config-printer = callPackage ../tools/misc/system-config-printer {
     libxml2 = libxml2Python;
-    pythonPackages = python3Packages;
    };
 
   stricat = callPackage ../tools/security/stricat { };


### PR DESCRIPTION
Fixes some dialogs with our version of gtk like 
```
 grid.attach (entry, 1, 2, i, i + 1, 0, 0)
TypeError: Gtk.Grid.attach() takes exactly 6 arguments (8 given)
```



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
