### PR TITLE
v4l2loopback: 0.12.0 -> 0.12.2

### DIFF
--- a/pkgs/os-specific/linux/v4l2loopback/default.nix
+++ b/pkgs/os-specific/linux/v4l2loopback/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "v4l2loopback-${version}-${kernel.version}";
-  version = "0.12.0";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
     owner = "umlaeute";
     repo = "v4l2loopback";
     rev = "v${version}";
-    sha256 = "1rf8dvabksxb2sj14j32h7n7pw7byqfnpqs4m4afj3398y9y23c4";
+    sha256 = "1bcypfz5nlfmdm2a00yl7rgl0jh0g2nmwndxlsrblqclznhjilg2";
   };
 
   hardeningDisable = [ "format" "pic" ];


### PR DESCRIPTION
Fixes #71782.

```
v4l2loopback (0.12.2) unstable; urgency=medium

  [ wuweixin ]
  * Update README.md

  [ Theodore Cipicchio ]
  * Replace v4l2_get_timestamp with ktime_get_ts(64)

  [ IOhannes m zmölnig ]
  * Mention support for 5.0.0
  * Fix typo

 -- IOhannes m zmölnig (Debian/GNU) <umlaeute@debian.org>  Mon, 27 May 2019 20:32:08 +0200

v4l2loopback (0.12.1) unstable; urgency=medium

  [ IOhannes m zmölnig ]
  * Fix permission of source code files
  * Initialize variables
  * Use %u to print size_t
  * Improve coding style by removing unused variables
  * More coding style fixes
  * Use GStreamer-1.0 caps in the documentation
  * Gst1.0 compat for example-script
  * Protect VP9 and HEVC by #ifdef guards

  [ Andrii Danyleiko ]
  * Fix typo

  [ Kai Kang ]
  * Replace do_gettimeofday with v4l2_get_timestamp for linux-5 compat

 -- IOhannes m zmölnig (Debian/GNU) <umlaeute@debian.org>  Wed, 23 Jan 2019 21:59:29 +0100
```