### PR TITLE
qscintilla: Fix qt4 build

### DIFF
--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
 
-  patches = lib.optional (stdenv.isDarwin && withQt5) [ xcodePatch ];
+  patches = (lib.optional (stdenv.isDarwin && withQt5) xcodePatch) ++
+            (lib.optional (!withQt5) ./fix-qt4-build.patch );
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/qscintilla/fix-qt4-build.patch
+++ b/pkgs/development/libraries/qscintilla/fix-qt4-build.patch
@@ -1,0 +1,11 @@
+diff -ur QScintilla_gpl-2.11.2/Qt4Qt5/Qsci/qsciscintillabase.h QScintilla_gpl-2.11.2-fix/Qt4Qt5/Qsci/qsciscintillabase.h
+--- Qt4Qt5/Qsci/qsciscintillabase.h	2019-06-25 14:49:27.000000000 +0200
++++ Qt4Qt5-fix/Qsci/qsciscintillabase.h	2019-10-04 10:22:26.337474261 +0200
+@@ -27,6 +27,7 @@
+ #include <QByteArray>
+ #include <QPoint>
+ #include <QTimer>
++#include <QUrl>
+ 
+ #include <Qsci/qsciglobal.h>
+ 

--- a/pkgs/development/libraries/qscintilla/fix-qt4-build.patch
+++ b/pkgs/development/libraries/qscintilla/fix-qt4-build.patch
@@ -1,7 +1,7 @@
-diff -ur QScintilla_gpl-2.11.2/Qt4Qt5/Qsci/qsciscintillabase.h QScintilla_gpl-2.11.2-fix/Qt4Qt5/Qsci/qsciscintillabase.h
---- Qt4Qt5/Qsci/qsciscintillabase.h	2019-06-25 14:49:27.000000000 +0200
-+++ Qt4Qt5-fix/Qsci/qsciscintillabase.h	2019-10-04 10:22:26.337474261 +0200
-@@ -27,6 +27,7 @@
+diff -ur QScintilla_gpl-2.9.4/Qt4Qt5/Qsci/qsciscintillabase.h QScintilla_gpl-2.9.4-fix/Qt4Qt5/Qsci/qsciscintillabase.h
+--- QScintilla_gpl-2.9.4/Qt4Qt5/Qsci/qsciscintillabase.h	2016-12-25 23:01:54.000000000 +0100
++++ QScintilla_gpl-2.9.4-fix/Qt4Qt5/Qsci/qsciscintillabase.h	2019-10-22 09:07:55.429260135 +0200
+@@ -31,6 +31,7 @@
  #include <QByteArray>
  #include <QPoint>
  #include <QTimer>


### PR DESCRIPTION
Backport of #70391

###### Motivation for this change
Make applications that need qscintilla and qt4 available on release 19.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip -s -b release-19.09"`
  - not quite sure what to make of the result (see below)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peterhoeg

#### `nix-review` output

<details><summary>terminal output (click to expand)</summary>

```
$ git fetch --force https://github.com/NixOS/nixpkgs release-19.09:refs/nix-review/0
$ git worktree add /home/das-g/.cache/nix-review/rev-02351ddb3a528383f7e42bc4b0eda9f2f631c525-dirty-5/nixpkgs 02351ddb3a528383f7e42bc4b0eda9f2f631c525
Preparing worktree (detached HEAD 02351ddb3a5)
HEAD is now at 02351ddb3a5 Merge pull request #71600 from aanderse/zabbix
$ nix-env -f /home/das-g/.cache/nix-review/rev-02351ddb3a528383f7e42bc4b0eda9f2f631c525-dirty-5/nixpkgs -qaP --xml --out-path --show-trace
Applying `nixpkgs` diff...
<stdin>:36: trailing whitespace.
 
<stdin>:38: trailing whitespace.
 
<stdin>:38: new blank line at EOF.
+
warning: 3 lines add whitespace errors.
$ nix-env -f /home/das-g/.cache/nix-review/rev-02351ddb3a528383f7e42bc4b0eda9f2f631c525-dirty-5/nixpkgs -qaP --xml --out-path --show-trace --meta
$ nix build --no-link --keep-going --max-jobs 8 --option build-use-sandbox true -f /home/das-g/.cache/nix-review/rev-02351ddb3a528383f7e42bc4b0eda9f2f631c525-dirty-5/build.nix
warning: ignoring the user-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
builder for '/nix/store/8y51iagi8zrm6kw6415yk9mzh4zsc6jb-octave-4.3.0pre23269.drv' failed with exit code 2; last 10 log lines:
  updating oct-tex-parser.tab.cc
  updating oct-tex-parser.tab.hh
  /nix/store/p6yrqh9awh62n8h1dihim6463fkkd8aw-gnused-4.7/bin/sed: can't read libinterp/corefcn/oct-tex-parser.cc-t: No such file or directory
  make: *** [Makefile:30454: libinterp/corefcn/oct-tex-parser.h] Error 2
  make: *** Waiting for unfinished jobs....
  updating oct-parse.output
  updating oct-parse.tab.cc
  updating oct-parse.tab.hh
  /nix/store/p6yrqh9awh62n8h1dihim6463fkkd8aw-gnused-4.7/bin/sed: can't read libinterp/parse-tree/oct-parse.cc-t: No such file or directory
  make: *** [Makefile:30454: libinterp/parse-tree/oct-parse.h] Error 2
cannot build derivation '/nix/store/85n5br9l0pn4b9yfyl9cwgrs37f81dgq-env.drv': 1 dependencies couldn't be built
[0 built (1 failed)]
error: build of '/nix/store/85n5br9l0pn4b9yfyl9cwgrs37f81dgq-env.drv' failed
1 package failed to build:
octaveHg

7 package were build:
minc_widgets octave octaveFull python27Packages.qscintilla qscintilla sqliteman tortoisehg

$ nix-shell /home/das-g/.cache/nix-review/rev-02351ddb3a528383f7e42bc4b0eda9f2f631c525-dirty-5/shell.nix

```

</details>

##### questions about `nix-review` output

* How can a patch that adds just one line have "3 lines" that "add whitespace errors"?
* Was `octaveHg` broken independently? Should it be marked as `broken`?
* Do I have to worry about `warning: ignoring the user-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user`?