### PR TITLE
jq: build from Git tag (instead of dist tarball)

### DIFF
--- a/pkgs/development/tools/jq/Gemfile
+++ b/pkgs/development/tools/jq/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "rake"
+gem "bonsai"
+gem "maruku"
+gem "ronn"
+gem "mustache", "<1.0" # to support ruby <2.0

--- a/pkgs/development/tools/jq/Gemfile.lock
+++ b/pkgs/development/tools/jq/Gemfile.lock
@@ -1,0 +1,81 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.1.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    bonsai (1.4.9)
+      activesupport (>= 3.0.3)
+      builder (>= 3.0.0)
+      i18n (>= 0.5.0)
+      launchy (>= 0.3.7)
+      liquid (>= 2.2.2)
+      maruku (>= 0.6.0)
+      rack
+      sass
+      sinatra (>= 1.0)
+      tilt (>= 1.3)
+      watch (>= 0.1.0)
+      yui-compressor
+    builder (3.2.4)
+    concurrent-ruby (1.1.7)
+    ffi (1.14.2)
+    hpricot (0.8.6)
+    i18n (1.8.7)
+      concurrent-ruby (~> 1.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    liquid (5.0.0)
+    maruku (0.7.3)
+    minitest (5.14.3)
+    mustache (0.99.8)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    public_suffix (4.0.6)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    rake (13.0.3)
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rdiscount (2.2.0.2)
+    ronn (0.7.3)
+      hpricot (>= 0.8.2)
+      mustache (>= 0.7.0)
+      rdiscount (>= 1.5.8)
+    ruby2_keywords (0.0.2)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    tilt (2.0.10)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    watch (0.1.0)
+    yui-compressor (0.12.0)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bonsai
+  maruku
+  mustache (< 1.0)
+  rake
+  ronn
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/development/tools/jq/default.nix
+++ b/pkgs/development/tools/jq/default.nix
@@ -1,44 +1,98 @@
-{ stdenv, nixosTests, fetchurl, oniguruma }:
+{ stdenv, buildPackages, bundlerUpdateScript, fetchFromGitHub, nixosTests
+, oniguruma
+# installCheck inputs
+, bundlerApp ? null
+# features
+# (enabling Valgrind checks for testing severly increases build time)
+, enableValgrindChecks ? false
+, valgrind ? null, which ? null
+}:
+
+assert enableValgrindChecks -> valgrind != null;
+assert enableValgrindChecks -> which != null;
+
+let
+  inherit (stdenv) lib;
+
+  # from ./docs/Gemfile{,.lock}
+  docsRubyApp = rec {
+    pname = "rake";
+    gemdir = ./.;
+    exes = [ "rake" ];
+  };
+  buildDocsRuby = buildPackages.bundlerApp docsRubyApp;
+  docsRuby = bundlerApp docsRubyApp;
+in
 
 stdenv.mkDerivation rec {
   pname = "jq";
   version = "1.6";
 
-  src = fetchurl {
-    url =
-      "https://github.com/stedolan/jq/releases/download/jq-${version}/jq-${version}.tar.gz";
-    sha256 = "0wmapfskhzfwranf6515nzmm84r7kwljgfs7dg6bjgxakbicis2x";
+  src = fetchFromGitHub {
+    owner = "stedolan";
+    repo = "jq";
+    rev = "jq-${version}";
+    sha256 = "1fnf2m46ya7r7afkcb8ba2j0sc4a85m749sh9jz64g4hx6z3r088";
   };
 
   outputs = [ "bin" "doc" "man" "dev" "lib" "out" ];
 
-  buildInputs = [ oniguruma ];
+  nativeBuildInputs = [
+    buildPackages.autoreconfHook
+  ];
+  buildInputs = [
+    oniguruma
+  ];
+  installCheckInputs = [
+    docsRuby
+  ] ++ lib.optionals enableValgrindChecks [
+    valgrind
+    which
+  ];
+
+  patches = [
+    ./nix-docs-ruby.patch
+    ./nix-version.patch
+  ];
+
+  postPatch = ''
+    for file in configure.ac scripts/version; do
+      substituteInPlace "$file" \
+        --subst-var version
+    done
+
+    substituteInPlace Makefile.am \
+      --subst-var-by docs_rake ${lib.escapeShellArg buildDocsRuby}/bin/rake
+  '';
 
   configureFlags = [
+    (lib.enableFeature enableValgrindChecks "valgrind")
     "--bindir=\${bin}/bin"
     "--sbindir=\${bin}/bin"
     "--datadir=\${doc}/share"
     "--mandir=\${man}/share/man"
-  ]
-  # jq is linked to libjq:
-    ++ stdenv.lib.optional (!stdenv.isDarwin) "LDFLAGS=-Wl,-rpath,\\\${libdir}";
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    # jq is linked to libjq:
+    "LDFLAGS=-Wl,-rpath,\\\${libdir}"
+  ];
 
   doInstallCheck = true;
   installCheckTarget = "check";
 
   postInstallCheck = ''
-    $bin/bin/jq --help >/dev/null
+    ''${bin}/bin/jq --help >/dev/null
   '';
 
   passthru.tests = { inherit (nixosTests) jq; };
+  passthru.updateScript = bundlerUpdateScript "jq";
 
-  meta = with stdenv.lib; {
-    description = "A lightweight and flexible command-line JSON processor";
-    license = licenses.mit;
-    maintainers = with maintainers; [ raskin globin ];
-    platforms = with platforms; linux ++ darwin;
-    downloadPage = "http://stedolan.github.io/jq/download/";
+  meta = {
+    description = ''A lightweight and flexible command-line JSON processor'';
+    downloadPage = "https://stedolan.github.io/jq/download/";
+    homepage = "https://stedolan.github.io/jq/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ raskin globin bb010g ];
+    platforms = with lib.platforms; linux ++ darwin;
     updateWalker = true;
-    inherit version;
   };
 }

--- a/pkgs/development/tools/jq/gemset.nix
+++ b/pkgs/development/tools/jq/gemset.nix
@@ -1,0 +1,325 @@
+{
+  activesupport = {
+    dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo" "zeitwerk"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08pahpg5444lv5arqxnh6x8mdayfn7jh464k7ywypfxjhqaxkmx1";
+      type = "gem";
+    };
+    version = "6.1.1";
+  };
+  addressable = {
+    dependencies = ["public_suffix"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fvchp2rhp2rmigx7qglf69xvjqvzq7x0g49naliw29r2bz656sy";
+      type = "gem";
+    };
+    version = "2.7.0";
+  };
+  bonsai = {
+    dependencies = ["activesupport" "builder" "i18n" "launchy" "liquid" "maruku" "rack" "sass" "sinatra" "tilt" "watch" "yui-compressor"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0924hwd0yxpz7z1mgqqzfs9vpp1js886q7gv9g0lg6bq8z721462";
+      type = "gem";
+    };
+    version = "1.4.9";
+  };
+  builder = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "045wzckxpwcqzrjr353cxnyaxgf0qg22jh00dcx7z38cys5g1jlr";
+      type = "gem";
+    };
+    version = "3.2.4";
+  };
+  concurrent-ruby = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vnxrbhi7cq3p4y2v9iwd10v1c7l15is4var14hwnb2jip4fyjzz";
+      type = "gem";
+    };
+    version = "1.1.7";
+  };
+  ffi = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15hgiy09i8ywjihyzyvjvk42ivi3kmy6dm21s5sgg9j7y3h3zkkx";
+      type = "gem";
+    };
+    version = "1.14.2";
+  };
+  hpricot = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jn8x9ch79gqmnzgyz78kppavjh5lqx0y0r6frykga2b86rz9s6z";
+      type = "gem";
+    };
+    version = "0.8.6";
+  };
+  i18n = {
+    dependencies = ["concurrent-ruby"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1kr0bx9323fv5ys6nlhsy05kmwcbs94h6ac7ka9qqywy0vbdvrrv";
+      type = "gem";
+    };
+    version = "1.8.7";
+  };
+  launchy = {
+    dependencies = ["addressable"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xdyvr5j0gjj7b10kgvh8ylxnwk3wx19my42wqn9h82r4p246hlm";
+      type = "gem";
+    };
+    version = "2.5.0";
+  };
+  liquid = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "05r2i4rz111cnkh421pw03dy5nf2z0zma4b64q4kw0cwgjlwr81a";
+      type = "gem";
+    };
+    version = "5.0.0";
+  };
+  maruku = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1r7bxpgnx2hp3g12bjrmdrpv663dfqxsdp0af69kjhxmaxpia56x";
+      type = "gem";
+    };
+    version = "0.7.3";
+  };
+  minitest = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ipjhdw8ds6q9h7bs3iw28bjrwkwp215hr4l3xf6215fsl80ky5j";
+      type = "gem";
+    };
+    version = "5.14.3";
+  };
+  mustache = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1g5hplm0k06vwxwqzwn1mq5bd02yp0h3rym4zwzw26aqi7drcsl2";
+      type = "gem";
+    };
+    version = "0.99.8";
+  };
+  mustermann = {
+    dependencies = ["ruby2_keywords"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ccm54qgshr1lq3pr1dfh7gphkilc19dp63rw6fcx7460pjwy88a";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  public_suffix = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xqcgkl7bwws1qrlnmxgh8g4g9m10vg60bhlw40fplninb3ng6d9";
+      type = "gem";
+    };
+    version = "4.0.6";
+  };
+  rack = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0i5vs0dph9i5jn8dfc6aqd6njcafmb20rwqngrf759c9cvmyff16";
+      type = "gem";
+    };
+    version = "2.2.3";
+  };
+  rack-protection = {
+    dependencies = ["rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "159a4j4kragqh0z0z8vrpilpmaisnlz3n7kgiyf16bxkwlb3qlhz";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  rake = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1iik52mf9ky4cgs38fp2m8r6skdkq1yz23vh18lk95fhbcxb6a67";
+      type = "gem";
+    };
+    version = "13.0.3";
+  };
+  rb-fsevent = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1k9bsj7ni0g2fd7scyyy1sk9dy2pg9akniahab0iznvjmhn54h87";
+      type = "gem";
+    };
+    version = "0.10.4";
+  };
+  rb-inotify = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jm76h8f8hji38z3ggf4bzi8vps6p7sagxn3ab57qc0xyga64005";
+      type = "gem";
+    };
+    version = "0.10.1";
+  };
+  rdiscount = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16srf8cr8ynlafyh6ls654b9a3bqgai8n3y86zzv9mcpvlk6k27g";
+      type = "gem";
+    };
+    version = "2.2.0.2";
+  };
+  ronn = {
+    dependencies = ["hpricot" "mustache" "rdiscount"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07plsxxfx5bxdk72ii9za6km0ziqlq8jh3bicr4774dalga6zpw2";
+      type = "gem";
+    };
+    version = "0.7.3";
+  };
+  ruby2_keywords = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17pcc0wgvh3ikrkr7bm3nx0qhyiqwidd13ij0fa50k7gsbnr2p0l";
+      type = "gem";
+    };
+    version = "0.0.2";
+  };
+  sass = {
+    dependencies = ["sass-listen"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0p95lhs0jza5l7hqci1isflxakz83xkj97lkvxl919is0lwhv2w0";
+      type = "gem";
+    };
+    version = "3.7.4";
+  };
+  sass-listen = {
+    dependencies = ["rb-fsevent" "rb-inotify"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xw3q46cmahkgyldid5hwyiwacp590zj2vmswlll68ryvmvcp7df";
+      type = "gem";
+    };
+    version = "4.0.0";
+  };
+  sinatra = {
+    dependencies = ["mustermann" "rack" "rack-protection" "tilt"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dd53rzpkxgs697pycbhhgc9vcnxra4ly4xar8ni6aiydx2f88zk";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  tilt = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rn8z8hda4h41a64l0zhkiwz2vxw9b1nb70gl37h1dg2k874yrlv";
+      type = "gem";
+    };
+    version = "2.0.10";
+  };
+  tzinfo = {
+    dependencies = ["concurrent-ruby"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10qp5x7f9hvlc0psv9gsfbxg4a7s0485wsbq1kljkxq94in91l4z";
+      type = "gem";
+    };
+    version = "2.0.4";
+  };
+  watch = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02g4g6ynnldyjjzrh19r584gj4z6ksff7h0ajz5jdwhpp5y7cghx";
+      type = "gem";
+    };
+    version = "0.1.0";
+  };
+  yui-compressor = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06x5r189vvy24yn41ndf94m0kgl8zcwxkr77bw7d2jz00wy46957";
+      type = "gem";
+    };
+    version = "0.12.0";
+  };
+  zeitwerk = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1746czsjarixq0x05f7p3hpzi38ldg6wxnxxw74kbjzh1sdjgmpl";
+      type = "gem";
+    };
+    version = "2.4.2";
+  };
+}

--- a/pkgs/development/tools/jq/nix-docs-ruby.patch
+++ b/pkgs/development/tools/jq/nix-docs-ruby.patch
@@ -1,0 +1,53 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -128,7 +128,7 @@
+ man_MANS = jq.1
+ if ENABLE_DOCS
+ jq.1: $(srcdir)/docs/content/3.manual/manual.yml
+-	$(AM_V_GEN) ( cd ${abs_srcdir}/docs; '$(BUNDLER)' exec rake manpage ) > $@ || { rm -f $@; false; }
++	$(AM_V_GEN) ( cd ${abs_srcdir}/docs; @docs_rake@ manpage ) > $@ || { rm -f $@; false; }
+ jq.1.prebuilt: jq.1
+ 	$(AM_V_GEN) cp $^ $@ || { rm -f $@; false; }
+ else
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -86,30 +86,6 @@
+ AC_ARG_ENABLE([all-static],
+    AC_HELP_STRING([--enable-all-static], [link jq with static libraries only]))
+ 
+-AS_IF([test "x$enable_docs" != "xno"],[
+-   AC_CHECK_PROGS(bundle_cmd, bundle)
+-
+-   AC_CACHE_CHECK([for Ruby dependencies], [jq_cv_ruby_deps],
+-     [jq_cv_ruby_deps=yes;
+-        AS_IF([test "x$bundle_cmd" = "x" || \
+-        ! bmsg="`cd ${srcdir}/docs; "$bundle_cmd" check 2>/dev/null`"],[
+-           AC_MSG_WARN([$bmsg])
+-           cat <<EOF
+-*****************************************************************
+-*  Ruby dependencies for building jq documentation not found.   *
+-*  You can still build, install and hack on jq, but the manpage *
+-*  will not be rebuilt and some of the tests will not run.      *
+-*  See docs/README.md for how to install the docs dependencies. *
+-*****************************************************************
+-EOF
+-           jq_cv_ruby_deps=no
+-     ])])
+-
+-   if test "x$jq_cv_ruby_deps" != "xyes"; then
+-     enable_docs=no
+-   fi
+-])
+-
+ AM_CONDITIONAL([ENABLE_VALGRIND], [test "x$enable_valgrind" != xno])
+ AM_CONDITIONAL([ENABLE_ASAN], [test "x$enable_asan" = xyes])
+ AM_CONDITIONAL([ENABLE_UBSAN], [test "x$enable_ubsan" = xyes])
+@@ -275,7 +251,6 @@
+ AC_SUBST(onig_LDFLAGS)
+ 
+ AM_CONDITIONAL([BUILD_ONIGURUMA], [test "x$build_oniguruma" = xyes])
+-AC_SUBST([BUNDLER], ["$bundle_cmd"])
+ 
+ AC_CONFIG_MACRO_DIR([config/m4])
+ AC_CONFIG_FILES([Makefile])

--- a/pkgs/development/tools/jq/nix-version.patch
+++ b/pkgs/development/tools/jq/nix-version.patch
@@ -1,0 +1,25 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,7 +1,4 @@
+-m4_define([jq_version],
+-          m4_esyscmd_s([(git rev-parse --verify -q jq-1.0 > /dev/null &&
+-                        (git describe --tags --dirty --match 'jq-*'|sed 's/^jq-//')) ||
+-                        echo `git rev-parse --abbrev-ref HEAD`-`git describe --always --dirty`])))
++m4_define([jq_version], [@version@])
+ 
+ AC_INIT([jq], [jq_version], [https://github.com/stedolan/jq/issues],
+              [jq], [https://stedolan.github.io/jq])
+--- a/scripts/version
++++ b/scripts/version
+@@ -1,10 +1,2 @@
+ #!/bin/sh
+-set -e
+-cd `dirname "$0"`
+-if git rev-parse --verify -q jq-1.0 > /dev/null 2>&1; then
+-    git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
+-else
+-    b=`git rev-parse --abbrev-ref HEAD`
+-    c=`git describe --always --dirty`
+-    echo "${b}-${c}"
+-fi
++echo "@version@"


### PR DESCRIPTION
This involves vendoring the Bundler specification for the docs's Rake invocation for now, but next release will mean a switch to Python (patching ~the same files). (I've already done this on Python for docs building, and it's kind of easier. Less vendoring for sure.)

We also now check with Valgrind by default, as per upstream. This takes longer. (We can turn this off by default if necessary to restore old installCheck times.)

###### Motivation for this change

I wanted to try out an unstable version of jq, and needed to make most of these changes anyways.

As per NixOS/nixpkgs#31236, building from source (here, Git) should be encouraged over building from release or distribution tarballs. This makes it easier to patch the derivation to use alternative VCS branches, among other benefits.

Valgrind is on by default in the Makefile, but we haven't ran the tests with it because they automatically turned it off when dependency discovery failed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)

  |        | out      | bin             | lib             | man           | doc         | dev             |
  |--------|----------|-----------------|-----------------|---------------|-------------|-----------------|
  | before |  96      | 29_528_224      | 29_492_112      | 32_064        | 14_568      | 29_541_768      |
  | after  |  96 (+0) | 29_528_224 (±0) | 29_492_112 (±0) | 32_784 (+720) | 14_568 (±0) | 29_541_768 (±0) |

  (Building with `{ enableValgrindChecks = false; }` does not change the closure size.)

- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c @globin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/71375)
<!-- Reviewable:end -->
