### PR TITLE
atheme: init at 7.2.10-r2

### DIFF
--- a/pkgs/servers/irc/atheme/default.nix
+++ b/pkgs/servers/irc/atheme/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, libmowgli, pkgconfig, git, gettext, pcre, libidn, cracklib, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "atheme";
+  version = "7.2.10-r2";
+
+  src = fetchgit {
+    url = "https://github.com/atheme/atheme.git";
+    rev = "v${version}";
+    sha256 = "1yasfvbmixj4zzfv449hlcp0ms5c250lrshdy6x6l643nbnix4y9";
+    leaveDotGit = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig git gettext ];
+  buildInputs = [ libmowgli pcre libidn cracklib openssl ];
+
+  configureFlags = [
+    "--with-pcre"
+    "--with-libidn"
+    "--with-cracklib"
+    "--enable-large-net"
+    "--enable-contrib"
+    "--enable-reproducible-builds"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A set of services for IRC networks";
+    homepage = https://atheme.github.io/;
+    license = licenses.isc;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ leo60228 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -662,6 +662,8 @@ in
     gsl = gsl_1;
   };
 
+  atheme = callPackage ../servers/irc/atheme { };
+
   atinout = callPackage ../tools/networking/atinout { };
 
   atomicparsley = callPackage ../tools/video/atomicparsley {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I wanted it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- N/A: Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- N/A: Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- N/A: Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
