### PR TITLE
pythonPackages.ansible: add support for hcloud

### DIFF
--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -14,6 +14,7 @@
 , dopy
 , windowsSupport ? false
 , pywinrm
+, hcloud # hcloud plugin
 }:
 
 buildPythonPackage rec {
@@ -39,7 +40,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     pycrypto paramiko jinja2 pyyaml httplib2 boto
-    six netaddr dnspython jmespath dopy
+    six netaddr dnspython jmespath dopy hcloud
   ] ++ lib.optional windowsSupport pywinrm;
 
   # dificult to test


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Using Hetzner Cloud [inventory plugin](https://docs.ansible.com/ansible/latest/plugins/inventory/hcloud.html) and [cloud modules](https://docs.ansible.com/ansible/latest/modules/list_of_cloud_modules.html#hcloud) requires the availability of [hcloud-python](https://github.com/hetznercloud/hcloud-python) (also: #69151).

A slight caveat is that due to the way Ansible works, using the cloud module on localhost may need something like this to work:

```
ansible_python_interpreter=`which python`
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @joamaki @costrouc 
