### PR TITLE
Python: add hook to check against dependencies in a requirements.txt file

### DIFF
--- a/pkgs/development/interpreters/python/check-requirements/check-requirements.py
+++ b/pkgs/development/interpreters/python/check-requirements/check-requirements.py
@@ -1,0 +1,55 @@
+# Check whether dependencies listed in a requiremens.txt are found
+# in the current environment.
+#
+# Based on https://github.com/pypa/pip/issues/2733#issuecomment-257340871
+import argparse
+import pip
+from pip.req import parse_requirements
+import pkg_resources
+from pkg_resources import DistributionNotFound, VersionConflict
+
+
+def get_dependencies(requirement_file_name):
+    dependencies = []
+    session = pip.download.PipSession()
+    for req in parse_requirements(requirement_file_name, session=session):
+        if req.req is not None:
+            dependencies.append(str(req.req))
+        else:
+            # The req probably refers to a url. Depending on the
+            # format req.link.url may be able to be parsed to find the
+            # required package.
+            pass
+    return dependencies
+
+
+def check_dependencies(dependencies):
+    """Checks to see if the python dependencies are fullfilled.
+    If check passes return 0. Otherwise print error and return 1
+    """
+    try:
+        pkg_resources.working_set.require(dependencies)
+    except VersionConflict as exc:
+        try:
+            print("{} was found on your system, "
+                  "but {} is required.\n".format(e.dist, e.req))
+            return(0)
+        except AttributeError:
+            print(e)
+            return 1
+    except DistributionNotFound as e:
+        print(e)
+        return 1
+    return 0
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    dependencies = get_dependencies(args.file)
+    exit(check_dependencies(dependencies))

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -70,6 +70,16 @@ in rec {
       name = "python-remove-bin-bytecode-hook";
     } ./python-remove-bin-bytecode-hook.sh) {};
 
+  requirementsCheckHook = callPackage ({ pip, setuptools }:
+    makeSetupHook {
+      name = "check-requirements-hook";
+      deps = [ pip setuptools ];
+      substitutions = {
+        inherit pythonCheckInterpreter;
+        requirementsCheckScript = ../check-requirements/check-requirements.py;
+      };
+  } ./requirements-check-hook.sh) {};
+
   setuptoolsBuildHook = callPackage ({ setuptools, wheel }:
     makeSetupHook {
       name = "setuptools-setup-hook";

--- a/pkgs/development/interpreters/python/hooks/requirements-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/requirements-check-hook.sh
@@ -1,0 +1,15 @@
+# Setup hook for requirements.
+echo "Sourcing requirements-check-hook"
+
+requirementsCheckPhase() {
+    if [ -z "$requirementsCheckFile" ]; then
+        echo "Error: no $requirementsCheckFile was given."
+        exit 1
+
+    @pythonCheckInterpreter@ @requirementsCheckScript@ $requirementsCheckFile
+}
+
+if [ -z "$dontUseRequirementsCheck" ]; then
+    echo "Using requirementsCheckPhase"
+    preDistPhases+=" requirementsCheckPhase"
+fi

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -108,7 +108,7 @@ in {
   inherit buildSetupcfg;
 
   inherit (callPackage ../development/interpreters/python/hooks { })
-    flitBuildHook pipBuildHook pipInstallHook pytestCheckHook pythonCatchConflictsHook pythonImportsCheckHook pythonRemoveBinBytecodeHook setuptoolsBuildHook setuptoolsCheckHook wheelUnpackHook;
+    flitBuildHook pipBuildHook pipInstallHook pytestCheckHook pythonCatchConflictsHook pythonImportsCheckHook pythonRemoveBinBytecodeHook requirementsCheckHook setuptoolsBuildHook setuptoolsCheckHook wheelUnpackHook;
 
   # helpers
 


### PR DESCRIPTION
Python applications are often not distributed as installable packages
using setuptools/flit/..., but instead a `requirements.txt` file is
often given.

This commit adds a hook to check whether the listed deps are fullfilled.

To ignore a certain requirement, use `substituteInPlace` to
replace/remove it.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
