### PR TITLE
macvim: snapshot-157 -> snapshot-161

### DIFF
--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -27,13 +27,13 @@ in
 stdenv.mkDerivation {
   pname = "macvim";
 
-  version = "8.1.1722";
+  version = "8.1.2234";
 
   src = fetchFromGitHub {
     owner = "macvim-dev";
     repo = "macvim";
-    rev = "snapshot-157";
-    sha256 = "1gmgc4pwaqy78gj4p7iib94n7j52ir0aa03ks595h3vy1hkcwwky";
+    rev = "snapshot-161";
+    sha256 = "1hp3y85pj1icz053g627a1wp5pnwgxhk07pyd4arwcxs2103agw4";
   };
 
   enableParallelBuilding = true;
@@ -106,9 +106,6 @@ stdenv.mkDerivation {
     substituteInPlace src/auto/config.mk --replace "PERL_CFLAGS	=" "PERL_CFLAGS	= -I${darwin.libutil}/include"
 
     substituteInPlace src/MacVim/vimrc --subst-var-by CSCOPE ${cscope}/bin/cscope
-
-    # Work around weird code-signing issue
-    substituteInPlace src/auto/config.mk --replace "XCODEFLAGS''\t=" "XCODEFLAGS''\t= CODE_SIGN_IDENTITY="
   '';
 
   postInstall = ''
@@ -151,5 +148,6 @@ stdenv.mkDerivation {
     license = licenses.vim;
     maintainers = with maintainers; [ cstrahan lilyball ];
     platforms   = platforms.darwin;
+    hydraPlatforms = []; # hydra can't build this as long as we rely on Xcode and sandboxProfile
   };
 }

--- a/pkgs/applications/editors/vim/macvim.patch
+++ b/pkgs/applications/editors/vim/macvim.patch
@@ -18,21 +18,6 @@ index e519018de..556a4127d 100644
  				PRODUCT_BUNDLE_IDENTIFIER = org.vim.MacVim;
  				PRODUCT_NAME = MacVim;
  				VERSIONING_SYSTEM = "apple-generic";
-diff --git a/src/MacVim/PSMTabBarControl/source/PSMTabBarCell.m b/src/MacVim/PSMTabBarControl/source/PSMTabBarCell.m
-index 6f1a06e46..a12e2cea4 100644
---- a/src/MacVim/PSMTabBarControl/source/PSMTabBarCell.m
-+++ b/src/MacVim/PSMTabBarControl/source/PSMTabBarCell.m
-@@ -13,7 +13,9 @@
- #import "PSMTabDragAssistant.h"
- 
- 
--@implementation PSMTabBarCell
-+@implementation PSMTabBarCell {
-+    id _controlView;
-+}
- 
- #pragma mark -
- #pragma mark Creation/Destruction
 diff --git a/src/MacVim/vimrc b/src/MacVim/vimrc
 index 23a06bf37..dfb10fe94 100644
 --- a/src/MacVim/vimrc
@@ -92,18 +77,6 @@ diff --git a/src/auto/configure b/src/auto/configure
 index 9e6a82f4a..3c6d1a89b 100755
 --- a/src/auto/configure
 +++ b/src/auto/configure
-@@ -4705,10 +4705,8 @@ fi
- rm -f core conftest.err conftest.$ac_objext \
-     conftest$ac_exeext conftest.$ac_ext
-   else
--    if test -z "$MACOSX_DEPLOYMENT_TARGET"; then
--      macosx_deployment_target=`/usr/bin/sw_vers -productVersion|/usr/bin/sed -e 's/^\([0-9]*\.[0-9]*\).*/\1/'`
-+      macosx_deployment_target=${MACOSX_DEPLOYMENT_TARGET:-10.12}
-       XCODEFLAGS="$XCODEFLAGS MACOSX_DEPLOYMENT_TARGET=$macosx_deployment_target"
--    fi
-   fi
- 
- 
 @@ -5829,10 +5829,7 @@ $as_echo "not found" >&6; }
  
      for path in "${vi_cv_path_mzscheme_pfx}/lib" "${SCHEME_LIB}"; do
@@ -214,23 +187,22 @@ index 9e6a82f4a..3c6d1a89b 100755
  
  	if test "X$librubyarg" != "X"; then
 diff --git a/src/vim.h b/src/vim.h
-index cb5be6c97..b703b31cd 100644
+index f158aab..a714da9 100644
 --- a/src/vim.h
 +++ b/src/vim.h
-@@ -241,18 +241,6 @@
+@@ -243,17 +243,6 @@
  # define SUN_SYSTEM
  #endif
  
--/* If we're compiling in C++ (currently only KVim), the system
-- * headers must have the correct prototypes or nothing will build.
-- * Conversely, our prototypes might clash due to throw() specifiers and
-- * cause compilation failures even though the headers are correct.  For
-- * a concrete example, gcc-3.2 enforces exception specifications, and
-- * glibc-2.2.5 has them in their system headers.
-- */
+-// If we're compiling in C++ (currently only KVim), the system
+-// headers must have the correct prototypes or nothing will build.
+-// Conversely, our prototypes might clash due to throw() specifiers and
+-// cause compilation failures even though the headers are correct.  For
+-// a concrete example, gcc-3.2 enforces exception specifications, and
+-// glibc-2.2.5 has them in their system headers.
 -#if !defined(__cplusplus) && defined(UNIX) \
--	&& !defined(MACOS_X) /* MACOS_X doesn't yet support osdef.h */
--# include "auto/osdef.h"	/* bring missing declarations in */
+-	&& !defined(MACOS_X) // MACOS_X doesn't yet support osdef.h
+-# include "auto/osdef.h"	// bring missing declarations in
 -#endif
 -
  #ifdef AMIGA


### PR DESCRIPTION
###### Motivation for this change
https://github.com/macvim-dev/macvim/releases/tag/snapshot-159
https://github.com/macvim-dev/macvim/releases/tag/snapshot-160
https://github.com/macvim-dev/macvim/releases/tag/snapshot-161

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing (using `relaxed` on macOS, as required by the use of a custom sandbox profile)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
