### PR TITLE
haskellPackages.rank2classes: not broken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8188,7 +8188,6 @@ broken-packages:
   - range-space
   - rangemin
   - rank1dynamic
-  - rank2classes
   - Ranka
   - rapid-term
   - rasa


### PR DESCRIPTION
###### Motivation for this change

Partial fix for #68468 (rank2classes). Fixed constraints for `grammatical-parsers` are still coming down the pipeline, but if [this discussion](https://github.com/blamario/grampa/pull/18#discussion_r334234501) does not result in a fixed sdist for that package, I will PR a `dontCheck` change.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti
