### PR TITLE
isomd5sum: init at 1.2.3

### DIFF
--- a/pkgs/tools/cd-dvd/isomd5sum/default.nix
+++ b/pkgs/tools/cd-dvd/isomd5sum/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub
+, python3
+, popt
+}:
+
+stdenv.mkDerivation rec {
+  pname = "isomd5sum";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "rhinstaller";
+    repo = pname;
+    rev = version;
+    sha256 = "1wjnh2hlp1hjjm4a8wzdhdrm73jq41lmpmy3ls0rh715p3j7z4q9";
+  };
+
+  buildInputs = [ python3 popt ] ;
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "#/usr/" "#"
+    substituteInPlace Makefile --replace "/usr/" "/"
+  '';
+
+  dontConfigure = true;
+
+  makeFlags = [ "DESTDIR=${placeholder "out"}" ];
+
+  # we don't install python stuff as it borks up directories
+  installTargets = "install-bin install-devel";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rhinstaller/isomd5sum;
+    description = "Utilities for working with md5sum implanted in ISO images";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ knl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2207,6 +2207,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Carbon IOKit;
   };
 
+  isomd5sum = callPackage ../tools/cd-dvd/isomd5sum { };
+
   mdf2iso = callPackage ../tools/cd-dvd/mdf2iso { };
 
   nrg2iso = callPackage ../tools/cd-dvd/nrg2iso { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds isomd5sum as a package. This nifty utility helps with modifying ISO files,
specifically MD5 sums embedded in them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
