### PR TITLE
[19.09] device-tree_rpi: Rename dtb source

### DIFF
--- a/pkgs/os-specific/linux/device-tree/raspberrypi.nix
+++ b/pkgs/os-specific/linux/device-tree/raspberrypi.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation {
 
     cp ${raspberrypifw}/share/raspberrypi/boot/bcm*.dtb .
 
-    cp bcm2708-rpi-0-w.dtb bcm2835-rpi-zero-w.dtb
+    cp bcm2708-rpi-zero-w.dtb bcm2835-rpi-zero-w.dtb
     cp bcm2708-rpi-b.dtb bcm2835-rpi-a.dtb
     cp bcm2708-rpi-b.dtb bcm2835-rpi-b.dtb
     cp bcm2708-rpi-b.dtb bcm2835-rpi-b-rev2.dtb


### PR DESCRIPTION
Upstream raspberrypifw has changed

###### Motivation for this change

Upstream has renamed their `.dtb` files, so `device-tree_rpi` no longer builds. This is fixed on master due to #68265 but this bit needs backporting to stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lheckemann @disassembler I think you're the right people for backports as release managers?
