### PR TITLE
cetch: init at 071796f

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6890,6 +6890,11 @@
     githubId = 1595132;
     name = "Kranium Gikos Mendoza";
   };
+  wooosh = {
+    email = "crimsonwombat42@gmail.com";
+    github = "wooosh";
+    name = "wooosh";
+  };
   worldofpeace = {
     email = "worldofpeace@protonmail.ch";
     github = "worldofpeace";

--- a/pkgs/tools/misc/cetch/default.nix
+++ b/pkgs/tools/misc/cetch/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, writeText, conf ? null }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "cetch";
+  version = "071796fab4850034f1f45e687021d7ff05d8302a";
+
+  src = fetchFromGitHub {
+    owner = "wooosh";
+    repo = name;
+    rev = version;
+    sha256 = "1mzlprkyd6imn5lm7srw78zxd1wy9xdb7a2diwpdfx1gfif0iimi";
+  };
+
+  configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
+  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "A fast, highly customizable system info script written in C";
+    homepage = https://github.com/trvv/cetch;
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.wooosh ];
+  };
+}

--- a/pkgs/tools/misc/cetch/default.nix
+++ b/pkgs/tools/misc/cetch/default.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "cetch";
-  version = "071796fab4850034f1f45e687021d7ff05d8302a";
+  version = "v1.0";
 
   src = fetchFromGitHub {
     owner = "wooosh";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -761,6 +761,8 @@ in
 
   certigo = callPackage ../tools/admin/certigo { };
 
+  cetch = callPackage ../tools/misc/cetch { };
+
   chezmoi = callPackage ../tools/misc/chezmoi { };
 
   chipsec = callPackage ../tools/security/chipsec {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Cetch is a system info utility akin to neofetch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).