### PR TITLE
java-darwin: upgrade 8.0_121 -> 8.0_212

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -7,11 +7,11 @@ let
   };
 
   jdk = stdenv.mkDerivation {
-    name = "zulu1.8.0_121-8.20.0.5";
+    name = "zulu1.8.0_212-8.38.0.13";
 
     src = fetchurl {
-      url = "http://cdn.azul.com/zulu/bin/zulu8.20.0.5-jdk8.0.121-macosx_x64.zip";
-      sha256 = "2a58bd1d9b0cbf0b3d8d1bcdd117c407e3d5a0ec01e2f53565c9bec5cf9ea78b";
+      url = "http://cdn.azul.com/zulu/bin/zulu8.38.0.13-ca-jdk8.0.212-macosx_x64.zip";
+      sha256 = "11i2j0cx3y1zrxdn9s4rnmq5iqvv2193b1g6rx7w46905141rdkk";
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-linux/";
     };
 


### PR DESCRIPTION
Upgrading jdk8 version for darwin to catch up with jdk8 version for linux (based on 19.09 stable channel).


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
There is no maintainers in openjdk/darwin/default.nix, notifying people who contributed to that file.
cc @matthewbauer @copumpkin @jfraudeau