### PR TITLE
rbtools: propagate setuptools

### DIFF
--- a/pkgs/development/python-modules/rbtools/default.nix
+++ b/pkgs/development/python-modules/rbtools/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , nose
 , six
+, setuptools
 , isPy3k
 }:
 
@@ -17,7 +18,7 @@ buildPythonPackage {
   };
 
   checkInputs = [ nose ];
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [ six setuptools ];
 
   checkPhase = "LC_ALL=C nosetests";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

rbtools is broken because it is missing `setuptools`:

```
Traceback (most recent call last):
  File "/nix/store/h0w1wr06n5wyk7v978n8ysyajw2m55m9-python2.7-rbtools-0.7.2/bin/.rbt-wrapped", line 7, in <module>
    from rbtools.commands.main import main
  File "/nix/store/h0w1wr06n5wyk7v978n8ysyajw2m55m9-python2.7-rbtools-0.7.2/lib/python2.7/site-packages/rbtools/commands/__init__.py", line 16, in <module>
    from rbtools.api.client import RBClient
  File "/nix/store/h0w1wr06n5wyk7v978n8ysyajw2m55m9-python2.7-rbtools-0.7.2/lib/python2.7/site-packages/rbtools/api/client.py", line 5, in <module>
    from rbtools.api.transport.sync import SyncTransport
  File "/nix/store/h0w1wr06n5wyk7v978n8ysyajw2m55m9-python2.7-rbtools-0.7.2/lib/python2.7/site-packages/rbtools/api/transport/sync.py", line 4, in <module>
    from rbtools.api.factory import create_resource
  File "/nix/store/h0w1wr06n5wyk7v978n8ysyajw2m55m9-python2.7-rbtools-0.7.2/lib/python2.7/site-packages/rbtools/api/factory.py", line 3, in <module>
    from rbtools.api.resource import (CountResource, ItemResource,
  File "/nix/store/h0w1wr06n5wyk7v978n8ysyajw2m55m9-python2.7-rbtools-0.7.2/lib/python2.7/site-packages/rbtools/api/resource.py", line 6, in <module>
    from pkg_resources import parse_version
ImportError: No module named pkg_resources
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @domenkozar 
