### PR TITLE
cocotb: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4059,6 +4059,12 @@
     githubId = 427866;
     name = "Matthias Beyer";
   };
+  matthuszagh = {
+    email = "huszaghmatt@gmail.com";
+    github = "matthuszagh";
+    githubId = 7377393;
+    name = "Matt Huszagh";
+  };
   matti-kariluoma = {
     email = "matti@kariluo.ma";
     github = "matti-kariluoma";

--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, setuptools, swig, verilog }:
+
+buildPythonPackage rec {
+  pname = "cocotb";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "091q63jcm87xggqgqi44lw2vjxhl1v4yl0mv2c76hgavb29w4w5y";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+  ];
+
+  postPatch = ''
+    patchShebangs bin/*.py
+
+    # POSIX portability (TODO: upstream this)
+    for f in \
+      cocotb/share/makefiles/Makefile.* \
+      cocotb/share/makefiles/simulators/Makefile.*
+    do
+      substituteInPlace $f --replace 'shell which' 'shell command -v'
+    done
+  '';
+
+  checkInputs = [ swig verilog ];
+
+  checkPhase = ''
+    export PATH=$out/bin:$PATH
+    make test
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python";
+    homepage = https://github.com/cocotb/cocotb;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ matthuszagh ];
+  };
+}

--- a/pkgs/development/python-modules/cocotb/default.nix
+++ b/pkgs/development/python-modules/cocotb/default.nix
@@ -24,6 +24,9 @@ buildPythonPackage rec {
       cocotb/share/makefiles/simulators/Makefile.*
     do
       substituteInPlace $f --replace 'shell which' 'shell command -v'
+      # replace hardcoded gcc. Remove once https://github.com/cocotb/cocotb/pull/1137 gets merged
+      substituteInPlace $f --replace 'gcc' '$(CC)'
+      substituteInPlace $f --replace 'g++' '$(CXX)'
     done
   '';
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -489,6 +489,8 @@ in {
 
   cnvkit = callPackage ../development/python-modules/cnvkit { };
 
+  cocotb = callPackage ../development/python-modules/cocotb { };
+
   connexion = callPackage ../development/python-modules/connexion { };
 
   cozy = callPackage ../development/python-modules/cozy { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
