### PR TITLE
buildGoModule: disable default go module proxy

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -73,6 +73,8 @@ let
     installPhase = args.modInstallPhase or ''
       runHook preInstall
 
+      # remove cached lookup results and tiles
+      rm -rf "''${GOPATH}/pkg/mod/cache/download/sumdb"
       cp -r "''${GOPATH}/pkg/mod/cache/download" $out
 
       runHook postInstall


### PR DESCRIPTION
Since GO 1.13, the go command uses by default [1]
GOPROXY="https://proxy.golang.org,direct" as module proxy, which caches
the latest signed tree size and tree hash in $GOPATH[2], hence producing
a different hash every time proxy.golang.org/latest changes.

[1] https://golang.org/cmd/go/#hdr-Module_downloading_and_verification
[2] https://go.googlesource.com/proposal/+/master/design/25530-sumdb.md#command-client

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc: @kalbasit, @c00w, @rvolosatovs
