### PR TITLE
python2: 2.7.16 -> 2.7.17

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -79,12 +79,6 @@ let
         sha256 = "0l9rw6r5r90iybdkp3hhl2pf0h0s1izc68h5d3ywrm92pq32wz57";
       })
 
-      (fetchpatch {
-        url = "https://github.com/python/cpython/commit/979daae300916adb399ab5b51410b6ebd0888f13.patch";
-        name = "CVE-2018-20852.patch";
-        sha256 = "0p838ycssd6abxzby69rhngjqqm59cmlp07910mpjx7lmsz049pb";
-      })
-
       # Fix race-condition during pyc creation. Has a slight backwards
       # incompatible effect: pyc symlinks will now be overridden
       # (https://bugs.python.org/issue17222). Included in python >= 3.4,

--- a/pkgs/development/interpreters/python/cpython/2.7/python-2.7-distutils-C++.patch
+++ b/pkgs/development/interpreters/python/cpython/2.7/python-2.7-distutils-C++.patch
@@ -93,8 +93,8 @@
                  _osx_support.customize_compiler(_config_vars)
                  _config_vars['CUSTOMIZED_OSX_COMPILER'] = 'True'
  
--        (cc, cxx, opt, cflags, ccshared, ldshared, so_ext, ar, ar_flags) = \
--            get_config_vars('CC', 'CXX', 'OPT', 'CFLAGS',
+-        (cc, cxx, cflags, ccshared, ldshared, so_ext, ar, ar_flags) = \
+-            get_config_vars('CC', 'CXX', 'CFLAGS',
 -                            'CCSHARED', 'LDSHARED', 'SO', 'AR',
 -                            'ARFLAGS')
 +        (cc, cxx, ccshared, ldshared, ldcxxshared, so_ext, ar, ar_flags) = \
@@ -120,8 +120,7 @@
              ldshared = ldshared + ' ' + os.environ['LDFLAGS']
 +            ldcxxshared = ldcxxshared + ' ' + os.environ['LDFLAGS']
          if 'CFLAGS' in os.environ:
--            cflags = opt + ' ' + os.environ['CFLAGS']
-+            cflags = os.environ['CFLAGS']
+             cflags = cflags + ' ' + os.environ['CFLAGS']
              ldshared = ldshared + ' ' + os.environ['CFLAGS']
 +        if 'CXXFLAGS' in os.environ:
 +            cxxflags = os.environ['CXXFLAGS']

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -52,10 +52,10 @@ in {
     sourceVersion = {
       major = "2";
       minor = "7";
-      patch = "16";
+      patch = "17";
       suffix = "";
     };
-    sha256 = "1mqfcqp5y8r0bfyr7ppl74n0lig45p9mc4b8adlcpvj74rhfy8pj";
+    sha256 = "0hds28cg226m8j8sr394nm9yc4gxhvlv109w0avsf2mxrlrz0hsd";
     inherit (darwin) CF configd;
     inherit passthruFun;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
