### PR TITLE
stups: init at 1.1.21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4508,6 +4508,12 @@
     githubId = 437005;
     name = "Mikkel Christiansen";
   };
+  mschuwalow = {
+    github = "mschuwalow";
+    githubId = 16665913;
+    name = "Maxim Schuwalow";
+    email = "maxim.schuwalow@gmail.com";
+  };
   msiedlarek = {
     email = "mikolaj@siedlarek.pl";
     github = "msiedlarek";

--- a/pkgs/development/python-modules/stups-cli-support/default.nix
+++ b/pkgs/development/python-modules/stups-cli-support/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, clickclick
+, dnspython
+, requests
+, pytest
+, pytestcov
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "stups-cli-support";
+  version = "1.1.20";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "zalando-stups";
+    repo = "stups-cli-support";
+    rev = version;
+    sha256 = "1r6g29gd009p87m8a6wv4rzx7f0564zdv67qz5xys4wsgvc95bx0";
+  };
+
+  propagatedBuildInputs = [
+    clickclick
+    dnspython
+    requests
+  ];
+
+  preCheck = "export HOME=$TEMPDIR";
+
+  checkInputs = [
+    pytest
+    pytestcov
+  ];
+
+  meta = with lib; {
+    description = "Helper library for all STUPS command line tools.";
+    homepage = "https://github.com/zalando-stups/stups-cli-support";
+    license = licenses.asl20;
+    maintainers = [ maintainers.mschuwalow ];
+  };
+}

--- a/pkgs/development/python-modules/stups-tokens/default.nix
+++ b/pkgs/development/python-modules/stups-tokens/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, requests
+, mock
+, pytest
+, pytestcov
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "stups-tokens";
+  version = "1.1.19";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "zalando-stups";
+    repo = "python-tokens";
+    rev = version;
+    sha256 = "09z3l3xzdlwpivbi141gk1k0zd9m75mjwbdy81zc386rr9k8s0im";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  checkInputs = [
+    mock
+    pytest
+    pytestcov
+  ];
+
+  meta = with lib; {
+    description = "A Python library that keeps OAuth 2.0 service access tokens in memory for your usage.";
+    homepage = "https://github.com/zalando-stups/python-tokens";
+    license = licenses.asl20;
+    maintainers = [ maintainers.mschuwalow ];
+  };
+}

--- a/pkgs/development/python-modules/stups-zign/default.nix
+++ b/pkgs/development/python-modules/stups-zign/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, stups-tokens
+, stups-cli-support
+, pytest
+, pytestcov
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "stups-zign";
+  version = "1.2";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "zalando-stups";
+    repo = "zign";
+    rev = version;
+    sha256 = "1vk6pnprnd5lfx96hc2c1n7kwh99f260r730x4y2h7lamlv82fh4";
+  };
+
+  patches = [
+    # pytest 5 is currently unsupported. Fetch and apply a pr that resolves this.
+    (fetchpatch {
+      url = https://github.com/zalando-stups/zign/commit/50140720211e547b0e59f7ddb39a732f0cc73ad7.patch;
+      sha256 = "1zmyvg1z1asaqqsmxvsx0srvxd6gkgavppvg3dblxwhkml01awqk";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    stups-tokens
+    stups-cli-support
+  ];
+
+  preCheck = "
+    export HOME=$TEMPDIR
+  ";
+
+  checkInputs = [
+    pytest
+    pytestcov
+  ];
+
+  meta = with lib; {
+    description = "OAuth2 token management command line utility.";
+    homepage = "https://github.com/zalando-stups/zign";
+    license = licenses.asl20;
+    maintainers = [ maintainers.mschuwalow ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1239,6 +1239,8 @@ in {
 
   stumpy = callPackage ../development/python-modules/stumpy { };
 
+  stups-cli-support = callPackage ../development/python-modules/stups-cli-support { };
+
   sumo = callPackage ../development/python-modules/sumo { };
 
   supervise_api = callPackage ../development/python-modules/supervise_api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1241,6 +1241,8 @@ in {
 
   stups-cli-support = callPackage ../development/python-modules/stups-cli-support { };
 
+  stups-tokens = callPackage ../development/python-modules/stups-tokens { };
+
   sumo = callPackage ../development/python-modules/sumo { };
 
   supervise_api = callPackage ../development/python-modules/supervise_api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1243,6 +1243,8 @@ in {
 
   stups-tokens = callPackage ../development/python-modules/stups-tokens { };
 
+  stups-zign = callPackage ../development/python-modules/stups-zign { };
+
   sumo = callPackage ../development/python-modules/sumo { };
 
   supervise_api = callPackage ../development/python-modules/supervise_api { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add derivations for https://github.com/zalando-stups/stups-cli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
