### PR TITLE
doc/stdenv.xml: wrapProgram buildInput requirement

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1692,7 +1692,7 @@ someVar=$(stripHash $name)
     </term>
     <listitem>
      <para>
-      Convenience function for <literal>makeWrapper</literal> that automatically creates a sane wrapper file It takes all the same arguments as <literal>makeWrapper</literal>, except for <literal>--argv0</literal>.
+      Convenience function for <literal>makeWrapper</literal> (needs the same as a build input) that automatically creates a sane wrapper file It takes all the same arguments as <literal>makeWrapper</literal>, except for <literal>--argv0</literal>.
      </para>
      <para>
       It cannot be applied multiple times, since it will overwrite the wrapper file.


### PR DESCRIPTION
Added `buildInput` requirement for `wrapProgram`, fixes https://github.com/NixOS/nixpkgs/issues/57792.

Please comment for improvement or discard if not appropriate for inclusion.