### PR TITLE
[r19.09] putty: add patch for CVE-2019-17069

### DIFF
--- a/pkgs/applications/networking/remote/putty/default.nix
+++ b/pkgs/applications/networking/remote/putty/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoconf, automake, pkgconfig, libtool
+{ stdenv, lib, fetchurl, fetchpatch, autoconf, automake, pkgconfig, libtool
 , gtk2, halibut, ncurses, perl
 }:
 
@@ -13,6 +13,14 @@ stdenv.mkDerivation rec {
     ];
     sha256 = "1f66iss0kqk982azmxbk4xfm2i1csby91vdvly6cr04pz3i1r4rg";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-17069.patch";
+      url = "https://git.tartarus.org/?p=simon/putty.git;a=patch;h=69201ad8936fe0ff1b8723b7a43accb5e9f1c888";
+      sha256 = "1gblwc2r26ikb26b22f2r61b2lkjf80pbclfb5dhhkkqal6kbvga";
+    })
+  ];
 
   preConfigure = lib.optionalString stdenv.hostPlatform.isUnix ''
     perl mkfiles.pl

--- a/pkgs/applications/networking/remote/putty/default.nix
+++ b/pkgs/applications/networking/remote/putty/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, fetchpatch, autoconf, automake, pkgconfig, libtool
-, gtk2, halibut, ncurses, perl
+, gtk2, halibut, ncurses, perl, darwin
 }:
 
 stdenv.mkDerivation rec {
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake halibut libtool perl pkgconfig ];
   buildInputs = lib.optionals stdenv.hostPlatform.isUnix [
     gtk2 ncurses
-  ];
+  ] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.libs.utmp;
   enableParallelBuilding = true;
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-17069

Added a build fix for darwin while I was at it.

https://nvd.nist.gov/vuln/detail/CVE-2019-17068 is also a thing but I'm quite convinced that vulnerability was only added in 0.72.

See #71270 for master.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
