### PR TITLE
prometheus, ekg-prometheus-adapter: Remove from broken-packages

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -4398,7 +4398,6 @@ broken-packages:
   - ekg-elasticsearch
   - ekg-influxdb
   - ekg-log
-  - ekg-prometheus-adapter
   - ekg-push
   - ekg-rrd
   - elevator
@@ -8078,7 +8077,6 @@ broken-packages:
   - projectile
   - prolog-graph
   - prolog-graph-lib
-  - prometheus
   - prometheus-effect
   - promise
   - pronounce


### PR DESCRIPTION
###### Motivation for this change
- Prometheus and ekg-prometheus-adapter were fixed in PR:
  https://github.com/NixOS/nixpkgs/pull/70956 but I forgot to remove them from the list of broken-packages.

###### Things done
- Removed prometheus and ekg-prometheus-adapter from list of broken-packages.

###### Notify maintainers

cc @peti 
