### PR TITLE
dbus: enable building with musl

### DIFF
--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , pkgconfig
 , expat
+, enableSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isMusl
 , systemd
 , libX11 ? null
 , libICE ? null
@@ -14,6 +15,8 @@
 assert
   x11Support ->
     libX11 != null && libICE != null && libSM != null;
+
+assert enableSystemd -> systemd != null;
 
 stdenv.mkDerivation rec {
   pname = "dbus";
@@ -50,11 +53,12 @@ stdenv.mkDerivation rec {
     expat
   ];
 
-  buildInputs = lib.optionals x11Support [
-    libX11
-    libICE
-    libSM
-  ] ++ lib.optional stdenv.isLinux systemd;
+  buildInputs =
+    lib.optionals x11Support [
+      libX11
+      libICE
+      libSM
+    ] ++ lib.optional enableSystemd systemd;
   # ToDo: optional selinux?
 
   configureFlags = [


### PR DESCRIPTION
When building dbus with musl, it must not take systemd as a buildInput, because systemd is not able to be built with musl.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is from https://github.com/nh2/static-haskell-nix/issues/50.  In that issue, I was trying to get `vte` built using `pkgsMusl`.  `vte` transitively depends on `dbus`, which can't be built with a `systemd` dependency, since `systemd` can't be compiled with musl.

In order to check this you can run the following command:

```console
$ nix-build -A pkgsMusl.dbus
...
/nix/store/g9hs0syglgv1f9cgmv1naqrx4vsqzm3x-dbus-1.12.16
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`) _they all seem to at least run somewhat_
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nh2 @domenkozar
