### PR TITLE
dnsutils: add 'delv' binary, remove obsolete sigchase

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -30,8 +30,6 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableSeccomp libseccomp
     ++ lib.optional enablePython (python3.withPackages (ps: with ps; [ ply ]));
 
-  STD_CDEFINES = [ "-DDIG_SIGCHASE=1" ]; # support +sigchase
-
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   configureFlags = [

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
     moveToOutput bin/host $host
 
     moveToOutput bin/dig $dnsutils
+    moveToOutput bin/delv $dnsutils
     moveToOutput bin/nslookup $dnsutils
     moveToOutput bin/nsupdate $dnsutils
 


### PR DESCRIPTION
###### Motivation for this change

Upstream has added [delv](https://kb.isc.org/docs/aa-01152), a replacement for `dig` with better DNSSEC support. It is already being built, just remember to copy it to the output `/bin` directory.

Also I'm removing the `-DDIG_SIGCHASE=1` define, which is [removed upstream](https://gitlab.isc.org/isc-projects/bind9/commit/c4cfb0b4dc066b185b3ce3c9bb06075a106423d1) and I'm pretty sure doesn't have any effect (just `grep -ri sigchase` in the source).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti @globin 
