### PR TITLE
testing: Configure the login shell of the backdoor service

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.xml
+++ b/nixos/doc/manual/development/writing-nixos-tests.xml
@@ -8,7 +8,7 @@
  <para>
   A NixOS test is a Nix expression that has the following structure:
 <programlisting>
-import ./make-test.nix {
+import ./make-test.nix {} {
 
   # Either the configuration of a single machine:
   machine =

--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -7,6 +7,8 @@
 , pkgs
 , # NixOS configuration to add to the VMs
   extraConfigurations ? []
+, # The shell used for accessing the VM through the backdoor
+  backdoorShell ? null
 }:
 
 with pkgs.lib;
@@ -35,7 +37,7 @@ rec {
       modules = configurations ++ extraConfigurations;
       baseModules =  (import ../modules/module-list.nix) ++
         [ ../modules/virtualisation/qemu-vm.nix
-          ../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
+          (import ../modules/testing/test-instrumentation.nix { inherit config pkgs backdoorShell; lib = pkgs.lib; } )# !!! should only get added for automated test runs
           { key = "no-manual"; documentation.nixos.enable = false; }
           { key = "qemu"; system.build.qemu = qemu; }
           { key = "nodes"; _module.args.nodes = nodes; }

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -5,9 +5,12 @@
   # Ignored
 , config ? {}
   # Modules to add to each VM
-, extraConfigurations ? [] }:
+, extraConfigurations ? []
+  # Backdoor shell to be used when accessing the VM
+, backdoorShell ? null
+}:
 
-with import ./build-vms.nix { inherit system pkgs minimal extraConfigurations; };
+with import ./build-vms.nix { inherit system pkgs minimal extraConfigurations backdoorShell; };
 with pkgs;
 
 let

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -1,7 +1,7 @@
 # This module allows the test driver to connect to the virtual machine
 # via a root shell attached to port 514.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, backdoorShell ? null, ... }:
 
 with lib;
 with import ../../lib/qemu-flags.nix { inherit pkgs; };
@@ -43,7 +43,7 @@ with import ../../lib/qemu-flags.nix { inherit pkgs; };
             echo "connecting to host..." >&2
             stty -F /dev/hvc0 raw -echo # prevent nl -> cr/nl conversion
             echo
-            PS1= exec /bin/sh
+            PS1= exec ${if (backdoorShell != null) then backdoorShell else "/bin/sh"}
           '';
         serviceConfig.KillSignal = "SIGHUP";
       };

--- a/nixos/tests/ammonite.nix
+++ b/nixos/tests/ammonite.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "ammonite";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus ];

--- a/nixos/tests/atd.nix
+++ b/nixos/tests/atd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "atd";

--- a/nixos/tests/automysqlbackup.nix
+++ b/nixos/tests/automysqlbackup.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 
 {
   name = "automysqlbackup";

--- a/nixos/tests/avahi.nix
+++ b/nixos/tests/avahi.nix
@@ -1,5 +1,5 @@
 # Test whether `avahi-daemon' and `libnss-mdns' work as expected.
-import ./make-test.nix ({ pkgs, ... } : {
+import ./make-test.nix {} ({ pkgs, ... } : {
   name = "avahi";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco ];

--- a/nixos/tests/bcachefs.nix
+++ b/nixos/tests/bcachefs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "bcachefs";
   meta.maintainers = with pkgs.stdenv.lib.maintainers; [ chiiruno ];
 

--- a/nixos/tests/beanstalkd.nix
+++ b/nixos/tests/beanstalkd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 
 let
   pythonEnv = pkgs.python3.withPackages (p: [p.beanstalkc]);

--- a/nixos/tests/beegfs.nix
+++ b/nixos/tests/beegfs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... } :
+import ./make-test.nix {} ({ ... } :
 
 let
   connAuthFile="beegfs/auth-def.key";

--- a/nixos/tests/bees.nix
+++ b/nixos/tests/bees.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test.nix {} ({ lib, ... }:
 {
   name = "bees";
 

--- a/nixos/tests/bittorrent.nix
+++ b/nixos/tests/bittorrent.nix
@@ -6,7 +6,7 @@
 # which only works if the first client successfully uses the UPnP-IGD
 # protocol to poke a hole in the NAT.
 
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 let
 

--- a/nixos/tests/blivet.nix
+++ b/nixos/tests/blivet.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: with pkgs.python2Packages; rec {
+import ./make-test.nix {} ({ pkgs, ... }: with pkgs.python2Packages; rec {
   name = "blivet";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aszlig ];

--- a/nixos/tests/boot-stage1.nix
+++ b/nixos/tests/boot-stage1.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "boot-stage1";
 
   machine = { config, pkgs, lib, ... }: {

--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -1,9 +1,10 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  pkgs ? import ../.. { inherit system config; },
+  backdoorShell ? null
 }:
 
-with import ../lib/testing.nix { inherit system pkgs; };
+with import ../lib/testing.nix { inherit system pkgs backdoorShell; };
 with pkgs.lib;
 
 let
@@ -13,7 +14,7 @@ let
       inherit system;
       modules =
         [ ../modules/installer/cd-dvd/installation-cd-minimal.nix
-          ../modules/testing/test-instrumentation.nix
+          (import ../modules/testing/test-instrumentation.nix { inherit config pkgs backdoorShell; lib = pkgs.lib; })
         ];
     }).config.system.build.isoImage;
 
@@ -48,7 +49,7 @@ let
           inherit system;
           modules =
             [ ../modules/installer/netboot/netboot.nix
-              ../modules/testing/test-instrumentation.nix
+              (import ../modules/testing/test-instrumentation.nix { inherit config pkgs backdoorShell; lib = pkgs.lib; })
               { key = "serial"; }
             ];
         }).config;

--- a/nixos/tests/borgbackup.nix
+++ b/nixos/tests/borgbackup.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 let
   passphrase = "supersecret";

--- a/nixos/tests/cadvisor.nix
+++ b/nixos/tests/cadvisor.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... } : {
+import ./make-test.nix {} ({ pkgs, ... } : {
   name = "cadvisor";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ offline ];

--- a/nixos/tests/cassandra.nix
+++ b/nixos/tests/cassandra.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 let
   # Change this to test a different version of Cassandra:
   testPackage = pkgs.cassandra;

--- a/nixos/tests/ceph.nix
+++ b/nixos/tests/ceph.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({pkgs, lib, ...}: {
+import ./make-test.nix {} ({pkgs, lib, ...}: {
   name = "All-in-one-basic-ceph-cluster";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ johanot lejonet ];

--- a/nixos/tests/cfssl.nix
+++ b/nixos/tests/cfssl.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "cfssl";
 
   machine = { config, lib, pkgs, ... }:

--- a/nixos/tests/cjdns.nix
+++ b/nixos/tests/cjdns.nix
@@ -17,7 +17,7 @@ let
 
 in
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "cjdns";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ehmry ];

--- a/nixos/tests/clickhouse.nix
+++ b/nixos/tests/clickhouse.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "clickhouse";
   meta.maintainers = with pkgs.stdenv.lib.maintainers; [ ma27 ];
 

--- a/nixos/tests/cockroachdb.nix
+++ b/nixos/tests/cockroachdb.nix
@@ -95,7 +95,7 @@ let
       '';
     };
 
-in import ./make-test.nix ({ pkgs, ...} : {
+in import ./make-test.nix {} ({ pkgs, ...} : {
   name = "cockroachdb";
   meta.maintainers = with pkgs.stdenv.lib.maintainers;
     [ thoughtpolice ];

--- a/nixos/tests/codimd.nix
+++ b/nixos/tests/codimd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 {
   name = "codimd";
 

--- a/nixos/tests/colord.nix
+++ b/nixos/tests/colord.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "colord";

--- a/nixos/tests/containers-bridge.nix
+++ b/nixos/tests/containers-bridge.nix
@@ -7,7 +7,7 @@ let
   containerIp6 = "fc00::2/7";
 in
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-bridge";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aristid aszlig eelco kampfschlaefer ];

--- a/nixos/tests/containers-ephemeral.nix
+++ b/nixos/tests/containers-ephemeral.nix
@@ -1,6 +1,6 @@
 # Test for NixOS' container support.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-ephemeral";
 
   machine = { pkgs, ... }: {

--- a/nixos/tests/containers-extra_veth.nix
+++ b/nixos/tests/containers-extra_veth.nix
@@ -1,6 +1,6 @@
 # Test for NixOS' container support.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-bridge";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ kampfschlaefer ];

--- a/nixos/tests/containers-hosts.nix
+++ b/nixos/tests/containers-hosts.nix
@@ -1,6 +1,6 @@
 # Test for NixOS' container support.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-hosts";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ montag451 ];

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -1,6 +1,6 @@
 # Test for NixOS' container support.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-imperative";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aristid aszlig eelco kampfschlaefer ];

--- a/nixos/tests/containers-ipv4.nix
+++ b/nixos/tests/containers-ipv4.nix
@@ -1,6 +1,6 @@
 # Test for NixOS' container support.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-ipv4";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aristid aszlig eelco kampfschlaefer ];

--- a/nixos/tests/containers-ipv6.nix
+++ b/nixos/tests/containers-ipv6.nix
@@ -5,7 +5,7 @@ let
   localIp = "fc00::1";
 in
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-ipv6";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aristid aszlig eelco kampfschlaefer ];

--- a/nixos/tests/containers-macvlans.nix
+++ b/nixos/tests/containers-macvlans.nix
@@ -6,7 +6,7 @@ let
   containerIp2 = "192.168.1.254";
 in
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-macvlans";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ montag451 ];

--- a/nixos/tests/containers-physical_interfaces.nix
+++ b/nixos/tests/containers-physical_interfaces.nix
@@ -1,5 +1,5 @@
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-physical_interfaces";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ kampfschlaefer ];

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -7,7 +7,7 @@ let
   containerPort = 80;
 in 
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-portforward";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aristid aszlig eelco kampfschlaefer ianwookim ];

--- a/nixos/tests/containers-reloadable.nix
+++ b/nixos/tests/containers-reloadable.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ...} :
+import ./make-test.nix {} ({ pkgs, lib, ...} :
 let
   client_base = {
     

--- a/nixos/tests/containers-restart_networking.nix
+++ b/nixos/tests/containers-restart_networking.nix
@@ -16,7 +16,7 @@ let
       };
     };
   };
-in import ./make-test.nix ({ pkgs, ...} :
+in import ./make-test.nix {} ({ pkgs, ...} :
 {
   name = "containers-restart_networking";
   meta = with pkgs.stdenv.lib.maintainers; {

--- a/nixos/tests/containers-tmpfs.nix
+++ b/nixos/tests/containers-tmpfs.nix
@@ -1,6 +1,6 @@
 # Test for NixOS' container support.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "containers-tmpfs";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ kampka ];

--- a/nixos/tests/couchdb.nix
+++ b/nixos/tests/couchdb.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ...}:
+import ./make-test.nix {} ({ pkgs, lib, ...}:
 
 with lib;
 

--- a/nixos/tests/deluge.nix
+++ b/nixos/tests/deluge.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "deluge";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ flokli ];

--- a/nixos/tests/dnscrypt-proxy.nix
+++ b/nixos/tests/dnscrypt-proxy.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "dnscrypt-proxy";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ joachifm ];

--- a/nixos/tests/docker-containers.nix
+++ b/nixos/tests/docker-containers.nix
@@ -1,6 +1,6 @@
 # Test Docker containers as systemd units
 
-import ./make-test.nix ({ pkgs, lib, ... }: {
+import ./make-test.nix {} ({ pkgs, lib, ... }: {
   name = "docker-containers";
   meta = {
     maintainers = with lib.maintainers; [ benley ];

--- a/nixos/tests/docker-edge.nix
+++ b/nixos/tests/docker-edge.nix
@@ -1,6 +1,6 @@
 # This test runs docker and checks if simple container starts
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "docker";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus offline ];

--- a/nixos/tests/docker-preloader.nix
+++ b/nixos/tests/docker-preloader.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "docker-preloader";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ lewo ];

--- a/nixos/tests/docker-registry.nix
+++ b/nixos/tests/docker-registry.nix
@@ -1,6 +1,6 @@
 # This test runs docker-registry and check if it works
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "docker-registry";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ globin ma27 ironpinguin ];

--- a/nixos/tests/docker-tools-overlay.nix
+++ b/nixos/tests/docker-tools-overlay.nix
@@ -1,6 +1,6 @@
 # this test creates a simple GNU image with docker tools and sees if it executes
 
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 {
   name = "docker-tools-overlay";
   meta = with pkgs.stdenv.lib.maintainers; {

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -1,6 +1,6 @@
 # this test creates a simple GNU image with docker tools and sees if it executes
 
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "docker-tools";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ lnl7 ];

--- a/nixos/tests/docker.nix
+++ b/nixos/tests/docker.nix
@@ -1,6 +1,6 @@
 # This test runs docker and checks if simple container starts
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "docker";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus offline ];

--- a/nixos/tests/documize.nix
+++ b/nixos/tests/documize.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ...} : {
+import ./make-test.nix {} ({ pkgs, lib, ...} : {
   name = "documize";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ma27 ];

--- a/nixos/tests/ecryptfs.nix
+++ b/nixos/tests/ecryptfs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test.nix {} ({ ... }:
 {
   name = "ecryptfs";
 

--- a/nixos/tests/emacs-daemon.nix
+++ b/nixos/tests/emacs-daemon.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "emacs-daemon";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ];

--- a/nixos/tests/env.nix
+++ b/nixos/tests/env.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "environment";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus ];

--- a/nixos/tests/etcd-cluster.nix
+++ b/nixos/tests/etcd-cluster.nix
@@ -1,6 +1,6 @@
 # This test runs simple etcd cluster
 
-import ./make-test.nix ({ pkgs, ... } : let
+import ./make-test.nix {} ({ pkgs, ... } : let
 
   runWithOpenSSL = file: cmd: pkgs.runCommand file {
     buildInputs = [ pkgs.openssl ];

--- a/nixos/tests/etcd.nix
+++ b/nixos/tests/etcd.nix
@@ -1,6 +1,6 @@
 # This test runs simple etcd node
 
-import ./make-test.nix ({ pkgs, ... } : {
+import ./make-test.nix {} ({ pkgs, ... } : {
   name = "etcd";
 
   meta = with pkgs.stdenv.lib.maintainers; {

--- a/nixos/tests/ferm.nix
+++ b/nixos/tests/ferm.nix
@@ -1,5 +1,5 @@
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "ferm";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ mic92 ];

--- a/nixos/tests/firefox.nix
+++ b/nixos/tests/firefox.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "firefox";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco shlevy ];

--- a/nixos/tests/firewall.nix
+++ b/nixos/tests/firewall.nix
@@ -1,6 +1,6 @@
 # Test the firewall module.
 
-import ./make-test.nix ( { pkgs, ... } : {
+import ./make-test.nix {} ( { pkgs, ... } : {
   name = "firewall";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco ];

--- a/nixos/tests/fish.nix
+++ b/nixos/tests/fish.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "fish";
 
   machine =

--- a/nixos/tests/flannel.nix
+++ b/nixos/tests/flannel.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "flannel";
 
   meta = with pkgs.stdenv.lib.maintainers; {

--- a/nixos/tests/flatpak-builder.nix
+++ b/nixos/tests/flatpak-builder.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "flatpak-builder";

--- a/nixos/tests/flatpak.nix
+++ b/nixos/tests/flatpak.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "flatpak";

--- a/nixos/tests/fluentd.nix
+++ b/nixos/tests/fluentd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }: {
+import ./make-test.nix {} ({ pkgs, lib, ... }: {
   name = "fluentd";
 
   machine = { pkgs, ... }: {

--- a/nixos/tests/fontconfig-default-fonts.nix
+++ b/nixos/tests/fontconfig-default-fonts.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test.nix {} ({ lib, ... }:
 {
   name = "fontconfig-default-fonts";
 

--- a/nixos/tests/fwupd.nix
+++ b/nixos/tests/fwupd.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "fwupd";
 
   meta = {

--- a/nixos/tests/gdk-pixbuf.nix
+++ b/nixos/tests/gdk-pixbuf.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "gdk-pixbuf";
 
   meta = {

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -3,7 +3,7 @@
 let
   initialRootPassword = "notproduction";
 in
-import ./make-test.nix ({ pkgs, lib, ...} : with lib; {
+import ./make-test.nix {} ({ pkgs, lib, ...} : with lib; {
   name = "gitlab";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ globin ];

--- a/nixos/tests/gitolite.nix
+++ b/nixos/tests/gitolite.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...}:
+import ./make-test.nix {} ({ pkgs, ...}:
 
 let
   adminPrivateKey = pkgs.writeText "id_ed25519" ''

--- a/nixos/tests/gjs.nix
+++ b/nixos/tests/gjs.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "gjs";
 
   meta = {

--- a/nixos/tests/glib-networking.nix
+++ b/nixos/tests/glib-networking.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "glib-networking";

--- a/nixos/tests/glusterfs.nix
+++ b/nixos/tests/glusterfs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... } :
+import ./make-test.nix {} ({ ... } :
 
 let
   client = { pkgs, ... } : {

--- a/nixos/tests/gnome-photos.nix
+++ b/nixos/tests/gnome-photos.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 
 let
 

--- a/nixos/tests/gnome3-xorg.nix
+++ b/nixos/tests/gnome3-xorg.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "gnome3-xorg";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = pkgs.gnome3.maintainers;

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "gnome3";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = pkgs.gnome3.maintainers;

--- a/nixos/tests/gocd-agent.nix
+++ b/nixos/tests/gocd-agent.nix
@@ -9,7 +9,7 @@ let
   header = "Accept: application/vnd.go.cd.v2+json";
 in
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "gocd-agent";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ grahamc swarren83 ];

--- a/nixos/tests/gocd-server.nix
+++ b/nixos/tests/gocd-server.nix
@@ -2,7 +2,7 @@
 #   1. GoCD server starts
 #   2. GoCD server responds
 
-import ./make-test.nix ({ pkgs, ...} :
+import ./make-test.nix {} ({ pkgs, ...} :
 
 {
   name = "gocd-server";

--- a/nixos/tests/google-oslogin/default.nix
+++ b/nixos/tests/google-oslogin/default.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ pkgs, ... } :
+import ../make-test.nix {} ({ pkgs, ... } :
 let
   inherit (import ./../ssh-keys.nix pkgs)
     snakeOilPrivateKey snakeOilPublicKey;

--- a/nixos/tests/grafana.nix
+++ b/nixos/tests/grafana.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, pkgs, ... }:
+import ./make-test.nix {} ({ lib, pkgs, ... }:
 
 let
   inherit (lib) mkMerge nameValuePair maintainers;

--- a/nixos/tests/graphene.nix
+++ b/nixos/tests/graphene.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "graphene";

--- a/nixos/tests/graphite.nix
+++ b/nixos/tests/graphite.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... } :
+import ./make-test.nix {} ({ pkgs, ... } :
 {
   name = "graphite";
   nodes = {

--- a/nixos/tests/graylog.nix
+++ b/nixos/tests/graylog.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }: {
+import ./make-test.nix {} ({ pkgs, lib, ... }: {
   name = "graylog";
   meta.maintainers = with lib.maintainers; [ ma27 ];
 

--- a/nixos/tests/hadoop/hdfs.nix
+++ b/nixos/tests/hadoop/hdfs.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({...}: {
+import ../make-test.nix {} ({...}: {
   nodes = {
     namenode = {pkgs, ...}: {
       services.hadoop = {

--- a/nixos/tests/hadoop/yarn.nix
+++ b/nixos/tests/hadoop/yarn.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({...}: {
+import ../make-test.nix {} ({...}: {
   nodes = {
     resourcemanager = {pkgs, ...}: {
       services.hadoop.package = pkgs.hadoop_3_1;

--- a/nixos/tests/haka.nix
+++ b/nixos/tests/haka.nix
@@ -1,6 +1,6 @@
 # This test runs haka and probes it with hakactl
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "haka";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ tvestelind ];

--- a/nixos/tests/handbrake.nix
+++ b/nixos/tests/handbrake.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 let
   # Download Big Buck Bunny example, licensed under CC Attribution 3.0.
   testMkv = pkgs.fetchurl {

--- a/nixos/tests/haproxy.nix
+++ b/nixos/tests/haproxy.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...}: {
+import ./make-test.nix {} ({ pkgs, ...}: {
   name = "haproxy";
   nodes = {
     machine = { ... }: {

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "hardened";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ joachifm ];

--- a/nixos/tests/hibernate.nix
+++ b/nixos/tests/hibernate.nix
@@ -1,6 +1,6 @@
 # Test whether hibernation from partition works.
 
-import ./make-test.nix (pkgs: {
+import ./make-test.nix {} (pkgs: {
   name = "hibernate";
 
   nodes = {

--- a/nixos/tests/hitch/default.nix
+++ b/nixos/tests/hitch/default.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ pkgs, ... }:
+import ../make-test.nix {} ({ pkgs, ... }:
 {
   name = "hitch";
   meta = with pkgs.stdenv.lib.maintainers; {

--- a/nixos/tests/hocker-fetchdocker/default.nix
+++ b/nixos/tests/hocker-fetchdocker/default.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ pkgs, ...} : {
+import ../make-test.nix {} ({ pkgs, ...} : {
   name = "test-hocker-fetchdocker";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ixmatus ];

--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 let
   configDir = "/var/lib/foobar";

--- a/nixos/tests/hound.nix
+++ b/nixos/tests/hound.nix
@@ -1,5 +1,5 @@
 # Test whether `houndd` indexes nixpkgs
-import ./make-test.nix ({ pkgs, ... } : {
+import ./make-test.nix {} ({ pkgs, ... } : {
   name = "hound";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ grahamc ];

--- a/nixos/tests/hydra/default.nix
+++ b/nixos/tests/hydra/default.nix
@@ -34,7 +34,7 @@ let
   };
 
   tests = pkgs.lib.flip pkgs.lib.mapAttrs hydraPkgs (name: nix:
-    callTest (import ../make-test.nix ({ pkgs, lib, ... }:
+    callTest (import ../make-test.nix {} ({ pkgs, lib, ... }:
       {
         name = "hydra-with-${name}";
         meta = with pkgs.stdenv.lib.maintainers; {

--- a/nixos/tests/i3wm.nix
+++ b/nixos/tests/i3wm.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "i3wm";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aszlig ];

--- a/nixos/tests/icingaweb2.nix
+++ b/nixos/tests/icingaweb2.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "icingaweb2";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ das_j ];

--- a/nixos/tests/iftop.nix
+++ b/nixos/tests/iftop.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 
 with lib;
 

--- a/nixos/tests/incron.nix
+++ b/nixos/tests/incron.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 
 {
   name = "incron";

--- a/nixos/tests/influxdb.nix
+++ b/nixos/tests/influxdb.nix
@@ -1,6 +1,6 @@
 # This test runs influxdb and checks if influxdb is up and running
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "influxdb";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ offline ];

--- a/nixos/tests/initrd-network-ssh/default.nix
+++ b/nixos/tests/initrd-network-ssh/default.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ lib, ... }:
+import ../make-test.nix {} ({ lib, ... }:
 
 {
   name = "initrd-network-ssh";

--- a/nixos/tests/initrd-network.nix
+++ b/nixos/tests/initrd-network.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "initrd-network";
 
   meta.maintainers = [ pkgs.stdenv.lib.maintainers.eelco ];

--- a/nixos/tests/ipfs.nix
+++ b/nixos/tests/ipfs.nix
@@ -1,5 +1,5 @@
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "ipfs";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ mguentner ];

--- a/nixos/tests/ipv6.nix
+++ b/nixos/tests/ipv6.nix
@@ -1,7 +1,7 @@
 # Test of IPv6 functionality in NixOS, including whether router
 # solicication/advertisement using radvd works.
 
-import ./make-test.nix ({ pkgs, lib, ...} : {
+import ./make-test.nix {} ({ pkgs, lib, ...} : {
   name = "ipv6";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco ];

--- a/nixos/tests/jackett.nix
+++ b/nixos/tests/jackett.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test.nix {} ({ lib, ... }:
 
 with lib;
 

--- a/nixos/tests/jellyfin.nix
+++ b/nixos/tests/jellyfin.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ...}:
+import ./make-test.nix {} ({ lib, ...}:
 
 {
   name = "jellyfin";

--- a/nixos/tests/jenkins.nix
+++ b/nixos/tests/jenkins.nix
@@ -3,7 +3,7 @@
 #   2. jenkins user can be extended on both master and slave
 #   3. jenkins service not started on slave node
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "jenkins";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ bjornfor coconnor domenkozar eelco ];

--- a/nixos/tests/jormungandr.nix
+++ b/nixos/tests/jormungandr.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "jormungandr";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ mmahut ];

--- a/nixos/tests/kerberos/heimdal.nix
+++ b/nixos/tests/kerberos/heimdal.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({pkgs, ...}: {
+import ../make-test.nix {} ({pkgs, ...}: {
   name = "kerberos_server-heimdal";
   machine = { config, libs, pkgs, ...}:
   { services.kerberos_server =

--- a/nixos/tests/kerberos/mit.nix
+++ b/nixos/tests/kerberos/mit.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({pkgs, ...}: {
+import ../make-test.nix {} ({pkgs, ...}: {
   name = "kerberos_server-mit";
   machine = { config, libs, pkgs, ...}:
   { services.kerberos_server =

--- a/nixos/tests/kernel-latest.nix
+++ b/nixos/tests/kernel-latest.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "kernel-latest";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus ];

--- a/nixos/tests/kernel-lts.nix
+++ b/nixos/tests/kernel-lts.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "kernel-lts";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus ];

--- a/nixos/tests/kernel-testing.nix
+++ b/nixos/tests/kernel-testing.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "kernel-testing";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus ];

--- a/nixos/tests/kexec.nix
+++ b/nixos/tests/kexec.nix
@@ -1,6 +1,6 @@
 # Test whether fast reboots via kexec work.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "kexec";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco ];

--- a/nixos/tests/knot.nix
+++ b/nixos/tests/knot.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ...} :
+import ./make-test.nix {} ({ pkgs, lib, ...} :
 let
   common = {
     networking.firewall.enable = false;

--- a/nixos/tests/krb5/deprecated-config.nix
+++ b/nixos/tests/krb5/deprecated-config.nix
@@ -1,7 +1,7 @@
 # Verifies that the configuration suggested in deprecated example values
 # will result in the expected output.
 
-import ../make-test.nix ({ pkgs, ...} : {
+import ../make-test.nix {} ({ pkgs, ...} : {
   name = "krb5-with-deprecated-config";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eqyiel ];

--- a/nixos/tests/krb5/example-config.nix
+++ b/nixos/tests/krb5/example-config.nix
@@ -1,7 +1,7 @@
 # Verifies that the configuration suggested in (non-deprecated) example values
 # will result in the expected output.
 
-import ../make-test.nix ({ pkgs, ...} : {
+import ../make-test.nix {} ({ pkgs, ...} : {
   name = "krb5-with-example-config";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eqyiel ];

--- a/nixos/tests/ldap.nix
+++ b/nixos/tests/ldap.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ...} :
+import ./make-test.nix {} ({ pkgs, lib, ...} :
 
 let
   unlines = lib.concatStringsSep "\n";

--- a/nixos/tests/leaps.nix
+++ b/nixos/tests/leaps.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs,  ... }:
+import ./make-test.nix {} ({ pkgs,  ... }:
 
 {
   name = "leaps";

--- a/nixos/tests/libgdata.nix
+++ b/nixos/tests/libgdata.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "libgdata";

--- a/nixos/tests/libxmlb.nix
+++ b/nixos/tests/libxmlb.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "libxmlb";

--- a/nixos/tests/lidarr.nix
+++ b/nixos/tests/lidarr.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test.nix {} ({ lib, ... }:
 
 with lib;
 

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "lightdm";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aszlig worldofpeace ];

--- a/nixos/tests/limesurvey.nix
+++ b/nixos/tests/limesurvey.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "limesurvey";
   meta.maintainers = [ pkgs.stdenv.lib.maintainers.aanderse ];
 

--- a/nixos/tests/login.nix
+++ b/nixos/tests/login.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, latestKernel ? false, ... }:
+import ./make-test.nix {} ({ pkgs, latestKernel ? false, ... }:
 
 {
   name = "login";

--- a/nixos/tests/loki.nix
+++ b/nixos/tests/loki.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, pkgs, ... }:
+import ./make-test.nix {} ({ lib, pkgs, ... }:
 
 {
   name = "loki";

--- a/nixos/tests/magnetico.nix
+++ b/nixos/tests/magnetico.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "magnetico";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ rnhmjoj ];

--- a/nixos/tests/mailcatcher.nix
+++ b/nixos/tests/mailcatcher.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test.nix {} ({ lib, ... }:
 
 {
   name = "mailcatcher";

--- a/nixos/tests/make-test.nix
+++ b/nixos/tests/make-test.nix
@@ -1,9 +1,11 @@
+{ backdoorShell ? null }:
 f: {
   system ? builtins.currentSystem,
   pkgs ? import ../.. { inherit system; config = {}; },
   ...
 } @ args:
 
-with import ../lib/testing.nix { inherit system pkgs; };
+  with import ../lib/testing.nix { inherit system pkgs backdoorShell; };
 
-makeTest (if pkgs.lib.isFunction f then f (args // { inherit pkgs; inherit (pkgs) lib; }) else f)
+  makeTest (if pkgs.lib.isFunction f then f (args // { inherit pkgs; inherit (pkgs) lib; }) else f)
+

--- a/nixos/tests/mathics.nix
+++ b/nixos/tests/mathics.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "mathics";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ benley ];

--- a/nixos/tests/matrix-synapse.nix
+++ b/nixos/tests/matrix-synapse.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... } : let
+import ./make-test.nix {} ({ pkgs, ... } : let
 
 
   runWithOpenSSL = file: cmd: pkgs.runCommand file {

--- a/nixos/tests/mediawiki.nix
+++ b/nixos/tests/mediawiki.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }: {
+import ./make-test.nix {} ({ pkgs, lib, ... }: {
   name = "mediawiki";
   meta.maintainers = [ lib.maintainers.aanderse ];
 

--- a/nixos/tests/memcached.nix
+++ b/nixos/tests/memcached.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "memcached";
 
   nodes = {

--- a/nixos/tests/mesos.nix
+++ b/nixos/tests/mesos.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : rec {
+import ./make-test.nix {} ({ pkgs, ...} : rec {
   name = "mesos";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ offline kamilchm cstrahan ];

--- a/nixos/tests/metabase.nix
+++ b/nixos/tests/metabase.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "metabase";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ mmahut ];

--- a/nixos/tests/minidlna.nix
+++ b/nixos/tests/minidlna.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "minidlna";
 
   nodes = {

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 
 let
   port = 3142;

--- a/nixos/tests/minio.nix
+++ b/nixos/tests/minio.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} :
+import ./make-test.nix {} ({ pkgs, ...} :
 let
     accessKey = "BKIKJAA5BMMU2RHO6IBB";
     secretKey = "V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12";

--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -1,6 +1,6 @@
 # Miscellaneous small tests that don't warrant their own VM run.
 
-import ./make-test.nix ({ pkgs, ...} : rec {
+import ./make-test.nix {} ({ pkgs, ...} : rec {
   name = "misc";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco ];

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -1,6 +1,6 @@
 # This test start mongodb, runs a query using mongo shell
 
-import ./make-test.nix ({ pkgs, ...} : let
+import ./make-test.nix {} ({ pkgs, ...} : let
   testQuery = pkgs.writeScript "nixtest.js" ''
     db.greetings.insert({ "greeting": "hello" });
     print(db.greetings.findOne().greeting);

--- a/nixos/tests/moodle.nix
+++ b/nixos/tests/moodle.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }: {
+import ./make-test.nix {} ({ pkgs, lib, ... }: {
   name = "moodle";
   meta.maintainers = [ lib.maintainers.aanderse ];
 

--- a/nixos/tests/morty.nix
+++ b/nixos/tests/morty.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "morty";

--- a/nixos/tests/mosquitto.nix
+++ b/nixos/tests/mosquitto.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 let
   port = 1888;

--- a/nixos/tests/mpd.nix
+++ b/nixos/tests/mpd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
   let
     track = pkgs.fetchurl {
       # Sourced from http://freemusicarchive.org/music/Blue_Wave_Theory/Surf_Music_Month_Challenge/Skyhawk_Beach_fade_in

--- a/nixos/tests/mumble.nix
+++ b/nixos/tests/mumble.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : 
+import ./make-test.nix {} ({ pkgs, ...} : 
 
 let
   client = { pkgs, ... }: {

--- a/nixos/tests/munin.nix
+++ b/nixos/tests/munin.nix
@@ -1,7 +1,7 @@
 # This test runs basic munin setup with node and cron job running on the same
 # machine.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "munin";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ domenkozar eelco ];

--- a/nixos/tests/mutable-users.nix
+++ b/nixos/tests/mutable-users.nix
@@ -1,6 +1,6 @@
 # Mutable users tests.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "mutable-users";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ gleber ];

--- a/nixos/tests/mxisd.nix
+++ b/nixos/tests/mxisd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... } : {
+import ./make-test.nix {} ({ pkgs, ... } : {
 
   name = "mxisd";
   meta = with pkgs.stdenv.lib.maintainers; {

--- a/nixos/tests/mysql-backup.nix
+++ b/nixos/tests/mysql-backup.nix
@@ -1,5 +1,5 @@
 # Test whether mysqlBackup option works
-import ./make-test.nix ({ pkgs, ... } : {
+import ./make-test.nix {} ({ pkgs, ... } : {
   name = "mysql-backup";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ rvl ];

--- a/nixos/tests/mysql-replication.nix
+++ b/nixos/tests/mysql-replication.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} :
+import ./make-test.nix {} ({ pkgs, ...} :
 
 let
   replicateUser = "replicate";

--- a/nixos/tests/mysql.nix
+++ b/nixos/tests/mysql.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "mysql";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco shlevy ];

--- a/nixos/tests/nat.nix
+++ b/nixos/tests/nat.nix
@@ -3,7 +3,7 @@
 # client on the inside network, a server on the outside network, and a
 # router connected to both that performs Network Address Translation
 # for the client.
-import ./make-test.nix ({ pkgs, lib, withFirewall, withConntrackHelpers ? false, ... }:
+import ./make-test.nix {} ({ pkgs, lib, withFirewall, withConntrackHelpers ? false, ... }:
   let
     unit = if withFirewall then "firewall" else "nat";
 

--- a/nixos/tests/ndppd.nix
+++ b/nixos/tests/ndppd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ...} : {
+import ./make-test.nix {} ({ pkgs, lib, ...} : {
   name = "ndppd";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ fpletz ];

--- a/nixos/tests/netdata.nix
+++ b/nixos/tests/netdata.nix
@@ -1,6 +1,6 @@
 # This test runs netdata and checks for data via apps.plugin
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "netdata";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ cransom ];

--- a/nixos/tests/networking-proxy.nix
+++ b/nixos/tests/networking-proxy.nix
@@ -10,7 +10,7 @@ let default-config = {
 
         virtualisation.memorySize = 128;
       };
-in import ./make-test.nix ({ pkgs, ...} : {
+in import ./make-test.nix {} ({ pkgs, ...} : {
   name = "networking-proxy";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [  ];

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ pkgs, ...}: let
+import ../make-test.nix {} ({ pkgs, ...}: let
   adminpass = "notproduction";
   adminuser = "root";
 in {

--- a/nixos/tests/nextcloud/with-mysql-and-memcached.nix
+++ b/nixos/tests/nextcloud/with-mysql-and-memcached.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ pkgs, ...}: let
+import ../make-test.nix {} ({ pkgs, ...}: let
   adminpass = "hunter2";
   adminuser = "root";
 in {

--- a/nixos/tests/nextcloud/with-postgresql-and-redis.nix
+++ b/nixos/tests/nextcloud/with-postgresql-and-redis.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ pkgs, ...}: let
+import ../make-test.nix {} ({ pkgs, ...}: let
   adminpass = "hunter2";
   adminuser = "custom-admin-username";
 in {

--- a/nixos/tests/nexus.nix
+++ b/nixos/tests/nexus.nix
@@ -3,7 +3,7 @@
 #   2. nexus service can startup on server (creating database and all other initial stuff)
 #   3. the web application is reachable via HTTP
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "nexus";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ironpinguin ma27 ];

--- a/nixos/tests/nfs.nix
+++ b/nixos/tests/nfs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, version ? 4, ... }:
+import ./make-test.nix {} ({ pkgs, version ? 4, ... }:
 
 let
 

--- a/nixos/tests/nghttpx.nix
+++ b/nixos/tests/nghttpx.nix
@@ -1,7 +1,7 @@
 let
   nginxRoot = "/run/nginx";
 in
-  import ./make-test.nix ({...}: {
+  import ./make-test.nix {} ({...}: {
     name  = "nghttpx";
     nodes = {
       webserver = {

--- a/nixos/tests/nginx-sso.nix
+++ b/nixos/tests/nginx-sso.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "nginx-sso";
   meta = {
     maintainers = with pkgs.stdenv.lib.maintainers; [ delroth ];

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -4,7 +4,7 @@
 #   2. whether the ETag header is properly generated whenever we're serving
 #      files in Nix store paths
 #   3. nginx doesn't restart on configuration changes (only reloads)
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "nginx";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ mbbx6spp ];

--- a/nixos/tests/nix-ssh-serve.nix
+++ b/nixos/tests/nix-ssh-serve.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 let inherit (import ./ssh-keys.nix pkgs)
       snakeOilPrivateKey snakeOilPublicKey;
     ssh-config = builtins.toFile "ssh.conf" ''

--- a/nixos/tests/nixos-generate-config.nix
+++ b/nixos/tests/nixos-generate-config.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... } : {
+import ./make-test.nix {} ({ lib, ... } : {
   name = "nixos-generate-config";
   meta.maintainers = with lib.maintainers; [ basvandijk ];
   machine = {

--- a/nixos/tests/novacomd.nix
+++ b/nixos/tests/novacomd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "novacomd";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ dtzWill ];

--- a/nixos/tests/nsd.nix
+++ b/nixos/tests/nsd.nix
@@ -5,7 +5,7 @@ let
     # for a host utility with IPv6 support
     environment.systemPackages = [ pkgs.bind ];
   };
-in import ./make-test.nix ({ pkgs, ...} : {
+in import ./make-test.nix {} ({ pkgs, ...} : {
   name = "nsd";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aszlig ];

--- a/nixos/tests/nzbget.nix
+++ b/nixos/tests/nzbget.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "nzbget";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aanderse flokli ];

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 let inherit (import ./ssh-keys.nix pkgs)
       snakeOilPrivateKey snakeOilPublicKey;

--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({pkgs, lib, ...}:
+import ./make-test.nix {} ({pkgs, lib, ...}:
 let
   # A filesystem image with a (presumably) bootable debian
   debianImage = pkgs.vmTools.diskImageFuns.debian9i386 {

--- a/nixos/tests/osquery.nix
+++ b/nixos/tests/osquery.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 
 with lib;
 

--- a/nixos/tests/osrm-backend.nix
+++ b/nixos/tests/osrm-backend.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 let
   port = 5000;
 in {

--- a/nixos/tests/ostree.nix
+++ b/nixos/tests/ostree.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, lib, ... }: {
+import ./make-test.nix {} ({ pkgs, lib, ... }: {
   name = "ostree";
 
   meta = {

--- a/nixos/tests/overlayfs.nix
+++ b/nixos/tests/overlayfs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "overlayfs";
   meta.maintainers = with pkgs.stdenv.lib.maintainers; [ bachp ];
 

--- a/nixos/tests/packagekit.nix
+++ b/nixos/tests/packagekit.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "packagekit";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ peterhoeg ];

--- a/nixos/tests/pam-oath-login.nix
+++ b/nixos/tests/pam-oath-login.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test.nix {} ({ ... }:
 
 let
   oathSnakeoilSecret = "cdd4083ef8ff1fa9178c6d46bfb1a3";

--- a/nixos/tests/pam-u2f.nix
+++ b/nixos/tests/pam-u2f.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test.nix {} ({ ... }:
 
 {
   name = "pam-u2f";

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} :
+import ./make-test.nix {} ({ pkgs, ...} :
 
 {
   name = "pantheon";

--- a/nixos/tests/paperless.nix
+++ b/nixos/tests/paperless.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... } : {
+import ./make-test.nix {} ({ lib, ... } : {
   name = "paperless";
   meta = with lib.maintainers; {
     maintainers = [ earvstedt ];

--- a/nixos/tests/partition.nix
+++ b/nixos/tests/partition.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 with pkgs.lib;
 

--- a/nixos/tests/pdns-recursor.nix
+++ b/nixos/tests/pdns-recursor.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "powerdns";
 
   nodes.server = { ... }: {

--- a/nixos/tests/peerflix.nix
+++ b/nixos/tests/peerflix.nix
@@ -1,6 +1,6 @@
 # This test runs peerflix and checks if peerflix starts
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "peerflix";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ offline ];

--- a/nixos/tests/pgjwt.nix
+++ b/nixos/tests/pgjwt.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ...}:
+import ./make-test.nix {} ({ pkgs, lib, ...}:
 let
   test = with pkgs; runCommand "patch-test" {
     nativeBuildInputs = [ pgjwt ];

--- a/nixos/tests/pgmanage.nix
+++ b/nixos/tests/pgmanage.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... } :
+import ./make-test.nix {} ({ pkgs, ... } :
 let
   role     = "test";
   password = "secret";

--- a/nixos/tests/php-pcre.nix
+++ b/nixos/tests/php-pcre.nix
@@ -1,7 +1,7 @@
 
 let testString = "can-use-subgroups"; in
 
-import ./make-test.nix ({ ...}: {
+import ./make-test.nix {} ({ ...}: {
   name = "php-httpd-pcre-jit-test";
   machine = { lib, pkgs, ... }: {
     time.timeZone = "UTC";

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} :
+import ./make-test.nix {} ({ pkgs, ...} :
 
 {
   name = "plasma5";

--- a/nixos/tests/plotinus.nix
+++ b/nixos/tests/plotinus.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "plotinus";
   meta = {
     maintainers = pkgs.plotinus.meta.maintainers;

--- a/nixos/tests/postgis.nix
+++ b/nixos/tests/postgis.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "postgis";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ lsix ];

--- a/nixos/tests/powerdns.nix
+++ b/nixos/tests/powerdns.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "powerdns";
 
   nodes.server = { ... }: {

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -1,6 +1,6 @@
 # Test printing via CUPS.
 
-import ./make-test.nix ({pkgs, ... }:
+import ./make-test.nix {} ({pkgs, ... }:
 let
   printingServer = startWhenNeeded: {
     services.printing.enable = true;

--- a/nixos/tests/proxy.nix
+++ b/nixos/tests/proxy.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : 
+import ./make-test.nix {} ({ pkgs, ...} : 
 
 let
 

--- a/nixos/tests/quagga.nix
+++ b/nixos/tests/quagga.nix
@@ -5,7 +5,7 @@
 #
 # All interfaces are in OSPF Area 0.
 
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
   let
 
     ifAddr = node: iface: (pkgs.lib.head node.config.networking.interfaces.${iface}.ipv4.addresses).address;

--- a/nixos/tests/quake3.nix
+++ b/nixos/tests/quake3.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} :
+import ./make-test.nix {} ({ pkgs, ...} :
 
 let
 

--- a/nixos/tests/rabbitmq.nix
+++ b/nixos/tests/rabbitmq.nix
@@ -1,6 +1,6 @@
 # This test runs rabbitmq and checks if rabbitmq is up and running.
 
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "rabbitmq";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco offline ];

--- a/nixos/tests/radarr.nix
+++ b/nixos/tests/radarr.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test.nix {} ({ lib, ... }:
 
 with lib;
 

--- a/nixos/tests/radicale.nix
+++ b/nixos/tests/radicale.nix
@@ -28,7 +28,7 @@ let
 
 in
 
-  import ./make-test.nix ({ lib, ... }@args: {
+  import ./make-test.nix {} ({ lib, ... }@args: {
     name = "radicale";
     meta.maintainers = with lib.maintainers; [ aneeshusa infinisil ];
 

--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "redis";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ flokli ];

--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "roundcube";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ globin ];

--- a/nixos/tests/rxe.nix
+++ b/nixos/tests/rxe.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... } :
+import ./make-test.nix {} ({ ... } :
 
 let
   node = { pkgs, ... } : {

--- a/nixos/tests/samba.nix
+++ b/nixos/tests/samba.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "samba";

--- a/nixos/tests/signal-desktop.nix
+++ b/nixos/tests/signal-desktop.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} :
+import ./make-test.nix {} ({ pkgs, ...} :
 
 {
   name = "signal-desktop";

--- a/nixos/tests/simple.nix
+++ b/nixos/tests/simple.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "simple";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco ];

--- a/nixos/tests/slim.nix
+++ b/nixos/tests/slim.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "slim";
 
   meta = with pkgs.stdenv.lib.maintainers; {

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test.nix {} ({ lib, ... }:
 let
     mungekey = "mungeverryweakkeybuteasytointegratoinatest";
 

--- a/nixos/tests/smokeping.nix
+++ b/nixos/tests/smokeping.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "smokeping";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ cransom ];

--- a/nixos/tests/snapper.nix
+++ b/nixos/tests/snapper.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test.nix {} ({ ... }:
 {
   name = "snapper";
 

--- a/nixos/tests/sonarr.nix
+++ b/nixos/tests/sonarr.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test.nix {} ({ lib, ... }:
 
 with lib;
 

--- a/nixos/tests/strongswan-swanctl.nix
+++ b/nixos/tests/strongswan-swanctl.nix
@@ -16,7 +16,7 @@
 # See the NixOS manual for how to run this test:
 # https://nixos.org/nixos/manual/index.html#sec-running-nixos-tests-interactively
 
-import ./make-test.nix ({ pkgs, ...} :
+import ./make-test.nix {} ({ pkgs, ...} :
 
 let
   allowESP = "iptables --insert INPUT --protocol ESP --jump ACCEPT";

--- a/nixos/tests/sudo.nix
+++ b/nixos/tests/sudo.nix
@@ -4,7 +4,7 @@ let
   password = "helloworld";
 
 in
-  import ./make-test.nix ({ pkgs, ...} : {
+  import ./make-test.nix {} ({ pkgs, ...} : {
     name = "sudo";
     meta = with pkgs.stdenv.lib.maintainers; {
       maintainers = [ lschuermann ];

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -1,6 +1,6 @@
 # Test configuration switching.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "switch-test";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ gleber ];

--- a/nixos/tests/syncthing-init.nix
+++ b/nixos/tests/syncthing-init.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, pkgs, ... }: let
+import ./make-test.nix {} ({ lib, pkgs, ... }: let
 
   testId = "7CFNTQM-IMTJBHJ-3UWRDIU-ZGQJFR6-VCXZ3NB-XUH3KZO-N52ITXR-LAIYUAU";
 

--- a/nixos/tests/syncthing-relay.nix
+++ b/nixos/tests/syncthing-relay.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, pkgs, ... }: {
+import ./make-test.nix {} ({ lib, pkgs, ... }: {
   name = "syncthing-relay";
   meta.maintainers = with pkgs.stdenv.lib.maintainers; [ delroth ];
 

--- a/nixos/tests/systemd-networkd-wireguard.nix
+++ b/nixos/tests/systemd-networkd-wireguard.nix
@@ -45,7 +45,7 @@ let generateNodeConf = { lib, pkgs, config, privkpath, pubk, peerId, nodeId, ...
         };
       };
     };
-in import ./make-test.nix ({pkgs, ... }: {
+in import ./make-test.nix {} ({pkgs, ... }: {
   name = "networkd-wireguard";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ninjatrappeur ];

--- a/nixos/tests/systemd-timesyncd.nix
+++ b/nixos/tests/systemd-timesyncd.nix
@@ -1,7 +1,7 @@
 # Regression test for systemd-timesync having moved the state directory without
 # upstream providing a migration path. https://github.com/systemd/systemd/issues/12131
 
-import ./make-test.nix (let
+import ./make-test.nix {} (let
   common = { lib, ... }: {
     # override the `false` value from the qemu-vm base profile
     services.timesyncd.enable = lib.mkForce true;

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "systemd";
 
   machine = { lib, ... }: {

--- a/nixos/tests/taskserver.nix
+++ b/nixos/tests/taskserver.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: let
+import ./make-test.nix {} ({ pkgs, ... }: let
   snakeOil = pkgs.runCommand "snakeoil-certs" {
     outputs = [ "out" "cacert" "cert" "key" "crl" ];
     buildInputs = [ pkgs.gnutls.bin ];

--- a/nixos/tests/telegraf.nix
+++ b/nixos/tests/telegraf.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "telegraf";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ mic92 ];

--- a/nixos/tests/tiddlywiki.nix
+++ b/nixos/tests/tiddlywiki.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }: {
+import ./make-test.nix {} ({ ... }: {
   name = "tiddlywiki";
   nodes = {
     default = {

--- a/nixos/tests/timezone.nix
+++ b/nixos/tests/timezone.nix
@@ -1,5 +1,5 @@
 {
-  timezone-static = import ./make-test.nix ({ pkgs, ... }: {
+  timezone-static = import ./make-test.nix {} ({ pkgs, ... }: {
     name = "timezone-static";
     meta.maintainers = with pkgs.lib.maintainers; [ lheckemann ];
 
@@ -13,7 +13,7 @@
     '';
   });
 
-  timezone-imperative = import ./make-test.nix ({ pkgs, ... }: {
+  timezone-imperative = import ./make-test.nix {} ({ pkgs, ... }: {
     name = "timezone-imperative";
     meta.maintainers = with pkgs.lib.maintainers; [ lheckemann ];
 

--- a/nixos/tests/tinydns.nix
+++ b/nixos/tests/tinydns.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ...} : {
+import ./make-test.nix {} ({ lib, ...} : {
   name = "tinydns";
   meta = {
     maintainers = with lib.maintainers; [ basvandijk ];

--- a/nixos/tests/tor.nix
+++ b/nixos/tests/tor.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }: with lib;
+import ./make-test.nix {} ({ lib, ... }: with lib;
 
 rec {
   name = "tor";

--- a/nixos/tests/transmission.nix
+++ b/nixos/tests/transmission.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "transmission";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ coconnor ];

--- a/nixos/tests/trezord.nix
+++ b/nixos/tests/trezord.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test.nix {} ({ pkgs, ... }: {
   name = "trezord";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ mmahut ];

--- a/nixos/tests/udisks2.nix
+++ b/nixos/tests/udisks2.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 let
 

--- a/nixos/tests/upnp.nix
+++ b/nixos/tests/upnp.nix
@@ -5,7 +5,7 @@
 # this succeeds an external client will try to connect to the port
 # mapping.
 
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 let
   internalRouterAddress = "192.168.3.1";

--- a/nixos/tests/uwsgi.nix
+++ b/nixos/tests/uwsgi.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 {
   name = "uwsgi";
   meta = with pkgs.stdenv.lib.maintainers; {

--- a/nixos/tests/vault.nix
+++ b/nixos/tests/vault.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 {
   name = "vault";
   meta = with pkgs.stdenv.lib.maintainers; {

--- a/nixos/tests/wireguard/default.nix
+++ b/nixos/tests/wireguard/default.nix
@@ -2,7 +2,7 @@ let
   wg-snakeoil-keys = import ./snakeoil-keys.nix;
 in
 
-import ../make-test.nix ({ pkgs, ...} : {
+import ../make-test.nix {} ({ pkgs, ...} : {
   name = "wireguard";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ma27 ];

--- a/nixos/tests/wireguard/generated.nix
+++ b/nixos/tests/wireguard/generated.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ pkgs, ...} : {
+import ../make-test.nix {} ({ pkgs, ...} : {
   name = "wireguard-generated";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ma27 grahamc ];

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "wordpress";

--- a/nixos/tests/xautolock.nix
+++ b/nixos/tests/xautolock.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 
 with lib;
 

--- a/nixos/tests/xdg-desktop-portal.nix
+++ b/nixos/tests/xdg-desktop-portal.nix
@@ -1,5 +1,5 @@
 # run installed tests
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test.nix {} ({ pkgs, ... }:
 
 {
   name = "xdg-desktop-portal";

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "xfce";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco shlevy ];

--- a/nixos/tests/xfce4-14.nix
+++ b/nixos/tests/xfce4-14.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "xfce4-14";
 
   machine =

--- a/nixos/tests/xmonad.nix
+++ b/nixos/tests/xmonad.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "xmonad";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus ];

--- a/nixos/tests/xmpp/ejabberd.nix
+++ b/nixos/tests/xmpp/ejabberd.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ pkgs, ... }: {
+import ../make-test.nix {} ({ pkgs, ... }: {
   name = "ejabberd";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ajs124 ];

--- a/nixos/tests/xrdp.nix
+++ b/nixos/tests/xrdp.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "xrdp";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ volth ];

--- a/nixos/tests/xss-lock.nix
+++ b/nixos/tests/xss-lock.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 
 with lib;
 

--- a/nixos/tests/yabar.nix
+++ b/nixos/tests/yabar.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test.nix {} ({ pkgs, lib, ... }:
 
 with lib;
 

--- a/nixos/tests/zookeeper.nix
+++ b/nixos/tests/zookeeper.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test.nix {} ({ pkgs, ...} : {
   name = "zookeeper";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus ];


### PR DESCRIPTION
This change allows tests to pass a specific login shell to the backdoor
service. This is relevant for tests of modules that rely on specific
login / interactive shell behavior that is hard to replicate otherwise.

###### Motivation for this change

While trying to write a module and a test for #67670 I noticed it was quite difficult to emulate the desired behavior of a specific interactive login shell in a test environment as the backdoor is hardwired to `/bin/sh`.
This patch contains the approach I came up with to remedy that as it allows the test author to define the login shell used by the backdoor service himself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
