### PR TITLE
execlineb: change execlineb wrapper to C script

### DIFF
--- a/pkgs/tools/misc/execline/execlineb-wrapper.c
+++ b/pkgs/tools/misc/execline/execlineb-wrapper.c
@@ -1,0 +1,43 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include <skalibs/stralloc.h>
+#include <skalibs/djbunix.h>
+#include <skalibs/strerr2.h>
+#include <skalibs/env.h>
+
+#define dienomem() strerr_diefu1sys(111, "stralloc_catb")
+
+// macros from outside
+/* const char* EXECLINEB_PATH; */
+/* const char* EXECLINE_BIN_PATH; */
+
+int main(int argc, char const* argv[], char const *const *envp)
+{
+  PROG = "execlineb-wrapper";
+
+  char const* path = getenv("PATH");
+  stralloc path_modif = STRALLOC_ZERO;
+
+  // modify PATH if unset or EXECLINEB_BIN_PATH is not yet there
+  if ( !path || ! strstr(path, EXECLINE_BIN_PATH())) {
+    // prepend our execline path
+    if ( ! stralloc_cats(&path_modif, "PATH=")
+         || ! stralloc_cats(&path_modif, EXECLINE_BIN_PATH()) ) dienomem();
+    // old path was not empty
+    if ( path && path[0] ) {
+      if ( ! stralloc_catb(&path_modif, ":", 1)
+           || ! stralloc_cats(&path_modif, path) ) dienomem();
+    }
+    // append final \0
+    if ( ! stralloc_0(&path_modif) ) dienomem();
+  }
+
+  // exec into execlineb and append path_modif to the environment
+  xpathexec_r_name(
+    EXECLINEB_PATH(),
+    argv,
+    envp, env_len(envp),
+    path_modif.s, path_modif.len
+  );
+}


### PR DESCRIPTION
Instead of using execlineb to define the execlineb wrapper, we replace
it by a little C wrapper.

This is mainly done because on non-Linux systems (i.e. mainly macOS),
it is impossible for a shebang interpreter to be itself a shebang
script.
It is, however, perfectly fine to have a chain that goes
shebang -> ELF -> shebang -> ELF -> …

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@luke-clifton @pmahoney 