### PR TITLE
pythonPackage.jsonlines: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/jsonlines/default.nix
+++ b/pkgs/development/python-modules/jsonlines/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub, buildPythonPackage, six
+, flake8, pep8-naming, pytest, pytestcov, pytestpep8 }:
+
+buildPythonPackage rec {
+  pname = "jsonlines";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "wbolster";
+    repo = pname;
+    rev = version;
+    sha256 = "1f8zsqy8p9a41gqg2a5x7sppc5qhhq7gw58id2aigb270yxzs7jw";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ flake8 pep8-naming pytest pytestcov pytestpep8 ];
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Python library to simplify working with jsonlines and ndjson data";
+    homepage = https://github.com/wbolster/jsonlines;
+    maintainers = with maintainers; [ sondr3 ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1937,6 +1937,8 @@ in {
 
   impacket = callPackage ../development/python-modules/impacket { };
 
+  jsonlines = callPackage ../development/python-modules/jsonlines { };
+
   jsonrpc-async = callPackage ../development/python-modules/jsonrpc-async { };
 
   jsonrpc-base = callPackage ../development/python-modules/jsonrpc-base { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
