### PR TITLE
networkmanager: 1.20.2 -> 1.20.4

### DIFF
--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, dbus, nettle
+{ stdenv, fetchurl, pkgconfig, dbus, nettle, fetchpatch
 , libidn, libnetfilter_conntrack }:
 
 with stdenv.lib;
@@ -18,6 +18,15 @@ stdenv.mkDerivation rec {
     url = "http://www.thekelleys.org.uk/dnsmasq/${name}.tar.xz";
     sha256 = "1fv3g8vikj3sn37x1j6qsywn09w1jipvlv34j3q5qrljbrwa5ayd";
   };
+
+  patches = [
+    # Fix build with nettle 3.5
+    (fetchpatch {
+      name = "nettle-3.5.patch";
+      url = "thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=patch;h=ab73a746a0d6fcac2e682c5548eeb87fb9c9c82e";
+      sha256 = "1hnixij3jp1p6zc3bx2dr92yyf9jp1ahhl9hiiq7bkbhbrw6mbic";
+    })
+  ];
 
   preBuild = ''
     makeFlagsArray=("COPTS=${copts}")

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -10,11 +10,11 @@ let
   pythonForDocs = python3.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in stdenv.mkDerivation rec {
   pname = "network-manager";
-  version = "1.20.2";
+  version = "1.20.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${stdenv.lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "115cgz448vypc7c592lqqjd7lp2kzdczhjk4ran6qls65hzkfkji";
+    sha256 = "0k4i6m8acp48vl6l13267wv6kfkmzfjq2mraaa5m9n82wyvkimx3";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];
@@ -51,15 +51,6 @@ in stdenv.mkDerivation rec {
   ];
 
   patches = [
-    # 1.20.2 added a decorators.sh script but they forgot to distribute it (breaking the build)
-    # as it was to fix things with gtk-doc 1.32 we can safely revert it.
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/NetworkManager/NetworkManager/commit/2d941dc95a1d94d023ac8f98df2f344dbb1d223e.patch";
-      sha256 = "1mvbajddwd6diwk6dgjg5p65i6852gx6b9p3949rs63d2i6yzg21";
-      excludes = [ "tools/decorators.sh" ];
-      revert = true;
-    })
-
     (substituteAll {
       src = ./fix-paths.patch;
       inherit iputils kmod openconnect ethtool gnused dbus;

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -39,11 +39,33 @@ index 2f442bf23..c3e797bf4 100644
  #ExecReload=/bin/kill -HUP $MAINPID
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
+diff --git a/libnm/meson.build b/libnm/meson.build
+index 710ef181d..3aa182dd4 100644
+--- a/libnm/meson.build
++++ b/libnm/meson.build
+@@ -280,7 +280,7 @@ if enable_introspection
+     name,
+     input: libnm_gir[0],
+     output: name,
+-    command: [generate_setting_docs_env, python.path(), generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--output', '@OUTPUT@'],
++    command: [generate_setting_docs_env, generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--output', '@OUTPUT@'],
+     depends: libnm_gir,
+   )
+ 
+@@ -289,7 +289,7 @@ if enable_introspection
+     name,
+     input: libnm_gir[0],
+     output: name,
+-    command: [generate_setting_docs_env, python.path(), generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--overrides', nm_settings_docs_overrides, '--output', '@OUTPUT@'],
++    command: [generate_setting_docs_env, generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--overrides', nm_settings_docs_overrides, '--output', '@OUTPUT@'],
+     depends: libnm_gir,
+   )
+ endif
 diff --git a/src/devices/nm-device.c b/src/devices/nm-device.c
-index 823cf48a5..cda16e48d 100644
+index 67e23b8f9..b0ce52711 100644
 --- a/src/devices/nm-device.c
 +++ b/src/devices/nm-device.c
-@@ -12822,14 +12822,14 @@ nm_device_start_ip_check (NMDevice *self)
+@@ -12840,14 +12840,14 @@ nm_device_start_ip_check (NMDevice *self)
  			gw = nm_ip4_config_best_default_route_get (priv->ip_config_4);
  			if (gw) {
  				nm_utils_inet4_ntop (NMP_OBJECT_CAST_IP4_ROUTE (gw)->gateway, buf);


### PR DESCRIPTION
###### Motivation for this change
* fix-paths.patch
We had to add a diff to revert [0] as it makes it use the python
from meson which won't be the specific pythonForDocs that
has pygobject (breaking the build). Unfortunate that upstream
made assumptions like "Of course, who needs a way to invoke
the interpreter that works accross different distributions!"

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/blob/1.20.4/NEWS

[0]: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/commit/c162dc00e50431f3db2f560201051c0884ebbb1a

I've also enabled `polkit_agent` https://github.com/NixOS/nixpkgs/commit/ed5bd0024943800916446c837ffe16e286e0ec09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (on master)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
