### PR TITLE
compcert: 3.5 → 3.6; ocamlPackages.menhir: 20181113 → 20190626

### DIFF
--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -4,7 +4,7 @@
 }:
 
 assert lib.versionAtLeast ocamlPackages.ocaml.version "4.02";
-assert lib.versionAtLeast coq.coq-version "8.6.1";
+assert lib.versionAtLeast coq.coq-version "8.8.0";
 
 let
   ocaml-pkgs      = with ocamlPackages; [ ocaml findlib menhir ];
@@ -12,13 +12,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "compcert";
-  version = "3.5";
+  version = "3.6";
 
   src = fetchFromGitHub {
     owner = "AbsInt";
     repo = "CompCert";
     rev = "v${version}";
-    sha256 = "1g8067a5x3vd0l47d04gjvy5yx49nghh55am5d1fbrjirfsnsz8j";
+    sha256 = "1k9xhj7fgllhf7bn7rp3w6zfvs4clglnc4w39zp4678hrwvdcpha";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -27,7 +27,6 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     substituteInPlace ./configure \
-      --replace '|8.9.0' '|8.9.0|8.9.1' \
       --replace '{toolprefix}gcc' '{toolprefix}cc'
   '';
 

--- a/pkgs/development/ocaml-modules/menhir/default.nix
+++ b/pkgs/development/ocaml-modules/menhir/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ocaml, findlib, ocamlbuild
-, version ? if stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.02" then "20181113" else "20140422"
+, version ? if stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.02" then "20190626" else "20140422"
 }@args:
 
 let
@@ -7,6 +7,7 @@ let
   if version == "20140422" then { url = "http://cristal.inria.fr/~fpottier/menhir/menhir-20140422.tar.gz"; sha256 = "1ki1f2id6a14h9xpv2k8yb6px7dyw8cvwh39csyzj4qpzx7wia0d"; }
   else if version == "20170712" then { url = "http://gallium.inria.fr/~fpottier/menhir/menhir-20170712.tar.gz"; sha256 = "006hq3bwj81j67f2k9cgzj5wr4hai8j36925p5n3sd2j01ljsj6a"; }
   else if version == "20181113" then { url = "https://gitlab.inria.fr/fpottier/menhir/repository/20181113/archive.tar.gz"; sha256 = "0hl611l0gyl7b2bm7m0sk7vjz14m0i7znrnjq3gw58pylj934dx4"; }
+  else if version == "20190626" then { url = "https://gitlab.inria.fr/fpottier/menhir/repository/20190626/archive.tar.gz"; sha256 = "0nigjnskg89knyi2zj1w211mb1pvkrwfqpz9a0qbw80k3hm8gg0h"; }
   else throw ("menhir: unknown version " ++ version)
   );
 in


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @maggesi (menhir) @thoughtpolice @jwiegley (CompCert)
