### PR TITLE
trebleshot: init at 0.1.0-alpha2-15-ga7ac23c

### DIFF
--- a/pkgs/applications/networking/trebleshot/default.nix
+++ b/pkgs/applications/networking/trebleshot/default.nix
@@ -1,0 +1,29 @@
+{ mkDerivation, lib, fetchFromGitHub
+, cmake, qtbase, kdnssd
+}:
+
+mkDerivation rec {
+  pname = "trebleshot";
+  version = "0.1.0-alpha2-15-ga7ac23c";
+  # name="${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "genonbeta";
+    repo = "TrebleShot-Desktop";
+    rev = "${version}";
+    sha256 = "1k8wagw6arsi1lqkhn1nl6j11mb122vi1qs0q2np6nznwfy7pn1k";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ qtbase kdnssd ];
+
+  meta = with lib; {
+    description = "Android file transferring tool for desktop";
+    homepage = https://github.com/genonbeta/TrebleShot-Desktop;
+    license = licenses.gpl2;
+
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ woffs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6641,6 +6641,8 @@ in
 
   trash-cli = callPackage ../tools/misc/trash-cli { };
 
+  trebleshot = libsForQt5.callPackage ../applications/networking/trebleshot { };
+
   trickle = callPackage ../tools/networking/trickle {};
 
   inherit (nodePackages) triton;


### PR DESCRIPTION
###### Motivation for this change
The Desktop couterpart of TrebleShot Android app

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).