### PR TITLE
nixos/smokeping: replace smokeping.fcgi with a symlink

### DIFF
--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -315,5 +315,7 @@ in
       serviceConfig.Restart = "always";
     };
   };
+
+  meta.maintainers = with lib.maintainers; [ erictapen ];
 }
 

--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -299,7 +299,8 @@ in
         mkdir -m 0755 -p ${smokepingHome}/cache ${smokepingHome}/data
         rm -f ${smokepingHome}/cropper
         ln -s ${cfg.package}/htdocs/cropper ${smokepingHome}/cropper
-        cp ${cgiHome} ${smokepingHome}/smokeping.fcgi
+        rm -f ${smokepingHome}/smokeping.fcgi
+        ln -s ${cgiHome} ${smokepingHome}/smokeping.fcgi
         ${cfg.package}/bin/smokeping --check --config=${configPath}
         ${cfg.package}/bin/smokeping --static --config=${configPath}
       '';

--- a/pkgs/tools/networking/smokeping/default.nix
+++ b/pkgs/tools/networking/smokeping/default.nix
@@ -19,5 +19,6 @@ stdenv.mkDerivation rec {
     homepage = http://oss.oetiker.ch/smokeping;
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.erictapen ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This fixes a regression from bb649d96b038ab2c567439987bc182f6797bae5a.
There were permission problems, when the preStart script tried to copy the smokeping.fcgi file over the old file.

```
834fi85dzixkalmk383gp0v9ps6rd4gy-unit-script-smokeping-pre-start[1545]: cp: cannot create regular file '/var/lib/smokeping/smokeping.fcgi': Permission denied
```

###### Things done

As I don't see any reason why `smokeping.fcgi` should be writable, I replaced it with a symlink from `/nix/store`.

**Warning**: If you experience this problem, applying this patch and rebuilding your system is not enough:
- You need to manually remove the old file with higher privileges than `smokeping` user has.
- I also needed to restart `thttpd.service`.

This needs to be **backported** to `nixos-19.09`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @cransom as they introduced the module.
