### PR TITLE
hsqldb: 1.8.0 -> 2.5.0

### DIFF
--- a/pkgs/development/libraries/java/hsqldb/builder.sh
+++ b/pkgs/development/libraries/java/hsqldb/builder.sh
@@ -1,6 +1,0 @@
-source $stdenv/setup
-
-unzip $src
-cd hsqldb*
-mkdir -p $out
-cp -R * $out/

--- a/pkgs/development/libraries/java/hsqldb/default.nix
+++ b/pkgs/development/libraries/java/hsqldb/default.nix
@@ -1,19 +1,37 @@
-{ stdenv, fetchurl, unzip
-}:
+{ stdenv, fetchurl, unzip, makeWrapper, jre }:
 
-stdenv.mkDerivation {
-  name = "hsqldb-2.4.0";
-  builder = ./builder.sh;
+stdenv.mkDerivation rec {
+  pname = "hsqldb";
+  version = "2.5.0";
+  underscoreMajMin = stdenv.lib.strings.replaceChars ["."] ["_"] (stdenv.lib.versions.majorMinor version);
 
   src = fetchurl {
-    url = mirror://sourceforge/hsqldb/hsqldb_1_8_0_9.zip;
-    sha256 = "1v5dslwsqb7csjmi5g78pghsay2pszidvlzhyi79y18mra5iv3g9";
+    url = "mirror://sourceforge/project/hsqldb/hsqldb/hsqldb_${underscoreMajMin}/hsqldb-${version}.zip";
+    sha256 = "0s64w7qq5vayrzcmdhrdfmd6iqqv6x6fpiq9lpy2gva3dckv3q6j";
   };
 
-  buildInputs = [ unzip
-  ];
+  nativeBuildInputs = [ unzip makeWrapper ];
+  buildInputs = [ jre ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib $out/bin
+    cp -R hsqldb/lib/*.jar $out/lib
+
+    makeWrapper ${jre}/bin/java $out/bin/hsqldb --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.server.Server"
+    makeWrapper ${jre}/bin/java $out/bin/runServer --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.server.Server"
+    makeWrapper ${jre}/bin/java $out/bin/runManagerSwing --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.util.DatabaseManagerSwing"
+    makeWrapper ${jre}/bin/java $out/bin/runWebServer --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.server.WebServer"
+    makeWrapper ${jre}/bin/java $out/bin/runManager --add-flags "-classpath $out/lib/hsqldb.jar org.hsqldb.util.DatabaseManager"
+    makeWrapper ${jre}/bin/java $out/bin/sqltool --add-flags "-jar $out/lib/sqltool.jar"
+
+   runHook postInstall
+  '';
 
   meta = with stdenv.lib; {
+    homepage = "http://hsqldb.org";
+    description = "A relational, embedable database management system written in Java and a set of related tools";
     platforms = platforms.unix;
     license = licenses.bsd3;
   };


### PR DESCRIPTION
###### Motivation for this change 
* Meta data were incomplete
* package name was misleading
* update available
* r-ryantm couldn't update the package, I guess because the version wasn't parametrized


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
