### PR TITLE
Clarify nixos-test screenshot name.

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.xml
+++ b/nixos/doc/manual/development/writing-nixos-tests.xml
@@ -183,6 +183,13 @@ startAll;
       Take a picture of the display of the virtual machine, in PNG format. The
       screenshot is linked from the HTML log.
      </para>
+     <note>
+      <para>
+       Using characters from the <literal>\w</literal> regex class in the
+       screenshot name will place the screenshot in the build result directory,
+       otherwise interpreted as an absolute path on the host machine.
+      </para>
+     </note>
     </listitem>
    </varlistentry>
    <varlistentry>


### PR DESCRIPTION
###### Motivation for this change

I tried to use a dash in the screenshot name, which resulted in a weird error.

###### Things done

Edited doc. Nothing else done.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
