### PR TITLE
skrooge: Fix build

### DIFF
--- a/pkgs/applications/office/skrooge/default.nix
+++ b/pkgs/applications/office/skrooge/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchurl,
+{ mkDerivation, lib, fetchpatch, fetchurl,
   cmake, extra-cmake-modules, qtwebengine, qtscript, grantlee,
   kxmlgui, kwallet, kparts, kdoctools, kjobwidgets, kdesignerplugin,
   kiconthemes, knewstuff, sqlcipher, qca-qt5, kactivities, karchive,
@@ -13,6 +13,14 @@ mkDerivation rec {
     url = "http://download.kde.org/stable/skrooge/${pname}-${version}.tar.xz";
     sha256 = "0rakfngp7j2x7h1isg6lbc5kva6k1kg99dz0zl43dc28s15can1w";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "skrooge-2.20.0-missing-header.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-office/skrooge/files/skrooge-2.20.0-missing-header.patch?id=cb8c91474b0ae2f9e889f89afe2d9114dbd1784f";
+      sha256 = "154zsidx45h6qrcqjh6czjxrcwrcmbyv3yh2k1s40v8pzvjwzrld";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake extra-cmake-modules kdoctools shared-mime-info
@@ -37,6 +45,5 @@ mkDerivation rec {
     license = with licenses; [ gpl3 ];
     maintainers = with maintainers; [ joko ];
     homepage = https://skrooge.org/;
-    broken = true;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes the skrooge build with current qt.

Patch is taken from freebsd: https://github.com/swills/freebsd-ports/blob/5387cf4b3d2e6fb0e1fa5187f0c0439f9c3f047a/finance/skrooge/files/patch-gentoo-kf5-5.61-headers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).