### PR TITLE
awslogs: propagate setuptools

### DIFF
--- a/pkgs/tools/admin/awslogs/default.nix
+++ b/pkgs/tools/admin/awslogs/default.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
   doCheck = false;
 
   propagatedBuildInputs = with python3Packages; [
-    boto3 termcolor dateutil docutils
+    boto3 termcolor dateutil docutils setuptools
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

awslogs is broken:

```
Traceback (most recent call last):
  File "/nix/store/r8c43gkr0awz054n7fq6kq9ldfnzpq1l-awslogs-0.11.0/bin/.awslogs-wrapped", line 7, in <module>
    from awslogs.bin import main
  File "/nix/store/r8c43gkr0awz054n7fq6kq9ldfnzpq1l-awslogs-0.11.0/lib/python3.7/site-packages/awslogs/__init__.py", line 1, in <module>
    from ._version import __version__  # noqa
  File "/nix/store/r8c43gkr0awz054n7fq6kq9ldfnzpq1l-awslogs-0.11.0/lib/python3.7/site-packages/awslogs/_version.py", line 1, in <module>
    from pkg_resources import get_distribution
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dbrock 
