### PR TITLE
lxqt.qps: 1.10.20 -> 2.0.0

### DIFF
--- a/pkgs/desktops/lxqt/qps/default.nix
+++ b/pkgs/desktops/lxqt/qps/default.nix
@@ -20,7 +20,7 @@ mkDerivation rec {
     description = "Qt based process manager";
     homepage = https://github.com/lxqt/qps;
     license = licenses.gpl2;
-    platforms = with platforms; unix;
+    platforms = with platforms; linux;  # does not build on darwin
     maintainers = with maintainers; [ romildo ];
   };
 }

--- a/pkgs/desktops/lxqt/qps/default.nix
+++ b/pkgs/desktops/lxqt/qps/default.nix
@@ -3,13 +3,13 @@
 
 mkDerivation rec {
   pname = "qps";
-  version = "1.10.20";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1g8j4cjy5x33jzjkx6vwyl5qbf9i2z2w01ipgk7nrik5drf9crbf";
+    sha256 = "03rl59yk3b24j0y0k8dpdpb3yi4f1l642zn5pp5br3s2vwx1vzkg";
   };
 
   nativeBuildInputs = [ cmake lxqt-build-tools ];
@@ -17,10 +17,10 @@ mkDerivation rec {
   buildInputs = [ qtbase qtx11extras qttools ];
 
   meta = with lib; {
-    description = "The Qt process manager";
+    description = "Qt based process manager";
     homepage = https://github.com/lxqt/qps;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ romildo ];
     platforms = with platforms; unix;
+    maintainers = with maintainers; [ romildo ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to version [2.0.0](https://blog.lxqt.org/2019/10/release-qps-2-0-0/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).