### PR TITLE
neteria: init at 1.0.3.160123.05

### DIFF
--- a/pkgs/development/python-modules/neteria/default.nix
+++ b/pkgs/development/python-modules/neteria/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchFromGitHub, rsa }:
+
+buildPythonPackage rec {
+  pname = "neteria";
+  version = "1.0.3.160123.05";
+
+  src = fetchFromGitHub {
+    owner = "ShadowBlip";
+    repo = "Neteria";
+    rev = "1a8c976eb2beeca0a5a272a34ac58b2c114495a4";
+    sha256 = "1c2fa0d4k2n3b88ac8awajqnfbar2y77zhsxa3wg0hix8lgkmgz3";
+  };
+
+  propagatedBuildInputs = [ rsa ];
+
+  meta = {
+    homepage = "https://github.com/ShadowBlip/Neteria";
+    description = "Open source game networking framework for Python";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2613,6 +2613,8 @@ in {
 
   netdisco = callPackage ../development/python-modules/netdisco { };
 
+  neteria = callPackage ../development/python-modules/neteria { };
+
   Nikola = callPackage ../development/python-modules/Nikola { };
 
   nmigen = callPackage ../development/python-modules/nmigen { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This PR adds the [Neteria](https://github.com/ShadowBlip/Neteria) framework for Python.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
