### PR TITLE
doc: nixos.configuration.abstractions: Explore

### DIFF
--- a/nixos/doc/manual/configuration/modularity.xml
+++ b/nixos/doc/manual/configuration/modularity.xml
@@ -114,7 +114,7 @@ true
 </screen>
   Interactive exploration of the configuration is possible using <command>nix
   repl</command>, a read-eval-print loop for Nix expressions. A typical use:
-<screen>
+ <screen>
 <prompt>$ </prompt>nix repl '&lt;nixpkgs/nixos>'
 
 <prompt>nix-repl> </prompt>config.<xref linkend="opt-networking.hostName"/>
@@ -122,7 +122,26 @@ true
 
 <prompt>nix-repl> </prompt>map (x: x.hostName) config.<xref linkend="opt-services.httpd.virtualHosts"/>
 [ "example.org" "example.gov" ]
+
+# in which files is this particular option set 
+<prompt> nix-repl> </prompt> :p options.environment.shellAliases.files
+[ "/home/danbst/power-profile/profiles/base.nix" "/nix/var/nix/profiles/per-user/root/channels/nixpkgs/nixos/modules/config/shells-environment.nix" ]                   
+
+# what values are defined in respective files
+</prompt>nix-repl> </prompt>:p options.environment.shellAliases.definitions
+[ { nix-env = /home/danbst/power-profile/experimental/declarative-env.sh; t = "/home/danbst/dev/todo.txt-cli/todo.sh"; } { l = { _type = "override"; content = "ls -alh"; priority = 1000; }; ll = { _type = "override"; content = "ls -l"; priority = 1000; }; ls = { _type = "override"; content = "ls --color=tty"; priority = 1000; }; } ]   
+
+# in which files is this option created (declared)
+<prompt> nix-repl> </prompt>:p options.environment.shellAliases.declarations
+[ "/nix/var/nix/profiles/per-user/root/channels/nixpkgs/nixos/modules/config/shells-environment.nix" ]                                                                  
+
+
+# read option description in-place
+<prompt> nix-repl> </prompt> options.environment.shellAliases.description
+"An attribute set that maps aliases (the top level attribute names in\nthis option) to command strings or directly to build outputs. The\naliases are added to all users' shells.\nAliases mapped to <code>null</code> are ignored.\n"
+
 </screen>
+  
  </para>
 
  <para>


### PR DESCRIPTION
Explore nixos options using nix repl. 
From: https://discourse.nixos.org/t/how-do-you-explore-a-nix-expression/4088/3

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
