### PR TITLE
nixos/dnsdist: Add CAP_NET_BIND_SERVICE to AmbientCapabilities

### DIFF
--- a/nixos/modules/services/networking/dnsdist.nix
+++ b/nixos/modules/services/networking/dnsdist.nix
@@ -46,11 +46,10 @@ in {
         RestartSec="1";
         DynamicUser = true;
         StartLimitInterval="0";
-        PrivateTmp=true;
         PrivateDevices=true;
-        CapabilityBoundingSet="CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID";
+        AmbientCapabilities="CAP_NET_BIND_SERVICE";
+        CapabilityBoundingSet="CAP_NET_BIND_SERVICE";
         ExecStart = "${pkgs.dnsdist}/bin/dnsdist --supervised --disable-syslog --config ${configFile}";
-        ProtectSystem="full";
         ProtectHome=true;
         RestrictAddressFamilies="AF_UNIX AF_INET AF_INET6";
         LimitNOFILE="16384";


### PR DESCRIPTION
###### Motivation for this change

It seems that dnsdist doesn't actually request CAP_NET_BIND_SERVICE, which is why normally it's executed and root and changes uid to another, unprivileged, user. This means that as it is, dnsdist will be unable to bind to any port under 1024 and will fail with access denied.

Removing CAP_SETGID and CAP_SETUID is also related to this as we don't actually change the uid or gid as we use DynamicUser. (That part isn't strictly NEEDED but there's no reason to have those capabilities if we don't use them).

There are also some additional sandboxing we can remove from the service definition as they are assumed true or strict by DynamicUser: specifically PrivateTmp and ProtectSystem respectively.

ProtectHome is still there, despite being assumed read-only as setting it to true means they are seen as empty. I don't think it really matters as I don't know if systemd will ignore it or not, but I didn't see any reason to go hunting for excuses to make it a bigger change.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ disassembler
