### PR TITLE
pythonPackages.onnx: init at version 1.6.0

### DIFF
--- a/pkgs/development/python-modules/onnx/default.nix
+++ b/pkgs/development/python-modules/onnx/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, fetchpatch
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, isPy27
+, cmake
+, protobuf
+, numpy
+, six
+, typing-extensions
+, typing
+, pytestrunner
+, pytest
+, nbval
+, tabulate
+}:
+
+buildPythonPackage rec {
+  pname = "onnx";
+  version = "1.6.0";
+
+  # Due to Protobuf packaging issues this build of Onnx with Python 2 gives
+  # errors on import
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ig33jl3591041lyylxp52yi20rfrcqx3i030hd6al8iabzc721v";
+  };
+
+  # Remove the unqualified requirement for the typing package for running the
+  # tests. typing is already required for the installation, where it is
+  # correctly qualified so as to only be required for sufficiently old Python
+  # versions.
+  # This patch should be in the next release (>1.6).
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/onnx/onnx/commit/c963586d0f8dd5740777b2fd06f04ec60816de9f.patch";
+      sha256 = "1hl26cw5zckc91gmh0bdah87jyprccxiw0f4i5h1gwkq28hm6wbj";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  propagatedBuildInputs = [
+    protobuf
+    numpy
+    six
+    typing-extensions
+  ] ++ lib.optional (pythonOlder "3.5") [ typing ];
+
+  checkInputs = [
+    pytestrunner
+    pytest
+    nbval
+    tabulate
+  ];
+
+  postPatch = ''
+    patchShebangs tools/protoc-gen-mypy.py
+  '';
+
+  # The executables are just utility scripts that aren't too important
+  postInstall = ''
+    rm -r $out/bin
+  '';
+
+  # The setup.py does all the configuration (running CMake)
+  dontConfigure = true;
+
+  meta = {
+    homepage    = http://onnx.ai;
+    description = "Open Neural Network Exchange";
+    license     = lib.licenses.mit;
+    maintainers = [ lib.maintainers.acairncross ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -804,6 +804,8 @@ in {
 
   oauthenticator = callPackage ../development/python-modules/oauthenticator { };
 
+  onnx = callPackage ../development/python-modules/onnx { };
+
   ordered-set = callPackage ../development/python-modules/ordered-set { };
 
   ortools = (toPythonModule (pkgs.or-tools.override {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
