### PR TITLE
release-lib.nix: initialize pkgs for the currentSystem

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -6,7 +6,10 @@ with import ../lib;
 , configuration ? {}
 }:
 
-with import ../pkgs/top-level/release-lib.nix { inherit supportedSystems; };
+with import ../pkgs/top-level/release-lib.nix {
+  inherit supportedSystems;
+  system = "x86_64-linux";
+};
 
 let
 

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -7,7 +7,10 @@
   scrubJobs ? true
 }:
 
-with import ./release-lib.nix { inherit supportedSystems scrubJobs; };
+with import ./release-lib.nix {
+  inherit supportedSystems scrubJobs;
+  system = "x86_64-linux";
+};
 
 let
   nativePlatforms = all;

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -3,6 +3,8 @@
 , scrubJobs ? true
 , # Attributes passed to nixpkgs. Don't build packages marked as unfree.
   nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
+  # System used to evaluate the initial pkgs set.
+, system ? builtins.currentSystem
 }:
 
 let
@@ -11,7 +13,7 @@ in with lib;
 
 rec {
 
-  pkgs = packageSet (lib.recursiveUpdate { system = "x86_64-linux"; config.allowUnsupportedSystem = true; } nixpkgsArgs);
+  pkgs = packageSet (lib.recursiveUpdate { inherit system; config.allowUnsupportedSystem = true; } nixpkgsArgs);
   inherit lib;
 
 

--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -7,7 +7,10 @@
   supportedSystems ? [ "x86_64-linux" ]
 }:
 
-with import ./release-lib.nix {inherit supportedSystems; };
+with import ./release-lib.nix {
+  inherit supportedSystems;
+  system = "x86_64-linux";
+};
 with lib;
 
 let

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -5,7 +5,10 @@
 , supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 }:
 
-with import ./release-lib.nix { inherit supportedSystems; };
+with import ./release-lib.nix {
+  inherit supportedSystems;
+  system = "x86_64-linux";
+};
 
 {
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -19,7 +19,10 @@
 ,  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
-with import ./release-lib.nix { inherit supportedSystems scrubJobs nixpkgsArgs; };
+with import ./release-lib.nix {
+  inherit supportedSystems scrubJobs nixpkgsArgs;
+  system = "x86_64-linux";
+};
 
 let
 


### PR DESCRIPTION
Previously calling release-lib for only x86_64-darwin like:

```
  import ./release-lib.nix {
    supportedSystems = [ "x86_64-darwin" ];
  }
```

would still cause the packageSet to be evaluated for
x86_64-linux. This is annoying if you are evaluating this on
x86_64-darwin and your packageSet uses Import From Derivation to
produce a jobset. In that case you need to have a x86_64-linux build
machine configured in order to finish the evaluation.

This commit initializes `pkgs` for the currentSystem such that all IFD
derivations are build for the current system.

This shouldnt change anything for hydra.nixos.org since there
`builtins.currentSystem == "x86-64-linux"`.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
