### PR TITLE
gnupg-pkcs11-scd: init at 0.9.2

### DIFF
--- a/pkgs/tools/security/gnupg-pkcs11-scd/default.nix
+++ b/pkgs/tools/security/gnupg-pkcs11-scd/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, libgpgerror, libassuan, libgcrypt, pkcs11helper,
+  pkgconfig, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "gnupg-pkcs11-scd";
+  version = "0.9.2";
+
+  src = fetchurl {
+    url = "https://github.com/alonbl/${pname}/releases/download/${pname}-${version}/${pname}-${version}.tar.bz2";
+    sha256 = "sha256:1mfh9zjbahjd788rq1mzx009pd7p1sq62sbz586rd7szif7pkpgx";
+  };
+
+  buildInputs = [ pkcs11helper pkgconfig openssl ];
+
+  configureFlags = [
+    "--with-libgpg-error-prefix=${libgpgerror.dev}"
+    "--with-libassuan-prefix=${libassuan.dev}"
+    "--with-libgcrypt-prefix=${libgcrypt.dev}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A smart-card daemon to enable the use of PKCS#11 tokens with GnuPG";
+    longDescription = ''
+    gnupg-pkcs11 is a project to implement a BSD-licensed smart-card
+    daemon to enable the use of PKCS#11 tokens with GnuPG.
+    '';
+    homepage = http://gnupg-pkcs11.sourceforge.net/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ philandstuff ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/tools/security/gnupg-pkcs11-scd/default.nix
+++ b/pkgs/tools/security/gnupg-pkcs11-scd/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://gnupg-pkcs11.sourceforge.net/;
     license = licenses.bsd3;
-    maintainers = with maintainers; [ philandstuff ];
+    maintainers = with maintainers; [ lschuermann philandstuff ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3506,6 +3506,8 @@ in
   };
   gnupg = gnupg22;
 
+  gnupg-pkcs11-scd = callPackage ../tools/security/gnupg-pkcs11-scd { };
+
   gnuplot = libsForQt5.callPackage ../tools/graphics/gnuplot { };
 
   gnuplot_qt = gnuplot.override { withQt = true; };


### PR DESCRIPTION
###### Motivation for this change

This adds gnupg-pkcs11-scd, a smart card daemon for GnuPG that supports
PKCS#11 smartcards (such as the Yubikey PIV module).

You can use it by adding something like this to your
~/.gnupg/gpg-agent.conf:

    scdaemon-program /home/<user>/.nix-profile/bin/gnupg-pkcs11-scd

You will also need to install `opensc` and have a
~/.gnupg/gnupg-pkcs11-scd.conf with something like the following:

    providers opensc

    provider-opensc-library /home/philandstuff/.nix-profile/lib/pkcs11/opensc-pkcs11.so

Then `gpg` smartcard operations will access your PKCS#11-capable
smartcard.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
