### PR TITLE
monotoneViz, haxe: refactor out of ocamlPackages

### DIFF
--- a/pkgs/applications/version-management/monotone-viz/default.nix
+++ b/pkgs/applications/version-management/monotone-viz/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, lablgtk, libgnomecanvas, camlp4, glib, pkgconfig, makeWrapper
+{ stdenv, fetchurl, ocamlPackages, gnome2, pkgconfig, makeWrapper
 , libtool, libpng, yacc, expat, fontconfig, gd, pango, libjpeg, libwebp, xlibsWrapper, libXaw
 }:
 # We need an old version of Graphviz for format compatibility reasons.
@@ -7,6 +7,8 @@ let graphviz_2_0 = import ./graphviz-2.0.nix {
       inherit stdenv fetchurl pkgconfig xlibsWrapper libpng libjpeg expat libXaw
         yacc libtool fontconfig pango gd libwebp;
     }; in
+let inherit (gnome2) libgnomecanvas glib; in
+let inherit (ocamlPackages) ocaml lablgtk camlp4; in
 stdenv.mkDerivation rec {
   version = "1.0.2";
   pname = "monotone-viz";

--- a/pkgs/development/compilers/haxe/default.nix
+++ b/pkgs/development/compilers/haxe/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchgit, coreutils, ocaml, zlib, pcre, neko, camlp4 }:
+{ stdenv, fetchgit, coreutils, ocamlPackages, zlib, pcre, neko }:
+
+let inherit (ocamlPackages) ocaml camlp4; in
 
 let
   generic = { version, sha256, prePatch }:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7947,7 +7947,9 @@ in
       graphviz = graphviz-nox;
     });
 
-  inherit (ocaml-ng.ocamlPackages_4_05.haxe) haxe_3_2 haxe_3_4;
+  inherit (callPackage ../development/compilers/haxe {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
+  }) haxe_3_2 haxe_3_4;
   haxe = haxe_3_4;
   haxePackages = recurseIntoAttrs (callPackage ./haxe-packages.nix { });
   inherit (haxePackages) hxcpp;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19700,7 +19700,9 @@ in
     lua = lua5;
   };
 
-  inherit (ocaml-ng.ocamlPackages_4_01_0) monotoneViz;
+  monotoneViz = callPackage ../applications/version-management/monotone-viz {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_01_0;
+  };
 
   moolticute = libsForQt5.callPackage ../applications/misc/moolticute { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1093,8 +1093,6 @@ let
 
     # Apps / from all-packages
 
-    haxe = callPackage ../development/compilers/haxe { };
-
     ocamlnat = callPackage  ../development/ocaml-modules/ocamlnat { };
 
     trv = callPackage ../development/tools/misc/trv { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1103,11 +1103,6 @@ let
 
     google-drive-ocamlfuse = callPackage ../applications/networking/google-drive-ocamlfuse { };
 
-
-    monotoneViz = callPackage ../applications/version-management/monotone-viz {
-      inherit (pkgs.gnome2) libgnomecanvas glib;
-    };
-
     unison = callPackage ../applications/networking/sync/unison {
       enableX11 = config.unison.enableX11 or true;
     };


### PR DESCRIPTION
###### Motivation for this change

These programs are not OCaml libraries; and they only build with specific versions of OCaml. They do not belong to `ocamlPackages`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c (monotoneViz) @marcweber (haxe)
