### PR TITLE
screenfetch: add to path pciutils

### DIFF
--- a/pkgs/tools/misc/screenfetch/default.nix
+++ b/pkgs/tools/misc/screenfetch/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper, coreutils, gawk, procps, gnused
-, bc, findutils, xdpyinfo, xprop, gnugrep, ncurses
+, bc, findutils, xdpyinfo, xprop, gnugrep, ncurses, pciutils
 , darwin
 }:
 
 let
   path = lib.makeBinPath ([
     coreutils gawk gnused findutils
-    gnugrep ncurses bc
+    gnugrep ncurses bc pciutils
   ] ++ lib.optionals stdenv.isLinux [
     procps
     xdpyinfo


### PR DESCRIPTION
###### Motivation for this change
Fix this error
`/nix/store/kgx9r4wd1r8bv93s204yw4y2n85qnm8j-screenFetch-3.9.0/bin/.screenfetch-wrapped: line 1653: lspci: command not found
`
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
