### PR TITLE
Gleam

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3974,12 +3974,12 @@
     githubId = 34086;
     name = "Marc Weber";
   };
-	marenz = {
-		email = "marenz@arkom.men";
-		github = "marenz2569";
-		githubId = 12773269;
-		name = "Markus Schmidl";
-	};
+  marenz = {
+    email = "marenz@arkom.men";
+    github = "marenz2569";
+    githubId = 12773269;
+    name = "Markus Schmidl";
+  };
   markus1189 = {
     email = "markus1189@gmail.com";
     github = "markus1189";
@@ -4707,6 +4707,12 @@
     github = "nmattia";
     githubId = 6930756;
     name = "Nicolas Mattia";
+  };
+  nobbz = {
+    name = "Norbert Melzer";
+    email = "timmelzer@gmail.com";
+    github = "NobbZ";
+    githubId = 58951;
   };
   nocent = {
     email = "nocent@protonmail.ch";

--- a/pkgs/development/compilers/gleam/default.nix
+++ b/pkgs/development/compilers/gleam/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, rustPlatform, fetchFromGitHub }:
+{ pkgs, rustPlatform, fetchFromGitHub, stdenv }:
 
 rustPlatform.buildRustPackage rec {
   pname = "gleam";
@@ -12,4 +12,11 @@ rustPlatform.buildRustPackage rec {
   }}/gleam";
 
   cargoSha256 = "06dr5p5qin48d9bjai6l46xg14hvhzlwk7fykbjdv7il9z5lpc8v";
+
+  meta = with stdenv.lib; {
+    homepage = "https://gleam.run/";
+    description = "A statically typed language for the Erlang VM";
+    license = licenses.asl20;
+    maintainers = [ maintainers.nobbz ];
+  };
 }

--- a/pkgs/development/compilers/gleam/default.nix
+++ b/pkgs/development/compilers/gleam/default.nix
@@ -1,15 +1,19 @@
 { pkgs, rustPlatform, fetchFromGitHub, stdenv }:
 
-rustPlatform.buildRustPackage rec {
-  pname = "gleam";
+let
   version = "0.4.1";
 
-  src = "${fetchFromGitHub {
+  github = fetchFromGitHub {
     owner = "lpil";
     repo = "gleam";
     rev = "v${version}";
     sha256 = "0d341aqgvnx5881wbwlb7r5l5ybfw69cq7jv25f1wac2cfhzl4xh";
-  }}/gleam";
+  };
+in rustPlatform.buildRustPackage {
+  pname = "gleam";
+  inherit version;
+
+  src = "${github}/gleam";
 
   cargoSha256 = "06dr5p5qin48d9bjai6l46xg14hvhzlwk7fykbjdv7il9z5lpc8v";
 

--- a/pkgs/development/compilers/gleam/default.nix
+++ b/pkgs/development/compilers/gleam/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gleam";
+  version = "0.4.1";
+
+  src = "${fetchFromGitHub {
+    owner = "lpil";
+    repo = "gleam";
+    rev = "v${version}";
+    sha256 = "0d341aqgvnx5881wbwlb7r5l5ybfw69cq7jv25f1wac2cfhzl4xh";
+  }}/gleam";
+
+  cargoSha256 = "06dr5p5qin48d9bjai6l46xg14hvhzlwk7fykbjdv7il9z5lpc8v";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7904,6 +7904,9 @@ in
 
   gtk-server = callPackage ../development/interpreters/gtk-server {};
 
+  # Gleam
+  gleam = callPackage ../development/compilers/gleam {};
+
   # Haskell and GHC
 
   haskell = callPackage ./haskell-packages.nix { };


### PR DESCRIPTION
###### Motivation for this change

Make the [gleam compiler](https://gleam.run/) available via nix.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions (Arch Linux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc ?
