### PR TITLE
ocamlPackages.sawja: 1.5.6 → 1.5.7

### DIFF
--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -1,10 +1,10 @@
-{stdenv, fetchurl, which, perl, ocaml, findlib, javalib, camlp4 }:
+{stdenv, fetchurl, which, perl, ocaml, findlib, javalib }:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12";
 
 let
   pname = "sawja";
-  version = "1.5.6";
+  version = "1.5.7";
   webpage = "http://sawja.inria.fr/";
 in
 stdenv.mkDerivation {
@@ -12,11 +12,11 @@ stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-${pname}-${version}";
 
   src = fetchurl {
-    url = https://gforge.inria.fr/frs/download.php/file/37819/sawja-1.5.6.tar.bz2;
-    sha256 = "0dkfdc8h94r7kj4p8q57fz7fssypgmjrix8xff0va7x1nya5sdp3";
+    url = https://gforge.inria.fr/frs/download.php/file/38117/sawja-1.5.7.tar.bz2;
+    sha256 = "08xv1bq4pragc1g93w4dnbn0mighcjwfp3ixj9jzmhka2vzqm4cc";
   };
 
-  buildInputs = [ which perl ocaml findlib camlp4 ];
+  buildInputs = [ which perl ocaml findlib ];
 
   patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
