### PR TITLE
openarena: add module and test

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6666,6 +6666,12 @@
     githubId = 178444;
     name = "Thomas Bereknyei";
   };
+  tomfitzhenry = {
+    email = "tom@tom-fitzhenry.me.uk";
+    github = "tomfitzhenry";
+    githubId = 61303;
+    name = "Tom Fitzhenry";
+  };
   tomsmeets = {
     email = "tom.tsmeets@gmail.com";
     github = "tomsmeets";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -321,6 +321,7 @@
   ./services/games/factorio.nix
   ./services/games/minecraft-server.nix
   ./services/games/minetest-server.nix
+  ./services/games/openarena.nix
   ./services/games/terraria.nix
   ./services/hardware/acpid.nix
   ./services/hardware/actkbd.nix

--- a/nixos/modules/services/games/openarena.nix
+++ b/nixos/modules/services/games/openarena.nix
@@ -1,0 +1,56 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.openarena;
+in
+{
+  options = {
+    services.openarena = {
+      enable = mkEnableOption "OpenArena";
+
+      openPorts = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to open firewall ports for OpenArena";
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''Extra flags to pass to <command>oa_ded</command>'';
+        example = [
+          "+set dedicated 2"
+          "+set sv_hostname 'My NixOS OpenArena Server'"
+          # Load a map. Mandatory for clients to be able to connect.
+          "+map oa_dm1"
+        ];
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall = mkIf cfg.openPorts {
+      allowedUDPPorts = [ 27960 ];
+    };
+
+    systemd.services.openarena = {
+      description = "OpenArena";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        DynamicUser = true;
+        StateDirectory = "openarena";
+        ExecStart = "${pkgs.openarena}/bin/openarena-server +set fs_basepath ${pkgs.openarena}/openarena-0.8.8 +set fs_homepath /var/lib/openarena ${concatStringsSep " " cfg.extraFlags}";
+        Restart = "on-failure";
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -201,6 +201,7 @@ in
   novacomd = handleTestOn ["x86_64-linux"] ./novacomd.nix {};
   nsd = handleTest ./nsd.nix {};
   nzbget = handleTest ./nzbget.nix {};
+  openarena = handleTest ./openarena.nix {};
   openldap = handleTest ./openldap.nix {};
   opensmtpd = handleTest ./opensmtpd.nix {};
   openssh = handleTest ./openssh.nix {};

--- a/nixos/tests/openarena.nix
+++ b/nixos/tests/openarena.nix
@@ -1,0 +1,36 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "openarena";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ tomfitzhenry ];
+  };
+
+  machine =
+    { pkgs, ... }:
+
+    { imports = [];
+      environment.systemPackages = with pkgs; [
+        socat
+      ];
+      services.openarena = {
+        enable = true;
+        extraFlags = [
+          "+set dedicated 2"
+          "+set sv_hostname 'My NixOS server'"
+          "+map oa_dm1"
+        ];
+      };
+    };
+
+  testScript =
+    ''
+      $machine->waitForUnit("openarena.service");
+      $machine->waitUntilSucceeds("ss --numeric --udp --listening | grep -q 27960");
+
+      # The log line containing 'resolve address' is last and only message that occurs after
+      # the server starts accepting clients.
+      $machine->waitUntilSucceeds("journalctl -u openarena.service | grep 'resolve address: dpmaster.deathmask.net'");
+
+      # Check it's possible to join the server.
+      $machine->succeed("echo -n -e '\\xff\\xff\\xff\\xffgetchallenge' | socat - UDP4-DATAGRAM:127.0.0.1:27960 | grep -q challengeResponse");
+    '';
+})

--- a/pkgs/games/openarena/default.nix
+++ b/pkgs/games/openarena/default.nix
@@ -25,9 +25,15 @@ stdenv.mkDerivation {
       patchelf --set-interpreter "${interpreter}" "${gameDir}/openarena.x86_64"
       makeWrapper "${gameDir}/openarena.x86_64" "$out/bin/openarena" \
         --prefix LD_LIBRARY_PATH : "${libPath}"
+      patchelf --set-interpreter "${interpreter}" "${gameDir}/oa_ded.x86_64"
+      makeWrapper "${gameDir}/oa_ded.x86_64" "$out/bin/openarena-server" \
+        --prefix LD_LIBRARY_PATH : "${libPath}"
     '' else ''
       patchelf --set-interpreter "${interpreter}" "${gameDir}/openarena.i386"
       makeWrapper "${gameDir}/openarena.i386" "$out/bin/openarena" \
+        --prefix LD_LIBRARY_PATH : "${libPath}"
+      patchelf --set-interpreter "${interpreter}" "${gameDir}/oa_ded.i386"
+      makeWrapper "${gameDir}/oa_ded.i386" "$out/bin/openarena-server" \
         --prefix LD_LIBRARY_PATH : "${libPath}"
     ''}
   '';


### PR DESCRIPTION
###### Motivation for this change

A new NIxOS module and test for running a dedicated OpenArena server.

Motivation is 🔫🚀💥, I suppose.

###### Things done

nix-build on the test passes. To observe the test failing, remove the "+map oa_dm1" flag, which will cause `openarena.service` to not respond to `getchallenge`.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

n/a