### PR TITLE
nixos/make-iso9660-image: Fix storeContents documentation

### DIFF
--- a/nixos/lib/make-iso9660-image.nix
+++ b/nixos/lib/make-iso9660-image.nix
@@ -12,7 +12,7 @@
 , # In addition to `contents', the closure of the store paths listed
   # in `storeContents' are also placed in the Nix store of the CD.
   # This is a list of attribute sets {object, symlink} where `object'
-  # if a store path whose closure will be copied, and `symlink' is a
+  # is a store path whose closure will be copied, and `symlink' is a
   # symlink to `object' that will be added to the CD.
   storeContents ? []
 

--- a/nixos/lib/make-iso9660-image.nix
+++ b/nixos/lib/make-iso9660-image.nix
@@ -10,9 +10,9 @@
   contents
 
 , # In addition to `contents', the closure of the store paths listed
-  # in `packages' are also placed in the Nix store of the CD.  This is
-  # a list of attribute sets {object, symlink} where `object' if a
-  # store path whose closure will be copied, and `symlink' is a
+  # in `storeContents' are also placed in the Nix store of the CD.
+  # This is a list of attribute sets {object, symlink} where `object'
+  # if a store path whose closure will be copied, and `symlink' is a
   # symlink to `object' that will be added to the CD.
   storeContents ? []
 


### PR DESCRIPTION
`packages` was renamed to `storeContents` in
668c146e33291e933ccfb19fd39fab9cd2b7900d, but this comment
describing its purpose was not updated to match.