### PR TITLE
xzoom: fix version

### DIFF
--- a/pkgs/tools/X11/xzoom/default.nix
+++ b/pkgs/tools/X11/xzoom/default.nix
@@ -1,19 +1,21 @@
 { stdenv, fetchurl, libX11, libXext, libXt, imake, gccmakedep}:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}.${patchlevel}";
+  name = "${pname}-${version}";
   pname = "xzoom";
-  version = "0.3";
-  patchlevel = "24";
+  major = "0";
+  minor = "3";
+  patch = "24";
+  version = "${major}.${minor}.${patch}";
 
   # or fetchFromGitHub(owner,repo,rev) or fetchgit(rev)
   src = fetchurl {
-    url = "http://www.ibiblio.org/pub/linux/libs/X/${pname}-${version}.tgz";
+    url = "http://www.ibiblio.org/pub/linux/libs/X/${pname}-${major}.${minor}.tgz";
     sha256 = "0jzl5py4ny4n4i58lxx2hdwq9zphqf7h3m14spl3079y5mlzssxj";
   };
   patches = [
     (fetchurl {
-       url = "http://http.debian.net/debian/pool/main/x/xzoom/xzoom_${version}-${patchlevel}.diff.gz";
+       url = "http://http.debian.net/debian/pool/main/x/xzoom/xzoom_${major}.${minor}-${patch}.diff.gz";
        sha256 = "0zhc06whbvaz987bzzzi2bz6h9jp6rv812qs7b71drivvd820qbh";
     })
   ];


### PR DESCRIPTION
###### Motivation for this change

This should fix the issue repology reported:

`xzoom: ERROR: name "xzoom-0.3.24" does not end with version "0.3"`

but it makes it also more verbose

Related to https://github.com/NixOS/nixpkgs/issues/68531

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c
