### PR TITLE
ocamlPackages.duff: init at 0.2

### DIFF
--- a/pkgs/development/ocaml-modules/duff/default.nix
+++ b/pkgs/development/ocaml-modules/duff/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchurl, buildDunePackage
+, cstruct, fmt
+, bos, cmdliner, fpath, logs
+, alcotest
+}:
+
+buildDunePackage rec {
+  pname = "duff";
+  version = "0.2";
+  src = fetchurl {
+    url = "https://github.com/mirage/duff/releases/download/v${version}/duff-v${version}.tbz";
+    sha256 = "0bi081w4349cqc1n9jsjh1lrcqlnv3nycmvh9fniscv8lz1c0gjq";
+  };
+
+  buildInputs = [ bos cmdliner fpath logs ] ++ lib.optional doCheck alcotest;
+  propagatedBuildInputs = [ cstruct fmt ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Pure OCaml implementation of libXdiff (Rabin’s fingerprint)";
+    homepage = "https://github.com/mirage/duff";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -225,6 +225,8 @@ let
 
     dtoa = callPackage ../development/ocaml-modules/dtoa { };
 
+    duff = callPackage ../development/ocaml-modules/duff { };
+
     dune = callPackage ../development/tools/ocaml/dune { };
 
     earley = callPackage ../development/ocaml-modules/earley { };


### PR DESCRIPTION
###### Motivation for this change

Dependency of ocaml-git ≥ 2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
