### PR TITLE
pipenv: fix dependencies

### DIFF
--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonApplication
-, flake8
+, certifi
+, setuptools
 , invoke
 , parver
 , pip
@@ -21,22 +22,17 @@ buildPythonApplication rec {
 
   LC_ALL = "en_US.UTF-8";
 
+  nativeBuildInputs = [ invoke parver ];
+
   propagatedBuildInputs = [
-    flake8
-    invoke
-    parver
+    certifi
+    setuptools
     pip
-    requests
     virtualenv
     virtualenv-clone
   ];
 
   doCheck = false;
-
-  makeWrapperArgs = [
-    "--set PYTHONPATH \".:$PYTHONPATH\""
-    "--set PIP_IGNORE_INSTALLED 1"
-  ];
 
   meta = with lib; {
     description = "Python Development Workflow for Humans";


### PR DESCRIPTION
- setup_requires belong in nativeBuildInputs
- requests is only for Python 2. We offer only a Python 3 version of
pipenv
- setting PYTHONPATH is not needed because the magical sed expression
injects the dependencies in the executables. Otherwise, we would use
NIX_PYTHONPATH.
- PIP_IGNORE_INSTALLED was needed because of PYTHONPATH, but since we do
not set that anymore we can remove.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes #71110

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @berdario 
