### PR TITLE
python3Packages.pwntools: init at unstable-2019-10-09

### DIFF
--- a/pkgs/development/python-modules/pwntools/2.nix
+++ b/pkgs/development/python-modules/pwntools/2.nix
@@ -1,0 +1,36 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, Mako, packaging, pysocks, pygments, ROPGadget
+, capstone, paramiko, pip, psutil
+, pyelftools, pyserial, dateutil
+, requests, tox, unicorn, intervaltree, fetchpatch }:
+
+buildPythonPackage rec {
+  version = "3.12.0";
+  pname = "pwntools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09a7yhsyqxb4xf2r6mbn3p5zx1wp89lxq7lj34y4zbin6ns5929s";
+  };
+
+  propagatedBuildInputs = [ Mako packaging pysocks pygments ROPGadget capstone paramiko pip psutil pyelftools pyserial dateutil requests tox unicorn intervaltree ];
+
+  disabled = isPy3k;
+  doCheck = false; # no setuptools tests for the package
+
+  # Can be removed when 3.13.0 is released
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/Gallopsled/pwntools/commit/9859f54a21404174dd17efee02f91521a2dd09c5.patch";
+      sha256 = "0p0h87npn1mwsd8ciab7lg74bk3ahlk5r0mjbvx4jhihl2gjc3z2";
+    })
+  ];
+
+
+  meta = with stdenv.lib; {
+    homepage = "http://pwntools.com";
+    description = "CTF framework and exploit development library";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bennofs kristoff3r ];
+  };
+}

--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -1,36 +1,32 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+{ stdenv, buildPythonPackage, fetchFromGitHub
 , Mako, packaging, pysocks, pygments, ROPGadget
 , capstone, paramiko, pip, psutil
 , pyelftools, pyserial, dateutil
-, requests, tox, unicorn, intervaltree, fetchpatch }:
+, requests, sortedcontainers, tox, unicorn
+, intervaltree }:
+
 
 buildPythonPackage rec {
-  version = "3.12.0";
+  version = "unstable-2019-10-09";
   pname = "pwntools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "09a7yhsyqxb4xf2r6mbn3p5zx1wp89lxq7lj34y4zbin6ns5929s";
+  src = fetchFromGitHub {
+    owner = "Gallopsled";
+    repo = pname;
+    rev = "fb1178418b11c7aabc816331fbc2874231121a25";
+    sha256 = "130qar90i0vl3s1yqahf3m31mlsmbgj1lnqhdmncwyzhjzbp0x33";
   };
 
-  propagatedBuildInputs = [ Mako packaging pysocks pygments ROPGadget capstone paramiko pip psutil pyelftools pyserial dateutil requests tox unicorn intervaltree ];
+  propagatedBuildInputs = [
+		Mako packaging pysocks pygments ROPGadget capstone paramiko pip psutil pyelftools pyserial dateutil requests sortedcontainers tox unicorn intervaltree
+	];
 
-  disabled = isPy3k;
-  doCheck = false; # no setuptools tests for the package
-
-  # Can be removed when 3.13.0 is released
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/Gallopsled/pwntools/commit/9859f54a21404174dd17efee02f91521a2dd09c5.patch";
-      sha256 = "0p0h87npn1mwsd8ciab7lg74bk3ahlk5r0mjbvx4jhihl2gjc3z2";
-    })
-  ];
-
+  doCheck = false; # no unit tests for the package
 
   meta = with stdenv.lib; {
     homepage = "http://pwntools.com";
     description = "CTF framework and exploit development library";
     license = licenses.mit;
-    maintainers = with maintainers; [ bennofs kristoff3r ];
+    maintainers = with maintainers; [ bennofs kristoff3r pamplemousse ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6008,7 +6008,10 @@ in {
 
   packet-python = callPackage ../development/python-modules/packet-python { };
 
-  pwntools = callPackage ../development/python-modules/pwntools { };
+  pwntools = if isPy3k then
+       callPackage ../development/python-modules/pwntools { }
+     else
+       callPackage ../development/python-modules/pwntools/2.nix { };
 
   ROPGadget = callPackage ../development/python-modules/ROPGadget { };
 


### PR DESCRIPTION
##### Motivation for this change

`pwntools` now works with Python3!


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


###### Notify maintainers

cc @bennofs @kristoff3r 
