### PR TITLE
nixos/rabbitmq: use a literalExample for example configItems

### DIFF
--- a/nixos/modules/services/amqp/rabbitmq.nix
+++ b/nixos/modules/services/amqp/rabbitmq.nix
@@ -80,10 +80,12 @@ in {
       configItems = mkOption {
         default = {};
         type = types.attrsOf types.str;
-        example = {
-          "auth_backends.1.authn" = "rabbit_auth_backend_ldap";
-          "auth_backends.1.authz" = "rabbit_auth_backend_internal";
-        };
+        example = literalExample ''
+          {
+            "auth_backends.1.authn" = "rabbit_auth_backend_ldap";
+            "auth_backends.1.authz" = "rabbit_auth_backend_internal";
+          }
+        '';
         description = ''
           Configuration options in RabbitMQ's new config file format,
           which is a simple key-value format that can not express nested


### PR DESCRIPTION
a small style fix suggested by @Infinisil 