### PR TITLE
buildRustCrate: fix linking problems

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -77,18 +77,6 @@
     EXTRA_LIB=""
     CRATE_NAME=$(echo ${libName} | sed -e "s/-/_/g")
 
-    if [[ -e target/link_ ]]; then
-      EXTRA_BUILD="$(cat target/link_) $EXTRA_BUILD"
-    fi
-
-    if [[ -e "${libPath}" ]]; then
-       build_lib ${libPath}
-    elif [[ -e src/lib.rs ]]; then
-       build_lib src/lib.rs
-    elif [[ -e src/${libName}.rs ]]; then
-       build_lib src/${libName}.rs
-    fi
-
     echo "$EXTRA_LINK_SEARCH" | while read i; do
        if [[ ! -z "$i" ]]; then
          for lib in $i; do
@@ -116,6 +104,19 @@
        tr '\n' ' ' < target/link > target/link_
        LINK=$(cat target/link_)
     fi
+
+    if [[ -e target/link_ ]]; then
+      EXTRA_BUILD="$(cat target/link_) $EXTRA_BUILD"
+    fi
+
+    if [[ -e "${libPath}" ]]; then
+       build_lib ${libPath}
+    elif [[ -e src/lib.rs ]]; then
+       build_lib src/lib.rs
+    elif [[ -e src/${libName}.rs ]]; then
+       build_lib src/${libName}.rs
+    fi
+
     ${lib.optionalString (crateBin != "") ''
     printf "%s\n" "${crateBin}" | head -n1 | tr -s ',' '\n' | while read -r BIN_NAME BIN_PATH; do
       mkdir -p target/bin


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
When a derivation using `buildRustCrate` doesn't use `extraLinkFlags`, but the `build.rs` or similar emits `cargo:rustc-link-lib=X`, then the link flags were only being applied to executables and not libraries. This was causing frustration for one of my co-workers, which this change fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andir 
