### PR TITLE
mlarchive2maildir: 0.0.6 -> 0.0.8

### DIFF
--- a/pkgs/applications/networking/mailreaders/mlarchive2maildir/default.nix
+++ b/pkgs/applications/networking/mailreaders/mlarchive2maildir/default.nix
@@ -2,11 +2,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "mlarchive2maildir";
-  version = "0.0.6";
+  version = "0.0.8";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "025mv890zsk25cral9cas3qgqdsszh5025khz473zs36innjd0mw";
+    sha256 = "1din3yay2sas85178v0xr0hbm2396y4dalkcqql1ny9vdm94h6sp";
   };
 
   nativeBuildInputs = with python3.pkgs; [ setuptools_scm ];


### PR DESCRIPTION
###### Motivation for this change
mlarchive2maildir added support for importing things from outside pipermail.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andir 
