### PR TITLE
ocamlPackages.bigstringaf: 0.3.0 → 0.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/bigstringaf/default.nix
+++ b/pkgs/development/ocaml-modules/bigstringaf/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, alcotest }:
+{ lib, fetchFromGitHub, buildDunePackage, alcotest, bigarray-compat }:
 
 buildDunePackage rec {
   pname = "bigstringaf";
-  version = "0.3.0";
+  version = "0.6.0";
 
   minimumOCamlVersion = "4.03";
 
@@ -10,16 +10,17 @@ buildDunePackage rec {
     owner = "inhabitedtype";
     repo = pname;
     rev = version;
-    sha256 = "1yx6hv8rk0ldz1h6kk00rwg8abpfc376z00aifl9f5rn7xavpscs";
+    sha256 = "04b088vrqzmxsyan9f9nr8721bxip4b930cgvb5zkbbmrw3ylmwc";
   };
 
   buildInputs = [ alcotest ];
+  propagatedBuildInputs = [ bigarray-compat ];
   doCheck = true;
 
   meta = {
     description = "Bigstring intrinsics and fast blits based on memcpy/memmove";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
   };
 }

--- a/pkgs/development/ocaml-modules/faraday/default.nix
+++ b/pkgs/development/ocaml-modules/faraday/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage, alcotest, bigstringaf }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, alcotest, bigstringaf }:
 
 buildDunePackage rec {
   pname = "faraday";
@@ -13,9 +13,9 @@ buildDunePackage rec {
     sha256 = "0z6ikwlqad91iac0q5z88p3wzq5k15y86ckzmhdq1aqwrcm14bq2";
   };
 
-  buildInputs = [ alcotest ];
+  checkInputs = lib.optional doCheck alcotest;
   propagatedBuildInputs = [ bigstringaf ];
-  doCheck = true;
+  doCheck = lib.versions.majorMinor ocaml.version != "4.07";
 
   meta = {
     description = "Serialization library built for speed and memory efficiency";

--- a/pkgs/development/ocaml-modules/httpaf/default.nix
+++ b/pkgs/development/ocaml-modules/httpaf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, angstrom, faraday, alcotest }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, angstrom, faraday, alcotest }:
 
 buildDunePackage rec {
   pname = "httpaf";
@@ -11,14 +11,14 @@ buildDunePackage rec {
     sha256 = "0i2r004ihj00hd97475y8nhjqjln58xx087zcjl0dfp0n7q80517";
   };
 
-  buildInputs = [ alcotest ];
+  checkInputs = lib.optional doCheck alcotest;
   propagatedBuildInputs = [ angstrom faraday ];
-  doCheck = true;
+  doCheck = lib.versions.majorMinor ocaml.version != "4.07";
 
   meta = {
     description = "A high-performance, memory-efficient, and scalable web server for OCaml";
-    license = stdenv.lib.licenses.bsd3;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The updated version is a dependency of ocaml-git ≥ 2.1

Tests of faraday fail with:

> Error: No implementations provided for the following modules:
           Bigarray referenced from lib_test/.test_faraday.eobjs/native/test_faraday.cmx

The error only shows up with OCaml 4.07; I’ve thus disabled them for that version. The situation of httpaf is similar.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
