### PR TITLE
python3Packages.minio: 4.0.17 -> 5.0.1

### DIFF
--- a/pkgs/development/python-modules/minio/default.nix
+++ b/pkgs/development/python-modules/minio/default.nix
@@ -1,19 +1,18 @@
 { lib, buildPythonPackage, isPy3k, fetchPypi
-, urllib3, python-dateutil , pytz, faker, mock, nose }:
+, urllib3, python-dateutil , pytz, faker, mock, nose, future }:
 
 buildPythonPackage rec {
   pname = "minio";
-  version = "4.0.21";
+  version = "5.0.1";
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "35643f056b4d12e053fa7d8f40d98394ed7cc4d5d44ba53c9971e7428fd58e60";
+    sha256 = "0dgpw21gb6q7d2i9nkzqbxsiqpxzj95b20yb08rwmpsh0z5a2ywg";
   };
 
-  disabled = !isPy3k;
-
+  propagatedBuildInputs = [ future urllib3 python-dateutil pytz ];
   checkInputs = [ faker mock nose ];
-  propagatedBuildInputs = [ urllib3 python-dateutil pytz ];
 
   meta = with lib; {
     description = "Simple APIs to access any Amazon S3 compatible object storage server";


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken while reviewing another PR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

3 broken on master
```
https://github.com/NixOS/nixpkgs/pull/71683
1 package failed to build:
python37Packages.rl-coach

2 package were build:
python37Packages.minio python38Packages.minio
```
```
[08:39:47] jon@jon-desktop /home/jon/projects/nixpkgs (master)
$ nix build -f . --keep-going python37Packages.rl-coach python38Packages.minio python38Packages.rl-coach
...
[0 built (7 failed), 1 copied (0.3 MiB), 0.1 MiB DL]
error: build of '/nix/store/f0nkd6bwb2bihy17dhygdx6jy44c71qk-python3.8-minio-4.0.17.drv', '/nix/store/vszpq77l9sd5pz56jcvagpkngdh7lai8-python3.7-rl-coach-0.12.1.drv', '/nix/store/x42alxim9nrv0j64p4mi7a8rwigbhkfy-python3.8-rl-coach-0.12.1.drv' failed
```