### PR TITLE
dumb-init: init at 1.2.2

### DIFF
--- a/pkgs/applications/virtualization/dumb-init/default.nix
+++ b/pkgs/applications/virtualization/dumb-init/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, glibc }:
+
+stdenv.mkDerivation rec {
+  pname = "dumb-init";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Yelp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "15hgl8rz5dmrl5gx21sq5269l1hq539qn68xghjx0bv9hgbx0g20";
+  };
+
+  buildInputs = [ glibc.static ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin dumb-init
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A minimal init system for Linux containers";
+    homepage = "https://github.com/Yelp/dumb-init";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -215,6 +215,8 @@ in
 
   dotnet-sdk = callPackage ../development/compilers/dotnet/sdk { };
 
+  dumb-init = callPackage ../applications/virtualization/dumb-init {};
+
   dispad = callPackage ../tools/X11/dispad { };
 
   dump1090 = callPackage ../applications/radio/dump1090 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add dumb-init https://github.com/Yelp/dumb-init

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
