### PR TITLE
ricty: change mirror and homepage url

### DIFF
--- a/pkgs/data/fonts/ricty/default.nix
+++ b/pkgs/data/fonts/ricty/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "4.1.1";
 
   src = fetchurl {
-      url = "https://www.rs.tus.ac.jp/yyusa/ricty/ricty_generator-${version}.sh";
+      url = "http://www.yusa.lab.uec.ac.jp/~yusa/ricty/ricty_generator-${version}.sh";
       sha256 = "03fngb8f5hl7ifigdm5yljhs4z2x80cq8y8kna86d07ghknhzgw6";
   };
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A high-quality Japanese font based on Inconsolata and Migu 1M";
-    homepage = https://www.rs.tus.ac.jp/yyusa/ricty.html;
+    homepage = http://www.yusa.lab.uec.ac.jp/~yusa/ricty.html;
     license = licenses.unfree;
     maintainers = [ maintainers.mikoim ];
   };


### PR DESCRIPTION
The old mirror and homepage at www.rs.tus.ac.jp return a 403 Forbidden.

This should fix #71436.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc  @mikoim 
