### PR TITLE
ocamlPackages.decompress: 0.6 →0.9.0; ocamlPackages.git: 1.11.5 → 2.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/checkseum/default.nix
+++ b/pkgs/development/ocaml-modules/checkseum/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
 
   inherit (dune) installPhase;
 
+  passthru = { inherit hasC; };
+
   meta = {
     homepage = "https://github.com/mirage/checkseum";
     description = "ADLER-32 and CRC32C Cyclic Redundancy Check";

--- a/pkgs/development/ocaml-modules/decompress/default.nix
+++ b/pkgs/development/ocaml-modules/decompress/default.nix
@@ -1,30 +1,27 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, topkg
+{ lib, fetchurl, buildDunePackage
+, checkseum, cmdliner
+, alcotest, bos, camlzip, mmap, re
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
-then throw "decompress is not available for OCaml ${ocaml.version}"
-else
+buildDunePackage rec {
+	version = "0.9.0";
+	pname = "decompress";
 
-stdenv.mkDerivation rec {
-	version = "0.6";
-	name = "ocaml${ocaml.version}-decompress-${version}";
-
-	src = fetchFromGitHub {
-		owner = "mirage";
-		repo = "decompress";
-		rev = "v${version}";
-		sha256 = "0hfs5zrvimzvjwdg57vrxx9bb7irvlm07dk2yv3s5qhj30zimd08";
+	src = fetchurl {
+		url = "https://github.com/mirage/decompress/releases/download/v${version}/decompress-v${version}.tbz";
+		sha256 = "0fryhcvv96vfca51c7kqdn3n3canqsbbvfbi75ya6lca4lmpipbh";
 	};
 
-	buildInputs = [ ocaml findlib ocamlbuild topkg ];
-
-	inherit (topkg) buildPhase installPhase;
+	buildInputs = [ cmdliner ];
+	propagatedBuildInputs = [ checkseum ];
+	checkInputs = lib.optionals doCheck [ alcotest bos camlzip mmap re ];
+	doCheck = true;
 
 	meta = {
 		description = "Pure OCaml implementation of Zlib";
-		license = stdenv.lib.licenses.mit;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
-		inherit (src.meta) homepage;
-		inherit (ocaml.meta) platforms;
+		license = lib.licenses.mit;
+		maintainers = [ lib.maintainers.vbgl ];
+		homepage = "https://github.com/mirage/decompress";
+		broken = !checkseum.hasC;
 	};
 }

--- a/pkgs/development/ocaml-modules/encore/default.nix
+++ b/pkgs/development/ocaml-modules/encore/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildDunePackage, fetchurl, ocaml, alcotest, angstrom, ke }:
+
+buildDunePackage rec {
+  pname = "encore";
+  version = "0.3";
+  src = fetchurl {
+    url = "https://github.com/mirage/encore/releases/download/v${version}/encore-v${version}.tbz";
+    sha256 = "05nv6yms5axsmq9cspr7884rz5kirj50izx3vdm89q4yl186qykl";
+  };
+  propagatedBuildInputs = [ angstrom ke ];
+  checkInputs = lib.optional doCheck alcotest;
+  doCheck = lib.versions.majorMinor ocaml.version != "4.07";
+
+  meta = {
+    homepage = "https://github.com/mirage/encore";
+    description = "Library to generate encoder/decoder which ensure isomorphism";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -1,27 +1,28 @@
-{ stdenv, fetchFromGitHub, buildDunePackage
-, astring, decompress, fmt, hex, logs, mstruct, ocaml_lwt, ocamlgraph, ocplib-endian, uri
-, alcotest, mtime, nocrypto
+{ lib, fetchFromGitHub, buildDunePackage
+, alcotest, git, mtime, nocrypto
+, angstrom, astring, cstruct, decompress, digestif, encore, duff, fmt
+, fpath, hex, ke, logs, lru, ocaml_lwt, ocamlgraph, ocplib-endian, uri, rresult
 }:
 
 buildDunePackage rec {
   pname = "git";
-	version = "1.11.5";
+	version = "2.1.0";
 
 	src = fetchFromGitHub {
 		owner = "mirage";
 		repo = "ocaml-git";
 		rev = version;
-		sha256 = "0r1bxpxjjnl9hh8xbabsxl7svzvd19hfy73a2y1m4kljmw64dpfh";
+		sha256 = "0v55zkwgml6i5hp0kzynbi58z6j15k3qgzg06b3h8pdbv5fwd1jp";
 	};
 
-	buildInputs = [ alcotest mtime nocrypto ];
-	propagatedBuildInputs = [ astring decompress fmt hex logs mstruct ocaml_lwt ocamlgraph ocplib-endian uri ];
+	propagatedBuildInputs = [ angstrom astring cstruct decompress digestif encore duff fmt fpath hex ke logs lru ocaml_lwt ocamlgraph ocplib-endian uri rresult ];
+	checkInputs = lib.optionals doCheck [ alcotest git mtime nocrypto ];
 	doCheck = true;
 
 	meta = {
 		description = "Git format and protocol in pure OCaml";
-		license = stdenv.lib.licenses.isc;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.isc;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
 	};
 }

--- a/pkgs/development/ocaml-modules/imagelib/default.nix
+++ b/pkgs/development/ocaml-modules/imagelib/default.nix
@@ -1,26 +1,27 @@
-{ stdenv, fetchFromGitHub, which, ocaml, findlib, ocamlbuild, decompress }:
+{ lib, fetchFromGitHub, fetchpatch, buildDunePackage, decompress }:
 
-stdenv.mkDerivation rec {
-  version = "20171028";
-  name = "ocaml${ocaml.version}-imagelib-${version}";
+buildDunePackage rec {
+  minimumOCamlVersion = "4.07";
+  version = "20191011";
+  pname = "imagelib";
   src = fetchFromGitHub {
     owner = "rlepigre";
     repo = "ocaml-imagelib";
-    rev = "ocaml-imagelib_${version}";
-    sha256 = "1frkrgcrv4ybdmqcfxpfsywx0hm1arxgxp32n8kzky6qip1g0zxf";
+    rev = "03fed7733825cef7e0465163f398f6af810e2e75";
+    sha256 = "0h7vgyss42nhlfqpbdnb54nxq86rskqi2ilx8b87r0hi19hqx463";
   };
 
-  buildInputs = [ which ocaml findlib ocamlbuild ];
+  patches = [ (fetchpatch {
+    url = "https://github.com/rlepigre/ocaml-imagelib/pull/24/commits/4704fd44adcda62e0d96ea5b1927071326aa6111.patch";
+    sha256 = "0ipjab1hfa2v2pnd8g1k3q2ia0plgiw7crm3fa4w2aqpzdyabkb9";
+  }) ];
 
   propagatedBuildInputs = [ decompress ];
 
-  createFindlibDestdir = true;
-
   meta = {
     description = "Image formats such as PNG and PPM in OCaml";
-    license = stdenv.lib.licenses.lgpl3;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/imagelib/unix.nix
+++ b/pkgs/development/ocaml-modules/imagelib/unix.nix
@@ -1,0 +1,8 @@
+{ buildDunePackage, imagelib }:
+
+buildDunePackage {
+  pname = "imagelib-unix";
+  inherit (imagelib) version src meta;
+
+  propagatedBuildInputs = [ imagelib ];
+}

--- a/pkgs/development/ocaml-modules/ke/default.nix
+++ b/pkgs/development/ocaml-modules/ke/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildDunePackage, fetchurl
+, bigarray-compat, fmt
+, alcotest, bigstringaf
+}:
+
+buildDunePackage rec {
+  pname = "ke";
+  version = "0.4";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ke/releases/download/v${version}/ke-v${version}.tbz";
+    sha256 = "13c9xy60vmq29mnwpg3h3zgl6gjbjfwbx1s0crfc6xwvark0zxnx";
+  };
+
+  propagatedBuildInputs = [ bigarray-compat fmt ];
+
+  checkInputs = lib.optionals doCheck [ alcotest bigstringaf ];
+  doCheck = true;
+
+  minimumOCamlVersion = "4.03";
+
+  meta = {
+    description = "Fast implementation of queue in OCaml";
+    homepage = "https://github.com/mirage/ke";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -362,6 +362,8 @@ let
 
     jsonm = callPackage ../development/ocaml-modules/jsonm { };
 
+    ke = callPackage ../development/ocaml-modules/ke { };
+
     lablgl = callPackage ../development/ocaml-modules/lablgl { };
 
     lablgtk3 = callPackage ../development/ocaml-modules/lablgtk3 { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -233,6 +233,8 @@ let
 
     elpi = callPackage ../development/ocaml-modules/elpi { };
 
+    encore = callPackage ../development/ocaml-modules/encore { };
+
     enumerate = callPackage ../development/ocaml-modules/enumerate { };
 
     eqaf = callPackage ../development/ocaml-modules/eqaf { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -289,6 +289,8 @@ let
 
     imagelib = callPackage ../development/ocaml-modules/imagelib { };
 
+    imagelib-unix = callPackage ../development/ocaml-modules/imagelib/unix.nix { };
+
     inotify = callPackage ../development/ocaml-modules/inotify { };
 
     integers = callPackage ../development/ocaml-modules/integers { };
@@ -316,7 +318,7 @@ let
 
     gg = callPackage ../development/ocaml-modules/gg { };
 
-    git = callPackage ../development/ocaml-modules/git { };
+    git = callPackage ../development/ocaml-modules/git { inherit (pkgs) git; };
 
     git-http = callPackage ../development/ocaml-modules/git-http { };
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.08

Also add a new dependency of ocaml-git (`encore` — with its dependency `ke`).

Also update `imagelib` to keep compatibility with `decompress`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
