### PR TITLE
tab: init at 7.2

### DIFF
--- a/pkgs/tools/text/tab/default.nix
+++ b/pkgs/tools/text/tab/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromBitbucket, python2 }:
+
+stdenv.mkDerivation rec {
+  version = "7.2";
+  pname = "tab";
+
+  src = fetchFromBitbucket {
+    owner = "tkatchev";
+    repo = pname;
+    rev = version;
+    sha256 = "1bm15lw0vp901dj2vsqx6yixmn7ls3brrzh1w6zgd1ksjzlm5aax";
+  };
+
+  nativeBuildInputs = [ python2 ];
+
+  doCheck = true;
+
+  checkTarget = "test";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 -t $out/bin tab
+    install -Dm444 -t $out/share/doc/tab docs/*.html
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Programming language/shell calculator";
+    homepage    = https://tkatchev.bitbucket.io/tab/;
+    license     = licenses.boost;
+    maintainers = with maintainers; [ mstarzyk ];
+    platforms   = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5557,6 +5557,8 @@ in
   plex = callPackage ../servers/plex { };
   plexRaw = callPackage ../servers/plex/raw.nix { };
 
+  tab = callPackage ../tools/text/tab { };
+
   tautulli = callPackage ../servers/tautulli { python = python2; };
 
   ploticus = callPackage ../tools/graphics/ploticus {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
