### PR TITLE
git-my: init at 1.1.2

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -104,6 +104,8 @@ let
 
   git-machete = python3Packages.callPackage ./git-machete { };
 
+  git-my = callPackage ./git-my { };
+
   git-octopus = callPackage ./git-octopus { };
 
   git-open = callPackage ./git-open { };

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -24,7 +24,7 @@ let
 
   bump2version = pkgs.python37Packages.callPackage ./bump2version { };
 
-  darcsToGit = callPackage ./darcs-to-git { };
+  darcs-to-git = callPackage ./darcs-to-git { };
 
   delta = callPackage ./delta { };
 
@@ -153,9 +153,9 @@ let
 
   git2cl = callPackage ./git2cl { };
 
-  gitFastExport = callPackage ./fast-export { };
+  git-fast-export = callPackage ./fast-export { };
 
-  gitRemoteGcrypt = callPackage ./git-remote-gcrypt { };
+  git-remote-gcrypt = callPackage ./git-remote-gcrypt { };
 
   gitflow = callPackage ./gitflow { };
 
@@ -192,7 +192,7 @@ let
 
   tig = callPackage ./tig { };
 
-  topGit = callPackage ./topgit { };
+  top-git = callPackage ./topgit { };
 
   transcrypt = callPackage ./transcrypt { };
 
@@ -200,8 +200,12 @@ let
 
 } // lib.optionalAttrs (config.allowAliases or true) (with self; {
   # aliases
+  darcsToGit = darcs-to-git;
   gitAnnex = git-annex;
+  gitFastExport = git-fast-export;
+  gitRemoteGcrypt = git-remote-gcrypt;
   svn_all_fast_export = svn-all-fast-export;
+  topGit = top-git;
 });
 in
   self

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -167,8 +167,6 @@ let
     inherit (darwin) Security;
   };
 
-  hubUnstable = throw "use gitAndTools.hub instead";
-
   lab = callPackage ./lab { };
 
   lefthook = callPackage ./lefthook { };

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -40,29 +40,6 @@ let
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  git-appraise = callPackage ./git-appraise {};
-
-  git-fame = callPackage ./git-fame {};
-
-  git-filter-repo = callPackage ./git-filter-repo {
-    pythonPackages = python3Packages;
-  };
-
-  gita = python3Packages.callPackage ./gita {};
-
-  # The full-featured Git.
-  gitFull = gitBase.override {
-    svnSupport = true;
-    guiSupport = true;
-    sendEmailSupport = true;
-    withLibsecret = !stdenv.isDarwin;
-  };
-
-  # Git with SVN support, but without GUI.
-  gitSVN = lowPrio (appendToName "with-svn" (gitBase.override {
-    svnSupport = true;
-  }));
-
   git-annex = pkgs.haskellPackages.git-annex;
 
   git-annex-metadata-gui = libsForQt5.callPackage ./git-annex-metadata-gui {
@@ -84,6 +61,8 @@ let
 
   git-annex-utils = callPackage ./git-annex-utils { };
 
+  git-appraise = callPackage ./git-appraise {};
+
   git-bug = callPackage ./git-bug { };
 
   # support for bugzilla
@@ -100,6 +79,14 @@ let
   };
 
   git-extras = callPackage ./git-extras { };
+
+  git-fame = callPackage ./git-fame {};
+
+  git-fast-export = callPackage ./fast-export { };
+
+  git-filter-repo = callPackage ./git-filter-repo {
+    pythonPackages = python3Packages;
+  };
 
   git-gone = callPackage ./git-gone {
     inherit (darwin.apple_sdk.frameworks) Security;
@@ -127,6 +114,8 @@ let
     utillinux = if stdenv.isLinux then utillinuxMinimal else utillinux;
   };
 
+  git-remote-gcrypt = callPackage ./git-remote-gcrypt { };
+
   git-remote-hg = callPackage ./git-remote-hg { };
 
   git-reparent = callPackage ./git-reparent { };
@@ -153,9 +142,20 @@ let
 
   git2cl = callPackage ./git2cl { };
 
-  git-fast-export = callPackage ./fast-export { };
+  # The full-featured Git.
+  gitFull = gitBase.override {
+    svnSupport = true;
+    guiSupport = true;
+    sendEmailSupport = true;
+    withLibsecret = !stdenv.isDarwin;
+  };
 
-  git-remote-gcrypt = callPackage ./git-remote-gcrypt { };
+  # Git with SVN support, but without GUI.
+  gitSVN = lowPrio (appendToName "with-svn" (gitBase.override {
+    svnSupport = true;
+  }));
+
+  gita = python3Packages.callPackage ./gita {};
 
   gitflow = callPackage ./gitflow { };
 
@@ -171,22 +171,21 @@ let
 
   lefthook = callPackage ./lefthook { };
 
-  pre-commit = pkgs.python3Packages.toPythonApplication pkgs.python3Packages.pre-commit;
-
   pass-git-helper = python3Packages.callPackage ./pass-git-helper { };
+
+  pre-commit = pkgs.python3Packages.toPythonApplication pkgs.python3Packages.pre-commit;
 
   qgit = qt5.callPackage ./qgit { };
 
-  stgit = callPackage ./stgit {
-  };
+  stgit = callPackage ./stgit { };
 
   subgit = callPackage ./subgit { };
+
+  svn-all-fast-export = libsForQt5.callPackage ./svn-all-fast-export { };
 
   svn2git = callPackage ./svn2git {
     git = gitSVN;
   };
-
-  svn-all-fast-export = libsForQt5.callPackage ./svn-all-fast-export { };
 
   thicket = callPackage ./thicket { };
 

--- a/pkgs/applications/version-management/git-and-tools/git-my/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-my/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "git-my";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "davidosomething";
+    repo = "git-my";
+    rev = version;
+    sha256 = "0jji5zw25jygj7g4f6f3k0p0s9g37r8iad8pa0s67cxbq2v4sc0v";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm755 -t "$out"/bin ./git-my
+  '';
+
+  meta = with stdenv.lib; {
+    description =
+      "List remote branches if they're merged and/or available locally";
+    homepage = https://github.com/davidosomething/git-my;
+    license = licenses.free;
+    maintainers = with maintainers; [ bb010g ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -85,7 +85,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs =
     [ makeWrapper autoconf automake libtool unzip nukeReferences sqlite libpqxx
-      gitAndTools.topGit mercurial darcs subversion bazaar openssl bzip2 libxslt
+      gitAndTools.top-git mercurial darcs subversion bazaar openssl bzip2 libxslt
       guile # optional, for Guile + Guix support
       perlDeps perl nix
       postgresql # for running the tests
@@ -95,7 +95,7 @@ in stdenv.mkDerivation rec {
 
   hydraPath = lib.makeBinPath (
     [ sqlite subversion openssh nix coreutils findutils pixz
-      gzip bzip2 lzma gnutar unzip git gitAndTools.topGit mercurial darcs gnused bazaar
+      gzip bzip2 lzma gnutar unzip git gitAndTools.top-git mercurial darcs gnused bazaar
     ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
Introduces [git-my](https://github.com/davidosomething/git-my) into gitAndTools.

Also takes the luxury beforehand to strongly normalize gitAndTools's naming and sorting. The only package referenced elsewhere in Nixpkgs, git-top, has had its reference updated to not point at the new alias. These are done in separate commits to keep things clean.

#### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)

  (Which of these are we supposed to post?)
  - 615_240 (derivation)
  - 29_474_872 (output)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/71378)
<!-- Reviewable:end -->
