### PR TITLE
networkmanager: use modify_system=true

### DIFF
--- a/nixos/doc/manual/configuration/network-manager.xml
+++ b/nixos/doc/manual/configuration/network-manager.xml
@@ -16,14 +16,6 @@
  </para>
 
  <para>
-  All users that should have permission to change network settings must belong
-  to the <code>networkmanager</code> group:
-<programlisting>
-<link linkend="opt-users.users._name__.extraGroups">users.users.alice.extraGroups</link> = [ "networkmanager" ];
-</programlisting>
- </para>
-
- <para>
   NetworkManager is controlled using either <command>nmcli</command> or
   <command>nmtui</command> (curses-based terminal user interface). See their
   manual pages for details on their usage. Some desktop environments (GNOME,

--- a/nixos/doc/manual/configuration/user-mgmt.xml
+++ b/nixos/doc/manual/configuration/user-mgmt.xml
@@ -14,12 +14,12 @@
   <link linkend="opt-users.users._name__.isNormalUser">isNormalUser</link> = true;
   <link linkend="opt-users.users._name__.home">home</link> = "/home/alice";
   <link linkend="opt-users.users._name__.description">description</link> = "Alice Foobar";
-  <link linkend="opt-users.users._name__.extraGroups">extraGroups</link> = [ "wheel" "networkmanager" ];
+  <link linkend="opt-users.users._name__.extraGroups">extraGroups</link> = [ "wheel" ];
   <link linkend="opt-users.users._name__.openssh.authorizedKeys.keys">openssh.authorizedKeys.keys</link> = [ "ssh-dss AAAAB3Nza... alice@foobar" ];
 };
 </programlisting>
   Note that <literal>alice</literal> is a member of the
-  <literal>wheel</literal> and <literal>networkmanager</literal> groups, which
+  <literal>wheel</literal> group, which
   allows her to use <command>sudo</command> to execute commands as
   <literal>root</literal> and to configure the network, respectively. Also note
   the SSH public key that allows remote logins with the corresponding private

--- a/nixos/doc/manual/configuration/wireless.xml
+++ b/nixos/doc/manual/configuration/wireless.xml
@@ -6,9 +6,8 @@
  <title>Wireless Networks</title>
 
  <para>
-  For a desktop installation using NetworkManager (e.g., GNOME), you just have
-  to make sure the user is in the <code>networkmanager</code> group and you can
-  skip the rest of this section on wireless networks.
+  For a desktop installation using NetworkManager (e.g., GNOME) please see the
+  <link linkend="sec-networkmanager">NetworkManager section</link>.
  </para>
 
  <para>

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -34,7 +34,7 @@ with lib;
     # Use less privileged nixos user
     users.users.nixos = {
       isNormalUser = true;
-      extraGroups = [ "wheel" "networkmanager" "video" ];
+      extraGroups = [ "wheel" "video" ];
       # Allow the graphical user to login without password
       initialHashedPassword = "";
     };

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -51,32 +51,6 @@ let
     ${cfg.extraConfig}
   '';
 
-  /*
-    [network-manager]
-    Identity=unix-group:networkmanager
-    Action=org.freedesktop.NetworkManager.*
-    ResultAny=yes
-    ResultInactive=no
-    ResultActive=yes
-
-    [modem-manager]
-    Identity=unix-group:networkmanager
-    Action=org.freedesktop.ModemManager*
-    ResultAny=yes
-    ResultInactive=no
-    ResultActive=yes
-  */
-  polkitConf = ''
-    polkit.addRule(function(action, subject) {
-      if (
-        subject.isInGroup("networkmanager")
-        && (action.id.indexOf("org.freedesktop.NetworkManager.") == 0
-            || action.id.indexOf("org.freedesktop.ModemManager")  == 0
-        ))
-          { return polkit.Result.YES; }
-    });
-  '';
-
   ns = xs: pkgs.writeText "nameservers" (
     concatStrings (map (s: "nameserver ${s}\n") xs)
   );
@@ -469,8 +443,6 @@ in {
         wireless.iwd.enable = true;
       })
     ];
-
-    security.polkit.extraConfig = polkitConf;
 
     services.dbus.packages = cfg.packages
       ++ optional cfg.enableStrongSwan pkgs.strongswanNM

--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     "--localstatedir=/var"
     "--with-systemd-suspend-resume"
     "--with-systemd-journal"
+    "--with-polkit=permissive"
   ];
 
   preCheck = ''

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -48,6 +48,8 @@ in stdenv.mkDerivation rec {
     "-Dqt=false"
     # Allow using iwd when configured to do so
     "-Diwd=true"
+    # Allow users to modify system connections
+    "-Dmodify_system=true"
     "-Dlibaudit=yes-disabled-by-default"
   ];
 


### PR DESCRIPTION
This does the following:
Allow users to modify system connections [0].

Technically what it does is change the NM_MODIFY_SYSTEM_POLICY
to "yes" instead of "auth_admin_keep" which would require a password prompt.
That is inacted in the following polkit policy [1].

This allows us to drop a permissive looking polkit rule, and we don't
have to instruct users to add themselves to the "networkmanager" group.

All relevant documentation is updated.

[0]: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/blob/1.20.4/meson_options.txt#L17
[1]: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/blob/1.20.4/data/org.freedesktop.NetworkManager.policy.in.in#L115

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
