### PR TITLE
ocamlPackages.ppx_tools: enable at 5.3+4.08.0 for OCaml 4.09

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -23,6 +23,9 @@ let param = {
   "4.08" = {
     version = "5.3+4.08.0";
     sha256 = "0vdmhs3hpmh5iclx4lzgdpf362m4l35zprxs73r84z1yhr4jcr4m"; };
+  "4.09" = {
+    version = "5.3+4.08.0";
+    sha256 = "0vdmhs3hpmh5iclx4lzgdpf362m4l35zprxs73r84z1yhr4jcr4m"; };
 }.${ocaml.meta.branch};
 in
   stdenv.mkDerivation {

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchzip, which, ocaml, ocamlbuild }:
 
+if stdenv.lib.versionAtLeast ocaml.version "4.09"
+then throw "camlp4 is not available for OCaml ${ocaml.version}"
+else
+
 let param = {
   "4.02" = {
      version = "4.02+6";


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
