### PR TITLE
elmPackages: elm-format GHC 8.8.1 patch

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -27,9 +27,23 @@ let
             The elm-format expression is updated via a script in the https://github.com/avh4/elm-format repo:
             `package/nix/build.sh`
             */
-            #elm-format = justStaticExecutables (doJailbreak (self.callPackage ./packages/elm-format.nix {}));
+            elm-format = justStaticExecutables (overrideCabal (self.callPackage ./packages/elm-format.nix {}) (drv: {
+              # GHC 8.8.1 support
+              # https://github.com/avh4/elm-format/pull/640
+              patches = [(
+                fetchpatch {
+                  url = "https://github.com/turboMaCk/elm-format/commit/4f4abdc7117ed6ce3335f6cf39b6495b48067b7c.patch";
+                  sha256 = "1zqk6q6w0ph12mnwffgwzf4h1hcgqg0v09ws9q2g5bg2riq4rvd9";
+                }
+              )];
+              # Tests are failing after upgrade to ghc881.
+              # Cause is probably just a minor change in stdout output
+              # see https://github.com/avh4/elm-format/pull/640
+              doCheck = false;
+              jailbreak = true;
+            }));
             elmi-to-json = justStaticExecutables (overrideCabal (self.callPackage ./packages/elmi-to-json.nix {}) (drv: {
-              prePatch = '' 
+              prePatch = ''
                 substituteInPlace package.yaml --replace "- -Werror" ""
                 hpack
               '';

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6322,7 +6322,6 @@ broken-packages:
   - incremental-computing
   - incremental-maps
   - increments
-  - indents
   - indexation
   - IndexedList
   - indextype


### PR DESCRIPTION
Add back elm-format removed in https://github.com/NixOS/nixpkgs/pull/71538.
upstream PR: https://github.com/avh4/elm-format/pull/640

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @domenkozar @avh4 
