### PR TITLE
pass-checkup: init at 0.2.0

### DIFF
--- a/pkgs/tools/security/pass/extensions/checkup.nix
+++ b/pkgs/tools/security/pass/extensions/checkup.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub
+, curl, findutils, gnugrep, gnused }:
+
+stdenv.mkDerivation rec {
+  pname = "pass-checkup";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "etu";
+    repo = "pass-checkup";
+    rev = version;
+    sha256 = "17fyf8zj535fg43yddjww1jhxfb3nbdkn622wjxaai2nf46jzh7y";
+  };
+
+  patchPhase = ''
+    substituteInPlace checkup.bash \
+      --replace curl ${curl}/bin/curl \
+      --replace find ${findutils}/bin/find \
+      --replace grep ${gnugrep}/bin/grep \
+      --replace sed ${gnused}/bin/sed
+  '';
+
+  installPhase = ''
+    install -D -m755 checkup.bash $out/lib/password-store/extensions/checkup.bash
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A pass extension to check against the Have I been pwned API to see if your passwords are publicly leaked or not.";
+    homepage = "https://github.com/etu/pass-checkup";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/security/pass/extensions/default.nix
+++ b/pkgs/tools/security/pass/extensions/default.nix
@@ -6,6 +6,7 @@ with pkgs;
   pass-audit = callPackage ./audit.nix {
     pythonPackages = python3Packages;
   };
+  pass-checkup = callPackage ./checkup.nix {};
   pass-import = callPackage ./import.nix {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Pass checkup is a pass extension to check if your passwords is leaked against the haveibeenpwned database.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @adisbladis @grahamc 
