### PR TITLE
pytmx: init at 3.21.7

### DIFF
--- a/pkgs/development/python-modules/pytmx/default.nix
+++ b/pkgs/development/python-modules/pytmx/default.nix
@@ -1,0 +1,33 @@
+{ lib, fetchFromGitHub, isPy3k, buildPythonPackage, pygame, pyglet, pysdl2, six }:
+
+buildPythonPackage rec {
+  pname = "pytmx";
+  version = "3.21.7";
+
+  src = fetchFromGitHub {
+    # The release was not git tagged.
+    owner = "bitcraft";
+    repo = "PyTMX";
+    rev = "38519b94ab9a2db7cacb8e18de4d83750ec6fac2";
+    sha256 = "0p2gc6lgian1yk4qvhbkxfkmndf9ras70amigqzzwr02y2jvq7j8";
+  };
+
+  propagatedBuildInputs = [ pygame pyglet pysdl2 six ];
+
+  # The tests are failing for Python 2.7.
+  doCheck = isPy3k;
+  checkPhase = ''
+    # The following test imports an example file from the current working
+    # directory. Thus, we're cd'ing into the test directory.
+
+    cd tests/
+    python -m unittest test_pytmx
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/bitcraft/PyTMX";
+    description = "Python library to read Tiled Map Editor's TMX maps";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1086,6 +1086,8 @@ in {
 
   pytest-xprocess = callPackage ../development/python-modules/pytest-xprocess { };
 
+  pytmx = callPackage ../development/python-modules/pytmx { };
+
   python-binance = callPackage ../development/python-modules/python-binance { };
 
   python-dbusmock = callPackage ../development/python-modules/python-dbusmock { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adds the [PyTMX](https://github.com/bitcraft/PyTMX) library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
