### PR TITLE
sshfs: add ssh program to the environment

### DIFF
--- a/pkgs/tools/filesystems/sshfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/sshfs-fuse/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, fetchFromGitHub, meson, pkgconfig, ninja, docutils
+{ stdenv, fetchFromGitHub, meson, pkgconfig, ninja, docutils, makeWrapper
 , fuse3, glib
 , which, python3Packages
+, openssh
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "0gvk8snivpi2sjidjnd9ypc66ny7lr0z9v4swl56rwjv539dkbx2";
   };
 
-  nativeBuildInputs = [ meson pkgconfig ninja docutils ];
+  nativeBuildInputs = [ meson pkgconfig ninja docutils makeWrapper ];
   buildInputs = [ fuse3 glib ];
   checkInputs = [ which python3Packages.pytest ];
 
@@ -25,6 +26,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/sbin
     ln -sf $out/bin/sshfs $out/sbin/mount.sshfs
+    wrapProgram $out/bin/sshfs --prefix PATH : "${openssh}/bin"
   '';
 
   #doCheck = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

sshfs calls the "ssh" program, without it being in the closure. For me, this makes the "sftp" plugin of kdeconnect work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Result of `nix-review` [1](https://github.com/Mic92/nix-review)
<details>
  <summary>6 package were build:</summary>

  - backintime-common (sshfsFuse)
  - kdeconnect (sshfsFuse)
  - rmount (sshfsFuse)
  - sshfs (sshfsFuse)
  - telepresence (sshfsFuse)
  - x2goserver (sshfsFuse)
</details>

###### Notify maintainers

cc @primeos 
