### PR TITLE
qgroundcontrol: 3.3.0 -> 3.5.5, fix build

### DIFF
--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -7,7 +7,7 @@
 
 mkDerivation rec {
   pname = "qgroundcontrol";
-  version = "3.5.4";
+  version = "3.5.5";
 
   qtInputs = [
     qtbase qtcharts qtlocation qtserialport qtsvg qtquickcontrols2
@@ -59,7 +59,7 @@ mkDerivation rec {
   src = fetchgit {
     url = "https://github.com/mavlink/qgroundcontrol.git";
     rev = "v${version}";
-    sha256 = "1ja92zk2fr96r8lj2bs9498afxxhvl2sh6v6brdk3p4krjqbwl3s";
+    sha256 = "05zy6w9lwwh254wa8c6wysa67kk0flywcvipii9b1rmy47slflhs";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/science/robotics/qgroundcontrol/default.nix
+++ b/pkgs/applications/science/robotics/qgroundcontrol/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchgit, git,  SDL2, udev, doxygen
-, qtbase, qtlocation, qtserialport, qtdeclarative, qtconnectivity, qtxmlpatterns
-, qtsvg, qtquick1, qtquickcontrols, qtgraphicaleffects, qmake, qtspeech
+{ lib, mkDerivation, fetchgit, SDL2
+, qtbase, qtcharts, qtlocation, qtserialport, qtsvg, qtquickcontrols2
+, qtgraphicaleffects, qtspeech, qmake
 , makeWrapper
 , gst_all_1, pkgconfig
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "qgroundcontrol";
-  version = "3.3.0";
+  version = "3.5.4";
 
   qtInputs = [
-    qtbase qtlocation qtserialport qtdeclarative qtconnectivity qtxmlpatterns qtsvg
-    qtquick1 qtquickcontrols qtgraphicaleffects qtspeech
+    qtbase qtcharts qtlocation qtserialport qtsvg qtquickcontrols2
+    qtgraphicaleffects qtspeech
   ];
 
   gstInputs = with gst_all_1; [
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
-  buildInputs = [ SDL2 udev doxygen git ] ++ gstInputs ++ qtInputs;
+  buildInputs = [ SDL2 ] ++ gstInputs ++ qtInputs;
   nativeBuildInputs = [ pkgconfig makeWrapper qmake ];
 
   preConfigure = ''
@@ -58,17 +58,16 @@ stdenv.mkDerivation rec {
   # TODO: package mavlink so we can build from a normal source tarball
   src = fetchgit {
     url = "https://github.com/mavlink/qgroundcontrol.git";
-    rev = "refs/tags/v${version}";
-    sha256 = "0abjm0wywp24qlgg9w8g35ijprjg5csq4fgba9caaiwvmpfbhmpw";
+    rev = "v${version}";
+    sha256 = "1ja92zk2fr96r8lj2bs9498afxxhvl2sh6v6brdk3p4krjqbwl3s";
     fetchSubmodules = true;
   };
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Provides full ground station support and configuration for the PX4 and APM Flight Stacks";
-    homepage = http://qgroundcontrol.org/;
+    homepage = "http://qgroundcontrol.org/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ pxc ];
-    broken = true;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates QGroundControl to the latest version and makes it work correctly using the new QT `mkDerivation`.

I removed a lot of dependencies that I could not find any reference to in the code, as well as some that were only required by features which are not enabled by default.

The only issue I know of with this package is that it is unable to detect its version number, so it is shown as "None". This occurs because the build system attempts to extract the version number from git. Even if the `leaveDotGit` parameter is passed to `fetchgit`, the build system ends up extracting one of the tags `fetchgit` creates instead of the correct version number tag.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @therealpxc 
