### PR TITLE
Backport of mupdf to address various CVEs

### DIFF
--- a/pkgs/applications/misc/k2pdfopt/default.nix
+++ b/pkgs/applications/misc/k2pdfopt/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     cp -r ${v251a_src}/* $sourceRoot
   '';
 
-  patches = [ ./k2pdfopt.patch ];
+  patches = [ ./k2pdfopt.patch ./k2pdfopt-mupdf-1.16.1.patch ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     #  corresponding files in the respective source trees, resolving any errors
     #  with more recent versions of these depencencies, and running diff.
     mupdf_modded = mupdf.overrideAttrs (attrs: {
-      patches = attrs.patches ++ [ ./mupdf.patch ]; # Last verified with mupdf 1.14.0
+      patches = attrs.patches ++ [ ./mupdf.patch ]; # Last verified with mupdf 1.16.1
     });
     leptonica_modded = leptonica.overrideAttrs (attrs: {
       patches = [ ./leptonica.patch ]; # Last verified with leptonica 1.78.0

--- a/pkgs/applications/misc/k2pdfopt/k2pdfopt-mupdf-1.16.1.patch
+++ b/pkgs/applications/misc/k2pdfopt/k2pdfopt-mupdf-1.16.1.patch
@@ -1,0 +1,151 @@
+diff --git a/willuslib/wmupdf.c b/willuslib/wmupdf.c
+index 81627ef..f14a96c 100644
+--- a/willuslib/wmupdf.c
++++ b/willuslib/wmupdf.c
+@@ -189,8 +189,6 @@ int wmupdf_remake_pdf(char *infile,char *outfile,WPDFPAGEINFO *pageinfo,int use_
+     pdf_write_opts.do_compress=1;
+     pdf_write_opts.do_linear=0;
+     pdf_write_opts.do_garbage=1; /* 2 and 3 don't work for this. */
+-    pdf_write_opts.continue_on_error=0;
+-    pdf_write_opts.errors=NULL;
+     write_failed=0;
+     wpdfpageinfo_sort(pageinfo);
+     xref=NULL;
+@@ -1687,8 +1685,8 @@ WPDFOUTLINE *wpdfoutline_read_from_pdf_file(char *filename)
+         /* Sumatra version of MuPDF v1.4 -- use locally installed fonts */
+         pdf_install_load_system_font_funcs(ctx);
+         fz_try(ctx) { doc=fz_open_document(ctx,filename); }
+-        fz_catch(ctx) 
+-            { 
++        fz_catch(ctx)
++            {
+             fz_drop_context(ctx);
+             return(NULL);
+             }
+@@ -1890,5 +1888,5 @@ static pdf_obj *pdf_new_string_utf8(fz_context *ctx,char *string)
+     willus_mem_free((double **)&utfbuf,funcname);
+     return(pdfobj);
+     }
+-    
++
+ #endif /* HAVE_MUPDF_LIB */
+diff --git a/willuslib/wmupdfinfo.c b/willuslib/wmupdfinfo.c
+index 5c7f38c..9b9e6fd 100644
+--- a/willuslib/wmupdfinfo.c
++++ b/willuslib/wmupdfinfo.c
+@@ -237,23 +237,22 @@ static void showglobalinfo(fz_context *ctx, globals *glo,char *filename)
+         pdf_obj *robj;
+ 
+         robj=pdf_resolve_indirect(ctx,obj);
+-        n=pdf_sprint_obj(ctx,NULL,0,robj,1);
+-        buf=malloc(n+2);
++        buf=pdf_sprint_obj(ctx,NULL,0,&n,robj,1,0);
+         if (buf==NULL)
+             {
+             fz_write_printf(ctx,out,"Info object (%d %d R):\n",pdf_to_num(ctx,obj),pdf_to_gen(ctx,obj));
+-		    pdf_print_obj(ctx,out,robj,1);
++		    pdf_print_obj(ctx,out,robj,1,0);
+             }
+         else
+             {
+-            pdf_sprint_obj(ctx,buf,n+2,robj,1);
++            pdf_sprint_obj(ctx,buf,n+2,&n,robj,1,0);
+             display_pdf_field(ctx,out,buf,"Title","TITLE");
+             display_pdf_field(ctx,out,buf,"CreationDate","CREATED");
+             display_pdf_field(ctx,out,buf,"ModDate","LAST MODIFIED");
+             display_pdf_field(ctx,out,buf,"Producer","PDF PRODUCER");
+             display_pdf_field(ctx,out,buf,"Creator","CREATOR");
+             display_file_size(ctx,out,filename);
+-            free(buf);
++            fz_free(ctx,buf);
+             }
+ 	    }
+     if (glo->dims==1)
+@@ -275,7 +274,7 @@ static void showglobalinfo(fz_context *ctx, globals *glo,char *filename)
+ 	if (obj)
+         {
+ 		fz_write_printf(ctx,out, "\nEncryption object (%d %d R):\n", pdf_to_num(ctx,obj), pdf_to_gen(ctx,obj));
+-		pdf_print_obj(ctx,out, pdf_resolve_indirect(ctx,obj), 1);
++		pdf_print_obj(ctx,out, pdf_resolve_indirect(ctx,obj), 1, 0);
+         }
+     }
+ 
+@@ -396,7 +395,7 @@ gatherdimensions(fz_context *ctx, globals *glo, int page, pdf_obj *pageref, pdf_
+ 	if (j < glo->dims)
+ 		return;
+ 
+-	glo->dim = fz_resize_array(ctx, glo->dim, glo->dims+1, sizeof(struct info));
++	glo->dim = fz_realloc_array(ctx, glo->dim, glo->dims+1, struct info);
+ 	glo->dims++;
+ 
+ 	glo->dim[glo->dims - 1].page = page;
+@@ -441,7 +440,7 @@ gatherfonts(fz_context *ctx, globals *glo, int page, pdf_obj *pageref, pdf_obj *
+ 		if (k < glo->fonts)
+ 			continue;
+ 
+-		glo->font = fz_resize_array(ctx, glo->font, glo->fonts+1, sizeof(struct info));
++		glo->font = fz_realloc_array(ctx, glo->font, glo->fonts+1, struct info);
+ 		glo->fonts++;
+ 
+ 		glo->font[glo->fonts - 1].page = page;
+@@ -510,7 +509,7 @@ gatherimages(fz_context *ctx, globals *glo, int page, pdf_obj *pageref, pdf_obj
+ 		if (k < glo->images)
+ 			continue;
+ 
+-		glo->image = fz_resize_array(ctx, glo->image, glo->images+1, sizeof(struct info));
++		glo->image = fz_realloc_array(ctx, glo->image, glo->images+1, struct info);
+ 		glo->images++;
+ 
+ 		glo->image[glo->images - 1].page = page;
+@@ -568,7 +567,7 @@ gatherforms(fz_context *ctx, globals *glo, int page, pdf_obj *pageref, pdf_obj *
+ 		if (k < glo->forms)
+ 			continue;
+ 
+-		glo->form = fz_resize_array(ctx, glo->form, glo->forms+1, sizeof(struct info));
++		glo->form = fz_realloc_array(ctx, glo->form, glo->forms+1, struct info);
+ 		glo->forms++;
+ 
+ 		glo->form[glo->forms - 1].page = page;
+@@ -613,7 +612,7 @@ gatherpsobjs(fz_context *ctx, globals *glo, int page, pdf_obj *pageref, pdf_obj
+ 		if (k < glo->psobjs)
+ 			continue;
+ 
+-		glo->psobj = fz_resize_array(ctx, glo->psobj, glo->psobjs+1, sizeof(struct info));
++		glo->psobj = fz_realloc_array(ctx, glo->psobj, glo->psobjs+1, struct info);
+ 		glo->psobjs++;
+ 
+ 		glo->psobj[glo->psobjs - 1].page = page;
+@@ -656,7 +655,7 @@ gathershadings(fz_context *ctx, globals *glo, int page, pdf_obj *pageref, pdf_ob
+ 		if (k < glo->shadings)
+ 			continue;
+ 
+-		glo->shading = fz_resize_array(ctx, glo->shading, glo->shadings+1, sizeof(struct info));
++		glo->shading = fz_realloc_array(ctx, glo->shading, glo->shadings+1, struct info);
+ 		glo->shadings++;
+ 
+ 		glo->shading[glo->shadings - 1].page = page;
+@@ -724,7 +723,7 @@ gatherpatterns(fz_context *ctx, globals *glo, int page, pdf_obj *pageref, pdf_ob
+ 		if (k < glo->patterns)
+ 			continue;
+ 
+-		glo->pattern = fz_resize_array(ctx, glo->pattern, glo->patterns+1, sizeof(struct info));
++		glo->pattern = fz_realloc_array(ctx, glo->pattern, glo->patterns+1, struct info);
+ 		glo->patterns++;
+ 
+ 		glo->pattern[glo->patterns - 1].page = page;
+@@ -1216,7 +1215,7 @@ void wmupdfinfo_get(char *filename,int *pagelist,char **buf)
+     if (fout==NULL)
+         return;
+     */
+-    
++
+     ctx = fz_new_context(NULL, NULL, FZ_STORE_UNLIMITED);
+     if (!ctx)
+         {
+@@ -1307,5 +1306,5 @@ static void date_convert(char *dst,char *src)
+     else if (src[i]!='\0')
+         sprintf(&dst[strlen(dst)]," %s",&src[i]);
+     }
+-    
++
+ #endif /* HAVE_MUPDF_LIB */

--- a/pkgs/applications/misc/k2pdfopt/mupdf.patch
+++ b/pkgs/applications/misc/k2pdfopt/mupdf.patch
@@ -1,4 +1,4 @@
-From 3d763f84872351c250ffea26150e73b02b8f4c6f Mon Sep 17 00:00:00 2001
+From d8927c969e3387ca2669a616c0ba53bce918a031 Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Fri, 13 Sep 2019 15:11:45 -0400
 Subject: [PATCH] Willus mod for k2pdfopt
@@ -904,10 +904,10 @@ index 000000000..45de8cfd3
 +#endif
 +}
 diff --git a/source/fitz/font.c b/source/fitz/font.c
-index 733d91dae..69c46d968 100644
+index 00c6e8f99..1448b4a56 100644
 --- a/source/fitz/font.c
 +++ b/source/fitz/font.c
-@@ -5,8 +5,11 @@
+@@ -4,8 +4,11 @@
  #include "draw-imp.h"
  
  #include <ft2build.h>
@@ -920,13 +920,13 @@ index 733d91dae..69c46d968 100644
  #include <assert.h>
  
 diff --git a/source/fitz/stext-device.c b/source/fitz/stext-device.c
-index 0ba944d44..3c05c51ac 100644
+index 2df90305e..b1f99e056 100644
 --- a/source/fitz/stext-device.c
 +++ b/source/fitz/stext-device.c
-@@ -692,6 +692,11 @@ fz_new_stext_device(fz_context *ctx, fz_stext_page *page, const fz_stext_options
- 	dev->trm = fz_identity;
+@@ -825,6 +825,11 @@ fz_new_stext_device(fz_context *ctx, fz_stext_page *page, const fz_stext_options
  	dev->lastchar = ' ';
  	dev->curdir = 1;
+ 	dev->lasttext = NULL;
 +    /* willus mod -- seems like this should be here, but not sure. */
 +    if (opts)
 +        dev->flags = opts->flags;
@@ -936,11 +936,11 @@ index 0ba944d44..3c05c51ac 100644
  	return (fz_device*)dev;
  }
 diff --git a/source/fitz/string.c b/source/fitz/string.c
-index e70ae6e6e..b310463f4 100644
+index f8eedb682..7a767983d 100644
 --- a/source/fitz/string.c
 +++ b/source/fitz/string.c
-@@ -448,6 +448,10 @@ fz_utflen(const char *s)
- 
+@@ -560,6 +560,10 @@ fz_utflen(const char *s)
+ */
  float fz_atof(const char *s)
  {
 +/* willus mod: atof(s), #if-#else-#endif */
@@ -949,20 +949,20 @@ index e70ae6e6e..b310463f4 100644
 +#else
  	float result;
  
- 	errno = 0;
-@@ -457,6 +461,7 @@ float fz_atof(const char *s)
+ 	if (s == NULL)
+@@ -572,6 +576,7 @@ float fz_atof(const char *s)
  		return 1;
  	result = fz_clamp(result, -FLT_MAX, FLT_MAX);
  	return result;
 +#endif
  }
  
- int fz_atoi(const char *s)
+ /*
 diff --git a/source/pdf/pdf-annot.c b/source/pdf/pdf-annot.c
-index 68de8898a..5d43485bd 100644
+index 4dfdf36fe..acff7d12a 100644
 --- a/source/pdf/pdf-annot.c
 +++ b/source/pdf/pdf-annot.c
-@@ -4,8 +4,20 @@
+@@ -5,8 +5,20 @@
  #include <string.h>
  #include <time.h>
  
@@ -983,12 +983,12 @@ index 68de8898a..5d43485bd 100644
 +    }
  #endif
  
- #define TEXT_ANNOT_SIZE (25.0f)
+ #define isdigit(c) (c >= '0' && c <= '9')
 diff --git a/source/pdf/pdf-link.c b/source/pdf/pdf-link.c
-index ae5beaa35..b5a52a000 100644
+index 37444b471..613cc05b9 100644
 --- a/source/pdf/pdf-link.c
 +++ b/source/pdf/pdf-link.c
-@@ -351,6 +351,9 @@ pdf_resolve_link(fz_context *ctx, pdf_document *doc, const char *uri, float *xp,
+@@ -345,6 +345,9 @@ pdf_resolve_link(fz_context *ctx, pdf_document *doc, const char *uri, float *xp,
  		}
  		return page;
  	}
@@ -999,10 +999,10 @@ index ae5beaa35..b5a52a000 100644
  	return -1;
  }
 diff --git a/source/pdf/pdf-parse.c b/source/pdf/pdf-parse.c
-index 501c5626a..927ba6cd5 100644
+index 04a772204..9dd0cd898 100644
 --- a/source/pdf/pdf-parse.c
 +++ b/source/pdf/pdf-parse.c
-@@ -586,9 +586,14 @@ pdf_parse_ind_obj(fz_context *ctx, pdf_document *doc,
+@@ -663,9 +663,14 @@ pdf_parse_ind_obj(fz_context *ctx, pdf_document *doc,
  			if (c == '\r')
  			{
  				c = fz_peek_byte(ctx, file);
@@ -1018,10 +1018,10 @@ index 501c5626a..927ba6cd5 100644
  			}
  			stm_ofs = fz_tell(ctx, file);
 diff --git a/source/pdf/pdf-xref.c b/source/pdf/pdf-xref.c
-index 2475b6e86..bc163563a 100644
+index 8f888059b..08de7bfba 100644
 --- a/source/pdf/pdf-xref.c
 +++ b/source/pdf/pdf-xref.c
-@@ -707,8 +707,11 @@ pdf_xref_size_from_old_trailer(fz_context *ctx, pdf_document *doc, pdf_lexbuf *b
+@@ -710,8 +710,11 @@ pdf_xref_size_from_old_trailer(fz_context *ctx, pdf_document *doc, pdf_lexbuf *b
  		if (!s)
  			fz_throw(ctx, FZ_ERROR_GENERIC, "xref subsection length missing");
  		len = fz_atoi(fz_strsep(&s, " "));
@@ -1033,7 +1033,7 @@ index 2475b6e86..bc163563a 100644
  
  		/* broken pdfs where the section is not on a separate line */
  		if (s && *s != '\0')
-@@ -1372,7 +1375,10 @@ pdf_init_document(fz_context *ctx, pdf_document *doc)
+@@ -1378,7 +1381,10 @@ pdf_init_document(fz_context *ctx, pdf_document *doc)
  	{
  		pdf_drop_xref_sections(ctx, doc);
  		fz_rethrow_if(ctx, FZ_ERROR_TRYLATER);
@@ -1044,7 +1044,7 @@ index 2475b6e86..bc163563a 100644
  		repaired = 1;
  	}
  
-@@ -1496,7 +1502,10 @@ pdf_drop_document_imp(fz_context *ctx, pdf_document *doc)
+@@ -1506,7 +1512,10 @@ pdf_drop_document_imp(fz_context *ctx, pdf_document *doc)
  		/* Swallow error, but continue dropping */
  	}
  

--- a/pkgs/applications/misc/llpp/default.nix
+++ b/pkgs/applications/misc/llpp/default.nix
@@ -5,12 +5,12 @@ assert lib.versionAtLeast (lib.getVersion ocaml) "4.07";
 
 stdenv.mkDerivation rec {
   pname = "llpp";
-  version = "30";
+  version = "31";
 
   src = fetchgit {
     url = "git://repo.or.cz/llpp.git";
     rev = "v${version}";
-    sha256 = "0iilpzf12hs0zky58j55l4y5dvzv7fc53nsrg324n9vka92mppvd";
+    sha256 = "14ibsm1zzxfidjajcj30b5m9in10q3817izahsjvkmryrvvn6qsg";
     fetchSubmodules = false;
   };
 

--- a/pkgs/applications/misc/llpp/fix-build-bash.patch
+++ b/pkgs/applications/misc/llpp/fix-build-bash.patch
@@ -1,14 +1,5 @@
-From cccadedfbcb6764a38382154838113a6b2fd4dee Mon Sep 17 00:00:00 2001
-From: Michael Hoang <enzime@users.noreply.github.com>
-Date: Mon, 10 Dec 2018 15:08:01 +1100
-Subject: [PATCH] Patch build.bash for nixpkgs
-
----
- build.bash | 37 ++-----------------------------------
- 1 file changed, 2 insertions(+), 35 deletions(-)
-
 diff --git a/build.bash b/build.bash
-index 1588011..72117d9 100755
+index 7c278b6..41494c5 100755
 --- a/build.bash
 +++ b/build.bash
 @@ -29,7 +29,6 @@ srcd="$(dirname $0)"
@@ -20,10 +11,10 @@ index 1588011..72117d9 100755
  mkdir -p $outd/{$wsid,lablGL}
  :>$outd/ordered
 @@ -39,12 +38,6 @@ isfresh() { test -r "$1.past" && . "$1.past" && test "$k" = "$2"; }
- mbt=native
+ mbt=${mbt:-native}
  mulibs="$mudir/build/$mbt/libmupdf.a" # $mudir/build/$mbt/libmupdf-third.a
  
--keycmd="(cd $mudir && git describe --tags --dirty); digest $mulibs"
+-keycmd="(cd $mudir && make -q build=$mbt libs && echo); digest $mulibs"
 -isfresh "$mulibs" "$(eval $keycmd)" || (
 -    make -C "$mudir" build=$mbt -j $mjobs libs
 -    echo "k='$(eval $keycmd)'" >$mudir/build/$mbt/libmupdf.a.past
@@ -32,12 +23,12 @@ index 1588011..72117d9 100755
  oincs() {
      local i=
      local incs1=
-@@ -90,32 +83,6 @@ mflags() {
+@@ -90,34 +83,6 @@ mflags() {
  }
  
  overs="$(ocamlc -vnum 2>/dev/null)" || overs=""
--test "$overs" = "4.07.0" || {
--    url=https://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.0.tar.xz
+-test "$overs" = "4.08" || {
+-    url=https://caml.inria.fr/pub/distrib/ocaml-4.08/ocaml-4.08.0.tar.xz
 -    txz=$outd/$(basename $url)
 -    isfresh $txz $url || {
 -        executable_p() { command -v "$1" >/dev/null 2>&1; }
@@ -54,8 +45,10 @@ index 1588011..72117d9 100755
 -        tar xf $txz -C $outd
 -        bn=$(basename $url)
 -        cd $outd/${bn%.tar.xz}
--        ./configure -prefix $absprefix                                      \
--                    -no-graph -no-debugger -no-ocamldoc -no-native-compiler
+-        ./configure --disable-vmthreads --disable-graph-lib \
+-                    --disable-ocamldoc --enable-debugger=no \
+-                    --disable-flat-float-array              \
+-                    --prefix=$absprefix
 -        make -j $mjobs world
 -        make install
 -        echo "k='$url'" >$absprefix/bin/ocamlc.past
@@ -65,7 +58,7 @@ index 1588011..72117d9 100755
  
  bocaml1() {
      grep -q "$3" $outd/ordered || {
-@@ -224,7 +191,7 @@ bobjc() {
+@@ -227,7 +192,7 @@ bobjc() {
      } && vecho "fresh $o"
  }
  
@@ -74,7 +67,7 @@ index 1588011..72117d9 100755
  
  cmd="(. $srcd/genconfstr.sh >$outd/confstruct.ml)"
  keycmd="digest $srcd/genconfstr.sh $outd/confstruct.ml"
-@@ -278,7 +245,7 @@ for m in ml_gl ml_glarray ml_raw; do
+@@ -281,7 +246,7 @@ for m in ml_gl ml_glarray ml_raw; do
  done
  
  libs="str.cma unix.cma"
@@ -83,6 +76,3 @@ index 1588011..72117d9 100755
  if $darwin; then
      mcomp=$(ocamlc -config | grep bytecomp_c_co | { read _ c; echo $c; })
      clibs="$clibs -framework Cocoa -framework OpenGL"
--- 
-2.19.2
-

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -14,24 +14,17 @@ let
 
 
 in stdenv.mkDerivation rec {
-  version = "1.14.0";
+  version = "1.16.1";
   pname = "mupdf";
 
   src = fetchurl {
     url = "https://mupdf.com/downloads/archive/${pname}-${version}-source.tar.gz";
-    sha256 = "093p7lv6pgyymagn28n58fs0np928r0i5p2az9cc4gwccwx4hhy4";
+    sha256 = "0iz4ickj52fxjp8crg573kjrl4viq279g589isdpgpckslysf7g7";
   };
 
   patches =
     # Use shared libraries to decrease size
-    [( fetchpatch
-      {
-          name = "CVE-2018-18662";
-          url = "http://git.ghostscript.com/?p=mupdf.git;a=patch;h=164ddc22ee0d5b63a81d5148f44c37dd132a9356";
-          sha256 = "1jkzh20n3b854871h86cy5y7fvy0d5wyqy51b3fg6gj3a0jqpzzd";
-      }
-    )]
-    ++ stdenv.lib.optional (!stdenv.isDarwin) ./mupdf-1.14-shared_libs.patch
+    stdenv.lib.optional (!stdenv.isDarwin) ./mupdf-1.14-shared_libs.patch
     ++ stdenv.lib.optional stdenv.isDarwin ./darwin.patch
   ;
 

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig, zathura_core, cairo , gtk-mac-integration, girara, mupdf }:
 
 stdenv.mkDerivation rec {
-  version = "0.3.4";
+  version = "0.3.5";
   pname = "zathura-pdf-mupdf";
 
   # pwmt.org server was down at the time of last update
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "pwmt";
     repo = "zathura-pdf-mupdf";
     rev = version;
-    sha256 = "1m4w4jrybpjmx6pi33a5saxzmfd8rrym2k13jpd1fv543s17d9dy";
+    sha256 = "0wb46hllykbi30ir69s8s23mihivqn13mgfdzawbsn2a21p8y4zl";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is PR #68506 rebased on the release 19.09 branch. mupdf in 19.09 has various known vulnerabilities:

https://github.com/NixOS/nixpkgs/issues/70113

I checked the builds of the references derivations and ran the binaries. Since I do not know/use all of these programs, I could not test them extensively.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vrthra @fpletz 

@teto 
