### PR TITLE
elastix: 4.9.0 -> 5.0.0 (and mark unbroken)

### DIFF
--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, cmake, itk, python }:
+{ stdenv, fetchFromGitHub, cmake, itk, python }:
 
 stdenv.mkDerivation rec {
   pname    = "elastix";
-  pversion = "4.9.0";
-  name  = "${pname}-${pversion}";
+  version = "5.0.0";
 
-  src = fetchurl {
-    url    = "https://github.com/SuperElastix/${pname}/archive/${pversion}.tar.gz";
-    sha256 = "02pbln36nq98xxfyqwlxg7b6gmigdq4fgfqr9mym1qn58aj04shg";
+  src = fetchFromGitHub {
+    owner  = "SuperElastix";
+    repo   = pname;
+    rev    = version;
+    sha256 = "1zrl7rz4lwsx88b2shnl985f3a97lmp4ksbd437h9y0hfjq8l0lj";
   };
-
   nativeBuildInputs = [ cmake python ];
   buildInputs = [ itk ];
 
@@ -19,6 +19,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.linux;
     license = licenses.asl20;
-    broken = true;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

For ZHF (#68361).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
