### PR TITLE
arrayfire: do not use cudatoolkit at all on darwin

### DIFF
--- a/pkgs/development/libraries/arrayfire/default.nix
+++ b/pkgs/development/libraries/arrayfire/default.nix
@@ -7,6 +7,8 @@
 let
   version = "3.6.4";
 
+  cudaOnLinux = str: stdenv.lib.optionalString stdenv.isLinux str;
+
   clfftSource = fetchFromGitHub {
     owner = "arrayfire";
     repo = "clFFT";
@@ -41,7 +43,7 @@ in stdenv.mkDerivation {
     "-DAF_BUILD_OPENCL=OFF"
     "-DAF_BUILD_EXAMPLES=OFF"
     "-DBUILD_TESTING=OFF"
-    "-DCMAKE_LIBRARY_PATH=${cudatoolkit}/lib/stubs"
+    (cudaOnLinux "-DCMAKE_LIBRARY_PATH=${cudatoolkit}/lib/stubs")
   ];
 
   patches = [ ./no-download.patch ];
@@ -55,7 +57,7 @@ in stdenv.mkDerivation {
     cp -R --no-preserve=mode,ownership ${cl2hppSource} ./build/include/CL/cl2.hpp
   '';
 
-  preBuild = ''
+  preBuild = cudaOnLinux ''
     export CUDA_PATH="${cudatoolkit}"
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @chessai @dmjio 