### PR TITLE
libusb1: enable compiling with musl

### DIFF
--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -1,4 +1,14 @@
-{ stdenv, fetchurl, pkgconfig, systemd ? null, libobjc, IOKit, withStatic ? false }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, enableSystemd ? stdenv.isLinux && !stdenv.hostPlatform.isMusl
+, systemd ? null
+, libobjc
+, IOKit
+, withStatic ? false
+}:
+
+assert enableSystemd -> systemd != null;
 
 stdenv.mkDerivation (rec {
   pname = "libusb";
@@ -13,12 +23,17 @@ stdenv.mkDerivation (rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs =
-    stdenv.lib.optional stdenv.isLinux systemd ++
+    stdenv.lib.optional enableSystemd systemd ++
     stdenv.lib.optionals stdenv.isDarwin [ libobjc IOKit ];
 
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
 
-  preFixup = stdenv.lib.optionalString stdenv.isLinux ''
+  configureFlags =
+    # We use `isLinux` here only to avoid mass rebuilds for Darwin, where
+    # disabling udev happens automatically. Remove `isLinux` at next big change!
+    stdenv.lib.optional (stdenv.isLinux && !enableSystemd) "--disable-udev";
+
+  preFixup = stdenv.lib.optionalString enableSystemd ''
     sed 's,-ludev,-L${systemd.lib}/lib -ludev,' -i $out/lib/libusb-1.0.la
   '';
 


### PR DESCRIPTION
This PR enables compiling `libusb1` with musl.

libusb1 can't depend on systemd in order to be compiled with musl, because systemd can't be built with musl.

Since systemd provides udev, udev support also needs to be disabled when building libusb1.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is motivated by https://github.com/nh2/static-haskell-nix/issues/50.  I'd like to build GTK apps with musl.  The `gtk3` library depends on `cups`, which depends on `libusb1`.

You can try building this with the following command:

```console
$ nix-build -A pkgsMusl.libusb1
...
/nix/store/qqq6bgrsxd28wqy4cd6npwcv4hz1d3qv-libusb-1.0.23
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nh2 @domenkozar 

