### PR TITLE
networkmanager: fix udev rule warning

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, substituteAll, intltool, pkgconfig, dbus, dbus-glib
+{ stdenv, fetchurl, fetchpatch, substituteAll, intltool, pkgconfig, dbus, dbus-glib
 , gnome3, systemd, libuuid, polkit, gnutls, ppp, dhcp, iptables, python3, vala
 , libgcrypt, dnsmasq, bluez5, readline, libselinux, audit
 , gobject-introspection, modemmanager, openresolv, libndp, newt, libsoup
@@ -53,6 +53,13 @@ in stdenv.mkDerivation rec {
   ];
 
   patches = [
+    # fix udev warning
+    # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/commit/27d380b70ea839c7badab420361e4e65e023e8e9
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/NetworkManager/NetworkManager/commit/27d380b70ea839c7badab420361e4e65e023e8e9.patch";
+      sha256 = "02mnvslp9iyca492p1lrj6r1hh1fiywhvmi0p5m3qnz7n65x32xb";
+    })
+
     (substituteAll {
       src = ./fix-paths.patch;
       inherit iputils kmod openconnect ethtool gnused dbus;

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -18,8 +18,8 @@
  # Determine ID_NET_DRIVER if there's no ID_NET_DRIVER or DRIVERS (old udev?)
  ENV{ID_NET_DRIVER}=="?*", GOTO="nm_drivers_end"
  DRIVERS=="?*", GOTO="nm_drivers_end"
--PROGRAM="/bin/sh -c 'ethtool -i $1 | sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
-+PROGRAM="@shell@ -c '@ethtool@/bin/ethtool -i $1 | @gnused@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
+-PROGRAM="/bin/sh -c '/usr/sbin/ethtool -i $$1 |/usr/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", ENV{ID_NET_DRIVER}="%c"
++PROGRAM="@shell@ -c '@ethtool@/bin/ethtool -i $1 | @gnused@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", ENV{ID_NET_DRIVER}="%c"
  
  LABEL="nm_drivers_end"
 --- a/data/NetworkManager.service.in


### PR DESCRIPTION
Apply upstream patch to fix an annoying warning:

    /nix/store/hj3g05ypn2a6iwd1qdv8cysbbkhp1apj-udev-rules/84-nm-drivers.rules:10 Invalid value "/nix/store/l6h4ya0wzb4b8mr0y58k2gh2nhfql4sn-bash-4.4-p23/bin/bash -c '/nix/store/qv79j3glsdmfhdzwjwa5ys3s7k0kary5-ethtool-5.2/bin/ethtool -i $1 | /nix/store/5pwj1q9zbs89xv9wlmp554p4fixz9im4-gnused-4.7/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}" for PROGRAM (char 142: invalid substitution type), ignoring, but please fix it.