### PR TITLE
[19.09] Backport cargo-audit

### DIFF
--- a/pkgs/tools/package-management/cargo-audit/default.nix
+++ b/pkgs/tools/package-management/cargo-audit/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, rustPlatform, fetchFromGitHub, openssl, pkg-config, Security, libiconv }:
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-audit";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "RustSec";
+    repo = "cargo-audit";
+    rev = "v${version}";
+    sha256 = "0j556dh0lf2l8nq7pfl5bbypgsvp00fh6ckms9wr4dgb8xvpf2r1";
+  };
+
+  cargoSha256 = "0200x0bdllq7mpxmp7ly5jarpkc3gpg22gxq8qvdbnmyd39b7wx0";
+
+  buildInputs = [ openssl libiconv ] ++ lib.optionals stdenv.isDarwin [ Security ];
+  nativeBuildInputs = [ pkg-config ];
+
+  # The tests require network access which is not available in sandboxed Nix builds.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Audit Cargo.lock files for crates with security vulnerabilities";
+    homepage = "https://rustsec.org";
+    license = with licenses; [ mit asl20 ];
+    maintainers = with maintainers; [ basvandijk ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/package-management/cargo-audit/default.nix
+++ b/pkgs/tools/package-management/cargo-audit/default.nix
@@ -1,16 +1,16 @@
 { stdenv, lib, rustPlatform, fetchFromGitHub, openssl, pkg-config, Security, libiconv }:
 rustPlatform.buildRustPackage rec {
   pname = "cargo-audit";
-  version = "0.9.1";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "RustSec";
     repo = "cargo-audit";
     rev = "v${version}";
-    sha256 = "0j556dh0lf2l8nq7pfl5bbypgsvp00fh6ckms9wr4dgb8xvpf2r1";
+    sha256 = "0yd3qj475hh394f1ya0hwki3pbzkfyz5cssy28cq9bimibxhyfd8";
   };
 
-  cargoSha256 = "0200x0bdllq7mpxmp7ly5jarpkc3gpg22gxq8qvdbnmyd39b7wx0";
+  cargoSha256 = "0ba4xrjrh8cbi4pksax3gs7jaiw5mrb9hdrdwaghkikmiza1c08g";
 
   buildInputs = [ openssl libiconv ] ++ lib.optionals stdenv.isDarwin [ Security ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8309,6 +8309,9 @@ in
 
   defaultCrateOverrides = callPackage ../build-support/rust/default-crate-overrides.nix { };
 
+  cargo-audit = callPackage ../tools/package-management/cargo-audit {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-download = callPackage ../tools/package-management/cargo-download { };
   cargo-edit = callPackage ../tools/package-management/cargo-edit { };
   cargo-graph = callPackage ../tools/package-management/cargo-graph { };


### PR DESCRIPTION
###### Motivation for this change

Backport cargo-audit to nixpkgs 19.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @basvandijk 