### PR TITLE
catt: init at 0.10.2

### DIFF
--- a/pkgs/applications/video/catt/default.nix
+++ b/pkgs/applications/video/catt/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonApplication, fetchPypi, lib
+, youtube-dl
+, PyChromecast
+, click
+, ifaddr
+, requests
+}:
+
+buildPythonApplication rec {
+  pname = "catt";
+  version = "0.10.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n6aa2vvbq0z3vcg4cylhpqxch783cxvxk234647knklgg9vdf1r";
+  };
+
+  propagatedBuildInputs = [
+    youtube-dl PyChromecast click ifaddr requests
+  ];
+
+  doCheck = false; # attempts to access various URLs
+
+  meta = with lib; {
+    description = "Cast All The Things allows you to send videos from many, many online sources to your Chromecast";
+    homepage = "https://github.com/skorokithakis/catt";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17828,6 +17828,8 @@ in
 
   catimg = callPackage ../tools/misc/catimg { };
 
+  catt = python3Packages.callPackage ../applications/video/catt { };
+
   cava = callPackage ../applications/audio/cava { };
 
   cb2bib = libsForQt5.callPackage ../applications/office/cb2bib { };


### PR DESCRIPTION
###### Motivation for this change

"Cast All The Things"! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).