### PR TITLE
[WIP] [Very WIP] nixos/desktop-managers: cfg.fallbackXsetrootParam to customize fallback from lack of wallpaper

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -53,6 +53,63 @@ in
             When set to <literal>false</literal> the wallpaper is duplicated to all screens.
           '';
         };
+
+        fallbackXsetrootParam = mkOption {
+          type = types.oneOf
+            (types.submodule { options = {
+              solidColor = mkOption {
+                type = types.string;
+                default = "black";
+                example = "red";
+                description = ''
+                  See man 1 xsetroot option -solid.
+                '';
+              };
+            };})
+            (types.submodule { options = {
+              fgColor = mkOption {
+                type = types.string;
+                default = "black";
+                example = "#444";
+                description = ''
+                  See man 1 xsetroot option -fg and -mod.
+                '';
+              };
+              bgColor = mkOption {
+                type = types.string;
+                default = "white";
+                example = "#555";
+                description = ''
+                  See man 1 xsetroot option -bg and -mod.
+                '';
+              };
+              mod = mkOption {
+                type = types.submodule { options = let
+                  xy = mkOption {
+                    type = types.ints.between 1 16;
+                    default = 1;
+                    example = 4;
+                    description = ''
+                      See man 1 xsetroot option -mod.
+                    '';
+                  }; in { x = xy; y=xy; };
+              };
+            })
+            types.path
+            (types.enum [ "gray" ]);
+          default = { solidColor = "black"; };
+          example = {
+            fgColor = "#444";
+            bgColor = "#555";
+            mod = { x = 4; y = 4; };
+          };
+          description = ''
+            See man 1 xsetroot.
+
+            If a path, then it's -bitmap option.
+          '';
+          # apply = # convert to "-solid color"/"-fg color -bg color -mod x y"/"-bitmap filename"/"-gray"
+        };
       };
 
       session = mkOption {
@@ -77,7 +134,7 @@ in
                 ${pkgs.feh}/bin/feh --bg-${cfg.wallpaper.mode} ${optionalString cfg.wallpaper.combineScreens "--no-xinerama"} $HOME/.background-image
               else
                 # Use a solid black background as fallback
-                ${pkgs.xorg.xsetroot}/bin/xsetroot -solid black
+                ${pkgs.xorg.xsetroot}/bin/xsetroot ${cfg.fallbackXsetrootParam.apply}
               fi
             '';
           }) list;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

nixos/desktop-managers: cfg.fallbackXsetrootParam to customize xsetroot fallback from lack of wallpaper (WIP)

###### Things done

Not even syntax checked. Not even braces and semicolons aligned bc unconfigured editor. Totally WIP. Yet to be force-pushed into, and squashed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
