### PR TITLE
libechonest: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/development/libraries/libechonest/default.nix
+++ b/pkgs/development/libraries/libechonest/default.nix
@@ -1,20 +1,36 @@
-{ stdenv, fetchurl, cmake, qt4, qjson, doxygen, boost }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, doxygen, qt4, qjson }:
 
 stdenv.mkDerivation rec {
   pname = "libechonest";
-  version = "2.3.0";
+  version = "2.3.1";
 
-  src = fetchurl {
-    url = "http://files.lfranchi.com/${pname}-${version}.tar.bz2";
-    sha1 = "cf1b279c96f15c87c36fdeb23b569a60cdfb01db";
+  src = fetchFromGitHub {
+    owner = "lfranchi";
+    repo = pname;
+    rev = version;
+    sha256 = "0xbavf9f355dl1d3qv59x4ryypqrdanh9xdvw2d0q66l008crdkq";
   };
 
-  buildInputs = [ cmake qt4 qjson doxygen boost ];
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/lfranchi/libechonest/commit/009514f65044823ef29045397d4b58dd04d09977.patch";
+      sha256 = "0dmmpi7hixdngwiv045ilqrzyzkf56xpfyihcsx5i3xya2m0mynx";
+    })
+    (fetchpatch {
+      url = "https://github.com/lfranchi/libechonest/commit/3ce779536d56a163656e8098913f923e6cda2b5c.patch";
+      sha256 = "1vasd3sgqah562vxk71jibyws5cbihjjfnffd50qvdm2xqgvbx94";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake doxygen ];
+  buildInputs = [ qt4 qjson ];
+
   enableParallelBuilding = true;
+  doCheck = false; # requires network access
 
   meta = {
     description = "A C++/Qt wrapper around the Echo Nest API";
-    homepage = http://projects.kde.org/projects/playground/libs/libechonest;
+    homepage = "https://projects.kde.org/projects/playground/libs/libechonest";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Just a package revamp
\+ one less sha1 hash in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

---

Result of `nix-review` [1](https://github.com/Mic92/nix-review)
<details>
  <summary>3 package were build:</summary>

  - clementine
  - clementineUnfree
  - libechonest
</details>
