### PR TITLE
node updater improvements

### DIFF
--- a/pkgs/development/node-packages/generate.sh
+++ b/pkgs/development/node-packages/generate.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -I nixpkgs=../../.. -i bash -p nodePackages.node2nix
-# NOTE: Script must be run from the node-packages directory
-
+#! nix-shell shell-generate.nix -i bash
 set -eu -o pipefail
 
-rm -f node-env.nix
-node2nix --nodejs-10 -i node-packages-v10.json -o node-packages-v10.nix -c composition-v10.nix
-node2nix --nodejs-12 -i node-packages-v12.json -o node-packages-v12.nix -c composition-v12.nix
-node2nix --nodejs-13 -i node-packages-v13.json -o node-packages-v13.nix -c composition-v13.nix
+cd "$NODE_NIXPKGS_PATH/pkgs/development/node-packages"
+rm -f ./node-env.nix
+for version in 10 12 13; do
+    tmpdir=$(mktemp -d)
+    node2nix --nodejs-$version -i node-packages-v$version.json -o $tmpdir/node-packages-v$version.nix -c $tmpdir/composition-v$version.nix
+    if [ $? -eq 0 ]; then
+        mv $tmpdir/node-packages-v$version.nix .
+        mv $tmpdir/composition-v$version.nix .
+    fi
+done
+cd -

--- a/pkgs/development/node-packages/shell-generate.nix
+++ b/pkgs/development/node-packages/shell-generate.nix
@@ -1,0 +1,9 @@
+{ nixpkgs ? import ../../.. {} }:
+with nixpkgs;
+mkShell {
+  buildInputs = [
+    bash nodePackages.node2nix
+  ];
+  NODE_NIXPKGS_PATH = toString ./.;
+}
+


### PR DESCRIPTION
- Make it run from anywhere
- overwrite old packages only on success to prevent getting into a bad
state

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
