### PR TITLE
idris2: init at unstable-2019-10-13

### DIFF
--- a/pkgs/development/idris-modules/default.nix
+++ b/pkgs/development/idris-modules/default.nix
@@ -113,6 +113,8 @@
 
     iaia = callPackage ./iaia.nix {};
 
+    idris2 = callPackage ./idris2 {};
+
     idrishighlighter = callPackage ./idrishighlighter.nix {};
 
     idrisscript = callPackage ./idrisscript.nix {};

--- a/pkgs/development/idris-modules/idris2/0001-optimization.patch
+++ b/pkgs/development/idris-modules/idris2/0001-optimization.patch
@@ -1,0 +1,16 @@
+diff --git a/idris2.ipkg b/idris2.ipkg
+index 6963bdc..457c353 100644
+--- a/idris2.ipkg
++++ b/idris2.ipkg
+@@ -124,9 +124,9 @@ modules =
+ 
+ sourcedir = src
+ executable = idris2
+--- opts = "--cg-opt -O2 --partial-eval"
++opts = "--cg-opt -O2 --partial-eval"
+ -- opts = "--cg-opt -pg --partial-eval"
+-opts = "--partial-eval"
++-- opts = "--partial-eval"
+ -- opts = "--partial-eval --cg-opt -lws2_32" -- windows
+ 
+ main = Idris.Main

--- a/pkgs/development/idris-modules/idris2/0010-disable-network-test.patch
+++ b/pkgs/development/idris-modules/idris2/0010-disable-network-test.patch
@@ -1,0 +1,13 @@
+diff --git a/libs/network/Makefile b/libs/network/Makefile
+index 6fb6610..0acc711 100644
+--- a/libs/network/Makefile
++++ b/libs/network/Makefile
+@@ -50,7 +50,7 @@ test: build test.c
+ 	cp $(DYLIBTARGET) lib$(DYLIBTARGET) # to make C linker happy
+ 	$(CC) -o network-tests -L. -I. test.c -l$(LIBNAME)
+ 	LD_LIBRARY_PATH=. ./network-tests
+-	./lib-tests
++	# ./lib-tests
+ 
+ $(OBJS): $(HDRS)
+ 

--- a/pkgs/development/idris-modules/idris2/default.nix
+++ b/pkgs/development/idris-modules/idris2/default.nix
@@ -1,0 +1,35 @@
+{ build-idris-package
+, fetchFromGitHub
+, contrib
+, lib
+, optimized ? true
+}:
+build-idris-package rec {
+  name = "idris2";
+  version = "unstable-2019-10-13";
+
+  idrisDeps = [ contrib ];
+
+  src = fetchFromGitHub {
+    owner = "edwinb";
+    repo = name;
+    rev = "4e019d80937a2209cc920bb651fd088b12406463";
+    sha256 = "0y3dp2llbzdiwmm6x737srz7n441c3rjx7f1wpc4bqqmc1xh0n9m";
+  };
+
+  buildPhase = ''
+    env PREFIX="$out" make install
+  '';
+
+  patches =
+    # If we want an optimized binary (mentioned in the README)
+    lib.optional optimized ./0001-optimization.patch
+    # The Nix sandbox blocks the network tests, so we patch them out.
+    ++ [ ./0010-disable-network-test.patch ];
+
+  meta = with lib; {
+    description = "A dependently typed programming language, a successor to Idris";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ synthetica ];
+  };
+}

--- a/pkgs/development/idris-modules/idris2/default.nix
+++ b/pkgs/development/idris-modules/idris2/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , contrib
 , lib
+, chez
 , optimized ? true
 }:
 build-idris-package rec {
@@ -9,6 +10,8 @@ build-idris-package rec {
   version = "unstable-2019-10-13";
 
   idrisDeps = [ contrib ];
+
+  extraBuildInputs = [ chez ];
 
   src = fetchFromGitHub {
     owner = "edwinb";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8013,6 +8013,8 @@ in
 
   idris = idrisPackages.with-packages [ idrisPackages.base ] ;
 
+  idris2 = idrisPackages.idris2;
+
   intel-graphics-compiler = callPackage ../development/compilers/intel-graphics-compiler { };
 
   intercal = callPackage ../development/compilers/intercal { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
