### PR TITLE
pythonPackages.bokeh: added packaging dependency

### DIFF
--- a/pkgs/development/python-modules/bokeh/default.nix
+++ b/pkgs/development/python-modules/bokeh/default.nix
@@ -8,6 +8,7 @@
 , mock
 , numpy
 , nodejs
+, packaging
 , pillow
 , pytest
 , python
@@ -48,6 +49,7 @@ buildPythonPackage rec {
     pyyaml
     tornado
     numpy
+    packaging
   ]
   ++ lib.optionals ( !isPy3k ) [ futures ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Previously Bokeh would build and pass tests, but `import bokeh.plotting` would fail with 
```
  File "/nix/store/d7rlq9db362d9zgvrd0rb9x0bhzp0p03-python3.7-bokeh-1.3.4/lib/python3.7/site-packages/bokeh/util/dependencies.py", line 28, in <module>
    from packaging.version import Version as V
ModuleNotFoundError: No module named 'packaging'
```
[Note that `packaging` is in Bokeh's requirements](https://github.com/bokeh/bokeh/blob/761a2b869988f8fe253a755ce50f75a691bc8517/setup.py#L89-L98), and [here is the commit that introduced it](https://github.com/bokeh/bokeh/commit/34800c4745dcff045e21190b649e177825c09fdd#diff-9773c1b6f19d42fd0af19d6913002f4c).

###### Things done
Just added `packaging` to `propagatedBuildInputs`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I'm inexperienced at all this stuff, sorry if I got anything wrong.

###### Notify maintainers

cc @
