### PR TITLE
franz: 5.3.3 -> 5.4.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/franz/default.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/default.nix
@@ -3,13 +3,13 @@
 , gnome2, dbus, nss, nspr, alsaLib, cups, expat, udev, libnotify, xdg_utils }:
 
 let
-  version = "5.3.3";
+  version = "5.4.0";
 in stdenv.mkDerivation {
   pname = "franz";
   inherit version;
   src = fetchurl {
     url = "https://github.com/meetfranz/franz/releases/download/v${version}/franz_${version}_amd64.deb";
-    sha256 = "03ii1gpc2wijy917565pqig1ihd4zhal12i2f5k916i7fp8912m1";
+    sha256 = "0jqxanihklb88igxs7ilnjlavag64mdj84zrhpr22km3m3c0agq5";
   };
 
   # don't remove runtime deps

--- a/pkgs/applications/networking/instant-messengers/franz/default.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/default.nix
@@ -50,7 +50,7 @@ in stdenv.mkDerivation {
     description = "A free messaging app that combines chat & messaging services into one application";
     homepage = https://meetfranz.com;
     license = licenses.free;
-    maintainers = with maintainers; [ davidtwco gnidorah ];
+    maintainers = [ maintainers.davidtwco ];
     platforms = ["x86_64-linux"];
     hydraPlatforms = [];
   };

--- a/pkgs/applications/networking/instant-messengers/franz/default.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/default.nix
@@ -50,7 +50,7 @@ in stdenv.mkDerivation {
     description = "A free messaging app that combines chat & messaging services into one application";
     homepage = https://meetfranz.com;
     license = licenses.free;
-    maintainers = [ maintainers.gnidorah ];
+    maintainers = with maintainers; [ davidtwco gnidorah ];
     platforms = ["x86_64-linux"];
     hydraPlatforms = [];
   };

--- a/pkgs/applications/networking/instant-messengers/franz/default.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/default.nix
@@ -3,13 +3,13 @@
 , gnome2, dbus, nss, nspr, alsaLib, cups, expat, udev, libnotify, xdg_utils }:
 
 let
-  version = "5.4.0";
+  version = "5.4.1";
 in stdenv.mkDerivation {
   pname = "franz";
   inherit version;
   src = fetchurl {
     url = "https://github.com/meetfranz/franz/releases/download/v${version}/franz_${version}_amd64.deb";
-    sha256 = "0jqxanihklb88igxs7ilnjlavag64mdj84zrhpr22km3m3c0agq5";
+    sha256 = "1g1z5zjm9l081hpqslfc4h7pqh4k76ccmlz71r21204wy630mw6h";
   };
 
   # don't remove runtime deps


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[v5.4.0](https://github.com/meetfranz/franz/releases/tag/v5.4.0) of Franz was released.

I've included a second commit which adds myself as an additional maintainer to this package, as I've submitted a handful of PRs to update this package: #68976, #68899, #68256, #65258 and #62586.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @gnidorah
