### PR TITLE
cutecom: 0.50.0 -> 0.51.0

### DIFF
--- a/pkgs/tools/misc/cutecom/default.nix
+++ b/pkgs/tools/misc/cutecom/default.nix
@@ -1,25 +1,29 @@
-{ stdenv, fetchFromGitHub, qtbase, qtserialport, cmake }:
+{ mkDerivation, lib, fetchFromGitLab, qtbase, qtserialport, cmake }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "cutecom";
-  version = "0.50.0";
-  src = fetchFromGitHub {
-    owner = "neundorf";
-    repo = "CuteCom";
+  version = "0.51.0";
+
+  src = fetchFromGitLab {
+    owner = "cutecom";
+    repo = "cutecom";
     rev = "v${version}";
-    sha256 = "0zjmbjrwwan9z5cphqjcq2h71cm4mw88j457lzdqb29cg4bdn3ag";
+    sha256 = "1zprabjs4z26hsb64fc3k790aiiqiz9d88j666xrzi4983m1bfv8";
   };
 
   preConfigure = ''
-    substituteInPlace CMakeLists.txt --replace "#find_package(Serialport REQUIRED)" "find_package(Qt5SerialPort REQUIRED)"
+    substituteInPlace CMakeLists.txt \
+      --replace "#find_package(Serialport REQUIRED)" "find_package(Qt5SerialPort REQUIRED)"
   '';
-  buildInputs = [qtbase qtserialport cmake];
 
-  meta = {
+  buildInputs = [ qtbase qtserialport ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
     description = "A graphical serial terminal";
-    homepage = http://cutecom.sourceforge.net/;
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = [ stdenv.lib.maintainers.bennofs ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "https://gitlab.com/cutecom/cutecom/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ bennofs ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change
This PR updates `cutecom` to its current release and changes its upstream repository which has moved to GitLab. Furthermore, its prefixing `QT_PLUGIN_PATH` as discussed in #56921 / 89cfbb9cb27317ef688e0d4e3d5681faaa53f87b.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bennofs
