### PR TITLE
jackett: 0.11.751 -> 0.12.907

### DIFF
--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -1,12 +1,22 @@
 { lib, stdenv, fetchurl, makeWrapper, curl, icu60, openssl, zlib }:
 
-stdenv.mkDerivation rec {
+let
+  arch =
+    with stdenv.hostPlatform;
+    if isx86_64 then "AMDx64"
+    else if isAarch32 then "ARM32"
+    else if isAarch64 then "ARM64"
+    else abort "Unsupported architecture";
+in stdenv.mkDerivation rec {
   pname = "jackett";
   version = "0.11.751";
 
   src = fetchurl {
-    url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.LinuxAMDx64.tar.gz";
-    sha256 = "09y9pck35pj2g89936zallxr3hanmbgp8jc42nj2js68l0z64qz3";
+    url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.Linux${arch}.tar.gz";
+    sha256 = with stdenv.hostPlatform;
+             if isAarch64 then "1qidc8qx4jhxvls304w61pypg74m0vw22bp9hacrdd901an8fjcw"
+             else if isAarch32 then "1sgl3nxbh97xl2781m6yz3pw8j278anxkg5hczp0bk97a10g4cd7"
+             else "09y9pck35pj2g89936zallxr3hanmbgp8jc42nj2js68l0z64qz3";
   };
 
   buildInputs = [ makeWrapper ];
@@ -35,6 +45,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/Jackett/Jackett/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ edwtjo nyanloutre ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -9,14 +9,14 @@ let
     else abort "Unsupported architecture";
 in stdenv.mkDerivation rec {
   pname = "jackett";
-  version = "0.11.751";
+  version = "0.12.907";
 
   src = fetchurl {
     url = "https://github.com/Jackett/Jackett/releases/download/v${version}/Jackett.Binaries.Linux${arch}.tar.gz";
     sha256 = with stdenv.hostPlatform;
-             if isAarch64 then "1qidc8qx4jhxvls304w61pypg74m0vw22bp9hacrdd901an8fjcw"
-             else if isAarch32 then "1sgl3nxbh97xl2781m6yz3pw8j278anxkg5hczp0bk97a10g4cd7"
-             else "09y9pck35pj2g89936zallxr3hanmbgp8jc42nj2js68l0z64qz3";
+             if isAarch64 then "10vv8lf4gz4xm8862fhwvv6v06ycc7xl7pcqz2cf0mfq1l1xailq"
+             else if isAarch32 then "0547m70lxdpxgmid9z4la9a9w51d0d0xnavw1jk7vplzrv7y2i8z"
+             else "0f88zjd8abkr72sjbzm51npxsjbk6xklfqd7iyaq3j0l5hxh6b8w";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Support for ARM binary

close  #71620

I don't know how to test the arm build as I don't have an arm machine on hand

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))  (only x86-linux)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
