### PR TITLE
coqPackages.coq-bits: init at 20190812

### DIFF
--- a/pkgs/development/coq-modules/coq-bits/default.nix
+++ b/pkgs/development/coq-modules/coq-bits/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, coq, mathcomp-algebra }:
+
+let
+  version = "20190812";
+in
+
+stdenv.mkDerivation {
+  name = "coq${coq.coq-version}-coq-bits-${version}";
+
+  src = fetchFromGitHub {
+    owner = "coq-community";
+    repo = "coq-bits";
+    rev = "f74498a6c67e97d9565e139d62be8eaae7111f06";
+    sha256 = "1ibg37qxgkmpbpvc78qcb179bcnzl149z1kzwdm8n98xk5ibavrf";
+  };
+
+  buildInputs = [ coq ];
+  propagatedBuildInputs = [ mathcomp-algebra ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    make -f Makefile CoqMakefile
+    make -f CoqMakefile COQLIB=$out/lib/coq/${coq.coq-version}/ install
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/coq-community/coq-bits;
+    description = "A formalization of bitset operations in Coq";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ptival ];
+    platforms = coq.meta.platforms;
+  };
+
+  passthru = {
+    compatibleCoqVersions = v: builtins.elem v [ "8.7" "8.8" "8.9" "8.10" ];
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -16,6 +16,7 @@ let
       category-theory = callPackage ../development/coq-modules/category-theory { };
       Cheerios = callPackage ../development/coq-modules/Cheerios {};
       CoLoR = callPackage ../development/coq-modules/CoLoR {};
+      coq-bits = callPackage ../development/coq-modules/coq-bits {};
       coq-elpi = callPackage ../development/coq-modules/coq-elpi {};
       coq-ext-lib = callPackage ../development/coq-modules/coq-ext-lib {};
       coq-extensible-records = callPackage ../development/coq-modules/coq-extensible-records {};


### PR DESCRIPTION
###### Motivation for this change
Adding a bit library to the Coq packages.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
