### PR TITLE
writeC: fix escape

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -98,7 +98,7 @@ rec {
         gcc \
             ${optionalString (libraries != [])
               "$(pkg-config --cflags --libs ${
-                concatMapStringsSep " " (pkg: "$(find ${escapeShellArg pkg}/lib/pkgsconfig -name \*.pc -exec basename {} \;)") libraries
+                concatMapStringsSep " " (pkg: "$(find ${escapeShellArg pkg}/lib/pkgsconfig -name \\*.pc -exec basename {} \\;)") libraries
               })"
             } \
             -O \


### PR DESCRIPTION
`\*` and `\;` are just `*` and `;` in single-quoted string
