### PR TITLE
skawarePackages.skalibs: empty default path

### DIFF
--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -18,6 +18,9 @@ buildPackage {
     "--dynlibdir=\${lib}/lib"
     "--includedir=\${dev}/include"
     "--sysdepdir=\${lib}/lib/skalibs/sysdeps"
+    # Empty the default path, which would be "/usr/bin:bin".
+    # It would be set when PATH is empty. This hurts hermeticity.
+    "--with-default-path="
   ];
 
   postInstall = ''


### PR DESCRIPTION
If `PATH` is unset, the exec wrappers in skalibs set a default path to
`/usr/bin:bin`.

This has very unfortunate effects when you e.g. try to run tests on CI
in an empty environment (minus tools explicitely provided by nix with
absolute store paths), because suddenly binaries from outside are
picked up again, especially on non-NixOS.
Even on NixOS, /bin/sh provides another escape hatch if it’s available
from PATH. But on systems like Ubuntu or MacOS (which most CI systems
run on), this picks up all the non-nix binaries.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @pmahoney 
