### PR TITLE
splice.nix: don’t mash all package sets

### DIFF
--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -29,15 +29,10 @@ let
                , pkgsHostHost, pkgsHostTarget
                , pkgsTargetTarget
                }: let
-    mash =
-      # Other pkgs sets
-      pkgsBuildBuild // pkgsBuildTarget // pkgsHostHost // pkgsTargetTarget
-      # The same pkgs sets one probably intends
-      // pkgsBuildHost // pkgsHostTarget;
     merge = name: {
       inherit name;
       value = let
-        defaultValue = mash.${name};
+        defaultValue = pkgsHostTarget.${name};
         # `or {}` is for the non-derivation attsert splicing case, where `{}` is the identity.
         valueBuildBuild = pkgsBuildBuild.${name} or {};
         valueBuildHost = pkgsBuildHost.${name} or {};
@@ -88,7 +83,7 @@ let
         # `__functor__` for functions instead.
         } else defaultValue;
     };
-  in lib.listToAttrs (map merge (lib.attrNames mash));
+  in lib.listToAttrs (map merge (lib.attrNames pkgsHostTarget));
 
   splicePackages = { pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget
                    , pkgsHostHost, pkgsHostTarget


### PR DESCRIPTION
Mostly trying this to see if it improves performance / memory usage.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
