### PR TITLE
kmymoney: 5.0.5 -> 5.0.7

### DIFF
--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "kmymoney";
-  version = "5.0.5";
+  version = "5.0.7";
 
   src = fetchurl {
     url = "mirror://kde/stable/kmymoney/${version}/src/${pname}-${version}.tar.xz";
-    sha256 = "1hghs4676kn2giwpwz1y7p6djpmi41x64idf3ybiz8ky14a5s977";
+    sha256 = "1h5mzvgpfyl2j66b3nsw17yxvg0ja1qhjlcmfkz62221vcqsrp6m";
   };
 
   # Hidden dependency that wasn't included in CMakeLists.txt:
@@ -70,6 +70,5 @@ stdenv.mkDerivation rec {
     homepage = https://kmymoney.org/;
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Plus;
-    broken = true;
   };
 }


### PR DESCRIPTION
and mark as not broken anymore

see PR #69616 for the corresponding change on master

###### Motivation for this change

Make the package build again, and available again on NixOS 19.09. (It was building and available on NixOS 19.03. In #68361 for NixOS 19.09 it was marked as broken due to not building.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] Tested execution of `./result/bin/kmymoney`
    &rarr; works fine
  - [ ] Tested execution of `./result/bin/.kmymoney-wrapped`
    (no idea how to do that - running it naïvely results in an error: `qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

<!-- cc @ -->
(There seem to be none for this package ...)
