### PR TITLE
networkmanager: enable polkit_agent

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -41,6 +41,7 @@ in stdenv.mkDerivation rec {
     "-Dcrypto=gnutls"
     "-Dsession_tracking=systemd"
     "-Dmodem_manager=true"
+    "-Dpolkit_agent=true"
     "-Dnmtui=true"
     "-Ddocs=true"
     "-Dtests=no"


### PR DESCRIPTION
###### Motivation for this change
Not sure why we had this disabled.
This is for the nmcli/nmtui `agent` subcommand [0]
which allows it to act as a polkit agent.

> nmcli agent { secret | polkit | all }
> Run nmcli as a NetworkManager secret agent, or polkit agent.

For example, this is useful if you want to use nmcli/nmtui to authenti-
cate with polkit on a headless server.

[0]: https://developer.gnome.org/NetworkManager/stable/nmcli.html

---

Thanks for verifying my findings in #nm @jtojnar :+1: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
