### PR TITLE
libredwg: init at 0.10.1

### DIFF
--- a/pkgs/development/libraries/libredwg/default.nix
+++ b/pkgs/development/libraries/libredwg/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, texinfo, pcre2
+, enablePython ? false, python, swig, libxml2, ncurses
+}:
+let
+  isPython3 = enablePython && python.pythonAtLeast "3";
+in
+stdenv.mkDerivation rec {
+  pname = "libredwg";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "LibreDWG";
+    repo = pname;
+    rev = version;
+    sha256 = "1zd721z2nriw1jlrh4y1fj59b0dnymhd4kwp8rqw16bs84gda37n";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config texinfo ] 
+    ++ lib.optional enablePython swig;
+
+  buildInputs = [ pcre2 ]
+    ++ lib.optionals enablePython [ python ]
+    # configurePhase fails with python 3 when ncurses is missing
+    ++ lib.optional isPython3 ncurses
+  ;
+
+  # prevent python tests from running when not building with python
+  configureFlags = lib.optional (!enablePython) "--disable-python";
+
+  doCheck = true;
+
+  # the "xmlsuite" test requires the libxml2 c library as well as the python module
+  checkInputs = lib.optionals enablePython [ libxml2 libxml2.dev ];
+
+  meta = with lib; {
+    description = "Free implementation of the DWG file format";
+    homepage = "https://savannah.gnu.org/projects/libredwg/";
+    maintainers = with maintainers; [ tweber ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13196,6 +13196,9 @@ in
   libplist = callPackage ../development/libraries/libplist { };
 
   libre = callPackage ../development/libraries/libre {};
+
+  libredwg = callPackage ../development/libraries/libredwg {};
+
   librem = callPackage ../development/libraries/librem {};
 
   librelp = callPackage ../development/libraries/librelp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4417,6 +4417,11 @@ in {
   }));
 
   libkeepass = callPackage ../development/python-modules/libkeepass { };
+  
+  libredwg = toPythonModule (pkgs.libredwg.override {
+    enablePython = true;
+    inherit (self) python libxml2;
+  });
 
   librepo = pipe pkgs.librepo [
     toPythonModule


### PR DESCRIPTION
###### Motivation for this change
add library libredwg, including python bindings

fixes #71192

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Still needs testing on non nixos platforms, though.