### PR TITLE
VM test closure checks

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -43,6 +43,7 @@ rec {
             # Ensure that NixOS configurations don't have -dev paths
             # or gcc.out in their closures.
             system.forbiddenDependencies = mkDefault "(-dev$)|(-gcc-[0-9\.]+$)|(gcc-wrapper)";
+            system.maxClosureSize = mkDefault (1024 * 1024 * 1024);
           }
         ] ++ optional minimal ../modules/testing/minimal-kernel.nix;
     };

--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -36,9 +36,14 @@ rec {
       baseModules =  (import ../modules/module-list.nix) ++
         [ ../modules/virtualisation/qemu-vm.nix
           ../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
-          { key = "no-manual"; documentation.nixos.enable = false; }
-          { key = "qemu"; system.build.qemu = qemu; }
-          { key = "nodes"; _module.args.nodes = nodes; }
+          { key = "vm";
+            documentation.nixos.enable = false;
+            system.build.qemu = qemu;
+            _module.args.nodes = nodes;
+            # Ensure that NixOS configurations don't have -dev paths
+            # or gcc.out in their closures.
+            system.forbiddenDependencies = mkDefault "(-dev$)|(-gcc-[0-9\.]+$)|(gcc-wrapper)";
+          }
         ] ++ optional minimal ../modules/testing/minimal-kernel.nix;
     };
 

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -423,7 +423,7 @@ in
 
     system.maxClosureSize = mkOption {
       default = null;
-      example = "-dev$";
+      example = 512 * 1024 * 1024;
       type = types.nullOr types.int;
       description = ''
         The maximum size of the system closure in bytes (computed as the sum of

--- a/nixos/tests/simple.nix
+++ b/nixos/tests/simple.nix
@@ -6,6 +6,7 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   machine = { ... }: {
     imports = [ ../modules/profiles/minimal.nix ];
+    system.maxClosureSize = 640 * 1024 * 1024;
   };
 
   testScript =


### PR DESCRIPTION
This adds checks to ensure that the `config.system.build.toplevel` derivation of a VM does not have `-dev` outputs or `gcc` in its closure, and that the size of the closure is not unexpectedly high. (The default is 1 GiB, but this can be overriden per test.)