### PR TITLE
clfft: init at 2.12.2

### DIFF
--- a/pkgs/development/libraries/clfft/default.nix
+++ b/pkgs/development/libraries/clfft/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake, fftw, fftwFloat, boost166, opencl-clhpp, ocl-icd }:
+
+let
+  version = "2.12.2";
+in stdenv.mkDerivation {
+  pname = "clfft";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "clMathLibraries";
+    repo = "clFFT";
+    rev = "refs/tags/v${version}";
+    sha256 = "134vb6214hn00qy84m4djg4hqs6hw19gkp8d0wlq8gb9m3mfx7na";
+  };
+
+  sourceRoot = "source/src";
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ fftw fftwFloat boost166 opencl-clhpp ocl-icd ];
+
+  meta = with stdenv.lib; {
+    description = "Library containing FFT functions written in OpenCL";
+    longDescription = ''
+      clFFT is a software library containing FFT functions written in OpenCL.
+      In addition to GPU devices, the library also supports running on CPU devices to facilitate debugging and heterogeneous programming.
+    '';
+    license = licenses.asl20;
+    homepage = "http://clmathlibraries.github.io/clFFT/";
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ chessai ];
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10607,6 +10607,8 @@ in
 
   clearsilver = callPackage ../development/libraries/clearsilver { };
 
+  clfft = callPackage ../development/libraries/clfft { };
+
   clipp  = callPackage ../development/libraries/clipp { };
 
   clipper = callPackage ../development/libraries/clipper { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @chessai 
