### PR TITLE
[19.09] ocrmypdf: 8.2.3 -> 9.0.3

### DIFF
--- a/pkgs/tools/text/ocrmypdf/default.nix
+++ b/pkgs/tools/text/ocrmypdf/default.nix
@@ -28,14 +28,14 @@ let
 
 in buildPythonApplication rec {
   pname = "ocrmypdf";
-  version = "8.2.3";
+  version = "9.0.3";
   disabled = ! python3Packages.isPy3k;
 
   src = fetchFromGitHub {
     owner = "jbarlow83";
     repo = "OCRmyPDF";
     rev = "v${version}";
-    sha256 = "1ldlyhxkav34y9d7g2kx3d4p26c2b82vnwi0ywnfynb16sav36d5";
+    sha256 = "1qnjdcbwkxxqfahylzl0wj1gk51yi9m8akd4d1rrq37vg2vwdkjy";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -51,12 +51,14 @@ in buildPythonApplication rec {
     img2pdf
     pdfminer
     pikepdf
+    pillow
     reportlab
     ruffus
+    setuptools
+    tqdm
   ];
 
   checkInputs = with python3Packages; [
-    hocr-tools
     pypdf2
     pytest
     pytest-helpers-namespace
@@ -66,7 +68,6 @@ in buildPythonApplication rec {
     python-xmp-toolkit
     setuptools
   ] ++ runtimeDeps;
-
 
   postPatch = ''
     substituteInPlace src/ocrmypdf/leptonica.py \
@@ -92,6 +93,8 @@ in buildPythonApplication rec {
     and not test_bad_utf8 \
     and not test_old_unpaper'
   '';
+
+  makeWrapperArgs = [ "--prefix PATH : ${stdenv.lib.makeBinPath [ ghostscript jbig2enc pngquant qpdf tesseract4 unpaper ]}" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/jbarlow83/OCRmyPDF";


### PR DESCRIPTION
###### Motivation for this change

This fixes ocrmypdf in nixpkgs 19.09, which currently shows:

```
# ocrmypdf --help
Traceback (most recent call last):
  File "/nix/store/b0lv6kp74xs12bh05jprlw6q4p37hsg7-ocrmypdf-8.2.3/bin/.ocrmypdf-wrapped", line 7, in <module>
    from ocrmypdf.__main__ import run_pipeline
  File "/nix/store/b0lv6kp74xs12bh05jprlw6q4p37hsg7-ocrmypdf-8.2.3/lib/python3.7/site-packages/ocrmypdf/__init__.py", line 18, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Kiwi 
