### PR TITLE
pythonPackages.confuse: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/confuse/default.nix
+++ b/pkgs/development/python-modules/confuse/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pyyaml
+, coverage
+, nose
+, nose-show-skipped
+, flake8
+, flake8-future-import
+, pep8-naming
+}:
+
+buildPythonPackage rec {
+  pname = "confuse";
+  version = "1.0.0";
+
+  # use fetchFromGitHub instead of fetchPypi because
+  # "test/__init__.py" is missing in MANIFEST.in
+  src = fetchFromGitHub {
+    owner = "beetbox";
+    repo = pname;
+    rev = "1619d3ac33d2959cd5f4aa9ad725935b790ad12f";
+    sha256 = "0my2f97da6d1l9xjg3i493xhngrx3d2n8i0hbb2la6d37i7kj5l2";
+  };
+
+  propagatedBuildInputs = [ pyyaml ];
+
+  checkInputs = [
+    pyyaml
+    coverage
+    nose
+    nose-show-skipped
+    flake8
+    flake8-future-import
+    pep8-naming
+  ];
+
+  checkPhase = ''
+  nosetests --with-coverage
+  nosetests
+  '';
+
+  meta = with lib; {
+    description = "Painless YAML config files for Python";
+    homepage = "https://github.com/beetbox/confuse";
+    maintainers = with maintainers; [ melsigl ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/nose-show-skipped/default.nix
+++ b/pkgs/development/python-modules/nose-show-skipped/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "nose-show-skipped";
+  version = "0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a202f9c4b35107e9e1d6d8438eff4a930cb31a7e17517a69b319448f136815ce";
+  };
+
+  propagatedBuildInputs = [ nose ];
+
+  meta = with lib; {
+    description = "A nose plugin to show skipped tests and their messages";
+    homepage = "https://github.com/cpcloud/nose-show-skipped";
+    maintainers = with maintainers; [ melsigl ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3999,6 +3999,8 @@ in {
 
   nose-randomly = callPackage ../development/python-modules/nose-randomly { };
 
+  nose-show-skipped = callPackage ../development/python-modules/nose-show-skipped { };
+
   nose2 = callPackage ../development/python-modules/nose2 { };
 
   nose-cover3 = callPackage ../development/python-modules/nose-cover3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1891,6 +1891,8 @@ in {
 
   kafka-python = callPackage ../development/python-modules/kafka-python {};
 
+  confuse = callPackage ../development/python-modules/confuse {};
+
   construct = callPackage ../development/python-modules/construct {};
 
   consul = callPackage ../development/python-modules/consul { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Confuse is a configuration library for Python that uses YAML.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
