### PR TITLE
python3Packages.trezor_agent: fix startup error

### DIFF
--- a/pkgs/development/python-modules/trezor_agent/default.nix
+++ b/pkgs/development/python-modules/trezor_agent/default.nix
@@ -8,6 +8,7 @@
 , mnemonic
 , keepkey
 , semver
+, setuptools
 , wheel
 , pinentry
 }:
@@ -21,7 +22,7 @@ buildPythonPackage rec{
     sha256 = "e82bf000c1178b1a7612f2a90487eb34c6234d2edb15dc8e310ad875d8298690";
   };
 
-  propagatedBuildInputs = [ trezor libagent ecdsa ed25519 mnemonic keepkey semver wheel pinentry ];
+  propagatedBuildInputs = [ setuptools trezor libagent ecdsa ed25519 mnemonic keepkey semver wheel pinentry ];
 
   meta = with stdenv.lib; {
     description = "Using Trezor as hardware SSH agent";


### PR DESCRIPTION
###### Motivation for this change

`python3Packages.trezor_agent` fails on startup on 19.09 with

```
Traceback (most recent call last):
  File "/nix/store/nd21l71zzy2833bbab1rmikmwg29602p-python3.7-trezor_agent-0.10.0/bin/.trezor-agent-wrapped", line 7, in <module>
    from trezor_agent import ssh_agent
  File "/nix/store/nd21l71zzy2833bbab1rmikmwg29602p-python3.7-trezor_agent-0.10.0/bin/trezor_agent.py", line 1, in <module>
    import libagent.gpg
  File "/nix/store/hlzgj54s9pvn702qd4mzgv7h19yi3xh7-python3-3.7.4-env/lib/python3.7/site-packages/libagent/gpg/__init__.py", line 21, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @np @mmahut 
