### PR TITLE
[19.09] ocamlPackages.llvm: propagate needed libs, fix missing build parameter

### DIFF
--- a/pkgs/development/ocaml-modules/llvm/default.nix
+++ b/pkgs/development/ocaml-modules/llvm/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation {
 
   inherit (llvm) src;
 
-  buildInputs = [ python cmake llvm ocaml findlib ctypes ];
+  buildInputs = [ python cmake ocaml findlib ctypes ];
+  propagatedBuildInputs = [ llvm ];
 
   patches = [ (fetchpatch {
     url = https://raw.githubusercontent.com/ocaml/opam-repository/2bdc193f5a9305ea93bf0f0dfc1fbc327c8b9306/packages/llvm/llvm.7.0.0/files/fix-shared.patch;
@@ -18,6 +19,7 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DLLVM_OCAML_OUT_OF_TREE=TRUE"
     "-DLLVM_OCAML_INSTALL_PATH=${placeholder "out"}/ocaml"
+    "-DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR=${stdenv.lib.getLib llvm}/lib"
   ];
 
   buildFlags = "ocaml_all";
@@ -29,6 +31,10 @@ stdenv.mkDerivation {
     mv $out/ocaml $OCAMLFIND_DESTDIR/llvm
     mv $OCAMLFIND_DESTDIR/llvm/META{.llvm,}
   '';
+
+  passthru = {
+    inherit llvm;
+  };
 
   meta = {
     inherit (llvm.meta) license homepage;


### PR DESCRIPTION
[Backport of #70929]

The opam patch makes ocaml link dependent executables with
-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}. This variable was previously
undefined and as a result the linker would previously be called with
just -L which makes it ignore the next argument. This would lead strange
linking errors, like missing caml_apply2.

Despite defining this variable correctly, propagating llvm is still
necessary for linking to complete. In case ocaml-llvm is a transitive
dependency only, propagatedBuildInputs is not enough. To avoid having to
guess which version of llvm was used, we provide the right one in
passthrough.

(cherry picked from commit 55ac8ffa43fa078929e24b33f4571321829ae9c3)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vbgl
