### PR TITLE
putty: 0.71 -> 0.73, fixing CVE-2019-17069

### DIFF
--- a/pkgs/applications/networking/remote/putty/default.nix
+++ b/pkgs/applications/networking/remote/putty/default.nix
@@ -1,9 +1,9 @@
 { stdenv, lib, fetchurl, autoconf, automake, pkgconfig, libtool
-, gtk2, halibut, ncurses, perl
+, gtk2, halibut, ncurses, perl, darwin
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.71";
+  version = "0.73";
   pname = "putty";
 
   src = fetchurl {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
       "https://the.earth.li/~sgtatham/putty/${version}/${pname}-${version}.tar.gz"
       "ftp://ftp.wayne.edu/putty/putty-website-mirror/${version}/${pname}-${version}.tar.gz"
     ];
-    sha256 = "1f66iss0kqk982azmxbk4xfm2i1csby91vdvly6cr04pz3i1r4rg";
+    sha256 = "076z34jpik2dmlwxicvf1djjgnahcqv12rjhmb9yq6ml7x0bbc1x";
   };
 
   # glib-2.62 deprecations
@@ -20,9 +20,6 @@ stdenv.mkDerivation rec {
   preConfigure = lib.optionalString stdenv.hostPlatform.isUnix ''
     perl mkfiles.pl
     ( cd doc ; make );
-    sed -e '/AM_PATH_GTK(/d' \
-        -e '/AC_OUTPUT/iAM_PROG_CC_C_O' \
-        -e '/AC_OUTPUT/iAM_PROG_AR' -i configure.ac
     ./mkauto.sh
     cd unix
   '' + lib.optionalString stdenv.hostPlatform.isWindows ''
@@ -41,7 +38,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake halibut libtool perl pkgconfig ];
   buildInputs = lib.optionals stdenv.hostPlatform.isUnix [
     gtk2 ncurses
-  ];
+  ] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.libs.utmp;
   enableParallelBuilding = true;
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-17069

Technically 0.73 fixes CVE-2019-17068 as well, but I'm fairly convinced that only 0.72 was ever vulnerable to that.

I'll attempt to patch for 19.09 so no automatic backport please...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
