### PR TITLE
vit 2.0.0

### DIFF
--- a/pkgs/development/python-modules/tasklib/default.nix
+++ b/pkgs/development/python-modules/tasklib/default.nix
@@ -1,0 +1,36 @@
+{ lib, pythonPackages, taskwarrior, writeShellScriptBin }:
+
+with pythonPackages;
+
+let
+
+wsl_stub = writeShellScriptBin "wsl" "true";
+
+in buildPythonPackage rec {
+  pname = "tasklib";
+  version = "1.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3964fb7e87f86dc5e2708addb67e69d0932534991991b6bae2e37a0c2059273f";
+  };
+
+  propagatedBuildInputs = [
+    six
+    pytz
+    tzlocal
+  ];
+
+  checkInputs = [
+    taskwarrior
+    wsl_stub
+  ];
+
+  meta = with lib; {
+    homepage = https://github.com/robgolding/tasklib;
+    description = "A library for interacting with taskwarrior databases";
+    maintainers = with maintainers; [ arcnmx ];
+    platforms = platforms.all;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5001,6 +5001,8 @@ in {
 
   tadasets = callPackage ../development/python-modules/tadasets { };
 
+  tasklib = callPackage ../development/python-modules/tasklib { };
+
   tempita = callPackage ../development/python-modules/tempita { };
 
   terminado = callPackage ../development/python-modules/terminado { };


### PR DESCRIPTION
##### Motivation for this change

https://groups.google.com/forum/#!topic/taskwarrior-user/0dTbvFOOZY0

I'm not sure whether I should remove the previous `vit` package and replace the attr with this, or keep it around as `vit1`, or?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill as maintainer of the existing vit 1.3 package, also do you want to be on this version too?
