### PR TITLE
pythonPackages.phik: init at 0.9.8

### DIFF
--- a/pkgs/development/python-modules/phik/default.nix
+++ b/pkgs/development/python-modules/phik/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, pytest
+, pytest-pylint
+, nbconvert
+, jupyter_client
+, numpy
+, scipy
+, pandas
+, matplotlib
+, numba
+}:
+
+buildPythonPackage rec {
+  pname = "phik";
+  version = "0.9.8";
+  format = "wheel";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version format;
+    python = "py3";
+    sha256 = "c398452c5c1eea153905666b289c6a153712cf3d58811fa41e2bbbd27a65d678";
+  };
+
+  checkInputs = [
+    pytest
+    pytest-pylint
+    nbconvert
+    jupyter_client
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    pandas
+    matplotlib
+    numba
+  ];
+
+  postInstall = ''
+  rm -r $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Phi_K correlation analyzer library";
+    longDescription = "Phi_K is a new and practical correlation coefficient based on several refinements to Pearson’s hypothesis test of independence of two variables.";
+    homepage = https://phik.readthedocs.io/en/latest/;
+    maintainers = with maintainers; [ melsigl ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -848,6 +848,8 @@ in {
 
   phonopy = callPackage ../development/python-modules/phonopy { };
 
+  phik = callPackage ../development/python-modules/phik {};
+
   piccata = callPackage ../development/python-modules/piccata {};
 
   pims = callPackage ../development/python-modules/pims { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Phi_K is a new and practical correlation coefficient based on several refinements to Pearson’s hypothesis test of independence of two variables.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
