### PR TITLE
chromium: jdk.jre -> jre8

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -16,7 +16,7 @@
 , libXScrnSaver, libXcursor, libXtst, libGLU_combined, libGL
 , protobuf, speechd, libXdamage, cups
 , ffmpeg, libxslt, libxml2, at-spi2-core
-, jdk
+, jre8
 
 # optional dependencies
 , libgcrypt ? null # gnomeSupport || cupsSupport
@@ -125,7 +125,7 @@ let
       glib gtk3 dbus-glib
       libXScrnSaver libXcursor libXtst libGLU_combined
       pciutils protobuf speechd libXdamage at-spi2-core
-      jdk.jre
+      jre8
     ] ++ optional gnomeKeyringSupport libgnome-keyring3
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]
       ++ optionals cupsSupport [ libgcrypt cups ]


### PR DESCRIPTION
`pkgs.jdk` is an overridable shortcat which is not always point to `openjdk8`
chromium build fails when `pkgs.jdk` points to either Java which lacks `.jre` (for example `graalvm8`) or to Java11
cc @ivan
