### PR TITLE
nixosTests.gnome3-flashback: init

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -69,8 +69,9 @@ in rec {
         (all nixos.tests.firefox)
         (all nixos.tests.firewall)
         (all nixos.tests.fontconfig-default-fonts)
-        (all nixos.tests.gnome3-xorg)
         (all nixos.tests.gnome3)
+        (all nixos.tests.gnome3-flashback.metacity)
+        (all nixos.tests.gnome3-xorg)
         (all nixos.tests.pantheon)
         nixos.tests.installer.zfsroot.x86_64-linux or [] # ZFS is 64bit only
         (except ["aarch64-linux"] nixos.tests.installer.lvm)

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -103,9 +103,9 @@ in
   glib-networking = handleTest ./glib-networking.nix {};
   glusterfs = handleTest ./glusterfs.nix {};
   gnome-photos = handleTest ./gnome-photos.nix {};
-  gnome3 = handleTest ./gnome3.nix {};
-  gnome3-flashback = pkgs.recurseIntoAttrs (handleTest ./gnome3-flashback.nix {});
-  gnome3-xorg = handleTest ./gnome3-xorg.nix {};
+  gnome3 = handleTest ./gnome3 {};
+  gnome3-flashback = pkgs.recurseIntoAttrs (handleTest ./gnome3/flashback.nix {});
+  gnome3-xorg = handleTest ./gnome3/xorg.nix {};
   gocd-agent = handleTest ./gocd-agent.nix {};
   gocd-server = handleTest ./gocd-server.nix {};
   google-oslogin = handleTest ./google-oslogin {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -102,9 +102,10 @@ in
   gjs = handleTest ./gjs.nix {};
   glib-networking = handleTest ./glib-networking.nix {};
   glusterfs = handleTest ./glusterfs.nix {};
-  gnome3-xorg = handleTest ./gnome3-xorg.nix {};
-  gnome3 = handleTest ./gnome3.nix {};
   gnome-photos = handleTest ./gnome-photos.nix {};
+  gnome3 = handleTest ./gnome3.nix {};
+  gnome3-flashback = pkgs.recurseIntoAttrs (handleTest ./gnome3-flashback.nix {});
+  gnome3-xorg = handleTest ./gnome3-xorg.nix {};
   gocd-agent = handleTest ./gocd-agent.nix {};
   gocd-server = handleTest ./gocd-server.nix {};
   google-oslogin = handleTest ./google-oslogin {};

--- a/nixos/tests/gnome3-flashback.nix
+++ b/nixos/tests/gnome3-flashback.nix
@@ -1,0 +1,97 @@
+# GNOME Flashback Terminal tests for various custom sessions.
+
+{ system ? builtins.currentSystem,
+  config ? {},
+  pkgs ? import ../.. { inherit system config; }
+}:
+
+with import ../lib/testing.nix { inherit system pkgs; };
+with pkgs.lib;
+
+let
+
+  baseConfig = {
+    imports = [ ./common/user-account.nix ];
+
+    services.xserver.enable = true;
+
+    services.xserver.displayManager.gdm.enable = false;
+    services.xserver.displayManager.lightdm.enable = true;
+    services.xserver.displayManager.lightdm.autoLogin.enable = true;
+    services.xserver.displayManager.lightdm.autoLogin.user = "alice";
+    services.xserver.desktopManager.gnome3.enable = true;
+
+    virtualisation.memorySize = 2047;
+  };
+
+  makeFlashbackTest =
+    { wmName
+    , wmLabel ? ""
+    , wmCommand ? ""
+    , useMetacity ? false
+    }:
+    makeTest rec {
+      name = "gnome-flashback-${wmName}";
+
+      meta = with pkgs.stdenv.lib.maintainers; {
+        maintainers = pkgs.gnome3.maintainers;
+      };
+
+      machine = { ... }: {
+        imports = [ baseConfig ];
+
+        services.xserver.desktopManager.default = "gnome-flashback-${wmName}";
+
+        services.xserver.desktopManager.gnome3.flashback = {
+          enableMetacity = useMetacity;
+
+          customSessions = mkIf (!useMetacity) [
+            { inherit wmName wmLabel wmCommand; }
+          ];
+        };
+
+      };
+
+      testScript =
+        ''
+          $machine->waitForX;
+
+          # wait for alice to be logged in
+          $machine->waitForUnit("default.target","alice");
+
+          # Check that logging in has given the user ownership of devices.
+          $machine->succeed("getfacl -p /dev/snd/timer | grep -q alice");
+
+          $machine->succeed("su - alice -c 'DISPLAY=:0.0 gnome-terminal &'");
+          $machine->succeed("xauth merge ~alice/.Xauthority");
+          $machine->waitForWindow(qr/alice.*machine/);
+          $machine->succeed("timeout 900 bash -c 'while read msg; do if [[ \$msg =~ \"GNOME Shell started\" ]]; then break; fi; done < <(journalctl -f)'");
+          $machine->sleep(10);
+          $machine->screenshot("screen");
+      '';
+    };
+
+in
+
+{
+
+  metacity = makeFlashbackTest {
+    useMetacity = true;
+    wmName = "metacity";
+  };
+
+  # TODO: These are currently broken with gnome-session 3.34
+  # See: https://github.com/NixOS/nixpkgs/pull/71212#issuecomment-544303107
+  # i3 = makeFlashbackTest {
+  #   wmName = "i3";
+  #   wmLabel = "i3";
+  #   wmCommand = "${pkgs.i3}/bin/i3";
+  # };
+
+  # xmonad = makeFlashbackTest {
+  #   wmName = "xmonad";
+  #   wmLabel = "XMonad";
+  #   wmCommand = "${pkgs.haskellPackages.xmonad}/bin/xmonad";
+  # };
+
+}

--- a/nixos/tests/gnome3/default.nix
+++ b/nixos/tests/gnome3/default.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ../make-test.nix ({ pkgs, ...} : {
   name = "gnome3";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = pkgs.gnome3.maintainers;
@@ -7,7 +7,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   machine =
     { ... }:
 
-    { imports = [ ./common/user-account.nix ];
+    { imports = [ ../common/user-account.nix ];
 
       services.xserver.enable = true;
 

--- a/nixos/tests/gnome3/flashback.nix
+++ b/nixos/tests/gnome3/flashback.nix
@@ -2,16 +2,16 @@
 
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  pkgs ? import ../../.. { inherit system config; }
 }:
 
-with import ../lib/testing.nix { inherit system pkgs; };
+with import ../../lib/testing.nix { inherit system pkgs; };
 with pkgs.lib;
 
 let
 
   baseConfig = {
-    imports = [ ./common/user-account.nix ];
+    imports = [ ../common/user-account.nix ];
 
     services.xserver.enable = true;
 

--- a/nixos/tests/gnome3/flashback.nix
+++ b/nixos/tests/gnome3/flashback.nix
@@ -15,6 +15,7 @@ let
 
     services.xserver.enable = true;
 
+    # See: https://github.com/NixOS/nixpkgs/issues/66443
     services.xserver.displayManager.gdm.enable = false;
     services.xserver.displayManager.lightdm.enable = true;
     services.xserver.displayManager.lightdm.autoLogin.enable = true;

--- a/nixos/tests/gnome3/xorg.nix
+++ b/nixos/tests/gnome3/xorg.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ../make-test.nix ({ pkgs, ...} : {
   name = "gnome3-xorg";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = pkgs.gnome3.maintainers;
@@ -7,7 +7,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   machine =
     { ... }:
 
-    { imports = [ ./common/user-account.nix ];
+    { imports = [ ../common/user-account.nix ];
 
       services.xserver.enable = true;
 

--- a/nixos/tests/gnome3/xorg.nix
+++ b/nixos/tests/gnome3/xorg.nix
@@ -11,6 +11,7 @@ import ../make-test.nix ({ pkgs, ...} : {
 
       services.xserver.enable = true;
 
+      # See: https://github.com/NixOS/nixpkgs/issues/66443
       services.xserver.displayManager.gdm.enable = false;
       services.xserver.displayManager.lightdm.enable = true;
       services.xserver.displayManager.lightdm.autoLogin.enable = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/70561.

Test script is identical to the ancient one we have for gnome3-xorg, but at least by having this we'll catch things like https://github.com/NixOS/nixpkgs/pull/71210, and just testing the session is convenient on GitHub.

Has https://github.com/NixOS/nixpkgs/pull/71210 because you can't actually test the tests without it.
(please merge that first).

###### Things done
Haven't tested the tests yet :smile:, as I have to run all three of them.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).