### PR TITLE
sqlite: 3.28.0 backport fix for CVE-2019-16168

### DIFF
--- a/pkgs/development/libraries/sqlite/cve_2019_16168.patch
+++ b/pkgs/development/libraries/sqlite/cve_2019_16168.patch
@@ -1,0 +1,26 @@
+This fix is based on https://www.sqlite.org/src/vpatch?from=4f5b2d938194fab7&to=98357d8c1263920b
+and is adapted to the "amalgamated" source release.
+
+It addresses https://nvd.nist.gov/vuln/detail/CVE-2019-16168
+
+--- a/sqlite3.c	2019-07-10 20:07:04.000000000 +0200
++++ b/sqlite3.c	2019-10-17 13:51:00.899376230 +0200
+@@ -105933,7 +105933,9 @@
+       if( sqlite3_strglob("unordered*", z)==0 ){
+         pIndex->bUnordered = 1;
+       }else if( sqlite3_strglob("sz=[0-9]*", z)==0 ){
+-        pIndex->szIdxRow = sqlite3LogEst(sqlite3Atoi(z+3));
++        int sz = sqlite3Atoi(z+3);
++        if( sz<2 ) sz = 2;
++        pIndex->szIdxRow = sqlite3LogEst(sz);
+       }else if( sqlite3_strglob("noskipscan*", z)==0 ){
+         pIndex->noSkipScan = 1;
+       }
+@@ -143260,6 +143262,7 @@
+     ** it to pNew->rRun, which is currently set to the cost of the index
+     ** seek only. Then, if this is a non-covering index, add the cost of
+     ** visiting the rows in the main table.  */
++    assert( pSrc->pTab->szTabRow>0 );
+     rCostIdx = pNew->nOut + 1 + (15*pProbe->szIdxRow)/pSrc->pTab->szTabRow;
+     pNew->rRun = sqlite3LogEstAdd(rLogSize, rCostIdx);
+     if( (pNew->wsFlags & (WHERE_IDX_ONLY|WHERE_IPK))==0 ){

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -23,6 +23,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib ] ++ optionals interactive [ readline ncurses ];
 
+  patches = [
+    # CVE-2019-16168: backported patch for a division by zero caused crash
+    # Once we can upgrade to >= 3.30 this should be removed.
+    ./cve_2019_16168.patch
+  ];
+
   configureFlags = [ "--enable-threadsafe" ] ++ optional interactive "--enable-readline";
 
   NIX_CFLAGS_COMPILE = [


### PR DESCRIPTION
###### Motivation for this change

This is a manually backported patch for a crash induced by a division by
zero. The patch had to be manually adopted to the "amalgamated" source
release.

Related: https://github.com/NixOS/nixpkgs/pull/70593
Addresses https://github.com/NixOS/nixpkgs/issues/68583 for 19.09

I'm suggesting this for 19.09 so that we don't have to bump versions.
Fix was manually verified using: https://www.sqlite.org/src/info/e4598ecbdd18bd82945f6029013296690e719a62

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh 
