### PR TITLE
 azure-cli: init at 2.0.76

### DIFF
--- a/pkgs/development/python-modules/azure-cosmos/default.nix
+++ b/pkgs/development/python-modules/azure-cosmos/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , lib
+, python
 , fetchPypi
 , six
 , requests
@@ -15,6 +16,10 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ six requests ];
+
+  postInstall = ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+  '';
 
   # requires an active Azure Cosmos service
   doCheck = false;

--- a/pkgs/development/python-modules/azure-functions-devops-build/default.nix
+++ b/pkgs/development/python-modules/azure-functions-devops-build/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, jinja2
+, msrest
+, vsts
+}:
+
+buildPythonPackage rec {
+  version = "0.0.22";
+  pname = "azure-functions-devops-build";
+
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = "azure-functions-devops-build";
+    # rev picked based on pypi release date
+    rev = "c8249670acc77333e3de8b21dec60faf7ecf0951";
+    sha256 = "1slc7jd92v9q1qg1yacnrpi2a7hi7iw61wzbzfd6wx9q63pw9yqi";
+  };
+
+  propagatedBuildInputs = [ jinja2 msrest vsts ];
+
+  # circular dependency with azure-cli-core
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Integrate Azure Functions with Azure DevOps. Specifically made for the Azure CLI";
+    homepage = "https://github.com/Azure/azure-functions-devops-build";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault/default.nix
@@ -1,5 +1,7 @@
 { lib
 , buildPythonPackage
+, python
+, isPy3k
 , fetchPypi
 , azure-common
 , azure-nspkg
@@ -25,6 +27,10 @@ buildPythonPackage rec {
     msrestazure
     cryptography
   ];
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-apimanagement/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-apimanagement/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.1.0";
+  pname = "azure-mgmt-apimanagement";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06bqqkn5mx127x1z7ycm6rl8ajxlrmrm2kcdpgkbl4baii1x6iax";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.apimanagement" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure API Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-appconfiguration/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-appconfiguration/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.1.0";
+  pname = "azure-mgmt-appconfiguration";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0z2f0rbv7drdxihny479bv80bnhgvx8gb2pr0jvbaslll6d6rxig";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.appconfiguration" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure App Configuration Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-applicationinsights/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-applicationinsights/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, python
 , fetchPypi
 , msrest
 , msrestazure
@@ -25,6 +26,11 @@ buildPythonPackage rec {
   ] ++ lib.optionals (!isPy3k) [
     azure-mgmt-nspkg
   ];
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-batchai/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-batchai/default.nix
@@ -24,6 +24,11 @@ buildPythonPackage rec {
     azure-mgmt-nspkg
   ];
 
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
+
   # has no tests
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-mgmt-billing/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-billing/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , msrestazure
 , azure-common
 , azure-mgmt-nspkg
@@ -8,26 +8,32 @@
 , isPy3k
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "azure-mgmt-billing";
   version = "0.2.0"; #pypi's 0.2.0 doesn't build ootb
 
-  src = fetchFromGitHub {
-    owner = "Azure";
-    repo = "azure-sdk-for-python";
-    rev = "ee5b47525d6c1eae3b1fd5f65b0421eab62a6e6f";
-    sha256 = "0xzdn7da5c3q5knh033vbsqk36vwbm75cx8vf10x0yj58krb4kn4";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1li2bcdwdapwwx7xbvgfsq51f2mrwm0qyzih8cjhszcah2rkpxw5";
+    extension = "zip";
   };
-
-  preBuild = ''
-    cd ./azure-mgmt-billing
-  '';
 
   propagatedBuildInputs = [
     msrestazure
     azure-common
     azure-mgmt-nspkg
   ];
+
+  preBuild = ''
+    rm azure_bdist_wheel.py
+    substituteInPlace setup.cfg \
+      --replace "azure-namespace-package = azure-mgmt-nspkg" ""
+  '';
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-botservice/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-botservice/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.2.0";
+  pname = "azure-mgmt-botservice";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10sxllwvybjlp35h5mjdxhkw2wzpl4b03i08p4jnv8cswrc8h7dj";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.botservice" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure API Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-consumption/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-consumption/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrestazure
 , azure-common
 , azure-mgmt-nspkg
@@ -21,6 +23,11 @@ buildPythonPackage rec {
     azure-common
     azure-mgmt-nspkg
   ];
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-containerregistry/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-containerregistry/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "2.8.0";
+  pname = "azure-mgmt-containerregistry";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "193k07a77z7bj61zn2gxvvfqi20cgxksvxp7if71bwsl1l2y2jxj";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.containerregistry" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure Container Registry Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-datalake-analytics/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-analytics/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrestazure
 , azure-common
 , azure-mgmt-datalake-nspkg
@@ -21,6 +23,12 @@ buildPythonPackage rec {
     azure-common
     azure-mgmt-datalake-nspkg
   ];
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/datalake/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-datalake-store/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-store/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrestazure
 , azure-common
 , azure-mgmt-datalake-nspkg
@@ -22,6 +24,12 @@ buildPythonPackage rec {
     azure-mgmt-datalake-nspkg
   ];
 
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/datalake/__init__.py
+  '';
+
   # has no tests
   doCheck = false;
 
@@ -29,6 +37,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Data Lake Store Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer mwilsoninsight ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-datamigration/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datamigration/default.nix
@@ -1,11 +1,12 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , msrestazure
 , azure-common
 , azure-mgmt-nspkg
-, isPy3k
 }:
 
 buildPythonPackage rec {
@@ -26,6 +27,11 @@ buildPythonPackage rec {
     azure-mgmt-nspkg
   ];
 
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
+
   # has no tests
   doCheck = false;
 
@@ -33,6 +39,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Data Migration Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer mwilsoninsight ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-deploymentmanager/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-deploymentmanager/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.1.0";
+  pname = "azure-mgmt-deploymentmanager";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gvh17bhfcpvr6w0nd06v482m8lqxchlk256w68agi2qnqw6v2ir";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.deploymentmanager" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure Deployment Manager Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-devtestlabs/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-devtestlabs/default.nix
@@ -1,11 +1,12 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , msrestazure
 , azure-common
 , azure-mgmt-nspkg
-, isPy3k
 }:
 
 buildPythonPackage rec {
@@ -26,6 +27,11 @@ buildPythonPackage rec {
     azure-mgmt-nspkg
   ];
 
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
+
   # has no tests
   doCheck = false;
 
@@ -33,6 +39,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure DevTestLabs Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer mwilsoninsight ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-dns/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-dns/default.nix
@@ -1,12 +1,12 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , msrestazure
 , azure-common
 , azure-mgmt-nspkg
-, python
-, isPy3k
 }:
 
 buildPythonPackage rec {
@@ -26,6 +26,11 @@ buildPythonPackage rec {
     azure-mgmt-nspkg
   ];
 
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
+
   # has no tests
   doCheck = false;
 
@@ -33,6 +38,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure DNS Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer mwilsoninsight ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-hdinsight/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-hdinsight/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "1.2.0";
+  pname = "azure-mgmt-hdinsight";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1yq9s7a2ch8j84af3hzj350jnjq5s3ysiqvmypvcb7vl6rkkd2lm";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.hdinsight" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure HDInsight Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-imagebuilder/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-imagebuilder/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.2.1";
+  pname = "azure-mgmt-imagebuilder";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mwlvy4x5nr3hsz7wdpdhpzwarzzwz4225bfpd68hr0pcjgzspky";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.imagebuilder" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure Image Builder Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , msrestazure
 , azure-common
@@ -24,6 +26,11 @@ buildPythonPackage rec {
     azure-mgmt-nspkg
   ];
 
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
+
   # has no tests
   doCheck = false;
 
@@ -31,6 +38,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure IoTHub Provisioning Services Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer mwilsoninsight ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-keyvault/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , msrestazure
 , azure-common
@@ -24,6 +26,11 @@ buildPythonPackage rec {
     azure-mgmt-nspkg
   ];
 
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
+
   # has no tests
   doCheck = false;
 
@@ -31,6 +38,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Key Vault Management Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ jonringer mwilsoninsight ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-kusto/azure-mgmt-apimanagement/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-kusto/azure-mgmt-apimanagement/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.1.0";
+  pname = "azure-mgmt-apimanagement";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06bqqkn5mx127x1z7ycm6rl8ajxlrmrm2kcdpgkbl4baii1x6iax";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.apimanagement" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure API Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-kusto/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-kusto/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.4.0";
+  pname = "azure-mgmt-kusto";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sx8f98206wccj0mbmb75c4wyhf57g3pnkhl9wn70lqzi9n4mk0b";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.kusto" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure Kusto Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-loganalytics/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-loganalytics/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , msrestazure
 , azure-common
@@ -23,6 +25,11 @@ buildPythonPackage rec {
     azure-common
     azure-mgmt-nspkg
   ];
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-managedservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-managedservices/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "1.0.0";
+  pname = "azure-mgmt-managedservices";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06ddfqriqlvwjsjhqka9r5vhshardyj9c10xgjissfkpqsgkkn7y";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.managedservices" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure Managed Services Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-maps/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-maps/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , msrestazure
 , azure-common
@@ -23,6 +25,11 @@ buildPythonPackage rec {
     azure-common
     azure-mgmt-nspkg
   ];
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-monitor/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-monitor/default.nix
@@ -1,11 +1,12 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , msrestazure
 , azure-common
 , azure-mgmt-nspkg
-, isPy3k
 }:
 
 buildPythonPackage rec {
@@ -25,6 +26,11 @@ buildPythonPackage rec {
   ] ++ lib.optionals (!isPy3k) [
     azure-mgmt-nspkg
   ];
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-msi/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-msi/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , msrestazure
 , azure-common
@@ -23,6 +25,11 @@ buildPythonPackage rec {
     azure-common
     azure-mgmt-nspkg
   ];
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-netapp/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-netapp/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.6.0";
+  pname = "azure-mgmt-netapp";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10ymvyj386z9bjdm2g1b5a4vfnn87ig2zm6xn2xddvbpy0jxnyfv";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.netapp" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure NetApp Files Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-privatedns/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-privatedns/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.1.0";
+  pname = "azure-mgmt-privatedns";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08wdvfkk8jh90m3l4nz7knd5vikgfvsx70lk7mkhcvl0xj6gv76j";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.privatedns" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure DNS Private Zones Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-relay/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-relay/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrestazure
 , azure-common
 , azure-mgmt-nspkg
@@ -21,6 +23,11 @@ buildPythonPackage rec {
     azure-common
     azure-mgmt-nspkg
   ];
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-security/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-security/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.3.0";
+  pname = "azure-mgmt-security";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0z766424783a6y5dp5ybxssb0bfzqb8kpa6zra8ccnbfg4fn478v";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.security" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure Security Center Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-servicefabric/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-servicefabric/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , msrestazure
 , azure-common
@@ -23,6 +25,11 @@ buildPythonPackage rec {
     azure-common
     azure-mgmt-nspkg
   ];
+
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+  '';
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/azure-mgmt-sqlvirtualmachine/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-sqlvirtualmachine/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.4.0";
+  pname = "azure-mgmt-sqlvirtualmachine";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1jxmikjvyxkwr8c9kn6xw8gvj9pajlk7y8111rq8fgkivwjq8wcm";
+    extension = "zip";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.mgmt.sqlvirtualmachine" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure SQL Virtual Machine Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-multiapi-storage/default.nix
+++ b/pkgs/development/python-modules/azure-multiapi-storage/default.nix
@@ -1,0 +1,36 @@
+{ lib, python, buildPythonPackage, fetchPypi, isPy27
+, azure-common
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  version = "0.2.4";
+  pname = "azure-multiapi-storage";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zqapc4dx6qd9bcim5fjykk3n1j84p85nwqyb876nb7qmqx9spig";
+  };
+
+  propagatedBuildInputs = [ azure-common msrest msrestazure ];
+
+  # fix namespace issues
+  postInstall = ''
+    rm $out/${python.sitePackages}/azure/__init__.py
+    rm $out/${python.sitePackages}/azure/multiapi/__init__.py
+  '';
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "azure.common" "azure.multiapi.storage" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure Storage Client Library for Python with multi API version support.";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/javaproperties/default.nix
+++ b/pkgs/development/python-modules/javaproperties/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, six
+, pytest
+, dateutil
+}:
+
+buildPythonPackage rec {
+  version = "0.5.2";
+  pname = "javaproperties";
+
+  src = fetchFromGitHub {
+    owner = "jwodder";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "14hrp94cjj44yldf3k71wbq88cmlf01dfadi53gcirnsa56ddz5d";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ dateutil pytest ];
+  checkPhase = ''
+    rm tox.ini
+    pytest -k 'not dumps and not time' --ignore=test/test_propclass.py
+  '';
+
+  meta = with lib; {
+    description = "Microsoft Azure API Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -18,7 +18,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.6.9";
+  version = "0.6.10";
   pname = "msrest";
 
   # no tests in PyPI tarball
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "Azure";
     repo = "msrest-for-python";
     rev = "v${version}";
-    sha256 = "0540dmxz90jsmwvd4q06cr1ficixknjk8q06f2dqcp06w92vnl8r";
+    sha256 = "1l08daq748lk8rwiv4jdlnmfl9mi7g1ln46gibhnd9xvrrjp0sdx";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/msrestazure/default.nix
+++ b/pkgs/development/python-modules/msrestazure/default.nix
@@ -12,7 +12,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.6.1";
+  version = "0.6.2";
   pname = "msrestazure";
 
   # Pypi tarball doesnt include tests
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "Azure";
     repo = "msrestazure-for-python";
     rev = "v${version}";
-    sha256 = "09swndz57131b8x57mzibnsr1sv0l80pk62p89q99gsd6mvc389c";
+    sha256 = "09qwdg4la4jwp5ibypdwsn7h8m2sh8c1kdxvffyxcjan50h14s04";
   };
 
   propagatedBuildInputs = [ adal msrest ];

--- a/pkgs/development/python-modules/portalocker/default.nix
+++ b/pkgs/development/python-modules/portalocker/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage
 , fetchPypi
 , lib
+, fetchpatch
 , sphinx
 , flake8
 , pytest
@@ -25,6 +26,13 @@ buildPythonPackage rec {
     pytestcov
     pytest-flakes
     pytestpep8
+  ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/WoLpH/portalocker/commit/7741925738c7e66ae9c4a0944a04b6a3088037d5.patch";
+      sha256 = "1g95rnfbnagkkk9qfzzd5346dl3clbgjnzr2wk09m0wphds7zd8z";
+    })
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/secure/default.nix
+++ b/pkgs/development/python-modules/secure/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, maya
+, requests
+}:
+
+buildPythonPackage rec {
+  version = "0.2.1";
+  pname = "secure";
+
+  src = fetchFromGitHub {
+    owner = "typeerror";
+    repo = "secure.py";
+    rev = "v${version}";
+    sha256 = "1nbxwi0zccrha6js14ibd596kdi1wpqr7jgs442mqclw4b3f77q5";
+  };
+
+  propagatedBuildInputs = [ maya requests ];
+
+  # no tests in release
+  doCheck = false;
+
+  pythonImportsCheck = [ "secure" ];
+
+  meta = with lib; {
+    description = "Adds optional security headers and cookie attributes for Python web frameworks";
+    homepage = "https://github.com/TypeError/secure.py";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/sshtunnel/default.nix
+++ b/pkgs/development/python-modules/sshtunnel/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi
+, paramiko
+, pytest
+, mock
+}:
+
+buildPythonPackage rec {
+  version = "0.1.5";
+  pname = "sshtunnel";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0jcjppp6mdfsqrbfc3ddfxg1ybgvkjv7ri7azwv3j778m36zs4y8";
+  };
+
+  propagatedBuildInputs = [ paramiko ];
+
+  checkInputs = [ pytest mock ];
+
+  # disable impure tests
+  checkPhase = ''
+    pytest -k 'not connect_via_proxy and not read_ssh_config'
+  '';
+
+  meta = with lib; {
+    description = "Pure python SSH tunnels";
+    homepage = "https://github.com/pahaz/sshtunnel";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/vsts-cd-manager/default.nix
+++ b/pkgs/development/python-modules/vsts-cd-manager/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, msrest
+, mock
+}:
+
+buildPythonPackage rec {
+  version = "1.0.2";
+  pname = "vsts-cd-manager";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ys4hrmjbxl4qr26qr3dhhs27yfwn1635vwjdqh1qgjmrmcr1c0b";
+  };
+
+  propagatedBuildInputs = [ msrest mock ];
+
+  # no tests included
+  doCheck = false;
+
+  pythonImportsCheck = [ "vsts_cd_manager" ];
+
+  meta = with lib; {
+    description = "Microsoft Azure API Management Client Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -1,0 +1,248 @@
+{ lib, python, fetchFromGitHub, installShellFiles }:
+
+let
+  version = "2.0.76";
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = "azure-cli";
+    rev = "azure-cli-${version}";
+    sha256 = "0zfy8nhw4nx0idh94qidr06vsfxgdk2ky0ih76s27121pdwr05aa";
+  };
+
+  # put packages that needs to be overriden in the py package scope
+  py = import ./python-packages.nix { inherit python lib src version; };
+in
+py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage {
+  pname = "azure-cli";
+  inherit version src;
+  disabled = python.isPy27; # namespacing assumes PEP420, which isn't compat with py2
+
+  sourceRoot = "source/src/azure-cli";
+
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "javaproperties==0.5.1" "javaproperties" \
+      --replace "pytz==2019.1" "pytz" \
+      --replace "mock~=2.0" "mock" \
+      --replace "azure-mgmt-reservations==0.3.1" "azure-mgmt-reservations~=0.3.1"
+
+    # remove namespace hacks
+    # remove urllib3 because it was added as 'urllib3[secure]', which doesn't get handled well
+    sed -i setup.py \
+      -e '/azure-cli-command_modules-nspkg/d' \
+      -e '/azure-cli-nspkg/d' \
+      -e '/urllib3/d'
+  '';
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  propagatedBuildInputs = with py.pkgs; [
+    azure-batch
+    azure-cli-core
+    azure-cli-telemetry
+    azure-cosmos
+    azure-datalake-store
+    azure-functions-devops-build
+    azure-graphrbac
+    azure-keyvault
+    azure-mgmt-advisor
+    azure-mgmt-apimanagement
+    azure-mgmt-applicationinsights
+    azure-mgmt-appconfiguration
+    azure-mgmt-authorization
+    azure-mgmt-batch
+    azure-mgmt-batchai
+    azure-mgmt-billing
+    azure-mgmt-botservice
+    azure-mgmt-cdn
+    azure-mgmt-cognitiveservices
+    azure-mgmt-compute
+    azure-mgmt-consumption
+    azure-mgmt-containerinstance
+    azure-mgmt-containerregistry
+    azure-mgmt-containerservice
+    azure-mgmt-cosmosdb
+    azure-mgmt-datalake-analytics
+    azure-mgmt-datalake-store
+    azure-mgmt-datamigration
+    azure-mgmt-deploymentmanager
+    azure-mgmt-devtestlabs
+    azure-mgmt-dns
+    azure-mgmt-eventgrid
+    azure-mgmt-eventhub
+    azure-mgmt-hdinsight
+    azure-mgmt-imagebuilder
+    azure-mgmt-iotcentral
+    azure-mgmt-iothub
+    azure-mgmt-iothubprovisioningservices
+    azure-mgmt-keyvault
+    azure-mgmt-kusto
+    azure-mgmt-loganalytics
+    azure-mgmt-managedservices
+    azure-mgmt-managementgroups
+    azure-mgmt-maps
+    azure-mgmt-marketplaceordering
+    azure-mgmt-media
+    azure-mgmt-monitor
+    azure-mgmt-msi
+    azure-mgmt-network
+    azure-mgmt-netapp
+    azure-mgmt-policyinsights
+    azure-mgmt-privatedns
+    azure-mgmt-rdbms
+    azure-mgmt-recoveryservices
+    azure-mgmt-recoveryservicesbackup
+    azure-mgmt-redis
+    azure-mgmt-relay
+    azure-mgmt-reservations
+    azure-mgmt-resource
+    azure-mgmt-search
+    azure-mgmt-security
+    azure-mgmt-servicebus
+    azure-mgmt-servicefabric
+    azure-mgmt-signalr
+    azure-mgmt-sql
+    azure-mgmt-sqlvirtualmachine
+    azure-mgmt-storage
+    azure-mgmt-trafficmanager
+    azure-mgmt-web
+    azure-multiapi-storage
+    azure-storage-blob
+    colorama
+    cryptography
+    Fabric
+    jsmin
+    knack
+    mock
+    paramiko
+    pydocumentdb
+    pygments
+    pyopenssl
+    pytz
+    pyyaml
+    psutil
+    requests
+    scp
+    six
+    sshtunnel
+    urllib3
+    vsts-cd-manager
+    websocket_client
+    xmltodict
+    javaproperties
+    jsondiff
+    # urllib3[secure]
+    ipaddress
+    # shell completion
+    argcomplete
+  ];
+
+  # TODO: make shell completion actually work
+  # uses argcomplete, so completion needs PYTHONPATH to work
+  postInstall = ''
+    installShellCompletion --bash --name az.bash az.completion.sh
+    installShellCompletion --zsh --name _az az.completion.sh
+
+    # remove garbage
+    rm $out/bin/az.bat
+    rm $out/bin/az.completion.sh
+  '';
+
+  # wrap the executable so that the python packages are available
+  # it's just a shebang script which calls `python -m azure.cli "$@"`
+  postFixup = ''
+    wrapProgram $out/bin/az \
+      --set PYTHONPATH $PYTHONPATH
+  '';
+
+  # almost the entire test suite requires an azure account setup and networking
+  # ensure that the azure namespaces are setup correctly and that azure.cli can be accessed
+  checkPhase = ''
+    cd azure # avoid finding local copy
+    ${py.interpreter} -c 'import azure.cli.core; assert "${version}" == azure.cli.core.__version__'
+    HOME=$TMPDIR ${py.interpreter} -m azure.cli --help
+  '';
+
+  # ensure these namespaces are able to be accessed
+  pythonImportsCheck = [
+    "azure.batch"
+    "azure.cli.core"
+    "azure.cli.telemetry"
+    "azure.cosmos"
+    "azure.datalake.store"
+    "azure_functions_devops_build"
+    "azure.graphrbac"
+    "azure.keyvault"
+    "azure.mgmt.advisor"
+    "azure.mgmt.apimanagement"
+    "azure.mgmt.applicationinsights"
+    "azure.mgmt.appconfiguration"
+    "azure.mgmt.authorization"
+    "azure.mgmt.batch"
+    "azure.mgmt.batchai"
+    "azure.mgmt.billing"
+    "azure.mgmt.botservice"
+    "azure.mgmt.cdn"
+    "azure.mgmt.cognitiveservices"
+    "azure.mgmt.compute"
+    "azure.mgmt.consumption"
+    "azure.mgmt.containerinstance"
+    "azure.mgmt.containerregistry"
+    "azure.mgmt.containerservice"
+    "azure.mgmt.cosmosdb"
+    "azure.mgmt.datalake.analytics"
+    "azure.mgmt.datalake.store"
+    "azure.mgmt.datamigration"
+    "azure.mgmt.deploymentmanager"
+    "azure.mgmt.devtestlabs"
+    "azure.mgmt.dns"
+    "azure.mgmt.eventgrid"
+    "azure.mgmt.eventhub"
+    "azure.mgmt.hdinsight"
+    "azure.mgmt.imagebuilder"
+    "azure.mgmt.iotcentral"
+    "azure.mgmt.iothub"
+    "azure.mgmt.iothubprovisioningservices"
+    "azure.mgmt.keyvault"
+    "azure.mgmt.kusto"
+    "azure.mgmt.loganalytics"
+    "azure.mgmt.managedservices"
+    "azure.mgmt.managementgroups"
+    "azure.mgmt.maps"
+    "azure.mgmt.marketplaceordering"
+    "azure.mgmt.media"
+    "azure.mgmt.monitor"
+    "azure.mgmt.msi"
+    "azure.mgmt.network"
+    "azure.mgmt.netapp"
+    "azure.mgmt.policyinsights"
+    "azure.mgmt.privatedns"
+    "azure.mgmt.rdbms"
+    "azure.mgmt.recoveryservices"
+    "azure.mgmt.recoveryservicesbackup"
+    "azure.mgmt.redis"
+    "azure.mgmt.relay"
+    "azure.mgmt.reservations"
+    "azure.mgmt.resource"
+    "azure.mgmt.search"
+    "azure.mgmt.security"
+    "azure.mgmt.servicebus"
+    "azure.mgmt.servicefabric"
+    "azure.mgmt.signalr"
+    "azure.mgmt.sql"
+    "azure.mgmt.sqlvirtualmachine"
+    "azure.mgmt.storage"
+    "azure.mgmt.trafficmanager"
+    "azure.mgmt.web"
+    "azure.storage.blob"
+    "azure.storage.common"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Azure/azure-cli";
+    description = "Next generation multi-platform command line experience for Azure";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+})
+

--- a/pkgs/tools/admin/azure-cli/python-packages.nix
+++ b/pkgs/tools/admin/azure-cli/python-packages.nix
@@ -1,0 +1,247 @@
+{ python, lib, src, version }:
+
+let
+  buildAzureCliPackage = with py.pkgs; attrs: buildPythonPackage (attrs // {
+    # Remove overly restrictive version contraints and obsolete namespace setup
+    prePatch = (attrs.prePatch or "") + ''
+      rm -f azure_bdist_wheel.py tox.ini
+      substituteInPlace setup.py \
+        --replace "wheel==0.30.0" "wheel"
+      sed -i "/azure-namespace-package/c\ " setup.cfg
+    '';
+
+    # Prevent these __init__'s from violating PEP420, only needed for python2
+    postInstall = (attrs.postInstall or "") + ''
+      rm $out/${python.sitePackages}/azure/{,__pycache__/}__init__.* \
+         $out/${python.sitePackages}/azure/cli/{,__pycache__/}__init__.*
+    '';
+
+    checkInputs = [ mock pytest ] ++ (attrs.checkInputs or []);
+    checkPhase = attrs.checkPhase or ''
+      cd azure
+      HOME=$TMPDIR pytest
+    '';
+  });
+
+  overrideAzureMgmtPackage = package: version: extension: sha256:
+    package.overrideAttrs(oldAttrs: rec {
+      inherit version;
+
+      src = py.pkgs.fetchPypi {
+        inherit (oldAttrs) pname;
+        inherit version sha256 extension;
+      };
+
+      preBuild = ''
+        rm -f azure_bdist_wheel.py
+        substituteInPlace setup.cfg \
+          --replace "azure-namespace-package = azure-mgmt-nspkg" ""
+      '';
+    });
+
+  py = python.override {
+    packageOverrides = self: super: {
+      inherit buildAzureCliPackage;
+
+      # core and the actual application are highly coupled
+      azure-cli-core = buildAzureCliPackage {
+        pname = "azure-cli-core";
+        inherit version src;
+
+        sourceRoot = "source/src/azure-cli-core";
+
+        propagatedBuildInputs = with self; [
+          adal
+          argcomplete
+          azure-cli-telemetry
+          colorama
+          jmespath
+          humanfriendly
+          knack
+          msrest
+          msrestazure
+          paramiko
+          pygments
+          pyjwt
+          pyopenssl
+          pyyaml
+          requests
+          six
+          azure-mgmt-resource
+          tabulate
+          pyperclip
+          psutil
+        ]
+        ++ lib.optionals isPy3k [ antlr4-python3-runtime ]
+        ++ lib.optionals (!isPy3k) [ enum34 futures antlr4-python2-runtime ndg-httpsclient ];
+
+        # ignore test that does network call
+        checkPhase = ''
+          HOME=$TMPDIR pytest --ignore=azure/cli/core/tests/test_profile.py
+        '';
+
+        pythonImportsCheck = [
+          "azure.cli.telemetry"
+          "azure.cli.core"
+        ];
+      };
+
+      azure-cli-telemetry = buildAzureCliPackage {
+        pname = "azure-cli-telemetry";
+        version = "1.0.4"; # might be wrong, but doesn't really matter
+        inherit src;
+
+        sourceRoot = "source/src/azure-cli-telemetry";
+
+        propagatedBuildInputs = with super; [
+          applicationinsights
+          portalocker
+        ];
+
+        # ignore flaky test
+        checkPhase = ''
+          cd azure
+          HOME=$TMPDIR pytest -k 'not test_create_telemetry_note_file_from_scratch'
+        '';
+      };
+
+      azure-mgmt-resource = overrideAzureMgmtPackage super.azure-mgmt-resource "4.0.0" "zip"
+        "0gy89bi89ikg5hps8rvnq28r33lixci3sk2m86jvziv9fh9rz41b";
+
+      azure-mgmt-compute = overrideAzureMgmtPackage super.azure-mgmt-compute "8.0.0" "zip"
+        "06hmf9iq2yqpmmvw7pr9zm4v427q03i436lnin3aczizfndrk76i";
+
+      azure-mgmt-consumption = overrideAzureMgmtPackage super.azure-mgmt-consumption "2.0.0" "zip"
+        "12ai4qps73ivawh0yzvgb148ksx02r30pqlvfihx497j62gsi1cs";
+
+      azure-mgmt-containerservice = overrideAzureMgmtPackage super.azure-mgmt-containerservice "7.0.0" "zip"
+        "104w7rxv7hy84yzddbbpkjqha04ghr0zz9qy788n3wl69cj4cv1a";
+
+      azure-mgmt-iothub = overrideAzureMgmtPackage super.azure-mgmt-iothub "0.8.2" "zip"
+        "0w3w1d156rnkwjdarv3qvycklxr3z2j7lry7a3jfgj3ykzny12rq";
+
+      azure-mgmt-kusto = overrideAzureMgmtPackage super.azure-mgmt-kusto "0.3.0" "zip"
+        "1pmcdgimd66h964a3d5m2j2fbydshcwhrk87wblhwhfl3xwbgf4y";
+
+      azure-mgmt-devtestlabs = overrideAzureMgmtPackage super.azure-mgmt-devtestlabs "2.2.0" "zip"
+        "15lpyv9z8ss47rjmg1wx5akh22p9br2vckaj7jk3639vi38ac5nl";
+
+      azure-mgmt-netapp = overrideAzureMgmtPackage super.azure-mgmt-netapp "0.6.0" "zip"
+        "10ymvyj386z9bjdm2g1b5a4vfnn87ig2zm6xn2xddvbpy0jxnyfv";
+
+      azure-mgmt-dns = overrideAzureMgmtPackage super.azure-mgmt-dns "2.1.0" "zip"
+        "1l55py4fzzwhxlmnwa41gpmqk9v2ncc79w7zq11sm9a5ynrv2c1p";
+
+      azure-mgmt-network = overrideAzureMgmtPackage super.azure-mgmt-network "7.0.0" "zip"
+        "0ss5yc9k3dh78lb88nfh3z98yz1pcd8d7d7cfjlxmv4n3dlr1kij";
+
+      azure-mgmt-msi = overrideAzureMgmtPackage super.azure-mgmt-msi "0.2.0" "zip"
+        "0rvik03njz940x2hvqg6iiq8k0d88gyygsr86w8s0sa12sdbq8l6";
+
+      azure-mgmt-web = overrideAzureMgmtPackage super.azure-mgmt-web "0.42.0" "zip"
+        "0vp40i9aaw5ycz7s7qqir6jq7327f7zg9j9i8g31qkfl1h1c7pdn";
+
+      azure-mgmt-reservations = overrideAzureMgmtPackage super.azure-mgmt-reservations "0.3.2" "zip"
+        "0nksxjh5kh09dr0zw667fg8mzik4ymvfq3dipwag6pynbqr9ls4l";
+
+      azure-mgmt-security = overrideAzureMgmtPackage super.azure-mgmt-security "0.1.0" "zip"
+        "1cb466722bs0ribrirb32kc299716pl0pwivz3jyn40dd78cwhhx";
+
+      azure-mgmt-datamigration = overrideAzureMgmtPackage super.azure-mgmt-datamigration "0.1.0" "zip"
+        "1pq5rn32yvrf5kqjafnj0kc92gpfg435w2l0k7cm8gvlja4r4m77";
+
+      azure-mgmt-relay = overrideAzureMgmtPackage super.azure-mgmt-relay "0.1.0" "zip"
+        "1jss6qhvif8l5s0lblqw3qzijjf0h88agciiydaa7f4q577qgyfr";
+
+      azure-mgmt-eventhub = overrideAzureMgmtPackage super.azure-mgmt-eventhub "2.6.0" "zip"
+        "1nnp2ki4iz4f4897psmwb0v5khrwh84fgxja7nl7g73g3ym20sz8";
+
+      azure-mgmt-keyvault = overrideAzureMgmtPackage super.azure-mgmt-keyvault "1.1.0" "zip"
+        "16a0d3j5dilbp7pd7gbwf8jr46vzbjim1p9alcmisi12m4km7885";
+
+      azure-mgmt-containerregistry = overrideAzureMgmtPackage super.azure-mgmt-containerregistry "3.0.0rc7" "zip"
+        "1bzfpbz186dhnxn0blgr20xxnk67gkr8ysn2b3f1r41bq9hz97xp";
+
+      azure-mgmt-monitor = overrideAzureMgmtPackage super.azure-mgmt-monitor "0.5.2" "zip"
+        "1r01aq5rbynbc1my4qljdifjdj9h65bh8cdzgd7vm4ij7r48v9gi";
+
+      azure-mgmt-advisor =  overrideAzureMgmtPackage super.azure-mgmt-advisor "2.0.1" "zip"
+        "1wsfkprdrn22mwm24y2zlcms8ppp7jwq3s86r3ymbl29pbaxca8r";
+
+      azure-mgmt-applicationinsights = overrideAzureMgmtPackage super.azure-mgmt-applicationinsights "0.1.1" "zip"
+        "16raxr5naszrxmgbfhsvh7rqcph5cx6x3f480790m79ykvmjj0pi";
+
+      azure-mgmt-authorization = overrideAzureMgmtPackage super.azure-mgmt-authorization "0.52.0" "zip"
+        "0357laxgldb7lvvws81r8xb6mrq9dwwnr1bnwdnyj4bw6p21i9hn";
+
+      azure-mgmt-storage = overrideAzureMgmtPackage super.azure-mgmt-storage "5.0.0" "zip"
+        "1gzsscfnnfb8gxs34dq9hs339hidlzas7kgivw0234v3qz4gy9yx";
+
+      azure-mgmt-servicefabric = overrideAzureMgmtPackage super.azure-mgmt-servicefabric "0.2.0" "zip"
+        "1bcq6fcgrsvmk6q7v8mxzn1180jm2qijdqkqbv1m117zp1wj5gxj";
+
+      azure-mgmt-hdinsight = overrideAzureMgmtPackage super.azure-mgmt-hdinsight "1.1.0" "zip"
+        "0lj9dhb14dx4ag5pgd2zvrmn9y5ziq2qywvw38ccbv9g3bxpglkn";
+
+      azure-graphrbac = super.azure-graphrbac.overrideAttrs(oldAttrs: rec {
+        version = "0.60.0";
+
+        src = super.fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "1zna5vb887clvpyfp5439vhlz3j4z95blw9r7y86n6cfpzc65fyh";
+          extension = "zip";
+        };
+      });
+
+      azure-storage-blob = super.azure-storage-blob.overrideAttrs(oldAttrs: rec {
+        version = "1.5.0";
+        src = super.fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "0b15dzy75fml994gdfmaw5qcyij15gvh968mk3hg94d1wxwai1zi";
+        };
+      });
+
+      azure-storage-common = super.azure-storage-common.overrideAttrs(oldAttrs: rec {
+        version = "1.4.2";
+        src = super.fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "00g41b5q4ijlv02zvzjgfwrwy71cgr3lc3if4nayqmyl6xsprj2f";
+        };
+      });
+
+      # part of azure.mgmt.datalake namespace
+      azure-mgmt-datalake-analytics = super.azure-mgmt-datalake-analytics.overrideAttrs(oldAttrs: rec {
+        version = "0.2.1";
+
+        src = super.fetchPypi {
+          inherit (oldAttrs) pname;
+          inherit version;
+          sha256 = "192icfx82gcl3igr18w062744376r2ivh63c8nd7v17mjk860yac";
+          extension = "zip";
+        };
+
+        preBuild = ''
+          rm azure_bdist_wheel.py
+          substituteInPlace setup.cfg \
+            --replace "azure-namespace-package = azure-mgmt-datalake-nspkg" ""
+        '';
+      });
+
+
+
+
+
+
+
+
+
+
+
+
+    };
+  };
+in
+  py

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -706,6 +706,8 @@ in
 
   iamy = callPackage ../tools/admin/iamy { };
 
+  azure-cli = callPackage ../tools/admin/azure-cli { python = python3; };
+
   azure-storage-azcopy = callPackage ../development/tools/azcopy { };
 
   azure-vhd-utils  = callPackage ../tools/misc/azure-vhd-utils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6192,6 +6192,8 @@ in {
 
   jaraco_stream = callPackage ../development/python-modules/jaraco_stream { };
 
+  javaproperties = callPackage ../development/python-modules/javaproperties { };
+
   tempora= callPackage ../development/python-modules/tempora { };
 
   hypchat = callPackage ../development/python-modules/hypchat { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -397,6 +397,8 @@ in {
 
   azure-mgmt-msi = callPackage ../development/python-modules/azure-mgmt-msi { };
 
+  azure-mgmt-netapp = callPackage ../development/python-modules/azure-mgmt-netapp { };
+
   azure-mgmt-network = callPackage ../development/python-modules/azure-mgmt-network { };
 
   azure-mgmt-notificationhubs = callPackage ../development/python-modules/azure-mgmt-notificationhubs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -381,6 +381,8 @@ in {
 
   azure-mgmt-machinelearningcompute = callPackage ../development/python-modules/azure-mgmt-machinelearningcompute { };
 
+  azure-mgmt-managedservices = callPackage ../development/python-modules/azure-mgmt-managedservices { };
+
   azure-mgmt-managementgroups = callPackage ../development/python-modules/azure-mgmt-managementgroups { };
 
   azure-mgmt-managementpartner = callPackage ../development/python-modules/azure-mgmt-managementpartner { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -303,6 +303,8 @@ in {
 
   azure-mgmt-advisor = callPackage ../development/python-modules/azure-mgmt-advisor { };
 
+  azure-mgmt-apimanagement = callPackage ../development/python-modules/azure-mgmt-apimanagement { };
+
   azure-mgmt-applicationinsights = callPackage ../development/python-modules/azure-mgmt-applicationinsights { };
 
   azure-mgmt-authorization = callPackage ../development/python-modules/azure-mgmt-authorization { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -305,6 +305,8 @@ in {
 
   azure-mgmt-apimanagement = callPackage ../development/python-modules/azure-mgmt-apimanagement { };
 
+  azure-mgmt-appconfiguration = callPackage ../development/python-modules/azure-mgmt-appconfiguration { };
+
   azure-mgmt-applicationinsights = callPackage ../development/python-modules/azure-mgmt-applicationinsights { };
 
   azure-mgmt-authorization = callPackage ../development/python-modules/azure-mgmt-authorization { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -331,6 +331,8 @@ in {
 
   azure-mgmt-containerinstance = callPackage ../development/python-modules/azure-mgmt-containerinstance { };
 
+  azure-mgmt-containerregistry = callPackage ../development/python-modules/azure-mgmt-containerregistry { };
+
   azure-mgmt-containerservice = callPackage ../development/python-modules/azure-mgmt-containerservice { };
 
   azure-mgmt-cosmosdb = callPackage ../development/python-modules/azure-mgmt-cosmosdb { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -361,6 +361,8 @@ in {
 
   azure-mgmt-hanaonazure = callPackage ../development/python-modules/azure-mgmt-hanaonazure { };
 
+  azure-mgmt-hdinsight = callPackage ../development/python-modules/azure-mgmt-hdinsight { };
+
   azure-mgmt-iotcentral = callPackage ../development/python-modules/azure-mgmt-iotcentral { };
 
   azure-mgmt-iothub = callPackage ../development/python-modules/azure-mgmt-iothub { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5504,6 +5504,8 @@ in {
     then callPackage ../development/python-modules/secretstorage { }
     else callPackage ../development/python-modules/secretstorage/2.nix { };
 
+  secure = callPackage ../development/python-modules/secure { };
+
   semantic = callPackage ../development/python-modules/semantic { };
 
   sandboxlib = callPackage ../development/python-modules/sandboxlib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -351,6 +351,8 @@ in {
 
   azure-mgmt-devtestlabs = callPackage ../development/python-modules/azure-mgmt-devtestlabs { };
 
+  azure-mgmt-deploymentmanager = callPackage ../development/python-modules/azure-mgmt-deploymentmanager { };
+
   azure-mgmt-dns = callPackage ../development/python-modules/azure-mgmt-dns { };
 
   azure-mgmt-eventgrid = callPackage ../development/python-modules/azure-mgmt-eventgrid { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -373,6 +373,8 @@ in {
 
   azure-mgmt-keyvault = callPackage ../development/python-modules/azure-mgmt-keyvault { };
 
+  azure-mgmt-kusto = callPackage ../development/python-modules/azure-mgmt-kusto { };
+
   azure-mgmt-loganalytics = callPackage ../development/python-modules/azure-mgmt-loganalytics { };
 
   azure-mgmt-logic = callPackage ../development/python-modules/azure-mgmt-logic { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -437,6 +437,8 @@ in {
 
   azure-mgmt-sql = callPackage ../development/python-modules/azure-mgmt-sql { };
 
+  azure-mgmt-sqlvirtualmachine = callPackage ../development/python-modules/azure-mgmt-sqlvirtualmachine { };
+
   azure-mgmt-storage = callPackage ../development/python-modules/azure-mgmt-storage { };
 
   azure-mgmt-subscription = callPackage ../development/python-modules/azure-mgmt-subscription { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -447,6 +447,8 @@ in {
 
   azure-mgmt-web = callPackage ../development/python-modules/azure-mgmt-web { };
 
+  azure-multiapi-storage = callPackage ../development/python-modules/azure-multiapi-storage { };
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -363,6 +363,8 @@ in {
 
   azure-mgmt-hdinsight = callPackage ../development/python-modules/azure-mgmt-hdinsight { };
 
+  azure-mgmt-imagebuilder = callPackage ../development/python-modules/azure-mgmt-imagebuilder { };
+
   azure-mgmt-iotcentral = callPackage ../development/python-modules/azure-mgmt-iotcentral { };
 
   azure-mgmt-iothub = callPackage ../development/python-modules/azure-mgmt-iothub { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -271,6 +271,8 @@ in {
 
   azure-eventgrid = callPackage ../development/python-modules/azure-eventgrid { };
 
+  azure-functions-devops-build = callPackage ../development/python-modules/azure-functions-devops-build { };
+
   azure-graphrbac = callPackage ../development/python-modules/azure-graphrbac { };
 
   azure-keyvault = callPackage ../development/python-modules/azure-keyvault { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -407,6 +407,8 @@ in {
 
   azure-mgmt-powerbiembedded = callPackage ../development/python-modules/azure-mgmt-powerbiembedded { };
 
+  azure-mgmt-privatedns = callPackage ../development/python-modules/azure-mgmt-privatedns { };
+
   azure-mgmt-rdbms = callPackage ../development/python-modules/azure-mgmt-rdbms { };
 
   azure-mgmt-recoveryservices = callPackage ../development/python-modules/azure-mgmt-recoveryservices { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -317,6 +317,8 @@ in {
 
   azure-mgmt-billing = callPackage ../development/python-modules/azure-mgmt-billing { };
 
+  azure-mgmt-botservice = callPackage ../development/python-modules/azure-mgmt-botservice { };
+
   azure-mgmt-cdn = callPackage ../development/python-modules/azure-mgmt-cdn { };
 
   azure-mgmt-cognitiveservices = callPackage ../development/python-modules/azure-mgmt-cognitiveservices { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5286,6 +5286,8 @@ in {
 
   vsts = callPackage ../development/python-modules/vsts { };
 
+  vsts-cd-manager = callPackage ../development/python-modules/vsts-cd-manager { };
+
   python-vlc = callPackage ../development/python-modules/python-vlc { };
 
   weasyprint = callPackage ../development/python-modules/weasyprint { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1293,6 +1293,8 @@ in {
 
   sshpubkeys = callPackage ../development/python-modules/sshpubkeys { };
 
+  sshtunnel = callPackage ../development/python-modules/sshtunnel { };
+
   sslib = callPackage ../development/python-modules/sslib { };
 
   statistics = callPackage ../development/python-modules/statistics { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -427,6 +427,8 @@ in {
 
   azure-mgmt-search = callPackage ../development/python-modules/azure-mgmt-search { };
 
+  azure-mgmt-security = callPackage ../development/python-modules/azure-mgmt-security { };
+
   azure-mgmt-servicebus = callPackage ../development/python-modules/azure-mgmt-servicebus { };
 
   azure-mgmt-servicefabric = callPackage ../development/python-modules/azure-mgmt-servicefabric { };


### PR DESCRIPTION
###### Motivation for this change
Add proper azure cli support back into nix after the node "v1.0" was deprecated.

Still have some clean up to do, definitely not in a final state. Just wanted people to comment while still a draft PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
