### PR TITLE
keybase, keybase-gui, kbfs: 4.6.0 -> 4.7.2, added dependencies

### DIFF
--- a/pkgs/tools/security/keybase/default.nix
+++ b/pkgs/tools/security/keybase/default.nix
@@ -1,11 +1,12 @@
-{ stdenv, lib, buildGoPackage, fetchFromGitHub
+{ stdenv, substituteAll, lib, buildGoPackage, fetchFromGitHub
 , AVFoundation, AudioToolbox, ImageIO, CoreMedia
 , Foundation, CoreGraphics, MediaToolbox
+, gnupg
 }:
 
 buildGoPackage rec {
   pname = "keybase";
-  version = "4.6.0";
+  version = "4.7.2";
 
   goPackagePath = "github.com/keybase/client";
   subPackages = [ "go/keybase" ];
@@ -16,10 +17,18 @@ buildGoPackage rec {
     owner = "keybase";
     repo = "client";
     rev = "v${version}";
-    sha256 = "1aqj5s3vfji1zl7xdzphnsw3b8pnbg22n9rzdxkcdjf7via5wz2k";
+    sha256 = "1ixfq9qv71misg04fvf4892z956w5aydq0r1wk6qk5jjqp6gf4lv";
   };
 
-  buildInputs = lib.optionals stdenv.isDarwin [ AVFoundation AudioToolbox ImageIO CoreMedia Foundation CoreGraphics MediaToolbox ];
+  patches = [
+    (substituteAll {
+      src = ./fix-paths-keybase.patch;
+      gpg = "${gnupg}/bin/gpg";
+      gpg2 = "${gnupg}/bin/gpg2";
+    })
+  ];
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ AVFoundation AudioToolbox ImageIO CoreMedia Foundation CoreGraphics MediaToolbox ];
   buildFlags = [ "-tags production" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/security/keybase/fix-paths-kbfs.patch
+++ b/pkgs/tools/security/keybase/fix-paths-kbfs.patch
@@ -1,0 +1,48 @@
+diff --git a/go/kbfs/libfuse/mounter.go b/go/kbfs/libfuse/mounter.go
+index d791ffc2..b116ad5d 100644
+--- a/go/kbfs/libfuse/mounter.go
++++ b/go/kbfs/libfuse/mounter.go
+@@ -108,7 +108,7 @@ func (m *mounter) Unmount() (err error) {
+ 	case "darwin":
+ 		_, err = exec.Command("/sbin/umount", dir).Output()
+ 	case "linux":
+-		fusermountOutput, fusermountErr := exec.Command("fusermount", "-u", dir).CombinedOutput()
++		fusermountOutput, fusermountErr := exec.Command("@fusermount@", "-u", dir).CombinedOutput()
+ 		// Only clean up mountdir on a clean unmount.
+ 		if fusermountErr == nil {
+ 			m.log.Info("Successfully unmounted")
+@@ -135,7 +135,7 @@ func (m *mounter) Unmount() (err error) {
+ 				"/usr/sbin/diskutil", "unmountDisk", "force", dir).Output()
+ 		case "linux":
+ 			// Lazy unmount; will unmount when KBFS is no longer in use.
+-			_, err = exec.Command("fusermount", "-u", "-z", dir).Output()
++			_, err = exec.Command("@fusermount@", "-u", "-z", dir).Output()
+ 		default:
+ 			err = errors.New("Forced unmount is not supported on this platform yet")
+ 		}
+diff --git a/go/vendor/bazil.org/fuse/mount_linux.go b/go/vendor/bazil.org/fuse/mount_linux.go
+index ec7fd89c..4d0a9e30 100644
+--- a/go/vendor/bazil.org/fuse/mount_linux.go
++++ b/go/vendor/bazil.org/fuse/mount_linux.go
+@@ -196,7 +196,7 @@ func mount(dir string, conf *mountConfig, ready chan<- struct{}, _ *error) (fuse
+ 	defer readFile.Close()
+ 
+ 	cmd := exec.Command(
+-		"fusermount",
++		"@fusermount@",
+ 		"-o", conf.getOptions(),
+ 		"--",
+ 		dir,
+diff --git a/go/vendor/bazil.org/fuse/unmount_linux.go b/go/vendor/bazil.org/fuse/unmount_linux.go
+index f02448af..6e4c6c23 100644
+--- a/go/vendor/bazil.org/fuse/unmount_linux.go
++++ b/go/vendor/bazil.org/fuse/unmount_linux.go
+@@ -21,7 +21,7 @@ func unmount(dir string) error {
+ 		return sysunix.Unmount(dir, sysunix.MNT_DETACH)
+ 	}
+ 
+-	cmd := exec.Command("fusermount", "-u", dir)
++	cmd := exec.Command("@fusermount@", "-u", dir)
+ 	output, err := cmd.CombinedOutput()
+ 	if err != nil {
+ 		if len(output) > 0 {

--- a/pkgs/tools/security/keybase/fix-paths-keybase.patch
+++ b/pkgs/tools/security/keybase/fix-paths-keybase.patch
@@ -1,0 +1,16 @@
+diff --git a/go/libkb/gpg_cli.go b/go/libkb/gpg_cli.go
+index 3c7c6257..ae8f7e2f 100644
+--- a/go/libkb/gpg_cli.go
++++ b/go/libkb/gpg_cli.go
+@@ -54,9 +54,9 @@ func (g *GpgCLI) Configure(mctx MetaContext) (err error) {
+ 	if len(prog) > 0 {
+ 		err = canExec(prog)
+ 	} else {
+-		prog, err = exec.LookPath("gpg2")
++		prog, err = exec.LookPath("@gpg2@")
+ 		if err != nil {
+-			prog, err = exec.LookPath("gpg")
++			prog, err = exec.LookPath("@gpg@")
+ 		}
+ 	}
+ 	if err != nil {

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -4,16 +4,16 @@
 , runtimeShell, gsettings-desktop-schemas }:
 
 let
-  versionSuffix = "20191010154240.134c2d892b";
+  versionSuffix = "20191028173732.6fc2e969b4";
 in
 
 stdenv.mkDerivation rec {
   pname = "keybase-gui";
-  version = "4.6.0"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
+  version = "4.7.2"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
 
   src = fetchurl {
     url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version + "-" + versionSuffix}_amd64.deb";
-    sha256 = "a25f0c676c00d306859d32e4dad7a23dd4955fa0b352be50c281081f2cf000ae";
+    sha256 = "01slhdxcjs1543rz1khxhzn25g26vm9fd9mcyd5ahp2v4g37b8sd";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/security/keybase/kbfs.nix
+++ b/pkgs/tools/security/keybase/kbfs.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, keybase }:
+{ stdenv, substituteAll, buildGoPackage, fetchFromGitHub, fuse, osxfuse, keybase }:
 
 buildGoPackage {
   pname = "kbfs";
@@ -9,6 +9,13 @@ buildGoPackage {
   subPackages = [ "go/kbfs/kbfsfuse" "go/kbfs/kbfsgit/git-remote-keybase" ];
 
   dontRenameImports = true;
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths-kbfs.patch;
+      fusermount = "${fuse}/bin/fusermount";
+    })
+  ];
 
   buildFlags = [ "-tags production" ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding:
- `fuse` or `osxfuse` as a dependency for `kbfs` (I rely on this [kbfs README.md#status](https://github.com/keybase/client/tree/master/go/kbfs#status))
- `gnupg` as a dependency for `keybase` (for command `$ keybase pgp gen`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
