### PR TITLE
pythonPackages.pgsanity: add missing postgresql checkInput

### DIFF
--- a/pkgs/development/python-modules/pgsanity/default.nix
+++ b/pkgs/development/python-modules/pgsanity/default.nix
@@ -25,13 +25,12 @@ buildPythonPackage rec {
     description = "Checks the syntax of Postgresql SQL files";
     longDescription = ''
       PgSanity checks the syntax of Postgresql SQL files by
-      taking a file that has a list of bare SQL in it, 
-      making that file look like a C file with embedded SQL, 
-      run it through ecpg and 
+      taking a file that has a list of bare SQL in it,
+      making that file look like a C file with embedded SQL,
+      run it through ecpg and
       let ecpg report on the syntax errors of the SQL.
     '';
     license = stdenv.lib.licenses.mit;
     maintainers = with maintainers; [ nalbyuites ];
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pgsanity/default.nix
+++ b/pkgs/development/python-modules/pgsanity/default.nix
@@ -17,6 +17,7 @@ buildPythonPackage rec {
     ${python.interpreter} -m unittest discover -s test
   '';
 
+  checkInputs = [ postgresql ];
   propagatedBuildInputs = [ postgresql ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Without this, the package doesn't build because all the tests fail.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).