### PR TITLE
lightdm: hardcode path to plymouth

### DIFF
--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -1,8 +1,32 @@
-{ stdenv, fetchFromGitHub, pam, pkgconfig, autoconf, automake, libtool, libxcb
-, glib, libXdmcp, itstool, intltool, libxklavier, libgcrypt, audit, busybox
-, polkit, accountsservice, gtk-doc, gnome3, gobject-introspection, vala, fetchpatch
-, withQt4 ? false, qt4
-, withQt5 ? false, qtbase
+{ stdenv
+, fetchFromGitHub
+, substituteAll
+, plymouth
+, pam
+, pkgconfig
+, autoconf
+, automake
+, libtool
+, libxcb
+, glib
+, libXdmcp
+, itstool
+, intltool
+, libxklavier
+, libgcrypt
+, audit
+, busybox
+, polkit
+, accountsservice
+, gtk-doc
+, gnome3
+, gobject-introspection
+, vala
+, fetchpatch
+, withQt4 ? false
+, qt4
+, withQt5 ? false
+, qtbase
 }:
 
 with stdenv.lib;
@@ -53,10 +77,19 @@ stdenv.mkDerivation rec {
       url = "https://src.fedoraproject.org/rpms/lightdm/raw/4cf0d2bed8d1c68970b0322ccd5dbbbb7a0b12bc/f/lightdm-1.25.1-disable_dmrc.patch";
       sha256 = "06f7iabagrsiws2l75sx2jyljknr9js7ydn151p3qfi104d1541n";
     })
+
     # Don't use etc/dbus-1/system.d
     (fetchpatch {
       url = "https://github.com/canonical/lightdm/commit/a99376f5f51aa147aaf81287d7ce70db76022c47.patch";
       sha256 = "1zyx1qqajrmqcf9hbsapd39gmdanswd9l78rq7q6rdy4692il3yn";
+    })
+
+    # Hardcode plymouth to fix transitions.
+    # For some reason it can't find `plymouth`
+    # even when it's in PATH in environment.systemPackages.
+    (substituteAll {
+      src = ./fix-paths.patch;
+      plymouth = "${plymouth}/bin/plymouth";
     })
   ];
 

--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -116,6 +116,10 @@ stdenv.mkDerivation rec {
       --replace /bin/rm ${busybox}/bin/rm
   '';
 
+  postInstall = ''
+    rm -rf $out/etc/apparmor.d $out/etc/init $out/etc/pam.d
+  '';
+
   meta = {
     homepage = https://github.com/CanonicalLtd/lightdm;
     description = "A cross-desktop display manager";

--- a/pkgs/applications/display-managers/lightdm/fix-paths.patch
+++ b/pkgs/applications/display-managers/lightdm/fix-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/src/plymouth.c b/src/plymouth.c
+index d1ed91f4..318f9409 100644
+--- a/src/plymouth.c
++++ b/src/plymouth.c
+@@ -24,7 +24,7 @@ static gboolean has_active_vt = FALSE;
+ static gboolean
+ plymouth_run_command (const gchar *command, gint *exit_status)
+ {
+-    g_autofree gchar *command_line = g_strdup_printf ("plymouth %s", command);
++    g_autofree gchar *command_line = g_strdup_printf ("@plymouth@ %s", command);
+     g_autoptr(GError) error = NULL;
+     gboolean result = g_spawn_command_line_sync (command_line, NULL, NULL, exit_status, &error);
+ 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/71061 uncovered that lightdm's way of communicating to plymouth is broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
