### PR TITLE
ameba: init at 0.10.1

### DIFF
--- a/pkgs/development/tools/ameba/default.nix
+++ b/pkgs/development/tools/ameba/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, fetchFromGitHub, crystal, shards }:
+
+stdenv.mkDerivation {
+  pname = "ameba";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner  = "crystal-ameba";
+    repo   = "ameba";
+    rev    = "v0.10.1";
+    sha256 = "0dcw7px7g0c5pxpdlirhirqzhcc7gdwdfiwb9kgm4x1k74ghjgxq";
+  };
+
+  nativeBuildInputs = [ crystal shards ];
+
+  buildPhase = ''
+    runHook preBuild
+    shards build --release
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 -t $out/bin bin/ameba
+    runHook postInstall
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    crystal spec
+    runHook postCheck
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A static code analysis tool for Crystal";
+    homepage = https://crystal-ameba.github.io;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kimburgess ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9220,6 +9220,8 @@ in
     alloy5
     alloy;
 
+  ameba = callPackage ../development/tools/ameba { };
+
   augeas = callPackage ../tools/system/augeas { };
 
   inherit (callPackage ../tools/admin/ansible { })


### PR DESCRIPTION
###### Motivation for this change
Adds support for [Ameba](https://crystal-ameba.github.io/), a crystal-lang static analysis tool.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).