### PR TITLE
pythonPackages.apsw: 3.22.0-r1 -> 3.29.0-r1 + sqlite fix

### DIFF
--- a/pkgs/development/python-modules/apsw/default.nix
+++ b/pkgs/development/python-modules/apsw/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub
+{ stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch
 , sqlite, isPyPy }:
 
 buildPythonPackage rec {
   pname = "apsw";
-  version = "3.22.0-r1";
+  version = "3.29.0-r1";
 
   disabled = isPyPy;
 
@@ -11,10 +11,18 @@ buildPythonPackage rec {
     owner = "rogerbinns";
     repo = "apsw";
     rev = version;
-    sha256 = "02ldvshcgr4c7c8anp4flfnw8g8ys5bflkb8b51rb618qxhhwyak";
+    sha256 = "1p3sgmk9qwd0a634lirva44qgpyq0a74r9d70wxb6hsa52yjj9xb";
   };
 
   buildInputs = [ sqlite ];
+
+  patches = [
+    # Fixes a test failure with sqlite 3.30, see https://github.com/rogerbinns/apsw/issues/275
+    (fetchpatch {
+      url = "https://github.com/rogerbinns/apsw/commit/13df0b57bff59542978abf7c0a440c9274e3aac3.diff";
+      sha256 = "1wi1mfis2mr21389wdnvq44phg0bpm5vpwmxhvrj211vwfm0q7dv";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "A Python wrapper for the SQLite embedded relational database engine";


### PR DESCRIPTION
###### Motivation for this change

Bumping version of apsw to be able to backport an upstream fix for
SQLite >= 3.30.0 which fixes a failing test.

Proposing this for staging, as the sqlite bump and sqlalchemy fix are on it too.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh  @dtzWill 
