### PR TITLE
codeowners: add jonringer as python packages codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,9 +52,9 @@
 
 # Python-related code and docs
 /maintainers/scripts/update-python-libraries	@FRidh
-/pkgs/top-level/python-packages.nix     @FRidh
+/pkgs/top-level/python-packages.nix     @FRidh @jonringer
 /pkgs/development/interpreters/python   @FRidh
-/pkgs/development/python-modules        @FRidh
+/pkgs/development/python-modules        @FRidh @jonringer
 /doc/languages-frameworks/python.section.md     @FRidh
 
 # Haskell


### PR DESCRIPTION
###### Motivation for this change

@FRidh has a lot on his plate, I would like to help him out. For most python packages, my knowledge should suffice, and should enable him to focus on other things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
