### PR TITLE
iwd: 0.20 -> 0.22

### DIFF
--- a/pkgs/os-specific/linux/ell/default.nix
+++ b/pkgs/os-specific/linux/ell/default.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "ell";
-  version = "0.22";
+  version = "0.24";
 
   outputs = [ "out" "dev" ];
 
   src = fetchgit {
      url = "https://git.kernel.org/pub/scm/libs/${pname}/${pname}.git";
      rev = version;
-     sha256 = "0dk4j1b8sy4j6w91cq5ga99f3hln9fgh79ayi9kvn8xgzksmhjdp";
+     sha256 = "1dspi6ds58dy7g1q3chapxydfiyz8bjjlryq66jvwgpynzp0c1h1";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -5,32 +5,24 @@
 , pkgconfig
 , ell
 , coreutils
+, docutils
 , readline
 , python3Packages
 }:
 
 stdenv.mkDerivation rec {
   pname = "iwd";
-  version = "0.20";
+  version = "0.22";
 
   src = fetchgit {
     url = https://git.kernel.org/pub/scm/network/wireless/iwd.git;
     rev = version;
-    sha256 = "03ca47d4hn28vkf5fr6ck1gz5py4lm1pw3nw9s1ckw7cqxw961sf";
+    sha256 = "0mjc08ayq2k7sinqanrlm97dn88dxkqkyk2vqqcx1nqjvwvbpbsp";
   };
-
-  patches = [
-    # Undo creating ReadWritePaths as instalation target.
-    (fetchpatch {
-      name = "revert-create-dirs-on-install.patch";
-      url = "https://git.kernel.org/pub/scm/network/wireless/iwd.git/patch/?id=5a96c11664eb553bc28a2142af382b190254edbb";
-      sha256 = "08gkz3ia1l5xsh3pbx4abimgf7m88wygfpfyg77yi6dwavjqm6cx";
-      revert = true;
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook
+    docutils
     pkgconfig
     python3Packages.wrapPython
   ];


### PR DESCRIPTION
###### Motivation for this change
This bumps iwd to 0.22, which finally supports certificate domain matching.

Switched my systems' NetworkManager wifi backend to `iwd` via

```
networking.networkmanager.wifi.backend = "iwd";
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NixOS/backports for backporting