### PR TITLE
pipenv: add back wrapper

### DIFF
--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -33,6 +33,10 @@ buildPythonApplication rec {
   ];
 
   doCheck = false;
+  makeWrapperArgs = [
+    "--set PYTHONPATH \".:$PYTHONPATH\""
+    "--set PIP_IGNORE_INSTALLED 1"
+  ];
 
   meta = with lib; {
     description = "Python Development Workflow for Humans";

--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -1,17 +1,18 @@
 { lib
-, buildPythonApplication
-, certifi
-, setuptools
-, invoke
-, parver
-, pip
-, requests
-, virtualenv
-, fetchPypi
-, virtualenv-clone
+, python3
 }:
 
-buildPythonApplication rec {
+with python3.pkgs;
+
+let
+  runtimeDeps = [
+    certifi
+    setuptools
+    pip
+    virtualenv
+    virtualenv-clone
+  ];
+in buildPythonApplication rec {
   pname = "pipenv";
   version = "2018.11.26";
 
@@ -24,17 +25,11 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [ invoke parver ];
 
-  propagatedBuildInputs = [
-    certifi
-    setuptools
-    pip
-    virtualenv
-    virtualenv-clone
-  ];
+  propagatedBuildInputs = runtimeDeps;
 
   doCheck = false;
   makeWrapperArgs = [
-    "--set PYTHONPATH \".:$PYTHONPATH\""
+    "--set PYTHONPATH ${makePythonPath runtimeDeps}"
     "--set PIP_IGNORE_INSTALLED 1"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8999,7 +8999,7 @@ in
 
   pew = callPackage ../development/tools/pew {};
   poetry = with python3Packages; toPythonApplication poetry;
-  pipenv = python3Packages.callPackage ../development/tools/pipenv {};
+  pipenv = callPackage ../development/tools/pipenv {};
 
   pipewire = callPackage ../development/libraries/pipewire {};
 


### PR DESCRIPTION
Turns out that when creating a virtualenv, it ignores what has been injected
into `sys.path` with the magical sed expression. Also, `NIX_PYTHONPATH` is
not used.

Likely a subprocess is invoked in which case both are no longer visible.
That's the reason `PYTHONPATH` needs to be used.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @kaali
