### PR TITLE
Enable soft real time for gnome shell 

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -269,6 +269,26 @@ in
         source-sans-pro
       ];
 
+      ## Enable soft realtime scheduling, only supported on wayland ##
+
+      security.wrappers.".gnome-shell-wrapped" = {
+        source = "${pkgs.gnome3.gnome-shell}/bin/.gnome-shell-wrapped";
+        capabilities = "cap_sys_nice=ep";
+      };
+
+      systemd.user.services.gnome-shell-wayland = let
+        gnomeShellRT = with pkgs.gnome3; pkgs.runCommand "gnome-shell-rt" {} ''
+          mkdir -p $out/bin/
+          cp ${gnome-shell}/bin/gnome-shell $out/bin
+          sed -i "s@${gnome-shell}/bin/@${config.security.wrapperDir}/@" $out/bin/gnome-shell
+        '';
+      in {
+        # Note we need to clear ExecStart before overriding it
+        serviceConfig.ExecStart = ["" "${gnomeShellRT}/bin/gnome-shell"];
+        # Do not use the default environment, it provides a broken PATH
+        environment = mkForce {};
+      };
+
       # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/gnome-3-32/elements/core/meta-gnome-core-shell.bst
       environment.systemPackages = with pkgs.gnome3; [
         adwaita-icon-theme

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, fetchpatch, substituteAll, stdenv, pkgconfig, gnome3, gettext, gobject-introspection, upower, cairo
-, pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
+, pango, cogl, json-glib, libstartup_notification, zenity, libcanberra-gtk3
 , ninja, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
 , gsettings-desktop-schemas, glib, gtk3, gnome-desktop
 , geocode-glib, pipewire, libgudev, libwacom, xwayland, meson
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     # required for pkgconfig to detect mutter-clutter
     libXtst
+    json-glib
   ];
 
   nativeBuildInputs = [
@@ -46,7 +47,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib gobject-introspection gtk3 gsettings-desktop-schemas upower
-    gnome-desktop cairo pango cogl clutter zenity libstartup_notification
+    gnome-desktop cairo pango cogl zenity libstartup_notification
     geocode-glib libinput libgudev libwacom
     libcanberra-gtk3 zenity xkeyboard_config libxkbfile
     libxkbcommon pipewire xwayland

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -9,6 +9,7 @@
 , wrapGAppsHook
 , sysprof
 , desktop-file-utils
+, libcap_ng
 }:
 
 stdenv.mkDerivation rec {
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
     # required for pkgconfig to detect mutter-clutter
     libXtst
     json-glib
+    libcap_ng
   ];
 
   nativeBuildInputs = [
@@ -55,6 +57,9 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
+    # Drop inheritable cap_sys_nice, to prevent the ambient set from leaking
+    # from mutter/gnome-shell, see https://github.com/NixOS/nixpkgs/issues/71381
+    ./drop-inheritable.patch
    # TODO: submit upstream
    ./0001-build-use-get_pkgconfig_variable-for-sysprof-dbusdir.patch
     (substituteAll {

--- a/pkgs/desktops/gnome-3/core/mutter/drop-inheritable.patch
+++ b/pkgs/desktops/gnome-3/core/mutter/drop-inheritable.patch
@@ -1,0 +1,132 @@
+From e9c772e265b2293af031c79f4bbc99b5847dfe3c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tor=20Hedin=20Br=C3=B8nner?= <torhedinbronner@gmail.com>
+Date: Sat, 19 Oct 2019 13:26:05 +0200
+Subject: [PATCH] drop inheritable
+
+Adapted from https://gitlab.gnome.org/GNOME/mutter/commit/c53c47ae123b03cc66044d2b846342123ecb3a01
+
+We only want to drop inheritable though, to prevent the ambient set leaking further than gnome-shell.
+
+---
+ config.h.meson    |  3 +++
+ meson.build       |  5 +++++
+ meson_options.txt |  6 ++++++
+ src/core/main.c   | 11 +++++++++++
+ src/meson.build   |  1 +
+ 5 files changed, 26 insertions(+)
+
+diff --git a/config.h.meson b/config.h.meson
+index 0bab71848..202fb7ed1 100644
+--- a/config.h.meson
++++ b/config.h.meson
+@@ -58,6 +58,9 @@
+ /* Xwayland applications allowed to issue keyboard grabs */
+ #mesondefine XWAYLAND_GRAB_DEFAULT_ACCESS_RULES
+ 
++/* Defined if libcap-ng is available */
++#mesondefine HAVE_LIBCAPNG
++
+ /* XKB base prefix */
+ #mesondefine XKB_BASE
+ 
+diff --git a/meson.build b/meson.build
+index 3322bd3b1..01c8020fa 100644
+--- a/meson.build
++++ b/meson.build
+@@ -35,6 +35,7 @@ libstartup_notification_req = '>= 0.7'
+ libcanberra_req = '>= 0.26'
+ libwacom_req = '>= 0.13'
+ atk_req = '>= 2.5.3'
++libcapng_req = '>= 0.7.9'
+ 
+ # optional version requirements
+ udev_req = '>= 228'
+@@ -125,6 +126,7 @@ xau_dep = dependency('xau')
+ ice_dep = dependency('ice')
+ atk_dep = dependency('atk', version: atk_req)
+ libcanberra_dep = dependency('libcanberra', version: libcanberra_req)
++libcapng_dep = dependency('libcap-ng', required: get_option('libcapng'))
+ 
+ # For now always require X11 support
+ have_x11 = true
+@@ -256,6 +258,7 @@ have_core_tests = false
+ have_cogl_tests = false
+ have_clutter_tests = false
+ have_installed_tests = false
++have_libcapng = libcapng_dep.found()
+ 
+ if have_tests
+   have_core_tests = get_option('core_tests')
+@@ -361,6 +364,7 @@ cdata.set('HAVE_LIBWACOM', have_libwacom)
+ cdata.set('HAVE_SM', have_sm)
+ cdata.set('HAVE_STARTUP_NOTIFICATION', have_startup_notification)
+ cdata.set('HAVE_INTROSPECTION', have_introspection)
++cdata.set('HAVE_LIBCAPNG', have_libcapng)
+ cdata.set('HAVE_PROFILER', have_profiler)
+ 
+ xkb_base = xkeyboard_config_dep.get_pkgconfig_variable('xkb_base')
+@@ -443,6 +447,7 @@ output = [
+   '        Startup notification..... ' + have_startup_notification.to_string(),
+   '        Introspection............ ' + have_introspection.to_string(),
+   '        Profiler................. ' + have_profiler.to_string(),
++  '        libcap-ng................ ' + have_libcapng.to_string(),
+   '',
+   '    Tests:',
+   '',
+diff --git a/meson_options.txt b/meson_options.txt
+index 73aa7adde..8bfaacd9a 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -152,3 +152,9 @@ option('xwayland_grab_default_access_rules',
+   value: 'gnome-boxes,remote-viewer,virt-viewer,virt-manager,vinagre,vncviewer,Xephyr',
+   description: 'Comma delimited list of applications ressources or class allowed to issue X11 grabs in Xwayland'
+ )
++
++option('libcapng',
++  type: 'feature',
++  value: 'auto',
++  description: 'Enable libcap-ng support'
++)
+diff --git a/src/core/main.c b/src/core/main.c
+index 7f4f666d2..b27968f13 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -66,6 +66,10 @@
+ #include <girepository.h>
+ #endif
+ 
++#ifdef HAVE_LIBCAPNG
++#include <cap-ng.h>
++#endif
++
+ #if defined(HAVE_NATIVE_BACKEND) && defined(HAVE_WAYLAND)
+ #include <systemd/sd-login.h>
+ #endif /* HAVE_WAYLAND && HAVE_NATIVE_BACKEND */
+@@ -673,6 +677,12 @@ meta_run (void)
+   if (!meta_display_open ())
+     meta_exit (META_EXIT_ERROR);
+ 
++#ifdef HAVE_LIBCAPNG
++  capng_clear(CAPNG_SELECT_BOTH);
++  capng_update(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED, CAP_SYS_NICE);
++  capng_apply(CAPNG_SELECT_BOTH);
++#endif
++
+   g_main_loop_run (meta_main_loop);
+ 
+   meta_finalize ();
+diff --git a/src/meson.build b/src/meson.build
+index 90d80734f..a9fffa2c2 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -18,6 +18,7 @@ mutter_pkg_deps = [
+   glib_dep,
+   gsettings_desktop_schemas_dep,
+   gtk3_dep,
++  libcapng_dep,
+   pango_dep,
+ ]
+ 
+-- 
+2.23.0
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Make gnome-shell wayland run with cap_sys_nice to improve performance.

closes https://github.com/NixOS/nixpkgs/issues/71381

###### Things done

Patched mutter to drop `cap_sys_nice=i` on startup, which prevents the ambient set leaking into processes gnome-shell spawns.

Overrode `gnome-shell-wayland.service` to launch through an added capability wrapper. (This proved a bit fiddly as NixOS provides a rather bad default environment for user services). Thought this was cleaner than mucking about in the gnome-shell derivation.

Running this at the moment, and it seems to work:
![image](https://user-images.githubusercontent.com/71978/67147390-d4c0d680-f294-11e9-850f-e42db12800c3.png)




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
