### PR TITLE
buku: relax mypy-extensions version req

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -54,6 +54,8 @@ with python3.pkgs; buildPythonApplication rec {
       --replace "@pytest.mark.slowtest" "@unittest.skip('skipping')" \
       --replace "self.assertEqual(shorturl, 'http://tny.im/yt')" "" \
       --replace "self.assertEqual(url, 'https://www.google.com')" ""
+    substituteInPlace setup.py \
+      --replace mypy-extensions==0.4.1 mypy-extensions>=0.4.1
   '';
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

buku requires `mypy-extensions==0.4.1` but it was recently updated to 0.4.2 in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fridh
