### PR TITLE
botocore, boto3, awscli: upgrade to latest release

### DIFF
--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname =  "boto3";
-  version = "1.9.205"; # N.B: if you change this, change botocore too
+  version = "1.9.253"; # N.B: if you change this, change botocore too
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1zxz1d6w3f4ip04bm26xplpxjhblc2vfmqcs5n63a9y1h43mk171";
+    sha256 = "1qyb0hlsv0sznwy7adal0f5257nb38lnf86srlmf0rmwqis1fgyr";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -12,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.12.205"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.12.253"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "19ls7hdmcaqrrq8przqy05s8chsy8315ic2zg185k6m64pvr0qhd";
+    sha256 = "12y44x5r8w627wqyn3qd4ly2f0idv1k52vwjm6nh4mjp328i5brv";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -28,11 +28,11 @@ let
 
 in py.pkgs.buildPythonApplication rec {
   pname = "awscli";
-  version = "1.16.215"; # N.B: if you change this, change botocore to a matching version too
+  version = "1.16.263"; # N.B: if you change this, change botocore to a matching version too
 
   src = py.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "13r32z8iyza4gvpf81l6l2ywv37yxi4bb08ry7cli5m6ny9xqlq8";
+    sha256 = "1qqmw4fgdj8zvcl87q62sm0199j43b7y75rkls5dkxsydqsp4j2g";
   };
 
   # No tests included


### PR DESCRIPTION
###### Motivation for this change
Update the core AWS Python packages for the latest features/bugfixes.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
