### PR TITLE
Qt: Do not require mkDerivation

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -158,7 +158,7 @@ let
         patches = patches.qtbase;
         inherit bison cups harfbuzz libGL;
         withGtk3 = true; inherit dconf gtk3;
-        inherit developerBuild decryptSslTraffic;
+        inherit debug developerBuild decryptSslTraffic;
       };
 
       qtcharts = callPackage ../modules/qtcharts.nix {};

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -210,6 +210,7 @@ let
       qmake = makeSetupHook {
         deps = [ self.qtbase.dev ];
         substitutions = {
+          inherit debug;
           fix_qmake_libtool = ../hooks/fix-qmake-libtool.sh;
         };
       } ../hooks/qmake-hook.sh;

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -182,6 +182,7 @@ let
       qmake = makeSetupHook {
         deps = [ self.qtbase.dev ];
         substitutions = {
+          inherit debug;
           fix_qmake_libtool = ../hooks/fix-qmake-libtool.sh;
         };
       } ../hooks/qmake-hook.sh;

--- a/pkgs/development/libraries/qt-5/5.14/default.nix
+++ b/pkgs/development/libraries/qt-5/5.14/default.nix
@@ -132,7 +132,7 @@ let
         patches = patches.qtbase;
         inherit bison cups harfbuzz libGL;
         withGtk3 = true; inherit dconf gtk3;
-        inherit developerBuild decryptSslTraffic;
+        inherit debug developerBuild decryptSslTraffic;
       };
 
       qtcharts = callPackage ../modules/qtcharts.nix {};

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -179,6 +179,7 @@ let
       qmake = makeSetupHook {
         deps = [ self.qtbase.dev ];
         substitutions = {
+          inherit debug;
           fix_qmake_libtool = ../hooks/fix-qmake-libtool.sh;
         };
       } ../hooks/qmake-hook.sh;

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -3,6 +3,9 @@
 qmakeFlags=( ${qmakeFlags-} )
 
 qmakePrePhase() {
+    qmakeFlags_orig=( "${qmakeFlags[@]}" )
+
+    # These flags must be added _before_ the flags specified in the derivation.
     qmakeFlags=( \
         "PREFIX=$out" \
         "NIX_OUTPUT_OUT=$out" \
@@ -11,8 +14,15 @@ qmakePrePhase() {
         "NIX_OUTPUT_DOC=${!outputDev}/${qtDocPrefix:?}" \
         "NIX_OUTPUT_QML=${!outputBin}/${qtQmlPrefix:?}" \
         "NIX_OUTPUT_PLUGIN=${!outputBin}/${qtPluginPrefix:?}" \
-        "${qmakeFlags[@]}" \
     )
+
+    if [ -n "@debug@" ]; then
+        qmakeFlags+=( "CONFIG+=debug" )
+    else
+        qmakeFlags+=( "CONFIG+=release" )
+    fi
+
+    qmakeFlags+=( "${qmakeFlags_orig[@]}" )
 }
 prePhases+=" qmakePrePhase"
 

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -5,6 +5,14 @@ qtDocPrefix=@qtDocPrefix@
 . @fix_qt_builtin_paths@
 . @fix_qt_module_paths@
 
+# Integration with CMake:
+# Set the CMake build type corresponding to how qtbase was built.
+if [ -n "@debug@" ]; then
+    cmakeFlags="${cmakeFlags}${cmakeFlags:+ }-DCMAKE_BUILD_TYPE=Debug"
+else
+    cmakeFlags="${cmakeFlags}${cmakeFlags:+ }-DCMAKE_BUILD_TYPE=Release"
+fi
+
 providesQtRuntime() {
     [ -d "$1/$qtPluginPrefix" ] || [ -d "$1/$qtQmlPrefix" ]
 }

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -5,6 +5,12 @@ qtDocPrefix=@qtDocPrefix@
 . @fix_qt_builtin_paths@
 . @fix_qt_module_paths@
 
+# Disable debug symbols if qtbase was built without debugging.
+# This stops -dev paths from leaking into other outputs.
+if [ -z "@debug@" ]; then
+    NIX_CFLAGS_COMPILE="${NIX_CFLAGS_COMPILE}${NIX_CFLAGS_COMPILE:+ }-DQT_NO_DEBUG"
+fi
+
 # Integration with CMake:
 # Set the CMake build type corresponding to how qtbase was built.
 if [ -n "@debug@" ]; then

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -1,11 +1,12 @@
 if [[ -n "$__nix_qtbase" ]]; then
+    # Throw an error if a different version of Qt was already set up.
     if [[ "$__nix_qtbase" != "@dev@" ]]; then
         echo >&2 "Error: detected mismatched Qt dependencies:"
         echo >&2 "    @dev@"
         echo >&2 "    $__nix_qtbase"
         exit 1
     fi
-else
+else # Only set up Qt once.
 __nix_qtbase="@dev@"
 
 qtPluginPrefix=@qtPluginPrefix@

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -1,10 +1,11 @@
-if [ -n "$__nix_qtbase" -a "$__nix_qtbase" != "@dev@" ]; then
-    echo >&2 "Error: detected mismatched Qt dependencies:"
-    echo >&2 "    @dev@"
-    echo >&2 "    $__nix_qtbase"
-    exit 1
-elif [ -z "$__nix_qtbase" ]; then
-
+if [[ -n "$__nix_qtbase" ]]; then
+    if [[ -a "$__nix_qtbase" != "@dev@" ]]; then
+        echo >&2 "Error: detected mismatched Qt dependencies:"
+        echo >&2 "    @dev@"
+        echo >&2 "    $__nix_qtbase"
+        exit 1
+    fi
+else
 __nix_qtbase="@dev@"
 
 qtPluginPrefix=@qtPluginPrefix@

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -44,7 +44,7 @@ export QMAKEPATH
 QMAKEMODULES=
 export QMAKEMODULES
 
-declare -Ag qmakePathSeen=()
+declare -Ag qmakePathSeen
 qmakePathHook() {
     [ -n "${qmakePathSeen[$1]}" ] || return 0
     qmakePathSeen[$1]=1
@@ -62,7 +62,7 @@ envBuildHostHooks+=(qmakePathHook)
 # package depending on the building package. (This is necessary in case
 # the building package does not provide runtime dependencies itself and so
 # would not be propagated to the user environment.)
-declare -Ag qtEnvHostTargetSeen=()
+declare -Ag qtEnvHostTargetSeen
 qtEnvHostTargetHook() {
     [ -n "${qtEnvHostTargetSeen[$1]}" ] || return 0
     qtEnvHostTargetSeen[$1]=1

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -1,5 +1,5 @@
 if [[ -n "$__nix_qtbase" ]]; then
-    if [[ -a "$__nix_qtbase" != "@dev@" ]]; then
+    if [[ "$__nix_qtbase" != "@dev@" ]]; then
         echo >&2 "Error: detected mismatched Qt dependencies:"
         echo >&2 "    @dev@"
         echo >&2 "    $__nix_qtbase"

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -44,7 +44,7 @@ export QMAKEPATH
 QMAKEMODULES=
 export QMAKEMODULES
 
-declare -A qmakePathSeen
+declare -Ag qmakePathSeen=()
 qmakePathHook() {
     [ -n "${qmakePathSeen[$1]}" ] || return 0
     qmakePathSeen[$1]=1
@@ -62,7 +62,7 @@ envBuildHostHooks+=(qmakePathHook)
 # package depending on the building package. (This is necessary in case
 # the building package does not provide runtime dependencies itself and so
 # would not be propagated to the user environment.)
-declare -A qtEnvHostTargetSeen
+declare -Ag qtEnvHostTargetSeen=()
 qtEnvHostTargetHook() {
     [ -n "${qtEnvHostTargetSeen[$1]}" ] || return 0
     qtEnvHostTargetSeen[$1]=1

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -1,3 +1,12 @@
+if [ -n "$__nix_qtbase" -a "$__nix_qtbase" != "@dev@" ]; then
+    echo >&2 "Error: detected mismatched Qt dependencies:"
+    echo >&2 "    @dev@"
+    echo >&2 "    $__nix_qtbase"
+    exit 1
+elif [ -z "$__nix_qtbase" ]; then
+
+__nix_qtbase="@dev@"
+
 qtPluginPrefix=@qtPluginPrefix@
 qtQmlPrefix=@qtQmlPrefix@
 qtDocPrefix=@qtDocPrefix@
@@ -77,4 +86,6 @@ postPatchMkspecs() {
 }
 if [ -z "${dontPatchMkspecs-}" ]; then
     postPhases="${postPhases-}${postPhases:+ }postPatchMkspecs"
+fi
+
 fi

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -1,4 +1,4 @@
-if [[ -n "$__nix_qtbase" ]]; then
+if [[ -n "${__nix_qtbase-}" ]]; then
     # Throw an error if a different version of Qt was already set up.
     if [[ "$__nix_qtbase" != "@dev@" ]]; then
         echo >&2 "Error: detected mismatched Qt dependencies:"

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -19,7 +19,7 @@ qtDocPrefix=@qtDocPrefix@
 # Disable debug symbols if qtbase was built without debugging.
 # This stops -dev paths from leaking into other outputs.
 if [ -z "@debug@" ]; then
-    NIX_CFLAGS_COMPILE="${NIX_CFLAGS_COMPILE}${NIX_CFLAGS_COMPILE:+ }-DQT_NO_DEBUG"
+    NIX_CFLAGS_COMPILE="${NIX_CFLAGS_COMPILE-}${NIX_CFLAGS_COMPILE:+ }-DQT_NO_DEBUG"
 fi
 
 # Integration with CMake:

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -25,9 +25,9 @@ fi
 # Integration with CMake:
 # Set the CMake build type corresponding to how qtbase was built.
 if [ -n "@debug@" ]; then
-    cmakeFlags="${cmakeFlags}${cmakeFlags:+ }-DCMAKE_BUILD_TYPE=Debug"
+    cmakeFlags="${cmakeFlags-}${cmakeFlags:+ }-DCMAKE_BUILD_TYPE=Debug"
 else
-    cmakeFlags="${cmakeFlags}${cmakeFlags:+ }-DCMAKE_BUILD_TYPE=Release"
+    cmakeFlags="${cmakeFlags-}${cmakeFlags:+ }-DCMAKE_BUILD_TYPE=Release"
 fi
 
 providesQtRuntime() {

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -25,9 +25,9 @@ fi
 # Integration with CMake:
 # Set the CMake build type corresponding to how qtbase was built.
 if [ -n "@debug@" ]; then
-    cmakeFlags="${cmakeFlags-}${cmakeFlags:+ }-DCMAKE_BUILD_TYPE=Debug"
+    cmakeBuildType="Debug"
 else
-    cmakeFlags="${cmakeFlags-}${cmakeFlags:+ }-DCMAKE_BUILD_TYPE=Release"
+    cmakeBuildType="Release"
 fi
 
 providesQtRuntime() {

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -44,7 +44,10 @@ export QMAKEPATH
 QMAKEMODULES=
 export QMAKEMODULES
 
+declare -A qmakePathSeen
 qmakePathHook() {
+    [ -n "${qmakePathSeen[$1]}" ] || return 0
+    qmakePathSeen[$1]=1
     if [ -d "$1/mkspecs" ]
     then
         QMAKEMODULES="${QMAKEMODULES}${QMAKEMODULES:+:}/mkspecs"
@@ -59,7 +62,10 @@ envBuildHostHooks+=(qmakePathHook)
 # package depending on the building package. (This is necessary in case
 # the building package does not provide runtime dependencies itself and so
 # would not be propagated to the user environment.)
+declare -A qtEnvHostTargetSeen
 qtEnvHostTargetHook() {
+    [ -n "${qtEnvHostTargetSeen[$1]}" ] || return 0
+    qtEnvHostTargetSeen[$1]=1
     if providesQtRuntime "$1" && [ "z${!outputBin}" != "z${!outputDev}" ]
     then
         propagatedBuildInputs+=" $1"

--- a/pkgs/development/libraries/qt-5/mkDerivation.nix
+++ b/pkgs/development/libraries/qt-5/mkDerivation.nix
@@ -9,9 +9,6 @@ args:
 let
   args_ = {
 
-    qmakeFlags = [ ("CONFIG+=" + (if debug then "debug" else "release")) ]
-              ++ (args.qmakeFlags or []);
-
     NIX_CFLAGS_COMPILE = toString (
       optional (!debug) "-DQT_NO_DEBUG"
       ++ lib.toList (args.NIX_CFLAGS_COMPILE or []));

--- a/pkgs/development/libraries/qt-5/mkDerivation.nix
+++ b/pkgs/development/libraries/qt-5/mkDerivation.nix
@@ -13,12 +13,6 @@ let
       optional (!debug) "-DQT_NO_DEBUG"
       ++ lib.toList (args.NIX_CFLAGS_COMPILE or []));
 
-    cmakeFlags =
-      (args.cmakeFlags or [])
-      ++ [
-        ("-DCMAKE_BUILD_TYPE=" + (if debug then "Debug" else "Release"))
-      ];
-
     enableParallelBuilding = args.enableParallelBuilding or true;
 
     nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ wrapQtAppsHook ];

--- a/pkgs/development/libraries/qt-5/mkDerivation.nix
+++ b/pkgs/development/libraries/qt-5/mkDerivation.nix
@@ -9,10 +9,6 @@ args:
 let
   args_ = {
 
-    NIX_CFLAGS_COMPILE = toString (
-      optional (!debug) "-DQT_NO_DEBUG"
-      ++ lib.toList (args.NIX_CFLAGS_COMPILE or []));
-
     enableParallelBuilding = args.enableParallelBuilding or true;
 
     nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ wrapQtAppsHook ];

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -22,6 +22,7 @@
   libGL,
   buildExamples ? false,
   buildTests ? false,
+  debug ? false,
   developerBuild ? false,
   decryptSslTraffic ? false
 }:
@@ -39,6 +40,7 @@ stdenv.mkDerivation {
 
   name = "qtbase-${version}";
   inherit qtCompatVersion src version;
+  inherit debug;
 
   propagatedBuildInputs =
     [


### PR DESCRIPTION

###### Motivation for this change

This removes the need to use a custom `mkDerivation` with Qt applications. For compatibility, it remains, but it doesn't do much besides include `wrapQtAppsHook`.

See also: https://github.com/NixOS/nixpkgs/issues/65399#issuecomment-541076520

TODO:

- [ ] Port #70691.
- [ ] Update documentation to remove references to `mkDerivation`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
