### PR TITLE
ncspot: init at 2019-10-12

### DIFF
--- a/pkgs/applications/audio/ncspot/default.nix
+++ b/pkgs/applications/audio/ncspot/default.nix
@@ -1,0 +1,43 @@
+{ lib, fetchFromGitHub, rustPlatform, pkg-config, ncurses, openssl
+, withALSA ? true, alsaLib ? null
+, withPulseAudio ? false, libpulseaudio ? null
+, withPortAudio ? false, portaudio ? null
+}:
+
+let
+  features = [ "cursive/pancurses-backend" ]
+    ++ lib.optional withALSA "alsa_backend"
+    ++ lib.optional withPulseAudio "pulseaudio_backend"
+    ++ lib.optional withPortAudio "portaudio_backend";
+in
+rustPlatform.buildRustPackage rec {
+  pname = "ncspot-unstable";
+  version = "2019-10-12";
+
+  src = fetchFromGitHub {
+    owner = "hrkfdn";
+    repo = "ncspot";
+    rev = "4defded54646958268a20787917e4721ae96407d";
+    sha256 = "1w3cmilwjzk3pfnq97qgz6hzxgjgi27dm8jq7maw87qyl3v17gyg";
+  };
+
+  cargoSha256 = "1w1fk39pragfy2i2myw99mqf63w6fw4nr2kri8ily2iqc6g9xpgw";
+
+  cargoBuildFlags = [ "--no-default-features" "--features" "${lib.concatStringsSep "," features}" ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ ncurses openssl ]
+    ++ lib.optional withALSA alsaLib
+    ++ lib.optional withPulseAudio libpulseaudio
+    ++ lib.optional withPortAudio portaudio;
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Cross-platform ncurses Spotify client written in Rust, inspired by ncmpc and the likes";
+    homepage = "https://github.com/hrkfdn/ncspot";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20003,6 +20003,12 @@ in
 
   ncdc = callPackage ../applications/networking/p2p/ncdc { };
 
+  ncspot = callPackage ../applications/audio/ncspot {
+    withALSA = stdenv.isLinux;
+    withPulseAudio = config.pulseaudio or stdenv.isLinux;
+    withPortAudio = stdenv.isDarwin;
+  };
+
   ncview = callPackage ../tools/X11/ncview { } ;
 
   ne = callPackage ../applications/editors/ne { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/hrkfdn/ncspot

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
