### PR TITLE
openconnect: Add darwin support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6646,6 +6646,12 @@
     githubId = 1312290;
     name = "Trevor Joynson";
   };
+  tricktron = {
+    email = "tgagnaux@gmail.com";
+    github = "tricktron";
+    githubId = 16036882;
+    name = "Thibault Gagnaux";
+  };
   trino = {
     email = "muehlhans.hubert@ekodia.de";
     github = "hmuehlhans";

--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -1,8 +1,14 @@
-{ stdenv, fetchurl, pkgconfig, vpnc, openssl ? null, gnutls ? null, gmp, libxml2, stoken, zlib } :
+{ stdenv, fetchurl, pkgconfig, openssl ? null, gnutls ? null, gmp, libxml2, stoken, zlib, fetchgit, darwin } :
 
 assert (openssl != null) == (gnutls == null);
 
-stdenv.mkDerivation rec {
+let vpnc = fetchgit {
+  url = "git://git.infradead.org/users/dwmw2/vpnc-scripts.git";
+  rev = "c84fb8e5a523a647a01a1229a9104db934e19f00";
+  sha256 = "01xdclx0y3x66mpbdr77n4ilapwzjz475h32q88ml9gnq6phjxrs";
+};
+
+in stdenv.mkDerivation rec {
   pname = "openconnect";
   version = "8.05";
 
@@ -14,21 +20,23 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" ];
-
+  
   configureFlags = [
-    "--with-vpnc-script=${vpnc}/etc/vpnc/vpnc-script"
+    "--with-vpnc-script=${vpnc}/vpnc-script"
     "--disable-nls"
     "--without-openssl-version-check"
   ];
 
+  buildInputs = [ openssl gnutls gmp libxml2 stoken zlib ]
+    ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.PCSC;
   nativeBuildInputs = [ pkgconfig ];
-  propagatedBuildInputs = [ vpnc openssl gnutls gmp libxml2 stoken zlib ];
+  propagatedBuildInputs = [ vpnc ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "VPN Client for Cisco's AnyConnect SSL VPN";
     homepage = http://www.infradead.org/openconnect/;
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = with stdenv.lib.maintainers; [ pradeepchhetri ];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ pradeepchhetri tricktron ];
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };
 }

--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -30,7 +30,6 @@ in stdenv.mkDerivation rec {
   buildInputs = [ openssl gnutls gmp libxml2 stoken zlib ]
     ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.PCSC;
   nativeBuildInputs = [ pkgconfig ];
-  propagatedBuildInputs = [ vpnc ];
 
   meta = with stdenv.lib; {
     description = "VPN Client for Cisco's AnyConnect SSL VPN";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
So far the derivation had no Darwin support. The build was failing on darwin because yubikey needs the PCSC framework dependency so I added it. I also upgraded to the latest `vpnc-script` as recommended on the openconnect homepage (see: https://www.infradead.org/openconnect/platforms.html) because with the old `vpnc-script` openconnect did not work properly. Lastly, I moved all dependencies which are not used at runtime from propagatedBuildInputs to buildInputs (Please correct me if that is wrong).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Things to do

Would be nice if someone could test it on NixOS and linux (Maybe @trobert in combination with your pkcs11 support). 

###### Notify maintainers

cc @pradeepchhetri
