### PR TITLE
cargo-generate: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-generate/default.nix
+++ b/pkgs/development/tools/rust/cargo-generate/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-generate";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "ashleygwilliams";
     repo = "cargo-generate";
     rev = "v${version}";
-    sha256 = "0n6na6xq4bvs9hc7vc86qqmlrkv824qdmja27b21l2wz3l77r4jb";
+    sha256 = "09276jrb0a735v6p06wz94kbk8bblwpca13vpvy8n0jjmqack2xb";
   };
 
-  cargoSha256 = "00fgzh1s63rr1vs3ahra604m81fc4imx3s09brw2y0n46syhwypi";
+  cargoSha256 = "1gbxfmhwzpxm0gs3zwzs010j0ndi5aw6xsvvngg0h1lpwg9ypnbr";
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
ruoutine update.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
