### PR TITLE
Clean up git-series packaging, use OpenSSL 1.1

### DIFF
--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, rustPlatform, openssl, cmake, perl, pkgconfig, zlib }:
+{ stdenv, fetchFromGitHub, fetchpatch, rustPlatform, openssl, cmake, perl, pkgconfig, zlib, curl }:
 
 with rustPlatform;
 
@@ -28,7 +28,7 @@ buildRustPackage rec {
   ];
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
-  buildInputs = [ openssl zlib ];
+  buildInputs = [ openssl zlib curl ];
 
   postBuild = ''
     install -D "$src/git-series.1" "$out/man/man1/git-series.1"

--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, rustPlatform, openssl_1_0_2, cmake, perl, pkgconfig, zlib }:
+{ stdenv, fetchFromGitHub, fetchpatch, rustPlatform, openssl, cmake, perl, pkgconfig, zlib }:
 
 with rustPlatform;
 
@@ -13,17 +13,22 @@ buildRustPackage rec {
     sha256 = "07mgq5h6r1gf3jflbv2khcz32bdazw7z1s8xcsafdarnm13ps014";
   };
 
-  cargoSha256 = "07b25pcndhwvpwa5khdh8y1fl44hdv6ff2pfj1mjc0wchbspqm6q";
+  cargoSha256 = "09y4fvv279cm5sgbpmskascb7rrwqgya5w5wkpz1bgx6pzw3mc7y";
 
   cargoPatches = [
     (fetchpatch {
       url = "https://github.com/Mic92/git-series/commit/3aa30a47d74ebf90b444dccdf8c153f07f119483.patch";
       sha256 = "06v8br9skvy75kcw2zgbswxyk82sqzc8smkbqpzmivxlc2i9rnh0";
     })
+    # Update Cargo.lock to allow using OpenSSL 1.1
+    (fetchpatch {
+      url = "https://github.com/edef1c/git-series/commit/11fe70ffcc18200e5f2a159c36aab070e8ff4228.patch";
+      sha256 = "0clwllf9mrhq86dhzyyhkw1q2ggpgqpw7s05dvp3gj9zhfsyya4s";
+    })
   ];
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
-  buildInputs = [ openssl_1_0_2 zlib ];
+  buildInputs = [ openssl zlib ];
 
   postBuild = ''
     install -D "$src/git-series.1" "$out/man/man1/git-series.1"

--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, rustPlatform, openssl, cmake, perl, pkgconfig, zlib, curl }:
+{ stdenv, fetchFromGitHub, fetchpatch, rustPlatform, openssl, cmake, perl, pkgconfig, zlib, curl, libgit2 }:
 
 with rustPlatform;
 
@@ -27,8 +27,9 @@ buildRustPackage rec {
     })
   ];
 
+  LIBGIT2_SYS_USE_PKG_CONFIG = true;
   nativeBuildInputs = [ cmake pkgconfig perl ];
-  buildInputs = [ openssl zlib curl ];
+  buildInputs = [ openssl zlib curl libgit2 ];
 
   postBuild = ''
     install -D "$src/git-series.1" "$out/man/man1/git-series.1"

--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -45,6 +45,6 @@ buildRustPackage rec {
     homepage = https://github.com/git-series/git-series;
 
     license = licenses.mit;
-    maintainers = [ maintainers.vmandela ];
+    maintainers = with maintainers; [ edef vmandela ];
   };
 }

--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -15,16 +15,12 @@ buildRustPackage rec {
 
   cargoSha256 = "07b25pcndhwvpwa5khdh8y1fl44hdv6ff2pfj1mjc0wchbspqm6q";
 
-  cargoDepsHook = ''
-    (
-      cd */
-      # see https://github.com/git-series/git-series/pull/56
-      patch -p1 < ${fetchpatch {
-        url = "https://github.com/Mic92/git-series/commit/3aa30a47d74ebf90b444dccdf8c153f07f119483.patch";
-        sha256 = "06v8br9skvy75kcw2zgbswxyk82sqzc8smkbqpzmivxlc2i9rnh0";
-      }}
-    )
-  '';
+  cargoPatches = [
+    (fetchpatch {
+      url = "https://github.com/Mic92/git-series/commit/3aa30a47d74ebf90b444dccdf8c153f07f119483.patch";
+      sha256 = "06v8br9skvy75kcw2zgbswxyk82sqzc8smkbqpzmivxlc2i9rnh0";
+    })
+  ];
 
   nativeBuildInputs = [ cmake pkgconfig perl ];
   buildInputs = [ openssl_1_0_2 zlib ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This cleans up the git-series packaging to use fewer vendored native libraries, and minimally upgrades some of the Cargo dependencies to allow using recent versions of OpenSSL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vmandela