### PR TITLE
release-notes 19.09: removal of non-LTS kernel attrs

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -565,11 +565,14 @@
    </listitem>
    <listitem>
      <para>
-       <literal>linux_5_1</literal>, <literal>linux_5_2</literal> and <literal>linux_5_3</literal> package
-       attributes have been removed to discourage dependence on specific non-LTS kernel versions in stable
-       NixOS releases. Please use an LTS kernel package, <literal>linux_latest</literal> or
-       <literal>linux_testing</literal>. For more details see
-       <link xlink:href="https://github.com/NixOS/nixpkgs/pull/70202">PR #70202</link>
+       Due to the short lifetime of non-LTS kernel releases package attributes like <literal>linux_5_1</literal>,
+       <literal>linux_5_2</literal> and <literal>linux_5_3</literal> have been removed to discourage dependence
+       on specific non-LTS kernel versions in stable NixOS releases.
+
+       Going forward, versioned attributes like <literal>linux_4_9</literal> will exist for LTS versions only.
+       Please use <literal>linux_latest</literal> or <literal>linux_testing</literal> if you depend on non-LTS
+       releases. Keep in mind that <literal>linux_latest</literal> and <literal>linux_testing</literal> will
+       change versions under the hood during the lifetime of a stable release and might include breaking changes.
      </para>
    </listitem>
   </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -563,6 +563,15 @@
        earlier version of NixOS.
      </para>
    </listitem>
+   <listitem>
+     <para>
+       <literal>linux_5_1</literal>, <literal>linux_5_2</literal> and <literal>linux_5_3</literal> package
+       attributes have been removed to discourage dependence on specific non-LTS kernel versions in stable
+       NixOS releases. Please use an LTS kernel package, <literal>linux_latest</literal> or
+       <literal>linux_testing</literal>. For more details see
+       <link xlink:href="https://github.com/NixOS/nixpkgs/pull/70202">PR #70202</link>
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 


### PR DESCRIPTION
###### Motivation for this change

Even though the release obviously already happened, I think it might
still make sense to add a short note about the attributes not being
supported any longer (and going forward).

Related to: https://github.com/NixOS/nixpkgs/pull/70202

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @alyssais  @grahamc @samueldr @NeQuissimus 
