### PR TITLE
installer: use sddm in plasma5

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -22,17 +22,7 @@ with lib;
     });
   '';
 
-  services.xserver = {
-    enable = true;
-
-    # Automatically login as nixos.
-    displayManager.slim = {
-      enable = true;
-      defaultUser = "nixos";
-      autoLogin = true;
-    };
-
-  };
+  services.xserver.enable = true;
 
   # Provide networkmanager for easy wireless configuration.
   networking.networkmanager.enable = true;

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -10,8 +10,6 @@ with lib;
 
   services.xserver.desktopManager.gnome3.enable = true;
 
-  services.xserver.displayManager.slim.enable = mkForce false;
-
   # Auto-login as root.
   services.xserver.displayManager.gdm.autoLogin = {
     enable = true;

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
@@ -13,6 +13,15 @@ with lib;
       enable = true;
       enableQt4Support = false;
     };
+
+    # Automatically login as nixos.
+    displayManager.sddm = {
+      enable = true;
+      autoLogin = {
+        enable = true;
+        user = "nixos";
+      };
+    };
   };
 
   environment.systemPackages = with pkgs; [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Slim is abandoned and won't work with wayland.
It's in our best interest to use the display-manager
that makes most sense for Plasma5, sddm.

We've already moved on from it being default in #30890
and the graphical.nix profile, which the virtualbox profile uses,
has sddm anyway.

---

It would also be a good idea, for 20.03, to decide if we want to remove slim entirely.

###### Additional context
What we have going on with "profiles" here is rather messy.
See https://github.com/NixOS/nixpkgs/issues/47256, currently the virtualbox appliance has a `demo` user with a default password, while we've added the `nixos` user.
I would resolve this but it seems like a hassle, and with https://github.com/NixOS/nixpkgs/pull/49821 they're now actually documented, which I believe wasn't the best decision because these profiles are working as nixos internals. So now they're like a public API, while being sub-optimal.
So for the foreseeable future I won't contribute a change consolidating this. I'd prefer to keep the installation configuration separate, and something the user cannot leverage publicly. 
It already contains dangerous configuration
* https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix#L17

and manually documenting is tedious. Unlike options, there's no generated documentation from values and such. Having something like an `mkProfile` which has some of the benefits of options would be helpful. That and not having scattered `imports`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
