### PR TITLE
bibata-extra-cursors,bibata-cursors-translucent: init (git revs)

### DIFF
--- a/pkgs/data/icons/bibata-cursors/default.nix
+++ b/pkgs/data/icons/bibata-cursors/default.nix
@@ -1,6 +1,6 @@
-{ fetchFromGitHub, gnome-themes-extra, inkscape, stdenv, xcursorgen }:
+{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "bibata-cursors";
   version = "0.4.1";
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     cp -pr Bibata_* $out/share/icons/
   '';
 
-  meta = with stdenv.lib; {
+  meta = with stdenvNoCC.lib; {
     description = "Material Based Cursor";
     homepage = https://github.com/KaizIqbal/Bibata_Cursor;
     license = licenses.gpl3;

--- a/pkgs/data/icons/bibata-cursors/extra.nix
+++ b/pkgs/data/icons/bibata-cursors/extra.nix
@@ -1,0 +1,41 @@
+{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "bibata-extra-cursors";
+  version = "unstable-2018-10-28";
+  
+  src = fetchFromGitHub {
+    owner = "KaizIqbal";
+    repo = "Bibata_Extra_Cursor";
+    rev = "66fb64b8dbe830e3f7ba2c2bdc4dacae7c438789";
+    sha256 = "1xb7v06sbxbwzd7cnghv9c55lpbbkcaf1nswdrqy87gd0bnpdd2n";
+  };
+
+  postPatch = ''
+    patchShebangs .
+    substituteInPlace build.sh --replace "gksu " ""
+  '';
+
+  nativeBuildInputs  = [
+    gnome-themes-extra
+    inkscape
+    xcursorgen
+  ];
+
+  buildPhase = ''
+    HOME="$NIX_BUILD_ROOT" ./build.sh
+  '';
+
+  installPhase = ''
+    install -dm 0755 $out/share/icons
+    cp -pr Bibata_* $out/share/icons/
+  '';
+
+  meta = with stdenvNoCC.lib; {
+    description = "Cursors Based on Bibata";
+    homepage = https://github.com/KaizIqbal/Bibata_Extra_Cursor;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/data/icons/bibata-cursors/translucent.nix
+++ b/pkgs/data/icons/bibata-cursors/translucent.nix
@@ -1,0 +1,41 @@
+{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "bibata-cursors-translucent";
+  version = "unstable-2019-09-13";
+  
+  src = fetchFromGitHub {
+    owner = "Silicasandwhich";
+    repo = "Bibata_Cursor_Translucent";
+    rev = "2eed979d817148817ea6bca15c594809aa9c2cb9";
+    sha256 = "1s688v40xx9jbvfncb4kgfnnxkmknji7igqx7c4q1ly9s7imbd1f";
+  };
+
+  postPatch = ''
+    patchShebangs .
+    substituteInPlace build.sh --replace "gksu " ""
+  '';
+
+  nativeBuildInputs  = [
+    gnome-themes-extra
+    inkscape
+    xcursorgen
+  ];
+
+  buildPhase = ''
+    HOME="$NIX_BUILD_ROOT" ./build.sh
+  '';
+
+  installPhase = ''
+    install -dm 0755 $out/share/icons
+    cp -pr Bibata_* $out/share/icons/
+  '';
+
+  meta = with stdenvNoCC.lib; {
+    description = "Translucent Varient of the Material Based Cursor";
+    homepage = https://github.com/Silicasandwhich/Bibata_Cursor_Translucent;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16843,6 +16843,7 @@ in
   bgnet = callPackage ../data/documentation/bgnet { };
 
   bibata-cursors = callPackage ../data/icons/bibata-cursors { };
+  bibata-extra-cursors = callPackage ../data/icons/bibata-cursors/extra.nix { };
 
   brise = callPackage ../data/misc/brise { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16844,6 +16844,7 @@ in
 
   bibata-cursors = callPackage ../data/icons/bibata-cursors { };
   bibata-extra-cursors = callPackage ../data/icons/bibata-cursors/extra.nix { };
+  bibata-cursors-translucent = callPackage ../data/icons/bibata-cursors/translucent.nix { };
 
   brise = callPackage ../data/misc/brise { };
 


### PR DESCRIPTION
###### Motivation for this change

More bibata! Muahaha

There's an adapta variant out there as well, if anyone wants to add it
too :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

- [X] Tested cursors load and at least work for the more common cursors