### PR TITLE
[19.09] Reliable epson

### DIFF
--- a/pkgs/misc/drivers/epson-escpr/cups-filter-ppd-dirs.patch
+++ b/pkgs/misc/drivers/epson-escpr/cups-filter-ppd-dirs.patch
@@ -1,8 +1,8 @@
 diff --git a/configure b/configure_new
-index 699bcb5..89a1832 100755
+index 12b4662..6ec641c 100755
 --- a/configure
 +++ b/configure_new
-@@ -11585,55 +11585,8 @@ else
+@@ -12162,55 +12162,8 @@ else
  $as_echo "no" >&6; }
  fi
  
@@ -44,7 +44,7 @@ index 699bcb5..89a1832 100755
 -   if test -d "${cups_default_prefix}/share/ppd" ; then
 -      CUPS_PPD_DIR="${cups_default_prefix}/share/ppd"
 -   elif test "xyes" = "x$have_cups_config" ; then
--            CUPS_PPD_DIR="${cups_default_prefix}/`cups-config --datadir | sed -e 's,^/[^/][^/]*,,'`/model"
+-            CUPS_PPD_DIR="${cups_default_prefix}`cups-config --datadir | sed -e 's,^/[^/][^/]*,,'`/model"
 -   else
 -      CUPS_PPD_DIR="${cups_default_prefix}/share/cups/model"
 -   fi
@@ -58,5 +58,5 @@ index 699bcb5..89a1832 100755
 +CUPS_FILTER_DIR="${prefix}/lib/cups/filter"
 +CUPS_PPD_DIR="${prefix}/share/cups/model"
  
- { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ANSI C header files" >&5
- $as_echo_n "checking for ANSI C header files... " >&6; }
+ # Check whether --enable-lsb was given.
+ if test "${enable_lsb+set}" = set; then :

--- a/pkgs/misc/drivers/epson-escpr/default.nix
+++ b/pkgs/misc/drivers/epson-escpr/default.nix
@@ -2,11 +2,19 @@
 
 stdenv.mkDerivation {
   pname = "epson-escpr";
-  version = "1.6.16";
+  version = "1.7.3";
 
   src = fetchurl {
-    url = "https://download3.ebz.epson.net/dsc/f/03/00/06/41/54/29588ed107f800e5bc3f91706661567efb369c1c/epson-inkjet-printer-escpr-1.6.16-1lsb3.2.tar.gz";
-    sha256 = "0v9mcih3dg3ws18hdcgm014k97hv6imga39hy2a84gnc6badp6n6";
+    # To find new versions, visit
+    # http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX and search for
+    # some printer like for instance "WF-7110" to get to the most recent
+    # version.  
+    # NOTE: Don't forget to update the webarchive link too!
+    urls = [
+      "https://download3.ebz.epson.net/dsc/f/03/00/09/83/26/f90d0f70b33a9d7d77a2408364c47fba1ccbf943/epson-inkjet-printer-escpr-1.7.3-1lsb3.2.tar.gz"
+      "https://web.archive.org/web/https://download3.ebz.epson.net/dsc/f/03/00/09/83/26/f90d0f70b33a9d7d77a2408364c47fba1ccbf943/epson-inkjet-printer-escpr-1.7.3-1lsb3.2.tar.gz"
+    ];
+    sha256 = "0r3jkdfk33irha9gpyvhha056ans59p7dq9i153i292ifjsd8458";
   };
 
   patches = [ ./cups-filter-ppd-dirs.patch ];

--- a/pkgs/misc/drivers/epson-escpr2/default.nix
+++ b/pkgs/misc/drivers/epson-escpr2/default.nix
@@ -5,10 +5,15 @@ stdenv.mkDerivation rec {
   version = "1.1.1";
 
   src = fetchurl {
-    # To find new versions, visit http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX
-    # and search for some printer like for instance "WF-7210" to get to the most recent version.
-    # NOTE: keep in mind that many parts of the URL change and not just version.
-    url = "https://download3.ebz.epson.net/dsc/f/03/00/09/72/04/c6d928e83e558c4ba1e7e8bcb5c1fe080b8095eb/${pname}-${version}-1lsb3.2.src.rpm";
+    # To find new versions, visit
+    # http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX and search for
+    # some printer like for instance "WF-7210" to get to the most recent
+    # version.  
+    # NOTE: Don't forget to update the webarchive link too!
+    urls = [ 
+      "https://download3.ebz.epson.net/dsc/f/03/00/09/72/04/c6d928e83e558c4ba1e7e8bcb5c1fe080b8095eb/epson-inkjet-printer-escpr2-1.1.1-1lsb3.2.src.rpm"
+      "https://web.archive.org/web/https://download3.ebz.epson.net/dsc/f/03/00/09/72/04/c6d928e83e558c4ba1e7e8bcb5c1fe080b8095eb/epson-inkjet-printer-escpr2-1.1.1-1lsb3.2.src.rpm"
+    ];
     sha256 = "02vdlhvinsx6vsjq172b2c1vrfzkg0w9j5lbsnjvj6yq3yqz5b5q";
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/70491.
Basically a fix for all the proprietary epson drivers with issues on removed src files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
