### PR TITLE
Update FPGA tools

### DIFF
--- a/pkgs/applications/science/logic/symbiyosys/default.nix
+++ b/pkgs/applications/science/logic/symbiyosys/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "symbiyosys";
-  version = "2019.08.13";
+  version = "2019.10.11";
 
   src = fetchFromGitHub {
     owner  = "yosyshq";
     repo   = "symbiyosys";
-    rev    = "9cb542ac7a310b3dfa626349db53bed6236b670c";
-    sha256 = "0c7nz740738ybk33zzlfl00cq86n31wvra8pqqkpl4ygxnwca1d6";
+    rev    = "23f89011b678daa9da406d4f45f790e45f8f68ca";
+    sha256 = "01596yvfj79iywwczjwlb2l9qnh7bsj7jff66jdk1ybjnxf841f0";
   };
 
   buildInputs = [ python3 yosys ];

--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -14,15 +14,26 @@ let
 in
 with stdenv; mkDerivation rec {
   pname = "nextpnr";
-  version = "2019.09.28";
+  version = "2019.10.13";
 
-  src = fetchFromGitHub {
-    owner  = "yosyshq";
-    repo   = "nextpnr";
-    rev    = "7cd1e0495122847611b17a8d1f007d97a05b288c";
-    sha256 = "13y739l92plb22g73jf35pyh3y94b2vq0i65r9c31r2rb7fw4bbl";
-    fetchSubmodules = true;
-  };
+  srcs = [
+    (fetchFromGitHub {
+      owner  = "YosysHQ";
+      repo   = "nextpnr";
+      rev    = "c365dd1cabc3a4308ab9110534918623622c246b";
+      sha256 = "1344pyq9xb5y1vxsnfgr488drfjsa6ls1jck0z9hwam6vg55s10r";
+      name   = "nextpnr";
+    })
+    (fetchFromGitHub {
+      owner  = "YosysHQ";
+      repo   = "nextpnr-tests";
+      rev    = "8f93e7e0f897b1b5da469919c9a43ba28b623b2a";
+      sha256 = "0zpd0w49k9l7rs3wmi2v8z5s4l4lad5rprs5l83w13667himpzyc";
+      name   = "nextpnr-tests";
+    })
+  ];
+
+  sourceRoot = "nextpnr";
 
   nativeBuildInputs
      = [ cmake ]
@@ -51,11 +62,15 @@ with stdenv; mkDerivation rec {
   # but works ok. We should probably make this overrideable upstream.
   patchPhase = with builtins; ''
     substituteInPlace ./CMakeLists.txt \
-      --replace 'git log -1 --format=%h' 'echo ${substring 0 11 src.rev}'
+      --replace 'git log -1 --format=%h' 'echo ${substring 0 11 (elemAt srcs 0).rev}'
 
     # use PyPy for icestorm if enabled
     substituteInPlace ./ice40/family.cmake \
       --replace ''\'''${PYTHON_EXECUTABLE}' '${icestorm.pythonInterp}'
+  '';
+
+  preBuild = ''
+    ln -s ../nextpnr-tests tests
   '';
 
   doCheck = true;

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -9,14 +9,14 @@ with builtins;
 
 stdenv.mkDerivation rec {
   pname = "yosys";
-  version = "2019.09.27";
+  version = "2019.10.18";
 
   srcs = [
     (fetchFromGitHub {
       owner  = "yosyshq";
       repo   = "yosys";
-      rev    = "c372e7baf9c48d41ebdbea4486a72e8dfaaddd3d";
-      sha256 = "18cyz900haf8lkpddqn0sns0a3hc8fqndzz7gg391671hzvy820k";
+      rev    = "3c41599ee1f62e4d77ba630fa1a245ef3fe236fa";
+      sha256 = "0jg2g8v08ax1q6qlvn8c1h147m03adzrgf21043xwbh4c7s5k137";
       name   = "yosys";
     })
 
@@ -26,8 +26,8 @@ stdenv.mkDerivation rec {
     (fetchFromGitHub {
       owner  = "berkeley-abc";
       repo   = "abc";
-      rev    = "5776ad07e7247993976bffed4802a5737c456782";
-      sha256 = "1la4idmssg44rp6hd63sd5vybvs3vr14yzvwcg03ls37p39cslnl";
+      rev    = "623b5e82513d076a19f864c01930ad1838498894";
+      sha256 = "1mrfqwsivflqdzc3531r6mzp33dfyl6dnqjdwfcq137arqh36m67";
       name   = "yosys-abc";
     })
   ];

--- a/pkgs/development/python-modules/glasgow/default.nix
+++ b/pkgs/development/python-modules/glasgow/default.nix
@@ -18,15 +18,15 @@
 
 buildPythonPackage rec {
   pname = "glasgow";
-  version = "unstable-2019-09-28";
-  # python setup.py --version
-  realVersion = "0.1.dev1234+g${lib.substring 0 7 src.rev}";
+  version = "unstable-2019-10-16";
+  # python software/setup.py --version
+  realVersion = "0.1.dev1286+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "GlasgowEmbedded";
-    repo = "Glasgow";
-    rev = "a1cc0333315847980806fd0330021c6de05c5395";
-    sha256 = "0rdx7fymz828i73bc559sr67aikydz1m8s2a0i6c86gznh1s3cfk";
+    repo = "glasgow";
+    rev = "4f968dbe6cf4e9d8e2d0a5163d82e996c24d5e30";
+    sha256 = "1b50n12dc0b3jmim5ywg7daq62k5j4wkgmwzk88ric5ri3b8dl2r";
   };
 
   nativeBuildInputs = [ setuptools_scm sdcc ];
@@ -42,6 +42,8 @@ buildPythonPackage rec {
     crcmod
   ];
 
+  checkInputs = [ yosys icestorm nextpnr ];
+
   preBuild = ''
     make -C firmware LIBFX2=${fx2}/share/libfx2
     cp firmware/glasgow.ihex software/glasgow
@@ -55,6 +57,12 @@ buildPythonPackage rec {
   checkPhase = ''
     python -m unittest discover
   '';
+
+  makeWrapperArgs = [
+    "--set" "YOSYS" "${yosys}/bin/yosys"
+    "--set" "ICEPACK" "${icestorm}/bin/icepack"
+    "--set" "NEXTPNR_ICE40" "${nextpnr}/bin/nextpnr-ice40"
+  ];
 
   meta = with lib; {
     description = "Software for Glasgow, a digital interface multitool";

--- a/pkgs/development/python-modules/nmigen-boards/default.nix
+++ b/pkgs/development/python-modules/nmigen-boards/default.nix
@@ -8,15 +8,15 @@
 
 buildPythonPackage rec {
   pname = "nmigen-boards";
-  version = "unstable-2019-09-23";
+  version = "unstable-2019-10-13";
   # python setup.py --version
-  realVersion = "0.1.dev55+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.1.dev79+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "m-labs";
     repo = "nmigen-boards";
-    rev = "b8b2bbaff34c905f2b1094a74b6865961feb2290";
-    sha256 = "00gsdm7qf6gsxqmkgqz1ing1yc0352s14pvw863rdbjbd1bv5r0m";
+    rev = "835c175d7cf9d143aea2c7dbc0c870ede655cfc2";
+    sha256 = "1mbxgfv6k9i3668lr1b3hrvial2vznvgn4ckjzc36hhizp47ypzw";
   };
 
   nativeBuildInputs = [ setuptools_scm ];

--- a/pkgs/development/python-modules/nmigen/default.nix
+++ b/pkgs/development/python-modules/nmigen/default.nix
@@ -8,28 +8,23 @@
 , bitarray
 , jinja2
 
-# nmigen.{test,build} call out to these
+# for tests
 , yosys
 , symbiyosys
-, nextpnr ? null
-, icestorm ? null
-, trellis ? null
-
-# for tests
 , yices
 }:
 
 buildPythonPackage rec {
   pname = "nmigen";
-  version = "unstable-2019-09-28";
+  version = "unstable-2019-10-17";
   # python setup.py --version
-  realVersion = "0.1.dev689+g${lib.substring 0 7 src.rev}";
+  realVersion = "0.1.rc2.dev5+g${lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "m-labs";
     repo = "nmigen";
-    rev = "a02e3750bfeba44bcaad4c5de8d9eb0ef055d9c6";
-    sha256 = "0m399c2nm7y54q2f0fbkmi4h35csbc2llckm6k9kqdf5qc6355wd";
+    rev = "9fba5ccb513cfbd53f884b1efca699352d2471b9";
+    sha256 = "02bjry4sqjsrhl0s42zl1zl06gk5na9i6br6vmz7fvxic29vl83v";
   };
 
   disabled = pythonOlder "3.6";
@@ -38,25 +33,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ setuptools pyvcd bitarray jinja2 ];
 
-  checkInputs = [ yosys yices ];
-
-  postPatch = let
-    tool = pkg: name:
-      if pkg == null then {} else { ${name} = "${pkg}/bin/${name}"; };
-
-    # Only FOSS toolchain supported out of the box, sorry!
-    toolchainOverrides =
-      tool yosys "yosys" //
-      tool symbiyosys "sby" //
-      tool nextpnr "nextpnr-ice40" //
-      tool nextpnr "nextpnr-ecp5" //
-      tool icestorm "icepack" //
-      tool trellis "ecppack";
-  in ''
-    substituteInPlace nmigen/_toolchain.py \
-      --replace 'overrides = {}' \
-                'overrides = ${builtins.toJSON toolchainOverrides}'
-  '';
+  checkInputs = [ yosys symbiyosys yices ];
 
   preBuild = ''
     export SETUPTOOLS_SCM_PRETEND_VERSION="${realVersion}"

--- a/pkgs/development/tools/trellis/default.nix
+++ b/pkgs/development/tools/trellis/default.nix
@@ -8,25 +8,25 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "trellis";
-  version = "2019.09.27";
+  version = "2019.10.13";
   # git describe --tags
   realVersion = with stdenv.lib; with builtins;
-    "1.0-71-g${substring 0 7 (elemAt srcs 0).rev}";
+    "1.0-95-g${substring 0 7 (elemAt srcs 0).rev}";
 
   srcs = [
     (fetchFromGitHub {
-       owner  = "symbiflow";
+       owner  = "SymbiFlow";
        repo   = "prjtrellis";
-       rev    = "06904938dfe8f52392e73f7c8b1e034327887c27";
-       sha256 = "1yk13pipj7wp2mma0qcss4sa0wx8h60x0l0x9awh8g2iyk1y8nfw";
+       rev    = "e2e10bfdfaa29fed5d19e83dc7460be9880f5af4";
+       sha256 = "0l59nliv75rdxnajl2plilib0r0bzbr3qqzc88cdal841x1m0izs";
        name   = "trellis";
      })
     (fetchFromGitHub {
-      owner  = "symbiflow";
+      owner  = "SymbiFlow";
       repo   = "prjtrellis-db";
-      rev    = "b4d626b6402c131e9a035470ffe4cf33ccbe7986";
-      sha256 = "0k26lq6c049ja8hhqcljwjb1y5k4gcici23l2n86gyp83jr03ilx";
-      name   = "database";
+      rev    = "5b5bb70bae13e6b8c971b4b2d26931f4a64b51bc";
+      sha256 = "1fi963zdny3gxdvq564037qs22i7b4y7mxc3yij2a1ww8rzrnpdj";
+      name   = "trellis-database";
     })
   ];
   sourceRoot = "trellis";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
nMigen 0.1 is [approaching release](https://twitter.com/whitequark/status/1183960591825809408), so here's another bump of the FOSS FPGA tools. I've also marked the [Clash](https://clash-lang.org/) Haskell packages as unbroken, since as of the 1.0 release they seem to compile and work fine here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).