### PR TITLE
pythonPackages.pybids: 0.9.2 -> 0.9.4

### DIFF
--- a/pkgs/development/python-modules/pybids/default.nix
+++ b/pkgs/development/python-modules/pybids/default.nix
@@ -15,12 +15,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.9.2";
+  version = "0.9.4";
   pname = "pybids";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "16c0v800yklp043prbrx1357vx1mq5gddxz5zqlcnf4akhzcqrxs";
+    sha256 = "0pw845g9kgp0jhnrq0cxxy43lmzgzw2l9xfaj1lm6gl27rbx7aq8";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
just updating packages I maintain

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @


python38Packages.pytest is broken on master
```
[4 built (5 failed), 46 copied (38.8 MiB), 12.1 MiB DL]
error: build of '/nix/store/nsn40kch3b3scmbscyfzi8nz9wz8vgvl-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/71458
2 package failed to build:
python38Packages.nipype python38Packages.pybids

4 package were build:
python27Packages.nipype python27Packages.pybids python37Packages.nipype python37Packages.pybids
```