### PR TITLE
collectd: plugins configuration, buildMinimalPackage

### DIFF
--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -16,8 +16,15 @@ let
       NotifyLevel "OKAY"
     </Plugin>
 
+    ${concatStrings (mapAttrsToList (plugin: pluginConfig: ''
+      LoadPlugin ${plugin}
+      <Plugin "${plugin}">
+      ${pluginConfig}
+      </Plugin>
+    '') cfg.plugins)}
+
     ${concatMapStrings (f: ''
-    Include "${f}"
+      Include "${f}"
     '') cfg.include}
 
     ${cfg.extraConfig}
@@ -66,6 +73,15 @@ in {
         Additional paths to load config from.
       '';
       type = listOf str;
+    };
+
+    plugins = mkOption {
+      default = {};
+      example = { cpu = ""; memory = ""; network = "Server 192.168.1.1 25826"; };
+      description = ''
+        Attribute set of plugin names to plugin config segments
+      '';
+      type = types.attrsOf types.str;
     };
 
     extraConfig = mkOption {

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -1,45 +1,12 @@
-{ stdenv, fetchurl, fetchpatch, darwin
+{ stdenv, fetchurl, fetchpatch, darwin, callPackage
 , autoreconfHook
 , pkgconfig
-, curl
-, iptables
-, jdk
-, libapparmor
-, libatasmart
-, libcap_ng
-, libcredis
-, libdbi
-, libgcrypt
-, libmemcached, cyrus_sasl
-, libmicrohttpd
-, libmodbus
-, libnotify, gdk-pixbuf
-, liboping
-, libpcap
-, libsigrok
-, libvirt
-, libxml2
 , libtool
-, lm_sensors
-, lvm2
-, libmysqlclient
-, numactl
-, postgresql
-, protobufc
-, python
-, rabbitmq-c
-, riemann_c_client
-, rrdtool
-, udev
-, varnish
-, yajl
-, net_snmp
-, hiredis
-, libmnl
-, mosquitto
-, rdkafka
-, mongoc
-}:
+, ...
+}@args:
+let
+  plugins = callPackage ./plugins.nix args;
+in
 stdenv.mkDerivation rec {
   version = "5.8.1";
   pname = "collectd";
@@ -58,27 +25,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [
-    curl libdbi libgcrypt libmemcached
-    cyrus_sasl libnotify gdk-pixbuf liboping libpcap libvirt
-    libxml2 postgresql protobufc rrdtool
-    varnish yajl jdk libtool python hiredis libmicrohttpd
-    riemann_c_client mosquitto rdkafka mongoc
-  ] ++ stdenv.lib.optionals (libmysqlclient != null) [ libmysqlclient
-  ] ++ stdenv.lib.optionals stdenv.isLinux [
-    iptables libatasmart libcredis libmodbus libsigrok
-    lm_sensors lvm2 rabbitmq-c udev net_snmp libmnl
-    # those might be no longer required when https://github.com/NixOS/nixpkgs/pull/51767
-    # is merged
-    libapparmor numactl libcap_ng
+    libtool
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.IOKit
     darwin.apple_sdk.frameworks.ApplicationServices
-  ];
+  ] ++ plugins.buildInputs;
 
   configureFlags = [
     "--localstatedir=/var"
     "--disable-werror"
-  ];
+  ] ++ plugins.configureFlags;
 
   # do not create directories in /var during installPhase
   postConfigure = ''

--- a/pkgs/tools/system/collectd/plugins.nix
+++ b/pkgs/tools/system/collectd/plugins.nix
@@ -20,6 +20,7 @@
 , libxml2
 , libapparmor, libcap_ng, numactl
 , lvm2
+, lua
 , lm_sensors
 , mongoc
 , mosquitto
@@ -139,7 +140,9 @@ let
       buildInputs = [ yajl ];
     };
     lpar = {};
-    lua = {};
+    lua = {
+      buildInputs = [ lua ];
+    };
     lvm = {};
     madwifi = {};
     match_empty_counter = {};

--- a/pkgs/tools/system/collectd/plugins.nix
+++ b/pkgs/tools/system/collectd/plugins.nix
@@ -1,0 +1,342 @@
+{ stdenv
+, curl
+, darwin
+, hiredis
+, iptables
+, jdk
+, libatasmart
+, libdbi
+, libgcrypt
+, libmemcached, cyrus_sasl
+, libmodbus
+, libmicrohttpd
+, libmnl
+, libmysqlclient
+, libnotify, gdk-pixbuf
+, liboping
+, libpcap
+, libsigrok
+, libvirt
+, libxml2
+, libapparmor, libcap_ng, numactl
+, lvm2
+, lm_sensors
+, mongoc
+, mosquitto
+, net_snmp
+, postgresql
+, protobufc
+, python
+, rabbitmq-c
+, rdkafka
+, riemann_c_client
+, rrdtool
+, udev
+, varnish
+, yajl
+# Defaults to `null` for all supported plugins,
+# list of plugin names for a custom build
+, enabledPlugins ? null
+, ...
+}:
+
+let
+  plugins = {
+    aggregation = {};
+    amqp = {
+      buildInputs = [ yajl ] ++
+        stdenv.lib.optionals stdenv.isLinux [ rabbitmq-c ];
+    };
+    apache = {
+      buildInputs = [ curl ];
+    };
+    apcups = {};
+    apple_sensors = {};
+    aquaero = {};
+    ascent = {
+      buildInputs = [ curl libxml2 ];
+    };
+    barometer = {};
+    battery = {
+      buildInputs = stdenv.lib.optionals stdenv.isDarwin [
+        darwin.apple_sdk.frameworks.IOKit
+      ];
+    };
+    bind = {
+      buildInputs = [ curl libxml2 ];
+    };
+    ceph = {
+      buildInputs = [ yajl ];
+    };
+    cgroups = {};
+    chrony = {};
+    conntrack = {};
+    contextswitch = {};
+    cpu = {};
+    cpufreq = {};
+    cpusleep = {};
+    csv = {};
+    curl = {
+      buildInputs = [ curl ];
+    };
+    curl_json = {
+      buildInputs = [ curl yajl ];
+    };
+    curl_xml = {
+      buildInputs = [ curl libxml2 ];
+    };
+    dbi = {
+      buildInputs = [ libdbi ];
+    };
+    df = {};
+    disk = {
+      buildInputs = stdenv.lib.optionals stdenv.isLinux [
+        udev
+      ] ++ stdenv.lib.optionals stdenv.isDarwin [
+        darwin.apple_sdk.frameworks.IOKit
+      ];
+    };
+    dns = {
+      buildInputs = [ libpcap ];
+    };
+    dpdkevents = {};
+    dpdkstat = {};
+    drbd = {};
+    email = {};
+    entropy = {};
+    ethstat = {};
+    exec = {};
+    fhcount = {};
+    filecount = {};
+    fscache = {};
+    gmond = {};
+    gps = {};
+    grpc = {};
+    hddtemp = {};
+    hugepages = {};
+    intel_pmu = {};
+    intel_rdt = {};
+    interface = {};
+    ipc = {};
+    ipmi = {};
+    iptables = {
+      buildInputs = [
+        libpcap
+      ] ++ stdenv.lib.optionals stdenv.isLinux [
+        iptables libmnl
+      ];
+    };
+    ipvs = {};
+    irq = {};
+    java = {
+      buildInputs = [ jdk libgcrypt libxml2 ];
+    };
+    load = {};
+    logfile = {};
+    log_logstash = {
+      buildInputs = [ yajl ];
+    };
+    lpar = {};
+    lua = {};
+    lvm = {};
+    madwifi = {};
+    match_empty_counter = {};
+    match_hashed = {};
+    match_regex = {};
+    match_timediff = {};
+    match_value = {};
+    mbmon = {};
+    mcelog = {};
+    md = {};
+    memcachec = {
+      buildInputs = [ libmemcached cyrus_sasl ];
+    };
+    memcached = {};
+    memory = {};
+    mic = {};
+    modbus = {
+      buildInputs = stdenv.lib.optionals stdenv.isLinux [ libmodbus ];
+    };
+    mqtt = {
+      buildInputs = [ mosquitto ];
+    };
+    multimeter = {};
+    mysql = {
+      buildInputs = stdenv.lib.optionals (libmysqlclient != null) [
+        libmysqlclient
+      ];
+    };
+    netapp = {};
+    netlink = {
+      buildInputs = [
+        libpcap
+      ] ++ stdenv.lib.optionals stdenv.isLinux [
+        libmnl
+      ];
+    };
+    network = {
+      buildInputs = [ libgcrypt ];
+    };
+    nfs = {};
+    nginx = {
+      buildInputs = [ curl ];
+    };
+    notify_desktop = {
+      buildInputs = [ libnotify gdk-pixbuf ];
+    };
+    notify_email = {};
+    notify_nagios = {};
+    ntpd = {};
+    numa = {};
+    nut = {};
+    olsrd = {};
+    onewire = {};
+    openldap = {};
+    openvpn = {};
+    oracle = {};
+    ovs_events = {
+      buildInputs = [ yajl ];
+    };
+    ovs_stats = {
+      buildInputs = [ yajl ];
+    };
+    perl = {};
+    pf = {};
+    pinba = {
+      buildInputs = [ protobufc ];
+    };
+    ping = {
+      buildInputs = [ liboping ];
+    };
+    postgresql = {
+      buildInputs = [ postgresql ];
+    };
+    powerdns = {};
+    processes = {};
+    protocols = {};
+    python = {
+      buildInputs = [ python ];
+    };
+    redis = {
+      buildInputs = [ hiredis ];
+    };
+    routeros = {};
+    rrdcached = {
+      buildInputs = [ rrdtool libxml2 ];
+    };
+    rrdtool = {
+      buildInputs = [ rrdtool libxml2 ];
+    };
+    sensors = {
+      buildInputs = stdenv.lib.optionals stdenv.isLinux [ lm_sensors ];
+    };
+    serial = {};
+    sigrok = {
+      buildInputs = stdenv.lib.optionals stdenv.isLinux [ libsigrok udev ];
+    };
+    smart = {
+      buildInputs = stdenv.lib.optionals stdenv.isLinux [ libatasmart udev ];
+    };
+    snmp = {
+      buildInputs = stdenv.lib.optionals stdenv.isLinux [ net_snmp ];
+    };
+    snmp_agent = {
+      buildInputs = stdenv.lib.optionals stdenv.isLinux [ net_snmp ];
+    };
+    statsd = {};
+    swap = {};
+    synproxy = {};
+    syslog = {};
+    table = {};
+    tail_csv = {};
+    tail = {};
+    tape = {};
+    target_notification = {};
+    target_replace = {};
+    target_scale = {};
+    target_set = {};
+    target_v5upgrade = {};
+    tcpconns = {};
+    teamspeak2 = {};
+    ted = {};
+    thermal = {};
+    threshold = {};
+    tokyotyrant = {};
+    turbostat = {};
+    unixsock = {};
+    uptime = {};
+    users = {};
+    uuid = {};
+    varnish = {
+      buildInputs = [ curl varnish ];
+    };
+    virt = {
+      buildInputs = [ libvirt libxml2 yajl ] ++
+        stdenv.lib.optionals stdenv.isLinux [ lvm2 udev
+          # those might be no longer required when https://github.com/NixOS/nixpkgs/pull/51767
+          # is merged
+          libapparmor numactl libcap_ng
+        ];
+    };
+    vmem = {};
+    vserver = {};
+    wireless = {};
+    write_graphite = {};
+    write_http = {
+      buildInputs = [ curl yajl ];
+    };
+    write_kafka = {
+      buildInputs = [ yajl rdkafka ];
+    };
+    write_log = {
+      buildInputs = [ yajl ];
+    };
+    write_mongodb = {
+      buildInputs = [ mongoc ];
+    };
+    write_prometheus = {
+      buildInputs = [ protobufc libmicrohttpd ];
+    };
+    write_redis = {
+      buildInputs = [ hiredis ];
+    };
+    write_riemann = {
+      buildInputs = [ protobufc riemann_c_client ];
+    };
+    write_sensu = {};
+    write_tsdb = {};
+    xencpu = {};
+    xmms = {};
+    zfs_arc = {};
+    zone = {};
+    zookeeper = {};
+  };
+
+  configureFlags =
+    if enabledPlugins == null
+    then []
+    else (map (plugin: "--enable-${plugin}") enabledPlugins) ++
+    (map (plugin: "--disable-${plugin}")
+      (builtins.filter (plugin: ! builtins.elem plugin enabledPlugins)
+        (builtins.attrNames plugins))
+    );
+
+  pluginBuildInputs = plugin:
+        if ! builtins.hasAttr plugin plugins
+        then throw "Unknown collectd plugin: ${plugin}"
+        else
+          let
+            pluginAttrs = builtins.getAttr plugin plugins;
+          in
+          if pluginAttrs ? "buildInputs"
+          then pluginAttrs.buildInputs
+          else [];
+
+  buildInputs =
+    if enabledPlugins == null
+    then builtins.concatMap pluginBuildInputs
+      (builtins.attrNames plugins)
+    else builtins.concatMap pluginBuildInputs enabledPlugins;
+in {
+  inherit configureFlags buildInputs;
+}

--- a/pkgs/tools/system/collectd/plugins.nix
+++ b/pkgs/tools/system/collectd/plugins.nix
@@ -41,6 +41,8 @@
 }:
 
 let
+  # All plugins and their dependencies.
+  # Please help complete this!
   plugins = {
     aggregation = {};
     amqp = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Allows configuration of collectd plugins in `services.collectd.plugins`.

Using this set of desired plugins, the user can now enable `services.collectd.buildMinimalPackage` to build only these plugins. This way is more obvious to users compared to overriding the packages input set with `null` values.

This feature is optional and backwards compatible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bjornfor @fpletz 
