### PR TITLE
pyznap: 1.2.1 -> 1.4.3

### DIFF
--- a/pkgs/tools/backup/pyznap/default.nix
+++ b/pkgs/tools/backup/pyznap/default.nix
@@ -1,16 +1,21 @@
 { lib
 , buildPythonApplication
 , fetchPypi
+, setuptools
 }:
 
 buildPythonApplication rec {
   pname = "pyznap";
-  version = "1.2.1";
+  version = "1.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0pnngr4zdxkf6b570ikzvkrm3a8fr47w6crjaw7ln094qkniywvj";
+    sha256 = "00xpw6rmkq5cfjfw23mv0917wfzvb5zxj420p6yh0rnl3swh7gi8";
   };
+
+  propagatedBuildInputs = [
+    setuptools
+  ];  
 
   # tests aren't included in the PyPI packages
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
Fix missing dependency and update to latest version.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

