### PR TITLE
kde_applications: 19.08.1 -> 19.08.2

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/19.08.1/ )
+WGET_ARGS=( https://download.kde.org/stable/applications/19.08.2/ )

--- a/pkgs/applications/kde/spectacle.nix
+++ b/pkgs/applications/kde/spectacle.nix
@@ -4,7 +4,7 @@
   ki18n, xcb-util-cursor,
   kconfig, kcoreaddons, kdbusaddons, kdeclarative, kio, kipi-plugins,
   knotifications, kscreen, kwidgetsaddons, kwindowsystem, kxmlgui, libkipi,
-  qtx11extras, knewstuff, qttools
+  qtx11extras, knewstuff, kwayland, qttools
 }:
 
 mkDerivation {
@@ -14,7 +14,7 @@ mkDerivation {
   buildInputs = [
     kconfig kcoreaddons kdbusaddons kdeclarative ki18n kio knotifications
     kscreen kwidgetsaddons kwindowsystem kxmlgui libkipi qtx11extras xcb-util-cursor
-    knewstuff
+    knewstuff kwayland
   ];
   postPatch = ''
     substituteInPlace desktop/org.kde.spectacle.desktop \

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,1739 +3,1739 @@
 
 {
   akonadi = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/akonadi-19.08.1.tar.xz";
-      sha256 = "32233b59c696a5053f2ee4b7368804635a04e2a5f6d3605848eadafa0306c44d";
-      name = "akonadi-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/akonadi-19.08.2.tar.xz";
+      sha256 = "f67f0fac07d480739b2d6715862ee47a93fd38f057ac7ef888ed8ddfdc99934f";
+      name = "akonadi-19.08.2.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/akonadi-calendar-19.08.1.tar.xz";
-      sha256 = "5e8c66d4c86e6458469dbb393458ee8b5e6afc1b4712ce8395709d4226864d6c";
-      name = "akonadi-calendar-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/akonadi-calendar-19.08.2.tar.xz";
+      sha256 = "5beba24af485c8dae96944e4b5bd570460eb2868ba069580c2e5d784be38a3c8";
+      name = "akonadi-calendar-19.08.2.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/akonadi-calendar-tools-19.08.1.tar.xz";
-      sha256 = "033fae40bcbdcfa52981026f783b7cc8fecde384d6683747cd3f307bd43b2570";
-      name = "akonadi-calendar-tools-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/akonadi-calendar-tools-19.08.2.tar.xz";
+      sha256 = "a352c2bf8659ad7939f31009b8e35e8b1e629162f681a70999e5e88f9aaf6cbb";
+      name = "akonadi-calendar-tools-19.08.2.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/akonadiconsole-19.08.1.tar.xz";
-      sha256 = "9a0f88903757eaf0d3271d4438b3a170640b7cb01a7b2f0fbf10a75fa0093184";
-      name = "akonadiconsole-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/akonadiconsole-19.08.2.tar.xz";
+      sha256 = "273b8f3d56ea65bd71a51103867b0e718d883478432bb971a262df1ea4c6df6c";
+      name = "akonadiconsole-19.08.2.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/akonadi-contacts-19.08.1.tar.xz";
-      sha256 = "f182883b4cc16034a798feb966df268e84d9c5b8d3c6e14d5698f7ead85a21d7";
-      name = "akonadi-contacts-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/akonadi-contacts-19.08.2.tar.xz";
+      sha256 = "eafeb550faea91a56109821864eedfbd619dc7850887746d31c1724ea7561920";
+      name = "akonadi-contacts-19.08.2.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/akonadi-import-wizard-19.08.1.tar.xz";
-      sha256 = "d66088ded8917f6034de8981ce71d5d0e1808f6d58f7fdb7e0a806ff0834e27b";
-      name = "akonadi-import-wizard-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/akonadi-import-wizard-19.08.2.tar.xz";
+      sha256 = "038713e7d30686eb1b8e49c595ec853ffa52d335e435a5b0bdf2f2a2448cae45";
+      name = "akonadi-import-wizard-19.08.2.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/akonadi-mime-19.08.1.tar.xz";
-      sha256 = "0a4f4652a665229b290431adb59940890effba0804fe33a0e79a24322f90b35c";
-      name = "akonadi-mime-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/akonadi-mime-19.08.2.tar.xz";
+      sha256 = "16f8034d7990828c50a85474fe16641dfa46e22d00f49d8045d3483c61815264";
+      name = "akonadi-mime-19.08.2.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/akonadi-notes-19.08.1.tar.xz";
-      sha256 = "44896f17fc2f625f9fc8c77690acd787291c5e08e8261c5d113c94045bd5bdd8";
-      name = "akonadi-notes-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/akonadi-notes-19.08.2.tar.xz";
+      sha256 = "64684c50d06664d8ccda098f8bfa536e861e4938c8f27688ef97653f7788fdde";
+      name = "akonadi-notes-19.08.2.tar.xz";
     };
   };
   akonadi-search = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/akonadi-search-19.08.1.tar.xz";
-      sha256 = "c68387f3452bcd390f1c99549531c72d95db0def29d8ba10330e68891b0d0b53";
-      name = "akonadi-search-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/akonadi-search-19.08.2.tar.xz";
+      sha256 = "75c9713b84a03c60a68ff36652decbf57f4f56a0fb39579f53e7ed80a5ee8525";
+      name = "akonadi-search-19.08.2.tar.xz";
     };
   };
   akregator = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/akregator-19.08.1.tar.xz";
-      sha256 = "b73fcf1c509398ff496864f0105491792b5b15f37c52f9a8ca74ca254a75494a";
-      name = "akregator-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/akregator-19.08.2.tar.xz";
+      sha256 = "cefc0785f40508a80fbf4534eef4d1164e349cfd50455483cef044945d1888c4";
+      name = "akregator-19.08.2.tar.xz";
     };
   };
   analitza = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/analitza-19.08.1.tar.xz";
-      sha256 = "f963a8abe31d4c0d2b0e0a7e78ec78ced8eb7a0af60df1620ccc2f2409df6a91";
-      name = "analitza-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/analitza-19.08.2.tar.xz";
+      sha256 = "cbd51fd14d5ba74a7a3590ddca18ed688cbf724cd40f21c87b905f12fadf9399";
+      name = "analitza-19.08.2.tar.xz";
     };
   };
   ark = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ark-19.08.1.tar.xz";
-      sha256 = "b5638bc4559d775d0a0c2aee022cadc021543bf92e8be6b9b803c50e7e7f1835";
-      name = "ark-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ark-19.08.2.tar.xz";
+      sha256 = "63fcec0a32d806cfc82fb1c136b5e037bfe75459b148ac08c00be7e45ac70c50";
+      name = "ark-19.08.2.tar.xz";
     };
   };
   artikulate = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/artikulate-19.08.1.tar.xz";
-      sha256 = "856488a4914ae0cfa594106b4d5c7b5ffd996b009075dfa009ab9cdd2cbc2f9d";
-      name = "artikulate-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/artikulate-19.08.2.tar.xz";
+      sha256 = "b2b0778f18f04096b84caf72c28dd4bdfdbbc8f0a22ef118b8d18dba19a3f85b";
+      name = "artikulate-19.08.2.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/audiocd-kio-19.08.1.tar.xz";
-      sha256 = "e072ed20f07fe246267b3e7c459812fe63d94125a1d2fbcda1c0403e9fe0a520";
-      name = "audiocd-kio-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/audiocd-kio-19.08.2.tar.xz";
+      sha256 = "383c0e9055b0093661b589395288bb8d173372572490a4ba4960d214b2746b3a";
+      name = "audiocd-kio-19.08.2.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/baloo-widgets-19.08.1.tar.xz";
-      sha256 = "83429a70de735edc4714dc1b6f1a5a8c7d3d68a93165e98d2cadeecafa82af7b";
-      name = "baloo-widgets-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/baloo-widgets-19.08.2.tar.xz";
+      sha256 = "529f3b587098eb9b7d1aaa8b311f98c58d16ed88384fa0900f9fb9f8e242c070";
+      name = "baloo-widgets-19.08.2.tar.xz";
     };
   };
   blinken = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/blinken-19.08.1.tar.xz";
-      sha256 = "dbe7b13bc6cad69f049f9eefa56f99012bc0906233193bf951477b3f5c8eb87e";
-      name = "blinken-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/blinken-19.08.2.tar.xz";
+      sha256 = "7f9d909bb845c365dbf49388b79687e7491c271dd7d2f9481a20397153a670f6";
+      name = "blinken-19.08.2.tar.xz";
     };
   };
   bomber = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/bomber-19.08.1.tar.xz";
-      sha256 = "750110da07a1e316e2a55d043a0e988c91e6e57866b941a5cce1b6f569096f4f";
-      name = "bomber-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/bomber-19.08.2.tar.xz";
+      sha256 = "26285fe9e510cd334bb933281c615c2971084bfa787618ba0190175c36ada741";
+      name = "bomber-19.08.2.tar.xz";
     };
   };
   bovo = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/bovo-19.08.1.tar.xz";
-      sha256 = "0d923b6b0eaf2ffd7a1eca833d1f110cc6fdaade3b11d07e8fa53a244a778658";
-      name = "bovo-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/bovo-19.08.2.tar.xz";
+      sha256 = "63f7a3860de2344be69366f636e841cd3db19743a8a29c42e14402256ed3122b";
+      name = "bovo-19.08.2.tar.xz";
     };
   };
   calendarsupport = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/calendarsupport-19.08.1.tar.xz";
-      sha256 = "74d1b19a924f2aad7f5a034a7e3b11f2ed5bb94cd21458f0255a64ac6163de97";
-      name = "calendarsupport-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/calendarsupport-19.08.2.tar.xz";
+      sha256 = "9ae448463ca60e075f1ea9a22489f0acf6ea672c00f9bd7b49027e548e82c2af";
+      name = "calendarsupport-19.08.2.tar.xz";
     };
   };
   cantor = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/cantor-19.08.1.tar.xz";
-      sha256 = "93b43426c3383718e6ff7b62f073e3c39371a519b98e890c2b7c15cb5086c039";
-      name = "cantor-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/cantor-19.08.2.tar.xz";
+      sha256 = "039bb1e61b996ab3776502db9367ed1f7fb7e674292647f1b28f5bd9b1c1b9cb";
+      name = "cantor-19.08.2.tar.xz";
     };
   };
   cervisia = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/cervisia-19.08.1.tar.xz";
-      sha256 = "726c8d4bd942280e08891e15e47d0a0a88ee951addb3c10e1e9955fad2794b7f";
-      name = "cervisia-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/cervisia-19.08.2.tar.xz";
+      sha256 = "7cbff9d32e2721f6f594a84b42feef6dd76f830e2cc27c6d442d9b6ccbe7fceb";
+      name = "cervisia-19.08.2.tar.xz";
     };
   };
   dolphin = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/dolphin-19.08.1.tar.xz";
-      sha256 = "a612dac0cf50301af46ad5fa29aad630bb33a8a4bd416a4d6023b65fb00f25cc";
-      name = "dolphin-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/dolphin-19.08.2.tar.xz";
+      sha256 = "0c56515737fc0f96020b3c157a93023095d1a1e23637e7670e068c6c286bbc3b";
+      name = "dolphin-19.08.2.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/dolphin-plugins-19.08.1.tar.xz";
-      sha256 = "ce2452d9f878dfcff45739ff9eb4a3bde69c449c36182dee6b768f362e75ae2e";
-      name = "dolphin-plugins-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/dolphin-plugins-19.08.2.tar.xz";
+      sha256 = "da2114bd8ed0a70fba3c3cba82a5543cce2f91af7e1dc12bc7457eeffc03099d";
+      name = "dolphin-plugins-19.08.2.tar.xz";
     };
   };
   dragon = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/dragon-19.08.1.tar.xz";
-      sha256 = "b015dbba4b8278a4987164f12a9d9e42745d2eb1772da8b8b0c849b28ba03c90";
-      name = "dragon-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/dragon-19.08.2.tar.xz";
+      sha256 = "3924dba504f370415c0d68cb5079acfc941aa761e9d9d2df2ea48b302ef9ce61";
+      name = "dragon-19.08.2.tar.xz";
     };
   };
   eventviews = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/eventviews-19.08.1.tar.xz";
-      sha256 = "a44d82e774017171f2eef3ef94b3c5b2765ce08fab5eec0a87b286fd5ea815f7";
-      name = "eventviews-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/eventviews-19.08.2.tar.xz";
+      sha256 = "48da7f85c86bcc7a64d475c5bbcbb531471e70cfc9f4bda76030280f0671132d";
+      name = "eventviews-19.08.2.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ffmpegthumbs-19.08.1.tar.xz";
-      sha256 = "527ef798db833e71e2faf315fc89596716bd2bd7d11c78bc1bb2ef9b1549a71b";
-      name = "ffmpegthumbs-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ffmpegthumbs-19.08.2.tar.xz";
+      sha256 = "deba57ff10525efdf404401f6b605c1be0f02ec0bfe00465e080b42dc379d570";
+      name = "ffmpegthumbs-19.08.2.tar.xz";
     };
   };
   filelight = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/filelight-19.08.1.tar.xz";
-      sha256 = "170e633e0d2f8c9b13cccfd5957590100be435f9e7258e84c6f15fabc636768e";
-      name = "filelight-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/filelight-19.08.2.tar.xz";
+      sha256 = "313ff23fceb427509b37efa012535e651618d42bde35c62cdc7732e463c346a6";
+      name = "filelight-19.08.2.tar.xz";
     };
   };
   granatier = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/granatier-19.08.1.tar.xz";
-      sha256 = "3015a25f961ae3d746db2814a322bfb204e4e39cd95145fbf2aa819f1dc0417e";
-      name = "granatier-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/granatier-19.08.2.tar.xz";
+      sha256 = "81a0c288edd0be6d7c994a8ad1469679b7e78174d641f9c4f90d31613bad4b47";
+      name = "granatier-19.08.2.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/grantlee-editor-19.08.1.tar.xz";
-      sha256 = "77661ac1d125349cd3439d130164ad172f0022376d6c6038c860c0440939e52c";
-      name = "grantlee-editor-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/grantlee-editor-19.08.2.tar.xz";
+      sha256 = "8e65ca3d949dcdd2b6c2edd582351b123eef49eb104a2dd6c027028315c2d502";
+      name = "grantlee-editor-19.08.2.tar.xz";
     };
   };
   grantleetheme = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/grantleetheme-19.08.1.tar.xz";
-      sha256 = "61ec8f4902573727d5a292ba55c3663b267d3b1b8017c003ac3445164c2627cb";
-      name = "grantleetheme-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/grantleetheme-19.08.2.tar.xz";
+      sha256 = "a9d4e70089debdfaffb4af881cf2064ba68a0ad3fe007985c8e5997f0cf0e836";
+      name = "grantleetheme-19.08.2.tar.xz";
     };
   };
   gwenview = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/gwenview-19.08.1.tar.xz";
-      sha256 = "1ed46507ea30c43e4672b51996ac413683a863978999be91a9df135f9369f3cb";
-      name = "gwenview-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/gwenview-19.08.2.tar.xz";
+      sha256 = "fa49352a208c9472c911d3579f7601fb915831ad42caf74a053ed749bf5bb1fb";
+      name = "gwenview-19.08.2.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/incidenceeditor-19.08.1.tar.xz";
-      sha256 = "591781da9b3bc4b0f366ffa8de658aa31f48e1f435a434669b7c11b5f3a55403";
-      name = "incidenceeditor-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/incidenceeditor-19.08.2.tar.xz";
+      sha256 = "f2f7bf3a12af21e6f9e4a5f2ba93346e06a6988366af7b452d6268ac9fb4fc3d";
+      name = "incidenceeditor-19.08.2.tar.xz";
     };
   };
   juk = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/juk-19.08.1.tar.xz";
-      sha256 = "f91de1fa697fba3fe73a086b0f3c254959fbceb769d3752353ee2078b86611f9";
-      name = "juk-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/juk-19.08.2.tar.xz";
+      sha256 = "b3f0e006d6defa58e0724088a1c99c1c412bc5764f8d1bebadf31b5f331d51d3";
+      name = "juk-19.08.2.tar.xz";
     };
   };
   k3b = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/k3b-19.08.1.tar.xz";
-      sha256 = "8995f39457932fb6597f0f6124e0dfe09ecb2a25a6ec8506ce3ef870da293749";
-      name = "k3b-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/k3b-19.08.2.tar.xz";
+      sha256 = "a16796a873018bc5fd9f562297fea56d3f6d32a1e903a3e145814ea7d9be5209";
+      name = "k3b-19.08.2.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kaccounts-integration-19.08.1.tar.xz";
-      sha256 = "7436bb0c8e024122d7137971749ef975878dee557befa4b95bc02ce0801a8450";
-      name = "kaccounts-integration-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kaccounts-integration-19.08.2.tar.xz";
+      sha256 = "b422c23eb3eefc3a79c4ccb9360ae6269a86982575e981bb949c0782f1f813ce";
+      name = "kaccounts-integration-19.08.2.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kaccounts-providers-19.08.1.tar.xz";
-      sha256 = "ce885be3c0d59b7f65373fbadc8ff4510998f9067d3a7c96dc1eb05df78b071b";
-      name = "kaccounts-providers-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kaccounts-providers-19.08.2.tar.xz";
+      sha256 = "d5ad6882ff151d2f0cff2b76a83e38cf37c72a0dbdf4a0aff64420903266a309";
+      name = "kaccounts-providers-19.08.2.tar.xz";
     };
   };
   kaddressbook = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kaddressbook-19.08.1.tar.xz";
-      sha256 = "8091a3bd77ec17757386d71a98a0ef2b6d68e35ca2f9f9b71e4e36c2a3cce5c9";
-      name = "kaddressbook-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kaddressbook-19.08.2.tar.xz";
+      sha256 = "4d67480ebf8ee96fcde85e66f8ad32119b006e36c87f4e4ac20ecfa967599260";
+      name = "kaddressbook-19.08.2.tar.xz";
     };
   };
   kajongg = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kajongg-19.08.1.tar.xz";
-      sha256 = "ae40b7ceb7c591f8d92371e3c7584eeae0d84e4680927834eca7ffacd5b9bbf6";
-      name = "kajongg-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kajongg-19.08.2.tar.xz";
+      sha256 = "08c80ea5d44ee25812de9d9e95d7800cc84c1c02006f59eb08e54f2a0d4c756b";
+      name = "kajongg-19.08.2.tar.xz";
     };
   };
   kalarm = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kalarm-19.08.1.tar.xz";
-      sha256 = "9eb7c6b160e82ae8d5d294ebd781ef2ac5579e556a564c70598c08925e2021fa";
-      name = "kalarm-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kalarm-19.08.2.tar.xz";
+      sha256 = "54d61b469042d27b8df903c5fc95dd68c1d108218f1402a733d974ab02576d24";
+      name = "kalarm-19.08.2.tar.xz";
     };
   };
   kalarmcal = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kalarmcal-19.08.1.tar.xz";
-      sha256 = "add9ee09287491236c9a25cfcb32d437845d094d8fef3682954f561dc2917984";
-      name = "kalarmcal-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kalarmcal-19.08.2.tar.xz";
+      sha256 = "4dc6e1cd8a9cbf6e3f8e593e68ef6fa912819ece56efa64852ab33e3f582e6b7";
+      name = "kalarmcal-19.08.2.tar.xz";
     };
   };
   kalgebra = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kalgebra-19.08.1.tar.xz";
-      sha256 = "c9859e0b2b847652007a3244bc658f7e160fe88fc70ea7da6e60f003f54f46c9";
-      name = "kalgebra-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kalgebra-19.08.2.tar.xz";
+      sha256 = "351a0df1bf637b14683d1a38d8f1eff0153596c5f93723f28f799aead6ee0757";
+      name = "kalgebra-19.08.2.tar.xz";
     };
   };
   kalzium = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kalzium-19.08.1.tar.xz";
-      sha256 = "2519866172476bec297e9d02ff917b1c676b980edc2f20a9c3297bc255e045f0";
-      name = "kalzium-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kalzium-19.08.2.tar.xz";
+      sha256 = "e63d88526c86dd67ab133694dc23b6a35fd5514643bd7a7f1790db8c2a8490d9";
+      name = "kalzium-19.08.2.tar.xz";
     };
   };
   kamera = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kamera-19.08.1.tar.xz";
-      sha256 = "109a030ef55b941758e8d4a58b2abed4c5e1bb7e13e8d239b7132867c801acf5";
-      name = "kamera-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kamera-19.08.2.tar.xz";
+      sha256 = "2db474afa6201f330631640e04e1bd6ebb96838ce4c16d37617a10063b1fa757";
+      name = "kamera-19.08.2.tar.xz";
     };
   };
   kamoso = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kamoso-19.08.1.tar.xz";
-      sha256 = "76d7a9ea70646f8e86e912b72bd9f9ab42711f0cd53c7bed1403a274de036675";
-      name = "kamoso-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kamoso-19.08.2.tar.xz";
+      sha256 = "2b84b3b3fb7f423bbe69716114563f018e02d63ce7b9b85084d098123e4e29b8";
+      name = "kamoso-19.08.2.tar.xz";
     };
   };
   kanagram = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kanagram-19.08.1.tar.xz";
-      sha256 = "85ba60dc1485f61054847262832edd112224a618effe8759a2dcc8ee73b130a6";
-      name = "kanagram-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kanagram-19.08.2.tar.xz";
+      sha256 = "251d08a8b73e85af4b90ed429d873b17f56c1e094c4a62116eee3b6bffc96388";
+      name = "kanagram-19.08.2.tar.xz";
     };
   };
   kapman = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kapman-19.08.1.tar.xz";
-      sha256 = "e80057b4fa9b8af86ecae30871005d4c7508bbc99618cf36dcf1c9c7fa905321";
-      name = "kapman-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kapman-19.08.2.tar.xz";
+      sha256 = "240d7b0c611728bd1974230227c669bdcfe80081cff2ddae6278d5393bab7a4e";
+      name = "kapman-19.08.2.tar.xz";
     };
   };
   kapptemplate = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kapptemplate-19.08.1.tar.xz";
-      sha256 = "c1e5d239ce3749e72bcce30dfc8c0a12c3d347b72a2566caa0d23dcc930499a2";
-      name = "kapptemplate-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kapptemplate-19.08.2.tar.xz";
+      sha256 = "2b719cf75bf8e9b495a8d9aa8288ddb528617c2e76bd1312cfdb2a43b27d6208";
+      name = "kapptemplate-19.08.2.tar.xz";
     };
   };
   kate = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kate-19.08.1.tar.xz";
-      sha256 = "5389e1620a7eb8d7bab7396ee0db1a886fbdd44c8415291db6a917e89dcc77b7";
-      name = "kate-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kate-19.08.2.tar.xz";
+      sha256 = "9897f652996e3ebca8a749562cc2d609d704c80b08ec4716622def38f5980b47";
+      name = "kate-19.08.2.tar.xz";
     };
   };
   katomic = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/katomic-19.08.1.tar.xz";
-      sha256 = "05453f2a1cba1a9bb7c558e9628361685d9b9b44fc4d65599eb05fec6ca3bd5d";
-      name = "katomic-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/katomic-19.08.2.tar.xz";
+      sha256 = "822963024107e122a3f53f55ae6863a10d92ca59eef5966cded6c9daf5f989b3";
+      name = "katomic-19.08.2.tar.xz";
     };
   };
   kbackup = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kbackup-19.08.1.tar.xz";
-      sha256 = "93ec83cdb8cb1ad28f444f85aaec2270fbbf3108b3ce0cf22f42a737e0f9cc59";
-      name = "kbackup-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kbackup-19.08.2.tar.xz";
+      sha256 = "1678ac00c1930f430d620f542dc7913bf1575106654cc9d4b534aed65e023fb8";
+      name = "kbackup-19.08.2.tar.xz";
     };
   };
   kblackbox = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kblackbox-19.08.1.tar.xz";
-      sha256 = "478b235e9498e9c5bf1c3626db651c85cf41bdd824dec484bccd38f6e73ffcc7";
-      name = "kblackbox-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kblackbox-19.08.2.tar.xz";
+      sha256 = "4ed8e2fe00e4d2ce0b194f85491f46ceaeec28114ff2dc667c0b112f8237a9ca";
+      name = "kblackbox-19.08.2.tar.xz";
     };
   };
   kblocks = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kblocks-19.08.1.tar.xz";
-      sha256 = "15afc3b7083fc1ea08d6caa196d883a6ec7f9603302b5774c7ad97eea833f449";
-      name = "kblocks-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kblocks-19.08.2.tar.xz";
+      sha256 = "8b52c949e2d446a4ccf81b09818fc90234f2f55d8722c385491ee67e1f2abf93";
+      name = "kblocks-19.08.2.tar.xz";
     };
   };
   kblog = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kblog-19.08.1.tar.xz";
-      sha256 = "e1926ebfb352f6b8c35963fdece240b03be8d3ec094cee46ba694e2869c85cae";
-      name = "kblog-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kblog-19.08.2.tar.xz";
+      sha256 = "f4d9017d38746b9669efebf5b6cfdc5ebf1cbaf1bbf45ab331530ade3c21cbb5";
+      name = "kblog-19.08.2.tar.xz";
     };
   };
   kbounce = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kbounce-19.08.1.tar.xz";
-      sha256 = "e3d67ab3fac471b07a45abbcd78d02912392ad3f25e9d48b70a050bfda4a5fb0";
-      name = "kbounce-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kbounce-19.08.2.tar.xz";
+      sha256 = "8436ba58bb88360b08c2d220c1a92c924b15587769103f04881ac17583cc93c8";
+      name = "kbounce-19.08.2.tar.xz";
     };
   };
   kbreakout = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kbreakout-19.08.1.tar.xz";
-      sha256 = "1f086f6794b40c6054f0c00d7fbebecea845f2ee7e7e3253efe33942f4ebe19e";
-      name = "kbreakout-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kbreakout-19.08.2.tar.xz";
+      sha256 = "9550d3ee6f6d412816bd12686272c3f0f0b5b9194242f9b22e2085c39d9720a9";
+      name = "kbreakout-19.08.2.tar.xz";
     };
   };
   kbruch = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kbruch-19.08.1.tar.xz";
-      sha256 = "74b387e6eafc5fac8b7a75df6f8d61a2b4b0380a82b5c43f3a10c9b75855318f";
-      name = "kbruch-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kbruch-19.08.2.tar.xz";
+      sha256 = "a2cead23cab880b21769e41086505b50de659630860d056b6a8504caafd4dcf0";
+      name = "kbruch-19.08.2.tar.xz";
     };
   };
   kcachegrind = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kcachegrind-19.08.1.tar.xz";
-      sha256 = "e677f82e5527caecb0cdacad3f001665c40ba9e6a542a6a4d91fb898b45026c1";
-      name = "kcachegrind-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kcachegrind-19.08.2.tar.xz";
+      sha256 = "baf17a5c11f21deb7b019a7e3a9819348ec8d20af5c8c4a6108b96266e425b46";
+      name = "kcachegrind-19.08.2.tar.xz";
     };
   };
   kcalc = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kcalc-19.08.1.tar.xz";
-      sha256 = "7b3c110a97b851e8db03302484cadc59a59ec8378501ee61dd094ac2c7caa203";
-      name = "kcalc-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kcalc-19.08.2.tar.xz";
+      sha256 = "94a6d004266813449b6b9efbe0e3b0da3e5368059134668277a344a720f65fd9";
+      name = "kcalc-19.08.2.tar.xz";
     };
   };
   kcalcore = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kcalcore-19.08.1.tar.xz";
-      sha256 = "8c1bbd8e7673907de2c3682cbc1c4fe4a165cbe0b9a2fe399c4b0ae73894228a";
-      name = "kcalcore-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kcalcore-19.08.2.tar.xz";
+      sha256 = "f7d33ec65cf954a0460258694ecb2e14bf6c00cee5ea9fdc3e015e78947d896a";
+      name = "kcalcore-19.08.2.tar.xz";
     };
   };
   kcalutils = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kcalutils-19.08.1.tar.xz";
-      sha256 = "b0f17fd7ced68d03666038ee97e6ca96bd504fc8b7f0ae9b53443cefb57558d7";
-      name = "kcalutils-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kcalutils-19.08.2.tar.xz";
+      sha256 = "3f789a18348152f9fc70965dbc2e9a8bd0ba872968c3d0631afacd0e78d3ce13";
+      name = "kcalutils-19.08.2.tar.xz";
     };
   };
   kcharselect = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kcharselect-19.08.1.tar.xz";
-      sha256 = "8b5c418e9b35a12eeaa1ebf7834f2a13613926e824699e13214fe35276c42457";
-      name = "kcharselect-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kcharselect-19.08.2.tar.xz";
+      sha256 = "ff2a8c78fc4a12dd727e8ad8677216d5a480a8c82aff97269397ee8ae01e36df";
+      name = "kcharselect-19.08.2.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kcolorchooser-19.08.1.tar.xz";
-      sha256 = "a36cccbbf5dda16c0d97bff2ce415e678481fee5c2a7640b2c2db2f0ea7c70cb";
-      name = "kcolorchooser-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kcolorchooser-19.08.2.tar.xz";
+      sha256 = "4eb50f314b190f1980e73212a45fe86db39f278f789288cd76cb0763f3176edc";
+      name = "kcolorchooser-19.08.2.tar.xz";
     };
   };
   kcontacts = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kcontacts-19.08.1.tar.xz";
-      sha256 = "020177eb155d3df44314e89da1824916d125aab48131fce76c2131b40eae8f39";
-      name = "kcontacts-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kcontacts-19.08.2.tar.xz";
+      sha256 = "0677177d6810047876a219445232c0bf91dc1cdba3cbe4133a0a7eda98c381e8";
+      name = "kcontacts-19.08.2.tar.xz";
     };
   };
   kcron = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kcron-19.08.1.tar.xz";
-      sha256 = "e60eb14cb2aef0b0398088930102d68817c96a83c54895af6626693fc18c7ed9";
-      name = "kcron-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kcron-19.08.2.tar.xz";
+      sha256 = "270ee81cba5ef9d92158a3fc71cf8c50c658468018eb0415c9d3d0bc7abea5e5";
+      name = "kcron-19.08.2.tar.xz";
     };
   };
   kdav = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdav-19.08.1.tar.xz";
-      sha256 = "38f34f39e165ba3a843acbc9efc3296c111a6bfa8c5ba23e1f55f98860b84d41";
-      name = "kdav-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdav-19.08.2.tar.xz";
+      sha256 = "8572a77ee3d0f8a7e09e4975fcf0420394c16e908c4a19aecc409415770595f9";
+      name = "kdav-19.08.2.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdebugsettings-19.08.1.tar.xz";
-      sha256 = "4195a000558b56d849eb6e79880c5140fc30cd8b0657d4a9932035434f4c2649";
-      name = "kdebugsettings-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdebugsettings-19.08.2.tar.xz";
+      sha256 = "2823e53da647dec2bd780a3029c6b093917faad3db973147ef74eb8f1c1733df";
+      name = "kdebugsettings-19.08.2.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kde-dev-scripts-19.08.1.tar.xz";
-      sha256 = "36af795eaa175f142556949fa4cc678a6d3fdad3607d169877d94bea785850d1";
-      name = "kde-dev-scripts-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kde-dev-scripts-19.08.2.tar.xz";
+      sha256 = "9a47b048cec42eedcec05602eb84d4124a1f67d451c22095e688cb24f7057327";
+      name = "kde-dev-scripts-19.08.2.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kde-dev-utils-19.08.1.tar.xz";
-      sha256 = "c529bb33dbd3b80e5c4737c3be0d17e88901ece48d3b19e61c8c14adab60177c";
-      name = "kde-dev-utils-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kde-dev-utils-19.08.2.tar.xz";
+      sha256 = "30bbcfa632cbf76a2b3a27f1044ff9708509921882b91a5623cc2a30d40acb32";
+      name = "kde-dev-utils-19.08.2.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdeedu-data-19.08.1.tar.xz";
-      sha256 = "107dff744219210c732aa007d97c8c8d8e87cff5cd446d987b8ac2600ea1f1b7";
-      name = "kdeedu-data-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdeedu-data-19.08.2.tar.xz";
+      sha256 = "0ead96a7a10ecbf98c88464f9987e7d8e2efdf7879782e5262b5cda694f3e343";
+      name = "kdeedu-data-19.08.2.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdegraphics-mobipocket-19.08.1.tar.xz";
-      sha256 = "b1760e3a22869715881f571c0bc79c1b91876e41f508a5ba53659be774a6628c";
-      name = "kdegraphics-mobipocket-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdegraphics-mobipocket-19.08.2.tar.xz";
+      sha256 = "9621b0b3564ce7fcd6890c15c48e11d00c1cf2d3b408b255ec590bd6d113439f";
+      name = "kdegraphics-mobipocket-19.08.2.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdegraphics-thumbnailers-19.08.1.tar.xz";
-      sha256 = "86a81ff786168778cbe0ad7c185320dbf052b1df2e6269f14323df04b48ed2ff";
-      name = "kdegraphics-thumbnailers-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdegraphics-thumbnailers-19.08.2.tar.xz";
+      sha256 = "12e2b096d65c5dfde6d16bc2c35b236343ce02ba1ef1b3b68b11257250da02c8";
+      name = "kdegraphics-thumbnailers-19.08.2.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdenetwork-filesharing-19.08.1.tar.xz";
-      sha256 = "b7d229d06926ad53dcffd4508fde70060260a03cdfc6b59551f5ea551274bdac";
-      name = "kdenetwork-filesharing-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdenetwork-filesharing-19.08.2.tar.xz";
+      sha256 = "ceffdaabd3417db306c05ecd6a62b521d0b3eb5996d320d65ae5c51ea46bfdda";
+      name = "kdenetwork-filesharing-19.08.2.tar.xz";
     };
   };
   kdenlive = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdenlive-19.08.1.tar.xz";
-      sha256 = "0d19c0d24e16518fd3b57eddffeb7d004723942889bd62e869749f02a1dcc036";
-      name = "kdenlive-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdenlive-19.08.2.tar.xz";
+      sha256 = "5ca3b7a2457d2aa355309bc7471791f691edd8774af9a19cbfc8fac39ad53c78";
+      name = "kdenlive-19.08.2.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdepim-addons-19.08.1.tar.xz";
-      sha256 = "eff8e21ae66bf99a33c946886e7d84f5d717b123b06f86e891c9528858b9ec32";
-      name = "kdepim-addons-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdepim-addons-19.08.2.tar.xz";
+      sha256 = "1e7d647689d2bfa243a2f4583df7030238409fb05bbcda5b168ef024e6accc89";
+      name = "kdepim-addons-19.08.2.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdepim-apps-libs-19.08.1.tar.xz";
-      sha256 = "40a265cde8770a3fd6181b656da49d460dc67ed06d175067da0092116cd9862e";
-      name = "kdepim-apps-libs-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdepim-apps-libs-19.08.2.tar.xz";
+      sha256 = "d542b1d532d3ce3d9f1c63f4455175c7e855cd1e095a1addf1322074afc11923";
+      name = "kdepim-apps-libs-19.08.2.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdepim-runtime-19.08.1.tar.xz";
-      sha256 = "d7dd6c0108f6c7a37dc1ac0d7b9449664c76ecd3ca4f303f3a1b214862a4b20e";
-      name = "kdepim-runtime-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdepim-runtime-19.08.2.tar.xz";
+      sha256 = "9b98980003d2d107596e9acc9482dfc3ea26a2485c75a700bd82b53b9be72ebf";
+      name = "kdepim-runtime-19.08.2.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdesdk-kioslaves-19.08.1.tar.xz";
-      sha256 = "4bf6d32a33f53b7668313d0e5be81568934b8309f86c9554b25e9346344b2051";
-      name = "kdesdk-kioslaves-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdesdk-kioslaves-19.08.2.tar.xz";
+      sha256 = "308bdbbd484f60d14bd4f75e72af1e3308c497696a5f7b011b18bc0f203fd7e5";
+      name = "kdesdk-kioslaves-19.08.2.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdesdk-thumbnailers-19.08.1.tar.xz";
-      sha256 = "3da4aa540435fbc848bfc4f1b39f37145072e0856da31b4f5ac3d89719308f03";
-      name = "kdesdk-thumbnailers-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdesdk-thumbnailers-19.08.2.tar.xz";
+      sha256 = "d607f956e9c62ee9e9aa000d5444d33e68621e0741072d0d8c14e52bd4cc96be";
+      name = "kdesdk-thumbnailers-19.08.2.tar.xz";
     };
   };
   kdf = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdf-19.08.1.tar.xz";
-      sha256 = "2aedb0a4f64d2417728b67e4a289488b59153683d5dd15bca259a64f9c51325e";
-      name = "kdf-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdf-19.08.2.tar.xz";
+      sha256 = "f0a27bbf25d5791272cc8598561e53afed9840d38bf08ed3146f36701dfb7b04";
+      name = "kdf-19.08.2.tar.xz";
     };
   };
   kdialog = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdialog-19.08.1.tar.xz";
-      sha256 = "6b2ed8636d50d13104b0029f33b11943d6f7087297ad089d61c76a57d3b425a0";
-      name = "kdialog-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdialog-19.08.2.tar.xz";
+      sha256 = "7aef7b5a5f340cc0066e02572ec8cef8b227bc6c7f5b066677ef6422632db95a";
+      name = "kdialog-19.08.2.tar.xz";
     };
   };
   kdiamond = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kdiamond-19.08.1.tar.xz";
-      sha256 = "20280e44742d57508b0a0c4a70f7545bdbacf913300ca35f427801b46c808f8e";
-      name = "kdiamond-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kdiamond-19.08.2.tar.xz";
+      sha256 = "e0e6104a34711864bc00d12acc5d4ac0143acfaefc5fec8a7f9ec5f7242d32e7";
+      name = "kdiamond-19.08.2.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/keditbookmarks-19.08.1.tar.xz";
-      sha256 = "f023c7b3d362c19373e3f886300420488ef53835f753c318f9fd9c0bb7e53a8a";
-      name = "keditbookmarks-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/keditbookmarks-19.08.2.tar.xz";
+      sha256 = "6a22c3ccdd89d07ad13b34b89704afcc9bf3b5a177d4dc137dcb5eaf1580f6dd";
+      name = "keditbookmarks-19.08.2.tar.xz";
     };
   };
   kfind = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kfind-19.08.1.tar.xz";
-      sha256 = "a4910d5a3f2b918090084c776ca16bf1e9ae47ced0c2e4eb2a3d0071204527de";
-      name = "kfind-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kfind-19.08.2.tar.xz";
+      sha256 = "7ce5255fa4ef3e98db937eb23e8cdc89bd6b5e5429ccb5fea769e99da2bc424a";
+      name = "kfind-19.08.2.tar.xz";
     };
   };
   kfloppy = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kfloppy-19.08.1.tar.xz";
-      sha256 = "c22864e0dfef37ccb9a5329467b9058a14880e88b54c448b5933b57aa98b021b";
-      name = "kfloppy-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kfloppy-19.08.2.tar.xz";
+      sha256 = "743f9043bdc24855bb597d3f7cf2bbf4793c58be22eb73cd72ff1e3f8cff2f69";
+      name = "kfloppy-19.08.2.tar.xz";
     };
   };
   kfourinline = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kfourinline-19.08.1.tar.xz";
-      sha256 = "a138908ccb21ab16399edf6a0aa6f95d6197a77dfef9e4ed87c8914ceb8d5b84";
-      name = "kfourinline-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kfourinline-19.08.2.tar.xz";
+      sha256 = "14d1cd1be7f1524758697f79d55c0c40e8e6359f2039929349e017a97acdc4dc";
+      name = "kfourinline-19.08.2.tar.xz";
     };
   };
   kgeography = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kgeography-19.08.1.tar.xz";
-      sha256 = "c0c04e902626d52118e81da9fc24fbd87d49d0bcf4ad229f83eef8e4f84fb551";
-      name = "kgeography-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kgeography-19.08.2.tar.xz";
+      sha256 = "ca535319e5dd3938e572d9d4f4a216a29a5435546742bb6616d2a716f1a1dfcc";
+      name = "kgeography-19.08.2.tar.xz";
     };
   };
   kget = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kget-19.08.1.tar.xz";
-      sha256 = "ecc9cc31f23304baa8c909335db57460460db27fbffb97438c1ed12703c6b9b9";
-      name = "kget-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kget-19.08.2.tar.xz";
+      sha256 = "e93795eec8f51cac2719ab31cfa6f5f4f642b166ffbb3f876ab3c866a4cd7df1";
+      name = "kget-19.08.2.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kgoldrunner-19.08.1.tar.xz";
-      sha256 = "78c284edc000ec3f3f64bcf0d6c92a50f79632804696de676ed149055de7a6f8";
-      name = "kgoldrunner-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kgoldrunner-19.08.2.tar.xz";
+      sha256 = "fc719386cd1f0784c9be9813326e3fded8eb2951096abf7fcc4d577e5ed5501a";
+      name = "kgoldrunner-19.08.2.tar.xz";
     };
   };
   kgpg = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kgpg-19.08.1.tar.xz";
-      sha256 = "441a0bfa58df14bad87f5f446b89113dc20365424f6a87aec30125c9221815c5";
-      name = "kgpg-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kgpg-19.08.2.tar.xz";
+      sha256 = "90795c649cd32b65b6030ed965e0db5b0570719afa36abb5d4893268461aa841";
+      name = "kgpg-19.08.2.tar.xz";
     };
   };
   khangman = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/khangman-19.08.1.tar.xz";
-      sha256 = "eb95c48baa57475319f456ee1df11b715e7ceb5b1912e2657a2b1f4617bf2b26";
-      name = "khangman-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/khangman-19.08.2.tar.xz";
+      sha256 = "dfa7d2f19ab7cd7aa90d91bab1818d48e6df88ddebf729732cca8d6aca15d1f3";
+      name = "khangman-19.08.2.tar.xz";
     };
   };
   khelpcenter = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/khelpcenter-19.08.1.tar.xz";
-      sha256 = "ae3243fcdc1281937772a091d902adaba0681abe82c222bf7ef895df0899ab63";
-      name = "khelpcenter-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/khelpcenter-19.08.2.tar.xz";
+      sha256 = "22b9f5225dfb9e8ad85becb7c2986cbee2a1366f84257fcbf76d5d7292dccdd9";
+      name = "khelpcenter-19.08.2.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kidentitymanagement-19.08.1.tar.xz";
-      sha256 = "3ff41eddf047fb1074473fd028b22ddd0fb467c062918148305f10c2fd74f42e";
-      name = "kidentitymanagement-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kidentitymanagement-19.08.2.tar.xz";
+      sha256 = "8f93f9546d570c8f7b2602a3a171641d488595ec8da3c47b0a08ef4f5083e884";
+      name = "kidentitymanagement-19.08.2.tar.xz";
     };
   };
   kig = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kig-19.08.1.tar.xz";
-      sha256 = "8b073fd0310e62483a548ada000b4230f2b70dec8ab11ac8303bd64961829675";
-      name = "kig-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kig-19.08.2.tar.xz";
+      sha256 = "60bab2ccdf69df8ebaed672dc9201e468563d78761f191c43ee5673f9a54246a";
+      name = "kig-19.08.2.tar.xz";
     };
   };
   kigo = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kigo-19.08.1.tar.xz";
-      sha256 = "7afc2e08192d7e7bf17d67e00aebc498e37b40b47ce78cb7cf2d943a5563817b";
-      name = "kigo-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kigo-19.08.2.tar.xz";
+      sha256 = "c53a85b312e4acfcc35905a7e5602f3d623e45227fbd3644410b3fd962a9f1a0";
+      name = "kigo-19.08.2.tar.xz";
     };
   };
   killbots = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/killbots-19.08.1.tar.xz";
-      sha256 = "16fb2338125d342166e630cf589a346a69874ea1da32c0a3c591d6e17241e05e";
-      name = "killbots-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/killbots-19.08.2.tar.xz";
+      sha256 = "c4407bf534dc9de604d6c169cf278b8cb9ca03055d96b71cbfe3916dbafea479";
+      name = "killbots-19.08.2.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kimagemapeditor-19.08.1.tar.xz";
-      sha256 = "0baa2f3fa5810ab63d08db2d0223af04407bb14e4bda20ad17dbfb6c63f33b3a";
-      name = "kimagemapeditor-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kimagemapeditor-19.08.2.tar.xz";
+      sha256 = "3be222d94bad94adf4d589fb98c9556af0f0e6c66106a217ee3b9ab031412597";
+      name = "kimagemapeditor-19.08.2.tar.xz";
     };
   };
   kimap = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kimap-19.08.1.tar.xz";
-      sha256 = "a4fde0c17fcdbc672b8e7ad6ed727e18b6bc2cc3c7f23857a6b1455d99999bbf";
-      name = "kimap-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kimap-19.08.2.tar.xz";
+      sha256 = "250479c78517610aab810f54184d8826fb981438ec9f0d5c423ad781a796ee00";
+      name = "kimap-19.08.2.tar.xz";
     };
   };
   kio-extras = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kio-extras-19.08.1.tar.xz";
-      sha256 = "de0ba7f3ce73db34b878cb88e36711d6b31aad57a5a735744330f92920666c52";
-      name = "kio-extras-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kio-extras-19.08.2.tar.xz";
+      sha256 = "a0b8f08ab8f9d36cfdc950470f75726e90e9fba159bc2035931cfa6efbfe4394";
+      name = "kio-extras-19.08.2.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kipi-plugins-19.08.1.tar.xz";
-      sha256 = "6cc8fdc47fbfa5d8b4f9aeb4d82b5f1c9779a300cffbc17f8776dcb2ed61f0e4";
-      name = "kipi-plugins-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kipi-plugins-19.08.2.tar.xz";
+      sha256 = "2894f50989a14f7fd4be0035efec3cb14583d2285ff11729605b641af0fed192";
+      name = "kipi-plugins-19.08.2.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kirigami-gallery-19.08.1.tar.xz";
-      sha256 = "b981b26fb268448f20077f3e69b3e12f45de91289f5b2026c618cdbff9ec5241";
-      name = "kirigami-gallery-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kirigami-gallery-19.08.2.tar.xz";
+      sha256 = "db6cf765cd3c7126d9e4d94cacf66478711fe8b676c9505c22604863092d975e";
+      name = "kirigami-gallery-19.08.2.tar.xz";
     };
   };
   kiriki = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kiriki-19.08.1.tar.xz";
-      sha256 = "ca22215394b7ea172cd1c5eef301871df2526a321b4f3c6b1aa042d4f15abf7c";
-      name = "kiriki-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kiriki-19.08.2.tar.xz";
+      sha256 = "8aa1749e2b14dbb4b508515a0b1f5164243ee793141ec2af7bfc6be1f6eb67da";
+      name = "kiriki-19.08.2.tar.xz";
     };
   };
   kiten = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kiten-19.08.1.tar.xz";
-      sha256 = "01e963fd76c87a631bb5a4f86bc8be624907571c60368e6bf5bdce55cff6b59a";
-      name = "kiten-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kiten-19.08.2.tar.xz";
+      sha256 = "e35552dd49507c66574ae7fc22fe75597a954044a09522652cc1e457d3425edc";
+      name = "kiten-19.08.2.tar.xz";
     };
   };
   kitinerary = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kitinerary-19.08.1.tar.xz";
-      sha256 = "f84dafa874c958b335ee80dbe85dce3605b40b83ac9468e6555250da8f480967";
-      name = "kitinerary-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kitinerary-19.08.2.tar.xz";
+      sha256 = "d814a2f1deaadce5fec85b1122aab6ff926c53ca8f020aadc99401bd31597eaa";
+      name = "kitinerary-19.08.2.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kjumpingcube-19.08.1.tar.xz";
-      sha256 = "18c7bc9ab96308a4b874226f92f15da38cbb293372fdae8deec45029d6d31f20";
-      name = "kjumpingcube-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kjumpingcube-19.08.2.tar.xz";
+      sha256 = "7ff90a22670818eee7d02fd8119923761e003e059d0666873d5299cd31c96eb3";
+      name = "kjumpingcube-19.08.2.tar.xz";
     };
   };
   kldap = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kldap-19.08.1.tar.xz";
-      sha256 = "b6fb822df67449870fb5c0bfe1adb1bd3d44535e3f2186ef6be286e4a590bd54";
-      name = "kldap-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kldap-19.08.2.tar.xz";
+      sha256 = "79c540693b85c138ae7bf4f72213dfad6dfa48dfc0ab414004d93f15d2ffac6e";
+      name = "kldap-19.08.2.tar.xz";
     };
   };
   kleopatra = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kleopatra-19.08.1.tar.xz";
-      sha256 = "ef63fbe1a24a24b8c6b491fe19e0bebd9518a2e1340a9dfee7215eb3740369c7";
-      name = "kleopatra-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kleopatra-19.08.2.tar.xz";
+      sha256 = "7d0667b71796f8cbf9081c74c80def1e6618366400d4fbe56e690bb7049e4085";
+      name = "kleopatra-19.08.2.tar.xz";
     };
   };
   klettres = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/klettres-19.08.1.tar.xz";
-      sha256 = "9d9616e35f2b82e39916b89a049bee4faca5a4235eb22989c9e8485c7e75239b";
-      name = "klettres-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/klettres-19.08.2.tar.xz";
+      sha256 = "919fc2b5d722bfdd741f0b1202f31c9aefc5d240ceb88ab785c2acd98a1b8284";
+      name = "klettres-19.08.2.tar.xz";
     };
   };
   klickety = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/klickety-19.08.1.tar.xz";
-      sha256 = "cb12f79123e96920b323e752b057f21942aba0844d79e310ad343bda0108b273";
-      name = "klickety-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/klickety-19.08.2.tar.xz";
+      sha256 = "97e165d250d88a5a9f00fc5e111f641c43bed8e1445fd9d7c59f986cf5517271";
+      name = "klickety-19.08.2.tar.xz";
     };
   };
   klines = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/klines-19.08.1.tar.xz";
-      sha256 = "e8ac5d344c6b9e6d8a9fa9a0fe7da5ebdceec049fbdc8ff476604a0760877aab";
-      name = "klines-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/klines-19.08.2.tar.xz";
+      sha256 = "1e7f5600b32a43ed4e5b7490430fb20309837e35aceb6b9b904951f23beec86f";
+      name = "klines-19.08.2.tar.xz";
     };
   };
   kmag = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmag-19.08.1.tar.xz";
-      sha256 = "28504935665df18246cc6db4288dc2b33f24ed7114007df008f4310ce8792ceb";
-      name = "kmag-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmag-19.08.2.tar.xz";
+      sha256 = "6e8ecfab87dca12804a5a8d0a8adf1545e9e17039e0f9667b10a8f2832512e71";
+      name = "kmag-19.08.2.tar.xz";
     };
   };
   kmahjongg = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmahjongg-19.08.1.tar.xz";
-      sha256 = "621e30ce5d76ab9f8736cfe13a076501c8822d7d1402d195bfe12c21ffa507c3";
-      name = "kmahjongg-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmahjongg-19.08.2.tar.xz";
+      sha256 = "8b2c4b0e3cb9bb85fa6d5f0fc5c55fcca96149e510cde25be2bcd688834a8d08";
+      name = "kmahjongg-19.08.2.tar.xz";
     };
   };
   kmail = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmail-19.08.1.tar.xz";
-      sha256 = "4deb5d7c5304c0856fbbafeb7bf09436e28782b96dc5ec342a09b2c26ea386c0";
-      name = "kmail-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmail-19.08.2.tar.xz";
+      sha256 = "0ad2a5439da7f255923eeb4c4cf267ece721619aa046a04439f56763aeabac85";
+      name = "kmail-19.08.2.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmail-account-wizard-19.08.1.tar.xz";
-      sha256 = "b4f2f769b44845dd02632ce282fc740a35f7f784e9fb54091153365ee88fb864";
-      name = "kmail-account-wizard-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmail-account-wizard-19.08.2.tar.xz";
+      sha256 = "769b151d0de47d49e41eaeca501526de41c174f9df99b46418e955163c38e9a8";
+      name = "kmail-account-wizard-19.08.2.tar.xz";
     };
   };
   kmailtransport = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmailtransport-19.08.1.tar.xz";
-      sha256 = "521bcfd334a0e7e4986e6cebff3bae4095175a11fd45f777da673f1460d733da";
-      name = "kmailtransport-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmailtransport-19.08.2.tar.xz";
+      sha256 = "c545fb5546e82f7dfcea4c6e1a8b565ad04e34851c33876c9bf74c9fbc3165c7";
+      name = "kmailtransport-19.08.2.tar.xz";
     };
   };
   kmbox = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmbox-19.08.1.tar.xz";
-      sha256 = "5fa59ffd16df1ae28f7ebf026f67df708c5b84e54e1ab47fd5de957c5b8fc75e";
-      name = "kmbox-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmbox-19.08.2.tar.xz";
+      sha256 = "82e2f64b90a1386100e13f9b2afea5d71952a1cb9547f965ddcdb3b8c59c35b1";
+      name = "kmbox-19.08.2.tar.xz";
     };
   };
   kmime = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmime-19.08.1.tar.xz";
-      sha256 = "e8693458734f11a9d33a4d761f2b5ccae8f9ed87bb1e9dfc97f4bd0fa7089557";
-      name = "kmime-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmime-19.08.2.tar.xz";
+      sha256 = "f153332bb71de9d4451b8d28135a914059f5156fc8dda33f6375671603477771";
+      name = "kmime-19.08.2.tar.xz";
     };
   };
   kmines = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmines-19.08.1.tar.xz";
-      sha256 = "8aedc9eeb3426a394a6e048508f700d466c18b262a9b98e01eff379a8d6003fb";
-      name = "kmines-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmines-19.08.2.tar.xz";
+      sha256 = "735a3b7b844fbfc970187ddc9d4fe312a5dd6c037e8ad87712388578482d12d8";
+      name = "kmines-19.08.2.tar.xz";
     };
   };
   kmix = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmix-19.08.1.tar.xz";
-      sha256 = "a6006ab35bdfc2896188aa99ba50f1b28e8d5172ec8a1068efb15a50c43f87a7";
-      name = "kmix-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmix-19.08.2.tar.xz";
+      sha256 = "5d852df8b54d3abca98db4aa2b259973231fed0a597d511d54fb41c6389ce61a";
+      name = "kmix-19.08.2.tar.xz";
     };
   };
   kmousetool = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmousetool-19.08.1.tar.xz";
-      sha256 = "d9a3164a0709fa0d2fc3e30ade2bd42c86fb73c7cf4adc341dd7e11e686f7956";
-      name = "kmousetool-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmousetool-19.08.2.tar.xz";
+      sha256 = "7cdc327e82548bf70c4ef4feab7a30938f3aefa1e80fccb343ce0d5ca8976ccb";
+      name = "kmousetool-19.08.2.tar.xz";
     };
   };
   kmouth = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmouth-19.08.1.tar.xz";
-      sha256 = "531b7b3716fea8c679c5c39c7c04214cb561430182747ce08a9854a76105821e";
-      name = "kmouth-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmouth-19.08.2.tar.xz";
+      sha256 = "7a71d9d15d6a5f72c86f41e874f7cb3b45d8edaae2b3bd5409b20bd7bad4a0d3";
+      name = "kmouth-19.08.2.tar.xz";
     };
   };
   kmplot = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kmplot-19.08.1.tar.xz";
-      sha256 = "7797dc95f64738b918cb19481bc74cebd1f66b5a537592bb53e98e1715701fe2";
-      name = "kmplot-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kmplot-19.08.2.tar.xz";
+      sha256 = "62017429db210c5b8f99301a6768a6eb10becd0f1f6af6d886a539657d8518a0";
+      name = "kmplot-19.08.2.tar.xz";
     };
   };
   knavalbattle = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/knavalbattle-19.08.1.tar.xz";
-      sha256 = "6fa3cc1b7de95d22a6c356f411367399626a334ce648abc50ac724a860468915";
-      name = "knavalbattle-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/knavalbattle-19.08.2.tar.xz";
+      sha256 = "31f25b5397c36434c1910bf8968f92548019ad172b4d5399e6c01939389915ba";
+      name = "knavalbattle-19.08.2.tar.xz";
     };
   };
   knetwalk = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/knetwalk-19.08.1.tar.xz";
-      sha256 = "0c62b756d3375f0c51046e92904f380544ba77bcc0109607bb38055907579ccf";
-      name = "knetwalk-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/knetwalk-19.08.2.tar.xz";
+      sha256 = "057b8571f165a716a6cc13ec6489e7b5f9b4c14fa72080180a2098fa0fa028a1";
+      name = "knetwalk-19.08.2.tar.xz";
     };
   };
   knights = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/knights-19.08.1.tar.xz";
-      sha256 = "bdd99e6ba75e03f19eac5fe6e50c84496eb614725da021208db9119539cea132";
-      name = "knights-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/knights-19.08.2.tar.xz";
+      sha256 = "2b70338d1cb2b770157a5b061a797620d8dd7dd8c6da0bcb7e2a9db375e71a07";
+      name = "knights-19.08.2.tar.xz";
     };
   };
   knotes = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/knotes-19.08.1.tar.xz";
-      sha256 = "30b835c063e03d3d9047cbaacf389ee1e261368d2cf73fdfab71b4f9138b8bf7";
-      name = "knotes-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/knotes-19.08.2.tar.xz";
+      sha256 = "aa0aa4d215507750b055e9af91f552e723aee8163b36f65a3dd19786cf327cf3";
+      name = "knotes-19.08.2.tar.xz";
     };
   };
   kolf = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kolf-19.08.1.tar.xz";
-      sha256 = "5199274d7ec557d396e74485debe4c7572050de6d31f128cca9ab737062f83bc";
-      name = "kolf-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kolf-19.08.2.tar.xz";
+      sha256 = "88b9a58885eda34bf5b349db5e84c20df9beb1462922ed6e973a61bd95d853e8";
+      name = "kolf-19.08.2.tar.xz";
     };
   };
   kollision = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kollision-19.08.1.tar.xz";
-      sha256 = "0f2bac3898ceb26bd17bdcc3481d76709b793a83ace75ba8f6f45fbf54428697";
-      name = "kollision-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kollision-19.08.2.tar.xz";
+      sha256 = "f2e7d851181033ce39d43a038601ca70c608ae9d0cb0e88228512ca1dbd0cf19";
+      name = "kollision-19.08.2.tar.xz";
     };
   };
   kolourpaint = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kolourpaint-19.08.1.tar.xz";
-      sha256 = "59c1a2a9d8f012ff1c483dae4f1019232ec667bd88e61c6c8fc07e47312ef23f";
-      name = "kolourpaint-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kolourpaint-19.08.2.tar.xz";
+      sha256 = "e8bde8d516159ae93dfe56565eea2919d2154606fd1814202f30caf21f659cda";
+      name = "kolourpaint-19.08.2.tar.xz";
     };
   };
   kompare = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kompare-19.08.1.tar.xz";
-      sha256 = "325a14529c8e015fbae0231511ddd5c61dd3d78cbc6ad92eaccfd1c90a2f1afd";
-      name = "kompare-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kompare-19.08.2.tar.xz";
+      sha256 = "b14f23ac6eb72622a06e2e489fc2d684124f520ad13e032338397fef342659eb";
+      name = "kompare-19.08.2.tar.xz";
     };
   };
   konqueror = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/konqueror-19.08.1.tar.xz";
-      sha256 = "48a2847c7fcd5e30ae02d64523c3053b958ae9d3a7a649685660b1340aa644df";
-      name = "konqueror-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/konqueror-19.08.2.tar.xz";
+      sha256 = "336da877ea44fb100ca5396bc843994d77d0939fe3c969ad8fa85f0e1644d111";
+      name = "konqueror-19.08.2.tar.xz";
     };
   };
   konquest = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/konquest-19.08.1.tar.xz";
-      sha256 = "114e76a10a992efb3fbd094bd1b66c3d6266c540c41289a0627ec04a8db52ec0";
-      name = "konquest-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/konquest-19.08.2.tar.xz";
+      sha256 = "3dda62a480e37d97aabdc4670a8ac1cf209605ed274c872ee3575ff1ecff6936";
+      name = "konquest-19.08.2.tar.xz";
     };
   };
   konsole = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/konsole-19.08.1.tar.xz";
-      sha256 = "7530157a3fa01a9b21971e271a9d46addb5c71dce290db97265928803b57d37f";
-      name = "konsole-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/konsole-19.08.2.tar.xz";
+      sha256 = "4702fe52279c99e7d8da313285ace26955776669a78bdcb6dac7aec76cabe5ed";
+      name = "konsole-19.08.2.tar.xz";
     };
   };
   kontact = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kontact-19.08.1.tar.xz";
-      sha256 = "7b57b44ee72211b30fc743fae6580867100ede718909617b90cb926732ecbabb";
-      name = "kontact-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kontact-19.08.2.tar.xz";
+      sha256 = "d24023381304fbe388a0840921599d13c86912a1285acfc0a7d607962e37c5cf";
+      name = "kontact-19.08.2.tar.xz";
     };
   };
   kontactinterface = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kontactinterface-19.08.1.tar.xz";
-      sha256 = "adb5c380fd73102b84c72ea27975689dc289b0f5c8dd10f86bf0a857e00170be";
-      name = "kontactinterface-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kontactinterface-19.08.2.tar.xz";
+      sha256 = "cbd34915ddf6fbcf02395f7c876050f2b732f3769627489f04979e419cfdc869";
+      name = "kontactinterface-19.08.2.tar.xz";
     };
   };
   kopete = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kopete-19.08.1.tar.xz";
-      sha256 = "c4943c5cbb384eb8697668be2a38dcc0dc16f26485a38c3657658c1cc4dbd2a8";
-      name = "kopete-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kopete-19.08.2.tar.xz";
+      sha256 = "cf4e4f6ff6dcd6e42a1c3d5339be4a65ed0379ef786155c12cf13f8af339e022";
+      name = "kopete-19.08.2.tar.xz";
     };
   };
   korganizer = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/korganizer-19.08.1.tar.xz";
-      sha256 = "d7e347df36986926d0e0d1af38130a089b581e400a90cc8bf199cecb29b78023";
-      name = "korganizer-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/korganizer-19.08.2.tar.xz";
+      sha256 = "969930b66a445873a28bfe2e67876388259e35e89ffce45607583b4a668d9194";
+      name = "korganizer-19.08.2.tar.xz";
     };
   };
   kpat = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kpat-19.08.1.tar.xz";
-      sha256 = "65bf7299c59d3d7512ab39174fd0e5d044f307784c02895130399534e044831c";
-      name = "kpat-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kpat-19.08.2.tar.xz";
+      sha256 = "6322d86e12996da3d95f6d4afd1d2e70cfd1771698bab393aaf987fd4fe0ef67";
+      name = "kpat-19.08.2.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kpimtextedit-19.08.1.tar.xz";
-      sha256 = "f7e0dc9c706c94fa74a561d42d41246eae57f60c03da1ec52f2311172052d7fe";
-      name = "kpimtextedit-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kpimtextedit-19.08.2.tar.xz";
+      sha256 = "e565774d77f310165fc44c8b109ef835aae82a2f763d89d1ffb6e5b820cd850d";
+      name = "kpimtextedit-19.08.2.tar.xz";
     };
   };
   kpkpass = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kpkpass-19.08.1.tar.xz";
-      sha256 = "893ee1f127c2d0c7135fe77c5c2895d04f95c9a6ed3b162c30856f4e99d4afb3";
-      name = "kpkpass-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kpkpass-19.08.2.tar.xz";
+      sha256 = "daf4da30fd5c834915e6210bf64609adc116e5c6919365d000a400b6cd5f3e26";
+      name = "kpkpass-19.08.2.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kqtquickcharts-19.08.1.tar.xz";
-      sha256 = "af191d150a4777e53b27c39c86f32f80cec8b6eb2442d03425496902f78e79c8";
-      name = "kqtquickcharts-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kqtquickcharts-19.08.2.tar.xz";
+      sha256 = "3341f99ba3a35e9c4fd70911faebaf4312d7700a342edd242de2118f9a77c9fb";
+      name = "kqtquickcharts-19.08.2.tar.xz";
     };
   };
   krdc = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/krdc-19.08.1.tar.xz";
-      sha256 = "319bccbc3c3274b89ae58679d063a303df4b95504b1bef97f925da70a0fbcbde";
-      name = "krdc-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/krdc-19.08.2.tar.xz";
+      sha256 = "c5e6193115afe742f25365bacb55aea21428acf38407659f77636217c589d8ff";
+      name = "krdc-19.08.2.tar.xz";
     };
   };
   kreversi = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kreversi-19.08.1.tar.xz";
-      sha256 = "f4c691dcc5c7864c8201f7e06470e2856996c35c5317020e56822c48af0b810e";
-      name = "kreversi-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kreversi-19.08.2.tar.xz";
+      sha256 = "345c72ad38b9bd759f7569c7c0541c08a2cdad5ab92d08c1db8b6cf8ffaf1ce2";
+      name = "kreversi-19.08.2.tar.xz";
     };
   };
   krfb = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/krfb-19.08.1.tar.xz";
-      sha256 = "3abe42f6e648f171fa38652fe03184725d1abcccf16bf1c1039ebada1f3c64c3";
-      name = "krfb-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/krfb-19.08.2.tar.xz";
+      sha256 = "08877020abf6b7ac38e393443c34e7791456fc5bea8c43c552551148fd67b67e";
+      name = "krfb-19.08.2.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kross-interpreters-19.08.1.tar.xz";
-      sha256 = "d6acb31bd4c97364aa4a77767e012af32ecd0f560da939901a81be5776f2de49";
-      name = "kross-interpreters-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kross-interpreters-19.08.2.tar.xz";
+      sha256 = "e0c63d73441c08c1b5b6627e9c02172c72f079ac0baeb596849a49ad38f8723c";
+      name = "kross-interpreters-19.08.2.tar.xz";
     };
   };
   kruler = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kruler-19.08.1.tar.xz";
-      sha256 = "040eef3746a660798e1701af6d9d17f4d091c30db9321dd5d37b172f5b91d59c";
-      name = "kruler-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kruler-19.08.2.tar.xz";
+      sha256 = "2a3c51a60f503807694cf49796b3bf82c6992ec4c0c15cf38adae92a8dbc24cc";
+      name = "kruler-19.08.2.tar.xz";
     };
   };
   kshisen = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kshisen-19.08.1.tar.xz";
-      sha256 = "1631baaff368ca40a386c60998a9a491a2054a951f5b7311bea74f708d61d65f";
-      name = "kshisen-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kshisen-19.08.2.tar.xz";
+      sha256 = "3c18bc546f2dadcff03af2a25b6f468357967560b7fddf916aea2b27d22c2364";
+      name = "kshisen-19.08.2.tar.xz";
     };
   };
   ksirk = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ksirk-19.08.1.tar.xz";
-      sha256 = "42e00d3591fbfbe1db6de4caad963606a0ca5ee9a224b757157594bebb8c733c";
-      name = "ksirk-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ksirk-19.08.2.tar.xz";
+      sha256 = "6016d929de52d6e03ae1c1ba483e5e505542f16edfbd37c8dfbb9d0913e7f7f8";
+      name = "ksirk-19.08.2.tar.xz";
     };
   };
   ksmtp = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ksmtp-19.08.1.tar.xz";
-      sha256 = "71401abcbb6aedd2845c84bca65f77297722b3414f4d4caeaa6ac6b8f2edc46c";
-      name = "ksmtp-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ksmtp-19.08.2.tar.xz";
+      sha256 = "0d1308fd01f7261e78bedb465983be2ccf5a1514cfa31125e0a3488f67ab6590";
+      name = "ksmtp-19.08.2.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ksnakeduel-19.08.1.tar.xz";
-      sha256 = "130e6545102a4e39f284a409213e9d45066ed27c077ff881839f33db78f62dd5";
-      name = "ksnakeduel-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ksnakeduel-19.08.2.tar.xz";
+      sha256 = "bb13aa91d0e75c1099a57606e0ea1f567a3ffe8f4efbf6a94420bd372ff10289";
+      name = "ksnakeduel-19.08.2.tar.xz";
     };
   };
   kspaceduel = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kspaceduel-19.08.1.tar.xz";
-      sha256 = "47a6d9c78b1d24e80803b7e1765bb6de37157e9f1e733ef5ce50a54612c16bf9";
-      name = "kspaceduel-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kspaceduel-19.08.2.tar.xz";
+      sha256 = "3e2af55afcf78f74ca1fa67ea46da2db4cbc6fd9f522a94d3adb9bed6b518aa8";
+      name = "kspaceduel-19.08.2.tar.xz";
     };
   };
   ksquares = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ksquares-19.08.1.tar.xz";
-      sha256 = "39fd1b73c3c13c3322a5658b8deed31261b0e68edc5cb9666ade374d5d9d8283";
-      name = "ksquares-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ksquares-19.08.2.tar.xz";
+      sha256 = "f16fa641f02a6462085d291ed8d3262891cdeeeff8bbbde4e0aabfdac3dc7bc9";
+      name = "ksquares-19.08.2.tar.xz";
     };
   };
   ksudoku = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ksudoku-19.08.1.tar.xz";
-      sha256 = "cae801e0c595009e35aa11df370de421164f10d9840ae4dede2cd57f19cd6866";
-      name = "ksudoku-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ksudoku-19.08.2.tar.xz";
+      sha256 = "4630117e12c10c2f326a4e55dceed7f19d183b597eadc3d4308aecf5a5455156";
+      name = "ksudoku-19.08.2.tar.xz";
     };
   };
   ksystemlog = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ksystemlog-19.08.1.tar.xz";
-      sha256 = "7dde2a350b32011027d6ab9648859218a053c5509ad08bce8c2de875d2ae73db";
-      name = "ksystemlog-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ksystemlog-19.08.2.tar.xz";
+      sha256 = "742bff9c71cc42d7a57a7732f039a944f60fe4dd70cf71c32f37ba914b57b5de";
+      name = "ksystemlog-19.08.2.tar.xz";
     };
   };
   kteatime = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kteatime-19.08.1.tar.xz";
-      sha256 = "a4b80c5ca6f48c1d291a9502c43293cd0aa383f2e089b9435b02ff79b317c310";
-      name = "kteatime-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kteatime-19.08.2.tar.xz";
+      sha256 = "075470af370b7913fdb085dd6984da91f863b6c03a4b713854e85437e6f9cdbe";
+      name = "kteatime-19.08.2.tar.xz";
     };
   };
   ktimer = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktimer-19.08.1.tar.xz";
-      sha256 = "f81af279e9e79bb3044718fa868973524e85df65dfaf654b8f45824b6f9d17cb";
-      name = "ktimer-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktimer-19.08.2.tar.xz";
+      sha256 = "81be41497e14f5fb72150e238805744c9b09463ac261cf5d7d2ca011a41a05a0";
+      name = "ktimer-19.08.2.tar.xz";
     };
   };
   ktnef = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktnef-19.08.1.tar.xz";
-      sha256 = "bab23e40af2fe5ba2dd0be71687fbdd56d0868f2ef2a399721da88b12c65764f";
-      name = "ktnef-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktnef-19.08.2.tar.xz";
+      sha256 = "d8efabe72eedd5e89f3de9637a1a6d68ce670ec071e031470aa6852f9ad8561d";
+      name = "ktnef-19.08.2.tar.xz";
     };
   };
   ktouch = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktouch-19.08.1.tar.xz";
-      sha256 = "d97ee5f253dd4e4d802bb8109c2e12d4d48bc7741686d07783e5687a499a2da7";
-      name = "ktouch-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktouch-19.08.2.tar.xz";
+      sha256 = "d36659c21d05465c7a77330dbfbbab09946093eac1db6c02147d81a838eba636";
+      name = "ktouch-19.08.2.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-accounts-kcm-19.08.1.tar.xz";
-      sha256 = "2f76fc870bd7a96540aa91054b3cac38b917f90c129fada86c3639815dfa27a5";
-      name = "ktp-accounts-kcm-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-accounts-kcm-19.08.2.tar.xz";
+      sha256 = "7995813bc983c80b200cddf6b0f55fa8c48be3297ee03e3e0a7601cbc86b8dd8";
+      name = "ktp-accounts-kcm-19.08.2.tar.xz";
     };
   };
   ktp-approver = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-approver-19.08.1.tar.xz";
-      sha256 = "a446c23836f6e38bb739246595cf1773f4909279cf1522b96ccd6626ba36430a";
-      name = "ktp-approver-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-approver-19.08.2.tar.xz";
+      sha256 = "74670d519578486e05237f5085a51fe0a8ce833be413c06702f38b27b27913ec";
+      name = "ktp-approver-19.08.2.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-auth-handler-19.08.1.tar.xz";
-      sha256 = "9a86ce184596cd54b914a7ff0424cadbee24b98f00b8736380e4153ee8596f64";
-      name = "ktp-auth-handler-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-auth-handler-19.08.2.tar.xz";
+      sha256 = "b13304909d8e66adc2a0658081fd41e72b0ef7513e041b9a8f3261a8ffd7bb22";
+      name = "ktp-auth-handler-19.08.2.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-call-ui-19.08.1.tar.xz";
-      sha256 = "bab48fcdc4f4a7becfeca99dbe9061b9d08a510f94548c6ebdf720100ddb5a4c";
-      name = "ktp-call-ui-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-call-ui-19.08.2.tar.xz";
+      sha256 = "0d735c34f937a436e82e994c9d60b851473d31b3dc07f1d2ec7eeeab63b83658";
+      name = "ktp-call-ui-19.08.2.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-common-internals-19.08.1.tar.xz";
-      sha256 = "985d55a259df9cb0593db50ac88bd5d3ab155c6e26563386230fe66294c3dc63";
-      name = "ktp-common-internals-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-common-internals-19.08.2.tar.xz";
+      sha256 = "b08cb6dc05e325c80f9d1753db23d1969fc6c2defc571401e7b2e87772721f7e";
+      name = "ktp-common-internals-19.08.2.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-contact-list-19.08.1.tar.xz";
-      sha256 = "a3ade7f7bacd53c90062923b488a7f60968a45d6d63890a618638f514dd3a5b2";
-      name = "ktp-contact-list-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-contact-list-19.08.2.tar.xz";
+      sha256 = "ab5778049e1351bc5cec29e3bfd98588f24b9877d385e787eb1f68715d624d34";
+      name = "ktp-contact-list-19.08.2.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-contact-runner-19.08.1.tar.xz";
-      sha256 = "385bc8bebb7847cefdd17738ecaf03b102794ac7f38dc58ebe10d100385b769f";
-      name = "ktp-contact-runner-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-contact-runner-19.08.2.tar.xz";
+      sha256 = "6ec9fd151b98c2f48d1ef4361c063e83fe51562fc34868c032d39495ab38fb85";
+      name = "ktp-contact-runner-19.08.2.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-desktop-applets-19.08.1.tar.xz";
-      sha256 = "ec26ba5893998f1e5c293d40e5410a7170ae4e0dea46f03bd5241c51c3240951";
-      name = "ktp-desktop-applets-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-desktop-applets-19.08.2.tar.xz";
+      sha256 = "96975cf9208d215da1844619e2792be0919238a03ede71073813584042d6c774";
+      name = "ktp-desktop-applets-19.08.2.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-filetransfer-handler-19.08.1.tar.xz";
-      sha256 = "34f7eed85709524efaa89924de85842c3532b1ade8572fe28dc2e8ce3f6026eb";
-      name = "ktp-filetransfer-handler-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-filetransfer-handler-19.08.2.tar.xz";
+      sha256 = "cd2a8fb944e76b6a1ea4f8c956db2d9914a0d5bd472c3fac2e9b568144bf87ab";
+      name = "ktp-filetransfer-handler-19.08.2.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-kded-module-19.08.1.tar.xz";
-      sha256 = "323b538c08da82aaf66503463b4334bc603a37bb358fa6f1d5794562c05eed4f";
-      name = "ktp-kded-module-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-kded-module-19.08.2.tar.xz";
+      sha256 = "340bffd880fee602868cb44bc4c5474db1c34be62375298affedf3cc7eb1579f";
+      name = "ktp-kded-module-19.08.2.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-send-file-19.08.1.tar.xz";
-      sha256 = "1e4f9348dab9546d344d00783d6a5ad93b9b299b96d551dd09325c95932cbcd2";
-      name = "ktp-send-file-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-send-file-19.08.2.tar.xz";
+      sha256 = "30a4a27b4c37c8ca75ebc407c6070395197b9b88ba8e422d7055eee93ec0ae9d";
+      name = "ktp-send-file-19.08.2.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktp-text-ui-19.08.1.tar.xz";
-      sha256 = "21c9c58bd498623a6bc9bbfa01c82548af29fdf7f690a359eb57ccd9a3de3105";
-      name = "ktp-text-ui-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktp-text-ui-19.08.2.tar.xz";
+      sha256 = "a0b7d8469b12ae6820541cc38dd57fad8866ad6e236c4864b7cf94629ca0cc33";
+      name = "ktp-text-ui-19.08.2.tar.xz";
     };
   };
   ktuberling = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/ktuberling-19.08.1.tar.xz";
-      sha256 = "b373c7552ff695e7d3428b7f2551315de00786177a5dc4bb96f777bdb84887cc";
-      name = "ktuberling-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/ktuberling-19.08.2.tar.xz";
+      sha256 = "e6cfcd7175c7ed081ecd743c2fdd845f88b25d6cb4d46f9e6d58e35eb11c66ad";
+      name = "ktuberling-19.08.2.tar.xz";
     };
   };
   kturtle = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kturtle-19.08.1.tar.xz";
-      sha256 = "5643434e861391471674e6cf86347c362b076e1d3fe1396022b5080b899bf934";
-      name = "kturtle-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kturtle-19.08.2.tar.xz";
+      sha256 = "1f1245c444aba511aea0630f80953171dd11334f55f6b9547a844e25293cf833";
+      name = "kturtle-19.08.2.tar.xz";
     };
   };
   kubrick = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kubrick-19.08.1.tar.xz";
-      sha256 = "51ff60a682c69f829af7f7e4748128d48e691aacd584379e099c437473a45c03";
-      name = "kubrick-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kubrick-19.08.2.tar.xz";
+      sha256 = "89c181f8c82db143cd671fe78105e95a229e43fd64cab17ccdb80774b4ca8638";
+      name = "kubrick-19.08.2.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kwalletmanager-19.08.1.tar.xz";
-      sha256 = "b6206da5001f79b67264f641210925b0400b41dc59562b978d402b9524835c14";
-      name = "kwalletmanager-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kwalletmanager-19.08.2.tar.xz";
+      sha256 = "5c0cd648d6bf4515cd71b4575ab8051004dcf505c2bfe502fb42b7ba01cb51b2";
+      name = "kwalletmanager-19.08.2.tar.xz";
     };
   };
   kwave = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kwave-19.08.1.tar.xz";
-      sha256 = "6febc3d01c15f94fa0f75a731a375b76642c2cdce9afc373a5c1e92fb3753891";
-      name = "kwave-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kwave-19.08.2.tar.xz";
+      sha256 = "7836b7737d3f578f6d44b40dddf8b3abae53eaa84b3352bfed242eb6ef3d5604";
+      name = "kwave-19.08.2.tar.xz";
     };
   };
   kwordquiz = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/kwordquiz-19.08.1.tar.xz";
-      sha256 = "ead21c1caa1d1665a8ef685c4b46a442b7423aba63153617008985e84ff4c318";
-      name = "kwordquiz-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/kwordquiz-19.08.2.tar.xz";
+      sha256 = "9bb9abc4058b8520a9229317d7da6cbbddb8a715549ca487c04af5f9eb425019";
+      name = "kwordquiz-19.08.2.tar.xz";
     };
   };
   libgravatar = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libgravatar-19.08.1.tar.xz";
-      sha256 = "d39d6970b5113b2b805b048ca9b14770ab16d59c8ec755b0c5f6d4f7d6df73a2";
-      name = "libgravatar-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libgravatar-19.08.2.tar.xz";
+      sha256 = "393370a9d7d4a74627469b2e67bb3f7a0ef73dac8b11a3ab5af6c384c20a0de5";
+      name = "libgravatar-19.08.2.tar.xz";
     };
   };
   libkcddb = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkcddb-19.08.1.tar.xz";
-      sha256 = "f73d3f802e1ffec6b75246505cbec5a7baa328b808c23b42608e05fd8c7b30a5";
-      name = "libkcddb-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkcddb-19.08.2.tar.xz";
+      sha256 = "f3e4c650b0abe10f281037bd6c805243a656fecdfc046a8586324c760ba90e48";
+      name = "libkcddb-19.08.2.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkcompactdisc-19.08.1.tar.xz";
-      sha256 = "53d206967d98e9ee8254aca58d1ba34458761106c323deb449fa94bed1e24037";
-      name = "libkcompactdisc-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkcompactdisc-19.08.2.tar.xz";
+      sha256 = "e185f528a4c6fea1b789186fe64a183197afc447c8cb939c9b6b9957f60d04e0";
+      name = "libkcompactdisc-19.08.2.tar.xz";
     };
   };
   libkdcraw = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkdcraw-19.08.1.tar.xz";
-      sha256 = "b159a669cb4c01770c363b4dd53033248402d37b29acb416ec45e71ac12449e2";
-      name = "libkdcraw-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkdcraw-19.08.2.tar.xz";
+      sha256 = "735ab40633efec394c6265d83f86ad7caf278f63d1dd33cc6edf572da4925fcb";
+      name = "libkdcraw-19.08.2.tar.xz";
     };
   };
   libkdegames = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkdegames-19.08.1.tar.xz";
-      sha256 = "1b365627bd0a3a42a32a0a8d401b53d2ac09f0f9cf040b4b0483c5574991b774";
-      name = "libkdegames-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkdegames-19.08.2.tar.xz";
+      sha256 = "83456cec44502a1f79c0be00c983090e32fd8aea5fec1461fbfbd37b5f8866ac";
+      name = "libkdegames-19.08.2.tar.xz";
     };
   };
   libkdepim = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkdepim-19.08.1.tar.xz";
-      sha256 = "46966eaae2bc71a5bab0c22bcfff858e299d7f1cec2203c1d12cebbc084ee9ce";
-      name = "libkdepim-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkdepim-19.08.2.tar.xz";
+      sha256 = "67578e4c98e7e5d94249144e3720ae5fbc17231d4ecc46cb0e1be6e7ced4a71b";
+      name = "libkdepim-19.08.2.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkeduvocdocument-19.08.1.tar.xz";
-      sha256 = "9e7eb36b0c649231a792f618b28fd110b3782ea086cce81436191e9f73c6674e";
-      name = "libkeduvocdocument-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkeduvocdocument-19.08.2.tar.xz";
+      sha256 = "74338cb3fcb9346a981585484f758aabd372d1a43afe9facd93d94c229424250";
+      name = "libkeduvocdocument-19.08.2.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkexiv2-19.08.1.tar.xz";
-      sha256 = "bee9a16eda002146b42f358b0dc58c5db832719870761264cc6cf0a199ab0537";
-      name = "libkexiv2-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkexiv2-19.08.2.tar.xz";
+      sha256 = "abdafabe834862e157356f2686ae871f00302d82ae639dbf89030d19ccc54b1b";
+      name = "libkexiv2-19.08.2.tar.xz";
     };
   };
   libkgapi = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkgapi-19.08.1.tar.xz";
-      sha256 = "1ad2491348cc97f591aa681f7a649f2337c9a92e845980304c1110c69eecd579";
-      name = "libkgapi-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkgapi-19.08.2.tar.xz";
+      sha256 = "b220908dd4a21e589a25b964b7786f1154f63ca98bf90c43ced3120adf4fb0a6";
+      name = "libkgapi-19.08.2.tar.xz";
     };
   };
   libkgeomap = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkgeomap-19.08.1.tar.xz";
-      sha256 = "aed369217007698beaa3230bf5b5360602d44ca6d333026158b15666f3670555";
-      name = "libkgeomap-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkgeomap-19.08.2.tar.xz";
+      sha256 = "145692b900d87a84b74507b53ddc05947e6c1cce46381d8960559b5907296219";
+      name = "libkgeomap-19.08.2.tar.xz";
     };
   };
   libkipi = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkipi-19.08.1.tar.xz";
-      sha256 = "ec2012821c90062e43ad7c77861ab519b24aea429ed9f0b7bdf6ef9c00e82ba4";
-      name = "libkipi-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkipi-19.08.2.tar.xz";
+      sha256 = "fcaf576afb961d9a36c1f69c034c43b9f0991cbd0726ea684c2c49096f36d5c6";
+      name = "libkipi-19.08.2.tar.xz";
     };
   };
   libkleo = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkleo-19.08.1.tar.xz";
-      sha256 = "5808a40d9c9358048d558a4c96f90e8c51b2dab3588ab3c678b02d5810020a31";
-      name = "libkleo-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkleo-19.08.2.tar.xz";
+      sha256 = "0acf296ffb0144096071e47ce1365b9e5b07b59cad4700f89c875c7bee4573bd";
+      name = "libkleo-19.08.2.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkmahjongg-19.08.1.tar.xz";
-      sha256 = "c4e3a29bb923ead76f1fb528fa62c677423ebb4ac07dd149a6fc3f6ae055eb39";
-      name = "libkmahjongg-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkmahjongg-19.08.2.tar.xz";
+      sha256 = "8699949fae90c0e92dd046b904b0624f79c37fecaa46557c808f20f24e215947";
+      name = "libkmahjongg-19.08.2.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libkomparediff2-19.08.1.tar.xz";
-      sha256 = "a020ba9287ee084a0f5a10896f1559f11aff1c97957405f47deeda32a0874b31";
-      name = "libkomparediff2-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libkomparediff2-19.08.2.tar.xz";
+      sha256 = "c5738f96dbda3d7272ad08ff9518722ae9b7ee737ab7e27c9e88cedb418371d7";
+      name = "libkomparediff2-19.08.2.tar.xz";
     };
   };
   libksane = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libksane-19.08.1.tar.xz";
-      sha256 = "215fae62d8ea1f70908cafc5bc8667c02d4f0329669d056c99443a7b14a6e589";
-      name = "libksane-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libksane-19.08.2.tar.xz";
+      sha256 = "97e05423f4a9205b9db0bbce5111615d6bf8e8d53a391d3398275babccd91aa0";
+      name = "libksane-19.08.2.tar.xz";
     };
   };
   libksieve = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/libksieve-19.08.1.tar.xz";
-      sha256 = "ab384877148710e7de92e88a192f52beaad667804bbc641b63c21cfdaa0aee31";
-      name = "libksieve-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/libksieve-19.08.2.tar.xz";
+      sha256 = "5c5bb9182e53a2a928d70985f6dd514c8b308891c4899b942784e80d221318f6";
+      name = "libksieve-19.08.2.tar.xz";
     };
   };
   lokalize = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/lokalize-19.08.1.tar.xz";
-      sha256 = "fe1e1f8fb2f2ad3cde1830b2ddbcce0e41ffe5696c6e32b0639c8931967b3943";
-      name = "lokalize-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/lokalize-19.08.2.tar.xz";
+      sha256 = "3fe3af9f647bcda7f89eab5c3ebb7bce4e9ceb0b7cfb5206c2f6ecdf9cdbe3ee";
+      name = "lokalize-19.08.2.tar.xz";
     };
   };
   lskat = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/lskat-19.08.1.tar.xz";
-      sha256 = "e4b073cc65be0f1e7e01b4b2aa28bed30480aef097f5185eb608b4e45b9352e9";
-      name = "lskat-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/lskat-19.08.2.tar.xz";
+      sha256 = "3ae219b92cbc4c9acfacbb16e262e82b03cd5ddba024820e82d8de7312327a9c";
+      name = "lskat-19.08.2.tar.xz";
     };
   };
   mailcommon = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/mailcommon-19.08.1.tar.xz";
-      sha256 = "3fb6f09ce8bc9ccddfa1420fa1a7c60a47065afdfbb5a30292179efbcebba833";
-      name = "mailcommon-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/mailcommon-19.08.2.tar.xz";
+      sha256 = "39df1544c0278600d5a1a57697835828358ae44203087e29430ce1bd0c355e20";
+      name = "mailcommon-19.08.2.tar.xz";
     };
   };
   mailimporter = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/mailimporter-19.08.1.tar.xz";
-      sha256 = "4236938a2dca5ea0bc572afbe76ae28fc6ad1e65f383743de98a4e505f674962";
-      name = "mailimporter-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/mailimporter-19.08.2.tar.xz";
+      sha256 = "27780c381919ebc9e6fc0de7021cd03277dd3962d4c4c15770fcf44cd6126814";
+      name = "mailimporter-19.08.2.tar.xz";
     };
   };
   marble = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/marble-19.08.1.tar.xz";
-      sha256 = "7e09e3037287be117e47de402d1f5ea7dd49f625ccf4a46d1d016a527d487e9e";
-      name = "marble-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/marble-19.08.2.tar.xz";
+      sha256 = "4add63522a51fdea7b425f29bd3d35c558a0b881336ff6a90bfc07483acbf6a6";
+      name = "marble-19.08.2.tar.xz";
     };
   };
   mbox-importer = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/mbox-importer-19.08.1.tar.xz";
-      sha256 = "3f4c96ee65ffa0488df09522e1bda2ea38c0adf420ae66fff11f670566c5536c";
-      name = "mbox-importer-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/mbox-importer-19.08.2.tar.xz";
+      sha256 = "644175d6fcb66b878309de899f4a3e060e29d4f31ce337d44ee6e1af5901044f";
+      name = "mbox-importer-19.08.2.tar.xz";
     };
   };
   messagelib = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/messagelib-19.08.1.tar.xz";
-      sha256 = "ec43d913028124a49eaa440e4b55dba23b6ab503728b897a3ad8e1fc5e446802";
-      name = "messagelib-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/messagelib-19.08.2.tar.xz";
+      sha256 = "d761e94d2fa71c2de6a52e0c1756f52f0006ada35711189b343eccdafe0a0390";
+      name = "messagelib-19.08.2.tar.xz";
     };
   };
   minuet = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/minuet-19.08.1.tar.xz";
-      sha256 = "524c389060c13b37a3df4662ca9ca5e2862d20ea71f47b1a5157a088d2d065d4";
-      name = "minuet-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/minuet-19.08.2.tar.xz";
+      sha256 = "1713ac758388443bbd1e2f5158cba594c35c3afdc5122a993fc66d70b07eb904";
+      name = "minuet-19.08.2.tar.xz";
     };
   };
   okular = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/okular-19.08.1.tar.xz";
-      sha256 = "9e363b73febd5da1a17e53a8f89914784b555c1f0085ddc0f55ef56082b0bd54";
-      name = "okular-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/okular-19.08.2.tar.xz";
+      sha256 = "ff3d2eac444a110a611add71c30b0556085f5aaccdd821a80bd070a646c9f6b3";
+      name = "okular-19.08.2.tar.xz";
     };
   };
   palapeli = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/palapeli-19.08.1.tar.xz";
-      sha256 = "c9eeafe854529ea5a09e9ef6fd37b8be3d0d370322938c009c826bd936953adc";
-      name = "palapeli-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/palapeli-19.08.2.tar.xz";
+      sha256 = "bae810595c7ba7bdac0fa5c27e6c2a3a9bb1bbdae3521cfc036ec0cdcd9ef1a7";
+      name = "palapeli-19.08.2.tar.xz";
     };
   };
   parley = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/parley-19.08.1.tar.xz";
-      sha256 = "6ee4d538ddaecd5b6c3d855db62a4b5061240b2089b3dcc592712398fd1d066b";
-      name = "parley-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/parley-19.08.2.tar.xz";
+      sha256 = "1201945d55657d6b89e309220edb1a60a61debf0bbf59b508d1c0a21a8dc407e";
+      name = "parley-19.08.2.tar.xz";
     };
   };
   picmi = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/picmi-19.08.1.tar.xz";
-      sha256 = "47e0dd79ee4ae86d8be6822f9328fac2f00ce68cf862202e889c0f77a88d0d91";
-      name = "picmi-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/picmi-19.08.2.tar.xz";
+      sha256 = "ecfa211043327991a0927be852c185223adebe5f15cdc39e79e31022802f904b";
+      name = "picmi-19.08.2.tar.xz";
     };
   };
   pimcommon = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/pimcommon-19.08.1.tar.xz";
-      sha256 = "5956e2767ea88efd73cbefef9cb80d16bb4cb5cb63857975fbb6ead1b984026c";
-      name = "pimcommon-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/pimcommon-19.08.2.tar.xz";
+      sha256 = "ccdf2624a055a9db31b0b8109c791776d111ae91438f41ed50dcb9faca287e4c";
+      name = "pimcommon-19.08.2.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/pim-data-exporter-19.08.1.tar.xz";
-      sha256 = "766e8b15f7853d84629bc49ad33aa59291d6d95cfd9db279e9e0ad70b0fab1fe";
-      name = "pim-data-exporter-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/pim-data-exporter-19.08.2.tar.xz";
+      sha256 = "e4703d7a10935814738394a38c5ad54f9923c58e43c397e2e78a4b1b1176f4c2";
+      name = "pim-data-exporter-19.08.2.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/pim-sieve-editor-19.08.1.tar.xz";
-      sha256 = "b49045d7326cf0ca7fabbf58d8508d61986701887871c4df53fad1f960a64438";
-      name = "pim-sieve-editor-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/pim-sieve-editor-19.08.2.tar.xz";
+      sha256 = "ae9f7de78ab9adffe2575bf1367b1ae4928afee1fd299bb91ca2d26b3bb86c03";
+      name = "pim-sieve-editor-19.08.2.tar.xz";
     };
   };
   poxml = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/poxml-19.08.1.tar.xz";
-      sha256 = "d38dce3114b01bc72163329dac629c4e5d36db15e09d52dd0ffbcaa645408d98";
-      name = "poxml-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/poxml-19.08.2.tar.xz";
+      sha256 = "c5e36bd10d3a8d0474f903eebd45e026ca306beb74829c43a1e7be4ed34ca9e8";
+      name = "poxml-19.08.2.tar.xz";
     };
   };
   print-manager = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/print-manager-19.08.1.tar.xz";
-      sha256 = "b1fd9aa067329a4f5bb715e7db736160954bbec303be0ba5bc8f98852071e731";
-      name = "print-manager-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/print-manager-19.08.2.tar.xz";
+      sha256 = "c0702208b6f485e2e44337aaf203b9e391adda22d6526bf0dd34b31230e0fb05";
+      name = "print-manager-19.08.2.tar.xz";
     };
   };
   rocs = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/rocs-19.08.1.tar.xz";
-      sha256 = "eaa2fefae8123071e5802d0c13016d0b99608f91c75c7c6e4fbe6f2c6dc12adf";
-      name = "rocs-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/rocs-19.08.2.tar.xz";
+      sha256 = "4e61226334f79a260f0ccc7789a099a91c7643d9fdfcdd052b002f2fe6f64885";
+      name = "rocs-19.08.2.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/signon-kwallet-extension-19.08.1.tar.xz";
-      sha256 = "7d558509cf015641c76d4203c8dadc4e9720278fb39b4561eb2bce4e5412bb83";
-      name = "signon-kwallet-extension-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/signon-kwallet-extension-19.08.2.tar.xz";
+      sha256 = "2521cd2c4f25717f5caf9915474f75614be7dec7053f1e94c1429fac7045cc29";
+      name = "signon-kwallet-extension-19.08.2.tar.xz";
     };
   };
   spectacle = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/spectacle-19.08.1.tar.xz";
-      sha256 = "21057fd4990048df33f5d739fc98af2a555ca4b7db50688333fecabc12f24786";
-      name = "spectacle-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/spectacle-19.08.2.tar.xz";
+      sha256 = "4cf2f0903cec2787a03a8bbdbd219acc29ac412f352a4ff94ef50ae9a6eb459e";
+      name = "spectacle-19.08.2.tar.xz";
     };
   };
   step = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/step-19.08.1.tar.xz";
-      sha256 = "533750dda4adcd0f3d8ec269103f35ee1ab4b4e9eae9721522b1b278660577a6";
-      name = "step-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/step-19.08.2.tar.xz";
+      sha256 = "dede94c073b2903fa4fa6806623cb980ebe93d15cc76376aadac4ca8cd61a96c";
+      name = "step-19.08.2.tar.xz";
     };
   };
   svgpart = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/svgpart-19.08.1.tar.xz";
-      sha256 = "4ed6277d3f2c12a4a53dd308911c613af5ae65f53819aeacf42e08dcd08dbd5b";
-      name = "svgpart-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/svgpart-19.08.2.tar.xz";
+      sha256 = "6c6510b604bba3aebbeca136ec9534c416bc0ba55125227bdd0af2a86052855c";
+      name = "svgpart-19.08.2.tar.xz";
     };
   };
   sweeper = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/sweeper-19.08.1.tar.xz";
-      sha256 = "cc539649fa4a2698ad07653f9427981381bf8b5344f05dab76acdf1704b4479a";
-      name = "sweeper-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/sweeper-19.08.2.tar.xz";
+      sha256 = "da65cbfc952d8b63ddfbcba373d9a828ef5acefc68196ddd4c2c602c672cbb5f";
+      name = "sweeper-19.08.2.tar.xz";
     };
   };
   umbrello = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/umbrello-19.08.1.tar.xz";
-      sha256 = "ce56fa6d96bbc78cf69246d6f45e9b098f8fcc75d7771875a8e638b01bbf6efa";
-      name = "umbrello-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/umbrello-19.08.2.tar.xz";
+      sha256 = "69a721d27ecedbe694d232e04469002dcf2319dd320982aacc2a02e32430c382";
+      name = "umbrello-19.08.2.tar.xz";
     };
   };
   yakuake = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/yakuake-19.08.1.tar.xz";
-      sha256 = "184fec9d07505faf820821e197582f7733694848cc17e71ee4f525772e78fc10";
-      name = "yakuake-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/yakuake-19.08.2.tar.xz";
+      sha256 = "3ebf477069c85a8705302b6b51902a74af7bb92349fab41000f71484a4de5aee";
+      name = "yakuake-19.08.2.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "19.08.1";
+    version = "19.08.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.08.1/src/zeroconf-ioslave-19.08.1.tar.xz";
-      sha256 = "0c5f8931dd2997345fc6d3e8ef73c36615a73f8c906fb6be9c27432bc038000a";
-      name = "zeroconf-ioslave-19.08.1.tar.xz";
+      url = "${mirror}/stable/applications/19.08.2/src/zeroconf-ioslave-19.08.2.tar.xz";
+      sha256 = "19e31534d1a4503d1dd4bd8ef60cfb48a91ee167dd4b0db99e53b318a355dae0";
+      name = "zeroconf-ioslave-19.08.2.tar.xz";
     };
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
