### PR TITLE
spotify-tui: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3271,6 +3271,12 @@
     githubId = 8460;
     name = "John Wiegley";
   };
+  jwijenbergh = {
+    email = "jeroenwijenbergh@protonmail.com";
+    github = "jwijenbergh";
+    githubId = 46386452;
+    name = "Jeroen Wijenbergh";
+  };
   jwilberding = {
     email = "jwilberding@afiniate.com";
     name = "Jordan Wilberding";

--- a/pkgs/applications/audio/spotify-tui/default.nix
+++ b/pkgs/applications/audio/spotify-tui/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl }:
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "spotify-tui";
@@ -12,9 +12,10 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "029g80mcqvmckszpbzm4hxs5w63n41ah4rc1b93i9c1nzvncd811";
-  
+
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security;
 
   meta = with stdenv.lib; {
     description = "Spotify for the terminal written in Rust";

--- a/pkgs/applications/audio/spotify-tui/default.nix
+++ b/pkgs/applications/audio/spotify-tui/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "spotify-tui";
+  version = "0.5.0";
+  
+  src = fetchFromGitHub {
+    owner = "Rigellute";
+    repo = "spotify-tui";
+    rev = "v${version}"; 
+    sha256 = "1spnr67fb2wjjf9sfkk3vps6q45w0zrk47an79bhv4imziy4dbs3";
+  };
+
+  cargoSha256 = "029g80mcqvmckszpbzm4hxs5w63n41ah4rc1b93i9c1nzvncd811";
+  
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openssl ];
+
+  meta = with stdenv.lib; {
+    description = "Spotify for the terminal written in Rust";
+    homepage = https://github.com/Rigellute/spotify-tui;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jwijenbergh ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20676,7 +20676,9 @@ in
 
   split2flac = callPackage ../applications/audio/split2flac { };
 
-  spotify-tui = callPackage ../applications/audio/spotify-tui { };
+  spotify-tui = callPackage ../applications/audio/spotify-tui {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   squishyball = callPackage ../applications/audio/squishyball {
     ncurses = ncurses5;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20676,6 +20676,8 @@ in
 
   split2flac = callPackage ../applications/audio/split2flac { };
 
+  spotify-tui = callPackage ../applications/audio/spotify-tui { };
+
   squishyball = callPackage ../applications/audio/squishyball {
     ncurses = ncurses5;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Spotify-tui is a spotify terminal client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
