### PR TITLE
Add support for libgda on darwin

### DIFF
--- a/pkgs/development/libraries/libgda/default.nix
+++ b/pkgs/development/libraries/libgda/default.nix
@@ -48,6 +48,6 @@ assert postgresSupport -> postgresql != null;
     homepage = https://www.gnome-db.org/;
     license = [ licenses.lgpl2 licenses.gpl2 ];
     maintainers = gnome3.maintainers;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/libgda/default.nix
+++ b/pkgs/development/libraries/libgda/default.nix
@@ -15,9 +15,11 @@ assert postgresSupport -> postgresql != null;
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "16vxv2qvysh22s8h9h6irx96sacagxkz0i4qgi1wc6ibly6fvjjr";
   };
-  configureFlags = with stdenv.lib; [ "--enable-gi-system-install=no" ]
-    ++ (optional (mysqlSupport) "--with-mysql=yes")
-    ++ (optional (postgresSupport) "--with-postgres=yes");
+  configureFlags = with stdenv.lib; [
+    "--enable-gi-system-install=no"
+    "--with-mysql=${if mysqlSupport then "yes" else "no"}"
+    "--with-postgres=${if postgresSupport then "yes" else "no"}"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libgda/default.nix
+++ b/pkgs/development/libraries/libgda/default.nix
@@ -19,6 +19,13 @@ assert postgresSupport -> postgresql != null;
     "--enable-gi-system-install=no"
     "--with-mysql=${if mysqlSupport then "yes" else "no"}"
     "--with-postgres=${if postgresSupport then "yes" else "no"}"
+
+    # macOS builds use the sqlite source code that comes with libgda,
+    # as opposed to using the system or brewed sqlite3, which is not supported on macOS,
+    # as mentioned in https://github.com/GNOME/libgda/blob/95eeca4b0470f347c645a27f714c62aa6e59f820/libgda/sqlite/README#L31,
+    # which references the paper https://web.archive.org/web/20100610151539/http://lattice.umiacs.umd.edu/files/functions_tr.pdf
+    # See also https://github.com/Homebrew/homebrew-core/blob/104f9ecd02854a82372b64d63d41356555378a52/Formula/libgda.rb
+    "--enable-system-sqlite=${if stdenv.isDarwin then "no" else "yes"}"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
   ```
    $ /nix/store/b3sddkvy7amam6rmr4cbf423rwazm5rl-libgda-5.2.9/bin/gda-sql
    gda> .lp
           Installed providers list
    Provider  │ Description
    ──────────┼──────────────────────────────
    MySQL     │ Provider for MySQL databases
    SQLCipher │ Provider for SQLCipher
    SQLite    │ Provider for SQLite databases
   ```
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jtojnar 