### PR TITLE
coqPackages_8_10.ltac2: init at 0.3

### DIFF
--- a/pkgs/development/coq-modules/ltac2/default.nix
+++ b/pkgs/development/coq-modules/ltac2/default.nix
@@ -11,10 +11,15 @@ let params = {
     rev = "0.1";
     sha256 = "1zz26cyv99whj7rrpgnhhm9dfqnpmrx5pqizn8ihf8jkq8d4drz7";
   };
-  "8.9" = {
-    version = "0.1";
-    rev = "a69551a49543b22a7d4e6a2484356b56bd05068e";
+  "8.9" = rec {
+    version = "0.2";
+    rev = version;
     sha256 = "0xby1kb26r9gcvk5511wqj05fqm9paynwfxlfqkmwkgnfmzk0x73";
+  };
+  "8.10" = rec {
+    version = "0.3";
+    rev = version;
+    sha256 = "0pzs5nsakh4l8ffwgn4ryxbnxdv2x0r1i7bc598ij621haxdirrr";
   };
 };
   param = params.${coq.coq-version};
@@ -31,7 +36,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ which ];
-  buildInputs = [ coq ] ++ (with coq.ocamlPackages; [ ocaml findlib camlp5 ]);
+  buildInputs = [ coq ] ++ (with coq.ocamlPackages; [ ocaml findlib ])
+  ++ stdenv.lib.optional (!stdenv.lib.versionAtLeast coq.coq-version "8.10")
+     coq.ocamlPackages.camlp5
+  ;
 
   installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
 


### PR DESCRIPTION
###### Motivation for this change

Bring Ltac2 to users of Coq 8.10.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
