### PR TITLE
arion: init at 0.1.0.0

### DIFF
--- a/pkgs/applications/virtualization/arion/default.nix
+++ b/pkgs/applications/virtualization/arion/default.nix
@@ -1,0 +1,83 @@
+{ pkgs
+, lib
+, haskellPackages
+, haskell
+, runCommand
+}:
+
+let
+
+  /* This derivation builds the arion tool.
+
+     It is based on the arion-compose Haskell package, but adapted and extended to
+       - have the correct name
+       - have a smaller closure size
+       - have functions to use Arion from inside Nix: arion.eval and arion.build
+       - make it self-contained by including docker-compose
+   */
+  arion =
+    justStaticExecutables (
+      overrideCabal
+        arion-compose
+        cabalOverrides
+      );
+
+  inherit (haskell.lib) justStaticExecutables overrideCabal;
+
+  inherit (haskellPackages) arion-compose;
+
+  cabalOverrides = o: {
+    buildTools = (o.buildTools or []) ++ [pkgs.makeWrapper];
+    passthru = (o.passthru or {}) // {
+      inherit eval build;
+    };
+    # Patch away the arion-compose name. Unlike the Haskell library, the program
+    # is called arion (arion was already taken on hackage).
+    pname = "arion";
+    src = arion-compose.src;
+
+    # PYTHONPATH
+    #
+    # We close off the python module search path!
+    #
+    # Accepting directories from the environment into the search path
+    # tends to break things. Docker Compose does not have a plugin
+    # system as far as I can tell, so I don't expect this to break a
+    # feature, but rather to make the program more robustly self-
+    # contained.
+
+    postInstall = ''${o.postInstall or ""}
+      mkdir -p $out/libexec
+      mv $out/bin/arion $out/libexec
+      makeWrapper $out/libexec/arion $out/bin/arion \
+        --unset PYTHONPATH \
+        --prefix PATH : ${lib.makeBinPath [ pkgs.docker-compose ]} \
+        ;
+    '';
+  };
+
+  # Unpacked sources for evaluation by `eval`
+  srcUnpacked = runCommand "arion-src" {}
+    "mkdir $out; tar -C $out --strip-components=1 -xf ${arion-compose.src}";
+
+  /* Function for evaluating a composition
+
+     Re-uses this Nixpkgs evaluation instead of `arion-pkgs.nix`.
+
+     Returns the module system's `config` and `options` variables.
+   */
+  eval = args@{...}:
+    import (srcUnpacked + "/src/nix/eval-composition.nix")
+      ({ inherit pkgs; } // args);
+
+  /* Function to derivation of the docker compose yaml file
+     NOTE: The output will change: https://github.com/hercules-ci/arion/issues/82
+
+    This function is particularly useful on CI, although the references
+    to image tarballs may not always be desirable.
+   */
+  build = args@{...}:
+    let composition = eval args;
+    in composition.config.out.dockerComposeYaml;
+
+in arion

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17571,6 +17571,8 @@ in
 
   ario = callPackage ../applications/audio/ario { };
 
+  arion = callPackage ../applications/virtualization/arion { };
+
   arora = callPackage ../applications/networking/browsers/arora { };
 
   artha = callPackage ../applications/misc/artha { };


### PR DESCRIPTION

###### Motivation for this change

Package Arion, a tool for working with Docker through Nix!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
   - arion: 124.0MB
   - of which docker-compose-1.24.1: 115.6 MB
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
