### PR TITLE
openorienteering-mapper: 0.8.4 -> 0.9.0

### DIFF
--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "OpenOrienteering-Mapper";
-  version = "0.8.4";
+  version = "0.9.0";
 
   buildInputs = [ gdal qtbase qttools qtlocation qtimageformats
                   qtsensors clipper zlib proj doxygen cups];
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "OpenOrienteering";
     repo = "mapper";
     rev = "v${version}";
-    sha256 = "0rw34kp2vd1la97vnk9plwvis6lvyib2bvs7lgkhpnm4p5l7dp1g";
+    sha256 = "0wnxj2xf529941dwss6ygb1krfx18lzl6rf67060b0zndc7n6l8f";
   };
 
   cmakeFlags =
@@ -40,9 +40,6 @@ stdenv.mkDerivation rec {
     "-DMapper_PACKAGE_GDAL=0"
     ]);
 
-  # Needs to be available when proj_api.h gets evaluted by CPP
-  NIX_CFLAGS_COMPILE = [ "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H" ];
-
   postInstall =
     stdenv.lib.optionalString stdenv.isDarwin ''
     # Fixes "This application failed to start because it could not find or load the Qt
@@ -60,6 +57,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.openorienteering.org/apps/mapper/;
     license = licenses.gpl3;
     platforms = with platforms; linux ++ darwin;
-    maintainers = with maintainers; [mpickering];
+    maintainers = with maintainers; [ mpickering sikmir ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

[Changelog](https://github.com/OpenOrienteering/mapper/releases/tag/v0.9.0)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/hn68ndkg7c97402w09953h3nrlf69wfn-OpenOrienteering-Mapper-0.8.4
/nix/store/hn68ndkg7c97402w09953h3nrlf69wfn-OpenOrienteering-Mapper-0.8.4	 658.7M
$ nix path-info -Sh /nix/store/nfcch1fr26l3jdf24pc3cb8iijgfxjac-OpenOrienteering-Mapper-0.9.0
/nix/store/nfcch1fr26l3jdf24pc3cb8iijgfxjac-OpenOrienteering-Mapper-0.9.0	 662.9M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mpickering
