### PR TITLE
[19.09] networkmanager: 1.18.2 -> 1.18.4

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -10,11 +10,11 @@ let
   pythonForDocs = python3.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in stdenv.mkDerivation rec {
   pname = "network-manager";
-  version = "1.18.2";
+  version = "1.18.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${stdenv.lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "1hx5dx5dgdqh3p8fq7q1pxy2bx2iymc74lj60ycrf7ydfjlprnad";
+    sha256 = "0pnh1wr2p1fqa5pr945fr3lngfc5ccfrmgddqsg55lxnjpv0ggd3";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -1,6 +1,8 @@
+diff --git a/clients/common/nm-vpn-helpers.c b/clients/common/nm-vpn-helpers.c
+index 081d60561..3b686f754 100644
 --- a/clients/common/nm-vpn-helpers.c
 +++ b/clients/common/nm-vpn-helpers.c
-@@ -214,10 +214,7 @@
+@@ -216,10 +216,7 @@ nm_vpn_openconnect_authenticate_helper (const char *host,
  		NULL,
  	};
  
@@ -10,11 +12,13 @@
 -		return FALSE;
 +	path = "@openconnect@/bin/openconnect";
  
- 	argv[0] = (char *) path;
- 	argv[1] = "--authenticate";
+ 	if (!g_spawn_sync (NULL,
+ 	                   (char **) NM_MAKE_STRV (path, "--authenticate", host),
+diff --git a/data/84-nm-drivers.rules b/data/84-nm-drivers.rules
+index d246ef6ce..f0e94ea6b 100644
 --- a/data/84-nm-drivers.rules
 +++ b/data/84-nm-drivers.rules
-@@ -7,6 +7,6 @@
+@@ -7,6 +7,6 @@ ACTION!="add|change", GOTO="nm_drivers_end"
  # Determine ID_NET_DRIVER if there's no ID_NET_DRIVER or DRIVERS (old udev?)
  ENV{ID_NET_DRIVER}=="?*", GOTO="nm_drivers_end"
  DRIVERS=="?*", GOTO="nm_drivers_end"
@@ -22,9 +26,11 @@
 +PROGRAM="@shell@ -c '@ethtool@/bin/ethtool -i $1 | @gnused@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
  
  LABEL="nm_drivers_end"
+diff --git a/data/NetworkManager.service.in b/data/NetworkManager.service.in
+index ff90456ff..a007f7021 100644
 --- a/data/NetworkManager.service.in
 +++ b/data/NetworkManager.service.in
-@@ -8,7 +8,7 @@
+@@ -8,7 +8,7 @@ Before=network.target @DISTRO_NETWORK_SERVICE@
  [Service]
  Type=dbus
  BusName=org.freedesktop.NetworkManager
@@ -33,9 +39,33 @@
  #ExecReload=/bin/kill -HUP $MAINPID
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
+diff --git a/libnm/meson.build b/libnm/meson.build
+index 2938d35d5..4b3df97f1 100644
+--- a/libnm/meson.build
++++ b/libnm/meson.build
+@@ -269,7 +269,7 @@ if enable_introspection
+     name,
+     input: libnm_gir[0],
+     output: name,
+-    command: [generate_setting_docs_env, python.path(), generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--output', '@OUTPUT@'],
++    command: [generate_setting_docs_env, generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--output', '@OUTPUT@'],
+     depends: libnm_gir,
+   )
+ 
+@@ -278,7 +278,7 @@ if enable_introspection
+     name,
+     input: libnm_gir[0],
+     output: name,
+-    command: [generate_setting_docs_env, python.path(), generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--overrides', nm_settings_docs_overrides, '--output', '@OUTPUT@'],
++    command: [generate_setting_docs_env, generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--overrides', nm_settings_docs_overrides, '--output', '@OUTPUT@'],
+     depends: libnm_gir,
+   )
+ endif
+diff --git a/src/devices/nm-device.c b/src/devices/nm-device.c
+index 43f03739b..3fb27ddbd 100644
 --- a/src/devices/nm-device.c
 +++ b/src/devices/nm-device.c
-@@ -12451,14 +12451,14 @@ nm_device_start_ip_check (NMDevice *self)
+@@ -12621,14 +12621,14 @@ nm_device_start_ip_check (NMDevice *self)
  			gw = nm_ip4_config_best_default_route_get (priv->ip_config_4);
  			if (gw) {
  				nm_utils_inet4_ntop (NMP_OBJECT_CAST_IP4_ROUTE (gw)->gateway, buf);
@@ -53,7 +83,7 @@
  			}
  		}
 diff --git a/src/nm-core-utils.c b/src/nm-core-utils.c
-index 6f55e62a7..93721e7fb 100644
+index fd1628027..e8a554edf 100644
 --- a/src/nm-core-utils.c
 +++ b/src/nm-core-utils.c
 @@ -442,7 +442,7 @@ nm_utils_modprobe (GError **error, gboolean suppress_error_logging, const char *


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Patch update is for [0], as they've backported this commit.

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/blob/1.18.4/NEWS

[0]: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/commit/c162dc00e50431f3db2f560201051c0884ebbb1a

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

@NixOS/backports 
