### PR TITLE
Split pinentry flavors and enable udisks2 on install media again

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -85,7 +85,14 @@
 
   <itemizedlist>
    <listitem>
-    <para />
+    <para>
+      GnuPG is now built without support for a graphical passphrase entry
+      by default. Please enable the <literal>gpg-agent</literal> user service
+      via the NixOS option <literal>programs.gnupg.agent.enable</literal>.
+      Note that upstream recommends using <literal>gpg-agent</literal> and
+      will spawn a <literal>gpg-agent</literal> on the first invocation of
+      GnuPG anyway.
+    </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -34,7 +34,6 @@ with lib;
       networkmanager-openvpn = super.networkmanager-openvpn.override { withGnome = false; };
       networkmanager-vpnc = super.networkmanager-vpnc.override { withGnome = false; };
       networkmanager-iodine = super.networkmanager-iodine.override { withGnome = false; };
-      pinentry = super.pinentry.override { gtk2 = null; gcr = null; qt4 = null; qt5 = null; };
       gobject-introspection = super.gobject-introspection.override { x11Support = false; };
     }));
   };

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -120,7 +120,11 @@ in
         # Some programs need SUID wrappers, can be configured further or are
         # started in user sessions.
         # programs.mtr.enable = true;
-        # programs.gnupg.agent = { enable = true; enableSSHSupport = true; };
+        # programs.gnupg.agent = {
+        #   enable = true;
+        #   enableSSHSupport = true;
+        #   flavour = "gnome3";
+        # };
 
         # List services that you want to enable:
 

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -31,9 +31,6 @@ with lib;
     # Let the user play Rogue on TTY 8 during the installation.
     #services.rogue.enable = true;
 
-    # Disable some other stuff we don't need.
-    services.udisks2.enable = mkDefault false;
-
     # Use less privileged nixos user
     users.users.nixos = {
       isNormalUser = true;

--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -76,7 +76,7 @@ in
         thus overrides the pinentry option in gpg-agent.conf in the user's
         home directory.
         If not set at all, it'll pick an appropriate flavor depending on the
-        system configuration (qt3 flavor for lxqt and plasma5, gtk2 for xfce
+        system configuration (qt flavor for lxqt and plasma5, gtk2 for xfce
         4.12, gnome3 on all other systems with X enabled, ncurses otherwise).
       '';
     };

--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -6,6 +6,19 @@ let
 
   cfg = config.programs.gnupg;
 
+  xserverCfg = config.services.xserver;
+
+  defaultPinentryFlavor =
+    if xserverCfg.desktopManager.lxqt.enable
+    || xserverCfg.desktopManager.plasma5.enable then
+      "qt"
+    else if xserverCfg.desktopManager.xfce.enable then
+      "gtk2"
+    else if xserverCfg.enable then
+      "gnome3"
+    else
+      null;
+
 in
 
 {
@@ -54,6 +67,20 @@ in
       '';
     };
 
+    agent.pinentryFlavor = mkOption {
+      type = types.nullOr (types.enum pkgs.pinentry.flavors);
+      example = "gnome3";
+      description = ''
+        Which pinentry interface to use. If not null, the path to the
+        pinentry binary will be passed to gpg-agent via commandline and
+        thus overrides the pinentry option in gpg-agent.conf in the user's
+        home directory.
+        If not set at all, it'll pick an appropriate flavor depending on the
+        system configuration (qt3 flavor for lxqt and plasma5, gtk2 for xfce
+        4.12, gnome3 on all other systems with X enabled, ncurses otherwise).
+      '';
+    };
+
     dirmngr.enable = mkOption {
       type = types.bool;
       default = false;
@@ -64,6 +91,16 @@ in
   };
 
   config = mkIf cfg.agent.enable {
+    programs.gnupg.agent.pinentryFlavor = mkDefault defaultPinentryFlavor;
+
+    # This overrides the systemd user unit shipped with the gnupg package
+    systemd.user.services.gpg-agent = mkIf (cfg.agent.pinentryFlavor != null) {
+      serviceConfig.ExecStart = [ "" ''
+        ${pkgs.gnupg}/bin/gpg-agent --supervised \
+          --pinentry-program ${pkgs.pinentry.${cfg.agent.pinentryFlavor}}/bin/pinentry
+      '' ];
+    };
+
     systemd.user.sockets.gpg-agent = {
       wantedBy = [ "sockets.target" ];
     };
@@ -83,7 +120,7 @@ in
     systemd.user.sockets.dirmngr = mkIf cfg.dirmngr.enable {
       wantedBy = [ "sockets.target" ];
     };
-    
+
     environment.systemPackages = with pkgs; [ cfg.package ];
     systemd.packages = [ cfg.package ];
 

--- a/nixos/modules/services/hardware/udisks2.nix
+++ b/nixos/modules/services/hardware/udisks2.nix
@@ -34,10 +34,7 @@ with lib;
 
     services.dbus.packages = [ pkgs.udisks2 ];
 
-    system.activationScripts.udisks2 =
-      ''
-        mkdir -m 0755 -p /var/lib/udisks2
-      '';
+    systemd.tmpfiles.rules = [ "d /var/lib/udisks2 0755 root root -" ];
 
     services.udev.packages = [ pkgs.udisks2 ];
 

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -54,8 +54,6 @@ let
 
         hardware.enableAllFirmware = lib.mkForce false;
 
-        services.udisks2.enable = lib.mkDefault false;
-
         ${replaceChars ["\n"] ["\n  "] extraConfig}
       }
     '';
@@ -294,8 +292,6 @@ let
               ]
               ++ optional (bootLoader == "grub" && grubVersion == 1) pkgs.grub
               ++ optionals (bootLoader == "grub" && grubVersion == 2) [ pkgs.grub2 pkgs.grub2_efi ];
-
-            services.udisks2.enable = mkDefault false;
 
             nix.binaryCaches = mkForce [ ];
             nix.extraOptions =

--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -51,12 +51,11 @@ let
       hashed-mirrors =
       connect-timeout = 1
     '';
-    services.udisks2.enable = lib.mkForce false;
   };
   # /etc/nixos/configuration.nix for the vm
   configFile = pkgs.writeText "configuration.nix"  ''
     {config, pkgs, ...}: ({
-    imports = 
+    imports =
           [ ./hardware-configuration.nix
             <nixpkgs/nixos/modules/testing/test-instrumentation.nix>
           ];

--- a/pkgs/development/libraries/gcr/default.nix
+++ b/pkgs/development/libraries/gcr/default.nix
@@ -24,11 +24,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig gettext gobject-introspection libxslt makeWrapper vala ];
 
-  buildInputs = let
-    gpg = gnupg.override { guiSupport = false; }; # prevent build cycle with pinentry_gnome
-  in [
-    gpg libgcrypt libtasn1 dbus-glib pango gdk-pixbuf atk
-  ];
+  buildInputs = [ gnupg libgcrypt libtasn1 dbus-glib pango gdk-pixbuf atk ];
 
   propagatedBuildInputs = [ glib gtk3 p11-kit ];
 

--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -3,7 +3,7 @@
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
-, pinentry ? null, guiSupport ? true
+, pinentry ? null, guiSupport ? false
 , openldap ? null, bzip2 ? null, libusb ? null, curl ? null
 }:
 

--- a/pkgs/tools/security/gnupg/22.nix
+++ b/pkgs/tools/security/gnupg/22.nix
@@ -4,7 +4,7 @@
 
 # Each of the dependencies below are optional.
 # Gnupg can be built without them at the cost of reduced functionality.
-, pinentry ? null, guiSupport ? true
+, pinentry ? null, guiSupport ? false
 , adns ? null, gnutls ? null, libusb ? null, openldap ? null
 , readline ? null, zlib ? null, bzip2 ? null
 }:

--- a/pkgs/tools/security/kwalletcli/default.nix
+++ b/pkgs/tools/security/kwalletcli/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, fetchFromGitHub, lib, makeWrapper, pkgconfig
-, kcoreaddons, ki18n, kwallet, mksh, pinentry_qt5 }:
+, kcoreaddons, ki18n, kwallet, mksh, pinentry-qt }:
 
 mkDerivation rec {
   pname = "kwalletcli";
@@ -36,7 +36,7 @@ mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/pinentry-kwallet \
-      --prefix PATH : $out/bin:${lib.makeBinPath [ pinentry_qt5 ]} \
+      --prefix PATH : $out/bin:${lib.makeBinPath [ pinentry-qt ]} \
       --set-default PINENTRY pinentry-qt
   '';
 

--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -1,60 +1,93 @@
-{ fetchurl, fetchpatch, stdenv, lib, pkgconfig, autoreconfHook
-, libgpgerror, libassuan
-, libcap ? null, libsecret ? null, ncurses ? null, gtk2 ? null, gcr ? null
-, qt4 ? null, qt5 ? null
-, enableEmacs ? false
+{ fetchurl, mkDerivation, fetchpatch, stdenv, lib, pkgconfig, autoreconfHook, wrapGAppsHook
+, libgpgerror, libassuan, qtbase, wrapQtAppsHook
+, ncurses, gtk2, gcr
+, libcap ? null, libsecret ? null
+, enabledFlavors ? [ "curses" "tty" "gtk2" "qt" "gnome3" "emacs" ]
 }:
 
-assert qt5 != null -> qt4 == null;
-assert qt4 != null -> qt5 == null;
+with stdenv.lib;
+
+assert isList enabledFlavors && enabledFlavors != [];
 
 let
-  mkDerivation =
-    if qt5 != null
-      then qt5.mkDerivation
+  pinentryMkDerivation =
+    if (builtins.elem "qt" enabledFlavors)
+      then mkDerivation
       else stdenv.mkDerivation;
+
+  mkFlag = pfxTrue: pfxFalse: cond: name:
+    "--${if cond then pfxTrue else pfxFalse}-${name}";
+  mkEnable = mkFlag "enable" "disable";
+  mkWith = mkFlag "with" "without";
+
+  mkEnablePinentry = f:
+    let
+      info = flavorInfo.${f};
+      flag = flavorInfo.${f}.flag or null;
+    in
+      optionalString (flag != null)
+        (mkEnable (elem f enabledFlavors) ("pinentry-" + flag));
+
+  flavorInfo = {
+    curses = { bin = "curses"; flag = "curses"; buildInputs = [ ncurses ]; };
+    tty = { bin = "tty"; flag = "tty"; };
+    gtk2 = { bin = "gtk-2"; flag = "gtk2"; buildInputs = [ gtk2 ]; };
+    gnome3 = { bin = "gnome3"; flag = "gnome3"; buildInputs = [ gcr ]; nativeBuildInputs = [ wrapGAppsHook ]; };
+    qt = { bin = "qt"; flag = "qt"; buildInputs = [ qtbase ]; nativeBuildInputs = [ wrapQtAppsHook ]; };
+    emacs = { bin = "emacs"; flag = "emacs"; buildInputs = []; };
+  };
+
 in
 
-mkDerivation rec {
-  name = "pinentry-1.1.0";
+pinentryMkDerivation rec {
+  pname = "pinentry";
+  version = "1.1.0";
 
   src = fetchurl {
-    url = "mirror://gnupg/pinentry/${name}.tar.bz2";
+    url = "mirror://gnupg/pinentry/${pname}-${version}.tar.bz2";
     sha256 = "0w35ypl960pczg5kp6km3dyr000m1hf0vpwwlh72jjkjza36c1v8";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook ];
-  buildInputs =
-    [ libgpgerror libassuan libcap libsecret gtk2 gcr ncurses qt4 ]
-    ++ stdenv.lib.optional (qt5 != null) qt5.qtbase;
+  nativeBuildInputs = [ pkgconfig autoreconfHook ]
+    ++ concatMap(f: flavorInfo.${f}.nativeBuildInputs or []) enabledFlavors;
+  buildInputs = [ libgpgerror libassuan libcap libsecret ]
+    ++ concatMap(f: flavorInfo.${f}.buildInputs or []) enabledFlavors;
 
-  prePatch = ''
-    substituteInPlace pinentry/pinentry-curses.c --replace ncursesw ncurses
-  '';
+  dontWrapGApps = true;
+  dontWrapQtApps = true;
 
   patches = [
     ./autoconf-ar.patch
-  ] ++ lib.optionals (gtk2 != null) [
+  ] ++ optionals (elem "gtk2" enabledFlavors) [
     (fetchpatch {
-      url = "https://salsa.debian.org/debian/pinentry/raw/debian/1.1.0-1/debian/patches/"
-          + "0007-gtk2-When-X11-input-grabbing-fails-try-again-over-0..patch";
+      url = "https://salsa.debian.org/debian/pinentry/raw/debian/1.1.0-1/debian/patches/0007-gtk2-When-X11-input-grabbing-fails-try-again-over-0..patch";
       sha256 = "15r1axby3fdlzz9wg5zx7miv7gqx2jy4immaw4xmmw5skiifnhfd";
     })
   ];
 
   configureFlags = [
-    (stdenv.lib.withFeature   (libcap != null)    "libcap")
-    (stdenv.lib.enableFeature (libsecret != null) "libsecret")
-    (stdenv.lib.enableFeature (ncurses != null)   "pinentry-curses")
-    (stdenv.lib.enableFeature true                "pinentry-tty")
-    (stdenv.lib.enableFeature enableEmacs         "pinentry-emacs")
-    (stdenv.lib.enableFeature (gtk2 != null)      "pinentry-gtk2")
-    (stdenv.lib.enableFeature (gcr != null)       "pinentry-gnome3")
-    (stdenv.lib.enableFeature (qt4 != null || qt5 != null) "pinentry-qt")
+    (mkWith   (libcap != null)    "libcap")
+    (mkEnable (libsecret != null) "libsecret")
+  ] ++ (map mkEnablePinentry (attrNames flavorInfo));
 
-    "--with-libassuan-prefix=${libassuan.dev}"
-    "--with-libgpg-error-prefix=${libgpgerror.dev}"
-  ];
+  postInstall =
+    concatStrings (flip map enabledFlavors (f:
+      let
+        binary = "pinentry-" + flavorInfo.${f}.bin;
+      in ''
+        moveToOutput bin/${binary} ${placeholder f}
+        ln -sf ${placeholder f}/bin/${binary} ${placeholder f}/bin/pinentry
+      '' + optionalString (f == "gnome3") ''
+        wrapGApp ${placeholder f}/bin/${binary}
+      '' + optionalString (f == "qt") ''
+        wrapQtApp ${placeholder f}/bin/${binary}
+      '')) + ''
+      ln -sf ${placeholder (head enabledFlavors)}/bin/pinentry-${flavorInfo.${head enabledFlavors}.bin} $out/bin/pinentry
+    '';
+
+  outputs = [ "out" ] ++ enabledFlavors;
+
+  passthru = { flavors = enabledFlavors; };
 
   meta = with stdenv.lib; {
     homepage = http://gnupg.org/aegypten2/;
@@ -65,6 +98,6 @@ mkDerivation rec {
       Pinentry provides a console and (optional) GTK and Qt GUIs allowing users
       to enter a passphrase when `gpg' or `gpg2' is run and needs it.
     '';
-    maintainers = [ maintainers.ttuegel ];
+    maintainers = with maintainers; [ ttuegel fpletz ];
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -290,6 +290,11 @@ mapAliases ({
   pg_hll = postgresqlPackages.pg_hll;
   pg_cron = postgresqlPackages.pg_cron;
   pg_topn = postgresqlPackages.pg_topn;
+  pinentry_curses = pinentry-curses; # added 2019-10-14
+  pinentry_emacs = pinentry-emacs; # added 2019-10-14
+  pinentry_gtk2 = pinentry-gtk2; # added 2019-10-14
+  pinentry_qt = pinentry-qt; # added 2019-10-14
+  pinentry_gnome = pinentry-gnome; # added 2019-10-14
   postgis = postgresqlPackages.postgis;
   # end
   ppl-address-book = throw "deprecated in 2019-05-02: abandoned by upstream.";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3499,10 +3499,12 @@ in
   gnupg1compat = callPackage ../tools/security/gnupg/1compat.nix { };
   gnupg1 = gnupg1compat;    # use config.packageOverrides if you prefer original gnupg1
   gnupg20 = callPackage ../tools/security/gnupg/20.nix {
-    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry;
+    guiSupport = stdenv.isDarwin;
+    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry_gtk2;
   };
   gnupg22 = callPackage ../tools/security/gnupg/22.nix {
-    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry;
+    guiSupport = stdenv.isDarwin;
+    pinentry = if stdenv.isDarwin then pinentry_mac else pinentry_gtk2;
   };
   gnupg = gnupg22;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5525,11 +5525,11 @@ in
     libcap = if stdenv.isDarwin then null else libcap;
   };
 
-  pinentry_curses = (stdenv.lib.getOutput "curses" pinentry);
-  pinentry_emacs = (stdenv.lib.getOutput "emacs" pinentry);
-  pinentry_gtk2 = (stdenv.lib.getOutput "gtk2" pinentry);
-  pinentry_qt = (stdenv.lib.getOutput "qt" pinentry);
-  pinentry_gnome = (stdenv.lib.getOutput "gnome" pinentry);
+  pinentry-curses = (stdenv.lib.getOutput "curses" pinentry);
+  pinentry-emacs = (stdenv.lib.getOutput "emacs" pinentry);
+  pinentry-gtk2 = (stdenv.lib.getOutput "gtk2" pinentry);
+  pinentry-qt = (stdenv.lib.getOutput "qt" pinentry);
+  pinentry-gnome = (stdenv.lib.getOutput "gnome" pinentry);
 
   pinentry_mac = callPackage ../tools/security/pinentry/mac.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5521,34 +5521,15 @@ in
 
   phodav = callPackage ../tools/networking/phodav { };
 
-  pinentry = callPackage ../tools/security/pinentry {
+  pinentry = libsForQt5.callPackage ../tools/security/pinentry {
     libcap = if stdenv.isDarwin then null else libcap;
-    gcr = null;
-    qt4 = null;
-    qt5 = null;
   };
 
-  pinentry_ncurses = res.pinentry.override {
-    gtk2 = null;
-  };
-
-  pinentry_emacs = res.pinentry.override {
-    enableEmacs = true;
-  };
-
-  pinentry_gnome = res.pinentry.override {
-    inherit gcr;
-  };
-
-  pinentry_qt4 = res.pinentry.override {
-    gtk2 = null;
-    inherit qt4;
-  };
-
-  pinentry_qt5 = res.pinentry.override {
-    gtk2 = null;
-    inherit qt5;
-  };
+  pinentry_curses = (stdenv.lib.getOutput "curses" pinentry);
+  pinentry_emacs = (stdenv.lib.getOutput "emacs" pinentry);
+  pinentry_gtk2 = (stdenv.lib.getOutput "gtk2" pinentry);
+  pinentry_qt = (stdenv.lib.getOutput "qt" pinentry);
+  pinentry_gnome = (stdenv.lib.getOutput "gnome" pinentry);
 
   pinentry_mac = callPackage ../tools/security/pinentry/mac.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa;


### PR DESCRIPTION
###### Motivation for this change
Follow-up of #49270, rebased to latest master and with qt4 removed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
