### PR TITLE
vte: enable compiling with musl

### DIFF
--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -1,5 +1,7 @@
 { stdenv
+, lib
 , fetchurl
+, fetchpatch
 , gettext
 , pkgconfig
 , meson
@@ -57,6 +59,17 @@ stdenv.mkDerivation rec {
     glib
     pango
   ];
+
+  patches =
+    # VTE needs a small patch to work with musl:
+    # https://gitlab.gnome.org/GNOME/vte/issues/72
+    lib.optional
+      stdenv.hostPlatform.isMusl
+      (fetchpatch {
+            name = "0001-Add-W_EXITCODE-macro-for-non-glibc-systems.patch";
+            url = "https://gitlab.gnome.org/GNOME/vte/uploads/c334f767f5d605e0f30ecaa2a0e4d226/0001-Add-W_EXITCODE-macro-for-non-glibc-systems.patch";
+            sha256 = "1ii9db9i5l3fy2alxz7bjfsgjs3lappnlx339dvxbi2141zknf5r";
+      });
 
   postPatch = ''
     patchShebangs perf/*


### PR DESCRIPTION
This enables VTE to be compiled with `pkgsMusl`.

VTE requires a small patch to be compiled with musl.

This has been upstreamed, but there appears to be some resistance to support enabling builds with musl:
https://gitlab.gnome.org/GNOME/vte/issues/72

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is for https://github.com/nh2/static-haskell-nix/issues/50.  I'd like to get VTE compiling with musl, and eventually compiling statically.

You can test this like the following:

```console
$ nix-build -A pkgsMusl.vte
...
/nix/store/4bbyrrnbildrs9807jcwpl544m0jc26h-vte-0.58.2
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nh2 @domenkozar @matthewbauer @astsmtl @antono @lethalman
