### PR TITLE
python38Packages.cython: fix build

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , python
 , glibcLocales
 , pkgconfig
@@ -25,11 +25,13 @@ let
 
 in buildPythonPackage rec {
   pname = "Cython";
-  version = "0.29.13";
+  version = "unstable-2019-10-14"; # includes python3.8 fixes
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "c29d069a4a30f472482343c866f7486731ad638ef9af92bfe5fca9c7323d638e";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "70dd7561d431f248e20c2a1365111418ea494cbd";
+    sha256 = "0l7h6z46a4870hwbi4g56f5lh1x78162yy5vzjz4ddzzgm7wap6a";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
iritating me that pretty much any python38 package that relies on cython is broken... this should fix it until they do another official update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
