### PR TITLE
awesome: Make sure it compiles with luajit

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -12,7 +12,10 @@
 # needed for beautiful.gtk to work
 assert gtk3Support -> gtk3 != null;
 
-with luaPackages; stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
+  lgi = luaPackages.lgi;
+  lua = luaPackages.lua;
+  ldoc = luaPackages.ldoc;
   pname = "awesome";
   version = "4.3";
 
@@ -49,8 +52,11 @@ with luaPackages; stdenv.mkDerivation rec {
                   xcbutilxrm ]
                   ++ stdenv.lib.optional gtk3Support gtk3;
 
-  #cmakeFlags = "-DGENERATE_MANPAGES=ON";
-  cmakeFlags = "-DOVERRIDE_VERSION=${version}";
+  cmakeFlags = [
+    #"-DGENERATE_MANPAGES=ON"
+    "-DOVERRIDE_VERSION=${version}"
+  ] ++ stdenv.lib.optional luaPackages.isLuaJIT "-DLUA_LIBRARY=${lua}/lib/libluajit-5.1.so"
+  ;
 
   GI_TYPELIB_PATH = "${pango.out}/lib/girepository-1.0";
   # LUA_CPATH and LUA_PATH are used only for *building*, see the --search flags


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Say a user wishes to have a derivation of awesome that will use `luajitPackages` instead of the default `lua52Packages`, he will probably use the following overlay:

```nix
self: super:

{
  awesome = super.awesome.override {
    luaPackages = super.luajitPackages;
  };
}
```

But, that will lead him to the following build error:

```
-- Could NOT find Lua (missing: LUA_LIBRARIES) (found version "5.1.4")
CMake Error at awesomeConfig.cmake:70 (message):
  Could not find Lua.  See the error above.

  You might want to hint it using the LUA_DIR environment variable, or set
  the LUA_INCLUDE_DIR / LUA_LIBRARY CMake variables.
Call Stack (most recent call first):
  CMakeLists.txt:33 (include)


-- Configuring incomplete, errors occurred!
See also "/build/source/build/CMakeFiles/CMakeOutput.log".
builder for '/nix/store/9lm5fh1ij4rxh2qmi1c5q9a3v8hmk145-awesome-4.3.drv' failed with exit code 1
error: build of '/nix/store/9lm5fh1ij4rxh2qmi1c5q9a3v8hmk145-awesome-4.3.drv' failed
```

Applying this patch fixes this error and it will allow to easily build a working derivation of Awesome that uses LuaJIT.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lovek323
cc @rasendubi
cc @ndowens