### PR TITLE
boulder: init at release-2019-10-13

### DIFF
--- a/pkgs/tools/admin/boulder/default.nix
+++ b/pkgs/tools/admin/boulder/default.nix
@@ -1,0 +1,33 @@
+{ buildGoPackage
+, libtool
+, fetchFromGitHub
+, lib
+}:
+
+let
+  version = "release-2019-10-13";
+
+in buildGoPackage {
+
+  pname = "boulder";
+  inherit version;
+
+  goPackagePath = "github.com/letsencrypt/boulder";
+
+  buildInputs = [ libtool ];
+
+  src = fetchFromGitHub {
+    owner = "letsencrypt";
+    repo = "boulder";
+    rev = version;
+    sha256 = "0kis23dnjja6jp192rjpv2m9m2zmzfwhs93440nxg354k6fp8jdg";
+  };
+
+  meta = {
+    homepage = "https://github.com/letsencrypt/boulder";
+    description = "An ACME-based CA, written in Go.";
+    license = [ lib.licenses.mpl20 ];
+    maintainers = [ ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10518,6 +10518,8 @@ in
   botan = callPackage ../development/libraries/botan { openssl = openssl_1_0_2; };
   botan2 = callPackage ../development/libraries/botan/2.0.nix { };
 
+  boulder = callPackage ../tools/admin/boulder { };
+
   box2d = callPackage ../development/libraries/box2d { };
 
   buddy = callPackage ../development/libraries/buddy { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
