### PR TITLE
pylibftdi: init at 0.18.1

### DIFF
--- a/pkgs/development/python-modules/pylibftdi/default.nix
+++ b/pkgs/development/python-modules/pylibftdi/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, httpserver
+, libftdi1
+, libusb1
+}:
+
+buildPythonPackage rec {
+  pname = "pylibftdi";
+  version = "0.18.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17c5h4xz1grynbpffngjflk3dlw2g2zbhkwb7h5v4n9rjdv41l5x";
+  };
+
+  propagatedBuildInputs = [
+    httpserver
+    libftdi1
+    libusb1
+  ];
+
+  postPatch = ''
+    substituteInPlace pylibftdi/driver.py \
+      --replace "self._load_library('libusb')" "cdll.LoadLibrary('${libusb1.out}/lib/libusb1.so')" \
+      --replace "self._load_library('libftdi')" "cdll.LoadLibrary('${libftdi1.out}/lib/libftdi1.so')"
+  '';
+
+  pythonImportsCheck = [ "pylibftdi" ];
+
+  meta = with lib; {
+    homepage = "https://bitbucket.org/codedstructure/pylibftdi/src/default/";
+    description = "Minimal pythonic wrapper to Intra2net's libftdi driver for FTDI's USB devices";
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthuszagh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1218,6 +1218,10 @@ in {
 
   pylev = callPackage ../development/python-modules/pylev { };
 
+  pylibftdi = callPackage ../development/python-modules/pylibftdi {
+    inherit (pkgs) libusb1;
+  };
+
   pymatgen = callPackage ../development/python-modules/pymatgen { };
 
   pymatgen-lammps = callPackage ../development/python-modules/pymatgen-lammps { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
