### PR TITLE
metamath: 0.172 -> 0.178

### DIFF
--- a/pkgs/development/interpreters/metamath/default.nix
+++ b/pkgs/development/interpreters/metamath/default.nix
@@ -2,20 +2,22 @@
 
 stdenv.mkDerivation {
   pname = "metamath";
-  version = "0.172";
+  version = "0.178";
 
   buildInputs = [ autoreconfHook ];
 
-  # This points to my own repository because there is no official repository
-  # for metamath; there's a download location but it gets updated in place with
-  # no permanent link. See discussion at
-  # https://groups.google.com/forum/#!topic/metamath/N4WEWQQVUfY
   src = fetchFromGitHub {
-    owner = "Taneb";
-    repo = "metamath";
-    rev = "43141cd17638f8efb409dc5d46e7de6a6c39ec42";
-    sha256 = "07c7df0zl0wsb0pvdgkwikpr8kz7fi3mshxzk61vkamyp68djjb5";
+    owner = "metamath";
+    repo = "metamath-exe";
+    rev = "4f59d60aeb03f92aea3cc7ecf5a2c0fcf08900a5";
+    sha256 = "0nrl4nzp6rm2sn365xyjf3g5l5fl58kca7rq08lqyz5gla0wgfcf";
   };
+
+  # the files necessary to build the DATA target are not in this distribution
+  # luckily, they're not really needed so we don't build it.
+  makeFlags = [ "DATA=" ];
+
+  installTargets = "install-exec";
 
   meta = with stdenv.lib; {
     description = "Interpreter for the metamath proof language";


### PR DESCRIPTION
This also moves away from my mirror of the distributiont one hosted by the metamath organization, which should generally be far more up-to-date. However, that doesn't include any data files, so we need to make sure we don't try to make those.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
