### PR TITLE
gnome3.gnome-online-accounts: build with meson

### DIFF
--- a/pkgs/development/libraries/gnome-online-accounts/default.nix
+++ b/pkgs/development/libraries/gnome-online-accounts/default.nix
@@ -6,13 +6,13 @@
 
 let
   pname = "gnome-online-accounts";
-  version = "3.34.0";
+  version = "3.34.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0mvz6wrw03zyp5sm46znkipncagb257xam29mfi06ixmxvjbqky4";
+    sha256 = "0fkqckqkkah5k1xrfqjkk4345aq9c0a6yyvfczy9g96k927clcj8";
   };
 
   outputs = [ "out" "man" "dev" "devdoc" ];

--- a/pkgs/development/libraries/gnome-online-accounts/default.nix
+++ b/pkgs/development/libraries/gnome-online-accounts/default.nix
@@ -1,14 +1,31 @@
-{ stdenv, fetchurl, pkgconfig, vala, glib, libxslt, gtk3, wrapGAppsHook
-, webkitgtk, json-glib, librest, libsecret, gtk-doc, gobject-introspection
-, gettext, icu, glib-networking
-, libsoup, docbook_xsl, docbook_xml_dtd_412, gnome3, gcr, kerberos
+{ stdenv
+, fetchurl
+, pkgconfig
+, vala
+, glib
+, libxslt
+, gtk3
+, wrapGAppsHook
+, webkitgtk
+, json-glib
+, librest
+, libsecret
+, gtk-doc
+, gobject-introspection
+, gettext
+, icu
+, glib-networking
+, libsoup
+, docbook_xsl
+, docbook_xml_dtd_412
+, gnome3
+, gcr
+, kerberos
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "gnome-online-accounts";
   version = "3.34.1";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
@@ -26,15 +43,30 @@ in stdenv.mkDerivation rec {
     "--enable-documentation"
   ];
 
-  enableParallelBuilding = true;
-
   nativeBuildInputs = [
-    pkgconfig gobject-introspection vala gettext wrapGAppsHook
-    libxslt docbook_xsl docbook_xml_dtd_412 gtk-doc
+    docbook_xml_dtd_412
+    docbook_xsl
+    gettext
+    gobject-introspection
+    gtk-doc
+    libxslt
+    pkgconfig
+    vala
+    wrapGAppsHook
   ];
+
   buildInputs = [
-    glib gtk3 webkitgtk json-glib librest libsecret glib-networking icu libsoup
-    gcr kerberos
+    gcr
+    glib
+    glib-networking
+    gtk3
+    icu
+    json-glib
+    kerberos
+    librest
+    libsecret
+    libsoup
+    webkitgtk
   ];
 
   passthru = {
@@ -45,7 +77,10 @@ in stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
+    homepage = "https://wiki.gnome.org/Projects/GnomeOnlineAccounts";
+    description = "Single sign-on framework for GNOME";
     platforms = platforms.linux;
+    license = licenses.lgpl2Plus;
     maintainers = gnome3.maintainers;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
See https://github.com/NixOS/nixpkgs/commit/5366676eba2713a27c9854926d652cd731ffb1f2 for meson port. Unfortunately had to add `NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0"`, wasn't sure how fix that with the generated code.

I've also disabled the Fedora provider as it's not useful for NixOS users.
(though the icons are still installed by the buildsystem?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
