### PR TITLE
srt: Fix wrong `srt.pc` include path

### DIFF
--- a/pkgs/development/libraries/srt/default.nix
+++ b/pkgs/development/libraries/srt/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ openssl ];
 
   cmakeFlags = [
+    # the cmake package does not handle absolute CMAKE_INSTALL_INCLUDEDIR correctly
+    # (setting it to an absolute path causes include files to go to $out/$out/include,
+    #  because the absolute path is interpreted with root at $out).
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
     # TODO Remove this when https://github.com/Haivision/srt/issues/538 is fixed and available to nixpkgs
     # Workaround for the fact that srt incorrectly disables GNUInstallDirs when LIBDIR is specified,
     # see https://github.com/NixOS/nixpkgs/pull/54463#discussion_r249878330


### PR DESCRIPTION
###### Motivation for this change

Fixes #70872.

Fix copied from:

https://github.com/NixOS/nixpkgs/blob/1230fc8674439df5a90fe4c1ea740256ef9906e4/pkgs/development/compilers/hhvm/default.nix#L41-L44

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nh2

FYI @j0sh
