### PR TITLE
clojure: 1.10.1.469 -> 1.10.1.478

### DIFF
--- a/pkgs/development/interpreters/clojure/default.nix
+++ b/pkgs/development/interpreters/clojure/default.nix
@@ -2,25 +2,23 @@
 
 stdenv.mkDerivation rec {
   pname = "clojure";
-  version = "1.10.1.469";
+  version = "1.10.1.478";
 
   src = fetchurl {
     url = "https://download.clojure.org/install/clojure-tools-${version}.tar.gz";
-    sha256 = "0hpb6rixmgllss69vl9zlpb41svm4mx4xmfbq1q7y12jsxckzgpq";
+    sha256 = "0q30pxbrmapb1vv0abyagkfnm29h975wki3x94nmdrasxlgz6jac";
   };
 
   buildInputs = [ makeWrapper ];
 
-  outputs = [ "out" "prefix" ];
-
   installPhase = let
     binPath = stdenv.lib.makeBinPath [ rlwrap jdk11 ];
   in ''
-    mkdir -p $prefix/libexec
-    cp clojure-tools-${version}.jar $prefix/libexec
-    cp example-deps.edn $prefix
+    mkdir -p $out/libexec
+    cp clojure-tools-${version}.jar $out/libexec
+    cp example-deps.edn $out
 
-    substituteInPlace clojure --replace PREFIX $prefix
+    substituteInPlace clojure --replace PREFIX $out
 
     install -Dt $out/bin clj clojure
     wrapProgram $out/bin/clj --prefix PATH : $out/bin:${binPath}


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Updates clojure and removes the `prefix` output, since it is not really necessary.
cc @yegortimoshenko since the `prefix` output was introduced in #35140, could you confirm if it looks good to you? or am I missing something?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

