### PR TITLE
automake-1.15: deterministic date in generated documentation

### DIFF
--- a/pkgs/development/tools/misc/automake/automake-1.15.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.15.x.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
+  patches = [ ./help2man-SOURCE_DATE_EPOCH-support.patch ];
+
   # Disable indented log output from Make, otherwise "make.test" will
   # fail.
   preCheck = "unset NIX_INDENT_MAKE";

--- a/pkgs/development/tools/misc/automake/help2man-SOURCE_DATE_EPOCH-support.patch
+++ b/pkgs/development/tools/misc/automake/help2man-SOURCE_DATE_EPOCH-support.patch
@@ -1,0 +1,41 @@
+From 2e3357d7f0d63f1caeb40d9644c2436a5cd0da5f Mon Sep 17 00:00:00 2001
+From: David Terry <me@xwvvvvwx.com>
+Date: Fri, 18 Oct 2019 10:23:11 +0200
+Subject: [PATCH] help2man: add support for SOURCE_DATE_EPOCH
+
+---
+ doc/help2man | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/doc/help2man b/doc/help2man
+index af4306f..4a64167 100755
+--- a/doc/help2man
++++ b/doc/help2man
+@@ -213,11 +213,23 @@ sub get_option_value;
+ my $help_text   = get_option_value $ARGV[0], $help_option;
+ $version_text ||= get_option_value $ARGV[0], $version_option;
+ 
++# By default the generated manual pages will include the current date.  This may
++# however be overriden by setting the environment variable $SOURCE_DATE_EPOCH
++# to an integer value of the seconds since the UNIX epoch.  This is primarily
++# intended to support reproducible builds (wiki.debian.org/ReproducibleBuilds)
++# and will additionally ensure that the output date string is UTC.
++my $epoch_secs = time;
++if (exists $ENV{SOURCE_DATE_EPOCH} and $ENV{SOURCE_DATE_EPOCH} =~ /^(\d+)$/)
++{
++    $epoch_secs = $1;
++    $ENV{TZ} = 'UTC';
++}
++
+ # Translators: the following message is a strftime(3) format string, which in
+ # the English version expands to the month as a word and the full year.  It
+ # is used on the footer of the generated manual pages.  If in doubt, you may
+ # just use %x as the value (which should be the full locale-specific date).
+-my $date = enc strftime _("%B %Y"), localtime;
++my $date = enc strftime _("%B %Y"), localtime $epoch_secs;
+ (my $program = $ARGV[0]) =~ s!.*/!!;
+ my $package = $program;
+ my $version;
+-- 
+2.23.0
+


### PR DESCRIPTION
###### Motivation for this change

automake 1.15 uses a bundled version of help2man from 2012 that does not support the SOURCE_DATE_EPOCH environment variable.

This means that the build date is included in the generated documentation, breaking reproducibility (see [here](https://r13y.com/diff/b94fd7955d40c4c683ebdc478c6045c15d1a2fa0cda08a5d9a2c3c9e9a454e26-2bf7ad8328298572ef7734d64c08e95f76cfe50f65b38e926fa9453f80df5ae5.html), [here](https://r13y.com/diff/bc8250b71af07c56a9198b9cfd5bb6e7ed7b5478685e5154ceeb145bee02f8e4-1cbd0c1c6c75d0fac0b508e8a11b0990d4ac020330d68ff18a5bd27fec403a4d.html), and [here](https://r13y.com/diff/0d4e607291a05046ca200b5e739dd2457e54d9f3b727f0bac86cdd18d695c4ab-b79d65f6133170cd16e358650412921103a8276afe7de68adc422c7acc393f97.html)).

This change adds the `SOURCE_DATE_EPOCH` support from the current `help2man` to the version bundled in automake 1.15.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
