### PR TITLE
sshping: init at 0.1.4

### DIFF
--- a/pkgs/tools/networking/sshping/default.nix
+++ b/pkgs/tools/networking/sshping/default.nix
@@ -1,0 +1,31 @@
+{stdenv, fetchFromGitHub, libssh}:
+
+stdenv.mkDerivation rec {
+  pname = "sshping";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "spook";
+    repo = "sshping";
+    rev = "v${version}";
+    sha256 = "0p1fvpgrsy44yvj44xp9k9nf6z1fh0sqcjvy75pcb9f5icgms815";
+  };
+
+  buildInputs = [ libssh ];
+
+  buildPhase = ''
+      g++ -Wall -I ext/ -o bin/sshping src/sshping.cxx -lssh
+    '';
+
+  installPhase = ''
+      install -Dm755 bin/sshping $out/bin/sshping
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/spook/sshping;
+    description = "Measure character-echo latency and bandwidth for an interactive ssh session";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jqueiroz ];
+  };
+}

--- a/pkgs/tools/networking/sshping/default.nix
+++ b/pkgs/tools/networking/sshping/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/spook/sshping;
+    homepage = "https://github.com/spook/sshping";
     description = "Measure character-echo latency and bandwidth for an interactive ssh session";
     license = licenses.mit;
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6252,6 +6252,8 @@ in
 
   sshguard = callPackage ../tools/security/sshguard {};
 
+  sshping = callPackage ../tools/networking/sshping {};
+
   suricata = callPackage ../applications/networking/ids/suricata {
     python = python3;
   };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
