### PR TITLE
vimPlugins.vader-vim: init at 2019-05-18

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2708,6 +2708,17 @@ let
     };
   };
 
+  vader-vim = buildVimPluginFrom2Nix {
+    pname = "vader-vim";
+    version = "2019-05-18";
+    src = fetchFromGitHub {
+      owner = "junegunn";
+      repo = "vader.vim";
+      rev = "de8a976f1eae2c2b680604205c3e8b5c8882493c";
+      sha256 = "1pibls5s74fkzvj7spdpdn2s6zka0zxg4yr02s6jd0bcniq210b5";
+    };
+  };
+
   vCoolor-vim = buildVimPluginFrom2Nix {
     pname = "vCoolor-vim";
     version = "2018-10-06";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -151,6 +151,7 @@ junegunn/fzf.vim
 junegunn/goyo.vim
 junegunn/limelight.vim
 junegunn/seoul256.vim
+junegunn/vader.vim
 junegunn/vim-easy-align
 junegunn/vim-github-dashboard
 junegunn/vim-peekaboo


### PR DESCRIPTION
Vader is a test framework for testing other vim plugins.
27 of the plugins in vim-plugin-names use Vader for their tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested this by running the `seoul256` tests like this:
```
git clone https://github.com/junegunn/seoul256.vim.git
$(nix-build -I nixpkgs="$HOME/devel/nixpkgs" -E 'with import <nixpkgs> {}; vim_configurable.customize { name = "vim-with-vader"; vimrcConfig.packages.myVimPackage = with pkgs.vimPlugins; { start = [ vader-vim seoul256-vim ]; }; }')/bin/vim-with-vader seoul256.vim/test/seoul256.vader
```
and then running the vim command `:Vader`.  Result:

![vader-seoul256](https://user-images.githubusercontent.com/1118859/67456521-e59b8000-f5e5-11e9-9ed4-db6eee40fe0a.png)

###### Notify maintainers

cc @
