### PR TITLE
xournalpp: 1.0.12 -> 1.0.15

### DIFF
--- a/pkgs/applications/graphics/xournalpp/default.nix
+++ b/pkgs/applications/graphics/xournalpp/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xournalpp";
-  version = "1.0.12";
+  version = "1.0.15";
 
   src = fetchFromGitHub {
     owner = "xournalpp";
-    repo = "xournalpp";
+    repo = pname;
     rev = version;
-    sha256 = "0yg70hsx58s3wb5kzccivrqa7kvmdapygxmif1j64hddah2rqcn9";
+    sha256 = "1q716hn2ajkxfba0dxp7vcnqfa31hx36ax09yz4d13sdw43rfjf4";
   };
 
   nativeBuildInputs = [ cmake gettext pkgconfig wrapGAppsHook ];


### PR DESCRIPTION
###### Motivation for this change

[Changelog](https://github.com/xournalpp/xournalpp/blob/master/CHANGELOG.md)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/4fw7drb3amadqlh9khjylwisxsk3cx3f-xournalpp-1.0.12
/nix/store/4fw7drb3amadqlh9khjylwisxsk3cx3f-xournalpp-1.0.12	 217.2M
$ nix path-info -Sh /nix/store/97wyhgp655qgb8bwlsn74i1m7vgiy0ad-xournalpp-1.0.15
/nix/store/97wyhgp655qgb8bwlsn74i1m7vgiy0ad-xournalpp-1.0.15	 189.1M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andrew-d 
