### PR TITLE
slimThemes: fix version

### DIFF
--- a/pkgs/applications/display-managers/slim/themes.nix
+++ b/pkgs/applications/display-managers/slim/themes.nix
@@ -4,7 +4,7 @@
 
 let
   buildTheme =
-    {fullName, src, version ? "testing"}:
+    {fullName, src, version ? "unstable"}:
 
     stdenv. mkDerivation rec {
       name = "${fullName}-${version}";
@@ -93,8 +93,8 @@ in {
   };
 
   lunar = buildTheme {
-    fullName = "lunar-0.4";
-    version = "";
+    fullName = "lunar";
+    version = "0.4";
     src = fetchurl {
       url = "mirror://sourceforge/slim.berlios/slim-lunar-0.4.tar.bz2";
       sha256 = "1543eb45e4d664377e0dd4f7f954aba005823034ba9692624398b3d58be87d76";
@@ -175,6 +175,7 @@ in {
 
   nixosSlim = buildTheme {
     fullName = "nixos-slim";
+    version = "2.0";
     src = fetchurl {
       url = "https://github.com/jagajaga/nixos-slim-theme/archive/2.0.tar.gz";
       sha256 = "0lldizhigx7bjhxkipii87y432hlf5wdvamnfxrryf9z7zkfypc8";


### PR DESCRIPTION
###### Motivation for this change

fix version for repology

2019-10-23 12:21:40   slimThemes.zenwalk: ERROR: cannot extract version from "zenwalk-testing"

instead of testing, unstable is now used.

also explicitely set known versions.

this hopefully also fixes this strange version:

![Screenshot from 2019-10-24 17-45-58](https://user-images.githubusercontent.com/91113/67502484-3498f200-f686-11e9-8627-627163291fce.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
