### PR TITLE
MythTV 29.1 -> 30.0

### DIFF
--- a/pkgs/applications/video/mythtv/default.nix
+++ b/pkgs/applications/video/mythtv/default.nix
@@ -1,40 +1,40 @@
-{ stdenv, fetchFromGitHub, which, qtbase, qtwebkit, qtscript, xlibsWrapper
+{ stdenv, mkDerivation, fetchFromGitHub, which, qtbase, qtwebkit, qtscript, xlibsWrapper
 , libpulseaudio, fftwSinglePrec , lame, zlib, libGLU_combined, alsaLib, freetype
-, perl, pkgconfig , libX11, libXv, libXrandr, libXvMC, libXinerama, libXxf86vm
-, libXmu , yasm, libuuid, taglib, libtool, autoconf, automake, file, exiv2
-, linuxHeaders, fetchpatch
+, perl, pkgconfig , libsamplerate, libbluray, lzo, libX11, libXv, libXrandr, libXvMC, libXinerama, libXxf86vm
+, libXmu , yasm, libuuid, taglib, libtool, autoconf, automake, file, exiv2, linuxHeaders
+, libXNVCtrl, enableXnvctrl ? false
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "mythtv";
-  version = "29.1";
+  version = "30.0";
 
   src = fetchFromGitHub {
     owner = "MythTV";
     repo = "mythtv";
     rev = "v${version}";
-    sha256 = "0pjxv4bmq8h285jsr02svgaa03614arsyk12fn9d4rndjsi2cc3x";
+    sha256 = "1pfzjb07xwd3mfgmbr4kkiyfyvwy9fkl13ik7bvqds86m0ws5bw4";
   };
 
   patches = [
     # Fixes build with exiv2 0.27.1.
-    (fetchpatch {
-      name = "004-exiv2.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/004-exiv2.patch?h=mythtv&id=76ea37f8556805b205878772ad7874e487c0d946";
-      sha256 = "0mh542f53qgky0w3s2bv0gmcxzvmb10834z3cfff40fby2ffr6k8";
-    })
+    ./exiv2.patch
+    # Disables OS detection used while checking for xnvctrl support.
+    ./disable-os-detection.patch
   ];
 
   setSourceRoot = ''sourceRoot=$(echo */mythtv)'';
 
   buildInputs = [
     freetype qtbase qtwebkit qtscript lame zlib xlibsWrapper libGLU_combined
-    perl alsaLib libpulseaudio fftwSinglePrec libX11 libXv libXrandr libXvMC
+    perl libsamplerate libbluray lzo alsaLib libpulseaudio fftwSinglePrec libX11 libXv libXrandr libXvMC
     libXmu libXinerama libXxf86vm libXmu libuuid taglib exiv2
-  ];
+  ] ++ stdenv.lib.optional enableXnvctrl libXNVCtrl;
   nativeBuildInputs = [ pkgconfig which yasm libtool autoconf automake file ];
 
-  configureFlags = [ "--dvb-path=${linuxHeaders}/include" ];
+  configureFlags = 
+    [ "--dvb-path=${linuxHeaders}/include" ]
+    ++ stdenv.lib.optionals (!enableXnvctrl) [  "--disable-xnvctrl" ];
 
   meta = with stdenv.lib; {
     homepage = https://www.mythtv.org/;

--- a/pkgs/applications/video/mythtv/disable-os-detection.patch
+++ b/pkgs/applications/video/mythtv/disable-os-detection.patch
@@ -1,0 +1,51 @@
+--- a/configure	1970-01-01 01:00:01.000000000 +0100
++++ b/configure	2019-10-26 11:54:01.920776490 +0200
+@@ -6642,29 +6642,29 @@
+     require libXinerama X11/extensions/Xinerama.h XineramaQueryExtension -lXinerama
+     require libXext "X11/Xdefs.h X11/Xlib.h X11/extensions/Xext.h" XMissingExtension -lXext
+     if enabled xnvctrl; then
+-        case $target_os in
+-            linux)
++#        case $target_os in
++#            linux)
+                 # Bah. Suse linux doesn't have xnvctrl.
+-                . /etc/os-release
+-                case $ID in
+-                    *suse*)
++#                . /etc/os-release
++#                case $ID in
++#                    *suse*)
+ 			# This is hopefully temporary.
+-			disable xnvctrl_external
+-			;;
+-		    *)
+-                        require XNVctrl "X11/Xlib.h NVCtrl/NVCtrl.h NVCtrl/NVCtrlLib.h" XNVCTRLIsNvScreen -lXNVCtrl || disable xnvctrl
+-                        ;;
+-                esac
+-                ;;
+-            freebsd)
++#			disable xnvctrl_external
++#			;;
++#		    *)
++        require XNVctrl "X11/Xlib.h NVCtrl/NVCtrl.h NVCtrl/NVCtrlLib.h" XNVCTRLIsNvScreen -lXNVCtrl || disable xnvctrl
++#                        ;;
++#                esac
++#                ;;
++#            freebsd)
+                 # This is hopefully temporary, and will eventually
+                 # check for a system library too.
+-                disable xnvctrl_external
+-                ;;
+-            *)
+-                disable xnvctrl
+-                ;;
+-        esac
++#                disable xnvctrl_external
++#                ;;
++#            *)
++#                disable xnvctrl
++#                ;;
++#        esac
+     fi
+ fi
+ 

--- a/pkgs/applications/video/mythtv/exiv2.patch
+++ b/pkgs/applications/video/mythtv/exiv2.patch
@@ -1,0 +1,19 @@
+Patch source: https://aur.archlinux.org/cgit/aur.git/plain/004-exiv2.patch?h=mythtv&id=76ea37f8556805b205878772ad7874e487c0d946
+--- a/libs/libmythmetadata/imagemetadata.cpp
++++ b/libs/libmythmetadata/imagemetadata.cpp
+@@ -7,14 +7,7 @@
+ #include "exitcodes.h"        // for ffprobe
+ 
+ // libexiv2 for Exif metadata
+-//#include <exiv2/exiv2.hpp>
+-// Note: Older versions of Exiv2 don't have the exiv2.hpp include
+-// file.  Using image.hpp instead seems to work.
+-#ifdef _MSC_VER
+-#include <exiv2/src/image.hpp>
+-#else
+-#include <exiv2/image.hpp>
+-#endif
++#include <exiv2/exiv2.hpp>
+ 
+ // To read FFMPEG Metadata
+ extern "C" {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19974,7 +19974,9 @@ in
 
   mypaint-brushes = callPackage ../development/libraries/mypaint-brushes { };
 
-  mythtv = libsForQt5.callPackage ../applications/video/mythtv { };
+  mythtv = libsForQt5.callPackage ../applications/video/mythtv {
+    libXNVCtrl = linuxPackages.nvidia_x11.settings.libXNVCtrl;
+  };
 
   micro = callPackage ../applications/editors/micro { };
 


### PR DESCRIPTION
Restoration of this pull request: https://github.com/NixOS/nixpkgs/pull/67191

#### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/54596

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

Jonathan Rudenberg <jonathan@titanous.com>
