### PR TITLE
boomerang: 0.4.X -> 0.5.1, various fixes and cleanups

### DIFF
--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, qtbase, capstone, bison, flex }:
+{ mkDerivation, lib, fetchFromGitHub, cmake, qtbase, capstone, bison, flex }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "boomerang";
   version = "0.5.1";
 
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
-    homepage = http://boomerang.sourceforge.net/;
+  meta = with lib; {
+    homepage = https://github.com/BoomerangDecompiler/boomerang;
     license = licenses.bsd3;
     description = "A general, open source, retargetable decompiler";
     maintainers = with maintainers; [ dtzWill ];

--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -14,24 +14,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake bison flex ];
   buildInputs = [ qtbase capstone ];
 
-  postPatch =
-  # Look in installation directory for required files, not relative to working directory
-  ''
-    substituteInPlace src/boomerang/core/Settings.cpp \
-      --replace "setDataDirectory(\"../share/boomerang\");" \
-                "setDataDirectory(\"$out/share/boomerang\");" \
-      --replace "setPluginDirectory(\"../lib/boomerang/plugins\");" \
-                "setPluginDirectory(\"$out/lib/boomerang/plugins\");"
-  ''
-  # Fixup version:
-  # * don't try to inspect with git
-  #   (even if we kept .git and such it would be "dirty" because of patching)
-  # * use date so version is monotonically increasing moving forward
-  + ''
-    sed -i cmake-scripts/boomerang-version.cmake \
-      -e 's/set(\(PROJECT\|BOOMERANG\)_VERSION ".*")/set(\1_VERSION "${version}")/'
-  '';
-
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "boomerang";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "BoomerangDecompiler";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "1q8qg506c39fidihqs8rbmqlr7bgkayyp5sscszgahs34cyvqic7";
+    sha256 = "046ba4km8c31kbnllx05nbqhjmk7bpi56d3n8md8bsr98nj21a2j";
   };
 
   nativeBuildInputs = [ cmake bison flex ];

--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -7,7 +7,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "BoomerangDecompiler";
     repo = pname;
-    rev = "refs/tags/v${version}";
+    rev = "v${version}";
     sha256 = "046ba4km8c31kbnllx05nbqhjmk7bpi56d3n8md8bsr98nj21a2j";
   };
 

--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchFromGitHub, cmake, qtbase }:
+{ stdenv, fetchFromGitHub, cmake, qtbase, capstone, bison, flex }:
 
 stdenv.mkDerivation rec {
   pname = "boomerang";
-  version = "0.4.0-alpha-2018-07-03";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
-    owner = "ceeac";
-    repo = "boomerang";
-    rev = "377ff2d7db93d892c925e2d3e61aef818371ce7d";
-    sha256 = "1ljbyj3b8xckr1wihyii3h576zgq0q88vli0ylpr3p4jxy5sm57j";
+    owner = "BoomerangDecompiler";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    sha256 = "1q8qg506c39fidihqs8rbmqlr7bgkayyp5sscszgahs34cyvqic7";
   };
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ qtbase ];
+  nativeBuildInputs = [ cmake bison flex ];
+  buildInputs = [ qtbase capstone ];
 
   postPatch =
   # Look in installation directory for required files, not relative to working directory


### PR DESCRIPTION
###### Motivation for this change

Newer, cleaner, better! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).