### PR TITLE
nixos/wireguard: allow setting a readable name for peers

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -122,6 +122,12 @@ let
 
     options = {
 
+      name = mkOption {
+        default = null;
+        type = with types; nullOr str;
+        description = "An optional name for the peer.";
+      };
+
       publicKey = mkOption {
         example = "xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=";
         type = types.str;
@@ -231,17 +237,18 @@ let
 
   generatePeerUnit = { interfaceName, interfaceCfg, peer }:
     let
+      name = if peer.name != null then peer.name else peer.publicKey;
       keyToUnitName = replaceChars
         [ "/" "-"    " "     "+"     "="      ]
         [ "-" "\\x2d" "\\x20" "\\x2b" "\\x3d" ];
-      unitName = keyToUnitName peer.publicKey;
+      unitName = keyToUnitName name;
       psk =
         if peer.presharedKey != null
           then pkgs.writeText "wg-psk" peer.presharedKey
           else peer.presharedKeyFile;
     in nameValuePair "wireguard-${interfaceName}-peer-${unitName}"
       {
-        description = "WireGuard Peer - ${interfaceName} - ${peer.publicKey}";
+        description = "WireGuard Peer - ${interfaceName} - ${name}";
         requires = [ "wireguard-${interfaceName}.service" ];
         after = [ "wireguard-${interfaceName}.service" ];
         wantedBy = [ "multi-user.target" "wireguard-${interfaceName}.service" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Makes the systemd unit names more easily mappable to what peer they correspond to (I don't memorize peer public keys :-) ).

```
stopping the following units: wireguard-wg-peer-1PLQcx\x2beVLgRwN6e7fim53rHQXB7pjIg6okOe2nFoi8\x3d.service, wireguard-wg-peer-aN5nU\x2bdNxgemk2Al9lZvSLyYl4kfrx\x2bfxnOPzgbaemg\x3d.service, wireguard-wg-peer-it4vdCJjH5PlpJjdcg4WIwneDmOfqy5fgM0X7tbOfxw\x3d.service, wireguard-wg-peer-jR5rxDnjobcNpiVP62-LLZpvuwYh3BotSYRdw8CdwFI\x3d.service, wireguard-wg-peer-tC\x2bMMRRM50Y5NkD7DJQny7TNwefdl41-J\x2bjsHHnszVU\x3d.service, wireguard-wg-peer-vllG0namXqtwo2xZ1q-oZ-\x2buGGWFvro3Pam2V3N1eW4\x3d.service
the following new units were started: wireguard-wg-peer-chaos.service, wireguard-wg-peer-duke.service, wireguard-wg-peer-eden.service, wireguard-wg-peer-lowell.service, wireguard-wg-peer-pixel.service, wireguard-wg-peer-yew.service
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

