### PR TITLE
users-groups: fix typo

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -251,7 +251,7 @@ let
         default = [];
         example = literalExample "[ pkgs.firefox pkgs.thunderbird ]";
         description = ''
-          The set of packages that should be made availabe to the user.
+          The set of packages that should be made available to the user.
           This is in contrast to <option>environment.systemPackages</option>,
           which adds packages to all users.
         '';


### PR DESCRIPTION
Fix typo in the ``users.users.<name>.packages`` option description.

No tests/confirmations run because just a one-word typo fix in documentation.