### PR TITLE
libxsmm: init at 1.13

### DIFF
--- a/pkgs/development/libraries/libxsmm/default.nix
+++ b/pkgs/development/libraries/libxsmm/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, coreutils, gfortran7, gnused
+, python27, utillinux, which, bash
+}:
+
+let
+  version = "1.13";
+in stdenv.mkDerivation {
+  pname = "libxsmm";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "hfp";
+    repo = "libxsmm";
+    rev = "refs/tags/${version}";
+    sha256 = "1c15ccy7vbmvxkfnc7sn26wnf6gr6gxgkmilpgpycm1fhi8ikd6w";
+  };
+
+  buildInputs = [
+    coreutils
+    gfortran7
+    gnused
+    python27
+    utillinux
+    which
+  ];
+
+  prePatch = ''
+    patchShebangs .
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Library targeting Intel Architecture for specialized dense and sparse matrix operations, and deep learning primitives";
+    license = licenses.bsd3;
+    homepage = https://github.com/hfp/libxsmm ;
+    platforms = platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ chessai ];
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13585,6 +13585,8 @@ in
     python = if stdenv.isDarwin then python2 else python3;
   };
 
+  libxsmm = callPackage ../development/libraries/libxsmm { };
+
   libixp_hg = callPackage ../development/libraries/libixp-hg { };
 
   libyaml = callPackage ../development/libraries/libyaml { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @chessai 
