### PR TITLE
hwloc: 2.0.4 -> 2.1.0

### DIFF
--- a/pkgs/development/libraries/hwloc/default.nix
+++ b/pkgs/development/libraries/hwloc/default.nix
@@ -7,7 +7,7 @@ assert x11Support -> libX11 != null && cairo != null;
 with stdenv.lib;
 
 let
-  version = "2.0.4";
+  version = "2.1.0";
   versmm = versions.major version + "." + versions.minor version;
   name = "hwloc-${version}";
 
@@ -16,7 +16,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.open-mpi.org/software/hwloc/v${versmm}/downloads/${name}.tar.bz2";
-    sha256 = "1aa7s208gdijk19vvzzahyl8pglk1va3yd6kdbpfa5pz5ms0ag35";
+    sha256 = "0qh8s7pphz0m5cwb7liqmc17xzfs23xhz5wn24r6ikvjyx99fhhr";
   };
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change
Regular update:
https://raw.githubusercontent.com/open-mpi/hwloc/v2.1/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fpletz 

### nix-review results:
As far as I can the tell the build failures are unrelated to `hwloc`.
```
45 package failed to build:
cntk ethminer libtensorflow python27Packages.baselines python27Packages.cntk python27Packages.dm-sonnet python27Packages.edward python27Packages.graph_nets python27Packages.tensorflow python27Packages.tensorflow-probability python27Packages.tensorflowWithCuda python27Packages.tflearn python37Packages.baselines python37Packages.datashader python37Packages.dm-sonnet python37Packages.edward python37Packages.graph_nets python37Packages.optuna python37Packages.rl-coach python37Packages.tensorflow python37Packages.tensorflow-probability python37Packages.tensorflowWithCuda python37Packages.tflearn python38Packages.baselines python38Packages.dask-jobqueue python38Packages.dask-mpi python38Packages.dask-xgboost python38Packages.datashader python38Packages.dftfit python38Packages.distributed python38Packages.dm-sonnet python38Packages.edward python38Packages.fipy python38Packages.graph_nets python38Packages.h5py-mpi python38Packages.lammps-cython python38Packages.mpi4py python38Packages.optuna python38Packages.rl-coach python38Packages.streamz python38Packages.stumpy python38Packages.tensorflow python38Packages.tensorflow-probability python38Packages.tensorflowWithCuda python38Packages.tflearn

51 package were build:
dl-poly-classic-mpi ethash freecad getdp globalarrays gromacsDoubleMpi gromacsMpi hdf5-mpi hpl hpx hwloc ior lammps-mpi migrate mpich mprime netcdf-mpi neuron-full neuron-mpi openmolcas openmpi parmetis python27Packages.fipy python27Packages.h5py-mpi python27Packages.mpi4py python27Packages.neurotools python27Packages.pyslurm python37Packages.dask-jobqueue python37Packages.dask-mpi python37Packages.dask-xgboost python37Packages.dftfit python37Packages.distributed python37Packages.fipy python37Packages.h5py-mpi python37Packages.lammps-cython python37Packages.mpi4py python37Packages.neuron-mpi python37Packages.pyslurm python37Packages.streamz python37Packages.stumpy python38Packages.neuron-mpi python38Packages.pyslurm quantum-espresso-mpi raxml-mpi scalapack scotch siesta-mpi slurm slurm-spank-x11 xmr-stak xmrig
```
