### PR TITLE
ripcord: init at 0.4.18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4101,6 +4101,12 @@
     githubId = 1377571;
     name = "Matthew S. Daiter";
   };
+  MDeltaX = {
+    email = "mdeltax@tuta.io";
+    github = "MDeltaX";
+    githubId = 18199828;
+    name = "Maximilian König";
+  };
   mdevlamynck = {
     email = "matthias.devlamynck@mailoo.org";
     github = "mdevlamynck";

--- a/pkgs/applications/networking/instant-messengers/ripcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ripcord/default.nix
@@ -6,7 +6,7 @@ let
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "https://cancel.fm/dl/${pname}-${version}-x86_64.AppImage";
+    url = "https://cancel.fm/dl/${name}-x86_64.AppImage";
     sha256 = "19nv5pq8643l57hr5bdgn84rrw3ak2p9s16gr202nvi62flnl44p";
   };
 

--- a/pkgs/applications/networking/instant-messengers/ripcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ripcord/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, appimageTools }:
+
+let
+  pname = "Ripcord";
+  version = "0.4.18";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://cancel.fm/dl/${pname}-${version}-x86_64.AppImage";
+    sha256 = "19nv5pq8643l57hr5bdgn84rrw3ak2p9s16gr202nvi62flnl44p";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+in appimageTools.wrapType2 rec {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/Ripcord.desktop $out/share/applications/Ripcord.desktop
+    install -m 444 -D ${appimageContents}/Ripcord_Icon.png $out/share/icons/hicolor/512x512/apps/Ripcord_Icon.png
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A desktop chat client for Discord and Slack";
+    homepage = "https://cancel.fm/ripcord/";
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ MDeltaX ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/ripcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ripcord/default.nix
@@ -22,7 +22,7 @@ in appimageTools.wrapType2 rec {
     install -m 444 -D ${appimageContents}/Ripcord_Icon.png $out/share/icons/hicolor/512x512/apps/Ripcord_Icon.png
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A desktop chat client for Discord and Slack";
     homepage = "https://cancel.fm/ripcord/";
     license = licenses.unfreeRedistributable;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5926,6 +5926,8 @@ in
   riemann_c_client = callPackage ../tools/misc/riemann-c-client { };
   riemann-tools = callPackage ../tools/misc/riemann-tools { };
 
+  ripcord = callPackage ../applications/networking/instant-messengers/ripcord { };
+
   ripmime = callPackage ../tools/networking/ripmime {};
 
   rkflashtool = callPackage ../tools/misc/rkflashtool { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

> Ripcord is a desktop chat client for group-centric services like Slack and Discord. It provides a traditional compact desktop interface designed for power users. It's not built on top of web browser technology: it responds quickly to input, sips gently from computer resources, and gets out of your way. It does voice chat, too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ldesgoui @MP2E @tadeokondrak
