### PR TITLE
[r19.09] ghostscript: add patches for CVE-2019-10216, CVE-2019-14811, CVE-2019-14812, CVE-2019-14813 and some of CVE-2019-14817

### DIFF
--- a/pkgs/misc/ghostscript/9.26-CVE-2019-10216.patch
+++ b/pkgs/misc/ghostscript/9.26-CVE-2019-10216.patch
@@ -1,0 +1,36 @@
+Based on upstream commit 5b85ddd19a8420a1bd2d5529325be35d78e94234
+--- a/Resource/Init/gs_type1.ps
++++ b/Resource/Init/gs_type1.ps
+@@ -118,25 +118,25 @@
+                          ( to be the same as glyph: ) print 1 index //== exec } if
+                    3 index exch 3 index //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
+                                                                  % scratch(string) RAGL(dict) AGL(dict) CharStrings(dict) cstring gname
+-                 }
++                 }executeonly
+                  {pop} ifelse
+-               } forall
++               } executeonly forall
+                pop pop
+-             }
++             } executeonly
+              {
+                pop pop pop
+              } ifelse
+-           }
++           } executeonly
+            {
+                                                                % scratch(string) RAGL(dict) AGL(dict) CharStrings(dict) cstring gname
+              pop pop
+            } ifelse
+-         } forall
++         } executeonly forall
+          3 1 roll pop pop
+-     } if
++     } executeonly if
+      pop
+      dup /.AGLprocessed~GS //true //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
+-   } if
++   } executeonly if
+ 
+    %% We need to excute the C .buildfont1 in a stopped context so that, if there
+    %% are errors we can put the stack back sanely and exit. Otherwise callers won't

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -62,6 +62,20 @@ stdenv.mkDerivation rec {
       url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=db24f253409d5d085c2760c814c3e1d3fa2dac59";
       sha256 = "1h6kpwc6ryr6jlxjr6bfnvmmf8x0kqmyjlx3hggqjs23n0wsr9p9";
     })
+    ./9.26-CVE-2019-10216.patch
+    (fetchpatch {
+        name = "CVE-2019-14811.CVE-2019-14812.CVE-2019-14813.patch";
+        url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=885444fcbe10dc42787ecb76686c8ee4dd33bf33";
+        sha256 = "19928sr7xpx7iibk9gn127g0r1yv2lcfpwgk2ipzz4wgrs3f5j70";
+    })
+    (fetchpatch {
+        name = "CVE-2019-14817-partial.patch";
+        url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=cd1b1cacadac2479e291efe611979bdc1b3bdb19";
+        # patch doesn't apply cleanly to all files, but at least partially applying it fixes
+        # *some* of the problematic sites.
+        excludes = ["Resource/Init/pdf_font.ps" "Resource/Init/pdf_draw.ps"];
+        sha256 = "04sy05svm3d2hyyzq41x5aqg3cgg2shaq08ivdqsys95nlihccpn";
+    })
   ];
 
   outputs = [ "out" "man" "doc" ];


### PR DESCRIPTION
###### Motivation for this change
As with master (#69728), not all of the CVE-2019-14817 patch applies cleanly, but the parts that do should provide some protection.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
