### PR TITLE
devilutionx: unstable-2019-07-28 -> 0.5.0

### DIFF
--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -1,19 +1,16 @@
 { stdenv, fetchFromGitHub, cmake, SDL2, SDL2_mixer, SDL2_ttf, libsodium, pkg-config }:
-stdenv.mkDerivation {
-  version = "unstable-2019-07-28";
+stdenv.mkDerivation rec {
+  version = "0.5.0";
   pname = "devilutionx";
 
   src = fetchFromGitHub {
     owner = "diasurgical";
     repo = "devilutionX";
-    rev = "b2f358874705598ec139f290b21e340c73d250f6";
-    sha256 = "0s812km118qq5pzlzvzfndvag0mp6yzvm69ykc97frdiq608zw4f";
+    rev = version;
+    sha256 = "010hxj129zmsynvizk89vm2y29dcxsfi585czh3f03wfr38rxa6b";
   };
 
   NIX_CFLAGS_COMPILE = "-I${SDL2_ttf}/include/SDL2";
-
-  # compilation will fail due to -Werror=format-security
-  hardeningDisable = [ "format" ];
 
   nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [ libsodium SDL2 SDL2_mixer SDL2_ttf ];
@@ -21,8 +18,13 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
+  '' + (if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+    mv devilutionx.app $out/Applications
+  '' else ''
     mkdir -p $out/bin
     cp devilutionx $out/bin
+  '') + ''
 
     runHook postInstall
   '';
@@ -30,6 +32,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     homepage = "https://github.com/diasurgical/devilutionX";
     description = "Diablo build for modern operating systems";
+    longDescription = "To make it work, it is necessary to put diabdat.mpq file in ~/.local/share/diasurgical/devilution";
     license = licenses.unlicense;
     maintainers = [ maintainers.karolchmist ];
     platforms = platforms.linux ++ platforms.darwin ++ platforms.windows;

--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = "https://github.com/diasurgical/devilutionX";
     description = "Diablo build for modern operating systems";
-    longDescription = "To make it work, it is necessary to put diabdat.mpq file in ~/.local/share/diasurgical/devilution";
+    longDescription = "In order to play this game a copy of diabdat.mpq is required. Place a copy of diabdat.mpq in ~/.local/share/diasurgical/devilution before executing the game.";
     license = licenses.unlicense;
     maintainers = [ maintainers.karolchmist ];
     platforms = platforms.linux ++ platforms.darwin ++ platforms.windows;


### PR DESCRIPTION
###### Motivation for this change

DevilutionX 0.5.0 release:
https://github.com/diasurgical/devilutionX/releases/tag/0.5.0

Based on Devilution 0.10.0

Features
- Sound is now accurate to the original
- All in-game issues fixed
- Delete hero, inline dialogs and scrollbars are now implemented
- Screenshots now have different names
- Multiple simultaneous dialogs fixed
- All builds are now 64bit (except for Windows and Raspberry Pi)
- Memory leaks and crashes fixed
- All keys are now mapped
- UI text now has correct shadows
- Much lower CPU usage

Known issues
- Error dialogs not implemented in main UI
- The game must restart after hosting multiplayer


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @karolchmist  (myself :P ) 
