### PR TITLE
gxmatcheq-lv2: init at 0.1

### DIFF
--- a/pkgs/applications/audio/gxmatcheq-lv2/default.nix
+++ b/pkgs/applications/audio/gxmatcheq-lv2/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, xorg, xorgproto, cairo, lv2, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "GxMatchEQ.lv2";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "brummer10";
+    repo = pname;
+    rev = "V${version}";
+    sha256 = "0azdmgzqwjn26nx38iw13666a1i4y2bv39wk89pf6ihdi46klf72";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    xorg.libX11 xorgproto cairo lv2
+  ];
+
+  # error: format not a string literal and no format arguments [-Werror=format-security]
+  hardeningDisable = [ "format" ];
+
+  installFlags = [ "INSTALL_DIR=$(out)/lib/lv2" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/brummer10/GxMatchEQ.lv2;
+    description = "Matching Equalizer to apply EQ curve from one source to another source";
+    maintainers = [ maintainers.magnetophon ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18861,6 +18861,8 @@ in
 
   gxmessage = callPackage ../applications/misc/gxmessage { };
 
+  gxmatcheq-lv2 = callPackage ../applications/audio/gxmatcheq-lv2 { };
+
   gxplugins-lv2 = callPackage ../applications/audio/gxplugins-lv2 { };
 
   hackrf = callPackage ../applications/radio/hackrf { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
