### PR TITLE
services.xserver.imwheel: add module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -866,6 +866,7 @@
   ./services/x11/hardware/digimend.nix
   ./services/x11/hardware/cmt.nix
   ./services/x11/gdk-pixbuf.nix
+  ./services/x11/imwheel.nix
   ./services/x11/redshift.nix
   ./services/x11/urxvtd.nix
   ./services/x11/window-managers/awesome.nix

--- a/nixos/modules/services/x11/imwheel.nix
+++ b/nixos/modules/services/x11/imwheel.nix
@@ -1,0 +1,68 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.xserver.imwheel;
+in
+  {
+    options = {
+      services.xserver.imwheel = {
+        enable = mkEnableOption "IMWheel service";
+
+        extraOptions = mkOption {
+          type = types.listOf types.str;
+          default = [ "--buttons 45" ];
+          example = [ "--debug" ];
+          description = ''
+            Additional command-line arguments to pass to
+            <command>imwheel</command>.
+          '';
+        };
+
+        rules = mkOption {
+          type = types.attrsOf types.str;
+          default = {};
+          example = literalExample ''
+            ".*" = '''
+              None,      Up,   Button4, 8
+              None,      Down, Button5, 8
+              Shift_L,   Up,   Shift_L|Button4, 4
+              Shift_L,   Down, Shift_L|Button5, 4
+              Control_L, Up,   Control_L|Button4
+              Control_L, Down, Control_L|Button5
+            ''';
+          '';
+          description = ''
+            Window class translation rules.
+            /etc/X11/imwheelrc is generated based on this config
+            which means this config is global for all users.
+            See <link xlink:href="http://imwheel.sourceforge.net/imwheel.1.html">offical man pages</link>
+            for more informations.
+          '';
+        };
+      };
+    };
+
+    config = mkIf cfg.enable {
+      environment.systemPackages = [ pkgs.imwheel ];
+
+      environment.etc."X11/imwheel/imwheelrc".source =
+        pkgs.writeText "imwheelrc" (concatStringsSep "\n\n"
+          (mapAttrsToList
+            (rule: conf: "\"${rule}\"\n${conf}") cfg.rules
+          ));
+
+      systemd.user.services.imwheel = {
+        description = "imwheel service";
+        wantedBy = [ "graphical-session.target" ];
+        partOf = [ "graphical-session.target" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.imwheel}/bin/imwheel " + escapeShellArgs ([
+            "--detach"
+            "--kill"
+          ] ++ cfg.extraOptions);
+          ExecStop = "${pkgs.procps}/bin/pkill imwheel";
+          Restart = "on-failure";
+        };
+      };
+    };
+  }

--- a/pkgs/tools/X11/imwheel/default.nix
+++ b/pkgs/tools/X11/imwheel/default.nix
@@ -10,10 +10,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libX11 libXext libXi libXmu libXt libXtst ];
 
-  postPatch = ''
-    substituteInPlace Makefile.in --replace "ETCDIR = " "ETCDIR = $out"
-    substituteInPlace util.c --replace "/etc/X11/imwheel" "$out/etc/X11/imwheel"
-  '';
+  makeFlags = [
+    "sysconfdir=/etc"
+    "ETCDIR=/etc"
+  ];
+
+  installFlags = [
+    "sysconfdir=${placeholder "out"}/etc"
+    "ETCDIR=${placeholder "out"}/etc"
+  ];
 
   meta = with stdenv.lib; {
     homepage = "http://imwheel.sourceforge.net/";


### PR DESCRIPTION
Add [IMWheel](https://wiki.archlinux.org/index.php/IMWheel) module.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
