### PR TITLE
kustomize: 3.1.0 -> 3.3.1

### DIFF
--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -1,29 +1,29 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, tree }:
 
 buildGoModule rec {
   pname = "kustomize";
-  version = "3.1.0";
-  # rev is the 3.1.0 commit, mainly for kustomize version command output
-  rev = "95f3303493fdea243ae83b767978092396169baf";
+  version = "3.3.1";
+  # rev is the 3.3.1 commit, mainly for kustomize version command output
+  rev = "f2ac5a2d0df13c047fb20cbc12ef1a3b41ce2dad";
 
-  goPackagePath = "sigs.k8s.io/kustomize";
-  subPackages = [ "cmd/kustomize" ];
-
-  buildFlagsArray = let t = "${goPackagePath}/v3/pkg/commands/misc"; in ''
+  buildFlagsArray = let t = "sigs.k8s.io/kustomize/v3/provenance"; in ''
     -ldflags=
-      -s -X ${t}.kustomizeVersion=${version}
+      -s -X ${t}.version=${version}
          -X ${t}.gitCommit=${rev}
          -X ${t}.buildDate=unknown
   '';
 
   src = fetchFromGitHub {
-    sha256 = "0kigcirkjvnj3xi1p28p9yp3s0lff24q5qcvf8ahjwvpbwka14sh";
-    rev = "v${version}";
-    repo = pname;
     owner = "kubernetes-sigs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0yxxz0b56r18w178y32s619zy8ci6l93c6vlzx11hhxhbw43f6v6";
   };
 
-  modSha256 = "0w8sp73pmj2wqrg7x7z8diglyfq6c6gn9mmck0k1gk90nv7s8rf1";
+  # avoid finding test and development commands
+  sourceRoot = "source/kustomize";
+
+  modSha256 = "1bas6al14ck0d2ccb4235426a5hldqsm0nf8vi76chz4nahzb71g";
 
   meta = with lib; {
     description = "Customization of kubernetes YAML configurations";


### PR DESCRIPTION
###### Motivation for this change
closes #69621

@vdemeester  I'm not sure how to get the version injected, they changed how their versioning works. If you have any ideas, I'm all ears; I tried for longer than I cared for :(. Also, I have no idea what I'm doing with golang :D.

If you're okay with --version spouting just `unknown`, I can clean up the commented out code, and finalize the PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
