### PR TITLE
Add missing Plover deps

### DIFF
--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, python27Packages, python36Packages, wmctrl }:
+{ stdenv, fetchurl, python27Packages, python36Packages, wmctrl,
+  qtbase, mkDerivationWith }:
 
 {
   stable = with python27Packages; buildPythonPackage rec {
@@ -23,7 +24,7 @@
     ];
   };
 
-  dev = with python36Packages; buildPythonPackage rec {
+  dev = with python36Packages; mkDerivationWith buildPythonPackage rec {
     pname = "plover";
     version = "4.0.0.dev8";
 
@@ -44,5 +45,10 @@
 
     checkInputs           = [ pytest mock ];
     propagatedBuildInputs = [ Babel pyqt5 xlib pyserial appdirs wcwidth setuptools ];
+
+    dontWrapQtApps = true;
+    makeWrapperArgs = [
+      "\${qtWrapperArgs[@]}"
+    ];
   };
 }

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -43,6 +43,6 @@
     postPatch = "sed -i /PyQt5/d setup.cfg";
 
     checkInputs           = [ pytest mock ];
-    propagatedBuildInputs = [ Babel pyqt5 xlib pyserial appdirs wcwidth ];
+    propagatedBuildInputs = [ Babel pyqt5 xlib pyserial appdirs wcwidth setuptools ];
   };
 }

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -19,7 +19,7 @@
     nativeBuildInputs     = [ setuptools_scm ];
     buildInputs           = [ pytest mock ];
     propagatedBuildInputs = [
-      six setuptools pyserial appdirs hidapi wxPython xlib wmctrl
+      six setuptools pyserial appdirs hidapi wxPython xlib wmctrl dbus-python
     ];
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20285,7 +20285,7 @@ in
 
   plex-media-player = libsForQt59.callPackage ../applications/video/plex-media-player { };
 
-  plover = recurseIntoAttrs (callPackage ../applications/misc/plover { });
+  plover = recurseIntoAttrs (libsForQt5.callPackage ../applications/misc/plover { });
 
   plugin-torture = callPackage ../applications/audio/plugin-torture { };
 


### PR DESCRIPTION
###### Motivation for this change
This fixes plover.dev crashing at startup due to missing `pkg_resources` and `qtbase`, and adds the optional `dbus-python` dependency to plover.stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @twey @KoviRobi