### PR TITLE
etcher: init at 1.5.60

### DIFF
--- a/pkgs/tools/misc/etcher/default.nix
+++ b/pkgs/tools/misc/etcher/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, stdenv
+, fetchurl
+, gcc-unwrapped
+, dpkg
+, polkit
+, bash
+, nodePackages
+, electron_3
+, gtk3
+, wrapGAppsHook
+}:
+
+let
+  libPath = lib.makeLibraryPath [
+    # for libstdc++.so.6
+    gcc-unwrapped.lib
+  ];
+
+  sha256 = {
+    "x86_64-linux" = "0zb9j34dz7ybjix018bm8g0b6kilw9300q4ahcm22p0ggg528dh7";
+    "i686-linux" = "0wsv4mvwrvsaz1pwiqs94b3854h5l8ff2dbb1ybxmvwjbfrkdcqc";
+  }."${stdenv.system}";
+
+  arch = {
+    "x86_64-linux" = "amd64";
+    "i686-linux" = "i386";
+  }."${stdenv.system}";
+
+in stdenv.mkDerivation rec {
+  pname = "etcher";
+  version = "1.5.60";
+
+  src = fetchurl {
+    url = "https://github.com/balena-io/etcher/releases/download/v${version}/balena-etcher-electron_${version}_${arch}.deb";
+    inherit sha256;
+  };
+
+  buildInputs = [
+    gtk3
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = ''
+    ${dpkg}/bin/dpkg-deb -x $src .
+  '';
+
+  # sudo-prompt has hardcoded binary paths on Linux and we patch them here
+  # along with some other paths
+  patchPhase = ''
+    ${nodePackages.asar}/bin/asar extract opt/balenaEtcher/resources/app.asar tmp
+    # Use Nix(OS) paths
+    sed -i "s|/usr/bin/pkexec|/usr/bin/pkexec', '/run/wrappers/bin/pkexec|" tmp/node_modules/sudo-prompt/index.js
+    sed -i 's|/bin/bash|${bash}/bin/bash|' tmp/node_modules/sudo-prompt/index.js
+    sed -i "s|process.resourcesPath|'$out/opt/balenaEtcher/resources/'|" tmp/generated/gui.js
+    ${nodePackages.asar}/bin/asar pack tmp opt/balenaEtcher/resources/app.asar
+    rm -rf tmp
+    # Fix up .desktop file
+    substituteInPlace usr/share/applications/balena-etcher-electron.desktop \
+      --replace "/opt/balenaEtcher/balena-etcher-electron" "$out/bin/balena-etcher-electron"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r opt $out/
+    cp -r usr/share $out/
+
+    # We'll use our Nixpkgs electron_3 instead
+    rm $out/opt/balenaEtcher/balena-etcher-electron
+
+    ln -s ${electron_3}/bin/electron $out/bin/balena-etcher-electron
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --add-flags $out/opt/balenaEtcher/resources/app.asar
+      --prefix LD_LIBRARY_PATH : ${libPath}
+    )
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Flash OS images to SD cards and USB drives, safely and easily";
+    homepage = "https://etcher.io/";
+    license = licenses.asl20;
+    maintainers = [ maintainers.shou ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2982,6 +2982,8 @@ in
     inherit (pythonPackages) buildPythonApplication pygtk numpy;
   };
 
+  etcher = callPackage ../tools/misc/etcher { };
+
   ethtool = callPackage ../tools/misc/ethtool { };
 
   ettercap = callPackage ../applications/networking/sniffers/ettercap {


### PR DESCRIPTION
We add Etcher, the Electron image flasher.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
