### PR TITLE
nixos.tests: silence getfacl absolute path message

### DIFF
--- a/nixos/tests/gnome3-xorg.nix
+++ b/nixos/tests/gnome3-xorg.nix
@@ -29,7 +29,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       $machine->waitForUnit("default.target","alice");
 
       # Check that logging in has given the user ownership of devices.
-      $machine->succeed("getfacl /dev/snd/timer | grep -q alice");
+      $machine->succeed("getfacl -p /dev/snd/timer | grep -q alice");
 
       $machine->succeed("su - alice -c 'DISPLAY=:0.0 gnome-terminal &'");
       $machine->succeed("xauth merge ~alice/.Xauthority");

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -44,7 +44,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       $machine->waitForUnit("default.target","alice");
 
       # Check that logging in has given the user ownership of devices.
-      $machine->succeed("getfacl /dev/snd/timer | grep -q alice");
+      $machine->succeed("getfacl -p /dev/snd/timer | grep -q alice");
 
       # Wait for the wayland server
       $machine->waitForFile("/run/user/1000/wayland-0");

--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -48,12 +48,12 @@ import ./make-test.nix ({ pkgs, latestKernel ? false, ... }:
       # Check whether systemd gives and removes device ownership as
       # needed.
       subtest "device permissions", sub {
-          $machine->succeed("getfacl /dev/snd/timer | grep -q alice");
+          $machine->succeed("getfacl -p /dev/snd/timer | grep -q alice");
           $machine->sendKeys("alt-f1");
           $machine->waitUntilSucceeds("[ \$(fgconsole) = 1 ]");
-          $machine->fail("getfacl /dev/snd/timer | grep -q alice");
+          $machine->fail("getfacl -p /dev/snd/timer | grep -q alice");
           $machine->succeed("chvt 2");
-          $machine->waitUntilSucceeds("getfacl /dev/snd/timer | grep -q alice");
+          $machine->waitUntilSucceeds("getfacl -p /dev/snd/timer | grep -q alice");
       };
 
       # Log out.

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -42,7 +42,7 @@ import ./make-test.nix ({ pkgs, ...} :
     $machine->waitForWindow(qr/plank/);
 
     # Check that logging in has given the user ownership of devices.
-    $machine->succeed("getfacl /dev/snd/timer | grep -q alice");
+    $machine->succeed("getfacl -p /dev/snd/timer | grep -q alice");
 
     # Open elementary terminal
     $machine->execute("su - alice -c 'DISPLAY=:0.0 io.elementary.terminal &'");

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -48,7 +48,7 @@ import ./make-test.nix ({ pkgs, ...} :
     $machine->waitForWindow("^Desktop ");
 
     # Check that logging in has given the user ownership of devices.
-    $machine->succeed("getfacl /dev/snd/timer | grep -q alice");
+    $machine->succeed("getfacl -p /dev/snd/timer | grep -q alice");
 
     $machine->execute("su - alice -c 'DISPLAY=:0.0 dolphin &'");
     $machine->waitForWindow(" Dolphin");

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -32,7 +32,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       $machine->sleep(10);
 
       # Check that logging in has given the user ownership of devices.
-      $machine->succeed("getfacl /dev/snd/timer | grep -q alice");
+      $machine->succeed("getfacl -p /dev/snd/timer | grep -q alice");
 
       $machine->succeed("su - alice -c 'DISPLAY=:0.0 xfce4-terminal &'");
       $machine->waitForWindow(qr/Terminal/);

--- a/nixos/tests/xfce4-14.nix
+++ b/nixos/tests/xfce4-14.nix
@@ -14,7 +14,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       services.xserver.desktopManager.xfce4-14.enable = true;
 
       hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
-  
+
       virtualisation.memorySize = 1024;
     };
 
@@ -27,7 +27,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       $machine->sleep(10);
 
       # Check that logging in has given the user ownership of devices.
-      $machine->succeed("getfacl /dev/snd/timer | grep -q alice");
+      $machine->succeed("getfacl -p /dev/snd/timer | grep -q alice");
 
       $machine->succeed("su - alice -c 'DISPLAY=:0.0 xfce4-terminal &'");
       $machine->waitForWindow(qr/Terminal/);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I noticed several `getfacl` messages about absolute paths in our tests logs.

Default getfacl behavior is to remove leading slash on absolute
paths in its header printed to stdout.
Before the header it will also print a message about it...

Switches `-p` -or `--absolute-names` can turn this off
and remove some noise from our tests logs.

---

output with noise:
```ini
$ getfacl /dev/snd/timer
getfacl: Removing leading '/' from absolute path names
# file: dev/snd/timer
# owner: root
# group: audio
user::rw-
user:demo:rw-
group::rw-
mask::rw-
other::---
```
-vs- a clean output:
```shell
$ getfacl -p /dev/snd/timer
# file: /dev/snd/timer
# owner: root
# group: audio
user::rw-
user:demo:rw-
group::rw-
mask::rw-
other::---
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
