### PR TITLE
pwndbg: fix runtime python deps, fixes #71071

### DIFF
--- a/pkgs/development/python-modules/capstone/default.nix
+++ b/pkgs/development/python-modules/capstone/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , fetchpatch
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -16,6 +17,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "3c0f73db9f8392f7048c8a244809f154d7c39f354e2167f6c477630aa517ed04";
   };
+
+  propagatedBuildInputs = [ setuptools ];
 
   patches = [
     (fetchpatch {

--- a/pkgs/development/tools/misc/pwndbg/default.nix
+++ b/pkgs/development/tools/misc/pwndbg/default.nix
@@ -1,33 +1,12 @@
 { stdenv
+, python3
 , fetchFromGitHub
 , makeWrapper
 , gdb
-, future
-, isort
-, psutil
-, pycparser
-, pyelftools
-, python-ptrace
-, ROPGadget
-, six
-, unicorn
-, pygments
-, }:
+}:
 
-stdenv.mkDerivation rec {
-  pname = "pwndbg";
-  version = "2019.01.25";
-
-  src = fetchFromGitHub {
-    owner = "pwndbg";
-    repo = "pwndbg";
-    rev = version;
-    sha256 = "0k7n6pcrj62ccag801yzf04a9mj9znghpkbnqwrzz0qn3rs42vgs";
-  };
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  propagatedBuildInputs = [
+let
+  pythonPath = with python3.pkgs; makePythonPath [
     future
     isort
     psutil
@@ -40,16 +19,27 @@ stdenv.mkDerivation rec {
     pygments
   ];
 
+in stdenv.mkDerivation rec {
+  pname = "pwndbg";
+  version = "2019.01.25";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "pwndbg";
+    repo = "pwndbg";
+    rev = version;
+    sha256 = "0k7n6pcrj62ccag801yzf04a9mj9znghpkbnqwrzz0qn3rs42vgs";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
   installPhase = ''
     mkdir -p $out/share/pwndbg
     cp -r *.py pwndbg $out/share/pwndbg
+    chmod +x $out/share/pwndbg/gdbinit.py
     makeWrapper ${gdb}/bin/gdb $out/bin/pwndbg \
-      --add-flags "-q -x $out/share/pwndbg/gdbinit.py"
-  '';
-
-  preFixup = ''
-    sed -i "/import sys/a import sys; sys.path[0:0] = '$PYTHONPATH'.split(':')" \
-      $out/share/pwndbg/gdbinit.py
+      --add-flags "-q -x $out/share/pwndbg/gdbinit.py" \
+      --set NIX_PYTHONPATH ${pythonPath}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5711,7 +5711,7 @@ in
 
   pwnat = callPackage ../tools/networking/pwnat { };
 
-  pwndbg = python3Packages.callPackage ../development/tools/misc/pwndbg { };
+  pwndbg = callPackage ../development/tools/misc/pwndbg { };
 
   pycangjie = pythonPackages.pycangjie;
 


### PR DESCRIPTION
pwndbg is a Python module for gdb. The built-in interpreter is used and
pwndbg offers additional routines. Packaging this is tricky because that
interpreter needs to be used. Using `python3.withPackages` won't work.
By setting `NIX_PYTHONPATH`, the interpreter should pick up pwndbg and
its dependencies.

If `NIX_PYTHONPATH` does not function we can fall back to `PYTHONPATH`.
An example of when that won't work is if pwndbg runs a script of itself
in a subshell. `NIX_PYTHONPATH` would be  unset, but `PYTHONPATH` not.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc  @n4074 @Mic92 
