### PR TITLE
arrayfire: add

### DIFF
--- a/pkgs/development/libraries/arrayfire/default.nix
+++ b/pkgs/development/libraries/arrayfire/default.nix
@@ -1,0 +1,86 @@
+{ stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig
+, cudatoolkit, opencl-clhpp, ocl-icd, fftw, fftwFloat, mkl
+, blas, openblas, boost, mesa, libGLU_combined
+, freeimage, python
+}:
+
+let
+  version = "3.6.4";
+
+  clfftSource = fetchFromGitHub {
+    owner = "arrayfire";
+    repo = "clFFT";
+    rev = "16925fb93338b3cac66490b5cf764953d6a5dac7";
+    sha256 = "0y35nrdz7w4n1l17myhkni3hwm37z775xn6f76xmf1ph7dbkslsc";
+    fetchSubmodules = true;
+  };
+
+  clblasSource = fetchFromGitHub {
+    owner = "arrayfire";
+    repo = "clBLAS";
+    rev = "1f3de2ae5582972f665c685b18ef0df43c1792bb";
+    sha256 = "154mz52r5hm0jrp5fqrirzzbki14c1jkacj75flplnykbl36ibjs";
+    fetchSubmodules = true;
+  };
+
+  cl2hppSource = fetchurl {
+    url = "https://github.com/KhronosGroup/OpenCL-CLHPP/releases/download/v2.0.10/cl2.hpp";
+    sha256 = "1v4q0g6b6mwwsi0kn7kbjn749j3qafb9r4ld3zdq1163ln9cwnvw";
+  };
+
+in stdenv.mkDerivation {
+  pname = "arrayfire";
+  inherit version;
+
+  src = fetchurl {
+    url = "http://arrayfire.com/arrayfire_source/arrayfire-full-${version}.tar.bz2";
+    sha256 = "1fin7a9rliyqic3z83agkpb8zlq663q6gdxsnm156cs8s7f7rc9h";
+  };
+
+  cmakeFlags = [
+    "-DAF_BUILD_OPENCL=OFF"
+    "-DAF_BUILD_EXAMPLES=OFF"
+    "-DBUILD_TESTING=OFF"
+    "-DCMAKE_LIBRARY_PATH=${cudatoolkit}/lib/stubs"
+  ];
+
+  patches = [ ./no-download.patch ];
+
+  postPatch = ''
+    mkdir -p ./build/third_party/clFFT/src
+    cp -R --no-preserve=mode,ownership ${clfftSource}/ ./build/third_party/clFFT/src/clFFT-ext/
+    mkdir -p ./build/third_party/clBLAS/src
+    cp -R --no-preserve=mode,ownership ${clblasSource}/ ./build/third_party/clBLAS/src/clBLAS-ext/
+    mkdir -p ./build/include/CL
+    cp -R --no-preserve=mode,ownership ${cl2hppSource} ./build/include/CL/cl2.hpp
+  '';
+
+  preBuild = ''
+    export CUDA_PATH="${cudatoolkit}"
+  '';
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+  ];
+
+  buildInputs = [
+    opencl-clhpp fftw fftwFloat
+    mkl
+    openblas
+    libGLU_combined
+    mesa freeimage
+    boost.out boost.dev python
+  ] ++ (stdenv.lib.optional stdenv.isLinux [ cudatoolkit ocl-icd ]);
+
+  meta = with stdenv.lib; {
+    description = "A general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices";
+    license = licenses.bsd3;
+    homepage = https://arrayfire.com/ ;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with stdenv.lib.maintainers; [ chessai ];
+    inherit version;
+  };
+}

--- a/pkgs/development/libraries/arrayfire/no-download.patch
+++ b/pkgs/development/libraries/arrayfire/no-download.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeModules/build_clBLAS.cmake b/CMakeModules/build_clBLAS.cmake
+index 8de529e8..6361b613 100644
+--- a/CMakeModules/build_clBLAS.cmake
++++ b/CMakeModules/build_clBLAS.cmake
+@@ -14,8 +14,7 @@ find_package(OpenCL)
+ 
+ ExternalProject_Add(
+     clBLAS-ext
+-    GIT_REPOSITORY https://github.com/arrayfire/clBLAS.git
+-    GIT_TAG arrayfire-release
++    DOWNLOAD_COMMAND true
+     BUILD_BYPRODUCTS ${clBLAS_location}
+     PREFIX "${prefix}"
+     INSTALL_DIR "${prefix}"
+diff --git a/CMakeModules/build_clFFT.cmake b/CMakeModules/build_clFFT.cmake
+index 28be38a3..85e3915e 100644
+--- a/CMakeModules/build_clFFT.cmake
++++ b/CMakeModules/build_clFFT.cmake
+@@ -20,8 +20,7 @@ ENDIF()
+ 
+ ExternalProject_Add(
+     clFFT-ext
+-    GIT_REPOSITORY https://github.com/arrayfire/clFFT.git
+-    GIT_TAG arrayfire-release
++    DOWNLOAD_COMMAND true
+     PREFIX "${prefix}"
+     INSTALL_DIR "${prefix}"
+     UPDATE_COMMAND ""

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10415,6 +10415,11 @@ in
 
   armadillo = callPackage ../development/libraries/armadillo {};
 
+  arrayfire = callPackage ../development/libraries/arrayfire {
+    # fails to build with gcc >= 7
+    stdenv = gcc6Stdenv;
+  };
+
   arrow-cpp = callPackage ../development/libraries/arrow-cpp {
     gtest = gtest.override { static = true; };
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add the missing arrayfire library to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers