### PR TITLE
pythonPackages.missingno: init at 0.4.2

### DIFF
--- a/pkgs/development/python-modules/missingno/default.nix
+++ b/pkgs/development/python-modules/missingno/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, matplotlib
+, scipy
+, seaborn
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "missingno";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "ResidentMario";
+    repo = pname;
+    rev = version;
+    sha256 = "0wxhj7qm2fcaiprdjfrx9p8nikc10qhivf7rzwi04r6mrzyi0i9x";
+  };
+
+  propagatedBuildInputs = [
+    matplotlib
+    scipy
+    seaborn
+  ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+  pytest tests/util_tests.py -k 'not cutoff'
+  '';
+
+  meta = with lib; {
+    description = "Missing data visualization module for Python.";
+    homepage = https://github.com/ResidentMario/missingno;
+    maintainers = with maintainers; [ melsigl ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2602,6 +2602,8 @@ in {
 
   misaka = callPackage ../development/python-modules/misaka {};
 
+  missingno = callPackage ../development/python-modules/missingno { };
+
   mlrose = callPackage ../development/python-modules/mlrose { };
 
   mt-940 = callPackage ../development/python-modules/mt-940 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
`missingno` is an easy to use Python package for data visualization, especially regarding messy data with missing vlaues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
