### PR TITLE
sphinxcontrib-qthelp init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
-, sphinx
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-qthelp";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f";
+  };
+
+  propagatedBuildInputs = [  ];
+
+  # Check is disabled due to circular dependency of sphinx
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document.";
+    homepage = http://sphinx-doc.org/;
+    license = licenses.bsd0;
+  };
+
+}

--- a/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
@@ -13,7 +13,6 @@ buildPythonPackage rec {
     sha256 = "79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f";
   };
 
-  propagatedBuildInputs = [  ];
 
   # Check is disabled due to circular dependency of sphinx
   doCheck = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5000,6 +5000,8 @@ in {
 
   sphinx-testing = callPackage ../development/python-modules/sphinx-testing { };
 
+  sphinxcontrib-qthelp = callPackage ../development/python-modules/sphinxcontrib-qthelp {};
+
   sphinxcontrib-bibtex = callPackage ../development/python-modules/sphinxcontrib-bibtex {};
 
   sphinx-navtree = callPackage ../development/python-modules/sphinx-navtree {};


### PR DESCRIPTION
build dep of sphinx 2.2.0

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
