### PR TITLE
ocamlPackages.ctypes: 0.13.1 → 0.15.1; ocamlPackages.integers: 0.2.2 → 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, buildOcaml, fetchzip, libffi, pkgconfig, ncurses, integers }:
+{ stdenv, fetchzip, ocaml, findlib, libffi, pkgconfig, ncurses, integers }:
 
-buildOcaml {
-  name = "ctypes";
-  version = "0.13.1";
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "ctypes is not available for OCaml ${ocaml.version}"
+else
 
-  minimumSupportedOcamlVersion = "4";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-ctypes-${version}";
+  version = "0.15.1";
 
   src = fetchzip {
-    url = "https://github.com/ocamllabs/ocaml-ctypes/archive/67e711ec891e087fbe1e0b4665aa525af4eaa409.tar.gz";
-    sha256 = "1z84s5znr3lj84rzv6m37xxj9h7fwx4qiiykx3djf52qgk1rb2xb";
+    url = "https://github.com/ocamllabs/ocaml-ctypes/archive/${version}.tar.gz";
+    sha256 = "0adas974bwinn8jidb6chljkpd70s041h2a969dicsj0xsg6wys6";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ncurses ];
+  buildInputs = [ ocaml findlib ncurses ];
   propagatedBuildInputs = [ integers libffi ];
-
-  hasSharedObjects = true;
 
   buildPhase =  ''
      make XEN=false libffi.config ctypes-base ctypes-stubs
@@ -23,6 +23,7 @@ buildOcaml {
   '';
 
   installPhase =  ''
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs
     make install XEN=false
   '';
 
@@ -31,5 +32,6 @@ buildOcaml {
     description = "Library for binding to C libraries using pure OCaml";
     license = licenses.mit;
     maintainers = [ maintainers.ericbmerritt ];
+    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/integers/default.nix
+++ b/pkgs/development/ocaml-modules/integers/default.nix
@@ -1,22 +1,18 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
+{ lib, fetchzip, buildDunePackage }:
 
-stdenv.mkDerivation {
-	name = "ocaml${ocaml.version}-integers-0.2.2";
+buildDunePackage rec {
+	pname = "integers";
+	version = "0.3.0";
 
-	src = fetchurl {
-		url = https://github.com/ocamllabs/ocaml-integers/releases/download/v0.2.2/integers-0.2.2.tbz;
-		sha256 = "08b1ljw88ny3l0mdq6xmffjk8anfc77igryva5jz1p6f4f746ywk";
+	src = fetchzip {
+		url = "https://github.com/ocamllabs/ocaml-integers/archive/${version}.tar.gz";
+		sha256 = "1yhif5zh4srh63mhimfx3p5ljpb3lixjdd3i9pjnbj2qgpzlqj8p";
 	};
-
-	buildInputs = [ ocaml findlib ocamlbuild topkg ];
-
-	inherit (topkg) buildPhase installPhase;
 
 	meta = {
 		description = "Various signed and unsigned integer types for OCaml";
-		license = stdenv.lib.licenses.mit;
+		license = lib.licenses.mit;
 		homepage = https://github.com/ocamllabs/ocaml-integers;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
-		inherit (ocaml.meta) platforms;
+		maintainers = [ lib.maintainers.vbgl ];
 	};
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ericbmerritt 
