### PR TITLE
networkmanager-fortisslvpn: create the local state directory

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -472,6 +472,7 @@ in {
     systemd.tmpfiles.rules = [
       "d /etc/NetworkManager/system-connections 0700 root root -"
       "d /etc/ipsec.d 0700 root root -"
+      "d /var/lib/NetworkManager-fortisslvpn 0700 root root -"
 
       "d /var/lib/dhclient 0755 root root -"
       "d /var/lib/misc 0755 root root -" # for dnsmasq.leases

--- a/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
@@ -32,9 +32,13 @@ in stdenv.mkDerivation {
   configureFlags = [
     "--without-libnm-glib"
     "--with-gnome=${if withGnome then "yes" else "no"}"
-    "--localstatedir=/tmp"
+    "--localstatedir=/var"
     "--enable-absolute-paths"
   ];
+
+  # the installer only create an empty directory in localstatedir, so
+  # we can drop it
+  installFlags = [ "localstatedir=." ];
 
   passthru = {
     updateScript = gnome3.updateScript {


### PR DESCRIPTION
Otherwise connecting simply fails:
VPN connection: failed to connect: 'La création du fichier « /tmp/lib/NetworkManager-fortisslvpn/0507e3ef-f0e0-4153-af64-b3d9a025877c.config.XSB19Z » a échoué : No such file or directory'

Currently the plugin is non-functional so I think a backport to 19.09 is required.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Tested by connecting to a vpn.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

