### PR TITLE
obinskit: init at 1.1.1

### DIFF
--- a/pkgs/applications/misc/obinskit/default.nix
+++ b/pkgs/applications/misc/obinskit/default.nix
@@ -1,0 +1,83 @@
+{ lib
+, stdenv
+, fetchurl
+, xorg
+, libxkbcommon
+, systemd
+, gcc-unwrapped
+, electron_3
+, wrapGAppsHook
+, makeDesktopItem
+}:
+
+let
+  libPath = lib.makeLibraryPath [
+    libxkbcommon
+    xorg.libXt
+    systemd.lib
+    stdenv.cc.cc.lib
+  ];
+
+  desktopItem = makeDesktopItem rec {
+    name = "Obinskit";
+    exec = "obinskit";
+    icon = "obinskit.png";
+    desktopName = "Obinskit";
+    genericName = "Obinskit keyboard configurator";
+    categories = "Utility";
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "obinskit";
+  version = "1.1.1";
+
+  src = fetchurl {
+    url = "http://releases.obins.net/occ/linux/tar/ObinsKit_${version}_x64.tar.gz";
+    sha256 = "0052m4msslc4k9g3i5vl933cz5q2n1affxhnm433w4apajr8h28h";
+  };
+
+  unpackPhase = "tar -xzf $src";
+
+  sourceRoot = "ObinsKit_${version}_x64";
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/opt/obinskit
+    install icudtl.dat $out/opt/obinskit/
+    install natives_blob.bin $out/opt/obinskit/
+    install v8_context_snapshot.bin $out/opt/obinskit/
+    install blink_image_resources_200_percent.pak $out/opt/obinskit/
+    install content_resources_200_percent.pak $out/opt/obinskit/
+    install content_shell.pak $out/opt/obinskit/
+    install ui_resources_200_percent.pak $out/opt/obinskit/
+    install views_resources_200_percent.pak $out/opt/obinskit/
+    cp -r resources $out/opt/obinskit/
+    cp -r locales $out/opt/obinskit/
+
+    mkdir -p $out/bin
+    ln -s ${electron_3}/bin/electron $out/bin/obinskit
+
+    mkdir -p $out/share/{applications,pixmaps}
+    install resources/icons/tray-darwin@2x.png $out/share/pixmaps/obinskit.png
+    ln -s ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --add-flags $out/opt/obinskit/resources/app.asar
+      --prefix LD_LIBRARY_PATH : "${libPath}"
+    )
+  '';
+
+  meta = with lib; {
+    description = "Graphical configurator for Anne Pro and Anne Pro II keyboards";
+    homepage = "http://en.obins.net/obinskit/";
+    license = licenses.unfree;
+    maintainers = [ maintainers.shou ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1901,6 +1901,8 @@ in
 
   optar = callPackage ../tools/graphics/optar {};
 
+  obinskit = callPackage ../applications/misc/obinskit {};
+
   pastel = callPackage ../applications/misc/pastel {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is the configuration software for the enthusiast Anne Pro mechanical keyboard, used to update the firmware, change keyboard settings, clear Bluetooth connections from the device, set up backlighting colours, and so forth. I'm an owner of one and don't think I'm alone so I thought it'd be convenient to have this packaged. [They have an official Github](https://github.com/obinslab), but the software is proprietary to my knowledge (no license provided).

I've tested that the software works with my own Anne Pro II.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
