### PR TITLE
pythonPackages.elementpath: 1.1.8 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/elementpath/default.nix
+++ b/pkgs/development/python-modules/elementpath/default.nix
@@ -1,17 +1,14 @@
-{ buildPythonPackage
-, lib
-, fetchFromGitHub
-}:
+{ lib, buildPythonPackage, fetchFromGitHub }:
 
 buildPythonPackage rec {
-  version = "1.1.8";
+  version = "1.3.0";
   pname = "elementpath";
 
   src = fetchFromGitHub {
     owner = "sissaschool";
     repo = "elementpath";
     rev = "v${version}";
-    sha256 = "0krczvf8r6pb3hb8qaxl9h2b4qwg180xk66gyxjf002im7ri75aj";
+    sha256 = "0ahqqqpcf3fd6xcdhiwwscincyj6h5xyjaacnqxwph1y1b8mnzyw";
   };
 
   # avoid circular dependency with xmlschema which directly depends on this

--- a/pkgs/development/python-modules/xmlschema/default.nix
+++ b/pkgs/development/python-modules/xmlschema/default.nix
@@ -4,14 +4,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.0.13";
+  version = "1.0.15";
   pname = "xmlschema";
 
   src = fetchFromGitHub {
     owner = "sissaschool";
     repo = "xmlschema";
     rev = "v${version}";
-    sha256 = "182439gqhlxhr9rdi9ak33z4ffy1w9syhykkckkl6mq050c80qdr";
+    sha256 = "1s8ggvy2s7513cxcal3r37rn1bhpkxhq3hs5m9pgvmrysxjdz8lb";
   };
 
   propagatedBuildInputs = [ elementpath ];
@@ -25,6 +25,7 @@ buildPythonPackage rec {
       --replace "SKIP_REMOTE_TESTS = " "SKIP_REMOTE_TESTS = True #"
     pytest . \
       --ignore=xmlschema/tests/test_factory.py \
+      --ignore=xmlschema/tests/test_memory.py \
       --ignore=xmlschema/tests/test_validators.py \
       --ignore=xmlschema/tests/test_schemas.py \
       -k 'not element_tree_import_script'


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date on repology

bumped xmlschema, as it was no longer compatible with old version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @


```
[5 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/71156
6 package were build:
python27Packages.elementpath python27Packages.xmlschema python37Packages.elementpath python37Packages.fints python37Packages.sepaxml python37Packages.xmlschema
```