### PR TITLE
Execline replace bash wrapper

### DIFF
--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -19,10 +19,6 @@ in {
   # mostly for moving and deleting files from the build directory
   # : lines
 , postInstall
-  # packages with setup hooks that should be run
-  # (see definition of `makeSetupHook`)
-  # : list drv
-, setupHooks ? []
   # : list Maintainer
 , maintainers ? []
 
@@ -66,8 +62,6 @@ in stdenv.mkDerivation {
 
   dontDisableStatic = true;
   enableParallelBuilding = true;
-
-  nativeBuildInputs = setupHooks;
 
   configureFlags = configureFlags ++ [
     "--enable-absolute-paths"

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -1,4 +1,4 @@
-{ skawarePackages, makeWrapper }:
+{ skawarePackages }:
 
 with skawarePackages;
 
@@ -10,8 +10,6 @@ buildPackage {
   description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
-
-  setupHooks = [ makeWrapper ];
 
   # TODO: nsss support
   configureFlags = [
@@ -32,11 +30,6 @@ buildPackage {
 
     mv doc $doc/share/doc/execline/html
     mv examples $doc/share/doc/execline/examples
-
-    # finally, add all tools to PATH so they are available
-    # from within execlineb scripts by default
-    wrapProgram $bin/bin/execlineb \
-      --suffix PATH : $bin/bin
   '';
 
 }

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -1,35 +1,90 @@
-{ skawarePackages }:
+{ lib, skawarePackages
+# for execlineb-with-builtins
+, coreutils, gnugrep, writeScriptBin, runCommand
+# Whether to wrap bin/execlineb to have the execline tools on its PATH.
+, execlineb-with-builtins ? true
+}:
 
 with skawarePackages;
 
-buildPackage {
-  pname = "execline";
-  version = "2.5.1.0";
-  sha256 = "0xr6yb50wm6amj1wc7jmxyv7hvlx2ypbnww1vc288j275625d9xi";
-
-  description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
-
+let
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
 
-  # TODO: nsss support
-  configureFlags = [
-    "--libdir=\${lib}/lib"
-    "--dynlibdir=\${lib}/lib"
-    "--bindir=\${bin}/bin"
-    "--includedir=\${dev}/include"
-    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs.dev}/include"
-    "--with-lib=${skalibs.lib}/lib"
-    "--with-dynlib=${skalibs.lib}/lib"
-  ];
+  execline =
+    buildPackage {
+      pname = "execline";
+      version = "2.5.1.0";
+      sha256 = "0xr6yb50wm6amj1wc7jmxyv7hvlx2ypbnww1vc288j275625d9xi";
 
-  postInstall = ''
-    # remove all execline executables from build directory
-    rm $(find -type f -mindepth 1 -maxdepth 1 -executable)
-    rm libexecline.*
+      description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 
-    mv doc $doc/share/doc/execline/html
-    mv examples $doc/share/doc/execline/examples
-  '';
+      inherit outputs;
 
-}
+      # TODO: nsss support
+      configureFlags = [
+        "--libdir=\${lib}/lib"
+        "--dynlibdir=\${lib}/lib"
+        "--bindir=\${bin}/bin"
+        "--includedir=\${dev}/include"
+        "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+        "--with-include=${skalibs.dev}/include"
+        "--with-lib=${skalibs.lib}/lib"
+        "--with-dynlib=${skalibs.lib}/lib"
+      ];
+
+      postInstall = ''
+        # remove all execline executables from build directory
+        rm $(find -type f -mindepth 1 -maxdepth 1 -executable)
+        rm libexecline.*
+
+        mv doc $doc/share/doc/execline/html
+        mv examples $doc/share/doc/execline/examples
+      '';
+
+    };
+
+  # a wrapper around execlineb, which provides all execline
+  # tools on `execlineb`’s PATH.
+  execlineb-with-builtins-drv =
+    let eldir = "${execline}/bin";
+    in writeScriptBin "execlineb" ''
+      #!${eldir}/execlineb -s0
+      # appends the execlineb bin dir to PATH if not yet in PATH
+      ${eldir}/define eldir ${eldir}
+      ''${eldir}/ifelse
+      {
+        # since this is nix, we can grep for the execline drv hash in PATH
+        # to see whether it’s already in there
+        ''${eldir}/pipeline
+        { ${coreutils}/bin/printenv PATH }
+        ${gnugrep}/bin/grep --quiet "${eldir}"
+      }
+      # it’s there already
+      { ''${eldir}/execlineb $@ }
+      # not there yet, add it
+      ''${eldir}/importas oldpath PATH
+      ''${eldir}/export PATH "''${eldir}:''${oldpath}"
+      ''${eldir}/execlineb $@
+    '';
+
+  # the original execline package, with bin/execlineb overwritten
+  execline-with-builtins = runCommand "my-execline"
+    (execline.drvAttrs // {
+      preferLocalBuild = true;
+      allowSubstitutes = false;
+    })
+    # copy every output and just overwrite the execlineb binary in $bin
+    ''
+      ${lib.concatMapStringsSep "\n"
+        (output: ''
+          cp -r ${execline.${output}} "''$${output}"
+          chmod --recursive +w "''$${output}"
+        '')
+        outputs}
+      install ${execlineb-with-builtins-drv}/bin/execlineb $bin/bin/execlineb
+    '';
+
+in
+  if execlineb-with-builtins
+  then execline-with-builtins
+  else execline


### PR DESCRIPTION
Followup to the issue raised in https://github.com/NixOS/nixpkgs/commit/b64d25c44782027414509460c1900646dee57db1#commitcomment-35482293 cc @luke-clifton.

It solves the problem of having the intermediate script invoke bash, just to execute execline. 

This does *not* solve the macOS problem with nested shebangs, but it provides an option to disable the `execlineb` wrapper (`execline.override { execlineb-with-builtins = false; }`) to work around that in the meantime.

Sorry for the crappy diff, it’s mainly because I indented the original expression; the original derivation is unchanged.

Tested the resulting `execlineb` wrapper manually.