### PR TITLE
nixos/network: remove 99-main.network

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -99,6 +99,22 @@
      reconfiguring <literal>hostsdir</literal>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      The <literal>99-main.network</literal> file was removed. Maching all
+      network interfaces caused many breakages, see
+      <link xlink:href="https://github.com/NixOS/nixpkgs/pull/18962">#18962</link>
+        and <link xlink:href="https://github.com/NixOS/nixpkgs/pull/71106">#71106</link>.
+    </para>
+    <para>
+      We already don't support the global <link linkend="opt-networking.useDHCP">networking.useDHCP</link>,
+      <link linkend="opt-networking.defaultGateway">networking.defaultGateway</link> and
+      <link linkend="opt-networking.defaultGateway6">networking.defaultGateway6</link> options
+      if <link linkend="opt-networking.useNetworkd">networking.useNetworkd</link> is enabled,
+      but direct users to configure the per-device
+      <link linkend="opt-networking.interfaces">networking.interfaces.&lt;name&gt;.…</link> options.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -76,15 +76,6 @@ in
           };
       in mkMerge [ {
         enable = true;
-        networks."99-main" = (genericNetwork mkDefault) // {
-          # We keep the "broken" behaviour of applying this to all interfaces.
-          # In general we want to get rid of this workaround but there hasn't
-          # been any work on that.
-          # See the following issues for details:
-          # - https://github.com/NixOS/nixpkgs/issues/18962
-          # - https://github.com/NixOS/nixpkgs/issues/61629
-          matchConfig = mkDefault { Name = "*"; };
-        };
       }
       (mkMerge (forEach interfaces (i: {
         netdevs = mkIf i.virtual ({


### PR DESCRIPTION
Just maching all network interfaces caused many breakages, see #18962
and #71106.

We already don't support the global networking.useDHCP,
networking.defaultGateway(6) options if networking.useNetworkd is
enabled, but direct users to configure the per-device
networking.interfaces.<name?>.… options.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
