### PR TITLE
pypi2nix: add missing setuptools dependency

### DIFF
--- a/pkgs/development/tools/pypi2nix/default.nix
+++ b/pkgs/development/tools/pypi2nix/default.nix
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
     requests
   ];
   buildInputs = [
-    pythonPackages.python pythonPackages.flake8
+    pythonPackages.python pythonPackages.flake8 pythonPackages.setuptools
     zip makeWrapper nix.out nix-prefetch-git nix-prefetch-hg
   ];
 


### PR DESCRIPTION
###### Motivation for this change

pypi2nix was broken by f7e28bf5d8181926e600a222cb70180519d09726, which removed
setuptools from the default propagatedBuildInputs of Python packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
