### PR TITLE
[19.09] networkmanager-fortisslvpn: create the local state directory

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -23,7 +23,7 @@ let
   enableIwd = cfg.wifi.backend == "iwd";
 
   # /var/lib/misc is for dnsmasq.leases.
-  stateDirs = "/var/lib/NetworkManager /var/lib/dhclient /var/lib/misc";
+  stateDirs = "/var/lib/NetworkManager /var/lib/dhclient /var/lib/misc /var/lib/NetworkManager-fortisslvpn";
 
   configFile = pkgs.writeText "NetworkManager.conf" ''
     [main]

--- a/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
@@ -27,9 +27,13 @@ in stdenv.mkDerivation {
   configureFlags = [
     "--without-libnm-glib"
     "--with-gnome=${if withGnome then "yes" else "no"}"
-    "--localstatedir=/tmp"
+    "--localstatedir=/var"
     "--enable-absolute-paths"
   ];
+
+  # the installer only create an empty directory in localstatedir, so
+  # we can drop it
+  installFlags = [ "localstatedir=." ];
 
   passthru = {
     updateScript = gnome3.updateScript {


### PR DESCRIPTION
Otherwise connecting simply fails:
VPN connection: failed to connect: 'La création du fichier « /tmp/lib/NetworkManager-fortisslvpn/0507e3ef-f0e0-4153-af64-b3d9a025877c.config.XSB19Z » a échoué : No such file or directory'


backport of #71298