### PR TITLE
pythonPackages.rpyc: enable tests

### DIFF
--- a/pkgs/development/python-modules/rpyc/default.nix
+++ b/pkgs/development/python-modules/rpyc/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , nose
 , plumbum
 }:
@@ -9,12 +9,21 @@ buildPythonPackage rec {
   pname = "rpyc";
   version = "4.1.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0df276076891797bbaaff322cc6debb02e10817426bba00a9beca915053a8a91";
+  src = fetchFromGitHub {
+    owner = "tomerfiliba";
+    repo = pname;
+    rev = version;
+    sha256 = "1xvrcik1650r1412fg79va0kd0fgg1ml241y1ai429qwy87dil1k";
   };
 
-  propagatedBuildInputs = [ nose plumbum ];
+  propagatedBuildInputs = [ plumbum ];
+
+  checkInputs = [ nose ];
+  checkPhase = ''
+    cd tests
+    # some tests have added complexities and some tests attempt network use
+    nosetests -I test_deploy -I test_gevent_server -I test_ssh -I test_registry
+  '';
 
   meta = with stdenv.lib; {
     description = "Remote Python Call (RPyC), a transparent and symmetric RPC library";


### PR DESCRIPTION
###### Motivation for this change
~https://nvd.nist.gov/vuln/detail/CVE-2019-16328~

This was originally a security bump of 4.1.1 -> 4.1.2, but that got superseded. Now this is just about the enabling of the tests that I did at the same time....

Noticed that the tests weren't actually running or present in the pypi tarball, so switched to the github source and fixed up their execution.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
