### PR TITLE
pythonPackages.mesa: init at 0.8.6

### DIFF
--- a/pkgs/development/python-modules/mesa/default.nix
+++ b/pkgs/development/python-modules/mesa/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy27
+, cookiecutter, networkx , pandas, tornado, tqdm
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "mesa";
+  version = "0.8.6";
+
+  # According to their docs, this library is for Python 3+.
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "projectmesa";
+    repo = "mesa";
+    rev = "v${version}";
+    sha256 = "0d8c636zhswxd91ldlmdxxlyym2fj3bk1iqmpc1jp3hg7vvc7w03";
+  };
+
+  checkInputs = [ pytest ];
+
+  # Ignore test which tries to mkdir in unreachable location.
+  checkPhase = ''
+    pytest tests -k "not scaffold"
+  '';
+
+  propagatedBuildInputs = [ cookiecutter networkx pandas tornado tqdm ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/projectmesa/mesa";
+    description = "An agent-based modeling (or ABM) framework in Python";
+    license = licenses.asl20;
+    maintainers = [ maintainers.dpaetzel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3796,6 +3796,8 @@ in {
 
   memory_profiler = callPackage ../development/python-modules/memory_profiler { };
 
+  mesa = callPackage ../development/python-modules/mesa { };
+
   metaphone = callPackage ../development/python-modules/metaphone { };
 
   mezzanine = callPackage ../development/python-modules/mezzanine { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1037,7 +1037,9 @@ in {
 
   pyschedule = callPackage ../development/python-modules/pyschedule { };
 
-  pyside = callPackage ../development/python-modules/pyside { };
+  pyside = callPackage ../development/python-modules/pyside {
+    inherit (pkgs) mesa;
+  };
 
   pysideShiboken = callPackage ../development/python-modules/pyside/shiboken.nix {
     inherit (pkgs) libxml2 libxslt; # Do not need the Python bindings.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

mesa is a Python 3+ library for creating multi-agent simulations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
