### PR TITLE
glibc: Fix building with musl on GCC 8

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation ({
     ++ lib.optional stdenv.buildPlatform.isDarwin ./darwin-cross-build.patch
 
     # Remove after upgrading to glibc 2.28+
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) (fetchpatch {
+    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform || stdenv.hostPlatform.isMusl) (fetchpatch {
       url = "https://sourceware.org/git/?p=glibc.git;a=patch;h=780684eb04298977bc411ebca1eadeeba4877833";
       name = "correct-pwent-parsing-issue-and-resulting-build.patch";
       sha256 = "08fja894vzaj8phwfhsfik6jj2pbji7kypy3q8pgxvsd508zdv1q";

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -40,7 +40,21 @@ callPackage ./common.nix { inherit stdenv; } {
     #      limit rebuilds by only disabling pie w/musl
       ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "pie";
 
-    NIX_CFLAGS_COMPILE = if withGd then "-Wno-error=stringop-truncation" else null;
+    NIX_CFLAGS_COMPILE =
+      if !stdenv.hostPlatform.isMusl
+        # TODO: This (returning a string or `null`, instead of a list) is to
+        #       not trigger a mass rebuild due to the introduction of the
+        #       musl-specific flags below.
+        #       At next change to non-musl glibc builds, remove this `then`
+        #       and the above condition, instead keeping only the `else` below.
+        then (if withGd then "-Wno-error=stringop-truncation" else null)
+        else
+          builtins.concatLists [
+            (stdenv.lib.optional withGd "-Wno-error=stringop-truncation")
+            # Fix -Werror build failure when building glibc with musl with GCC >= 8, see:
+            # https://github.com/NixOS/nixpkgs/pull/68244#issuecomment-544307798
+            (stdenv.lib.optional stdenv.hostPlatform.isMusl "-Wno-error=attribute-alias")
+          ];
 
     # When building glibc from bootstrap-tools, we need libgcc_s at RPATH for
     # any program we run, because the gcc will have been placed at a new


### PR DESCRIPTION
###### Motivation for this change

See

* https://github.com/NixOS/nixpkgs/pull/68244#issuecomment-544307798
* https://github.com/nh2/static-haskell-nix/issues/56

This commit takes care to not change the derivation for non-musl builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matthewbauer @edolstra