### PR TITLE
Repaired pythonModules.qscintilla-qt5

### DIFF
--- a/pkgs/development/python-modules/qscintilla-qt5/default.nix
+++ b/pkgs/development/python-modules/qscintilla-qt5/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage {
     lndir ${pyqt5} $out
     rm -rf "$out/nix-support"
     cd Python
+    substituteInPlace configure.py \
+      --replace "qmake = {'CONFIG': 'qscintilla2'}" "qmake = {'CONFIG': 'qscintilla2', 'QT': 'widgets printsupport'}"
     ${python.executable} ./configure.py \
       --pyqt=PyQt5 \
       --destdir=$out/${python.sitePackages}/PyQt5 \
@@ -45,6 +47,5 @@ buildPythonPackage {
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ lsix ];
     homepage = https://www.riverbankcomputing.com/software/qscintilla/;
-    broken = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

It seems that qmake does not automatically make QtWidgets header files visible. My change patches the configure.py file which in turn generates the Project file used with qmake, so that the relevant include files become visible at build time, and the package is no longer broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lsix 
