### PR TITLE
mediawiki: 1.33.0 -> 1.33.1

### DIFF
--- a/pkgs/servers/web-apps/mediawiki/default.nix
+++ b/pkgs/servers/web-apps/mediawiki/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mediawiki";
-  version = "1.33.0";
+  version = "1.33.1";
 
   src = with stdenv.lib; fetchurl {
     url = "https://releases.wikimedia.org/mediawiki/${versions.majorMinor version}/${pname}-${version}.tar.gz";
-    sha256 = "0rydzmr64r3p5n6g8v9rifk277z1v31p82s8ka8xap8cfkca4dc3";
+    sha256 = "19x10vsgg2fhcpmfvdswwilqwa65byrsmzvhk2v8bsxzhp6s95vx";
   };
 
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change

https://lists.wikimedia.org/pipermail/mediawiki-announce/2019-October/000236.html
https://www.mediawiki.org/wiki/Release_notes/1.33#Changes_since_MediaWiki_1.33.0

PR against master: https://github.com/NixOS/nixpkgs/pull/71369

Simple version bump. It does upgrade cleanly with no breakage to existing running instances.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aanderse 
(As you requested in PR#71369)

@tomberek 
(Reviewer from PR#71369)

