### PR TITLE
betaflight-configurator: 10.5.1 -> 10.6.0

### DIFF
--- a/pkgs/applications/science/robotics/betaflight-configurator/default.nix
+++ b/pkgs/applications/science/robotics/betaflight-configurator/default.nix
@@ -1,22 +1,22 @@
 {stdenv, fetchurl, unzip, makeDesktopItem, nwjs, wrapGAppsHook, gsettings-desktop-schemas, gtk3 }:
 
 let
-  strippedName = "betaflight-configurator";
+  pname = "betaflight-configurator";
   desktopItem = makeDesktopItem {
-    name = strippedName;
-    exec = strippedName;
-    icon = "${strippedName}-icon.png";
+    name = pname;
+    exec = pname;
+    icon = pname;
     comment = "Betaflight configuration tool";
     desktopName = "Betaflight Configurator";
     genericName = "Flight controller configuration tool";
   };
 in
 stdenv.mkDerivation rec {
-  name = "${strippedName}-${version}";
-  version = "10.5.1";
+  inherit pname;
+  version = "10.6.0";
   src = fetchurl {
-    url = "https://github.com/betaflight/betaflight-configurator/releases/download/${version}/${strippedName}_${version}_linux64.zip";
-    sha256 = "1l4blqgaqfrnydk05q6pwdqdhcly2f8nwzrv0749cqmfiinh8ygc";
+    url = "https://github.com/betaflight/${pname}/releases/download/${version}/${pname}_${version}_linux64.zip";
+    sha256 = "09hayzhwangh8b81r038p320vbg0xxlyzrdp9pcmfyxp6s00xslw";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];
@@ -25,14 +25,13 @@ stdenv.mkDerivation rec {
   
   installPhase = ''
     mkdir -p $out/bin \
-             $out/opt/${strippedName} \
-             $out/share/icons
+             $out/opt/${pname}
 
-    cp -r . $out/opt/${strippedName}/
-    cp icon/*_icon_128.png $out/share/icons/${strippedName}-icon.png
+    cp -r . $out/opt/${pname}/
+    install -m 444 -D icon/bf_icon_128.png $out/share/icons/hicolor/128x128/apps/${pname}.png
     cp -r ${desktopItem}/share/applications $out/share/
 
-    makeWrapper ${nwjs}/bin/nw $out/bin/${strippedName} --add-flags $out/opt/${strippedName}
+    makeWrapper ${nwjs}/bin/nw $out/bin/${pname} --add-flags $out/opt/${pname}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Also fix icon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @wucke13