### PR TITLE
epsxe: fix link with openssl

### DIFF
--- a/pkgs/misc/emulators/epsxe/default.nix
+++ b/pkgs/misc/emulators/epsxe/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, alsaLib, curl, gdk-pixbuf, glib, gtk3, libGLU_combined,
-  libX11, openssl, ncurses5, SDL, SDL_ttf, unzip, zlib, wrapGAppsHook }:
+  libX11, openssl_1_0_2, ncurses5, SDL, SDL_ttf, unzip, zlib, wrapGAppsHook }:
 
 with stdenv.lib;
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     gtk3
     libX11
     libGLU_combined
-    openssl
+    openssl_1_0_2
     ncurses5
     SDL
     SDL_ttf

--- a/pkgs/misc/emulators/epsxe/default.nix
+++ b/pkgs/misc/emulators/epsxe/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, alsaLib, curl, gdk-pixbuf, glib, gtk3, libGLU_combined,
-  libX11, openssl_1_0_2, ncurses5, SDL, SDL_ttf, unzip, zlib, wrapGAppsHook }:
+  libX11, openssl_1_0_2, ncurses5, SDL, SDL_ttf, unzip, zlib, wrapGAppsHook, autoPatchelfHook }:
 
 with stdenv.lib;
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
              else "1677lclam557kp8jwvchdrk27zfj50fqx2q9i3bcx26d9k61q3kl";
   };
 
-  nativeBuildInputs = [ unzip wrapGAppsHook ];
+  nativeBuildInputs = [ unzip wrapGAppsHook autoPatchelfHook ];
   sourceRoot = ".";
 
   buildInputs = [
@@ -40,10 +40,6 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -D ${if stdenv.is64bit then "epsxe_x64" else "ePSXe"} $out/bin/epsxe
-    patchelf \
-      --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
-      --set-rpath ${makeLibraryPath buildInputs} \
-      $out/bin/epsxe
   '';
 
   meta = {


### PR DESCRIPTION
Epsxe is hardcoded to build with openssl-1.0 (using libcrypto.so.1.0.0),
but current nixpkgs contains openssl-1.1, which provides
libcrypto.so.1.1.

This patchs just uses the previous version of the library.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`epsxe` is currently broken in nixpkgs: it fails at runtime link because it does not find `libcrypto.so`.

###### Things done

This PR introduces two changes:

- Fix the build by using `openssl_1_0` instead of the default `openssl-1.1`
- Use `autoPatchelfHook` for the rpath rewriting. This simplify a bit the file but it also fails at buildtime.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
