### PR TITLE
postgresql_12: init at 12.0

### DIFF
--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -34,6 +34,7 @@ let
 
         services.postgresqlBackup.enable = true;
         services.postgresqlBackup.databases = optional (!backup-all) "postgres";
+        services.postgresqlBackup.pgdumpOptions = "-Cb";
       };
 
     testScript = let

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -82,7 +82,9 @@ let
       ''
         moveToOutput "lib/pgxs" "$out" # looks strange, but not deleting it
         moveToOutput "lib/libpgcommon.a" "$out"
+        moveToOutput "lib/libpgcommon_shlib.a" "$out"
         moveToOutput "lib/libpgport.a" "$out"
+        moveToOutput "lib/libpgport_shlib.a" "$out"
         moveToOutput "lib/libecpg*" "$out"
 
         # Prevent a retained dependency on gcc-wrapper.
@@ -200,4 +202,11 @@ in self: {
     inherit self;
   };
 
+  postgresql_12 = self.callPackage generic {
+    version = "12.0";
+    psqlSchema = "12";
+    sha256 = "1ijm13gx1d9ai09n26nbdc77n9b8akh6pj21yy9vfn7p2mr3k8nd";
+    this = self.postgresql_12;
+    inherit self;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15097,6 +15097,7 @@ in
     postgresql_9_6
     postgresql_10
     postgresql_11
+    postgresql_12
   ;
   postgresql = postgresql_11.override { this = postgresql; };
   postgresqlPackages = recurseIntoAttrs postgresql.pkgs;


### PR DESCRIPTION
###### Motivation for this change

Postgresql-12 is out !

This PR adds it.

I had to change the `pgdumpOptions` in he dump service test since in pg_12, `pg_dump` does not have a `-o|--oids` option anymore. I think the default option of the service should be changed to `-Cb` to avoid this problem for people using `postgresql_12`, but for the time being, I have only changed it in the test.

cc @zagy 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
