### PR TITLE
nixos/containers: custom network namespaces

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -941,6 +941,7 @@
   ./tasks/network-interfaces.nix
   ./tasks/network-interfaces-systemd.nix
   ./tasks/network-interfaces-scripted.nix
+  ./tasks/network-namespaces.nix
   ./tasks/scsi-link-power-management.nix
   ./tasks/swraid.nix
   ./tasks/trackpoint.nix

--- a/nixos/modules/tasks/network-namespaces.nix
+++ b/nixos/modules/tasks/network-namespaces.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+with lib; {
+  options = {
+    networking.namespaces = mkOption {
+      default = [];
+      type = types.listOf types.str;
+      description = ''
+        A list of named network namespaces to create.
+      '';
+    };
+  };
+  config.systemd.services = builtins.listToAttrs (map (netns: {
+    name = "network-namespace-${netns}";
+    value = {
+      description = "Network Namespace: ${netns}";
+      before = [ "network-pre.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${pkgs.iproute}/bin/ip netns add ${strings.escapeShellArg netns}";
+        ExecStop = "${pkgs.iproute}/bin/ip netns del ${strings.escapeShellArg netns}";
+      };
+    };
+  }) config.networking.namespaces);
+}

--- a/nixos/tests/containers-network-namespace.nix
+++ b/nixos/tests/containers-network-namespace.nix
@@ -1,0 +1,47 @@
+import ./make-test-python.nix {
+
+  machine = {
+    networking.namespaces = [ "alice" "bob" ];
+
+    containers.alice = {
+      autoStart = true;
+      networkNamespace = "alice";
+      config = { };
+    };
+
+    containers.bob = {
+      autoStart = true;
+      networkNamespace = "bob";
+      config = { };
+    };
+  };
+
+  testScript =
+    ''
+      import json
+
+
+      def link_exists(name, links):
+          return len([link for link in json.loads(links) if link["ifname"] == name]) == 1
+
+
+      machine.wait_for_unit("default.target")
+
+
+      with subtest("namespaces created"):
+          assert "alice" in machine.succeed("ip netns"), "alice: missing network namespace"
+          assert "bob" in machine.succeed("ip netns"), "bob: missing network namespace"
+
+
+      with subtest("alice is created in the correct netns"):
+          machine.succeed("ip -n alice link add alice_nic type dummy")
+          links = machine.succeed("nixos-container run alice -- ip -j link")
+          assert link_exists("alice_nic", links)
+
+
+      with subtest("bob is created in the correct netns"):
+          machine.succeed("ip -n bob link add bob_nic type dummy")
+          links = machine.succeed("nixos-container run bob -- ip -j link")
+          assert link_exists("bob_nic", links)
+    '';
+}

--- a/nixos/tests/wireguard/namespaces.nix
+++ b/nixos/tests/wireguard/namespaces.nix
@@ -23,43 +23,42 @@ import ../make-test.nix ({ pkgs, ...} : {
     # interface should be created in the socketNamespace
     # and not moved from there
     peer0 = pkgs.lib.attrsets.recursiveUpdate node {
-      networking.wireguard.interfaces.wg0 = {
-        preSetup = ''
-          ip netns add ${socketNamespace}
-        '';
-        inherit socketNamespace;
+      networking = {
+        namespaces = [ socketNamespace ];
+        wireguard.interfaces.wg0 = {
+          inherit socketNamespace;
+        };
       };
     };
     # interface should be created in the init namespace
     # and moved to the interfaceNamespace
     peer1 = pkgs.lib.attrsets.recursiveUpdate node {
-      networking.wireguard.interfaces.wg0 = {
-        preSetup = ''
-          ip netns add ${interfaceNamespace}
-        '';
-        inherit interfaceNamespace;
+      networking = {
+        namespaces = [ interfaceNamespace ];
+        wireguard.interfaces.wg0 = {
+          inherit interfaceNamespace;
+        };
       };
     };
     # interface should be created in the socketNamespace
     # and moved to the interfaceNamespace
     peer2 = pkgs.lib.attrsets.recursiveUpdate node {
-      networking.wireguard.interfaces.wg0 = {
-        preSetup = ''
-          ip netns add ${socketNamespace}
-          ip netns add ${interfaceNamespace}
-        '';
-        inherit socketNamespace interfaceNamespace;
+      networking = {
+        namespaces = [ socketNamespace interfaceNamespace ];
+        wireguard.interfaces.wg0 = {
+          inherit socketNamespace interfaceNamespace;
+        };
       };
     };
     # interface should be created in the socketNamespace
     # and moved to the init namespace
     peer3 = pkgs.lib.attrsets.recursiveUpdate node {
-      networking.wireguard.interfaces.wg0 = {
-        preSetup = ''
-          ip netns add ${socketNamespace}
-        '';
-        inherit socketNamespace;
-        interfaceNamespace = "init";
+      networking = {
+        namespaces = [ socketNamespace ];
+        wireguard.interfaces.wg0 = {
+          inherit socketNamespace;
+          interfaceNamespace = "init";
+        };
       };
     };
   };


### PR DESCRIPTION
###### Motivation for this change

This change provides a declarative interface for creating named network namespaces, and spawning nixos containers within them.

This is useful if you:

- Want multiple containers to communicate over localhost ("sidecar" containers)
- Want to modify the network namespace from outside of the container

I use this for the second purpose. I want to be able to move interfaces in and out of a container's network namespace as part of a namespace based whole internet wireguard VPN solution (see [here](https://www.wireguard.com/netns/)).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
