### PR TITLE
nextcloud-client/owncloud-client/qtkeychain: Fix GNOME keyring integration

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -16,6 +16,12 @@
 , sqlite
 }:
 
+let
+  qtkeychainWithLibsecret = qtkeychain.override {
+    withLibsecret = true;
+  };
+in
+
 mkDerivation rec {
   pname = "nextcloud-client";
   version = "2.6.0";
@@ -42,7 +48,7 @@ mkDerivation rec {
     openssl
     pcre
     qtbase
-    qtkeychain
+    qtkeychainWithLibsecret
     qttools
     qtwebengine
     qtwebkit

--- a/pkgs/applications/networking/owncloud-client/default.nix
+++ b/pkgs/applications/networking/owncloud-client/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, fetchurl, mkDerivation, cmake, pkgconfig, qtbase, qtwebkit, qtkeychain, sqlite }:
+{ stdenv, fetchurl, mkDerivation, cmake, libsecret, pkgconfig, qtbase, qtwebkit, qtkeychain, sqlite }:
+
+let
+  qtkeychainWithLibsecret = qtkeychain.override {
+    withLibsecret = true;
+  };
+in
 
 mkDerivation rec {
   pname = "owncloud-client";
@@ -10,7 +16,11 @@ mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];
-  buildInputs = [ qtbase qtwebkit qtkeychain sqlite ];
+  buildInputs = [ qtbase qtwebkit qtkeychainWithLibsecret sqlite ];
+
+  qtWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ libsecret ]}"
+  ];
 
   cmakeFlags = [
     "-UCMAKE_INSTALL_LIBDIR"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

There had been a small mistake in the package definition of qtkeychain. The result had been that qtkeychain was being compiled without libsecret support. Therefore, integration with the GNOME keyring had not been working, forcing users to put in credentials whenever they started the clients for Nextcloud or Owncloud.

This pull request takes care that qtkeychain can be built with libsecret support. qtkeychain now has an option called withLibsecret which defaults to false. For nextcloud-client and owncloud-client, qtkeychain is built with withLibsecret = true.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS (qtkeychain only)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @caugner @Ma27 @qknight 
