### PR TITLE
poppler_0_61: add patch for CVE-2019-9959

### DIFF
--- a/pkgs/development/libraries/poppler/0.61-CVE-2019-9959.patch
+++ b/pkgs/development/libraries/poppler/0.61-CVE-2019-9959.patch
@@ -1,0 +1,20 @@
+diff --git a/poppler/JPEG2000Stream.cc b/poppler/JPEG2000Stream.cc
+--- a/poppler/JPEG2000Stream.cc
++++ b/poppler/JPEG2000Stream.cc
+@@ -201,7 +201,7 @@ void JPXStream::init()
+   if (getDict()) smaskInData = getDict()->lookup("SMaskInData");
+ 
+   int bufSize = BUFFER_INITIAL_SIZE;
+-  if (oLen.isInt()) bufSize = oLen.getInt();
++  if (oLen.isInt() && oLen.getInt() > 0) bufSize = oLen.getInt();
+ 
+   if (cspace.isArray() && cspace.arrayGetLength() > 0) {
+
+@@ -365,7 +365,7 @@ void JPXStream::init()
+   }
+ 
+   int bufSize = BUFFER_INITIAL_SIZE;
+-  if (oLen.isInt()) bufSize = oLen.getInt();
++  if (oLen.isInt() && oLen.getInt() > 0) bufSize = oLen.getInt();
+ 
+   if (cspace.isArray() && cspace.arrayGetLength() > 0) {

--- a/pkgs/development/libraries/poppler/0.61.nix
+++ b/pkgs/development/libraries/poppler/0.61.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  version = "0.61.0";
+  version = "0.61.1";
   mkFlag = optset: flag: "-DENABLE_${flag}=${if optset then "on" else "off"}";
 in
 stdenv.mkDerivation rec {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/poppler-${version}.tar.xz";
-    sha256 = "0zrbb1b77k6bm2qdnra08jnbyllv6vj29790igmp6fzs59xf3kak";
+    sha256 = "1afdrxxkaivvviazxkg5blsf2x24sjkfj92ib0d3q5pm8dihjrhj";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/poppler/0.61.nix
+++ b/pkgs/development/libraries/poppler/0.61.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
       url = "https://cgit.freedesktop.org/poppler/poppler/patch/?id=004e3c10df0abda214f0c293f9e269fdd979c5ee";
       sha256 = "1l8713s57xc6g81bldw934rsfm140fqc7ggd50ha5mxdl1b3app2";
     })
+    ./0.61-CVE-2019-9959.patch
   ];
 
   buildInputs = [ libiconv libintl ] ++ lib.optional withData poppler_data;


### PR DESCRIPTION
###### Motivation for this change
We still have an older 0.61 release of poppler in the tree (`poppler_0_61`). This should fix CVE-2019-9959 for it.

https://nvd.nist.gov/vuln/detail/CVE-2019-9959

Added a custom patch because while the upstream fix _does_ apply as a patch, it doesn't take into account the openjpeg1/openjpeg2 split 0.61 still has (simply requiring a duplicated section).

While I was here I also bumped it from `0.61.0` -> `0.61.1`.

For the main `poppler` package, we should be looking at merging #60701.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
