### PR TITLE
[staging] mariadb-connector-c: reduce closure size

### DIFF
--- a/pkgs/development/python-modules/mysqlclient/default.nix
+++ b/pkgs/development/python-modules/mysqlclient/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, libmysqlclient }:
+{ stdenv, buildPythonPackage, fetchPypi, libmysqlclient, zlib, openssl }:
 
 buildPythonPackage rec {
   pname = "mysqlclient";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
-    libmysqlclient
+    libmysqlclient zlib openssl
   ];
 
   # Tests need a MySQL database

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -1,10 +1,8 @@
-{ stdenv, fetchurl, cmake
+{ stdenv, lib, fetchurl, cmake
 , curl, openssl, zlib
 , libiconv
 , version, sha256, ...
 }:
-
-with stdenv.lib;
 
 stdenv.mkDerivation {
   pname = "mariadb-connector-c";
@@ -26,13 +24,12 @@ stdenv.mkDerivation {
   ];
 
   # The cmake setup-hook uses $out/lib by default, this is not the case here.
-  preConfigure = optionalString stdenv.isDarwin ''
+  preConfigure = lib.optionalString stdenv.isDarwin ''
     cmakeFlagsArray+=("-DCMAKE_INSTALL_NAME_DIR=$out/lib/mariadb")
   '';
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ curl openssl zlib ];
-  buildInputs = [ libiconv ];
+  buildInputs = [ libiconv curl openssl zlib ];
 
   enableParallelBuilding = true;
 
@@ -43,7 +40,7 @@ stdenv.mkDerivation {
     ln -sv mariadb_version.h $out/include/mariadb/mysql_version.h
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Client library that can be used to connect to MySQL or MariaDB";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ globin ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4849,7 +4849,7 @@ let
       sha256 = "0y4djb048i09dk19av7mzfb3khr72vw11p3ayw2p82jsy4gm8j2g";
     };
 
-    buildInputs = [ pkgs.libmysqlclient DevelChecklib TestDeep TestDistManifest TestPod ];
+    buildInputs = [ pkgs.libmysqlclient pkgs.zlib pkgs.openssl DevelChecklib TestDeep TestDistManifest TestPod ];
     propagatedBuildInputs = [ DBI ];
 
     doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
noticed some `-dev` paths in the tree when reviewing another PR

```
[13:49:30] jon@jon-workstation ~/projects/nixpkgs (master)
$ nix path-info -Sh ./result
/nix/store/k4ba1iabxgvkxd1bm4bnx5bpva5rihbi-mariadb-connector-c-3.1.2     48.5M
[13:46:18] jon@jon-workstation ~/projects/nixpkgs (reduce-mariadb-connector)
$ nix path-info -Sh ./result
/nix/store/xkw305kzcprh2x8d81h8irwg8i9pfqrg-mariadb-connector-c-3.1.2     36.7M
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

