### PR TITLE
waon: init at 0.11

### DIFF
--- a/pkgs/applications/audio/waon/default.nix
+++ b/pkgs/applications/audio/waon/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, fftw, gtk2, libao, libsamplerate
+, libsndfile, ncurses, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  pname = "waon";
+  version = "0.11";
+
+  src = fetchFromGitHub {
+    owner = "kichiki";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xmq8d2rj58xbp4rnyav95y1vnz3r9s9db7xxfa2rd0ilq0ps4y7";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ fftw gtk2 libao libsamplerate libsndfile ncurses ];
+
+  installPhase = ''
+    install -Dt $out/bin waon pv gwaon
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Wave-to-Notes transcriber";
+    homepage = https://kichiki.github.io/WaoN/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.puckipedia ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21427,6 +21427,8 @@ in
 
   vym = qt5.callPackage ../applications/misc/vym { };
 
+  waon = callPackage ../applications/audio/waon { };
+
   w3m = callPackage ../applications/networking/browsers/w3m { };
 
   # Should always be the version with the most features


### PR DESCRIPTION
###### Motivation for this change
I recently had some use for this tool, so I decided to package it :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

