### PR TITLE
mariadb-connector-c: 3.1.2 -> 3.1.4

### DIFF
--- a/pkgs/servers/sql/mariadb/connector-c/3_1.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/3_1.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./. (args // {
-  version = "3.1.2";
-  sha256 = "0pgz8m8d39mvj9wnjll6c83xvdl2h24273b3dkx0g5pxj7ga4shm";
+  version = "3.1.4";
+  sha256 = "05jkaq151a45rqpyh0vrn6xcpawayfxyzhwn1w32hk0fw3z746ks";
 })

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -19,9 +19,10 @@ stdenv.mkDerivation {
   };
 
   cmakeFlags = [
-    "-DWITH_EXTERNAL_ZLIB=ON"
     "-DMARIADB_UNIX_ADDR=/run/mysqld/mysqld.sock"
     "-DWITH_CURL=ON"
+    "-DWITH_EXTERNAL_ZLIB=ON"
+    "-DWITH_MYSQLCOMPAT=ON"
   ];
 
   # The cmake setup-hook uses $out/lib by default, this is not the case here.
@@ -39,10 +40,6 @@ stdenv.mkDerivation {
     ln -sv mariadb_config $out/bin/mysql_config
     ln -sv mariadb $out/lib/mysql
     ln -sv mariadb $out/include/mysql
-    ln -sv libmariadbclient.a $out/lib/mariadb/libmysqlclient.a
-    ln -sv libmariadbclient.a $out/lib/mariadb/libmysqlclient_r.a
-    ln -sv libmariadb.so $out/lib/mariadb/libmysqlclient.so
-    ln -sv libmariadb.so $out/lib/mariadb/libmysqlclient_r.so
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
Update connector-c to v3.1.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
