### PR TITLE
pythonPackages.setuptools: Remove windows files and make reproducible

### DIFF
--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -20,18 +20,20 @@ buildPythonPackage rec {
     sha256 = "66b86bbae7cc7ac2e867f52dc08a6bd064d938bac59dfec71b9b565dd36d6012";
   };
 
-  # There is nothing to build
-  dontBuild = true;
-
   nativeBuildInputs = [ bootstrapped-pip ];
+
+  buildPhase = ''
+      ${lib.strings.optionalString (!stdenv.hostPlatform.isWindows)
+        "export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0"}
+      pip wheel --no-cache --no-index .
+  '';
 
   installPhase = ''
       dst=$out/${python.sitePackages}
       mkdir -p $dst
       export PYTHONPATH="$dst:$PYTHONPATH"
-      ${lib.strings.optionalString (!stdenv.hostPlatform.isWindows)
-        "export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0"}
-      ${python.pythonForBuild.interpreter} setup.py install --prefix=$out
+      mkdir build-tmp
+      pip install --prefix "$out" --ignore-installed --no-cache --no-index --build ./build-tmp ./*.whl
       wrapPythonPrograms
   '';
 

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -6,6 +6,7 @@
 , unzip
 , callPackage
 , bootstrapped-pip
+, lib
 }:
 
 buildPythonPackage rec {
@@ -28,6 +29,8 @@ buildPythonPackage rec {
       dst=$out/${python.sitePackages}
       mkdir -p $dst
       export PYTHONPATH="$dst:$PYTHONPATH"
+      ${lib.strings.optionalString (!stdenv.hostPlatform.isWindows)
+        "export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=0"}
       ${python.pythonForBuild.interpreter} setup.py install --prefix=$out
       wrapPythonPrograms
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

* setuptools includes *.exe files by default, but can be excluded with an ENV variable.
* setuptools was built as an egg, which had reproducibility problems. Instead use a wheel

These are 2 separate commits, but I'm making one pull request against staging to limit rebuilds. Let me know if you would rather split it apart.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh 
