### PR TITLE
pythonPackages.twisted: disable for python2

### DIFF
--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , python
+, isPy27
 , zope_interface
 , incremental
 , automat
@@ -14,9 +15,11 @@
 , setuptools
 , idna
 }:
+
 buildPythonPackage rec {
   pname = "Twisted";
   version = "18.9.0";
+  disabled = isPy27; # zope_interface namespace collision
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change
zone_interface is now a namespace package and python2
can't load an environemtn without collisions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
