### PR TITLE
nixos/redis: [19.09] Disable hugepages for redis via sysctl and not via a sys…

### DIFF
--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -186,9 +186,9 @@ in
 
   config = mkIf config.services.redis.enable {
 
-    boot.kernel.sysctl = mkIf cfg.vmOverCommit {
-      "vm.overcommit_memory" = "1";
-    };
+    boot.kernel.sysctl = {
+      "vm.nr_hugepages" = "0";
+    } // mkIf cfg.vmOverCommit { "vm.overcommit_memory" = "1"; };
 
     networking.firewall = mkIf cfg.openFirewall {
       allowedTCPPorts = [ cfg.port ];
@@ -197,14 +197,6 @@ in
     users.users.redis.description = "Redis database user";
 
     environment.systemPackages = [ cfg.package ];
-
-    systemd.services.disable-transparent-huge-pages = {
-      description = "Disable Transparent Huge Pages (required by Redis)";
-      before = [ "redis.service" ];
-      wantedBy = [ "redis.service" ];
-      script = "echo never > /sys/kernel/mm/transparent_hugepage/enabled";
-      serviceConfig.Type = "oneshot";
-    };
 
     systemd.services.redis =
       { description = "Redis Server";


### PR DESCRIPTION
…temd-oneshot

This is the backport of #71584.
Fixes #71414
cc @flokli 