### PR TITLE
pythonPackages.azure*: point homepage to mono-repo

### DIFF
--- a/pkgs/development/python-modules/azure-applicationinsights/default.nix
+++ b/pkgs/development/python-modules/azure-applicationinsights/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Application Insights Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-applicotioninsights;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-batch/default.nix
+++ b/pkgs/development/python-modules/azure-batch/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Batch Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/batch?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-common/default.nix
+++ b/pkgs/development/python-modules/azure-common/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure common code";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-common;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ olcai mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-cosmos/default.nix
+++ b/pkgs/development/python-modules/azure-cosmos/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Azure Cosmos DB API";
-    homepage = https://github.com/Azure/azure-cosmos-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ jonringer ];
   };

--- a/pkgs/development/python-modules/azure-cosmosdb-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-cosmosdb-nspkg/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure CosmosDB namespace package";
-    homepage = https://github.com/Azure/azure-cosmos-table-python/tree/master/azure-cosmosdb-nspkg;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-cosmosdb-table/default.nix
+++ b/pkgs/development/python-modules/azure-cosmosdb-table/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Log Analytics Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/cosmosdb?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-datalake-store/default.nix
+++ b/pkgs/development/python-modules/azure-datalake-store/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This project is the Python filesystem library for Azure Data Lake Store";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/data-lake-store?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-eventgrid/default.nix
+++ b/pkgs/development/python-modules/azure-eventgrid/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A fully-managed intelligent event routing service that allows for uniform event consumption using a publish-subscribe model";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/event-grid?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-graphrbac/default.nix
+++ b/pkgs/development/python-modules/azure-graphrbac/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Graph RBAC Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-graphrbac;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Key Vault Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/key-vault?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-loganalytics/default.nix
+++ b/pkgs/development/python-modules/azure-loganalytics/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Log Analytics Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/loganalytics/client?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-advisor/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-advisor/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Advisor Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-advisor;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-applicationinsights/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-applicationinsights/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Application Insights Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-applicationinsights;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-authorization/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-authorization/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Authorization Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-authorization;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-batch/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-batch/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Batch Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-batch;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-batchai/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-batchai/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Batch AI Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-batchai;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-billing/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-billing/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Billing Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-billing;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-cdn/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cdn/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure CDN Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-cdn;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-cognitiveservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cognitiveservices/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Cognitive Services Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-cognitiveservices;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-commerce/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-commerce/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Commerce Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-commerce;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-common/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-common/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   meta = with pkgs.lib; {
     description = "This is the Microsoft Azure Resource Management common code";
-    homepage = https://pypi.org/project/azure-mgmt-common;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ olcai mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-compute/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-compute/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Compute Management Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-compute;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ olcai mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-consumption/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-consumption/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Consumption Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-consumption;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-containerinstance/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-containerinstance/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Container Instance Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-containerinstance;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-containerservice/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-containerservice/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Container Service Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-containerservice;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-cosmosdb/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cosmosdb/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Cosmos DB Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-cosmosdb;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-datafactory/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datafactory/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Data Factory Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-datafactory;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-datalake-analytics/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-analytics/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Data Lake Analytics Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-datalake-analytics;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-datalake-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-nspkg/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Data Lake Management namespace package";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-datalake-nspkg;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-datalake-store/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-store/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Data Lake Store Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-datalake-store;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-datamigration/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datamigration/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Data Migration Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-datamigration;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-devspaces/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-devspaces/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Dev Spaces Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-devspaces;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-devtestlabs/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-devtestlabs/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure DevTestLabs Management Client Library";
-    homepage = https://github.com/Azure/sdk-for-python/tree/master/azure-mgmt-devtestlabs;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-dns/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-dns/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure DNS Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/dns?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-eventgrid/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-eventgrid/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure EventGrid Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/event-grid?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-eventhub/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-eventhub/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure EventHub Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/event-hub?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-hanaonazure/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-hanaonazure/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure SAP Hana on Azure Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/hanaonazure?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-iotcentral/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iotcentral/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure IoTCentral Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/iot?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-iothub/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iothub/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure IoTHub Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/iot?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure IoTHub Provisioning Services Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/iot?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-keyvault/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Key Vault Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/key-vault?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-loganalytics/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-loganalytics/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Log Analytics Management Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-loganalytics;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-logic/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-logic/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Logic Apps Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/logic-apps?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-machinelearningcompute/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-machinelearningcompute/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Machine Learning Compute Management Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-machinelearningcompute;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-managementgroups/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-managementgroups/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Management Groups Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-managementgroups;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-managementpartner/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-managementpartner/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure ManagementPartner Management Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-managementpartner;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-maps/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-maps/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Maps Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-maps;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-marketplaceordering/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-marketplaceordering/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Market Place Ordering Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-marketplaceordering;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-media/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-media/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Media Services Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/media-services?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-monitor/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-monitor/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Monitor Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/monitoring?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-msi/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-msi/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure MSI Management Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-msi;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-network/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-network/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Microsoft Azure SDK for Python";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/network?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ olcai mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-notificationhubs/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-notificationhubs/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Notification Hubs Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/notification-hubs?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with pkgs.lib; {
     description = "Microsoft Azure SDK for Python";
-    homepage = https://github.com/Azure/azure-sdk-for-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ olcai mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-policyinsights/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-policyinsights/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Policy Insights Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/policy?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-powerbiembedded/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-powerbiembedded/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Power BI Embedded Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/power-bi?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-rdbms/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-rdbms/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure RDBMS Management Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-rdbms;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservices/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Recovery Services Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/recoveryservices?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Recovery Services Backup Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/recovery-services-backup?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-redis/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-redis/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Redis Cache Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/redis?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-relay/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-relay/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Relay Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/relay?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-reservations/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-reservations/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Reservations Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-reservations;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-resource/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with pkgs.lib; {
     description = "Microsoft Azure SDK for Python";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/resources?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ olcai mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-scheduler/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-scheduler/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Scheduler Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/scheduler?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-search/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-search/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Search Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/search?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-servicebus/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-servicebus/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Service Bus Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/servicebus?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-servicefabric/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-servicefabric/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Service Fabric Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/servicefabric?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-signalr/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-signalr/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure SignalR Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-signalr;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-sql/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-sql/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure SQL Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/sql?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-storage/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-storage/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Storage Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/storage?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ olcai mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-subscription/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-subscription/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Subscription Management Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-mgmt-subscription;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-trafficmanager/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-trafficmanager/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Traffic Manager Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/traffic-manager?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-mgmt-web/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-web/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Web Apps Management Client Library";
-    homepage = https://docs.microsoft.com/en-us/python/api/overview/azure/webapps?view=azure-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-nspkg/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Microsoft Azure SDK for Python";
-    homepage = https://github.com/Azure/azure-sdk-for-python;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ olcai mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-servicebus/default.nix
+++ b/pkgs/development/python-modules/azure-servicebus/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Service Bus Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/free/master/azure-servicebus;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-servicefabric/default.nix
+++ b/pkgs/development/python-modules/azure-servicefabric/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "This project provides a client library in Python that makes it easy to consume Microsoft Azure Storage services";
-    homepage = https://pypi.org/project/azure-servicefabric;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-servicemanagement-legacy/default.nix
+++ b/pkgs/development/python-modules/azure-servicemanagement-legacy/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage {
 
   meta = with lib; {
     description = "This is the Microsoft Azure Service Management Legacy Client Library";
-    homepage = https://github.com/Azure/azure-sdk-for-python/tree/master/azure-servicemanagement-legacy;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ olcai mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-storage-blob/default.nix
+++ b/pkgs/development/python-modules/azure-storage-blob/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Client library for Microsoft Azure Storage services containing the blob service APIs";
-    homepage = https://github.com/Azure/azure-storage-python/tree/master/azure-storage-blob;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ cmcdragonkai mwilsoninsight ];
   };

--- a/pkgs/development/python-modules/azure-storage-common/default.nix
+++ b/pkgs/development/python-modules/azure-storage-common/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Client library for Microsoft Azure Storage services containing common code shared by blob, file and queue";
-    homepage = https://github.com/Azure/azure-storage-python/tree/master/azure-storage-common;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ cmcdragonkai ];
   };

--- a/pkgs/development/python-modules/azure-storage-file/default.nix
+++ b/pkgs/development/python-modules/azure-storage-file/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Client library for Microsoft Azure Storage services containing the file service APIs";
-    homepage = https://github.com/Azure/azure-storage-python/tree/master/azure-storage-file;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ cmcdragonkai ];
   };

--- a/pkgs/development/python-modules/azure-storage-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-storage-nspkg/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Client library for Microsoft Azure Storage services owning the azure.storage namespace, user should not use this directly";
-    homepage = https://github.com/Azure/azure-storage-python/tree/master/azure-storage-nspkg;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ cmcdragonkai ];
   };

--- a/pkgs/development/python-modules/azure-storage-queue/default.nix
+++ b/pkgs/development/python-modules/azure-storage-queue/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Client library for Microsoft Azure Storage services containing the queue service APIs";
-    homepage = https://github.com/Azure/azure-storage-python/tree/master/azure-storage-queue;
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ cmcdragonkai ];
   };

--- a/pkgs/development/python-modules/azure-storage/default.nix
+++ b/pkgs/development/python-modules/azure-storage/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   meta = with pkgs.lib; {
     description = "Microsoft Azure SDK for Python";
-    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.asl20;
     maintainers = with maintainers; [ olcai ];
   };


### PR DESCRIPTION
###### Motivation for this change
noticed that ~100 problems on https://repology.org/repository/nix_unstable/problems was from the restructure of the azure-sdk repo, and url changes in docs.

Just made all the packages point to the root of the repo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
