### PR TITLE
handbrake: fix missing audio

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -7,7 +7,7 @@
 # be nice to add the native GUI (and/or the GTK GUI) as an option too, but that
 # requires invoking the Xcode build system, which is non-trivial for now.
 
-{ stdenv, lib, fetchurl,
+{ stdenv, lib, fetchurl, fetchpatch,
   # Main build tools
   python2, pkgconfig, autoconf, automake, cmake, nasm, libtool, m4, lzma,
   # Processing, video codecs, containers
@@ -80,6 +80,13 @@ stdenv.mkDerivation rec {
   dontUseCmakeConfigure = true;
   # cp: cannot create regular file './internal_defaults.json': File exists
   enableParallelBuilding = false;
+
+  # The samplerate patch should be removed when HandBrake 1.3.0 is released
+  patches = [(fetchpatch {
+    name = "set-ffmpeg-samplerate.patch";
+    url = "https://patch-diff.githubusercontent.com/raw/HandBrake/HandBrake/pull/2126.patch";
+    sha256 = "00lds9h27cvyr53qpvv8gbv01hfxdxd8gphxcwbwg8akqrvk9gbf";
+  })];
 
   preConfigure = ''
     patchShebangs scripts


### PR DESCRIPTION
We build HandBrake with a newer ffmpeg than upstream expects, triggering a problem where the audio samplerate defaults to zero because HandBrake was not explicitly setting it.

This has been [fixed](https://github.com/HandBrake/HandBrake/pull/2126) in HandBrake upstream, but we must cherry pick this change in order to produce videos with audio until HandBrake 1.3.0 is released.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix an issue where HandBrake could not produce videos with working audio.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @wmertens @Anton-Latukha 
