### PR TITLE
 EZminc: 2017-08-29 -> 2019-07-25; unbreak ezminc and pyezminc

### DIFF
--- a/pkgs/applications/science/biology/EZminc/default.nix
+++ b/pkgs/applications/science/biology/EZminc/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, fetchFromGitHub, cmake, libminc, bicpl, itk, fftwFloat, gsl }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, libminc, bicpl, itk, fftwFloat, gsl }:
 
-stdenv.mkDerivation rec { pname = "EZminc";
-  name  = "${pname}-2017-08-29";
+stdenv.mkDerivation rec {
+  pname = "EZminc";
+  name  = "${pname}-unstable-2019-07-25";
 
   src = fetchFromGitHub {
     owner  = "BIC-MNI";
     repo   = pname;
-    rev    = "4e017236cb6e7f6e07507446b18b759c584b6fc3";
-    sha256 = "1pg06x42pgsg7zy7dz9wf6ajakkm2n8by64lg9z64qi8qqy82b8v";
+    rev    = "9591edd5389a5bda2c1f606816c7cdb35c065adf";
+    sha256 = "02k87qbpx0f48l2lbcjmlqx82py684z3sfi29va5icfg3hjd6j7b";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ itk libminc bicpl fftwFloat gsl ];
 
   cmakeFlags = [ "-DLIBMINC_DIR=${libminc}/lib/"
@@ -26,6 +27,5 @@ stdenv.mkDerivation rec { pname = "EZminc";
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;
     license = licenses.free;
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/pyezminc/default.nix
+++ b/pkgs/development/python-modules/pyezminc/default.nix
@@ -29,6 +29,5 @@ buildPythonPackage rec {
     description = "Python API for libminc using EZMINC";
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ bcdarwin ];
-    broken = true;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix these packages for ZHF (https://github.com/NixOS/nixpkgs/issues/68361).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
