### PR TITLE
nordlicht: init at 0.4.5

### DIFF
--- a/pkgs/tools/video/nordlicht/default.nix
+++ b/pkgs/tools/video/nordlicht/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake, ffmpeg, popt, help2man }:
+    with cmake;
+    stdenv.mkDerivation rec {
+        name = "nordlicht-${version}";
+        version = "0.4.5-git.7ad3f008.4b1751bd";
+        license = "GNU GPL v2 or later";
+        description = "creates colorful barcodes from video files";
+        src = fetchFromGitHub {
+            owner  = "nordlicht";
+            repo   = "nordlicht";
+            rev    = "7ad3f008afe803037b332822028faed64b1751bd";
+            sha256 = "14657zfzvq0iki8sn6rq789bgjr7wvvid9y2clfy25bi0a1gvnix";
+        };
+        buildInputs = [ cmake ffmpeg popt help2man ];
+        configurePhase = ''
+            mkdir build && cd build && cmake ..
+            # why in the galaxy does cmake drop files to
+            # /var/lib/empty/local/ and /var/lib/empty/local/usr/lib64/ ?
+            # I don't know, but this seems to fix it:
+            for f in CMakeCache.txt cmake_install.cmake
+            do
+                for d in lib{64,32}
+                do
+                    substituteInPlace "$f" --replace "$d" lib
+                done
+                for d in /var/empty/local /usr/lib
+                do
+                    substituteInPlace "$f" --replace "$d" ""
+                done
+            done
+        '';
+        installFlags = [ "DESTDIR=$(out)" "CMAKE_INSTAL_PREFIX=$(out)" ];
+    }
+    


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Because... why not? :-)
Build and manual test seems to work for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
