### PR TITLE
virtualbox: discover extension packs at runtime

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-host.nix
+++ b/nixos/modules/virtualisation/virtualbox-host.nix
@@ -5,13 +5,17 @@ with lib;
 let
   cfg = config.virtualisation.virtualbox.host;
 
-  virtualbox = cfg.package.override {
+  virtualboxUnwrapped = cfg.package.override {
     inherit (cfg) enableHardening headless;
-    extensionPack = if cfg.enableExtensionPack then pkgs.virtualboxExtpack else null;
   };
+  virtualbox = if cfg.enableExtensionPack then
+    pkgs.callPackage ../../../pkgs/applications/virtualization/virtualbox/wrapper.nix {
+      virtualbox = virtualboxUnwrapped;
+    }
+  else virtualboxUnwrapped;
 
   kernelModules = config.boot.kernelPackages.virtualbox.override {
-    inherit virtualbox;
+    virtualbox = virtualboxUnwrapped;
   };
 
 in

--- a/pkgs/applications/virtualization/virtualbox/0001-ExtPackManagerImpl-read-vboxExtpackDir-from-VBOX_EXT.patch
+++ b/pkgs/applications/virtualization/virtualbox/0001-ExtPackManagerImpl-read-vboxExtpackDir-from-VBOX_EXT.patch
@@ -1,0 +1,32 @@
+From 568f46e8b1667ae7e3bd46714a050b238b7255fe Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Sat, 27 Oct 2018 18:07:59 +0100
+Subject: [PATCH] ExtPackManagerImpl: read vboxExtpackDir from VBOX_EXTPACK_DIR
+ if set
+
+---
+ src/VBox/Main/src-all/ExtPackManagerImpl.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/VBox/Main/src-all/ExtPackManagerImpl.cpp b/src/VBox/Main/src-all/ExtPackManagerImpl.cpp
+index 739efc34b9..6179ac6bab 100644
+--- a/src/VBox/Main/src-all/ExtPackManagerImpl.cpp
++++ b/src/VBox/Main/src-all/ExtPackManagerImpl.cpp
+@@ -2094,7 +2094,13 @@ HRESULT ExtPackManager::initExtPackManager(VirtualBox *a_pVirtualBox, VBOXEXTPAC
+     char szBaseDir[RTPATH_MAX];
+     int rc = RTPathAppPrivateArchTop(szBaseDir, sizeof(szBaseDir));
+     AssertLogRelRCReturn(rc, E_FAIL);
+-    rc = RTPathAppend(szBaseDir, sizeof(szBaseDir), VBOX_EXTPACK_INSTALL_DIR);
++    const char* vboxExtpackDir = getenv("VBOX_EXTPACK_DIR");
++    if(vboxExtpackDir == NULL) {
++        rc = RTPathAppend(szBaseDir, sizeof(szBaseDir), VBOX_EXTPACK_INSTALL_DIR);
++    }
++    else {
++        rc = vboxExtpackDir;
++    }
+     AssertLogRelRCReturn(rc, E_FAIL);
+ 
+     char szCertificatDir[RTPATH_MAX];
+-- 
+2.18.1
+

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -95,6 +95,7 @@ in stdenv.mkDerivation {
     # Kernel 5.3 fix, should be fixed with VirtualBox 6.0.14
     # https://www.virtualbox.org/ticket/18911
     ./kernel-5.3-fix.patch
+    ./0001-ExtPackManagerImpl-read-vboxExtpackDir-from-VBOX_EXT.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -1,20 +1,28 @@
-{fetchurl, lib}:
+{ stdenv, fetchurl, lib }:
 
 with lib;
 
-let version = "6.0.12";
-in
-fetchurl rec {
-  name = "Oracle_VM_VirtualBox_Extension_Pack-${version}.vbox-extpack";
-  url = "https://download.virtualbox.org/virtualbox/${version}/${name}";
-  sha256 =
-    # Manually sha256sum the extensionPack file, must be hex!
-    # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
-    # Checksums can also be found at https://www.virtualbox.org/download/hashes/${version}/SHA256SUMS
-    let value = "27a0956940654b0accf4d79692078bd496d9f062e4ed3da69e5421cba8d1e444";
-    in assert (builtins.stringLength value) == 64; value;
+stdenv.mkDerivation rec {
+  pname = "Oracle_VM_VirtualBox_Extension_Pack";
+  version = "6.0.12";
 
-  meta = {
+  src = fetchurl {
+    url = "http://download.virtualbox.org/virtualbox/${version}/${pname}-${version}.vbox-extpack";
+    sha256 = "0i74s6lcn8alksk3vvg4cbqdk5nlic3r55npyk60ljv581lrb817";
+  };
+
+  unpackCmd = ''
+    mkdir -p out
+    tar xf $curSrc -C out
+  '';
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/${pname}
+    cp -R * $out/${pname}
+  '';
+
+  meta = with stdenv.lib; {
     description = "Oracle Extension pack for VirtualBox";
     license = licenses.virtualbox-puel;
     homepage = https://www.virtualbox.org/;

--- a/pkgs/applications/virtualization/virtualbox/wrapper.nix
+++ b/pkgs/applications/virtualization/virtualbox/wrapper.nix
@@ -1,0 +1,18 @@
+{ stdenv, symlinkJoin, makeWrapper, virtualbox, virtualboxExtpack }:
+
+symlinkJoin {
+  name = "virtualbox-wrapped-${virtualbox.version}";
+
+  paths = [ virtualbox ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''\
+    for file in $(find $out/bin/*); do
+      # skip non-executables
+      patchelf --print-interpreter "$file" >/dev/null 2>&1 || continue
+      wrapProgram $file --set VBOX_EXTPACK_DIR ${virtualboxExtpack}
+    done
+  '';
+
+  inherit (virtualbox) meta version;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21326,9 +21326,7 @@ in
 
   virtualboxExtpack = callPackage ../applications/virtualization/virtualbox/extpack.nix { };
 
-  virtualboxWithExtpack = lowPrio (virtualbox.override {
-    extensionPack = virtualboxExtpack;
-  });
+  virtualboxWithExtpack = callPackage ../applications/virtualization/virtualbox/wrapper.nix { };
 
   virtualglLib = callPackage ../tools/X11/virtualgl/lib.nix {
     fltk = fltk13;


### PR DESCRIPTION
###### Motivation for this change

Currently, `virtualbox` with extension pack and `virtualbox` without extension pack need to be build separately, because it's just an argument in the same derivation leaving to a different `installPhase`.

As the extension pack is unfree (and unfree isn't built by hydra), this means users with extension pack enabled need to compile `virtualbox` by themselves quite often.

This changes virtualbox to load extension packs from a environment variable `VBOX_EXTPACK_DIR`, so we can build virtualbox once by hydra, and let users of the extension pack just use the wrapper in front of it.

See https://github.com/NixOS/nixpkgs/issues/34796#issuecomment-406095992 for the original idea.

However, this might not work with enabled hardening, as the environment variable will be ignored. To fix it there, we might want to hardcode `vboxExtpackDir` to some imperative location changed during configuration switch, or replace the wrapper with something binary-patching the original virtualbox.

This draft PR is also to get the discussion started.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers 
cc @ambrop72 @xeji @cdepillabout 
