### PR TITLE
openxcom: 1.0.0.2018.10.08 -> 1.0.0.2019.10.18

### DIFF
--- a/pkgs/games/openxcom/default.nix
+++ b/pkgs/games/openxcom/default.nix
@@ -1,15 +1,15 @@
 {stdenv, fetchFromGitHub, cmake, libGLU_combined, zlib, openssl, libyamlcpp, boost
 , SDL, SDL_image, SDL_mixer, SDL_gfx }:
 
-let version = "1.0.0.2018.10.08"; in
+let version = "1.0.0.2019.10.18"; in
 stdenv.mkDerivation {
   pname = "openxcom";
   inherit version;
   src = fetchFromGitHub {
-    owner = "SupSuper";
+    owner = "OpenXcom";
     repo = "OpenXcom";
-    rev = "13049d617fe762b91893faaf7c14ddefa49e2f1d";
-    sha256 = "0vpcfk3g1bnwwmrln14jkj2wvw2z8igxw2mdb7c3y66466wm93ig";
+    rev = "f9853b2cb8c8f741ac58707487ef493416d890a3";
+    sha256 = "0kbfawj5wsp1mwfcm5mwpkq6s3d13pailjm5w268gqpxjksziyq0";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
- Updated repo owner

###### Motivation for this change

Update to latest upstream version

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
