### PR TITLE
melpa-packages: 2019-10-24

### DIFF
--- a/pkgs/applications/editors/emacs-modes/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs-modes/recipes-archive-melpa.json
@@ -234,16 +234,16 @@
   "repo": "abstools/abs-mode",
   "unstable": {
    "version": [
-    20190404,
-    2304
+    20191013,
+    926
    ],
    "deps": [
     "erlang",
     "flymake",
     "maude-mode"
    ],
-   "commit": "31fb36f9206203062b8c618fef6ad484e44af226",
-   "sha256": "0h0zsjqhjm18ppmaqv2kn4q1mchc1igcz80zwz8523n2w2gk9bri"
+   "commit": "5332dc875e0a285f64dd075b204fb6de5ba719ad",
+   "sha256": "1p2nsc4in8w407irsfihm8q0fh5am8vrd53gg5q78hhybazr53cf"
   },
   "stable": {
    "version": [
@@ -961,8 +961,8 @@
     "auto-complete",
     "yasnippet"
    ],
-   "commit": "131961b0476c6ee4d7bd07ce8d42d9e5a0dde38a",
-   "sha256": "0b3cfrhpzjh96kdgfv7r9p0ssd7qkn9kq69jkqjzrv23jr9y80fi"
+   "commit": "84aa4f0c4ffafa2c2fdfbcb16662abac0a571013",
+   "sha256": "1miz6nwsdbc9n3jc7qcb0mvf2yp0k9a7pyl0ifbdjjr2160m2lql"
   },
   "stable": {
    "version": [
@@ -987,8 +987,8 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20190922,
-    428
+    20191023,
+    1045
    ],
    "deps": [
     "dash",
@@ -998,8 +998,8 @@
     "s",
     "xcscope"
    ],
-   "commit": "131961b0476c6ee4d7bd07ce8d42d9e5a0dde38a",
-   "sha256": "0b3cfrhpzjh96kdgfv7r9p0ssd7qkn9kq69jkqjzrv23jr9y80fi"
+   "commit": "84aa4f0c4ffafa2c2fdfbcb16662abac0a571013",
+   "sha256": "1miz6nwsdbc9n3jc7qcb0mvf2yp0k9a7pyl0ifbdjjr2160m2lql"
   },
   "stable": {
    "version": [
@@ -1065,8 +1065,8 @@
     "auto-complete",
     "rtags"
    ],
-   "commit": "d3d4bc9b7b829d39628a1af96f06eb23ba48670c",
-   "sha256": "0fgxrpqvqs988kjnkcc1lmyqnfc85ivhrarldl7iqgj25fvni6z1"
+   "commit": "f2633f565fc5e7e6958993ef105225f4e68e43ba",
+   "sha256": "1bjgr7wa82ccrc25r7agfaq3iz7xlp1qchvkmkx3xy59jv4yafjz"
   },
   "stable": {
    "version": [
@@ -1361,14 +1361,14 @@
   "repo": "abo-abo/ace-link",
   "unstable": {
    "version": [
-    20190716,
-    920
+    20191017,
+    941
    ],
    "deps": [
     "avy"
    ],
-   "commit": "9b6d02564650e963ce05d124f83ced17e0027d7f",
-   "sha256": "06jac3nlmnsbw9hiyqjxmf7igjs8xxcvdih6nf63lbnvm0qnazyn"
+   "commit": "483d0ea9d1e13884f13e54093b41082884325878",
+   "sha256": "1m4zcw27m99jlbjy5dyxxp4069pgwswqhyrps3c3zsnzs8hf1j0z"
   },
   "stable": {
    "version": [
@@ -1474,14 +1474,14 @@
   "repo": "abo-abo/ace-window",
   "unstable": {
    "version": [
-    20190708,
-    933
+    20191022,
+    1203
    ],
    "deps": [
     "avy"
    ],
-   "commit": "a5344925e399e1f015721cda6cf5db03c90ab87a",
-   "sha256": "18jm8gfgnf6ja9aarws5650lw2zfi3wdwc5j8r5ijn5fcqhfy7rc"
+   "commit": "edbbb1b77c3fb939e4d9057443bc1897321d0095",
+   "sha256": "1n8w6svks0pmslzg5zz1sny4hfnvych06cwzs3bvbmnfm4x6maqh"
   },
   "stable": {
    "version": [
@@ -1777,15 +1777,15 @@
   "stable": {
    "version": [
     0,
-    47
+    48
    ],
    "deps": [
     "cl-lib",
     "dash",
     "s"
    ],
-   "commit": "f2cfea210b165564e8d44f4c980b2fedac2462c1",
-   "sha256": "15kp99vwyi7hb1jkq3lwvqzw3v62ycixsq6y4pd1x0nn2v5p5m5r"
+   "commit": "bd81d68466e44301505629454dfc689b6c17d94b",
+   "sha256": "1p918y24vcn2pdliaymd210xp9fvhd4a1srqbv2lfiqrh59yjidx"
   }
  },
  {
@@ -1859,11 +1859,11 @@
   "repo": "takaxp/ah",
   "unstable": {
    "version": [
-    20190905,
-    1422
+    20191004,
+    250
    ],
-   "commit": "401135fd94c7f2df1ce23dbed32b4efd670689c7",
-   "sha256": "0n5g2fildhca5vlgpkzrhd8j60bvkfq74zzq4vzhqq7qflj17j3h"
+   "commit": "218b9ffacb615e7a307ee30c18d072ce3e33aad6",
+   "sha256": "16ak8bbha079lkg7gxxngysry6bgilqi3dz4aa2yd5w9y25rv6va"
   }
  },
  {
@@ -2344,11 +2344,35 @@
   }
  },
  {
-  "ename": "alt-codes",
-  "commit": "693e11e8a99697ff8da1fe7cd9209af4e415fecb",
-  "sha256": "0kh6fz38bzvqh78b17qa6riwnz6xvkw5w8rrlj413j4ypm464zxq",
+  "ename": "alsamixer",
+  "commit": "61a07f01ee94173fa59716d30b14a34ec967578e",
+  "sha256": "1kil28lpxaqnwgyw2h69dmx78q5lpn5k0l6y0fwyz2n6vayxw4yj",
   "fetcher": "github",
-  "repo": "elpa-host/alt-codes",
+  "repo": "remvee/alsamixer-el",
+  "unstable": {
+   "version": [
+    20191002,
+    1133
+   ],
+   "commit": "1bdb99e433acd38685f05408562746cfbf2bc820",
+   "sha256": "0c40vycphv5nf374rp8pnzvi50vlmgab3wrdq92hyprjw76gwxhk"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    1
+   ],
+   "commit": "1bdb99e433acd38685f05408562746cfbf2bc820",
+   "sha256": "0c40vycphv5nf374rp8pnzvi50vlmgab3wrdq92hyprjw76gwxhk"
+  }
+ },
+ {
+  "ename": "alt-codes",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "1h1hs0vxzmmrkf7mkm44lqb9d41jg02sk7iwb54s9g92rc7c10rg",
+  "fetcher": "github",
+  "repo": "jcs-elpa/alt-codes",
   "unstable": {
    "version": [
     20190701,
@@ -2421,29 +2445,6 @@
    ],
    "commit": "ca5faaa0d5115dc2c301e06e062e653a7b9cb927",
    "sha256": "07207h1643amlairnmpf8lnnkgf69kc04z3ri9k6fm4gmh6c9dy0"
-  }
- },
- {
-  "ename": "amixer",
-  "commit": "ebb2d6c70b1fd2ddfb33d915c2ea01cc0d6da663",
-  "sha256": "17bf6asrx5q71m8ry9fkdb1lavj4slx995j1v0vny7wgijmcyhdf",
-  "fetcher": "github",
-  "repo": "remvee/amixer-el",
-  "unstable": {
-   "version": [
-    20190923,
-    607
-   ],
-   "commit": "51016256450996aad3ffc0f99129a98ff32059be",
-   "sha256": "1r07im2zd22a9f6dpxw6qrhbr773dyb6lfxcqsg7jjx55fa7xw3g"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "commit": "052d5a2f91e43e7dfb7bf4e7c5537ce600ae1c4a",
-   "sha256": "0vmzca0pwdrqiysk5dbhmn02v2sqzs0qhi6987r1z6m9xzrwhmba"
   }
  },
  {
@@ -2547,8 +2548,8 @@
   "repo": "pythonic-emacs/anaconda-mode",
   "unstable": {
    "version": [
-    20190918,
-    353
+    20191001,
+    2056
    ],
    "deps": [
     "dash",
@@ -2556,8 +2557,8 @@
     "pythonic",
     "s"
    ],
-   "commit": "dc324ddea5d43e8f9a9d86936fc27ebfca8dac68",
-   "sha256": "0b8sdxdi9l78143mpachnm4wa6wivhx0q4kav801wxh0ncwfnk6i"
+   "commit": "1b31c03756b989b674969bb1eb45ac809e59313b",
+   "sha256": "0h6afysc7c5a379bd9scdb27g0r1ncqinz7gnspqlqri205dmj33"
   },
   "stable": {
    "version": [
@@ -2735,8 +2736,8 @@
   "repo": "davidshepherd7/anki-mode",
   "unstable": {
    "version": [
-    20181106,
-    1837
+    20191020,
+    1441
    ],
    "deps": [
     "dash",
@@ -2744,8 +2745,8 @@
     "request",
     "s"
    ],
-   "commit": "365fcfff45ed543f3df0d4110415f6f818ec2727",
-   "sha256": "021wvz0vxbpiigrdhgilbpkbxmwwjy127g1lrp0wmnqg5m3rl5rg"
+   "commit": "8022fbab57c47581102af831b4405fc27f71db92",
+   "sha256": "1nyiqd3093dbcimljj09vidanki6nbrzknzdxw4rkbl2kd1wfvlf"
   },
   "stable": {
    "version": [
@@ -2770,26 +2771,26 @@
   "repo": "noctuid/annalist.el",
   "unstable": {
    "version": [
-    20190905,
-    5
+    20190929,
+    207
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "8f52a365b2876f034fbf9b335786fa6bafc9ac80",
-   "sha256": "0qscah37qs65wykkw9nc5n5xgd4fy8w1jv6mznk4fbpds6qaxrjh"
+   "commit": "134fa3f0fb91a636a1c005c483516d4b64905a6d",
+   "sha256": "06dvk7hd3bqjng87apf5dsbdn0rv0gcrj66m7dz26c8bg19mddcc"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "0da9812e419b1687cf1e7040384f983be32d5328",
-   "sha256": "1dws8r39asjnxzjq4ixlja1ih6kphw0w666k685m7ncq9jmr6jw6"
+   "commit": "08df07e4530953a2c0b1aa553adcab37b7b614b0",
+   "sha256": "1jlb5w4972l8m2aa18q2l6arfpm65g4nk21dn1yi8c9dbpk2g67c"
   }
  },
  {
@@ -2800,11 +2801,11 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20190918,
-    714
+    20191022,
+    633
    ],
-   "commit": "cb8de5081ab4adda81806a44ba91ba70d05d4ffb",
-   "sha256": "1xxx2iafl8fkp2mmdkl6l8f7bml6g1azc746vwwxsx0yiim48jm9"
+   "commit": "54aefdec8d7d366d0987aec9242f035a52c54aa2",
+   "sha256": "11iqz6kncnzcnmxk2m037pmyflv6svq32r52cjw254fc3dvm39i0"
   },
   "stable": {
    "version": [
@@ -2898,28 +2899,28 @@
   "repo": "k1LoW/emacs-ansible",
   "unstable": {
    "version": [
-    20190619,
-    1255
+    20191003,
+    1430
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "2d35aa1280ace3cae404ea9e1231a8b26c7b9eb4",
-   "sha256": "1yv33bw2q87am4bi2dasrbya28l6p3y4nr8rs0yl5nsvdbk4vbpg"
+   "commit": "c6532e52161a381ed3dddfeaa7c92ae636d3f052",
+   "sha256": "16i0r019lj9fdkxcga2jb8ha0r2lf1mz7jywg44hnj7r3lzdcmwp"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "8a097176d6772b6667254dbbe19c5fb64527bf5d",
-   "sha256": "1m2cb88jb1wxa9rydkbn5llx2gql453l87b4cgzsjllha6j1488k"
+   "commit": "c6532e52161a381ed3dddfeaa7c92ae636d3f052",
+   "sha256": "16i0r019lj9fdkxcga2jb8ha0r2lf1mz7jywg44hnj7r3lzdcmwp"
   }
  },
  {
@@ -3567,11 +3568,11 @@
   "repo": "ragone/asx",
   "unstable": {
    "version": [
-    20190916,
-    2122
+    20191024,
+    1100
    ],
-   "commit": "903e01d2856a95427bdf7d41d9628b3886e90867",
-   "sha256": "09dv2imw5mcpw3n42hgwiw7c3wb31f74ci7hbqa5rk140rrvhf8j"
+   "commit": "5ca12cc51bb02b5926adf9a7976ba9ca08a1ea21",
+   "sha256": "16cwpzbi8xpmw25xnn9535djpgwwdjv4q4yh47mqfav3x5nqwgpk"
   }
  },
  {
@@ -3582,11 +3583,11 @@
   "repo": "jwiegley/emacs-async",
   "unstable": {
    "version": [
-    20190503,
-    656
+    20191009,
+    1018
    ],
-   "commit": "bd68cc1ab1ac6af890e250bdaa12ffb1cb9649be",
-   "sha256": "02n46dqbpdjlj65s1aka6ky49rgv2rpn06lzpfxwxl7kkzclc5f8"
+   "commit": "67c369555de998eaabd60056dead038c6c50b8fd",
+   "sha256": "0hhpyxb3d531jb2f3wvzx25183f0anm8nxv6mh0p825q2gkm6ly7"
   },
   "stable": {
    "version": [
@@ -3606,14 +3607,14 @@
   "repo": "chuntaro/emacs-async-await",
   "unstable": {
    "version": [
-    20170208,
-    1150
+    20191006,
+    422
    ],
    "deps": [
     "promise"
    ],
-   "commit": "56ab90e4019ed1f81fd4ad9e8701b5cec7ffa795",
-   "sha256": "1k6wisls6dqn63r4f4brnhrjbvzqpigw2zxdl9v8g1qcw49spk5s"
+   "commit": "c1348cc02ed54ccf49b7f39f1ebbf7df17e63c74",
+   "sha256": "18li54j0rnx64nnaw2wp2nl92msdryb7sjxmaip6b88q9qiwkdi5"
   }
  },
  {
@@ -3695,8 +3696,8 @@
   "repo": "jyp/attrap",
   "unstable": {
    "version": [
-    20190918,
-    828
+    20190927,
+    940
    ],
    "deps": [
     "dash",
@@ -3704,8 +3705,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "18cd1f7832870a36c404e872fa83a271fe8e688d",
-   "sha256": "078391949h0fgmshin8f79a1a595m06ig577rkgjqgngcp0d61l9"
+   "commit": "0e4a2848d0a0cb509a54dbee6dd7b04f96c17737",
+   "sha256": "0ds3ca3pw1aab4y0fzlv76imbnlccky5mphd10zdikmrnwdhsm2w"
   },
   "stable": {
    "version": [
@@ -3907,14 +3908,14 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20181230,
-    2216
+    20191020,
+    1040
    ],
    "deps": [
     "packed"
    ],
-   "commit": "f043133f37fe6d707fa03a1ec4ba619da24c2f35",
-   "sha256": "0h41vykrdn1jrwzn5db9idw5j3d77xhn616kwfv1syka7hvmyaq4"
+   "commit": "c46fb16c919d1f821cd69a43cc6e396757c51b2f",
+   "sha256": "06xfvn9s7kh3c0md431css5hz5yd3b2x6x788hx75hy3r7azi73s"
   },
   "stable": {
    "version": [
@@ -4307,8 +4308,8 @@
     20180527,
     1123
    ],
-   "commit": "e0e2ceb471a14a3e1763b47619fa4b8faef0be07",
-   "sha256": "1m96gs55jsjxj4mbx1wv080b809fjw53by67jv3ny70i4xjk36kp"
+   "commit": "17cfa1b54800fdef2975c0c0531dad34846a5065",
+   "sha256": "1jgq9b262pjr6npza3k0p2glb6mpp0dfpslgx3i2p8a5ipwhwaqa"
   },
   "stable": {
    "version": [
@@ -4525,14 +4526,14 @@
   "repo": "abo-abo/auto-yasnippet",
   "unstable": {
    "version": [
-    20190326,
-    958
+    20191015,
+    942
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "624b0d9711222073a2a3f2186e2605eb99fc83c9",
-   "sha256": "15g8wi067f345xhpi0c12w0h04p4f4lpccwmdjdfj8hzfl4gyxy9"
+   "commit": "db9e0dd4335b2202cd5dac95bbbc87a1032d9bbe",
+   "sha256": "0az8pip0gsq5xqpfizcz4rmj5hmkvz1fdkg996k9qqacp17p2caj"
   },
   "stable": {
    "version": [
@@ -4954,11 +4955,11 @@
   "repo": "sebasmonia/awscli-capf",
   "unstable": {
    "version": [
-    20190909,
-    1534
+    20190930,
+    1517
    ],
-   "commit": "6670b4db6bd35f0ea9ede598a9c17384046f4400",
-   "sha256": "0pnz8jiapd8i8ya2j9lns22rg903iq65pby89wpmz7cidzg6lgf0"
+   "commit": "1a75f88f53a2969fe821c31e6857861d0a0c0a5e",
+   "sha256": "13ry0lhh8ss93h9c60gc02i28bwc70jb4fzqmvw778fk0shj8jxn"
   }
  },
  {
@@ -5450,11 +5451,11 @@
   "repo": "codesuki/bazel-mode",
   "unstable": {
    "version": [
-    20190606,
-    800
+    20191002,
+    333
    ],
-   "commit": "f07e75fc2dd97ba20e40806927409357aaad2496",
-   "sha256": "0grbvzqy4x6wh2951jsh5mmbhwbd6j5figqj7v9q5px5alprjqsl"
+   "commit": "13a8efc7b388b3ac45dd981898953bd98dd1b3d3",
+   "sha256": "17b4q3crzaxmsrh98jrnnnlyyjlbqq3mzxdvw44cbzy4d4qqcaps"
   },
   "stable": {
    "version": [
@@ -5504,11 +5505,11 @@
   "url": "https://git.savannah.nongnu.org/git/bbdb.git",
   "unstable": {
    "version": [
-    20190609,
-    316
+    20190927,
+    1617
    ],
-   "commit": "1d26869d2787803672dd412cf658158d6bef0c7b",
-   "sha256": "1l503z8fklrxxawxf00xbwbw1wyx7bsn2mhm5249h49ckxnqhgcx"
+   "commit": "2bbe645ae71d84ad518e03dec698d4154af2f9f0",
+   "sha256": "1f18pzwm7p4k1ycnrx80la4wxlph59kv7zh18sk4iz3k6a3j3nnh"
   },
   "stable": {
    "version": [
@@ -5874,11 +5875,11 @@
   "repo": "gilbertw1/better-jumper",
   "unstable": {
    "version": [
-    20190510,
+    20191021,
     1647
    ],
-   "commit": "2c04d4bc09da88c5b8b276c87d3f9f56e517144e",
-   "sha256": "1gzmhgr17mvxj1qvcisfq74dbb2rsgzx2wrbjf36jrwfzx7sdjxw"
+   "commit": "3aa1a8a7662d4188633daf7d75a23e13ebdd902b",
+   "sha256": "1rn4mxh9anqk582x0x7v32dw6m5i96aapdpfpzsxs519wxs3j9q4"
   }
  },
  {
@@ -6062,8 +6063,8 @@
     "a",
     "pdf-tools"
    ],
-   "commit": "ebb2778052aeaf737adebc003957cb48cb01135e",
-   "sha256": "0qlvdpa88ic9gnb0qhijfsc9i6l3ba2zrvk4r4li3qrx0i9rpz5c"
+   "commit": "5f3e67448cc98fe2875115163849acae4d9e8526",
+   "sha256": "1w0dhyr4i0nx0g70smgclcfsbv6cfilb7df330njzaqk8j2gdfws"
   }
  },
  {
@@ -6810,16 +6811,16 @@
   "repo": "jyp/boon",
   "unstable": {
    "version": [
-    20190918,
-    601
+    20191001,
+    1211
    ],
    "deps": [
     "dash",
     "expand-region",
     "multiple-cursors"
    ],
-   "commit": "07534c76d6bd3cd9307cc53deb59f11746f91ecc",
-   "sha256": "16rzjr52g4jn96xsa6z1acl9zipq46pg8rhcgxri43cdanwkfqin"
+   "commit": "b17880bd39863b8f4acc7c8597fbf3f01b36e047",
+   "sha256": "0ad8vgn1sg1rmldh8nnavlgkjqb5ild5744wr4crmx6p9wyab298"
   },
   "stable": {
    "version": [
@@ -7710,19 +7711,19 @@
   "repo": "jorgenschaefer/emacs-buttercup",
   "unstable": {
    "version": [
-    20190906,
-    1433
+    20191006,
+    1305
    ],
-   "commit": "d2b6692d58828d0e604fa259cf484296795fb2a7",
-   "sha256": "0gb3d2039m71pi8m3n3mdncifljzq8qjvdg0j5gskx4shpg6k7jh"
+   "commit": "c2d75e9a48c93f96d1bc7f1bf151d69adb417abf",
+   "sha256": "1nzx39pf3lqbbc5h9r7qx30jm5r8g3k2zqc5hpmizv8d4l23fhcx"
   },
   "stable": {
    "version": [
     1,
-    17
+    18
    ],
-   "commit": "d2b6692d58828d0e604fa259cf484296795fb2a7",
-   "sha256": "0gb3d2039m71pi8m3n3mdncifljzq8qjvdg0j5gskx4shpg6k7jh"
+   "commit": "c2d75e9a48c93f96d1bc7f1bf151d69adb417abf",
+   "sha256": "1nzx39pf3lqbbc5h9r7qx30jm5r8g3k2zqc5hpmizv8d4l23fhcx"
   }
  },
  {
@@ -7739,8 +7740,8 @@
    "deps": [
     "buttercup"
    ],
-   "commit": "6bc28b6b0f36fb71b0915c9e45963c840c64a8df",
-   "sha256": "1rayxq1va7jpikfr37p8nq2pv339mhq7zqy082kzwvj5q6qfw88s"
+   "commit": "400227a45164e4e849048d288a02ab8243d09cd2",
+   "sha256": "1z972i1pzg8bkrzzbjha802486mybqyh9bhbvfk2sr6nzhvx2w1k"
   },
   "stable": {
    "version": [
@@ -8267,16 +8268,16 @@
   "repo": "kisaragi-hiu/cangjie.el",
   "unstable": {
    "version": [
-    20190829,
-    1530
+    20190929,
+    1221
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "b34a28dd06bd95a16b655f1917227925975314bc",
-   "sha256": "0xz62fivll6yv1x94f7f5m07zg7383llyz6wa1n5q1ysix2p20j1"
+   "commit": "0a703f4d1162259d77bfb3f862d13c1b1f11a711",
+   "sha256": "19f7xzc1204zdv8bbd5vfzxqrinhk8m9mw911dc77jab2in22348"
   },
   "stable": {
    "version": [
@@ -8414,8 +8415,8 @@
   "repo": "cask/cask",
   "unstable": {
    "version": [
-    20190718,
-    2055
+    20191004,
+    1155
    ],
    "deps": [
     "ansi",
@@ -8427,8 +8428,8 @@
     "s",
     "shut-up"
    ],
-   "commit": "1d031f77d3dcd540038e24151dbaf0a91de01db5",
-   "sha256": "1wz57lqmn9vzh8dlvb639lmfxh2h6m3f6kr9bglr2mf1hc3zrij1"
+   "commit": "a4715f7c6c9797639c3636399cb21c2b0332b354",
+   "sha256": "1zjz3mp8hgnsfyapq7qdfysj31g9f6syvrik2w057r3w3bxp8vkf"
   },
   "stable": {
    "version": [
@@ -8637,16 +8638,16 @@
   "repo": "MaskRay/emacs-ccls",
   "unstable": {
    "version": [
-    20190720,
-    935
+    20190927,
+    246
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "projectile"
    ],
-   "commit": "9061ebbf9d5ec3ee7e88dbd226c77017cf0447b1",
-   "sha256": "106jh25ivq0ydiz37p51agk5zbpai7fv91pwn6dpqzsq5g281ls7"
+   "commit": "b1acc336f27d8a3bbc750c2dc3be915a4ac1afea",
+   "sha256": "1qgfxc5d1hb32ks1fxpx7agpw7dvnkz99wydlflc9fqq75g8v142"
   }
  },
  {
@@ -8687,11 +8688,11 @@
   "repo": "cdominik/cdlatex",
   "unstable": {
    "version": [
-    20190130,
-    1419
+    20191006,
+    1030
    ],
-   "commit": "90d785a94c0db7aa0043ea62f5807af3df155438",
-   "sha256": "1yhry3wrqh1ijc0n7140pnbwcamrgi89a75pg03zx0cqb5g6c8i6"
+   "commit": "fea53d325bdc32e9b299971f906101f41d24e77e",
+   "sha256": "0gn2h9p60dbz6xcz2fn0p7vpg1bwsh2kn4n76yd9z1p40j1fn93a"
   },
   "stable": {
    "version": [
@@ -8810,15 +8811,15 @@
   "repo": "ema2159/centaur-tabs",
   "unstable": {
    "version": [
-    20190919,
-    2028
+    20191020,
+    237
    ],
    "deps": [
     "cl-lib",
     "powerline"
    ],
-   "commit": "90220c26cbc77b121eeb065e30f6d7a395ef131f",
-   "sha256": "1hrrsz4pbblmxyhds3253sjpk3gqb4zwjwwdl8b3shgamrhwl7y3"
+   "commit": "6a788ff518570d161674b4a7033f0a7a763b7417",
+   "sha256": "0a7nka9iha4c049gyb9qxdapgi33s5s5kav6r5p73wajx6iryzmz"
   }
  },
  {
@@ -8933,8 +8934,8 @@
     20171115,
     2108
    ],
-   "commit": "a886d605bc55f03250b12c45144aa4366ea5fb71",
-   "sha256": "10ppaz9lja7iipa2594ybfpq3cr593sq6xyy70gl8kb7wbxr7mig"
+   "commit": "3bdc063e56708301ccb51cc478fbd27bc7f71193",
+   "sha256": "1628afg4r1cbax43dc5ficpdmbawbxlwi2mmz3xv0rnrsm5vdld7"
   },
   "stable": {
    "version": [
@@ -9465,14 +9466,14 @@
   "repo": "SavchenkoValeriy/emacs-chocolate-theme",
   "unstable": {
    "version": [
-    20190818,
-    756
+    20191021,
+    1346
    ],
    "deps": [
     "autothemer"
    ],
-   "commit": "7de46341adcc7a5eaafcddc0d3a9d63274f5e9c7",
-   "sha256": "0s61lx5vhx01xzzqxy0blz6jxvljb8qjj3567nz17pwwdfcskc5v"
+   "commit": "1c6cd8d2fdc939bd4d26117d61e57c11cfe26512",
+   "sha256": "1knnj1kzjccr7hg5zbj4qfnkgjkf221bf7wv83km9hs7zs7brj5x"
   }
  },
  {
@@ -9572,8 +9573,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20190923,
-    739
+    20191019,
+    1042
    ],
    "deps": [
     "clojure-mode",
@@ -9584,14 +9585,14 @@
     "sesman",
     "spinner"
    ],
-   "commit": "c3c903adaa85d33c3935c7483f6d6c8c8ce73c41",
-   "sha256": "10vn4z578q3kiizbcx785jddpg5w0ssicc0n3qbpglik7sqdgp74"
+   "commit": "aba6567a12cdec01334f16f009e0c3c41b7aeb35",
+   "sha256": "1k3c4xrznyy3mya3n72y8c2brp0x3mr0pq6paw1wfdwzz9mn3764"
   },
   "stable": {
    "version": [
     0,
-    22,
-    1
+    23,
+    0
    ],
    "deps": [
     "clojure-mode",
@@ -9602,8 +9603,8 @@
     "sesman",
     "spinner"
    ],
-   "commit": "8a1262dae8f86f03fa2ec0abdbced10ff7e5ee1e",
-   "sha256": "0pjp1gcvhmbdh10w2yall9a7bbprg2z2hmmkwhqxcalsaacwfz0x"
+   "commit": "ce42702154709ef5d991e2732511c50d69de256c",
+   "sha256": "05yjkqc6d4grq9z5pxmv3anqh4zlhfg4v46jlccp6ynh030g7axs"
   }
  },
  {
@@ -9776,14 +9777,14 @@
   "repo": "jorgenschaefer/circe",
   "unstable": {
    "version": [
-    20190322,
-    1242
+    20191006,
+    1434
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "6ccd4b494cbae9d28091217654f052eaea321007",
-   "sha256": "0cr9flk310yn2jgvj4hbqw9nj5wlfi0fazdkqafzidgz6iq150wd"
+   "commit": "e4af7143bd32907d0bf922bee53a96399f0376fa",
+   "sha256": "1ccxin0vp3z8lxcfm9bci06jkwy0nwasdwg95wp9hdnccpr63s38"
   },
   "stable": {
    "version": [
@@ -9951,14 +9952,14 @@
   "repo": "emacsmirror/clang-format",
   "unstable": {
    "version": [
-    20190517,
-    722
+    20191019,
+    1213
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "77ee89a0b6c1b956bc68d192527d1a0391fe5baa",
-   "sha256": "1xfhxn6pn0clxwlsd9pqyy8srbqvkr0wmbyxr2979zv2fxzn17kd"
+   "commit": "113b767848ec1568f538e547d7c456a07d66b598",
+   "sha256": "1p2zz810nam5ciljd6hvln0qv9f8j53niry47fgwgsvwg527savx"
   }
  },
  {
@@ -10463,22 +10464,22 @@
     "s",
     "simple-httpd"
    ],
-   "commit": "a953d882dd4e476e58b04fcb6bb08d101588a8d1",
-   "sha256": "0s5sqcn8dwysvzbpvphvr4165yqh4h02r17lsy8fp5ddaqpdy6aw"
+   "commit": "292c8f5370a2c74094da46ede990b5e7cc8b55b8",
+   "sha256": "1rv57wqr09vl0caz4wjr0kqvhgvl5y1x6818v8m55rm2z8rim11i"
   },
   "stable": {
    "version": [
     0,
     0,
-    3
+    4
    ],
    "deps": [
     "cider",
     "s",
     "simple-httpd"
    ],
-   "commit": "d9783d42dbab9710afff5654bf931b00e9df4ac1",
-   "sha256": "0jwnsyg0vi9ghn9yfd97rjj9j9ja3ig8h63n4zjw71ww3bcdldc6"
+   "commit": "292c8f5370a2c74094da46ede990b5e7cc8b55b8",
+   "sha256": "1rv57wqr09vl0caz4wjr0kqvhgvl5y1x6818v8m55rm2z8rim11i"
   }
  },
  {
@@ -10672,17 +10673,19 @@
     20190710,
     1319
    ],
-   "commit": "b42cb1ff80dc056da4036c7b65109d1a77d84bf4",
-   "sha256": "1lw7rj57pg27gs0yfqrln16hhrb7npslv26jkd0jh3k5whs0fska"
+   "commit": "11897b824cb18f40bcbcee03ab4cb106a10ee436",
+   "sha256": "0hjkax8li2fzx0d716hm3yslkvgbbfnmrhdn92kmncq0mkr3nvzd"
   },
   "stable": {
    "version": [
     3,
-    15,
-    3
+    16,
+    0,
+    -1,
+    2
    ],
-   "commit": "26a0e200e5f4abe8268235c9fdb23a2612a1b3b1",
-   "sha256": "03qvdgfdxvbwwdipx8fbplnzrahf485w08j9fb0z1g27kq4wjjbb"
+   "commit": "92780281c2e8a46223b262b152caa9c8329373b1",
+   "sha256": "1qia99zl24n56wlpxigs1hmma5b1sydifcwd4v542p2jiwciwmny"
   }
  },
  {
@@ -10807,8 +10810,8 @@
     20190915,
     1009
    ],
-   "commit": "bf07c3db3900e36b0b87423f3b715d6378f86393",
-   "sha256": "1wraxwnhf3xmlhc0ijh1ca9xqrxzxgih4dzca34smwp7dssz3xha"
+   "commit": "7ca7db69e8c38ec45eb572ad16ab2b56086f2131",
+   "sha256": "1jfglmsknvyh3srqn7m6yr02j7n8xa7iznzyhhr34mwg2q71ihzr"
   }
  },
  {
@@ -11135,8 +11138,8 @@
     20161219,
     1144
    ],
-   "commit": "42a79266f1d7b473e9328e67a455e505e6c3eff5",
-   "sha256": "0mw5rnzzc4yfcflg59viy81ziws680r44xr05qg032b5x02l8ar9"
+   "commit": "4f7da6f955f7c584c5dfab2dc170f9a3debd80f8",
+   "sha256": "08wmllq3smg7cp7jspmvd67z5vzmxvi136c6j87r1gsgprhgmhw4"
   },
   "stable": {
    "version": [
@@ -11182,11 +11185,11 @@
   "repo": "purcell/color-theme-sanityinc-tomorrow",
   "unstable": {
    "version": [
-    20190904,
-    520
+    20191022,
+    2023
    ],
-   "commit": "d43905165503bc5e3bf4c658b414884f5cb434e5",
-   "sha256": "0hzy863abchc46cpig8mnn4c885df02h8m2z7m257krkv5aggmif"
+   "commit": "e63a6825fbc8a7a1cba1cd9980c8fb65900c58a2",
+   "sha256": "1mvd5bd66i12khjziswidk24pfvlx5dnlrpn90gmj6ryr6jd5vc1"
   },
   "stable": {
    "version": [
@@ -11223,11 +11226,11 @@
   "url": "https://git.sr.ht/~lthms/colorless-themes.el",
   "unstable": {
    "version": [
-    20190802,
-    725
+    20190927,
+    1305
    ],
-   "commit": "4f9d0ec5a078ab8442abdba0c35eb748728f3052",
-   "sha256": "1h8ggaqvrdj8cyknps9anh2xz08ar94137gydvxy8xgrmpa3jnc1"
+   "commit": "12678144d17edf36d34e6bcdc5435593e191d96d",
+   "sha256": "0fld15h92193bnbmka3ikq27hggxvsikzlzq4pi2n3kknq9hyh56"
   }
  },
  {
@@ -11271,10 +11274,10 @@
  },
  {
   "ename": "com-css-sort",
-  "commit": "ec27ae185c0308c445e461dc84f398483ca08c5a",
-  "sha256": "153yhyqrlmarz8rpcvb0rr7f388fhyb2val4qx2pzpsimklrwrcb",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "11cdp3cgcwwi06njjpwryh3vwmkdh2rzlin77p630590bynagw8c",
   "fetcher": "github",
-  "repo": "elpa-host/com-css-sort",
+  "repo": "jcs-elpa/com-css-sort",
   "unstable": {
    "version": [
     20190723,
@@ -11320,20 +11323,20 @@
   "repo": "matthewbauer/comint-hyperlink",
   "unstable": {
    "version": [
-    20190907,
-    1856
+    20191022,
+    1451
    ],
-   "commit": "7aae3ba615eec1d96f59a386a2fcf98d5b659707",
-   "sha256": "1r2rxda7jhb3rydzmwk9yxscmb6rj54jz9ihqsglfmlv8p2g8q6w"
+   "commit": "bd5a5e95f0e451a774fc5b197456f47f9eb4c50b",
+   "sha256": "0wri4ygdkyq54107hg0ij2nxzbpk8irfd2x2c94qkx97yql4yj54"
   },
   "stable": {
    "version": [
     0,
     1,
-    4
+    5
    ],
-   "commit": "7aae3ba615eec1d96f59a386a2fcf98d5b659707",
-   "sha256": "1r2rxda7jhb3rydzmwk9yxscmb6rj54jz9ihqsglfmlv8p2g8q6w"
+   "commit": "bd5a5e95f0e451a774fc5b197456f47f9eb4c50b",
+   "sha256": "0wri4ygdkyq54107hg0ij2nxzbpk8irfd2x2c94qkx97yql4yj54"
   }
  },
  {
@@ -11836,8 +11839,8 @@
   "repo": "cpitclaudel/company-coq",
   "unstable": {
    "version": [
-    20190425,
-    1851
+    20191004,
+    1358
    ],
    "deps": [
     "cl-lib",
@@ -11846,8 +11849,8 @@
     "dash",
     "yasnippet"
    ],
-   "commit": "779dabd2925fc786dc278270a20f2ff05a3c673c",
-   "sha256": "00rn79i2vackrxhqmbf0miw0k2z6s6gmqb1nj9dj0pfml5yac875"
+   "commit": "109f86ddbb87313b8ef763ae97d9445230b6d051",
+   "sha256": "1y2dl262g2l6zsjmlmmi6fk3p83wv2j8qh83x5j09dj1j1vyx4hy"
   },
   "stable": {
    "version": [
@@ -12111,10 +12114,10 @@
  },
  {
   "ename": "company-fuzzy",
-  "commit": "3c3957d27d4208db45e7545f86ad1c25f53ec532",
-  "sha256": "0yxr0j3zdsf8xfy2mk4ybnjfv6g861772dshbd6v4p3q0pbhhhg6",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "1xr5bilhj0xps0i0rgdvspq8yfiqkybq682jhzqjs1qzrm91apn0",
   "fetcher": "github",
-  "repo": "elpa-host/company-fuzzy",
+  "repo": "jcs-elpa/company-fuzzy",
   "unstable": {
    "version": [
     20190812,
@@ -12577,8 +12580,8 @@
     "cl-lib",
     "company"
    ],
-   "commit": "131961b0476c6ee4d7bd07ce8d42d9e5a0dde38a",
-   "sha256": "0b3cfrhpzjh96kdgfv7r9p0ssd7qkn9kq69jkqjzrv23jr9y80fi"
+   "commit": "84aa4f0c4ffafa2c2fdfbcb16662abac0a571013",
+   "sha256": "1miz6nwsdbc9n3jc7qcb0mvf2yp0k9a7pyl0ifbdjjr2160m2lql"
   },
   "stable": {
    "version": [
@@ -12701,8 +12704,8 @@
     "company",
     "prescient"
    ],
-   "commit": "2f01b640e3a487718dbc481d14406005c0212ed9",
-   "sha256": "1wqk1g8fjpcbpiz32k7arnisncd4n9zs84dn3qn9y8ggjzldqy91"
+   "commit": "6be551816e3d96865e0d187db3e5724eaaa5f248",
+   "sha256": "1ppyqw1hxjx7c1hrndd8afs9pdmqkzj1hn9sdzr5dam6qdff2nqx"
   },
   "stable": {
    "version": [
@@ -12858,8 +12861,8 @@
     "company",
     "rtags"
    ],
-   "commit": "d3d4bc9b7b829d39628a1af96f06eb23ba48670c",
-   "sha256": "0fgxrpqvqs988kjnkcc1lmyqnfc85ivhrarldl7iqgj25fvni6z1"
+   "commit": "f2633f565fc5e7e6958993ef105225f4e68e43ba",
+   "sha256": "1bjgr7wa82ccrc25r7agfaq3iz7xlp1qchvkmkx3xy59jv4yafjz"
   },
   "stable": {
    "version": [
@@ -13232,6 +13235,21 @@
   }
  },
  {
+  "ename": "compdef",
+  "commit": "462b3d92c8c5f72ae1b70fa4d48b803c2f3d07e2",
+  "sha256": "04cav3f1ggyjfgnbx1wsyfaj8d63sxwfqkjar869p6kz9gajy4qr",
+  "fetcher": "gitlab",
+  "repo": "jjzmajic/compdef",
+  "unstable": {
+   "version": [
+    20190929,
+    655
+   ],
+   "commit": "67104a38763cc819644f711248b170a43bce151b",
+   "sha256": "1f6y6cr67gps9jp5hd20xszfd3k26v70g6z4g5db6wdkvlnc2wkg"
+  }
+ },
+ {
   "ename": "composable",
   "commit": "1fc0f076198e4be46a33a26eea9f2d273dda12b8",
   "sha256": "1fs4pczjn9sv12sladf6zbkz0cmzxr0jaqkiwryydal1l5nqqxcy",
@@ -13349,8 +13367,8 @@
   "repo": "necaris/conda.el",
   "unstable": {
    "version": [
-    20190607,
-    1625
+    20191001,
+    1753
    ],
    "deps": [
     "dash",
@@ -13358,8 +13376,8 @@
     "pythonic",
     "s"
    ],
-   "commit": "d65f6d2a47c96e1ff1c7af0e83aee1f5acfe858e",
-   "sha256": "1bx60bipglviphxd9cj0q8jvml2ibd38daz44l2bwkcrp8jznf94"
+   "commit": "ffafcc47ddc58b53b5dac19f6f0f745b316d4522",
+   "sha256": "02pvi03blbfkyzy46ma7zg1xfgikxnxrs3silraaym25bn633rn5"
   },
   "stable": {
    "version": [
@@ -13805,26 +13823,26 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20190830,
-    1557
+    20191022,
+    1207
    ],
    "deps": [
     "swiper"
    ],
-   "commit": "79333e9edfee38ec3b367c33711a68bdf7783259",
-   "sha256": "0dyclc51sprhmr5fi4lylhwsrn8v1jgyblwk9ly60jj84lj6278z"
+   "commit": "3b35b458e138e7e7a51de7d9e0a1ac70b9f54780",
+   "sha256": "15hm9mrcngwk2vw65bxrhnl4dqi8xgi2gfpnj40npswsh868maw9"
   },
   "stable": {
    "version": [
     0,
-    12,
+    13,
     0
    ],
    "deps": [
     "swiper"
    ],
-   "commit": "85d1e2e779ca92e6ef8e47d08f866b13d4d87aee",
-   "sha256": "0xgngn3jhmyn6mlkk9kmgfgh0w5i50b27syr4cgfgarg6p77j05w"
+   "commit": "cd634c6f51458f81898ecf2821ac3169cb65a1eb",
+   "sha256": "0ghcwrg8a6r5q6fw2x8s08cwlmnz2d8qjhisnjwbnc2l4cgqpd9p"
   }
  },
  {
@@ -13904,16 +13922,16 @@
   "repo": "nathankot/counsel-dash",
   "unstable": {
    "version": [
-    20190823,
-    1334
+    20191021,
+    1648
    ],
    "deps": [
     "cl-lib",
     "counsel",
     "dash-docs"
    ],
-   "commit": "24d370be9e94e90d045c49967e19484b9903fce9",
-   "sha256": "18gp7hhgng271c7bh06k9p24zqic0f64j5cicivljmyk9c3nh7an"
+   "commit": "7027868d483b51d949b9f20fb8f34b122ca61520",
+   "sha256": "0h3f5pxnmb21pq4hh7k4w8jzflz1k2ap7nwpjc222w0q6x6jrbjp"
   },
   "stable": {
    "version": [
@@ -13939,15 +13957,15 @@
   "repo": "redguardtoo/counsel-etags",
   "unstable": {
    "version": [
-    20190802,
-    652
+    20191014,
+    50
    ],
    "deps": [
     "counsel",
     "ivy"
    ],
-   "commit": "d7fcec59c4ba919b93018d4d61da0c154233c66b",
-   "sha256": "1pawczhhb7im1q314wsba9fwcks04kddg1vv8mcpiad237mf5dx4"
+   "commit": "b08ed51b763e29fc5deb2952eb7e5ba7c3677b4a",
+   "sha256": "055iwjwkdbwirgm707xgar5afx2nr2kvrsdg5bnw96yvwvby6x4r"
   },
   "stable": {
    "version": [
@@ -13971,15 +13989,15 @@
   "repo": "cireu/counsel-ffdata",
   "unstable": {
    "version": [
-    20190725,
-    1630
+    20191017,
+    1237
    ],
    "deps": [
     "counsel",
     "emacsql"
    ],
-   "commit": "33f37112b068d72d866011461c6a4e9a0d43fc12",
-   "sha256": "00svf7b3an4dfcl7w2xycn5a6ib78p5xip6wy675w9k6v16sag73"
+   "commit": "88c2348c4039d9e562bd3d9a364708b01037c283",
+   "sha256": "0sbp3f72dcln8y789vjdmg73lxvyb4qs4pb5mg452b3y8c8xlj30"
   }
  },
  {
@@ -14095,15 +14113,15 @@
   "repo": "ericdanan/counsel-projectile",
   "unstable": {
    "version": [
-    20190817,
-    102
+    20191010,
+    1427
    ],
    "deps": [
     "counsel",
     "projectile"
    ],
-   "commit": "fda7f0bad93a471fddf5fa01d6fdee5684e7f880",
-   "sha256": "097ksmy85lf9zfi6v2xz9bxl54l0il6v0ybj1305qg6g8xampbdw"
+   "commit": "ace17b9a3243e934314860f161f0ed71e4922730",
+   "sha256": "06l8rr11ki31a35vmvfdhvvvsgm8nbx8v2wsn4d12y42i86sdfv5"
   },
   "stable": {
    "version": [
@@ -14249,16 +14267,16 @@
   "repo": "AdamNiederer/cov",
   "unstable": {
    "version": [
-    20180415,
-    2031
+    20191004,
+    36
    ],
    "deps": [
     "elquery",
     "f",
     "s"
    ],
-   "commit": "7c72a949b9628296af97cc7e4df0af6c3824d66e",
-   "sha256": "0rddchwanrshfpjiigmz6a0zz1sz9kxbbgvszvja2r4w0m6irb80"
+   "commit": "803592baf1fb210415d943689af2bf5b79cdd24e",
+   "sha256": "0wp89sq9jy97cvsihqn9dk62m7rp6154c00214f84xb1vab7bcpw"
   }
  },
  {
@@ -14269,15 +14287,15 @@
   "repo": "trezona-lecomte/coverage",
   "unstable": {
    "version": [
-    20180227,
-    457
+    20191008,
+    2203
    ],
    "deps": [
     "cl-lib",
     "ov"
    ],
-   "commit": "c73d984168955ca0f47f44b0464aa45282df42b6",
-   "sha256": "1kn61j91x4r4kc498y2jas5il4pc4qzhkj8392g2qiq5m3lbv4vl"
+   "commit": "2d9b662673a0f165c6929d8b7fb264f5ffb2ebcd",
+   "sha256": "0pdn309kcyrvb8bgzgjmy26mcgbfkr6p1d37ww6qjk9hps0jy92r"
   },
   "stable": {
    "version": [
@@ -14657,8 +14675,8 @@
    "deps": [
     "seq"
    ],
-   "commit": "308f17d914e2cd79cbc809de66d02b03ceb82859",
-   "sha256": "0rf84finwlvmy0xpgyljjvnrijlmkzjyw9rh97svgxp9c1rzfk0x"
+   "commit": "903db7b1a2052f4959d934cae26ec40a3f323ed4",
+   "sha256": "15wq0z9mnx60mi9xfkvgfgsfxdbiigwxr0wqabv3n2091dbzfas4"
   },
   "stable": {
    "version": [
@@ -14786,28 +14804,30 @@
   "repo": "hlolli/csound-mode",
   "unstable": {
    "version": [
-    20190321,
-    1559
+    20191005,
+    807
    ],
    "deps": [
+    "highlight",
     "multi",
     "shut-up"
    ],
-   "commit": "f4bc9236bbc5a696f7ff32d9402749536a332546",
-   "sha256": "0ds6cigm3pncsa5blqzfgisjn9v898ayj6nq2va6ssg73k0qfx1r"
+   "commit": "7d3f78477c725719be9c4a98b403a5aa409e4202",
+   "sha256": "154xnfspbx2fsk32h34ljw7mzsbsdymscmi0rqdc6r9bbbwapwqw"
   },
   "stable": {
    "version": [
     0,
     2,
-    0
+    1
    ],
    "deps": [
+    "highlight",
     "multi",
     "shut-up"
    ],
-   "commit": "5a892e6ad72e7844e8e14c0da04fcb6bc125fe5e",
-   "sha256": "1gzg2r7agllz2asp7dbxykydpnw3861whs2pfhr3fwwb39xf1pva"
+   "commit": "389be230aecfea03e8043e8ea6884ea21ea9230b",
+   "sha256": "1c88ak0jaj51fwiqniqxd7xyk23wjl9m57znzm8j267ld8g12znp"
   }
  },
  {
@@ -14818,11 +14838,11 @@
   "repo": "omajid/csproj-mode",
   "unstable": {
    "version": [
-    20190514,
-    1858
+    20191012,
+    49
    ],
-   "commit": "889334f8cd08dc79d133149b4504e0e001f5a769",
-   "sha256": "0j330rrj6abr7xay1h2kajwa22npij0fdh30fk5z7zgas7jz735h"
+   "commit": "95e797af7cc30d4675247b64496c39b77b82e18e",
+   "sha256": "08cxkvq7k14lixavv7nwi5kmmxqvkgmqr4i46ihsgv7jcmxyy8gx"
   }
  },
  {
@@ -15175,11 +15195,11 @@
   "repo": "the-frey/cyberpunk-2019",
   "unstable": {
    "version": [
-    20190722,
-    1332
+    20191008,
+    1133
    ],
-   "commit": "5b30794c4f906da6e48600ffc56443151cae45d1",
-   "sha256": "1vb04zff9231yvlxflgp6qicpjxqp40gzgpp70b4rrffbfk6hays"
+   "commit": "7e40c37210c363b2819fd9bb98a73101d7a3c206",
+   "sha256": "0fgh39lyq49b4zm10fiqhqzafwrg2vmpfn8k1frdkadansq4jl7z"
   }
  },
  {
@@ -15303,8 +15323,8 @@
     20190111,
     2150
    ],
-   "commit": "7e233ab00e117b2e7165c246941ac85a989be262",
-   "sha256": "1189hi8vp2albpvfz5b66327qizzkzkg9p9b6l8157jsm6a03y7p"
+   "commit": "a32a29e8aaa688e0507d374ab47e641eb1a427c4",
+   "sha256": "1ry1jcdkl0mcjlpa1lp2mdrp03mcrvkvx5p3y4f4d6h4bjk5zk65"
   },
   "stable": {
    "version": [
@@ -15339,11 +15359,11 @@
   "repo": "Emacs-D-Mode-Maintainers/Emacs-D-Mode",
   "unstable": {
    "version": [
-    20190826,
-    2244
+    20191009,
+    903
    ],
-   "commit": "f3843276e235c6b633ba5367f78d74fe7c04e244",
-   "sha256": "066kjyvginjp2cqmdi8ybrr558074m8wqd0jrwsicn4dps3njvcn"
+   "commit": "cfd1d0869d51b7548b3fb738b2f2593c76533d44",
+   "sha256": "0vkl470vvmxap8ca773a0jvjvalmvdbbax3qvgjdclp54ml75al4"
   },
   "stable": {
    "version": [
@@ -15470,8 +15490,8 @@
   "repo": "jyp/dante",
   "unstable": {
    "version": [
-    20190826,
-    1656
+    20191004,
+    1233
    ],
    "deps": [
     "company",
@@ -15482,8 +15502,8 @@
     "lcr",
     "s"
    ],
-   "commit": "a25ae9e5b5425cffdd88d498777e90ea8655fa37",
-   "sha256": "1ziw3snbs2z2cg8a3jbyjd48qkgrkzs4bh8lrbs0h2c87nzldvhd"
+   "commit": "38b589417294c7ea44bf65b73b8046d950f9531b",
+   "sha256": "1mnmn635552zlwd4zr68jbvdjipl6gi4mi6wiyck28fsmq8kw96h"
   },
   "stable": {
    "version": [
@@ -15511,8 +15531,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20190917,
-    548
+    20191019,
+    1707
    ],
    "deps": [
     "bui",
@@ -15523,8 +15543,8 @@
     "s",
     "tree-mode"
    ],
-   "commit": "2e0f7dd70656aad5a70ce2b4f5375870084a02f3",
-   "sha256": "0hckyrv470j8zx5sr24h16fa9a3fxa8i7iwywxs15wwrwl6mqh9m"
+   "commit": "0cd06db75a1afb9cc5d0c2fade414667aeacf0c1",
+   "sha256": "0ri3jdvxjb5a7ajkmxdpw8cqq4a8ls0c2myv1fcf6zldywq24kim"
   },
   "stable": {
    "version": [
@@ -15800,11 +15820,11 @@
   "repo": "xuchunyang/dash-alfred.el",
   "unstable": {
    "version": [
-    20190720,
-    415
+    20191024,
+    450
    ],
-   "commit": "ec8d9970fa00ee38bca798673c10cae44419541d",
-   "sha256": "1asa3cmncl2jvc89jzlvb4karpc4zdihsjvig0zjia6nbj46pqsr"
+   "commit": "fcd21bd6c7eb5cd31377be970406ff3d2454bd5c",
+   "sha256": "0cvkj0d45aan6g5c7930v9syp0m3l1w6zkdgsdvbbiav0i6kpqrx"
   }
  },
  {
@@ -15879,14 +15899,14 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20190721,
-    504
+    20191009,
+    1129
    ],
    "deps": [
     "page-break-lines"
    ],
-   "commit": "7a71e6ca4c32fdadde0c8624ea4e2e7c11474e7d",
-   "sha256": "09fgzw93x90bhq918p4i8hrfy8yxyp236rc118cr6hma9bh05hii"
+   "commit": "224fb2cb067d0f1f95fbbe8aa4073154cd255410",
+   "sha256": "1ndffcfhavb1pa8f2g8mbbi8w2386r1av5dfns1gz9fdzi6pqlz4"
   },
   "stable": {
    "version": [
@@ -16204,16 +16224,16 @@
   "repo": "Wilfred/deadgrep",
   "unstable": {
    "version": [
-    20190807,
-    2125
+    20191002,
+    2
    ],
    "deps": [
     "dash",
     "s",
     "spinner"
    ],
-   "commit": "329119c65126f7917d3910bc584f4191ba8f21ac",
-   "sha256": "0fxf7gq9sjfkgpdfqx10w3l3nd4rwa8kv9plyxk1fqacb3s5m6ai"
+   "commit": "e1ea4a358cfdac7551d0c6bf6ae70a4e191c1528",
+   "sha256": "161mb7kyr70k24kl25lms8v8b87fi5q66zj9hlbhzwksdxpa9z30"
   },
   "stable": {
    "version": [
@@ -16636,8 +16656,8 @@
     20190701,
     1306
    ],
-   "commit": "a3707e9fcf4371fe586e0d35a79331d1cf7309c9",
-   "sha256": "01xd5hhk66firnnmc18fa87ialcn1cr8b1vhgjrfa1p87hf496s1"
+   "commit": "d2706dd2d83cf9f3672a74b0b3fc490cc84b0f78",
+   "sha256": "1ymxxa1jpcg6c0wwxz8qi453bgik07yh297fsf4a03hh07rpx8a0"
   },
   "stable": {
    "version": [
@@ -16726,14 +16746,14 @@
   "repo": "psibi/dhall-mode",
   "unstable": {
    "version": [
-    20190919,
-    2242
+    20191006,
+    2324
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "57001a69917329e7933d80a7e21116fe11255ae7",
-   "sha256": "039lgmap36iawvw89jhkq25j9h2r9qb8s3612j5xhyzbbrg6q0pl"
+   "commit": "ef4d33debe224c6ba37e51a29b9dc8b74f20f1c2",
+   "sha256": "1232y2k4l3bsz90pgis78zxmrw7jv09dfaip21yc1w4vpxfyr384"
   }
  },
  {
@@ -16860,6 +16880,30 @@
    ],
    "commit": "9ef1672ecd367827381bbbc9af93685980083c5c",
    "sha256": "05xfgn9sabi1ykk8zbk2vza1g8pdrg08j5cb58f50nda3q8ndf4s"
+  }
+ },
+ {
+  "ename": "didyoumean",
+  "commit": "6030fcde06d23b98b0c81d40e1cdb5eb4412b9a1",
+  "sha256": "0hfd6kgqry0mcg77lqf0rvcb9clhjh7krq41hlz4wkrjyw0xbngg",
+  "fetcher": "gitlab",
+  "repo": "kisaragi-hiu/didyoumean.el",
+  "unstable": {
+   "version": [
+    20191020,
+    531
+   ],
+   "commit": "4a6049f2de36801e0a50e93b17a375501f16cf28",
+   "sha256": "0plwn23h96m71vx0jxilnl6nj7lsq4mpjv8mjaiankrxhvjcv6f0"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    0
+   ],
+   "commit": "6d0c4203eb192d73d89261b3a9bad52951e394af",
+   "sha256": "1rdmhsrlqn19a140i3099fp7f9wnlglp760rnrjp5p840wzfm74q"
   }
  },
  {
@@ -17114,10 +17158,10 @@
  },
  {
   "ename": "diminish-buffer",
-  "commit": "be1dc31aaad773f6504ded15d9ce2579fdf192af",
-  "sha256": "10rsdn2mlk3lnc9dc75zyphqckja7bzm5xgzjrbzvvbf4w87qa1f",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "1z0ini177r9dkn4bpdpcmyi014a3444blij8izvpj31bqkyckmqf",
   "fetcher": "github",
-  "repo": "elpa-host/diminish-buffer",
+  "repo": "jcs-elpa/diminish-buffer",
   "unstable": {
    "version": [
     20190921,
@@ -17245,8 +17289,8 @@
     "dash",
     "dired-hacks-utils"
    ],
-   "commit": "886befe113fae397407c804f72c45613d1d43535",
-   "sha256": "1cvibg90ggyrivpjmcfprpi2fx7dpa68f8kzg08s88gw5ib75djl"
+   "commit": "ae39981d7cc58206cfeb377d6621bdd9000fd472",
+   "sha256": "0q4fk5cg04pj83kpn1mvfqsjsr99ffqxayfnb7vcgdc33g19afjv"
   }
  },
  {
@@ -17265,8 +17309,8 @@
     "dired-hacks-utils",
     "f"
    ],
-   "commit": "886befe113fae397407c804f72c45613d1d43535",
-   "sha256": "1cvibg90ggyrivpjmcfprpi2fx7dpa68f8kzg08s88gw5ib75djl"
+   "commit": "ae39981d7cc58206cfeb377d6621bdd9000fd472",
+   "sha256": "0q4fk5cg04pj83kpn1mvfqsjsr99ffqxayfnb7vcgdc33g19afjv"
   }
  },
  {
@@ -17392,8 +17436,8 @@
     "dired-hacks-utils",
     "f"
    ],
-   "commit": "886befe113fae397407c804f72c45613d1d43535",
-   "sha256": "1cvibg90ggyrivpjmcfprpi2fx7dpa68f8kzg08s88gw5ib75djl"
+   "commit": "ae39981d7cc58206cfeb377d6621bdd9000fd472",
+   "sha256": "0q4fk5cg04pj83kpn1mvfqsjsr99ffqxayfnb7vcgdc33g19afjv"
   }
  },
  {
@@ -17410,8 +17454,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "886befe113fae397407c804f72c45613d1d43535",
-   "sha256": "1cvibg90ggyrivpjmcfprpi2fx7dpa68f8kzg08s88gw5ib75djl"
+   "commit": "ae39981d7cc58206cfeb377d6621bdd9000fd472",
+   "sha256": "0q4fk5cg04pj83kpn1mvfqsjsr99ffqxayfnb7vcgdc33g19afjv"
   }
  },
  {
@@ -17537,8 +17581,8 @@
     "dash",
     "dired-hacks-utils"
    ],
-   "commit": "886befe113fae397407c804f72c45613d1d43535",
-   "sha256": "1cvibg90ggyrivpjmcfprpi2fx7dpa68f8kzg08s88gw5ib75djl"
+   "commit": "ae39981d7cc58206cfeb377d6621bdd9000fd472",
+   "sha256": "0q4fk5cg04pj83kpn1mvfqsjsr99ffqxayfnb7vcgdc33g19afjv"
   }
  },
  {
@@ -17556,8 +17600,8 @@
     "dash",
     "dired-hacks-utils"
    ],
-   "commit": "886befe113fae397407c804f72c45613d1d43535",
-   "sha256": "1cvibg90ggyrivpjmcfprpi2fx7dpa68f8kzg08s88gw5ib75djl"
+   "commit": "ae39981d7cc58206cfeb377d6621bdd9000fd472",
+   "sha256": "0q4fk5cg04pj83kpn1mvfqsjsr99ffqxayfnb7vcgdc33g19afjv"
   }
  },
  {
@@ -17604,8 +17648,8 @@
     "dash",
     "dired-hacks-utils"
    ],
-   "commit": "886befe113fae397407c804f72c45613d1d43535",
-   "sha256": "1cvibg90ggyrivpjmcfprpi2fx7dpa68f8kzg08s88gw5ib75djl"
+   "commit": "ae39981d7cc58206cfeb377d6621bdd9000fd472",
+   "sha256": "0q4fk5cg04pj83kpn1mvfqsjsr99ffqxayfnb7vcgdc33g19afjv"
   }
  },
  {
@@ -17623,8 +17667,8 @@
     "dash",
     "dired-hacks-utils"
    ],
-   "commit": "886befe113fae397407c804f72c45613d1d43535",
-   "sha256": "1cvibg90ggyrivpjmcfprpi2fx7dpa68f8kzg08s88gw5ib75djl"
+   "commit": "ae39981d7cc58206cfeb377d6621bdd9000fd472",
+   "sha256": "0q4fk5cg04pj83kpn1mvfqsjsr99ffqxayfnb7vcgdc33g19afjv"
   }
  },
  {
@@ -17635,11 +17679,11 @@
   "repo": "Vifon/dired-recent.el",
   "unstable": {
    "version": [
-    20180921,
-    2238
+    20191004,
+    1500
    ],
-   "commit": "7c5a818ab88fdfa779674931cc6d9466308fcd86",
-   "sha256": "1pxa17rxc43yam0j8xi7ji8kxv0jq96jk0j3p3brj9nss2gfw48f"
+   "commit": "5c799f96da08a0a3200cb5f609baf6c184f558ea",
+   "sha256": "0kc97v80rh10ksfw49pp551ay0b1apwi6ba66rwbyix50d7drimw"
   }
  },
  {
@@ -17665,11 +17709,11 @@
   "url": "https://git.sr.ht/~jakob/dired-rmjunk",
   "unstable": {
    "version": [
-    20190526,
-    2029
+    20191007,
+    1232
    ],
-   "commit": "6a9fa6a35498e53e8c57282e3b08dedc896d880d",
-   "sha256": "0kpkd7qasrb303d0b01d62r82prhrmaasxqa14nf5lh01c213nr4"
+   "commit": "92af5fcc2bd0bc3826f4ce238a850e9a362533a4",
+   "sha256": "0720lnnm0sjf8yazr0xjwfrzqwia283jj3c6hcbgfp5l0z162m5b"
   },
   "stable": {
    "version": [
@@ -17719,14 +17763,26 @@
   "repo": "jojojames/dired-sidebar",
   "unstable": {
    "version": [
-    20190516,
-    159
+    20191024,
+    116
    ],
    "deps": [
     "dired-subtree"
    ],
-   "commit": "2c742326a6b7a76e36666586809aaf5efa150b3f",
-   "sha256": "0s2d8lirv8s9az8a7g97yzg7na2n1340a8vg6zja315d43qljis9"
+   "commit": "21ccb6723bea69f2e2ca25998268d8a039f904cc",
+   "sha256": "0mck4qk6srbbf8xnn2sg11j822z4ybxvgavvy402d5sli515i8ca"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "dired-subtree"
+   ],
+   "commit": "347f56480228c2aac97e14f4f5a762c4582d1323",
+   "sha256": "1ahmvbwwdnjddn8qk6gq5gjfkvi1mvm13a968n7zpcpnphk6ygzb"
   }
  },
  {
@@ -17768,8 +17824,8 @@
     "dash",
     "dired-hacks-utils"
    ],
-   "commit": "886befe113fae397407c804f72c45613d1d43535",
-   "sha256": "1cvibg90ggyrivpjmcfprpi2fx7dpa68f8kzg08s88gw5ib75djl"
+   "commit": "ae39981d7cc58206cfeb377d6621bdd9000fd472",
+   "sha256": "0q4fk5cg04pj83kpn1mvfqsjsr99ffqxayfnb7vcgdc33g19afjv"
   }
  },
  {
@@ -17830,8 +17886,8 @@
     20190629,
     231
    ],
-   "commit": "ec17789d2f72355e0fb6e31029c6ffa686337e2e",
-   "sha256": "1blnib2ckljdxqpn0fnihyn9akc1pm8zbfw4hqy0xz2xqmyfqxi1"
+   "commit": "d5aa50a5269d7374bc8ea981d3871729424d165d",
+   "sha256": "0jwzlf0nhn5699l5xjhszix0y1539zdxyy6434srf31cgr7q84cw"
   },
   "stable": {
    "version": [
@@ -17873,14 +17929,14 @@
   "repo": "wbolster/emacs-direnv",
   "unstable": {
    "version": [
-    20190622,
-    1853
+    20191016,
+    1907
    ],
    "deps": [
     "dash"
    ],
-   "commit": "fcec20c52fc37008d40a07c6dd0818c69e8be5f2",
-   "sha256": "0r1ryz1swafl1s1bwcwnc1wm5nga2kma0059x132rsglm4bla41n"
+   "commit": "fd0b6bbd5e3eaf6aa48bccd4a1ff3048bfb2c69b",
+   "sha256": "0py0if1wl61y6f55s4p8y11rjvrgx3yk2v5n1q2xl3gg7f4ra136"
   },
   "stable": {
    "version": [
@@ -18285,14 +18341,14 @@
   "repo": "unhammer/dix",
   "unstable": {
    "version": [
-    20181210,
-    1200
+    20191023,
+    1357
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b973de948deb7aa2995b1895e1e62bbe3129b5a5",
-   "sha256": "1bjxyidcp7y309asbk4pfb4mzgb8j62fmp3w3zl2nahdgv1rja45"
+   "commit": "466df0a7f5ab6ab19150bef92f7d1aac0dec2467",
+   "sha256": "1gb21rsczwcwhqc9bpw77zikwr2ycqmvks6n0y8mdrj3kc6qvzgc"
   },
   "stable": {
    "version": [
@@ -18322,8 +18378,8 @@
     "dix",
     "evil"
    ],
-   "commit": "b973de948deb7aa2995b1895e1e62bbe3129b5a5",
-   "sha256": "1bjxyidcp7y309asbk4pfb4mzgb8j62fmp3w3zl2nahdgv1rja45"
+   "commit": "466df0a7f5ab6ab19150bef92f7d1aac0dec2467",
+   "sha256": "1gb21rsczwcwhqc9bpw77zikwr2ycqmvks6n0y8mdrj3kc6qvzgc"
   },
   "stable": {
    "version": [
@@ -18578,11 +18634,11 @@
   "repo": "jhgorrell/dna-mode-el",
   "unstable": {
    "version": [
-    20170804,
-    814
+    20191001,
+    2108
    ],
-   "commit": "471d374de22c33eaddd8e41dd8ae29753fab2f6a",
-   "sha256": "05zsaypyavyn7gs0jk63chkxkm2rl4nbrqgv6zxrbqcar7gv86am"
+   "commit": "7a48393fcf0015eed2368fcb89b3091c9d029dc4",
+   "sha256": "05p1mllp7vgk69078gn6hc0vx5hfqz6k81i4ghkfkxr5fdm5fdk5"
   }
  },
  {
@@ -18630,8 +18686,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20190813,
-    1431
+    20191005,
+    650
    ],
    "deps": [
     "dash",
@@ -18641,8 +18697,8 @@
     "s",
     "tablist"
    ],
-   "commit": "fe74a499ce3246fb9a7d72e6931864b94ce5261d",
-   "sha256": "1prxz9fy9ca6lrv3qff408igxc1hic2laz528ba9mzyr5bc9qsq0"
+   "commit": "5027a3d541b1dcbb2f7ec0bac04a30dceeca7ce8",
+   "sha256": "1n4k5ar9h2a11f68nqdgmqnwpnlym5862vls89wkjqxl02ss34zn"
   },
   "stable": {
    "version": [
@@ -18905,30 +18961,30 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20190918,
-    1510
+    20191024,
+    1228
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "2690aa27892380b4e857efee4b7a76ff3a87e538",
-   "sha256": "020zwg15ww40mss7ndc56hji16rmpllab3rkm0k6z79h9jmmc01c"
+   "commit": "22b14c9b8e7a75f7f2231a74838085230e143fe7",
+   "sha256": "1vpf2fk6cng6myjjmf77qdy3s1p2pkaz6sfbvar4j0lms3gqvfr3"
   },
   "stable": {
    "version": [
     2,
     6,
-    1
+    2
    ],
    "deps": [
     "all-the-icons",
     "dash",
     "shrink-path"
    ],
-   "commit": "b117f2e86920c0bb3a61ce64c59a6f5db05a11e9",
-   "sha256": "1lzw3nfqrymrgc9vhd5zzffjy79sdfiihx3mphp5hny8f1nw912g"
+   "commit": "c7eb0fb93e11c2252dc9f1a928e26627f3f4b3a3",
+   "sha256": "1swbjrmfyq496rg03xm6vz5w00bsz06nly7mffvxy74jc3f6d5fc"
   }
  },
  {
@@ -18939,14 +18995,14 @@
   "repo": "hlissner/emacs-doom-themes",
   "unstable": {
    "version": [
-    20190904,
-    2252
+    20191023,
+    1600
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "1159463956223ae53df421bcd796e94610759c42",
-   "sha256": "0jacmhqvvsqy5w7zxsr5nxka1pxysz74zkv5lfvbqkay59asn95z"
+   "commit": "5d558f158f6677833076a9713efcb5824a61ee9f",
+   "sha256": "0cm0vaxlj0cdk2kc3i0qs9hqyn2w3i0kwk244dxjifph2g82mz86"
   },
   "stable": {
    "version": [
@@ -19027,8 +19083,8 @@
     20190325,
     1917
    ],
-   "commit": "166ca7f01a0c85faaa3f8d20dbb8f7c5e972eebb",
-   "sha256": "0nc0nvxmsjg7821c7jxzhzxnj9h00yc4i725a75qadqynmm60bq4"
+   "commit": "215ab684a204965497c4f841b110f0621ff1f09f",
+   "sha256": "0ns51z9fmqkypnm8s0lzkglds073rlbq8n0v78s84l82bir0kwzv"
   },
   "stable": {
    "version": [
@@ -19175,11 +19231,11 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20190107,
-    2016
+    20191022,
+    2033
    ],
-   "commit": "66e429f4d576346661ae3a111bafaa06febc1d94",
-   "sha256": "0lyy8vjzzcfcj4hm7scxl4cg4qm67rprzdj7dmyc3907yad4n023"
+   "commit": "320cc8cfc67e33c86045ef3e79b7627b91b9b517",
+   "sha256": "0pzlwxsa823sbcf2nq2lw303cld2jc2siaaiafld0qc4xasg9zyn"
   },
   "stable": {
    "version": [
@@ -19387,8 +19443,8 @@
   "repo": "dtk01/dtk",
   "unstable": {
    "version": [
-    20190803,
-    2120
+    20191016,
+    103
    ],
    "deps": [
     "cl-lib",
@@ -19396,8 +19452,8 @@
     "s",
     "seq"
    ],
-   "commit": "cc5807cc38417060725f1f5ab2efca8baf074053",
-   "sha256": "0vwx0s3hli1ql2rfkqcv4y7n6ln4yrp3h2a7x8vrp99h6rb6xxg0"
+   "commit": "abf5f50fd2bd2697f0c07991ab05e0132ae7f50d",
+   "sha256": "0zdmsqlb4ph9cdpl0gvvyizjdgygwdmww5vnsz3h84chzpza9x5q"
   }
  },
  {
@@ -19423,19 +19479,19 @@
   "repo": "jscheid/dtrt-indent",
   "unstable": {
    "version": [
-    20190128,
-    2101
+    20191019,
+    2141
    ],
-   "commit": "9ab9cb9d7f391fb09f61c9289c51c36374ddbcbb",
-   "sha256": "0pgf0pvqd8k4yzhdn2df9lp0y8hmlm2ccrh07jivwlccs95pcz7z"
+   "commit": "48221c928b72746d18c1e284c45748a0c2f1691f",
+   "sha256": "0jmlb54b0qrp2mr9cnbzki1vy7i0wv5y1h03ns8acwa2hmpjk30a"
   },
   "stable": {
    "version": [
     0,
-    8
+    9
    ],
-   "commit": "9ab9cb9d7f391fb09f61c9289c51c36374ddbcbb",
-   "sha256": "0pgf0pvqd8k4yzhdn2df9lp0y8hmlm2ccrh07jivwlccs95pcz7z"
+   "commit": "48221c928b72746d18c1e284c45748a0c2f1691f",
+   "sha256": "0jmlb54b0qrp2mr9cnbzki1vy7i0wv5y1h03ns8acwa2hmpjk30a"
   }
  },
  {
@@ -19505,8 +19561,8 @@
   "repo": "jacktasia/dumb-jump",
   "unstable": {
    "version": [
-    20190923,
-    1849
+    20190928,
+    1758
    ],
    "deps": [
     "dash",
@@ -19514,8 +19570,8 @@
     "popup",
     "s"
    ],
-   "commit": "d64ee2a31afa755d5b373ada2e8fea11149b44a3",
-   "sha256": "0jx0wsw99m9dwpfbssk9n4kpd08rzyhyhw5wjfwadapd2hhf11mw"
+   "commit": "34fb76982dafc62f8105c520aece4c3ceccb7307",
+   "sha256": "1f6hgrklnbadr15qnsb4icn3xa589cs3ms2jvn1fndbhv4ms2hv3"
   },
   "stable": {
    "version": [
@@ -19556,20 +19612,20 @@
   "repo": "ocaml/dune",
   "unstable": {
    "version": [
-    20190911,
-    1607
+    20191016,
+    1241
    ],
-   "commit": "27f97109256eb6336491536f2c62bf332716de03",
-   "sha256": "1llzmq56kvy8v1ijn62gyfr71g3z5s0svqcq4q4zan57rdhzchn0"
+   "commit": "50a2eebdb9fcb05f87dbe27c3a1b0cc32572f729",
+   "sha256": "15r2564k6wyg4jnnxfrksprf5h804zin4x7x88njbk2ps2fbgpdf"
   },
   "stable": {
    "version": [
     1,
     11,
-    3
+    4
    ],
-   "commit": "1fb491280dbe7e3bc7c00bb75ca837edc538333b",
-   "sha256": "0l4x0x2fz135pljv88zj8y6w1ninsqw0gn1mdxzprd6wbxbyn8wr"
+   "commit": "f7ac8f5c8fed67d31c2a63669006829263c2fe6d",
+   "sha256": "1bbicrfsrcc67v4q5qfi2vbzpqhzj5v55z9vkp6sljwnwfvm8jzr"
   }
  },
  {
@@ -19610,14 +19666,14 @@
   "repo": "harsman/dyalog-mode",
   "unstable": {
    "version": [
-    20190721,
-    1411
+    20191002,
+    1352
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "47f53d844b0862f7474714e1ed8f2fea5001e3f2",
-   "sha256": "03qz5mrq2i52lrj045fwk1l06ax6yl2dyj271p2zp5kv1fcbph6a"
+   "commit": "4e214c1804eefde07b1dcd2ea07b8e41f33d7ee7",
+   "sha256": "1vq1fhn8x6i6wmccwiq482dbrdpn5cllkdn3v0ki0427a8gwkdal"
   }
  },
  {
@@ -20019,28 +20075,28 @@
   "repo": "masasam/emacs-easy-hugo",
   "unstable": {
    "version": [
-    20190729,
-    454
+    20191013,
+    1814
    ],
    "deps": [
     "popup",
     "request"
    ],
-   "commit": "00a7dfb19b6ee9e6a2993104400334ea2ebb39f1",
-   "sha256": "18sm2nsfidvbp7walf3wrfq9ra7l5ww0b5p4xglr1ch73m47gdzj"
+   "commit": "0ff8033adc13ada55259e6c2fad27de143325917",
+   "sha256": "0hk7kcl598d43fi9k6c278syz7f11szpmi6x6v0vjaah805a07jb"
   },
   "stable": {
    "version": [
     3,
     8,
-    42
+    43
    ],
    "deps": [
     "popup",
     "request"
    ],
-   "commit": "2e2eb5720792512bb8a2ab2a7d9eb9ce86de8df9",
-   "sha256": "0zram35da92gvv72fdj1mpyxasagvv0i20rrqilawyvah7kr1njg"
+   "commit": "02f7f06d9d1e66cef6df9768dc2400217f488a6f",
+   "sha256": "17l7zpc7vcn4g19q78fj1pxmh63x5xf081x4f79d1v23fnakqrdb"
   }
  },
  {
@@ -20051,26 +20107,26 @@
   "repo": "masasam/emacs-easy-jekyll",
   "unstable": {
    "version": [
-    20190609,
-    146
+    20191013,
+    750
    ],
    "deps": [
     "request"
    ],
-   "commit": "8b83e491b0db4aa75a07662577a2526a698adc21",
-   "sha256": "1y8d90b2nh6l9cxyddhdggmhl913fhlzzgqa0pabqry6fqfz51la"
+   "commit": "c6f6640848df1b73fa04cba10a7a22dc9cc49db3",
+   "sha256": "1m1xn4b6dny1h7vq99c18s8lmxps2xzh5zy8bzms241p2d5zbbvk"
   },
   "stable": {
    "version": [
     2,
     2,
-    22
+    23
    ],
    "deps": [
     "request"
    ],
-   "commit": "9b065ac1bc5a85c6ad41a7b97553eeaa9e30c791",
-   "sha256": "1pj2hafyx1lq8ifahfg0j90z72swixi1pma52j6701vrn8a5aqw6"
+   "commit": "23d95261dce28a73e4ab11b10f447bde829b8a1f",
+   "sha256": "08y6v7rz33pw2crq3lq06sp7lvg2ww9afdwa41bp5i2xrlz069x7"
   }
  },
  {
@@ -20228,26 +20284,26 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20190922,
-    2000
+    20191015,
+    1716
    ],
    "deps": [
     "parsebib"
    ],
-   "commit": "b9c924d2a206f70caf714251a33bebcfef0c37c2",
-   "sha256": "18z58s3s1afr9spg57kpmpxfgkbwxdq7bv4rl5wk78rwj76bskpk"
+   "commit": "622faff85836383d8cc1a40ca65904338247785c",
+   "sha256": "0y75jdcd10l77ggxk7fd9ppkygm77iw35vscnj0yfms72qajava9"
   },
   "stable": {
    "version": [
     2,
-    16,
-    5
+    17,
+    3
    ],
    "deps": [
     "parsebib"
    ],
-   "commit": "eb6e7bf8cc525c41150bf5913d965e89e1fbf48d",
-   "sha256": "0jys32kvbcjrc65dwgfzz21g4fnycdhm0pybgk3akb80rv00x1vf"
+   "commit": "7a1e570e3d540e4c8d30bf1d23b62a30c1ae65a6",
+   "sha256": "1ifqa0scvq872yhvb6p6x2y8yilbnf754rdbqa69s0rvv9qzhvw9"
   }
  },
  {
@@ -20312,11 +20368,11 @@
   "repo": "abo-abo/eclipse-theme",
   "unstable": {
    "version": [
-    20190716,
-    916
+    20191007,
+    1354
    ],
-   "commit": "0239fa7bbbb5fb61ac1e96fc772974240d2a8996",
-   "sha256": "1dldf1qsf2j62i0gi9r3ax7w749yaj09q0vw5xlk49m4qpi50ga3"
+   "commit": "0381586948f4b0d56f43c4587afd618063834986",
+   "sha256": "0rzq6qfy7ssy4mmaysjw1l78xs2pgnhfl8wzad7yaig3hs71p81k"
   }
  },
  {
@@ -20753,26 +20809,26 @@
   "repo": "editorconfig/editorconfig-emacs",
   "unstable": {
    "version": [
-    20190703,
-    336
+    20191020,
+    333
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f24f651245344f5f97c348246ce035843419b322",
-   "sha256": "0djicwnbz7awzsnr6z1xggb9d7l83mf2h3xw3l1f9pv87m7mgndn"
+   "commit": "aee43302ff86cfff6067e7283ef8ba626f4b146b",
+   "sha256": "072a8q20kknf0i73p82kn76qjcwn9hyxqf908nfc9ijqppbzhknv"
   },
   "stable": {
    "version": [
     0,
     8,
-    0
+    1
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4b6c34d5d77025a11ae68462af9bf0a822a13242",
-   "sha256": "1b2cpqz75pivl323bs60j5rszwi787x6vy68csycikqz9mhpmjn9"
+   "commit": "0b65d5316bcab4d76b5823ea6ecf8f5880f460d2",
+   "sha256": "1djlhkap7zddknzvjsjz0agpfsms1ih05zcpg1bikid2vs4gddyr"
   }
  },
  {
@@ -21060,8 +21116,8 @@
     20190714,
     236
    ],
-   "commit": "20d33864e0e9d30edb0f146d89b6349776382bf3",
-   "sha256": "175mcx9hi6nnynamhj3pa9808wgpz2cxjs95b2ky8g6dfv07cmk6"
+   "commit": "65dff2c90834dda505ccd1d8401f3e86689aadef",
+   "sha256": "1mw2cjflh1r5irj0362rvg90gklrxj1b5kwcdjq9brj26g3fzpc9"
   },
   "stable": {
    "version": [
@@ -21081,27 +21137,27 @@
   "repo": "joaotavora/eglot",
   "unstable": {
    "version": [
-    20190924,
-    1547
+    20191024,
+    1132
    ],
    "deps": [
     "flymake",
     "jsonrpc"
    ],
-   "commit": "d7747541f3ee82fbc1b7ce3f9499737b4da9414b",
-   "sha256": "19jgmx9a1hmwcpix8dznjs6qscsn5x6z5jpcn7s6h47wfp470nav"
+   "commit": "32ba9d09ec40c68b086e6ff0a2d7c3bdd8393df0",
+   "sha256": "059bm1chzxvfs46izshc2q1fgg1c0gpffasjg5lgh49vk66jmyxf"
   },
   "stable": {
    "version": [
     1,
-    4
+    5
    ],
    "deps": [
     "flymake",
     "jsonrpc"
    ],
-   "commit": "35597d262b53bde52faa46ee6ae8c597d93114e8",
-   "sha256": "1qx3ixaaaffhmbh3ifi5041lp7xp4ab4x4n1mal3wcpp70asxvdp"
+   "commit": "33a4f869972f0958c15c33b47035672b265a8b55",
+   "sha256": "1x6nlsc93scq8lidx1l5ipi7r7s0p63m2vwkl77p3v59glir15cb"
   }
  },
  {
@@ -21135,11 +21191,15 @@
   "url": "https://framagit.org/eide/eide.git",
   "unstable": {
    "version": [
-    20190501,
-    2122
+    20191001,
+    2003
    ],
-   "commit": "0554252de694d01210e40cf071f212b6ca45e88e",
-   "sha256": "1ac8408m0rqyhda22b1c6jcn62mrmpvcn5d3nr2miiv7akvykvl9"
+   "commit": "eafa97e61383ef943bd6c3f8c7d50953257d4ae1",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "Initialized empty Git repository in /run/user/1000/git-checkout-tmp-vIinwX7z/eide-eafa97e/.git/\nfatal: unable to access 'https://framagit.org/eide/eide.git/': Could not resolve host: framagit.org\nfatal: unable to access 'https://framagit.org/eide/eide.git/': Could not resolve host: framagit.org\nUnable to checkout eafa97e61383ef943bd6c3f8c7d50953257d4ae1 from https://framagit.org/eide/eide.git.\n"
+   ]
   },
   "stable": {
    "version": [
@@ -21174,8 +21234,8 @@
   "repo": "millejoh/emacs-ipython-notebook",
   "unstable": {
    "version": [
-    20190813,
-    2156
+    20191020,
+    1934
    ],
    "deps": [
     "auto-complete",
@@ -21188,13 +21248,14 @@
     "skewer-mode",
     "websocket"
    ],
-   "commit": "a2872eff6c18a0706c531e9316c792a9fb99826f",
-   "sha256": "0i182ic59wnhqmik15qsqjsqza5fn67qw18i5gvvj7dsn3v05vac"
+   "commit": "0c207dfac1a3adcee7592d7d28200d86b0478fb1",
+   "sha256": "1nv6vjclx45h084hfdsb5vriyni272rclw57srs50aj5z0rasmaa"
   },
   "stable": {
    "version": [
     0,
     16,
+    2,
     2
    ],
    "deps": [
@@ -21208,8 +21269,8 @@
     "skewer-mode",
     "websocket"
    ],
-   "commit": "a2872eff6c18a0706c531e9316c792a9fb99826f",
-   "sha256": "0i182ic59wnhqmik15qsqjsqza5fn67qw18i5gvvj7dsn3v05vac"
+   "commit": "4399f92b6b5d23240e8f447b36521b8db2a650a3",
+   "sha256": "12zq35ab84j6rhwnq6flp3ljm17ild95nv73mxgig9vsrvx1y57v"
   }
  },
  {
@@ -21356,8 +21417,8 @@
     20181006,
     225
    ],
-   "commit": "156d1a0bbbf330b3f274b0afb7a8366d7f04b8c7",
-   "sha256": "1mm4xphk9h8p9f3pl4brqyksk3lmnw4cr78j933p28qcmgk8sr7w"
+   "commit": "29b43a17559bbf38d7a1db1edd5b524cacc4401f",
+   "sha256": "011i33igq9df0bcmk938yibgj4b417ri2pz16j6klwnnbl8dqkq3"
   },
   "stable": {
    "version": [
@@ -21747,11 +21808,11 @@
   "repo": "casouri/eldoc-box",
   "unstable": {
    "version": [
-    20190711,
-    1226
+    20191008,
+    1427
    ],
-   "commit": "8aa2b6d35a557864ff64762774fd5b4960cbeff0",
-   "sha256": "08h42a3mrhcn4qi77fz2s8yz5sbsfcm8vxyc707lhj8cvl8qp9c2"
+   "commit": "033df7175d454708460818c66ad9a8c589540ca9",
+   "sha256": "16shcbq8hl2xmbzyfk727sbbxflrkpms48y715hw4iy2a2qxnbwq"
   },
   "stable": {
    "version": [
@@ -21843,14 +21904,14 @@
   "repo": "davidshepherd7/electric-operator",
   "unstable": {
    "version": [
-    20190710,
-    858
+    20191005,
+    1109
    ],
    "deps": [
     "dash"
    ],
-   "commit": "97f600ccd9244f99ac802bf8cbd4a8241fbcb892",
-   "sha256": "08dpn776jcypibi3x7mlkxcpsd0i65dws206zwjc19nl3qan4a11"
+   "commit": "71d65e4abaef5e49a9e1b8fce706ce0296f9d5e2",
+   "sha256": "168ri3wahr6zjv2dvqc3jbqih2m4d0mfzp4gqw5mss000fqmx9ns"
   },
   "stable": {
    "version": [
@@ -22061,14 +22122,14 @@
   "repo": "TobiasZawada/elgrep",
   "unstable": {
    "version": [
-    20190917,
-    2320
+    20191022,
+    1746
    ],
    "deps": [
     "async"
    ],
-   "commit": "c644ed57337fdf117de5b7e342c2623d4f17e8f7",
-   "sha256": "1j757kclw54y3cn839jjdsbkydf3sc0bjkkii50gvy65kp46fqhp"
+   "commit": "13cfea5df14a24fe71afe6efd167caf107497698",
+   "sha256": "1g4rnc3y5ivz5ix0xvcai9wiq4kzqnv8skggq9vx1691p3s847nl"
   },
   "stable": {
    "version": [
@@ -22376,8 +22437,8 @@
     "f",
     "s"
    ],
-   "commit": "798c40de09ebfff40fd1aa5b996bd8390f803bdf",
-   "sha256": "1z1g1v3q5zdljkdziv8jnyjm2n4jxdfbds1qqwddlaz143b4h5zb"
+   "commit": "55b49500090247728d5abcd3670527a394ba16e4",
+   "sha256": "0gilc9z2mb53mp5702izdrbyjbmvij20jn8zgji1z629ckjivwh7"
   }
  },
  {
@@ -22616,26 +22677,44 @@
   "repo": "dochang/elpa-clone",
   "unstable": {
    "version": [
-    20190922,
-    2302
+    20191006,
+    1953
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "777ac63fef531bdecf29cd3bf06e15dbe51e9d09",
-   "sha256": "1lrkmbspcwgh97b30i49nacfm5pjpkgk69z6qfkkmm6xvxx8wp7d"
+   "commit": "827e2723b123618aaa32642d78c447cf2979a00a",
+   "sha256": "08psgia9vwwil16nymy0z12p823in3bxf9k7phjrmdicqqc01k42"
   },
   "stable": {
    "version": [
     0,
     0,
-    8
+    9
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "777ac63fef531bdecf29cd3bf06e15dbe51e9d09",
-   "sha256": "1lrkmbspcwgh97b30i49nacfm5pjpkgk69z6qfkkmm6xvxx8wp7d"
+   "commit": "827e2723b123618aaa32642d78c447cf2979a00a",
+   "sha256": "08psgia9vwwil16nymy0z12p823in3bxf9k7phjrmdicqqc01k42"
+  }
+ },
+ {
+  "ename": "elpa-deploy",
+  "commit": "d1708e6fa8778a79cd2423a56497140e3302b579",
+  "sha256": "1yv4sfipaxqgx3zwjfr3wzc25f59pl03snq0ja2s13r7l5kg6im8",
+  "fetcher": "github",
+  "repo": "oitofelix/elpa-deploy",
+  "unstable": {
+   "version": [
+    20191022,
+    718
+   ],
+   "deps": [
+    "f"
+   ],
+   "commit": "f5126a2da1e0e52981fad9c12028814be80328c2",
+   "sha256": "0s1cv983cgz8iysjllqbpbq80bcmsynqb6d3c8z177xqvvr4zaw8"
   }
  },
  {
@@ -22670,20 +22749,20 @@
   "repo": "tgvaughan/elpher",
   "unstable": {
    "version": [
-    20190921,
-    2324
+    20191014,
+    1459
    ],
-   "commit": "5b568bcfd841bcd8fa3972035f6bdff82cb5d3f0",
-   "sha256": "0wffrxc6k3pzh1r7hva6m16mrinf6365xzci452r33kdw1pj323h"
+   "commit": "798c375e25d988da94915f2949c51cb8669faf86",
+   "sha256": "1sp322h4m2n35q65hp9myfgh9nc53pddr5bg133n9gyp7sywq7w8"
   },
   "stable": {
    "version": [
     2,
     3,
-    5
+    6
    ],
-   "commit": "c0ff9d26c2e5cf62ade93852e7eb8a0f081bf028",
-   "sha256": "0khgplpwm7dzsxfh43i1lgwrwskmyxaz9qcgzs0vx9c4vm8c1byk"
+   "commit": "798c375e25d988da94915f2949c51cb8669faf86",
+   "sha256": "1sp322h4m2n35q65hp9myfgh9nc53pddr5bg133n9gyp7sywq7w8"
   }
  },
  {
@@ -22709,8 +22788,8 @@
   "repo": "jorgenschaefer/elpy",
   "unstable": {
    "version": [
-    20190925,
-    2241
+    20191022,
+    2056
    ],
    "deps": [
     "company",
@@ -22720,8 +22799,8 @@
     "s",
     "yasnippet"
    ],
-   "commit": "a1002f3682fe071652eb935e5c7c7de09c5ff2e1",
-   "sha256": "0r787z9xi821mhmh71wa73a3a0a9yl1jmmi3a9982rzv0xc1wpsa"
+   "commit": "7fb3b2e7e1fd2bba5f1c6a4470d84c39ecd11904",
+   "sha256": "157mk0n6y10qr0zdgrqg6a6bsw4vsil246qrl5kg5lb9wzbhd3nb"
   },
   "stable": {
    "version": [
@@ -22786,8 +22865,8 @@
   "repo": "emacs-elsa/Elsa",
   "unstable": {
    "version": [
-    20190825,
-    1513
+    20191002,
+    2030
    ],
    "deps": [
     "cl-lib",
@@ -22795,8 +22874,8 @@
     "f",
     "trinary"
    ],
-   "commit": "fa12fcfa37f399b56c8b45323e03c3328ae4fde3",
-   "sha256": "0aphgjzxm4qhpp5rc72mx7d6n7mfm1ah7gn5064j7kzdi630msjn"
+   "commit": "b43236e5e183249726b93f13e09c56a081817804",
+   "sha256": "0j0qppbhmb43nh1j1hrsyg6m0710m25i12sc9k9s2drz9wva7jc3"
   }
  },
  {
@@ -23024,11 +23103,11 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20190904,
-    1331
+    20191021,
+    1312
    ],
-   "commit": "aec740bb4453a8b671beccd31a583225fb2eb104",
-   "sha256": "144mh3klxqv70qz5qksj5dzgcczc6wwscwwi2mx07x6s3vbgmfal"
+   "commit": "a37c328eac07936ccb3e3e225a764c10e81fd3db",
+   "sha256": "02dy68df31fgdw0isxckg3nysnagxfxy65kgvcndbpb8prvpm0md"
   },
   "stable": {
    "version": [
@@ -23038,59 +23117,6 @@
    ],
    "commit": "457fca9d4bb0429b08c8f4e675f8b1f3e48297e3",
    "sha256": "0vpvdnmg95nk9bmrjysbpfwbyzxhipdqh9xfphxi2n63sd0vzk7z"
-  }
- },
- {
-  "ename": "emacs-setup",
-  "commit": "abb7101b2d48af56af09d1dc85c540300dba7b3c",
-  "sha256": "1x4rh8vx6fsb2d6dz2g9j6jamin1vmpppwy3yzbl1dnf7w4hx4kh",
-  "fetcher": "github",
-  "repo": "echosa/emacs-setup",
-  "unstable": {
-   "version": [
-    20120727,
-    1426
-   ],
-   "commit": "c783ec13e3b39093fffb6f6d64dccdce8ce4d375",
-   "sha256": "1crpjcxwanbrd1yd4lbb5lmqwvx1mczya7ff2qr3phk497czpsqm"
-  },
-  "stable": {
-   "version": [
-    1,
-    0
-   ],
-   "commit": "cc36ad5318c6c0e65d1b9ff8dff5ea2437675de2",
-   "sha256": "15l3ab11vcmzqibkd6h5zqw5a83k8dmgcp4n26px29c0gv6bkpy8"
-  }
- },
- {
-  "ename": "emacsagist",
-  "commit": "07612d46faebb28e1eeb8ddae2ac20e2dc0175f6",
-  "sha256": "1cyz7nf0zxa21979jf5kdmkgwiyd17vsmpcmrw1af37ly27l8l64",
-  "fetcher": "github",
-  "repo": "echosa/emacsagist",
-  "unstable": {
-   "version": [
-    20140331,
-    1830
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "aba342ba59c254a88017f25e9fb7a8cd6f2fda83",
-   "sha256": "0ciqxyahlzaxq854jm25zbrbmrhcaj5csdhxa0az9crwha8wkmw2"
-  },
-  "stable": {
-   "version": [
-    1,
-    0,
-    0
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "aba342ba59c254a88017f25e9fb7a8cd6f2fda83",
-   "sha256": "0ciqxyahlzaxq854jm25zbrbmrhcaj5csdhxa0az9crwha8wkmw2"
   }
  },
  {
@@ -23255,13 +23281,13 @@
   "unstable": {
    "version": [
     20190926,
-    452
+    1542
    ],
    "deps": [
     "emacsql"
    ],
-   "commit": "4bd7ec90a8fd029a29034fca2f051a8bc6f8ae7d",
-   "sha256": "1jrwhflwrcijmfj0zvig4m2m4sr7h14ywz86rj2ld4vd0fsdx7qd"
+   "commit": "e3c434ac212d77f112d4dc9e70784ed2ac48c649",
+   "sha256": "08szs2v7cz4155d2hv7ja40n81r3ph395gr5himi496a6q9kdggr"
   }
  },
  {
@@ -23361,14 +23387,14 @@
   "repo": "madnificent/ember-mode",
   "unstable": {
    "version": [
-    20190403,
-    1652
+    20190928,
+    1451
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "3510afc5023d760a66aef260ba601c15a31dc878",
-   "sha256": "06y5nd2fs0xskjxhd1dn4g9y03i7xamv7jiwq8cm0c2mli5pjpr1"
+   "commit": "f0324b20b6f4e6154a7ea787a2f4d6be464a90e1",
+   "sha256": "0mlj9q1k49wjx1n7dghmpk3pbbqyl4ljgdk7j23lmrq6hbmc4vf4"
   }
  },
  {
@@ -23766,8 +23792,8 @@
     20160726,
     1924
    ],
-   "commit": "10be897fa5165fd40fd35a89e38c759e008fa775",
-   "sha256": "1aanl5dd2m8jlyq27ymhc6l9i00cpi30wwhpaf67dlvk9gk89f64"
+   "commit": "8f159e8073b9b57a07a54b549df687424eeb98ee",
+   "sha256": "1hwikjy4ah1zkb4aknc9yni3d9cqgvnh5n955bdljyp0lvpvvhpr"
   },
   "stable": {
    "version": [
@@ -23802,15 +23828,15 @@
   "repo": "iqbalansari/emacs-emojify",
   "unstable": {
    "version": [
-    20190809,
-    959
+    20191017,
+    420
    ],
    "deps": [
     "ht",
     "seq"
    ],
-   "commit": "782ac307f37239e90c56810323db4263a6469219",
-   "sha256": "1x6ds9aj8yd5phkfw29jdlklqdxjl7g2gqwlm7ngb60nsk02vjvf"
+   "commit": "4c84ef9502988b52b1e296630bcee7f7c62cfc02",
+   "sha256": "11v7br4j1yx1hqqlv2phkxn3jx2qa3vrb4cq61ymfdx82v8j78jj"
   },
   "stable": {
    "version": [
@@ -23968,11 +23994,11 @@
   "repo": "zenspider/enhanced-ruby-mode",
   "unstable": {
    "version": [
-    20190513,
-    254
+    20191005,
+    2306
    ],
-   "commit": "f334c42986e93c60fba144d732becfcbdb13bb7d",
-   "sha256": "0xfdiajm2blkddxillnvn0mnik2i1q5zwgb5zc60i7p5dg1fj176"
+   "commit": "3b97c6f7c4e0e462b74d57d3a0164f6b6f9b498e",
+   "sha256": "07qk8pbwp8bk5dmcsnmyw08b6nzy7dh4asdraw8ml0rpdcqvvlxf"
   },
   "stable": {
    "version": [
@@ -24047,48 +24073,6 @@
    ],
    "commit": "75c84b53703e5d52cb18acc9251b87ffa400f388",
    "sha256": "1in4wbwkxn8qfcsfjbczzk73z74w4ixlml61wk666dw0kpscgbs5"
-  }
- },
- {
-  "ename": "ensime",
-  "commit": "502faab70af713f50dd8952be4f7a5131075e78e",
-  "sha256": "1d8y72l7bh93x9zdj3d3qjhrrzr804rgi6kjifyrin772dffjwby",
-  "fetcher": "github",
-  "repo": "ensime/ensime-emacs",
-  "unstable": {
-   "version": [
-    20180615,
-    1330
-   ],
-   "deps": [
-    "company",
-    "dash",
-    "popup",
-    "s",
-    "sbt-mode",
-    "scala-mode",
-    "yasnippet"
-   ],
-   "commit": "34eb11dac3ec9d1c554c2e55bf056ece6983add7",
-   "sha256": "0hgbxd538xjzna97843014xkbpgs20nz7xpb6smls7rdxp5a1fpd"
-  },
-  "stable": {
-   "version": [
-    2,
-    0,
-    2
-   ],
-   "deps": [
-    "company",
-    "dash",
-    "popup",
-    "s",
-    "sbt-mode",
-    "scala-mode",
-    "yasnippet"
-   ],
-   "commit": "3d3ab18436ad6089496b3bce1d49c64a86965431",
-   "sha256": "0p821zwpiznjh736af5avnx9abssx0zbb9xhs74yhh1mcdi1whq7"
   }
  },
  {
@@ -24346,15 +24330,15 @@
   "repo": "emacsomancer/equake",
   "unstable": {
    "version": [
-    20190630,
-    319
+    20191013,
+    1847
    ],
    "deps": [
     "dash",
     "tco"
    ],
-   "commit": "7eddc025ee61b83029363e22219af228b8c20681",
-   "sha256": "1c55pbqak3d02sw6z1139baxzy401b90g0gxzcc3j6sgplz6sc6w"
+   "commit": "e8561fe7fc69be9d230437cd164c8be3a7bfb911",
+   "sha256": "0ivrpgbavjdfn0451d3sl0v9vxpigpqkkjxl80kip7xwdxnlg7mw"
   }
  },
  {
@@ -24380,25 +24364,25 @@
   "repo": "atomontage/erc-crypt",
   "unstable": {
    "version": [
-    20190318,
-    2350
+    20191002,
+    2159
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "043b109409ee5b17bf06956fa46e1beb66d06ca4",
-   "sha256": "1k4y203m7d7cbgdyin3yq70ai9yw0rfln2v61xd7xa5zxvgvj2v2"
+   "commit": "8844d418fe249daf425eb0b0e3a41abe6c0ee805",
+   "sha256": "0v2bgiw08xkscyy0rskmhwk4h9zf8jxmmv3znr65qxhzaf0l4cxb"
   },
   "stable": {
    "version": [
     1,
-    7
+    8
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "1c8b1caed52a5994aab8bd4dd196881ed537d3aa",
-   "sha256": "0w1b4pqipzdlkak9807k8xgzlc6vvni86ab92snm07909kby9xd0"
+   "commit": "85706aba3ea03ea15fcf53c611c4257b9ae9c7b0",
+   "sha256": "1akxy2mh11bjjhhr9vfc09dj3dy2zrz8p1jynnyc7d5iiy0ai3bc"
   }
  },
  {
@@ -24713,8 +24697,8 @@
    "deps": [
     "dash"
    ],
-   "commit": "07ae21ff7102a8d2c2f088387e114d5b49ff9b34",
-   "sha256": "1mlzgn53ngswjn7vdinnrmhji9jxs5nyqlvb6xm6cznkn97xiy2a"
+   "commit": "bc86b9f63a3e7a5eb263875030d0e15d6f5f6e37",
+   "sha256": "1a3vvdlld66x0j3i7plhc0fm6mkj64mvd375j8g65nvfn6cwc3h4"
   },
   "stable": {
    "version": [
@@ -24819,19 +24803,28 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20190925,
-    1606
+    20191023,
+    843
    ],
-   "commit": "c3c731edfc64c00b03f9394bfdae4ae2b0063798",
-   "sha256": "0n5lvxb30s62n403pk3vmfwa6nr3zn59zlpwli5xmx30imh6dqmn"
+   "commit": "3e5a9d1ccd72bc279d7153b4d86cbea99bdc9b34",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "error: unable to download 'https://github.com/erlang/otp/archive/3e5a9d1ccd72bc279d7153b4d86cbea99bdc9b34.tar.gz': HTTP error 200 (curl error: Transferred a partial file)\n"
+   ]
   },
   "stable": {
    "version": [
     22,
-    1
+    1,
+    4
    ],
-   "commit": "e62a389ce5dd27e7b26802243a5565ffd1feaef0",
-   "sha256": "0p0lwajq5skbhrx1nw8ncphj409rl6wghjrgk7d3libz12hnwrpn"
+   "commit": "6611181ae71422a1c66798718b37474641a090a9",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "error: unable to download 'https://github.com/erlang/otp/archive/6611181ae71422a1c66798718b37474641a090a9.tar.gz': HTTP error 200 (curl error: Transferred a partial file)\n"
+   ]
   }
  },
  {
@@ -25622,14 +25615,14 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20190921,
-    1258
+    20191014,
+    1343
    ],
    "deps": [
     "julia-mode"
    ],
-   "commit": "9e522405814b3ae7a81853930d7c97d50cdadd4f",
-   "sha256": "0kfiyf5v66dbhwcpjj8ndc2ysnn767id5gws7gjng8q6wmkq97na"
+   "commit": "d31b96e02cb4c5d71effab893da9cd81f30d0470",
+   "sha256": "0rbasf6kfyyd6r72cqm6sr791f70q95447c240dvx2kjqp1jhckm"
   },
   "stable": {
    "version": [
@@ -25858,6 +25851,24 @@
    ],
    "commit": "dab96af559deb443c4c9c00e23389926e1607192",
    "sha256": "0ysxblc90kjcz84siprnyxwh94scflivqbxylzkvjm7hbx93rsh1"
+  }
+ },
+ {
+  "ename": "eterm-fn",
+  "commit": "a1955059915511fd16c2d671c262dde47adf724a",
+  "sha256": "1v4kpix16a07i95lcryj65ln0l31vs9k7jfnmdyrpsf7q2mw7z0j",
+  "fetcher": "github",
+  "repo": "oitofelix/eterm-fn",
+  "unstable": {
+   "version": [
+    20191010,
+    2331
+   ],
+   "deps": [
+    "term"
+   ],
+   "commit": "66f3b2f6308fa2ac4d8a32be5a7e35a96e08a9ee",
+   "sha256": "1vw2ha3x2yfkb20g9hfppkrb3mp9r07shb65wsf1b99mw8m22xwi"
   }
  },
  {
@@ -26262,28 +26273,30 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20190926,
-    221
+    20191023,
+    232
    ],
    "deps": [
+    "annalist",
     "cl-lib",
     "evil"
    ],
-   "commit": "492b20cc735a026a70c58f5438c341a112562e14",
-   "sha256": "1b2zcpfj7ivsn7hpnv9a11f22d6yqz48dqkf2xjmf7y2cq8fmi56"
+   "commit": "a96d06677d69322f072f47b5b59d94cb84cf7304",
+   "sha256": "0y8f8nmxq4ci8sq2cfsrr8q5dn8h2ziyxrnb6qp8pi1divg2y6da"
   },
   "stable": {
    "version": [
     0,
     0,
-    2
+    3
    ],
    "deps": [
+    "annalist",
     "cl-lib",
     "evil"
    ],
-   "commit": "986ca7eb0b75eccd843bdad2f7fdb48f4ca6ac22",
-   "sha256": "172sx5w50x5wrs5w0sb6rkbj3q22s7mmsnk4c6pwknhbz3vwlvwz"
+   "commit": "34d515e99e911f368b335bbccc026b71b42a9821",
+   "sha256": "1737dbwv8fa9kps340jsvjyz4gd5vjf3zrdzbvjcjh56ssvdaw2w"
   }
  },
  {
@@ -26794,15 +26807,15 @@
   "repo": "emacs-evil/evil-magit",
   "unstable": {
    "version": [
-    20190904,
-    1730
+    20191007,
+    1744
    ],
    "deps": [
     "evil",
     "magit"
    ],
-   "commit": "4b66a1db8285457147a5436f209391016a819ea1",
-   "sha256": "0kkmbswfh34k3amfl3v140vsnz1gq4n4mg9g4khjd9yjph3zms4h"
+   "commit": "1decef941f252bfd862be50d99bfbc0660dfa18c",
+   "sha256": "0n1c9cll6j05kj56vkdp0xnph8dha98780s0bl8ligx90abapbsl"
   },
   "stable": {
    "version": [
@@ -26856,14 +26869,14 @@
   "repo": "redguardtoo/evil-matchit",
   "unstable": {
    "version": [
-    20190924,
-    2348
+    20191023,
+    2322
    ],
    "deps": [
     "evil"
    ],
-   "commit": "ea1e867129174ef0d545574b883939fcc2019886",
-   "sha256": "0n0scxkp0c2a0b6n7jmcdj8xcsrfcxcp5hw6df4150bmmpwv7wkk"
+   "commit": "11d98debf8b051b10068137668eb54c2fede0e30",
+   "sha256": "1jppiqz1mlmz9wnxmaymg15sz6j59kghhrv95r6hkv90zwdvbqvw"
   },
   "stable": {
    "version": [
@@ -27486,14 +27499,14 @@
   "repo": "emacs-evil/evil-surround",
   "unstable": {
    "version": [
-    20190403,
-    418
+    20191013,
+    1656
    ],
    "deps": [
     "evil"
    ],
-   "commit": "5ad01dfa86424c4b22cd1dfa375f13bd8c656f43",
-   "sha256": "1ajsi6xn8mliwzl24h6pp9rd91z7f20yvkphr9q7k6zpjrd7fb9q"
+   "commit": "d210e1fc2cf1c2d095471cefa700a0d1703f4ab6",
+   "sha256": "1dh716rnyirr580r5y0zvqqx7dbxh459y7r0pcvz8jck5ipiryx7"
   },
   "stable": {
    "version": [
@@ -27607,14 +27620,15 @@
   "repo": "wbolster/evil-text-object-python",
   "unstable": {
    "version": [
-    20181126,
-    1324
+    20191010,
+    1328
    ],
    "deps": [
+    "dash",
     "evil"
    ],
-   "commit": "9a064fe6475429145cbcc3b270fcc963b67adb15",
-   "sha256": "074zpm6mmr1wfl6d5xdf8jk1fs4ccpbzf4ahhkwga9g71xiplszv"
+   "commit": "39d22fc524f0413763f291267eaab7f4e7984318",
+   "sha256": "0293hfgczpjghvg28s27c5r6ll1zaq466pasrhzj71sqzyvxq7ax"
   },
   "stable": {
    "version": [
@@ -27954,8 +27968,8 @@
     20190911,
     1319
    ],
-   "commit": "07793e2bd03ca3f473b1ecf6ed4637f7d2982ce0",
-   "sha256": "13zdsqnv6sasai8j7wlhlfp687s3a8yarrrwnxjvy5wbjjn604sk"
+   "commit": "17d5fda0b912813eb754f23547ad019e55a679da",
+   "sha256": "1p7y91hdd4qn0w09k8p1xna9c9lhqxsl4vlgmm214ybbvacrgm1n"
   },
   "stable": {
    "version": [
@@ -27980,8 +27994,8 @@
    "deps": [
     "ewal"
    ],
-   "commit": "07793e2bd03ca3f473b1ecf6ed4637f7d2982ce0",
-   "sha256": "13zdsqnv6sasai8j7wlhlfp687s3a8yarrrwnxjvy5wbjjn604sk"
+   "commit": "17d5fda0b912813eb754f23547ad019e55a679da",
+   "sha256": "1p7y91hdd4qn0w09k8p1xna9c9lhqxsl4vlgmm214ybbvacrgm1n"
   },
   "stable": {
    "version": [
@@ -28010,8 +28024,8 @@
     "ewal",
     "spacemacs-theme"
    ],
-   "commit": "07793e2bd03ca3f473b1ecf6ed4637f7d2982ce0",
-   "sha256": "13zdsqnv6sasai8j7wlhlfp687s3a8yarrrwnxjvy5wbjjn604sk"
+   "commit": "17d5fda0b912813eb754f23547ad019e55a679da",
+   "sha256": "1p7y91hdd4qn0w09k8p1xna9c9lhqxsl4vlgmm214ybbvacrgm1n"
   },
   "stable": {
    "version": [
@@ -28381,11 +28395,11 @@
   "repo": "agzam/exwm-edit",
   "unstable": {
    "version": [
-    20180905,
-    743
+    20191017,
+    107
    ],
-   "commit": "961c0f3ea45766b888c73d7353da13d329538034",
-   "sha256": "087pk5ckx753qrn6xpka9khhlp7iqlz76w7861x90av2f5cgy6fw"
+   "commit": "80c1cbecafde96a59e620d8fa7e5510a5a7bbd3d",
+   "sha256": "14qnnz3sa8ldhp8lgmvn7xh43prf6ajir90xxij3qaw85km25yi9"
   }
  },
  {
@@ -28524,14 +28538,14 @@
   "repo": "wasamasa/eyebrowse",
   "unstable": {
    "version": [
-    20190917,
-    1653
+    20190928,
+    1458
    ],
    "deps": [
     "dash"
    ],
-   "commit": "e0f6bdf3fc1eab2f036952721a7496e408ce860d",
-   "sha256": "10fwxryisgpyyxhcz8p2g3h085hd6j6qw1hi5pz70a94d3syr3ws"
+   "commit": "e483d35e905c2e26fac63f33c77b9e764729a364",
+   "sha256": "1y3v2cplvnnhw4ga2pw2agwdbffdjrfhjz73cfv6vaa5q8hp32vy"
   },
   "stable": {
    "version": [
@@ -28790,19 +28804,19 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20190821,
-    1918
+    20191018,
+    2049
    ],
-   "commit": "c88ed079add4e2c39401dda9fdeef96ea4ddb13c",
-   "sha256": "1a0ff8xmkkhiwj5809vrxfaj4mkdcvwyw8m656l6iidijskqnmh6"
+   "commit": "1c9729d18642f45f867c46744796f831c8d85042",
+   "sha256": "004llls46rvdw0ig75bwpgh758xwcwnqxxx3bgc3xi59mbwmpk5n"
   },
   "stable": {
    "version": [
     2,
-    5
+    8
    ],
-   "commit": "bb331f755f44f8d6db1b35c476948a080a4a40cf",
-   "sha256": "0llhsn79fp8c42hv57539k3zcyaqx0gc27hg21vq9nh8aa0jb6h2"
+   "commit": "1c9729d18642f45f867c46744796f831c8d85042",
+   "sha256": "004llls46rvdw0ig75bwpgh758xwcwnqxxx3bgc3xi59mbwmpk5n"
   }
  },
  {
@@ -28943,14 +28957,14 @@
   "repo": "ahungry/fast-scroll",
   "unstable": {
    "version": [
-    20190923,
-    310
+    20191016,
+    327
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "70a4d21638bf95646bd12ae9512dffbe1c4970d2",
-   "sha256": "1gbzwql0x6vmn8pip55qa31v4mrjw5wgcv1sx0hmwkrafji3mwjq"
+   "commit": "3f6ca0d5556fe9795b74714304564f2295dcfa24",
+   "sha256": "08nwjyqdkp1g27jqgq7b2nd90kzsfv9mjkkjpniprhfqdqjjcp63"
   },
   "stable": {
    "version": [
@@ -29182,11 +29196,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20190921,
-    359
+    20190927,
+    4
    ],
-   "commit": "686e4d28a8abeb1fa05cb21e14c4f0cc12217d63",
-   "sha256": "0wis927rya6v2mzyvsnjca1b2a1vrndlb7nskkgxs0ssvsvv68bn"
+   "commit": "deea7b971edf238f9018053de4e02fe931064694",
+   "sha256": "0bkpys736r70l9q7r101ghhik6lv14j303xf6sd8xk55v23wh1b8"
   }
  },
  {
@@ -30214,14 +30228,14 @@
   "repo": "defaultxr/fluxus-mode",
   "unstable": {
    "version": [
-    20170210,
-    1941
+    20191001,
+    1716
    ],
    "deps": [
     "osc"
    ],
-   "commit": "3661d4dfdaf249138e7f215f15f291c9391ede8d",
-   "sha256": "1dp974qs80agx9qcq5k5awdsr8p8smv8cdwkjz2d8xfd5wq2vhh9"
+   "commit": "3d05fa15f141ac3e936f908097bb7eb6295cc367",
+   "sha256": "0axjlvhv3xwg16zkpskqp9kvb1x513jl329pmrjzazn5mdh2m8cw"
   }
  },
  {
@@ -30313,8 +30327,8 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20190913,
-    1456
+    20191022,
+    1117
    ],
    "deps": [
     "dash",
@@ -30322,8 +30336,8 @@
     "pkg-info",
     "seq"
    ],
-   "commit": "0006a59259ebd02c9199ddc87f0e3ce22793a2ea",
-   "sha256": "09q3h6ldpg528cfbmsbb1x2vf5hmzgm3fshqn6kdy144jxcdjlf1"
+   "commit": "0eaf67211b83c062e598694d2ba4efb444dc1dc6",
+   "sha256": "1pb8clscs5gwfldnpy6bvczzpnj7j01hzr9c3p2xi1driszs35md"
   },
   "stable": {
    "version": [
@@ -30550,26 +30564,26 @@
   "repo": "ch1bo/flycheck-clang-tidy",
   "unstable": {
    "version": [
-    20190925,
-    2345
+    20191004,
+    801
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "11535422f483ecfccb345c559e7309a81648f088",
-   "sha256": "1y38r98d4f3sdxndhd8p0k3acp7qhzi6vf2k0ph9rj59pp6bqkg7"
+   "commit": "eb82f734529380217c0cd2a53c0d74102eedc301",
+   "sha256": "14hclnacnawmcqf0s3cd84an222blfh8vhan9yyyd0wgzg8llxhh"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "0775e3cde31010820585bb6fdb1239d9b6af67e2",
-   "sha256": "1bjagdi4f4gardwqdfpz2jnyrsn717hhk7lmmwndjxfi1phbqdc4"
+   "commit": "130e933a7089f4523648b5f45d08a658d540d5f3",
+   "sha256": "0cqw2kfi5lcwpzvv6c39ygzhaswjmcwx55z8nmfh87syqh54wj2y"
   }
  },
  {
@@ -31043,25 +31057,6 @@
   }
  },
  {
-  "ename": "flycheck-ensime",
-  "commit": "c8d1ef354566c7f337c62accbd1d2f86ffcbd98a",
-  "sha256": "11h7xwm8vwi8nca7yy9q0y30jcj77s07aa45xqz7n8rsqp6wdp3z",
-  "fetcher": "github",
-  "repo": "ncaq/flycheck-ensime",
-  "unstable": {
-   "version": [
-    20190212,
-    1042
-   ],
-   "deps": [
-    "ensime",
-    "flycheck"
-   ],
-   "commit": "9fe000e7004725bc8c3b7554237d717bca9cd9ac",
-   "sha256": "0fl6p2hvcm1f5snx8a82h53kkfnbgycik0d5a7krcjgiby6w7wam"
-  }
- },
- {
   "ename": "flycheck-flawfinder",
   "commit": "e67a84d1a8c890ea56bd842549d70d9841d1e7a7",
   "sha256": "1nabj00f5p1klzh6509ywnazxx2m017isdjdzzixg94g5mp0kv5i",
@@ -31191,14 +31186,18 @@
   "url": "https://git.deparis.io/flycheck-grammalecte/",
   "unstable": {
    "version": [
-    20190817,
-    935
+    20191003,
+    1844
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "d1ca6d9d4d64aa343598018134506930434ac5e0",
-   "sha256": "0s7kbs764nhq4nlfbbilz5clvadcyz5bi0ksrbm9kczhagisxnjv"
+   "commit": "11cc5a0480dbdd4a9fa2bc12184b3fb56efc5cf3",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "Initialized empty Git repository in /run/user/1000/git-checkout-tmp-SRFTNjEd/flycheck-grammalecte-11cc5a0/.git/\nfatal: unable to access 'https://git.deparis.io/flycheck-grammalecte/': Could not resolve host: git.deparis.io\nfatal: unable to access 'https://git.deparis.io/flycheck-grammalecte/': Could not resolve host: git.deparis.io\nUnable to checkout 11cc5a0480dbdd4a9fa2bc12184b3fb56efc5cf3 from https://git.deparis.io/flycheck-grammalecte/.\n"
+   ]
   },
   "stable": {
    "version": [
@@ -31293,8 +31292,8 @@
    "deps": [
     "flycheck"
    ],
-   "commit": "937f93afc0605c8e6c7cc56041a52b1312fff0fe",
-   "sha256": "1r7da45kmypz1qvpj07m7q9z2bjbx6ds5cx055gq5v03gzyg6n7i"
+   "commit": "6b1386296ddf2ccc11ca8fa719dc0b2f16808424",
+   "sha256": "0bd8k3jzipm0r0242hpl2lkcdfnb367yf4xpj6r23g3y99f6f0yk"
   }
  },
  {
@@ -31656,15 +31655,15 @@
   "repo": "ALSchwalm/flycheck-nim",
   "unstable": {
    "version": [
-    20160715,
-    428
+    20190927,
+    1514
    ],
    "deps": [
     "dash",
     "flycheck"
    ],
-   "commit": "6d27349b66e44578851e6148299709d64d2bde41",
-   "sha256": "08rjrh7rjx71fsxf931hhfcga7m6a8sd6bvvr4qbsmhldnzd1aa7"
+   "commit": "ddfade51001571c2399f78bcc509e0aa8eb752a4",
+   "sha256": "19xxwj66q45499s9jvw6rq8im0g7wxl9m66kq2a9ykds4v7sprlm"
   }
  },
  {
@@ -31769,15 +31768,15 @@
   "repo": "purcell/flycheck-package",
   "unstable": {
    "version": [
-    20161111,
-    2251
+    20191007,
+    51
    ],
    "deps": [
     "flycheck",
     "package-lint"
    ],
-   "commit": "31fe5d9731f30d076f14392401b3b101c9ca2260",
-   "sha256": "1j2jk11cag1scy4cid89lcvjspanhpamazqggksaaadg9b71ay04"
+   "commit": "d76e04009f2548581fc9e9a84f79f1a3112f1096",
+   "sha256": "1jndjq5mnhxmjvhaay4f07p5dbz4zsqv1zhyr98v8zc5dv7qkkfk"
   },
   "stable": {
    "version": [
@@ -31844,8 +31843,8 @@
     "flycheck",
     "phpstan"
    ],
-   "commit": "e8d33c75f6ab466ac15406fac5f2db6666d79deb",
-   "sha256": "1n6f4ibjdzrgll5zvikxc5gcfbpypq9nc2dhfxv011kllj22hpyc"
+   "commit": "81bcfa59d1e5708239d8c32d99cd84405449fb64",
+   "sha256": "1m4vk7v3aafj64qqs0aa9m1w8fbjziq0l6c9k4n10yr8dnm5j9aw"
   },
   "stable": {
    "version": [
@@ -32038,14 +32037,14 @@
   "repo": "msherry/flycheck-pycheckers",
   "unstable": {
    "version": [
-    20190715,
-    1807
+    20191003,
+    1712
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "680ed9bc1bfb6dc043294b705f5b6d87ca5a1700",
-   "sha256": "1d2caskc87kdclj6gsymnf8bxhyn4n9r9816z76hx88pn16xxqh5"
+   "commit": "c6a404cb6325ce17d682bbe24cf7f226b342860b",
+   "sha256": "0pj422carpmzsl87z272i76z35sjpjngwr5hps3jzpc1ln50rym2"
   },
   "stable": {
    "version": [
@@ -32111,8 +32110,8 @@
     "flycheck",
     "rtags"
    ],
-   "commit": "d3d4bc9b7b829d39628a1af96f06eb23ba48670c",
-   "sha256": "0fgxrpqvqs988kjnkcc1lmyqnfc85ivhrarldl7iqgj25fvni6z1"
+   "commit": "f2633f565fc5e7e6958993ef105225f4e68e43ba",
+   "sha256": "1bjgr7wa82ccrc25r7agfaq3iz7xlp1qchvkmkx3xy59jv4yafjz"
   },
   "stable": {
    "version": [
@@ -33905,11 +33904,11 @@
   "repo": "cadadr/elisp",
   "unstable": {
    "version": [
-    20190904,
-    1257
+    20191004,
+    1850
    ],
-   "commit": "ebb2778052aeaf737adebc003957cb48cb01135e",
-   "sha256": "0qlvdpa88ic9gnb0qhijfsc9i6l3ba2zrvk4r4li3qrx0i9rpz5c"
+   "commit": "5f3e67448cc98fe2875115163849acae4d9e8526",
+   "sha256": "1w0dhyr4i0nx0g70smgclcfsbv6cfilb7df330njzaqk8j2gdfws"
   }
  },
  {
@@ -33986,8 +33985,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20190924,
-    2125
+    20191017,
+    1801
    ],
    "deps": [
     "closql",
@@ -33999,8 +33998,8 @@
     "markdown-mode",
     "transient"
    ],
-   "commit": "b80e0988cc15d3f7e5754c05fc3ac9414cd97947",
-   "sha256": "0v8qqakv1bwn00b2kqcn8x87mfpnwdqik0573l4k9drvc3lax41q"
+   "commit": "63cbf81f166fc71861d8e3d246df8e5ccedcb9bb",
+   "sha256": "1yf2xjx3459py6rji740jm8bmh2pv66ghnbjxsvjd4jf9kcdav83"
   },
   "stable": {
    "version": [
@@ -34055,14 +34054,14 @@
   "repo": "lassik/emacs-format-all-the-code",
   "unstable": {
    "version": [
-    20190911,
-    2017
+    20191001,
+    917
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "15a33a9b62d7ac0580c722ee4a7130bd67ba9b49",
-   "sha256": "16zka3dcxzn25ig8fg06lhiv453pnyqp791hald4r90v46p4x7qq"
+   "commit": "f8ca73192482b67c70c6ef4777abb17e200ade30",
+   "sha256": "14scd97jgyqma4rcd7y8y70cs0rr55b1bcj3l2vckjmmy7w7s0xv"
   }
  },
  {
@@ -34186,20 +34185,20 @@
   "repo": "rnkn/fountain-mode",
   "unstable": {
    "version": [
-    20190913,
-    637
+    20191004,
+    351
    ],
-   "commit": "f663ea2cfea24bf17ca539bd7ffe844351b7efe8",
-   "sha256": "0svmsia57dbakdcyjx3435n0vwlrh548j21d5mrgm788dkn668nv"
+   "commit": "05db0789ceb658fbbed74381ba59c4583a004673",
+   "sha256": "0yibcya5v7ddkrn8dwan0bk6mmb7js8gr0h419nx4rrsgjzwd4sq"
   },
   "stable": {
    "version": [
     2,
-    7,
-    3
+    8,
+    0
    ],
-   "commit": "5fe797ebea7544749bc212c77780942329a1ff70",
-   "sha256": "1ghck97vv2ygqbwgwxgbzb0wvf87w0i6vff47lzmmr2ig1ggw2yb"
+   "commit": "05db0789ceb658fbbed74381ba59c4583a004673",
+   "sha256": "0yibcya5v7ddkrn8dwan0bk6mmb7js8gr0h419nx4rrsgjzwd4sq"
   }
  },
  {
@@ -34402,15 +34401,19 @@
   "url": "https://git.launchpad.net/frecentf.el",
   "unstable": {
    "version": [
-    20190903,
-    2109
+    20191016,
+    1243
    ],
    "deps": [
     "frecency",
     "persist"
    ],
-   "commit": "b32eb159de14b2e0d1d1c763acd65cc6784756ae",
-   "sha256": "15pskn85dmm7dblp56b0zzby9wbc2kysb7n3q07yp8680z6lnxhg"
+   "commit": "849dc6c40bff474b5cea5e1a47112d4a5dc75df5",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "Initialized empty Git repository in /run/user/1000/git-checkout-tmp-a587ED3W/frecentf.el-849dc6c/.git/\nfatal: unable to access 'https://git.launchpad.net/frecentf.el/': Could not resolve host: git.launchpad.net\nfatal: unable to access 'https://git.launchpad.net/frecentf.el/': Could not resolve host: git.launchpad.net\nUnable to checkout 849dc6c40bff474b5cea5e1a47112d4a5dc75df5 from https://git.launchpad.net/frecentf.el.\n"
+   ]
   }
  },
  {
@@ -34632,8 +34635,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "0150e4c30390ecea135cdd2f859eb8b88421da6e",
-   "sha256": "1dfjni5f688kj223wvg0hhnw0b38241486p2bxbvr1gnwg3w47cx"
+   "commit": "6cc7ca2a970faa7b800c862447cf36702eed315c",
+   "sha256": "0g0cx6kmgf5p6n438naap5ywclcy4bxi9cq79zvdwh5jfa4xg06d"
   },
   "stable": {
    "version": [
@@ -34786,14 +34789,14 @@
   "repo": "diku-dk/futhark-mode",
   "unstable": {
    "version": [
-    20190724,
-    2151
+    20191020,
+    1746
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f7b674b549f19a0cf936fe56ddeac4502c7b980d",
-   "sha256": "1i6hhpdz5pyv07jr3wikrajnw270fm27nmrji2rz31z8b20nn4z0"
+   "commit": "da6aa3895b5ccfad297446e9547c0604cd3c6e09",
+   "sha256": "02v508shs94w145m7j9ic04ybr26h8md9jhhcd0l2bcggpgqyvxa"
   }
  },
  {
@@ -34807,8 +34810,8 @@
     20190810,
     507
    ],
-   "commit": "f4e30922952470984460d6617e35939aa97640dd",
-   "sha256": "08dyp4z3yqc044wyff207z8bzj51z91yxfk92vv120cvach70k5z"
+   "commit": "56f08351c2ae91e010f6a5e810f11ae74d76deb0",
+   "sha256": "15fymhj82phj407bcnc64p16kv3nc860xbsnlnj7i8qvcnl3jpdl"
   },
   "stable": {
    "version": [
@@ -35169,11 +35172,11 @@
   "repo": "jaor/geiser",
   "unstable": {
    "version": [
-    20190905,
-    2337
+    20191022,
+    1613
    ],
-   "commit": "f76340bd11dc6eb5cf6c22cb5f39e76d52b15d66",
-   "sha256": "0si9d2xcxwkf9l6sly3cckyzlrvr67ihijffjmaswbx7qkgb7gk1"
+   "commit": "8d84a1fbc45de10f934aff2680bfba188a514a71",
+   "sha256": "1sprzfl26lxf46r92jg36fhrvk04gi1fhjsjcga3v3drr90lailw"
   },
   "stable": {
    "version": [
@@ -35192,14 +35195,14 @@
   "repo": "noctuid/general.el",
   "unstable": {
    "version": [
-    20190719,
-    140
+    20191001,
+    450
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f032c3a77079487d0ea563b17ee3e5b2fb084611",
-   "sha256": "0lgh5z17ag5wvvnqwagvam29cp1n1vd50amn6df02xln80bsbllx"
+   "commit": "f38fb2294bd29261374b772f765730f2fa168b3e",
+   "sha256": "1aqi5axkwfng6rm52sblf738c7rffp10sqs69dvkh2fv3ps8q28i"
   }
  },
  {
@@ -35547,16 +35550,16 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20190806,
-    959
+    20191007,
+    1420
    ],
    "deps": [
     "dash",
     "let-alist",
     "treepy"
    ],
-   "commit": "7d59937d7782d0062216130a4d059b45e8396f82",
-   "sha256": "1ngb61nij9gznqplwg1fmr1vq1czry759hmdibzngl4wqhxpfsjq"
+   "commit": "e19cd86ca4768a6d89285123933baa3f1460d696",
+   "sha256": "1d6f8sxlsl0fpkzwbpnaw77d1a5pkg63zfvf6a2fxir357lbdizx"
   },
   "stable": {
    "version": [
@@ -35772,20 +35775,20 @@
   "repo": "ryuslash/git-auto-commit-mode",
   "unstable": {
    "version": [
-    20190716,
-    1936
+    20191008,
+    429
    ],
-   "commit": "e533166a228a4969cbd391734301957c9d4fe7b6",
-   "sha256": "1diw1mwqy5x92a7f01vzynxcs5f2pb17d2hwx83ny2gp7k2gwfha"
+   "commit": "2f05046731330c8643fc21c40a6840d40d70fc26",
+   "sha256": "156zfq2dwm5liffjhc1yhbwwh6vvfc2m4m9shj11glbzy9ggfqsf"
   },
   "stable": {
    "version": [
     4,
-    4,
+    5,
     0
    ],
-   "commit": "075e5f9ded66c2035581a7b216896556cc586814",
-   "sha256": "0psmr7749nzxln4b500sl3vrf24x3qijp12ir0i5z4x25k72hrlh"
+   "commit": "3db70af7d3659d1fe0ed2edf34cae23708a6d511",
+   "sha256": "1w3v9pmlmdxl4pglsb6j0igp13lbzg5bhbr1rv2vll93m6zxmyma"
   }
  },
  {
@@ -35811,15 +35814,15 @@
   "repo": "10sr/git-command-el",
   "unstable": {
    "version": [
-    20190311,
-    511
+    20191024,
+    802
    ],
    "deps": [
     "term-run",
     "with-editor"
    ],
-   "commit": "89169f4b8e8d2546cac81d38bf584764e630812e",
-   "sha256": "1dgy9c7q0lxx5k5vdjcil6405qjpqpyq3s0ndh8fn6ybbhap9jda"
+   "commit": "773e96ad7f9c91d40da04f70e415a812949afb6b",
+   "sha256": "1f3ix0p87ibvnvvan35fffrby7m2s31dpvvlwp0kzjf7hxh3hcvr"
   },
   "stable": {
    "version": [
@@ -35844,15 +35847,15 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20190717,
-    29
+    20190928,
+    1746
    ],
    "deps": [
     "dash",
     "with-editor"
    ],
-   "commit": "f788dd7f4730316378b8a222aa5d6b6f1efce94e",
-   "sha256": "1v2ml8nk7fkaapdcm88098wcc2mcgi0d3mil5dd57vhqmrn7d23z"
+   "commit": "8b3172fc495d83830573461f877ed390e6408e0b",
+   "sha256": "09wcf1s7xnw4ssmg8bha94zw9ax9mz3prl5krl1l634740ajy6h4"
   },
   "stable": {
    "version": [
@@ -35876,8 +35879,8 @@
   "repo": "emacs-stuff/git-commit-insert-issue",
   "unstable": {
    "version": [
-    20171102,
-    1841
+    20191008,
+    950
    ],
    "deps": [
     "bitbucket",
@@ -35886,8 +35889,8 @@
     "projectile",
     "s"
    ],
-   "commit": "f986923b04b587206ce7ee8e0c456768600e8be7",
-   "sha256": "1gffjf6byasisa9jdcv9n4n5zqalvzfsxv7z75zl0g3ph7wc7bbm"
+   "commit": "51c863d9ba21bf11f6681b54be19b4c04d50d1ba",
+   "sha256": "16m3669vm7j0ksfxvp8xqli70z8smb2xlf4cbzgjkfsl3kffbww6"
   },
   "stable": {
    "version": [
@@ -36050,16 +36053,16 @@
   "repo": "akirak/git-identity.el",
   "unstable": {
    "version": [
-    20190706,
-    442
+    20191006,
+    443
    ],
    "deps": [
     "dash",
     "f",
     "hydra"
    ],
-   "commit": "9ef80401da9bfd8870888685e86330c864a2d554",
-   "sha256": "0hgsa8lm1f5a6c4k5gb93jg952p32kb5zm77rblrlrvjrmvrrp76"
+   "commit": "747ea7c2694754719261c2845cdd9f5f8b3aae20",
+   "sha256": "1hg2na6djk2ca4hdsnk3n04yk8q6cdjf6zm63142wgkmzd31qplx"
   },
   "stable": {
    "version": [
@@ -36706,14 +36709,14 @@
   "repo": "joewreschnig/gitlab-ci-mode",
   "unstable": {
    "version": [
-    20190824,
-    1528
+    20191022,
+    2017
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "2651e831aed84ee2512245952fac94901b086549",
-   "sha256": "16fb4r3vq8xkzl911v7gaky95w1agfxjlpaxpjmidwx48rbcar59"
+   "commit": "c861dc5fa17d380d5c3aca99dc3bbec5eee623bc",
+   "sha256": "0yd6s5vy5afkigm87xyh1nnwljplx1wdn5h02224ica0py48fzhd"
   },
   "stable": {
    "version": [
@@ -36748,15 +36751,15 @@
   },
   "stable": {
    "version": [
-    20180304,
+    20180605,
     1
    ],
    "deps": [
     "flycheck",
     "gitlab-ci-mode"
    ],
-   "commit": "388fd05f3ea88ed3ebafb09868fc021f6ecc7625",
-   "sha256": "0idpg4265rfx5i0i8cgfs6w3gncc766mbg81ldxqjhzvq3n28z39"
+   "commit": "30ea0eab74b24818f187242b079845785035e967",
+   "sha256": "0awv24znkxs0h8pkj4b5jwjajxkf1agam09m5glr8zn5g3xbj798"
   }
  },
  {
@@ -36862,11 +36865,11 @@
   "repo": "jimhourihan/glsl-mode",
   "unstable": {
    "version": [
-    20190514,
-    145
+    20191017,
+    2148
    ],
-   "commit": "eaea63a45d0dcb04ddbf069b4bcfd99f10919e44",
-   "sha256": "0fb6as099y1k8inc39n8hkmb63j1l4sd5q9cbyqz4shfczma3546"
+   "commit": "43d906688a8e2fe650005806eb69bea131d9321a",
+   "sha256": "1783gimn1adfgs2xybz15nrx8wsz1xb4xk8mxrc18hyci7fwk04r"
   }
  },
  {
@@ -37387,26 +37390,26 @@
   "repo": "benma/go-dlv.el",
   "unstable": {
    "version": [
-    20190413,
-    1623
+    20191005,
+    829
    ],
    "deps": [
     "go-mode"
    ],
-   "commit": "df03ade331d8fb46acc57ef358e696bc36129e04",
-   "sha256": "0sfx84cbxn8d3gsjg0zjam4yc7pjlyp3g94xa3xv91k71ncnijs1"
+   "commit": "d3cca689e76b71e0ef0ab827c7e01cd9042d2095",
+   "sha256": "0qdbfg9ihxwywjyir3lj1azwsaw425f90gp3182q7165j5v43k9w"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
    "deps": [
     "go-mode"
    ],
-   "commit": "df03ade331d8fb46acc57ef358e696bc36129e04",
-   "sha256": "0sfx84cbxn8d3gsjg0zjam4yc7pjlyp3g94xa3xv91k71ncnijs1"
+   "commit": "d3cca689e76b71e0ef0ab827c7e01cd9042d2095",
+   "sha256": "0qdbfg9ihxwywjyir3lj1azwsaw425f90gp3182q7165j5v43k9w"
   }
  },
  {
@@ -37536,8 +37539,8 @@
     "cl-lib",
     "go-mode"
    ],
-   "commit": "2a1584f06f95792f2c5a84c523bccaafbc5dbbab",
-   "sha256": "06aig4r5a4sfdpwh58pikj9ij95iiy2hakqjgszg54wdv5rljwvd"
+   "commit": "a414da86a48e490baeb24386fad495b47ec56fd9",
+   "sha256": "0q1m18g9n77x7znmmqmpqj3lmkw7g4jp7fp9cj2psi04bmvcsnr6"
   },
   "stable": {
    "version": [
@@ -37629,11 +37632,11 @@
   "repo": "dominikh/go-mode.el",
   "unstable": {
    "version": [
-    20190917,
-    1943
+    20191022,
+    2037
    ],
-   "commit": "2a1584f06f95792f2c5a84c523bccaafbc5dbbab",
-   "sha256": "06aig4r5a4sfdpwh58pikj9ij95iiy2hakqjgszg54wdv5rljwvd"
+   "commit": "a414da86a48e490baeb24386fad495b47ec56fd9",
+   "sha256": "0q1m18g9n77x7znmmqmpqj3lmkw7g4jp7fp9cj2psi04bmvcsnr6"
   },
   "stable": {
    "version": [
@@ -37737,8 +37740,8 @@
    "deps": [
     "go-mode"
    ],
-   "commit": "2a1584f06f95792f2c5a84c523bccaafbc5dbbab",
-   "sha256": "06aig4r5a4sfdpwh58pikj9ij95iiy2hakqjgszg54wdv5rljwvd"
+   "commit": "a414da86a48e490baeb24386fad495b47ec56fd9",
+   "sha256": "0q1m18g9n77x7znmmqmpqj3lmkw7g4jp7fp9cj2psi04bmvcsnr6"
   },
   "stable": {
    "version": [
@@ -37985,8 +37988,8 @@
     20180221,
     2015
    ],
-   "commit": "414d861bb4acf565ff8cb05f9906a2283b7dc75a",
-   "sha256": "1ixb7c3vv8ky7gk9kpknv4hg0wgk6xfcbxxrmql9vc16g6jvcspy"
+   "commit": "16217165b5de779cb6a5e4fc81fa9c1166fda457",
+   "sha256": "0jhwmwc0vykcmf164na0pnadl8gv7184b6pf3xayknwmzdw6vd7h"
   }
  },
  {
@@ -38030,8 +38033,8 @@
     20180130,
     1736
    ],
-   "commit": "5651966e0275572a9956199418d89c9ccc7b2b1a",
-   "sha256": "10lxzkz031lazd9zs3pwh2j7723gzpbhr564vsk1r4gdcbbbj2h3"
+   "commit": "83a9e8d7ca3d47239cb0a7bf532de791e6df3ba6",
+   "sha256": "01m0wxy5a7g82dc04kfjhh1hx7g5d04974b2jhbgsab38hdgggpd"
   }
  },
  {
@@ -38246,11 +38249,11 @@
   "repo": "wasamasa/gotham-theme",
   "unstable": {
    "version": [
-    20171013,
-    1916
+    20191022,
+    1809
    ],
-   "commit": "5e97554d1f9639698faedb0660e63694be33bd84",
-   "sha256": "18x0b2qmyzf9sddsv9ps1059pi4ndzq44rm4yl87slq03y75nxi9"
+   "commit": "02a7c7cd280747737792f4620b0df2e0b826e2c7",
+   "sha256": "017ibhznkyla2c3qymv3mlcd25svx8c55vavsb4apwzw061n8m79"
   },
   "stable": {
    "version": [
@@ -38264,10 +38267,10 @@
  },
  {
   "ename": "goto-char-preview",
-  "commit": "b856d9304ba8814050634db54c8abb88e5dce772",
-  "sha256": "1h9lq9ka469day511nnv566kggja23pa8zhqxa805p6lp7132b4d",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "1k7dp2zhlk3kyy0br5fqzj6sx9zkg215s3qs8flf3w0xji150r6k",
   "fetcher": "github",
-  "repo": "elpa-host/goto-char-preview",
+  "repo": "jcs-elpa/goto-char-preview",
   "unstable": {
    "version": [
     20190418,
@@ -38374,10 +38377,10 @@
  },
  {
   "ename": "goto-line-preview",
-  "commit": "ec27ae185c0308c445e461dc84f398483ca08c5a",
-  "sha256": "1id3msndzav59ljwdp7xnh0glbzc8d12phpywlb89h5nclj0rzsl",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "18q5x2rsg8qyll76cyi0rm5ywgcb4p0w1b2zl0pc9y3qi2g2lwvr",
   "fetcher": "github",
-  "repo": "elpa-host/goto-line-preview",
+  "repo": "jcs-elpa/goto-line-preview",
   "unstable": {
    "version": [
     20190308,
@@ -38404,8 +38407,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "b51c3b036a2f375ef5b95de2d29f3792aad064d7",
-   "sha256": "05b6v6z6dxgpx9b2cp8k3d3fvj01l3smqymikri10ay975g3xawv"
+   "commit": "194e2d1948c2c2e1db438fa7c7fdbed1d60b943b",
+   "sha256": "0y8i5hhqr3j5v68gfg9xlx6kk2ivb9yr4j5vr96yyjsgvmwyn4wg"
   },
   "stable": {
    "version": [
@@ -38579,8 +38582,8 @@
     20160504,
     911
    ],
-   "commit": "aa531c659758b896ff8fbd307080ce0d1d04ebfb",
-   "sha256": "0jcqldpgx9b0xsvxvj7lgqrb39cwn7adggrlxfcm0pgc40dpfwb4"
+   "commit": "09226f852cb3167f23012df8f77318037f5fe9c5",
+   "sha256": "1gq8zwnyqxdf2i9agwky9nhc0nz6g7y0jfi8vjvxgak8dyilrfma"
   },
   "stable": {
    "version": [
@@ -38752,11 +38755,11 @@
   "repo": "davazp/graphql-mode",
   "unstable": {
    "version": [
-    20190812,
-    2240
+    20191024,
+    1221
    ],
-   "commit": "3581ad03e04b11c67d4882cbaa9ab6af71eaf78d",
-   "sha256": "0mabd677yi7phzvvil9fyic5i9z4nyp224d0ifzp5mw0jpsvfxv1"
+   "commit": "7c37aee28bf8c8ffb3da73df5571c4e1e352562b",
+   "sha256": "0hjzqmrc024b98nisvn2ld8gn3bslg8ip19d1fnid3m8q9zk8w8b"
   }
  },
  {
@@ -38767,19 +38770,20 @@
   "repo": "ppareit/graphviz-dot-mode",
   "unstable": {
    "version": [
-    20181118,
-    551
+    20191012,
+    849
    ],
-   "commit": "243de72e09ddd5cdc4863613af8b749827a5e1cd",
-   "sha256": "10ss7mhlkqvxh7y2w7njzh3hiz3r7y49a3q9j41bwipia4yzq4n5"
+   "commit": "096ca0130f0bcbbacc0107a86e3cdfecdb88a087",
+   "sha256": "1y8szyj3g96vb8ybc7ynkbpm98wpflrx1q5cbbxygx3y21lv8dpw"
   },
   "stable": {
    "version": [
     0,
-    4
+    4,
+    1
    ],
-   "commit": "7301cc276206b6995d265bcb9eb308bb83c760be",
-   "sha256": "1zk664ilyz14p11csmqgzs73gx08hy32h3pnyymzqkavmgb6h3s0"
+   "commit": "1574c504d9810f34a85e2ff49b6f7648c2be5f27",
+   "sha256": "03l6zkkxhbcxj5i13hzjv6ypmzaw70zqqagh7ix1kdn33kpp37jj"
   }
  },
  {
@@ -38808,10 +38812,10 @@
  },
  {
   "ename": "grass-mode",
-  "commit": "5b7972602399f9df9139cff177e38653bb0f43ed",
-  "sha256": "1lq6bk4bwgcy4ra3d9rlca3fk87ydg7xnnqcqjg0pw4m9xnr3f7v",
-  "fetcher": "bitbucket",
-  "repo": "tws/grass-mode.el",
+  "commit": "c6f0b067cfbd2902a585b9d1eaadabcac3e62286",
+  "sha256": "1njzw4sparjcyhxki2z0xqrsbazfm52bxm7522szgvxcmjwxybcz",
+  "fetcher": "github",
+  "repo": "plantarum/grass-mode",
   "unstable": {
    "version": [
     20170503,
@@ -38821,8 +38825,19 @@
     "cl-lib",
     "dash"
    ],
-   "commit": "1ae8eae881173ddff64982d1fd0e14d4e7793fc1",
-   "sha256": "1sl3d5759fjm98pb50ykz2c05czb2298ipccwj2qz2hdzq63hfv8"
+   "commit": "8a7e9dcb2295eef1ec25d886b05e09c876bd8398",
+   "sha256": "023s9kn012z6m4aprsq77zv4kvfvwfics5gcdja7ig4xwqqrzymq"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "deps": [
+    "cl-lib"
+   ],
+   "commit": "23ca856ca979fec0f90196b357f2b74fe1cc3a73",
+   "sha256": "116247yggxs0hfbx1746j1d642gk9zbx15c2dw4p5pq9qkasmy95"
   }
  },
  {
@@ -39018,20 +39033,20 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20190909,
-    1939
+    20191022,
+    808
    ],
-   "commit": "eb574c874c76cd3e9b8ec39be04331eaeeac5f31",
-   "sha256": "1m7q1nbg3x6lgbrdsxnsbxchhfw5v0lf5dzix8lnw2wv1lsl51py"
+   "commit": "8fd4102a25c2dd9ccbbee082bc61d8f44eb5ed74",
+   "sha256": "0ylmn54znwhqv9m88zizgzi08ks0vxf1vxqsk4mk2a94ycw1xfkc"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    2
    ],
-   "commit": "eb574c874c76cd3e9b8ec39be04331eaeeac5f31",
-   "sha256": "1m7q1nbg3x6lgbrdsxnsbxchhfw5v0lf5dzix8lnw2wv1lsl51py"
+   "commit": "8fd4102a25c2dd9ccbbee082bc61d8f44eb5ed74",
+   "sha256": "0ylmn54znwhqv9m88zizgzi08ks0vxf1vxqsk4mk2a94ycw1xfkc"
   }
  },
  {
@@ -39100,15 +39115,15 @@
   "repo": "Groovy-Emacs-Modes/groovy-emacs-modes",
   "unstable": {
    "version": [
-    20190407,
-    2314
+    20190930,
+    2356
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "aa531c659758b896ff8fbd307080ce0d1d04ebfb",
-   "sha256": "0jcqldpgx9b0xsvxvj7lgqrb39cwn7adggrlxfcm0pgc40dpfwb4"
+   "commit": "09226f852cb3167f23012df8f77318037f5fe9c5",
+   "sha256": "1gq8zwnyqxdf2i9agwky9nhc0nz6g7y0jfi8vjvxgak8dyilrfma"
   },
   "stable": {
    "version": [
@@ -39288,11 +39303,11 @@
   "repo": "abo-abo/gtk-pomodoro-indicator",
   "unstable": {
    "version": [
-    20171230,
-    1640
+    20191007,
+    1500
    ],
-   "commit": "eb59b229de0dde307b20654075a9bbac69899a66",
-   "sha256": "0dmaazcscg9mdsmij26873af5jl2np4q9xf2klw1jmcl61wzggb0"
+   "commit": "cb026a595de8a9244b16e06876f10c60dce18676",
+   "sha256": "12az34hx714y0wqhxllpc8nk1rwh8s4lhhnvkzbqwki94qyqm87c"
   }
  },
  {
@@ -40205,10 +40220,10 @@
  },
  {
   "ename": "haxe-mode",
-  "commit": "efc5f69915e5284b955c096d5128b4fbb1c5b64b",
-  "sha256": "17n94a12zzigq5bn3jxqrmy1h3vb3brc60j5ckhbp5pvlf906yr9",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "14grb7lcaw57rzqlyy4ja10068r59i2ifxk0q177p4yg8rm519cy",
   "fetcher": "github",
-  "repo": "elpa-host/haxe-mode",
+  "repo": "jcs-elpa/haxe-mode",
   "unstable": {
    "version": [
     20190703,
@@ -40354,29 +40369,30 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20190926,
-    609
+    20191023,
+    1610
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "72f68624b6f19ead155a7e1006a5550d92b8ec9f",
-   "sha256": "07sjy78yb8gclmvh8xjgkbh9gk06ns77g2z53wysf3markwg6pky"
+   "commit": "1341b84aedd972e01396036ce4d496e70282dcac",
+   "sha256": "0nimmkvlvh811swzhynwddd2y06jx27a1s0cl5zmc9y5r4ycpxns"
   },
   "stable": {
    "version": [
     3,
-    3
+    5,
+    0
    ],
    "deps": [
     "async",
     "helm-core",
     "popup"
    ],
-   "commit": "12c50cf2a3748f44eb8c8ccad89ebd6e63fe99f6",
-   "sha256": "0fqhw7r9fcsja5d3pgbipw7pkw9nj534faav6hi45413hc3gyv92"
+   "commit": "610d06e4c170b76ba5a687fe479842cd18420b0a",
+   "sha256": "07bijcnfkv60l3swasxv53x32l6glds05mxnbb3xbnmkgm1pm9if"
   }
  },
  {
@@ -40705,8 +40721,8 @@
    "deps": [
     "helm-core"
    ],
-   "commit": "632495036c4a6ac30e408fc74ee9f209fd5ac429",
-   "sha256": "0rbgk982jlbqh1rhns3zmndfr3lpw7m2j9z7qylghkll4k8fcjpl"
+   "commit": "c722016622ad019202419cca60c3be3c53e56130",
+   "sha256": "08i8d6b41n4sq3jb4gvxkiml73am82jzqkqvvdm9mdhibb8x08mx"
   },
   "stable": {
    "version": [
@@ -41208,25 +41224,26 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20190924,
-    1617
+    20191013,
+    626
    ],
    "deps": [
     "async"
    ],
-   "commit": "72f68624b6f19ead155a7e1006a5550d92b8ec9f",
-   "sha256": "07sjy78yb8gclmvh8xjgkbh9gk06ns77g2z53wysf3markwg6pky"
+   "commit": "1341b84aedd972e01396036ce4d496e70282dcac",
+   "sha256": "0nimmkvlvh811swzhynwddd2y06jx27a1s0cl5zmc9y5r4ycpxns"
   },
   "stable": {
    "version": [
     3,
-    3
+    5,
+    0
    ],
    "deps": [
     "async"
    ],
-   "commit": "12c50cf2a3748f44eb8c8ccad89ebd6e63fe99f6",
-   "sha256": "0fqhw7r9fcsja5d3pgbipw7pkw9nj534faav6hi45413hc3gyv92"
+   "commit": "610d06e4c170b76ba5a687fe479842cd18420b0a",
+   "sha256": "07bijcnfkv60l3swasxv53x32l6glds05mxnbb3xbnmkgm1pm9if"
   }
  },
  {
@@ -41547,16 +41564,16 @@
   "repo": "emacs-helm/helm-emms",
   "unstable": {
    "version": [
-    20190422,
-    1522
+    20191001,
+    1414
    ],
    "deps": [
     "cl-lib",
     "emms",
     "helm"
    ],
-   "commit": "89ec04e6548f16c5848cc49ad506e0561cea87ab",
-   "sha256": "0cn1amwgf5nm73yjxnhjsl6dvfcvh8qb2j2rhsyd6i8kzzkyplf2"
+   "commit": "77f5dab62f9962e376dad99452f29edd0b5dc75a",
+   "sha256": "108ksri1a5hmfjbflqmm486zv3j0sy89xsdjs39q3xrr1s4gbc4q"
   },
   "stable": {
    "version": [
@@ -41777,10 +41794,10 @@
  },
  {
   "ename": "helm-file-preview",
-  "commit": "bf60b4c17c866cd89ff68b99aeb2941c6bc6d940",
-  "sha256": "0y3wkj98nj5nnf5v5iqaihipyx9p902i152gbcrsqcjbpgw3wlhz",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "0rvwf54xz3wb640z0r8gsdv9frf650r7llviicvy5gmfddrlpjh4",
   "fetcher": "github",
-  "repo": "elpa-host/helm-file-preview",
+  "repo": "jcs-elpa/helm-file-preview",
   "unstable": {
    "version": [
     20190903,
@@ -41954,15 +41971,15 @@
   "repo": "cireu/fuz.el",
   "unstable": {
    "version": [
-    20190815,
-    401
+    20191024,
+    1133
    ],
    "deps": [
     "fuz",
     "helm"
    ],
-   "commit": "f4e30922952470984460d6617e35939aa97640dd",
-   "sha256": "08dyp4z3yqc044wyff207z8bzj51z91yxfk92vv120cvach70k5z"
+   "commit": "56f08351c2ae91e010f6a5e810f11ae74d76deb0",
+   "sha256": "15fymhj82phj407bcnc64p16kv3nc860xbsnlnj7i8qvcnl3jpdl"
   },
   "stable": {
    "version": [
@@ -41998,10 +42015,10 @@
  },
  {
   "ename": "helm-fuzzy",
-  "commit": "e0172c8a4e2393a0263373c80e6e7f654bf74dc6",
-  "sha256": "1f7lj9prgh0wpf8xmy5xi5rhs5pj3j4lz68apd95nv2idnbrrlb7",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "088mrqqv9d2vrja67xrd37zzxl4k02rl5smscrp7ad6d60y1k1zy",
   "fetcher": "github",
-  "repo": "elpa-host/helm-fuzzy",
+  "repo": "jcs-elpa/helm-fuzzy",
   "unstable": {
    "version": [
     20190905,
@@ -43436,15 +43453,15 @@
   "repo": "tumashu/helm-posframe",
   "unstable": {
    "version": [
-    20180610,
-    1748
+    20191013,
+    1027
    ],
    "deps": [
     "helm",
     "posframe"
    ],
-   "commit": "d28f96ea92ee9393658901bb552723db10f40dc3",
-   "sha256": "1ycf5m06n32axqpm2vkvszff6gxdps1y8gm46682nf8mk2i3xa6f"
+   "commit": "86d6e6e4c32839dec96ef51ae3917d45259165a4",
+   "sha256": "0byb477lxxyys9q1kwyh37y46jlyk7j1q3xq6cllq47k2gnaix72"
   }
  },
  {
@@ -43916,8 +43933,8 @@
     "helm",
     "rtags"
    ],
-   "commit": "d3d4bc9b7b829d39628a1af96f06eb23ba48670c",
-   "sha256": "0fgxrpqvqs988kjnkcc1lmyqnfc85ivhrarldl7iqgj25fvni6z1"
+   "commit": "f2633f565fc5e7e6958993ef105225f4e68e43ba",
+   "sha256": "1bjgr7wa82ccrc25r7agfaq3iz7xlp1qchvkmkx3xy59jv4yafjz"
   },
   "stable": {
    "version": [
@@ -44079,16 +44096,16 @@
   "repo": "emacs-helm/helm-slime",
   "unstable": {
    "version": [
-    20190821,
-    1304
+    20191016,
+    1601
    ],
    "deps": [
     "cl-lib",
     "helm",
     "slime"
    ],
-   "commit": "e0dbf04d447098a1d074bc04e125764ff82091b7",
-   "sha256": "0mrpjhpijdrq353fnfvdj9l9xfsz390qlcvifcair9732ma7i8l0"
+   "commit": "7886cc49906a87ebd73be3b71f5dd6b1433a9b7b",
+   "sha256": "1g9fnp818d677xhx2m4820742fyblvmnsygmkdb5530lacdaksh2"
   },
   "stable": {
    "version": [
@@ -44231,14 +44248,14 @@
   "repo": "emacsorphanage/helm-swoop",
   "unstable": {
    "version": [
-    20190822,
-    501
+    20191008,
+    401
    ],
    "deps": [
     "helm"
    ],
-   "commit": "3cc15383fae9063de817d320e87a1f868a46eb83",
-   "sha256": "1jm1yvwbfqhrj0256n5ihvxb1zxhhhqv07yfzkfg2pv6k71hpd9h"
+   "commit": "884d2f5840108f0171d38fa19ae2334560f5c2d9",
+   "sha256": "0x6pspamns2hb2a7x01pwzs1zbzi1p0vq6rwrczjh978n2plrqjq"
   },
   "stable": {
    "version": [
@@ -44551,14 +44568,14 @@
   "repo": "brotzeit/helm-xref",
   "unstable": {
    "version": [
-    20190916,
-    1544
+    20190930,
+    1646
    ],
    "deps": [
     "helm"
    ],
-   "commit": "316e1bdb877ec4634addc422cdb9572ee3e2afe0",
-   "sha256": "14zgww1qyk7cp80p6f3viljjbibm3h0c51alplrmjdng57xy0wgq"
+   "commit": "bbd9a858c9eaceb6d3efab0a25d9caff32b3750c",
+   "sha256": "0hvgcpc47ki5arln473qq3qpcg5j83qjk6cmm9k1xqvjkyv19prl"
   }
  },
  {
@@ -44662,8 +44679,8 @@
   "repo": "Wilfred/helpful",
   "unstable": {
    "version": [
-    20190814,
-    308
+    20191001,
+    9
    ],
    "deps": [
     "dash",
@@ -44672,8 +44689,8 @@
     "f",
     "s"
    ],
-   "commit": "e9e958a5643619d0e32b9934bf4e9195c57cb71f",
-   "sha256": "1xhcl3i4cpm5j0q0qd3rcgv5cqfikgqxp4wnw96xkalmyhqdgi28"
+   "commit": "e2609e4ae9e058bd8be6239681b2f22195628f28",
+   "sha256": "00id29w31mq6ikaa95dp0m6l9hcmvm4m0z3mfgyj4713vnm162s0"
   },
   "stable": {
    "version": [
@@ -44729,26 +44746,25 @@
   "repo": "jjzmajic/hercules.el",
   "unstable": {
    "version": [
-    20190920,
-    518
+    20190929,
+    637
    ],
    "deps": [
     "which-key"
    ],
-   "commit": "e6fcb0df3fe877bec2d708f4d034da685d8a1081",
-   "sha256": "0i1bza4nj01z23ig340svyr0lcl284lcpg1lpnhc7cmybjlv27nl"
+   "commit": "031f8eec95240fc46481061f0f44822c0f7fe65e",
+   "sha256": "0snfmvri4cpmhrk5s4hxxlyzs3d58ysmqzaiyiz4979admdc1lmb"
   },
   "stable": {
    "version": [
     0,
-    2,
-    1
+    3
    ],
    "deps": [
     "which-key"
    ],
-   "commit": "489ed27f978c8ae7ce0587d4677ef14d59776008",
-   "sha256": "19939pf5d6p2facmfhpyghx0vipb5k6ry3bmkmjfkj1zp132zfqf"
+   "commit": "031f8eec95240fc46481061f0f44822c0f7fe65e",
+   "sha256": "0snfmvri4cpmhrk5s4hxxlyzs3d58ysmqzaiyiz4979admdc1lmb"
   }
  },
  {
@@ -45651,11 +45667,11 @@
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20190918,
-    2149
+    20191024,
+    1036
    ],
-   "commit": "d7673363ef318a417adc28e36cafb78d01a671af",
-   "sha256": "11d7kmgdpjmjlnfkhfhwvwjdjaag0iscscdbg6gf1hkch19055cp"
+   "commit": "823ca3751e4cac6e936800ddf2f19d6f96eeb422",
+   "sha256": "16isym4dp6vbc9f1pa1q1x1hwhm7nd61rr5y4inf58wllgflnb7f"
   },
   "stable": {
    "version": [
@@ -45675,16 +45691,16 @@
   "repo": "narendraj9/hledger-mode",
   "unstable": {
    "version": [
-    20190725,
-    2115
+    20191012,
+    1046
    ],
    "deps": [
     "async",
     "htmlize",
     "popup"
    ],
-   "commit": "7b4921f67074bf759c9a83ce227802ed627c7cdf",
-   "sha256": "19g1ps1ljmm9d7805pilxzy92fvbgzzamqlxx8gqj1q55hccflp2"
+   "commit": "8206f3c5d8e5b9b084733879191ec3724b60494d",
+   "sha256": "16y3xb8kc4j72gv1d59g4jw21q53i474hiksa6dzxvxkzva4wzf9"
   }
  },
  {
@@ -45766,11 +45782,11 @@
   "url": "https://gitlab.lrde.epita.fr/spot/emacs-modes.git",
   "unstable": {
    "version": [
-    20151203,
-    1650
+    20191010,
+    1132
    ],
-   "commit": "3c608e15b655d2375c5f81323ac561c7848dc029",
-   "sha256": "19360wx1i7lkr8igddm7zl9yh5hlm3r013rkd512cs18iz1y753x"
+   "commit": "558e55429acde26423332a03a3b65b12efdbce5f",
+   "sha256": "0a6jagjimr00dvzrbxj078vyranmv14zl2vn4dkcww4swjzpaag9"
   }
  },
  {
@@ -46181,10 +46197,10 @@
  },
  {
   "ename": "htmltagwrap",
-  "commit": "ec27ae185c0308c445e461dc84f398483ca08c5a",
-  "sha256": "19vav9mpqfg6x017b2f4fkhixfw9fslhs03n780qq2n79abp77n9",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "1jac5ri96wqwss933z2m3q7yrrz8s3mwz39fahfspwqbycbhx8sx",
   "fetcher": "github",
-  "repo": "elpa-host/htmltagwrap",
+  "repo": "jcs-elpa/htmltagwrap",
   "unstable": {
    "version": [
     20190517,
@@ -46378,30 +46394,30 @@
   "repo": "hylang/hy-mode",
   "unstable": {
    "version": [
-    20190620,
-    1804
+    20191003,
+    1902
    ],
    "deps": [
     "dash",
     "dash-functional",
     "s"
    ],
-   "commit": "8699b744c03e0399c049757b7819d69768cac3bc",
-   "sha256": "0axh3i1fga7znk466nqifkjf45ri7qkb9xvnkc9b5zl4f0z9b5gy"
+   "commit": "e2d5fecdaec602788aa7123ed13651c888b8d94b",
+   "sha256": "0gihxlmfminadaqdr8d2zccd7wwygl3m0gfzxsk5izi7f8hl4w7f"
   },
   "stable": {
    "version": [
     1,
     0,
-    3
+    4
    ],
    "deps": [
     "dash",
     "dash-functional",
     "s"
    ],
-   "commit": "27a9e6bee0df741f2699e00e64ea2c7a279b401d",
-   "sha256": "1jxximiznz7fw9ys5k6plw85zrbzvxidql7py1fdi425fdp4058z"
+   "commit": "e2d5fecdaec602788aa7123ed13651c888b8d94b",
+   "sha256": "0gihxlmfminadaqdr8d2zccd7wwygl3m0gfzxsk5izi7f8hl4w7f"
   }
  },
  {
@@ -46496,8 +46512,8 @@
     "cl-lib",
     "lv"
    ],
-   "commit": "435c55e9f75a8cf3ae6a4ba0c7725e3dc4e5963f",
-   "sha256": "0nzbjx5rnmzl0dhbrrmb5kbcmww6hzs1vwa62nlg9zfwq99zk42l"
+   "commit": "9936d1c6a83f8844c6e301c023c0be6394b3aa50",
+   "sha256": "1795hfrwrjgaf0p5r617kf7nvfcdnmgmd2h1bv4jd9cvnkqbgvn2"
   },
   "stable": {
    "version": [
@@ -48075,8 +48091,8 @@
   "repo": "NicolasPetton/Indium",
   "unstable": {
    "version": [
-    20190925,
-    1909
+    20191022,
+    2128
    ],
    "deps": [
     "company",
@@ -48085,14 +48101,14 @@
     "json-process-client",
     "seq"
    ],
-   "commit": "116d18c781eabf85bfc683e748a83f3c769a01ea",
-   "sha256": "0dsp614p827z7magdy7kn4acx6m9hzwwa3sd9zvarnrfymw9c5hi"
+   "commit": "9614d63fa5a5126bd5b68d62410894371da081bf",
+   "sha256": "1cvc9nk1cbym0ah6z0zmgv9bywj3lxvcaflywmavnn4gvxg67m9n"
   },
   "stable": {
    "version": [
     2,
     1,
-    3
+    4
    ],
    "deps": [
     "company",
@@ -48101,8 +48117,8 @@
     "json-process-client",
     "seq"
    ],
-   "commit": "3895b0cfda53d33ef7e6819e745f0b1e158acbfa",
-   "sha256": "18wl3yxlqcvb03mb4wv6v20fpy24w9yqfgiva5jrp453bqhp3mfk"
+   "commit": "9614d63fa5a5126bd5b68d62410894371da081bf",
+   "sha256": "1cvc9nk1cbym0ah6z0zmgv9bywj3lxvcaflywmavnn4gvxg67m9n"
   }
  },
  {
@@ -48128,14 +48144,14 @@
   "repo": "clojure-emacs/inf-clojure",
   "unstable": {
    "version": [
-    20190531,
-    1511
+    20191008,
+    843
    ],
    "deps": [
     "clojure-mode"
    ],
-   "commit": "0fc23509a1e66bcc3e694066f5067fdbd7b7961d",
-   "sha256": "0w42ms5p5f1f7ir745srj73pj9jy1rfkbh3nf85ms05jgrs10fw9"
+   "commit": "173d0e7f118b0009bf210be115485160abf554b1",
+   "sha256": "1514vrdpl467bj4k1qg48fk3526x7cx66px49jy8ynayfs0dhgjc"
   },
   "stable": {
    "version": [
@@ -48203,11 +48219,11 @@
   "repo": "nonsequitur/inf-ruby",
   "unstable": {
    "version": [
-    20190609,
-    1126
+    20190927,
+    1649
    ],
-   "commit": "928b1dd2c24c62be1900476cb4b7219eb2350856",
-   "sha256": "0rm0ns3kqq0y05gskfkplbq0bz6lb1j92fx3hjgr340fm72ixb1c"
+   "commit": "fd8d392fefd1d99eb58fc597d537d0d7df29c334",
+   "sha256": "0axnjqgamy762ky5al56aryx0mp2b2i9almw9gkjcvxm7nc6zlq9"
   },
   "stable": {
    "version": [
@@ -48310,6 +48326,21 @@
    ],
    "commit": "13dd9b6a7288e6bb692b210bcb9cd72016658dae",
    "sha256": "1h2q19574sc1lrxm9k78668pwcg3z17bnbgykmah01zlmbs264sx"
+  }
+ },
+ {
+  "ename": "info-rename-buffer",
+  "commit": "4750abf33d23bce4ca33eb1afe5b972f14f3af39",
+  "sha256": "05ab9apr6zx2k3xqfbq1jjfql9l3hdsf5i4pj8ay0b9lb2x11dpm",
+  "fetcher": "github",
+  "repo": "oitofelix/info-rename-buffer",
+  "unstable": {
+   "version": [
+    20191005,
+    2346
+   ],
+   "commit": "c983ae687481f39b8fd0d4ee9d85fd82b6a4ba03",
+   "sha256": "068flcy4rdzwjpzqqlxpcpcqjxd5f11xq00g55ph17vzxf4iwk3c"
   }
  },
  {
@@ -48578,10 +48609,10 @@
  },
  {
   "ename": "instapaper",
-  "commit": "5b7972602399f9df9139cff177e38653bb0f43ed",
-  "sha256": "1yibdpj3lx6vr33s75s1y415lxqljrk7pqc901f8nfa01kca7axn",
-  "fetcher": "bitbucket",
-  "repo": "jfm/emacs-instapaper",
+  "commit": "a187008942c14dc09f7952a3c5b2e320553cb5c9",
+  "sha256": "1lcrwf2ymlfkvn00djxdr0sd7cjbp2sjdszs3sfmsxffaqzmy9ap",
+  "fetcher": "git",
+  "url": "https://git.carcosa.net/jmcbray/emacs-instapaper.git",
   "unstable": {
    "version": [
     20130104,
@@ -48589,6 +48620,15 @@
    ],
    "commit": "8daa0058ede70025e9f020656abe0e0d01cd8f89",
    "sha256": "0krscid3yz2b7kv75gd9fs92zgfl7pnl77dbp5gycv5rmw5mivp8"
+  },
+  "stable": {
+   "version": [
+    0,
+    9,
+    5
+   ],
+   "commit": "4714ed1b014615f8213e6f93637e4ec1d9d5a37a",
+   "sha256": "12giyb5mgq257jl76dxqv2irr3kx6sidbhjjaf9n9k2h42pip3p4"
   }
  },
  {
@@ -48696,8 +48736,8 @@
     "flycheck",
     "haskell-mode"
    ],
-   "commit": "bab8e85b1aea9b03dfe05048bcdc0395e05e9b20",
-   "sha256": "19zl7dydg2lf8msl2ls9r85f4xw3x2796w5j4h7dxxz6flljhhby"
+   "commit": "3848723cbeeaf61ca13e2a44c5b87a7fcd66b7c5",
+   "sha256": "14cg856gsla77qfxv4sivg7mw7mpv3pqk7l4nrh4vna9ziy78z3m"
   },
   "stable": {
    "version": [
@@ -48972,28 +49012,28 @@
   "repo": "Sarcasm/irony-mode",
   "unstable": {
    "version": [
-    20190703,
-    1732
+    20191009,
+    2139
    ],
    "deps": [
     "cl-lib",
     "json"
    ],
-   "commit": "c7cca52b197babd023fd4745704ae4b695af0d10",
-   "sha256": "0iqjcgb2bg8g7fwsqigiifla8rc3air6ywvbpsrm91cb8a732mrc"
+   "commit": "e630c497f973fa4d1f0fd0e0fd87fb9d18666986",
+   "sha256": "0n2nfcq58md1p2xdhq1smh8v7lsyj0ci7ma5xyd6bkg5rvhsh10i"
   },
   "stable": {
    "version": [
     1,
-    3,
-    1
+    4,
+    0
    ],
    "deps": [
     "cl-lib",
     "json"
    ],
-   "commit": "79d5fc6152659f62b0f2e4df75665f5b625e9642",
-   "sha256": "09i2f99ysisv2d4a0cpn75c0azhbashvz6ja5xy09i2a5svzgzpx"
+   "commit": "e630c497f973fa4d1f0fd0e0fd87fb9d18666986",
+   "sha256": "0n2nfcq58md1p2xdhq1smh8v7lsyj0ci7ma5xyd6bkg5rvhsh10i"
   }
  },
  {
@@ -49035,10 +49075,10 @@
  },
  {
   "ename": "isearch-project",
-  "commit": "5c4f0a2f3080e9f4db82fb2bb9279418e4b9a7e2",
-  "sha256": "0f6f3lm5p4h8z9bnhbl27pzgwdjj58pp8lsvc5dic0yzykx7j2y8",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "1dcxbi1x2nbasiy03mp7af2lcmkmxpfblbdcsnm9srmmpdz9lwff",
   "fetcher": "github",
-  "repo": "elpa-host/isearch-project",
+  "repo": "jcs-elpa/isearch-project",
   "unstable": {
    "version": [
     20190505,
@@ -49277,20 +49317,20 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20190825,
-    1023
+    20191021,
+    1017
    ],
-   "commit": "79333e9edfee38ec3b367c33711a68bdf7783259",
-   "sha256": "0dyclc51sprhmr5fi4lylhwsrn8v1jgyblwk9ly60jj84lj6278z"
+   "commit": "3b35b458e138e7e7a51de7d9e0a1ac70b9f54780",
+   "sha256": "15hm9mrcngwk2vw65bxrhnl4dqi8xgi2gfpnj40npswsh868maw9"
   },
   "stable": {
    "version": [
     0,
-    12,
+    13,
     0
    ],
-   "commit": "85d1e2e779ca92e6ef8e47d08f866b13d4d87aee",
-   "sha256": "0xgngn3jhmyn6mlkk9kmgfgh0w5i50b27syr4cgfgarg6p77j05w"
+   "commit": "cd634c6f51458f81898ecf2821ac3169cb65a1eb",
+   "sha256": "0ghcwrg8a6r5q6fw2x8s08cwlmnz2d8qjhisnjwbnc2l4cgqpd9p"
   }
  },
  {
@@ -49404,8 +49444,8 @@
     "erlang",
     "ivy"
    ],
-   "commit": "fb2e31863cb0305bb3e16c094d29ff78a7414603",
-   "sha256": "0p16lxaana6zb2dlci3d6wwslcw4pifvnmhf3ymbhccmc36v5yqi"
+   "commit": "95bb7da0f7d0e89b6732d1d14d4bc49007b8b794",
+   "sha256": "0jnpfxzzcgyrk7zdfnprchl6b15558zhn12a1pf3h3z6d3zyirql"
   },
   "stable": {
    "version": [
@@ -49541,28 +49581,28 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20190829,
-    630
+    20191018,
+    1251
    ],
    "deps": [
     "hydra",
     "ivy"
    ],
-   "commit": "79333e9edfee38ec3b367c33711a68bdf7783259",
-   "sha256": "0dyclc51sprhmr5fi4lylhwsrn8v1jgyblwk9ly60jj84lj6278z"
+   "commit": "3b35b458e138e7e7a51de7d9e0a1ac70b9f54780",
+   "sha256": "15hm9mrcngwk2vw65bxrhnl4dqi8xgi2gfpnj40npswsh868maw9"
   },
   "stable": {
    "version": [
     0,
-    12,
+    13,
     0
    ],
    "deps": [
     "hydra",
     "ivy"
    ],
-   "commit": "85d1e2e779ca92e6ef8e47d08f866b13d4d87aee",
-   "sha256": "0xgngn3jhmyn6mlkk9kmgfgh0w5i50b27syr4cgfgarg6p77j05w"
+   "commit": "cd634c6f51458f81898ecf2821ac3169cb65a1eb",
+   "sha256": "0ghcwrg8a6r5q6fw2x8s08cwlmnz2d8qjhisnjwbnc2l4cgqpd9p"
   }
  },
  {
@@ -49626,15 +49666,15 @@
   "repo": "akirak/ivy-omni-org",
   "unstable": {
    "version": [
-    20190620,
-    1210
+    20191013,
+    423
    ],
    "deps": [
     "dash",
     "ivy"
    ],
-   "commit": "155acae1aa08d305731b292d62530e52711895f2",
-   "sha256": "0i2v3wj0s8mwx69iw7lgdamdi2p41gy5iaaphk6hvb1r4shhhw8k"
+   "commit": "8d856238a5d93abec3b896f643a69960b50e821d",
+   "sha256": "026cz4pdcpnqcavsh1wgh2xpwp7n6wrd4d62bk8rc1caf49y0i26"
   }
  },
  {
@@ -49713,15 +49753,15 @@
   "repo": "tumashu/ivy-posframe",
   "unstable": {
    "version": [
-    20190923,
-    2233
+    20190928,
+    554
    ],
    "deps": [
     "ivy",
     "posframe"
    ],
-   "commit": "fc0a6a7a80d4396ea44d7ee08879f0f4b46d1b67",
-   "sha256": "150n1gdlnyhqkflhck4m1h0g01y9mppzs6j4dp1rhn2mhhf90hrc"
+   "commit": "81f2ea14ddbdd4b840f18dd13ad3e30a6b791b4a",
+   "sha256": "0b5sip1lc61hxi6bpvkv96vy83xb7cjblssjnzm9yxlniqc778b9"
   }
  },
  {
@@ -49732,15 +49772,15 @@
   "repo": "raxod502/prescient.el",
   "unstable": {
    "version": [
-    20190921,
-    3
+    20191023,
+    347
    ],
    "deps": [
     "ivy",
     "prescient"
    ],
-   "commit": "2f01b640e3a487718dbc481d14406005c0212ed9",
-   "sha256": "1wqk1g8fjpcbpiz32k7arnisncd4n9zs84dn3qn9y8ggjzldqy91"
+   "commit": "6be551816e3d96865e0d187db3e5724eaaa5f248",
+   "sha256": "1ppyqw1hxjx7c1hrndd8afs9pdmqkzj1hn9sdzr5dam6qdff2nqx"
   },
   "stable": {
    "version": [
@@ -49794,14 +49834,14 @@
   "repo": "Yevgnen/ivy-rich",
   "unstable": {
    "version": [
-    20190707,
-    107
+    20191011,
+    226
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "e78fc4b9d467da338471f234393a1c791a6b0e6b",
-   "sha256": "1y8lrzn24vg2pwck6l36w3s8qlpx1cpv54i6gf0jjncp6z9iwh4v"
+   "commit": "7a667b135983a1f3ad33d6db8514638e2a3bdfb3",
+   "sha256": "1v5j6pak2j1wjw19y7rx9rhxif0bj2h47xyl2knfcl6fi4qiqm9y"
   },
   "stable": {
    "version": [
@@ -49831,8 +49871,8 @@
     "ivy",
     "rtags"
    ],
-   "commit": "d3d4bc9b7b829d39628a1af96f06eb23ba48670c",
-   "sha256": "0fgxrpqvqs988kjnkcc1lmyqnfc85ivhrarldl7iqgj25fvni6z1"
+   "commit": "f2633f565fc5e7e6958993ef105225f4e68e43ba",
+   "sha256": "1bjgr7wa82ccrc25r7agfaq3iz7xlp1qchvkmkx3xy59jv4yafjz"
   },
   "stable": {
    "version": [
@@ -50469,28 +50509,28 @@
   "repo": "tkf/emacs-jedi",
   "unstable": {
    "version": [
-    20160426,
-    456
+    20191011,
+    1750
    ],
    "deps": [
     "auto-complete",
     "jedi-core"
    ],
-   "commit": "d9b53d2ca103c46686f6fb4aa92d8af403107982",
-   "sha256": "0rcmcc8d1mfwb8c9bqk8pa1smrdyn7vjcvi7s9cp71p070d2hvqm"
+   "commit": "9d5f29116c4d42cae561a9d69e6fba2b61e2cf43",
+   "sha256": "1bckxppfzd5gwn0aw4h86igb7igal9axqncq7j8zmflg7zppncf1"
   },
   "stable": {
    "version": [
     0,
     2,
-    7
+    8
    ],
    "deps": [
     "auto-complete",
     "jedi-core"
    ],
-   "commit": "8da022c8cda511428c72a6dc4c5be3c0a0c88584",
-   "sha256": "0xbp9fcxgbf298w05hvf52z41kk7r52975ailgdn8sg60xc98fa7"
+   "commit": "9d5f29116c4d42cae561a9d69e6fba2b61e2cf43",
+   "sha256": "1bckxppfzd5gwn0aw4h86igb7igal9axqncq7j8zmflg7zppncf1"
   }
  },
  {
@@ -50501,30 +50541,30 @@
   "repo": "tkf/emacs-jedi",
   "unstable": {
    "version": [
-    20190620,
-    1820
+    20191011,
+    1750
    ],
    "deps": [
     "cl-lib",
     "epc",
     "python-environment"
    ],
-   "commit": "d9b53d2ca103c46686f6fb4aa92d8af403107982",
-   "sha256": "0rcmcc8d1mfwb8c9bqk8pa1smrdyn7vjcvi7s9cp71p070d2hvqm"
+   "commit": "9d5f29116c4d42cae561a9d69e6fba2b61e2cf43",
+   "sha256": "1bckxppfzd5gwn0aw4h86igb7igal9axqncq7j8zmflg7zppncf1"
   },
   "stable": {
    "version": [
     0,
     2,
-    7
+    8
    ],
    "deps": [
     "cl-lib",
     "epc",
     "python-environment"
    ],
-   "commit": "8da022c8cda511428c72a6dc4c5be3c0a0c88584",
-   "sha256": "0xbp9fcxgbf298w05hvf52z41kk7r52975ailgdn8sg60xc98fa7"
+   "commit": "9d5f29116c4d42cae561a9d69e6fba2b61e2cf43",
+   "sha256": "1bckxppfzd5gwn0aw4h86igb7igal9axqncq7j8zmflg7zppncf1"
   }
  },
  {
@@ -50764,15 +50804,15 @@
   "repo": "nyyManni/jiralib2",
   "unstable": {
    "version": [
-    20190923,
-    1809
+    20190927,
+    2010
    ],
    "deps": [
     "dash",
     "request"
    ],
-   "commit": "cb2bedb940afb7c163c5881f0cddc03d4a63c109",
-   "sha256": "16x1bwr9jwg8cfvn2vp8akqvl2j6q4pl8xkvpvimvvjv3girbq1a"
+   "commit": "e913f8e4a994850d2cff18ce2b1f4177cac62c91",
+   "sha256": "022jndjwj0ml2w829id0nx43p24h6jpmilc12n9hiy4p80vjgy1y"
   }
  },
  {
@@ -51578,11 +51618,11 @@
   "repo": "JuliaEditorSupport/julia-emacs",
   "unstable": {
    "version": [
-    20190813,
-    1326
+    20191002,
+    1352
    ],
-   "commit": "db84928742b3e4189dcc81997e4a3cad3eac7b68",
-   "sha256": "0hv43r037jacizmgql0sxxjj2g0f51k5zcxn7h30if86a6hhx659"
+   "commit": "ad6a4944feb61f5c7238cfaf6c99ae63544315c2",
+   "sha256": "1m4w0ha5zkclmdfr6wrpbwz1xqvjclbl63vxfsiq6qwmdajrq97g"
   }
  },
  {
@@ -51759,8 +51799,8 @@
   "repo": "dzop/emacs-jupyter",
   "unstable": {
    "version": [
-    20190924,
-    143
+    20191019,
+    1519
    ],
    "deps": [
     "cl-lib",
@@ -51768,8 +51808,8 @@
     "websocket",
     "zmq"
    ],
-   "commit": "53da538b6634afe7e72b18b7b561afd9d2eeeb38",
-   "sha256": "0lbvi9sf7d02gzxhvn02w55bmcf7fv2lwmmgxv9vp3ya6dc03sya"
+   "commit": "9e3c1633586982e278f072dfaaabd115fa4d19f7",
+   "sha256": "08aig8b2xh9yr5dqj6jivv54vc93277xffmmd3q0k5ghf4087c8n"
   },
   "stable": {
    "version": [
@@ -51825,14 +51865,14 @@
   "repo": "TxGVNN/emacs-k8s-mode",
   "unstable": {
    "version": [
-    20181231,
-    741
+    20191006,
+    849
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "1580ffd6ec7749ec6d069ccea95f8c926ca5db15",
-   "sha256": "0sl8xyhfjnpg46l9f8c3wwwwnl551ly03sghi9a4mx42xpb1g5k0"
+   "commit": "5984acee6f3891afa78acfd1d08c44a24953a233",
+   "sha256": "11x602pmqa3833azkzph1ghm354nypv6rr1y53k6kdrkwviwkcpm"
   }
  },
  {
@@ -51964,16 +52004,16 @@
   "repo": "jmorag/kakoune.el",
   "unstable": {
    "version": [
-    20190803,
-    1525
+    20191017,
+    1502
    ],
    "deps": [
     "expand-region",
     "multiple-cursors",
     "ryo-modal"
    ],
-   "commit": "fe8f8a02c38538f5f7776df3402b270639281ad8",
-   "sha256": "15wnwjlh333c3aykk6w4xxy93ic6lzb7wmxaigxahg37a9qlp3hs"
+   "commit": "d73d14e69ea38076af50cc69f846808383ff539d",
+   "sha256": "0nk6jdy1y5mc3ryd0smiqghrk6iv34d5grc7f7migmshlbq0np92"
   }
  },
  {
@@ -52348,11 +52388,11 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20190317,
-    135
+    20191023,
+    2135
    ],
-   "commit": "7bbebe6442720031e4f5d1fd909c5be2fbb1c1dc",
-   "sha256": "19a8vdzbfwk5klac5800aywlmrl41kfb7ansmfg4938i4gwnbak0"
+   "commit": "ab41be43b6d9efd5eff5ad7f22a997cc41e8daf0",
+   "sha256": "17hpyfkmr8ij3pr2cpl189svar2w5m01glmzvr95br6qmcifvvqa"
   },
   "stable": {
    "version": [
@@ -52738,8 +52778,8 @@
     20180702,
     2029
    ],
-   "commit": "0d1156a14f5fb59f420e67b1f3b899395cf595e0",
-   "sha256": "07i3jkvxja2a0bj7f7vlh2v2y2cialn4b4319r2kymaxlw5pmzk2"
+   "commit": "7947abfbb77cb50c6d7cce7c8739ab630e028034",
+   "sha256": "0qcwnq5wmc9yd253yi4x6b3v2p5d9vwb3skq9qv9igc0nhmq9gvb"
   },
   "stable": {
    "version": [
@@ -52759,14 +52799,15 @@
   "repo": "stardiviner/kiwix.el",
   "unstable": {
    "version": [
-    20190904,
-    1248
+    20191016,
+    951
    ],
    "deps": [
-    "cl-lib"
+    "cl-lib",
+    "request"
    ],
-   "commit": "878b02be15ea9aebe939189fd10598b057b739af",
-   "sha256": "18g1jid2z6gls4ijgz3k8b5gaij3fs5rwrn0i8bgly6jmk6nx8rp"
+   "commit": "1fdcfcc6c080b5232cf588460283e16180a81dc9",
+   "sha256": "0088bnizccf372yivkw07x541ispmak8yy6ri2kqa15pkmszjfjh"
   },
   "stable": {
    "version": [
@@ -52925,11 +52966,11 @@
   "repo": "Emacs-Kotlin-Mode-Maintainers/kotlin-mode",
   "unstable": {
    "version": [
-    20190917,
-    1807
+    20191021,
+    1834
    ],
-   "commit": "d6720fe9bc2ce447f213c470bd18fad8e04dc18b",
-   "sha256": "093yirwm3w0z2x0f07kggivkvgcaqhkar0fqbfagd9nly2f0jzr2"
+   "commit": "6aa6d56c0a04e655e3cbfd1ab7904a45b73ae21c",
+   "sha256": "1kdka9yqbh3m8nb3rpvax1fpjij7r3r2j2whys5cyvvrjfmp8hlh"
   }
  },
  {
@@ -52999,14 +53040,14 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20190819,
-    1434
+    20191014,
+    2010
    ],
    "deps": [
     "transient"
    ],
-   "commit": "88995f796e6ba20cc91abfb012c23fe5ab29e19f",
-   "sha256": "0b33gp6qkclb1jxsxwjkwa74wri1zj2gx4sw11igbs58kkyzja52"
+   "commit": "9ed130c6e5d35b5fa41156f9ec62aa50365c23e0",
+   "sha256": "0xqjsng9fdf96h0sa01d0sza5qpkl14r2ccf0mmcg3l7c2xw8ibl"
   }
  },
  {
@@ -53613,11 +53654,11 @@
   "repo": "conao3/leaf.el",
   "unstable": {
    "version": [
-    20190917,
-    1451
+    20191023,
+    1053
    ],
-   "commit": "31df91362e8e14e51ba3c16ea17d914e7c3986e1",
-   "sha256": "1zl6qkn6cd5f85d7w03w3az7s7dmz0jp3g6w1pwwhdf76dcw3lhx"
+   "commit": "d2e3367ca53718275a02c205ad68925c4c878d2a",
+   "sha256": "1785ydsjnbg1ldfjgwny2jv2xp1jq52bkbvxczc03zlfzi8vdp5k"
   },
   "stable": {
    "version": [
@@ -53756,11 +53797,11 @@
   "repo": "ledger/ledger-mode",
   "unstable": {
    "version": [
-    20190925,
-    1300
+    20191008,
+    1420
    ],
-   "commit": "129dfbab2f744c8d6b6bcd406001ff527c262aff",
-   "sha256": "09xq34q4zb6xq85nvp2aj56h96h8b3vy56ijn6i5zwrhlwwyj32i"
+   "commit": "214fad3ff8096bbd53cc079f71cfb845d12bfaa8",
+   "sha256": "05yjq15c7jj70vc5xp4k4h56nzybgibp48srkzjx8220q1w9656m"
   },
   "stable": {
    "version": [
@@ -53795,8 +53836,8 @@
   "repo": "kaiwk/leetcode.el",
   "unstable": {
    "version": [
-    20190924,
-    353
+    20191011,
+    800
    ],
    "deps": [
     "aio",
@@ -53804,8 +53845,8 @@
     "graphql",
     "spinner"
    ],
-   "commit": "296a9dfba4f0cd55e27e5eea8a678d7084cff270",
-   "sha256": "0xcipajyii5l6lk4s30i7ninp08spq4vlg0smjp9rrcdilyfpnbn"
+   "commit": "86e9e167c10eed487cf6715a764527d84ccb35fa",
+   "sha256": "0mq4a2jv5lpy4wcfhp2cg63gdyqjv10ffb2702yjyd24nqmh3q76"
   }
  },
  {
@@ -54083,8 +54124,8 @@
    "deps": [
     "request"
    ],
-   "commit": "fd90ff7989632452434fc19a609805f7276821f3",
-   "sha256": "0rpipbcfvi8ysx8aykj9sd23gkzq3knn656g84lb9h1zdjvc4zf1"
+   "commit": "29e369df4f96c7ad95bb33292de7a44122e0b4e7",
+   "sha256": "1xaa90dy1jq1yzcn9px931sgqsrsbwrc89lv0lss975jr827kfg2"
   },
   "stable": {
    "version": [
@@ -54137,11 +54178,11 @@
   "repo": "mpdel/libmpdel",
   "unstable": {
    "version": [
-    20190918,
-    1609
+    20191015,
+    803
    ],
-   "commit": "5cec415bd9db566088ec44b8bb4dd0a9cc76ccdc",
-   "sha256": "0qx7h6y9ih6qkijspzpn8gfpxjb486qrp0g4b9fpfzp8igc2ddik"
+   "commit": "983c27d11becf0078bc5b416746f171e7e238d6d",
+   "sha256": "0m8kb480v2cx3jniy73bim1g7kjsrvhh02li9d0qv7smala59nl3"
   },
   "stable": {
    "version": [
@@ -54161,11 +54202,11 @@
   "repo": "buzztaiki/lice-el",
   "unstable": {
    "version": [
-    20170220,
-    943
+    20191011,
+    631
    ],
-   "commit": "4339929927c62bd636f89bb39ea999d18d269250",
-   "sha256": "0879z761b7gajkhq176ps745xpdrivch349crransv8fnsc759yb"
+   "commit": "3ff90745cd43d1cc41216a01f55f871a00692ffe",
+   "sha256": "08aiwyd0cxwd37jdy1m78l1r35h7fiq7wygpys2yrms6mdl8063b"
   },
   "stable": {
    "version": [
@@ -54193,20 +54234,20 @@
  },
  {
   "ename": "line-reminder",
-  "commit": "ec27ae185c0308c445e461dc84f398483ca08c5a",
-  "sha256": "0cm9cv7ak1ibm68d2xrz26smh80g79dxjlwxj5qd9zc3yjyksdvi",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "1s3ibn7c1j6m7wdkb0z37apgfc0g8vhhrqcnmldf19zi3k13bm0x",
   "fetcher": "github",
-  "repo": "elpa-host/line-reminder",
+  "repo": "jcs-elpa/line-reminder",
   "unstable": {
    "version": [
-    20190807,
-    440
+    20191016,
+    1528
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "707dc65001778e6476085fd7c30e1a1a3f84563a",
-   "sha256": "07fd1gw1fwzc1ynfp59b06hm9hz93fnjhgkgxmhk464ri0nv0l60"
+   "commit": "ea7fc43210b5293beac4ac453b1bdde415f5183e",
+   "sha256": "13vspm2c53ph25li4xd77q2v7rqwsszsy8a842ivcgn0k3qn6w0r"
   }
  },
  {
@@ -54220,8 +54261,8 @@
     20180219,
     1024
    ],
-   "commit": "a00f8e380a8b87269a8ea0b68af63383a74ca5e8",
-   "sha256": "024hsx5jhr9myssmw60mxyizbj184hq6zxv8b0k1ivll026hbnpi"
+   "commit": "fefdee6fb6f7467b5afee6a591f677d7981b60bf",
+   "sha256": "0l176qgqvm9ia0z17y0wag38drhjz748qc4241g5y7ia2n20y3mb"
   },
   "stable": {
    "version": [
@@ -54435,20 +54476,20 @@
   "repo": "marcowahl/lisp-butt-mode",
   "unstable": {
    "version": [
-    20190822,
-    1102
+    20191024,
+    1229
    ],
-   "commit": "3199954a70594405ccb7b193e6e471264eae7b87",
-   "sha256": "12qvycibrxsd3mlpj7x673kwfxhyhg3266ghf3r11179yh12hgy9"
+   "commit": "47007084d0893373731fabd828c4d4f28058f8e1",
+   "sha256": "10hc9021q9paxcr0n1pcl6pfyz73an53mvfz8aa1bym931v0fdvb"
   },
   "stable": {
    "version": [
     1,
     0,
-    3
+    4
    ],
-   "commit": "f6ccceda1618aad0ec5a665dab912a7ebbc32f08",
-   "sha256": "0w4i478aybp9ca09ixmzsda83l9igqx5ryv0g8vpkmd2vg3r0dcy"
+   "commit": "1ad373fd18d9db62b236d9d85603cd923f62f084",
+   "sha256": "0nhikhnqnxyxx6s14vafhfwd4ph2bwvxz0m7mn0arrf6hjqzw7ws"
   }
  },
  {
@@ -54483,14 +54524,14 @@
  },
  {
   "ename": "lispy",
-  "commit": "e23c062ff32d7aeae486c01e29c56a74727dcf1d",
-  "sha256": "12qk2gpwzz7chfz7x3wds39r4iiipvcw2rjqncir46b6zzlb1q0g",
+  "commit": "29a704fede83b02e19c2ad213485f0f651931753",
+  "sha256": "1c8gz46ab5f07dljv2chr0i5lini81wl3zx4zw8xjysb4a5dp05v",
   "fetcher": "github",
   "repo": "abo-abo/lispy",
   "unstable": {
    "version": [
-    20190925,
-    1020
+    20191016,
+    1250
    ],
    "deps": [
     "ace-window",
@@ -54499,8 +54540,8 @@
     "iedit",
     "zoutline"
    ],
-   "commit": "17cfa867ae81d2024a242b17d7b61f5840c22ec0",
-   "sha256": "1l13yja6s6jnsc00bv5axyfgwl6a5lvhmjjhm44fwi4rpjfl0rj4"
+   "commit": "9f48176fe9a170848be0a07506d50e29b5f0dba3",
+   "sha256": "1410nghcficskk44jh1afgxwapmkhahc22bm7584rxrwbw7rl26s"
   },
   "stable": {
    "version": [
@@ -54730,25 +54771,25 @@
   "repo": "joodie/literal-string-mode",
   "unstable": {
    "version": [
-    20170301,
-    1530
+    20191023,
+    733
    ],
    "deps": [
-    "markdown-mode"
+    "edit-indirect"
    ],
-   "commit": "2ca4fc08b8e19e6183b1f1db747bb0a4aa4f98eb",
-   "sha256": "0wcz0lid05gnlmxpxm4ckw07cnxwjkyw6960nq7pylbjpg76g5ng"
+   "commit": "afffa86e626798ee9f9188ea3be2d5ee6ad17c39",
+   "sha256": "0nh14f3fv0b4i3rlx120s9a0s8gsaip0r15ki38446igl1macbq2"
   },
   "stable": {
    "version": [
     0,
-    1
+    5
    ],
    "deps": [
-    "markdown-mode"
+    "edit-indirect"
    ],
-   "commit": "46dd2b620df70d681261616f1a26afa4a032e2d5",
-   "sha256": "02a1jvxk2m1lb21p3281cr9xyhzix31cn8a9la53w90sz569i66r"
+   "commit": "afffa86e626798ee9f9188ea3be2d5ee6ad17c39",
+   "sha256": "0nh14f3fv0b4i3rlx120s9a0s8gsaip0r15ki38446igl1macbq2"
   }
  },
  {
@@ -54788,25 +54829,25 @@
   "repo": "jingtaozf/literate-elisp",
   "unstable": {
    "version": [
-    20190924,
-    526
+    20191012,
+    606
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "039b94b08ff750fc5b8a5b0e051eec288627c545",
-   "sha256": "124m56rb2878gmlygcqpyyi18i3kn9xmpw72q6bjizjmakcpl30p"
+   "commit": "2c91d49be2450650236638a8100d9373ccd59d70",
+   "sha256": "0i9468rh61l4xq918fgwk6li93lpm6zbn0lkpxr7pbvkgrl5xsr6"
   },
   "stable": {
    "version": [
     0,
-    6
+    8
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "1dd1aad8c4049423d1a7980191c25b4120681296",
-   "sha256": "07gp0l2y7ysl13n368jaqnj52fpqcirj0faz95rrzrysq9ap8xn8"
+   "commit": "2c91d49be2450650236638a8100d9373ccd59d70",
+   "sha256": "0i9468rh61l4xq918fgwk6li93lpm6zbn0lkpxr7pbvkgrl5xsr6"
   }
  },
  {
@@ -54879,11 +54920,11 @@
   "repo": "donkirkby/live-py-plugin",
   "unstable": {
    "version": [
-    20190614,
-    433
+    20191021,
+    102
    ],
-   "commit": "4c378e4afdffb09ab3ca338d3b37d9a2b69d9584",
-   "sha256": "1rchbqcpvdlrz3f95l5ldivh1hnf8hk67k8rpdi9zs7zva1hkdzv"
+   "commit": "4890a53082b4cacd8c64484dfae2037153453c8c",
+   "sha256": "015hh2mzm3b9kijl0dsxs3y2m6dxdwvblszy6ckp5j2qv32bmydn"
   },
   "stable": {
    "version": [
@@ -55088,11 +55129,11 @@
   "repo": "fourier/loccur",
   "unstable": {
    "version": [
-    20181203,
-    2038
+    20191022,
+    1955
    ],
-   "commit": "194d70e6be82c4622b7460ca46ced38109ac0507",
-   "sha256": "136ixa0w94imwacdjispcn81v5i7pb0qqzy6bzgjw2cr9z9539bx"
+   "commit": "4934c0560d2f63e6314b4584211a0cc0a7e671c4",
+   "sha256": "03hwvx3h64jj9nylmzpv2241b5fi97anhjjpwc5sjmfsq1wbf432"
   }
  },
  {
@@ -55239,17 +55280,17 @@
  },
  {
   "ename": "logpad",
-  "commit": "5148207367bf236223e952a1e4fd600f90571b5e",
-  "sha256": "1r688z3y98wnr15fg6zzcs4c4yw0l6ygah07gjhblj8b7q7i2qgg",
-  "fetcher": "bitbucket",
-  "repo": "tux_/logpad.el",
+  "commit": "c9747d42331eae20744f0bf4821e82a7832dbdc7",
+  "sha256": "0xmgbw9cv2gvhlfxjpwk41vg7ixrl1bw607h9ag5vga4s3sg5q8l",
+  "fetcher": "github",
+  "repo": "dertuxmalwieder/logpad.el",
   "unstable": {
    "version": [
-    20180607,
-    1915
+    20190927,
+    2043
    ],
-   "commit": "506ace0e996f4d130ba9ccbc323caada7d516ff5",
-   "sha256": "0z9dq37hsrzjkd3pynqmm8gbiv1sbqnjxlqkyq6lpps5fd9n5vsz"
+   "commit": "ff80fd198b196c4db9ca88ae8cf858cae491e121",
+   "sha256": "0hc6lp6qmiq9qhn6lx7whfv2w1zz5g2j6azzd9vs695kcbqk5qm7"
   }
  },
  {
@@ -55491,8 +55532,8 @@
   "repo": "emacs-lsp/lsp-java",
   "unstable": {
    "version": [
-    20190918,
-    1601
+    20191016,
+    1709
    ],
    "deps": [
     "dash",
@@ -55501,10 +55542,11 @@
     "ht",
     "lsp-mode",
     "markdown-mode",
-    "request"
+    "request",
+    "treemacs"
    ],
-   "commit": "df3cfc30eaa9d7605ac3db5d17d8a02efaf50527",
-   "sha256": "0whybqasbi09ki9714k139vm0hmzvxrn0r20ibk8rfj6lxprkwl5"
+   "commit": "52f61a539b9627122b39d9aff3885a1d94247d9a",
+   "sha256": "1hhkssgbv4s1q9ypav6k4siwnhmqhjhsdag3d6vs9jhsswysds0f"
   },
   "stable": {
    "version": [
@@ -55544,6 +55586,38 @@
   }
  },
  {
+  "ename": "lsp-julia",
+  "commit": "ca6a06ed4de499bcccce05163ea3d54e4dca9539",
+  "sha256": "1frjvq2x0xsf93kgpy6bp9mgzfpr7zhacskmm6x8kknb9vj18h4v",
+  "fetcher": "github",
+  "repo": "non-Jedi/lsp-julia",
+  "unstable": {
+   "version": [
+    20191011,
+    1005
+   ],
+   "deps": [
+    "julia-mode",
+    "lsp-mode"
+   ],
+   "commit": "6b0d1a3f32c5e6c5b4c0993f30303569a9e9e9bd",
+   "sha256": "11jisy6161j4mpqyi06slfr3l7cmmnp7xc6701hszmvl935znn3l"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "deps": [
+    "julia-mode",
+    "lsp-mode"
+   ],
+   "commit": "6b0d1a3f32c5e6c5b4c0993f30303569a9e9e9bd",
+   "sha256": "11jisy6161j4mpqyi06slfr3l7cmmnp7xc6701hszmvl935znn3l"
+  }
+ },
+ {
   "ename": "lsp-mode",
   "commit": "1a7b69312e688211089a23b75910c05efb507e35",
   "sha256": "0cklwllqxzsvs4wvvvsc1pqpmp9w99m8wimpby6v6wlijfg6y1m9",
@@ -55551,8 +55625,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20190926,
-    514
+    20191024,
+    457
    ],
    "deps": [
     "dash",
@@ -55562,8 +55636,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "0546d33e345c63265a6df812f2713e62dbe6a7ad",
-   "sha256": "1rp8abwx2pbm4zmsy13hkvhvxgpz876dnlfvxijvxchnf0dxwba4"
+   "commit": "27258c0a129803b080fa6f3d0aa40139d351cdfd",
+   "sha256": "1h6724k03a75cbvmf22dfw1yjcc8mc4jm7p8g8sj2wwc4lkpdabp"
   },
   "stable": {
    "version": [
@@ -55615,8 +55689,8 @@
    "deps": [
     "lsp-mode"
    ],
-   "commit": "156ba380cd6adc5df663420ae25c45046faeb68e",
-   "sha256": "0flp7a4lw9bfjw1g57kl6amnf0hzv7arnhjasibm1nq4w0p10pvr"
+   "commit": "54dd19d88cd561061ac3103dc452d6854e5899fa",
+   "sha256": "1kg8n215hg8x9gxi2sdjyk8whbir20p3fzc50za1iwhiq3gzx1fw"
   },
   "stable": {
    "version": [
@@ -55656,8 +55730,8 @@
   "repo": "emacs-lsp/lsp-python-ms",
   "unstable": {
    "version": [
-    20190911,
-    1324
+    20191024,
+    853
    ],
    "deps": [
     "cl-lib",
@@ -55665,8 +55739,8 @@
     "lsp-mode",
     "python"
    ],
-   "commit": "42222bacf09c4ca18302ac39d50ea09d196e2816",
-   "sha256": "09a8kjc47v5qcrd4p0b911idbhh760xdir2bgkn3gm2w5l4krfyj"
+   "commit": "b2593c6235e61c5f042ccd3a4fce536dfaf0b769",
+   "sha256": "1msgd6w19661afmn3zh08phvkp0v8d66sbwg6d8naqzgpbs0myqq"
   }
  },
  {
@@ -55737,8 +55811,8 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20190915,
-    856
+    20191023,
+    1558
    ],
    "deps": [
     "dash",
@@ -55746,8 +55820,8 @@
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "c8fa40c0f9c65877d1cabe1739e5f787adb24898",
-   "sha256": "040qzkd1zvyb0q3yxs2vd4f3qp37c8anr3zcmx96bjvj1v7pmpmn"
+   "commit": "f25367c8b56921d2af42dd6b1dc1a8cd82ce6021",
+   "sha256": "0v1wi8nkikc35jxwnm6znwzw7xabw3kg3nn90zc03ysr3kn2gc61"
   },
   "stable": {
    "version": [
@@ -55772,11 +55846,11 @@
   "repo": "immerrr/lua-mode",
   "unstable": {
    "version": [
-    20190113,
-    1050
+    20191015,
+    733
    ],
-   "commit": "95c64bb5634035630e8c59d10d4a1d1003265743",
-   "sha256": "0cawb544qylifkvqads307n0nfqg7lvyphqbpbzr2xvr5iyi4901"
+   "commit": "52cc3e465a2d35dbcbad8a87fd5fe548840f5822",
+   "sha256": "1iw0z6dxd1nwjmlgy800xd2pgv40f798j831ca1hh3pbai5f84zm"
   },
   "stable": {
    "version": [
@@ -55850,11 +55924,11 @@
   "repo": "abo-abo/hydra",
   "unstable": {
    "version": [
-    20190821,
-    947
+    20191016,
+    1443
    ],
-   "commit": "435c55e9f75a8cf3ae6a4ba0c7725e3dc4e5963f",
-   "sha256": "0nzbjx5rnmzl0dhbrrmb5kbcmww6hzs1vwa62nlg9zfwq99zk42l"
+   "commit": "9936d1c6a83f8844c6e301c023c0be6394b3aa50",
+   "sha256": "1795hfrwrjgaf0p5r617kf7nvfcdnmgmd2h1bv4jd9cvnkqbgvn2"
   },
   "stable": {
    "version": [
@@ -56180,8 +56254,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20190924,
-    2040
+    20191022,
+    1848
    ],
    "deps": [
     "async",
@@ -56190,8 +56264,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "f788dd7f4730316378b8a222aa5d6b6f1efce94e",
-   "sha256": "1v2ml8nk7fkaapdcm88098wcc2mcgi0d3mil5dd57vhqmrn7d23z"
+   "commit": "8b3172fc495d83830573461f877ed390e6408e0b",
+   "sha256": "09wcf1s7xnw4ssmg8bha94zw9ax9mz3prl5krl1l634740ajy6h4"
   },
   "stable": {
    "version": [
@@ -56518,8 +56592,8 @@
     "libgit",
     "magit"
    ],
-   "commit": "f788dd7f4730316378b8a222aa5d6b6f1efce94e",
-   "sha256": "1v2ml8nk7fkaapdcm88098wcc2mcgi0d3mil5dd57vhqmrn7d23z"
+   "commit": "8b3172fc495d83830573461f877ed390e6408e0b",
+   "sha256": "09wcf1s7xnw4ssmg8bha94zw9ax9mz3prl5krl1l634740ajy6h4"
   }
  },
  {
@@ -56569,8 +56643,8 @@
     "magit-popup",
     "p4"
    ],
-   "commit": "01e8bb24830861c50109878812550b4265cba82b",
-   "sha256": "169a6aq3m2xq2mvf5v8yix0052j2va78a3c4lirzc2ypbvch3fys"
+   "commit": "cdc05f2d564409baac9ca15b1a2a0110a6ff12b7",
+   "sha256": "0s2zmfw449gyc8lf8cqwm47wnqy9g5nai72agvapam2h5613mx4i"
   }
  },
  {
@@ -56931,28 +57005,28 @@
   "repo": "jerrypnz/major-mode-hydra.el",
   "unstable": {
    "version": [
-    20190814,
-    952
+    20191014,
+    337
    ],
    "deps": [
     "dash",
     "pretty-hydra"
    ],
-   "commit": "d9fb688dae3e134bb1ff7f35474c58f33a5bb992",
-   "sha256": "0aq2dk7c9jqq13p3bv0cq1aym00chcr5f9p3v93wl9h6pc3spbnc"
+   "commit": "fd362d2be7ed80889715ed8a30a61780a18ce6ea",
+   "sha256": "0vnmvpsm46izxlh0l0p89rhy6ifzzfpzk7j3kkf2608s6dy8hgcy"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
    "deps": [
     "dash",
     "pretty-hydra"
    ],
-   "commit": "d9fb688dae3e134bb1ff7f35474c58f33a5bb992",
-   "sha256": "0aq2dk7c9jqq13p3bv0cq1aym00chcr5f9p3v93wl9h6pc3spbnc"
+   "commit": "bba876b86f0b80495004bf185b2b1f6083a1ff3a",
+   "sha256": "08a15knkdq35pzjq82imff016fbfdib5q4glg2xmdy2b5fnk7jqa"
   }
  },
  {
@@ -57658,17 +57732,17 @@
  },
  {
   "ename": "marquee-header",
-  "commit": "7fad3e54df480d61e5f83aab053e834e6ef72cc7",
-  "sha256": "09yb1ds1r54xw2hsvb1w9i33a5qm0p79vgmj5ikw18zh68pnmzza",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "0hkrxx2gfilqhpjn7b0p3vvy8n4rqng3ac49kz7v45abqz5k79c0",
   "fetcher": "github",
-  "repo": "elpa-host/marquee-header",
+  "repo": "jcs-elpa/marquee-header",
   "unstable": {
    "version": [
-    20190805,
-    140
+    20191017,
+    1017
    ],
-   "commit": "ac33b04c5a50de95c937fce1d80001a3c3c9b26d",
-   "sha256": "1cq6v8wdmvi90fc3mnqpsscnv1m19cp9iv6ba1dv7y32fh1d95my"
+   "commit": "77e4becd8a812377eb219c77641a22a77b4fdfef",
+   "sha256": "0a51aw567gkdxz58v7h2vdfs2rmnvyllqhq4a1yy4gslr0xsqk9c"
   }
  },
  {
@@ -57817,11 +57891,15 @@
   "url": "https://git.code.sf.net/p/matlab-emacs/src",
   "unstable": {
    "version": [
-    20180928,
-    1526
+    20191010,
+    653
    ],
-   "commit": "3fbca4259b2584bde08df07ba51944d7e3e2b4f4",
-   "sha256": "1diqx2k16iyj5a7kcc58kyl6mzw05cyq6ia4z3fciz716gkspgpi"
+   "commit": "e8d02b83ee22e976c32de211b4a0f6513470c462",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "Initialized empty Git repository in /run/user/1000/git-checkout-tmp-LM8M7nQv/src-e8d02b8/.git/\nfatal: unable to access 'https://git.code.sf.net/p/matlab-emacs/src/': Could not resolve host: git.code.sf.net\nfatal: unable to access 'https://git.code.sf.net/p/matlab-emacs/src/': Could not resolve host: git.code.sf.net\nUnable to checkout e8d02b83ee22e976c32de211b4a0f6513470c462 from https://git.code.sf.net/p/matlab-emacs/src.\n"
+   ]
   }
  },
  {
@@ -57900,26 +57978,26 @@
   "repo": "dochang/mb-url",
   "unstable": {
    "version": [
-    20190921,
-    2101
+    20191006,
+    1930
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d0165204f8c1195bbf77b615f9cefaa327973639",
-   "sha256": "08qj938b6fd97bxkc3fcrx0fa1d72vxxawa2z6g207cfv0b3i6im"
+   "commit": "7230902e1f844e0a1388f741e9ae6260cda3de69",
+   "sha256": "09qsc4dl9ngl11i92bfslpl1b1i5ksnpkvfp2hhxn3hwfpgfh64s"
   },
   "stable": {
    "version": [
     0,
     5,
-    0
+    1
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d0165204f8c1195bbf77b615f9cefaa327973639",
-   "sha256": "08qj938b6fd97bxkc3fcrx0fa1d72vxxawa2z6g207cfv0b3i6im"
+   "commit": "7230902e1f844e0a1388f741e9ae6260cda3de69",
+   "sha256": "09qsc4dl9ngl11i92bfslpl1b1i5ksnpkvfp2hhxn3hwfpgfh64s"
   }
  },
  {
@@ -57974,11 +58052,11 @@
   "repo": "dimitri/mbsync-el",
   "unstable": {
    "version": [
-    20181002,
-    640
+    20191002,
+    751
    ],
-   "commit": "f549eccde6033449d24cd5b6148599484850c403",
-   "sha256": "1pdj41rq3pq4jdb5pma5j495xj7w7jgn8pnz1z1zwg75pn7ydfp0"
+   "commit": "b62491c0e0d89eb9c66261a16d7ac81231c9c453",
+   "sha256": "1zlih37mkqjn2czl12zn7lgxxljvrwhqqpbksj9c91zn0f0rm3mz"
   }
  },
  {
@@ -58210,11 +58288,11 @@
   "repo": "skeeto/emacs-memoize",
   "unstable": {
    "version": [
-    20190915,
-    37
+    20191004,
+    351
    ],
-   "commit": "8c1e5569550e783dd7814735e22c935416c4462d",
-   "sha256": "1pa9f8ydkabbxx5szgmvl4mn85pk2bw878z81vlfwbcz4nv8fr1h"
+   "commit": "b3129775a6d5c0d9cdacf5aede9683f5962c464e",
+   "sha256": "0mk7m2iwhpic688kdxgdyjg79rmp04daa0g8qgiiv1pm69ra2b71"
   },
   "stable": {
    "version": [
@@ -58288,11 +58366,11 @@
   "repo": "ocaml/merlin",
   "unstable": {
    "version": [
-    20190922,
-    655
+    20190926,
+    1346
    ],
-   "commit": "b090fe2b058206566505287599116e32f6c373b7",
-   "sha256": "0l0bh14hwff75awjpivpar8b4zkbpf04crd212vivda1szrgy674"
+   "commit": "e7e3f403ab25feabdd40726df4e9171cbaf2d793",
+   "sha256": "0b630140x9f1yxkfyq1w7vcx0vis9sf8rfqmz4bw29qgzwmbibl8"
   },
   "stable": {
    "version": [
@@ -58460,32 +58538,26 @@
  },
  {
   "ename": "metaweblog",
-  "commit": "6440f81aed1fcddcaf7afeedb74520e605211986",
-  "sha256": "0qgmcvq1fhgljia9ncjgvgrv0mzih0l9mglwbwcszn613wmx8bkg",
+  "commit": "cc7fde8f9de0f0e2ccc0c766884ca2b41d0bb5ce",
+  "sha256": "051xgrb620dq55k37wp6b32mdpw7x5ldn6r370n92xqlr1zmryhh",
   "fetcher": "github",
-  "repo": "org2blog/metaweblog",
+  "repo": "org2blog/org2blog",
   "unstable": {
    "version": [
-    20190212,
-    238
+    20191018,
+    242
    ],
-   "deps": [
-    "xml-rpc"
-   ],
-   "commit": "ec85ea7ec97347573613a578d2e91d5f8be74bae",
-   "sha256": "0qlk90qdjhakxklv4n0m7p6n1ykgp1v4xj453jd15mm7dj8bnc5m"
+   "commit": "b02a056e1fa1a044a5bc5d44cc0fb0b8c62e1442",
+   "sha256": "1vglshyg8i5q17zxs9s5f0r5qwm18rah7qp7rd00pn4qg48zhy2b"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     1
    ],
-   "deps": [
-    "xml-rpc"
-   ],
-   "commit": "aa14380eb7e7b879a0c16c96866b20a987cd3f2a",
-   "sha256": "146w9laysdqbikpzr2gc9vnjrdsa87d8i13f2swlh1kvq2dn3rz5"
+   "commit": "3cad357cd5c0f7f949fc6c7aa42d76155d036e78",
+   "sha256": "136l0lm8lv7fgpzply241fngxfl3ck11raamqwislyv0nnjwdfdi"
   }
  },
  {
@@ -58537,17 +58609,17 @@
     20190324,
     1908
    ],
-   "commit": "89bdafacb8d7c65a0e4bbd2697b30d281e2b70ae",
-   "sha256": "0zlh241358p5jhmbdk9ias21jzrwxf7icn57ndx9714xvsxqzp3z"
+   "commit": "2d23c1b0f3e8c53052a4a59f09da491e0548e9e0",
+   "sha256": "1jrzd36zxdl3hlpzl4jlbxg44imkmvbxhpg5433sinrs7lir63s2"
   },
   "stable": {
    "version": [
     0,
     0,
-    20
+    21
    ],
-   "commit": "da2a5f72bd68daab4bb29bca5b4661535948a105",
-   "sha256": "0njxgpqmk0rraf1l7i5s6i4lyrrq5fm3h13m9bsdcffz0jnyc9dx"
+   "commit": "6a7d904fae5014aabae8c91add220485108d485b",
+   "sha256": "0r0msrnbz9177cv1mlacsyd35k945nk2qaqm1f8ymgxa99zy124i"
   }
  },
  {
@@ -58741,14 +58813,25 @@
   "repo": "kiennq/emacs-mini-modeline",
   "unstable": {
    "version": [
-    20190925,
-    57
+    20191006,
+    1733
    ],
    "deps": [
     "dash"
    ],
-   "commit": "cee757ee72b9cf73fe87b5c472ac1edd823cd58a",
-   "sha256": "1pymxq18zijlvlwbf02bdk748g70zbxhf58c14sb2gbxy8p1j6hr"
+   "commit": "d523de5918a842cd67c029535cf399278396264b",
+   "sha256": "0vqn7wdwyr5hqqimncq4w1m734bixzkz4kxx64v45v3x51xfcivw"
+  },
+  "stable": {
+   "version": [
+    20191006,
+    1733
+   ],
+   "deps": [
+    "dash"
+   ],
+   "commit": "fe7b723b5e609a721a15800faa9bd8b34fddd3e3",
+   "sha256": "047v8x9i8j6vcn3ba2kzy2lzdxwcm867bby0a5l297jp6mqfw92h"
   }
  },
  {
@@ -59013,11 +59096,11 @@
   "repo": "jabranham/mixed-pitch",
   "unstable": {
    "version": [
-    20190307,
-    2210
+    20191023,
+    1025
    ],
-   "commit": "15bb9ec6d8be0812a46917205be6c3a1c78f68ff",
-   "sha256": "1458sy5b6bis1i0k23jdqk6hfqg0ghk637r3ajql2g19ym48rf58"
+   "commit": "f512a803fdfcea9ca17e0f57a16d4059b1772390",
+   "sha256": "0153lk2wv1jqacl5fxgqg07ypvz88pc8kyy96yrs7s18fp0fy55l"
   },
   "stable": {
    "version": [
@@ -59329,8 +59412,12 @@
     20181029,
     516
    ],
-   "commit": "bec2268fb42db58d22479a7b7ca3a956ead1af94",
-   "sha256": "0yqdc1z6n9cpa16drjij2r77yqk9jhj1z532cnyqnk7r90avbhzs"
+   "commit": "26ac7d97abdeb762ceaeab6b892f3ed7e3412494",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "warning: unable to download 'https://github.com/purcell/mode-line-bell/archive/26ac7d97abdeb762ceaeab6b892f3ed7e3412494.tar.gz': Couldn't connect to server (7); retrying in 304 ms\nwarning: unable to download 'https://github.com/purcell/mode-line-bell/archive/26ac7d97abdeb762ceaeab6b892f3ed7e3412494.tar.gz': Couldn't connect to server (7); retrying in 659 ms\nwarning: unable to download 'https://github.com/purcell/mode-line-bell/archive/26ac7d97abdeb762ceaeab6b892f3ed7e3412494.tar.gz': Couldn't connect to server (7); retrying in 1269 ms\nwarning: unable to download 'https://github.com/purcell/mode-line-bell/archive/26ac7d97abdeb762ceaeab6b892f3ed7e3412494.tar.gz': Couldn't connect to server (7); retrying in 2209 ms\nerror: unable to download 'https://github.com/purcell/mode-line-bell/archive/26ac7d97abdeb762ceaeab6b892f3ed7e3412494.tar.gz': Couldn't connect to server (7)\n"
+   ]
   },
   "stable": {
    "version": [
@@ -59642,20 +59729,24 @@
   "repo": "jessieh/mood-line",
   "unstable": {
    "version": [
-    20190911,
-    2023
+    20190930,
+    1013
    ],
-   "commit": "29ba63795911bdd535d569f0cc4e9d18cc3ac8e4",
-   "sha256": "0sp6cgpqrab1cgqy4vhgdfavmfz73h57aw0fxvywf348kxbqf28s"
+   "commit": "9d116403a8b55d76d65f4d6d450a1f4def74013d",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "warning: unable to download 'https://gitlab.com/jessieh/mood-line/repository/archive.tar.gz?ref=9d116403a8b55d76d65f4d6d450a1f4def74013d': Couldn't connect to server (7); retrying in 268 ms\nwarning: unable to download 'https://gitlab.com/jessieh/mood-line/repository/archive.tar.gz?ref=9d116403a8b55d76d65f4d6d450a1f4def74013d': Couldn't connect to server (7); retrying in 607 ms\nwarning: unable to download 'https://gitlab.com/jessieh/mood-line/repository/archive.tar.gz?ref=9d116403a8b55d76d65f4d6d450a1f4def74013d': Couldn't connect to server (7); retrying in 1032 ms\nwarning: unable to download 'https://gitlab.com/jessieh/mood-line/repository/archive.tar.gz?ref=9d116403a8b55d76d65f4d6d450a1f4def74013d': Couldn't connect to server (7); retrying in 2135 ms\nerror: unable to download 'https://gitlab.com/jessieh/mood-line/repository/archive.tar.gz?ref=9d116403a8b55d76d65f4d6d450a1f4def74013d': Couldn't connect to server (7)\n"
+   ]
   },
   "stable": {
    "version": [
     1,
-    1,
-    2
+    2,
+    1
    ],
-   "commit": "3560d8aafd8c856a218ff8fab5a30e1aa0db25b6",
-   "sha256": "08qh8x0gd7byvfp03jpkd95h70djh8vrwpm451932zwf66j7fnay"
+   "commit": "43682f713eb1b95b98c1ec18e4f51daebd9ad43f",
+   "sha256": "03ms3yfp05b7c65pgjncm00r45fqgzal9xsp5gj58cm0yhclkcsd"
   }
  },
  {
@@ -59666,20 +59757,20 @@
   "repo": "jessieh/mood-one-theme",
   "unstable": {
    "version": [
-    20190911,
-    2031
+    20191010,
+    125
    ],
-   "commit": "2f044f7b1f68d450fd4c3c67209c353401621277",
-   "sha256": "10x1a9r537qd80rzhhp99mxx08fp8gpd8knrbb0565iqi3czk1rz"
+   "commit": "4236e4209f82f16c1d80c5dfb71148713ff333f6",
+   "sha256": "182b2j2lhy2n2cis7qdq0j9x2lkrxi525ycldb0gyvyzyhljw78c"
   },
   "stable": {
    "version": [
     1,
     0,
-    3
+    4
    ],
-   "commit": "47fc825547664c3e3eb8f47f1a9cf74b23efc2c6",
-   "sha256": "17zz3nc3r2cm4w99frzqxnh768vnmzs71p9zz9bj03wc222n1kv6"
+   "commit": "98c2f3ca27dce87cec1bd7ffd322b48129213588",
+   "sha256": "1rs9az5d4279jqldvx963qx0plbxp49c3crksmcq6si0x1iwg86x"
   }
  },
  {
@@ -59690,11 +59781,11 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20190831,
-    1058
+    20191023,
+    2104
    ],
-   "commit": "ac17d739075a571a086756fcaed482814888bf5c",
-   "sha256": "1yisg83khzfmdyqp450kfqgsy76wglb003j1bsann0z0xkw5pla3"
+   "commit": "d37945b3a4c6ea5560eaf15f39d98aa23537d70c",
+   "sha256": "03ppghb45ply0888pac8axazybyxfzrkl608qn09arhkxkyrpxpq"
   },
   "stable": {
    "version": [
@@ -59714,11 +59805,11 @@
   "repo": "takaxp/moom",
   "unstable": {
    "version": [
-    20190820,
-    1114
+    20191004,
+    18
    ],
-   "commit": "52fe3ed21490e6a5266e5d2d7111199b997c2400",
-   "sha256": "00zk1ssfmks4bnw8j4zfxnjsvjzgdf9a3wb08h8jnbpkh48zff7i"
+   "commit": "3a4cda574152b03e4c83bc4197947b88ee6713c3",
+   "sha256": "00pmbbc9a9643sfpj1vmk6hd0lwj1zpfpfxfi1vyalcs1f3b0qaa"
   },
   "stable": {
    "version": [
@@ -60439,11 +60530,20 @@
   "repo": "mkcms/mu4e-overview",
   "unstable": {
    "version": [
-    20190421,
-    612
+    20191020,
+    842
    ],
-   "commit": "eb2d1e39c77c4725a8ee36dc68917aaf7b717b46",
-   "sha256": "08mchv8q8q3mnpm69vc888jlv4iik4vlkxqpmkrsgimq1gyb80pj"
+   "commit": "c34f45b3ab9cce892835e14c6701b531a4f54cce",
+   "sha256": "1jc291xwym2ddiqvn83s2b2jw6a08dd63x0f6526qv8g3yr1jl1s"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "c34f45b3ab9cce892835e14c6701b531a4f54cce",
+   "sha256": "1jc291xwym2ddiqvn83s2b2jw6a08dd63x0f6526qv8g3yr1jl1s"
   }
  },
  {
@@ -60605,11 +60705,11 @@
   "repo": "manateelazycat/multi-term",
   "unstable": {
    "version": [
-    20190624,
-    1147
+    20191020,
+    218
    ],
-   "commit": "0804b11e52b960c80f5cd0712ee1e53ae70d83a4",
-   "sha256": "0apvidmvb7rv05qjnjhax42ma8wrimik5vxx620dlbv17svz7iyf"
+   "commit": "59f54c4680f62b37a19587f20b7d81da10faa146",
+   "sha256": "16fzzmk9b85ma0n3gfafyr01gz4wlw6qn79ai4gg1lfpl8qx58si"
   },
   "stable": {
    "version": [
@@ -61027,21 +61127,6 @@
    ],
    "commit": "0f51b174a0ee6c9820baf9d79783923b270f3ffc",
    "sha256": "1gxp1a26sna0p3xq6by8bk4yphhh32bvll0sdm2p3wkpdaci7hyz"
-  }
- },
- {
-  "ename": "mysql2sqlite",
-  "commit": "9841d3cfd1ee954eb0ab9b2ca3a3f605eb0fd22a",
-  "sha256": "1jblrbw4rq2jwpb8d1dyna0fiv52b9va3sj881cb17rqx200y3nd",
-  "fetcher": "github",
-  "repo": "echosa/emacs-mysql2sqlite",
-  "unstable": {
-   "version": [
-    20170725,
-    2216
-   ],
-   "commit": "8e6e74451c942e2e92f90dc13222b95a7dbb285e",
-   "sha256": "18jriaj391n4wr0qiva68jf482yx9v9l4xagbzl9vw125lszkngb"
   }
  },
  {
@@ -62023,11 +62108,11 @@
   "repo": "m-cat/nimbus-theme",
   "unstable": {
    "version": [
-    20190909,
-    1313
+    20191023,
+    1143
    ],
-   "commit": "188af947416961b3ed86a7ac026952c8e530245d",
-   "sha256": "1bswdaxvx0f36zh9f8q343a8mr27g53jw5dxqpwk6x9ad7jiia83"
+   "commit": "0b527301a4f6a32e3f794bb12b6d83d74f484ef2",
+   "sha256": "1s49nynik0jpbgi5zws5hcxkyjll0dfyh8xhv9q0hm00sxajqf2s"
   }
  },
  {
@@ -62280,8 +62365,8 @@
   "repo": "dickmao/nnhackernews",
   "unstable": {
    "version": [
-    20190925,
-    1239
+    20191013,
+    120
    ],
    "deps": [
     "anaphora",
@@ -62289,8 +62374,8 @@
     "dash-functional",
     "request"
    ],
-   "commit": "2765b153a0a73b328d2a3a9ea3e3f5fbe6c2fd28",
-   "sha256": "1gip213471ni9yy0arvf7sii31a20q81mddmknlpmmvsx7raz6n8"
+   "commit": "e96a7f83e8780a867ea1a21892f67802b6418f34",
+   "sha256": "0vj544155mwb3q1z16ak20221kxgh3mrshajh7pgm9al5cr2l736"
   }
  },
  {
@@ -62316,8 +62401,8 @@
   "repo": "dickmao/nnreddit",
   "unstable": {
    "version": [
-    20190925,
-    1300
+    20191007,
+    1425
    ],
    "deps": [
     "anaphora",
@@ -62326,8 +62411,8 @@
     "request",
     "virtualenvwrapper"
    ],
-   "commit": "5081e2ab08a44a117a6d30cc046a972d37776d98",
-   "sha256": "1wjigf1w9nzm6lwf77v4d7myplci4456fd662lj5y8raxx6ygxgd"
+   "commit": "6ed30881fd1fc7776766ed3a31c1c1dd7d7c10a5",
+   "sha256": "0694acgkhribvv2pz0j8ia3bnc6pq51z033016a19nrgmf37arqg"
   }
  },
  {
@@ -62353,14 +62438,14 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20190811,
-    1527
+    20191022,
+    659
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e1e79c0211ad924ca220dac3a7a1a2e40710c073",
-   "sha256": "0cc4x62wynf71hzqk7gwx8g58gl4hm65pv0df8cir8g344li1c15"
+   "commit": "9f50a2fd5f5ca07323c09e47dc5456dc67c391cf",
+   "sha256": "1rg5a01msxdcxlw32wbvgjyvb6ddq2han818brmvp9cb7jzfkl4k"
   },
   "stable": {
    "version": [
@@ -62418,11 +62503,11 @@
   "repo": "NicolasPetton/noccur.el",
   "unstable": {
    "version": [
-    20150514,
-    2120
+    20191015,
+    719
    ],
-   "commit": "6cc02ce07178a61ae38a849f80472c01969272bc",
-   "sha256": "0wk86gm0by9c8mfbvydz5va07qd30n6wx067inqfa7wjffaq0xr7"
+   "commit": "fa91647a305e89561d3dbe53da002fff49abe0bb",
+   "sha256": "0slyy7qadc06cij7lgk7d36ym54dyh9a7vjdc38ysr1nh8g7agvm"
   },
   "stable": {
    "version": [
@@ -62621,8 +62706,8 @@
    "deps": [
     "colorless-themes"
    ],
-   "commit": "4f9d0ec5a078ab8442abdba0c35eb748728f3052",
-   "sha256": "1h8ggaqvrdj8cyknps9anh2xz08ar94137gydvxy8xgrmpa3jnc1"
+   "commit": "12678144d17edf36d34e6bcdc5435593e191d96d",
+   "sha256": "0fld15h92193bnbmka3ikq27hggxvsikzlzq4pi2n3kknq9hyh56"
   }
  },
  {
@@ -62666,17 +62751,17 @@
     20190525,
     1602
    ],
-   "commit": "74a1b5ac65b31f7ebc1258b259b8c355023e21b4",
-   "sha256": "0gbfwh9sccykb84mrckz8lyk2h76p4g2di4j0jkhjf4lzy5q414r"
+   "commit": "7eb9615b30274033cc0c828244569c709906c40b",
+   "sha256": "1x4sbvfwxj2b0sfkfkhkfb9q780xwxc4hmfs6b192qjfi2zin6k3"
   },
   "stable": {
    "version": [
     0,
     29,
-    1
+    2
    ],
-   "commit": "20842dfb6d64f4469c554525ab4c27c6571fbdfe",
-   "sha256": "0mw3bxmbjc5wwadf7v7vj5zf4i40c9wvschxqklxxg11qy5lhfis"
+   "commit": "1c8d9e172e57bad26ebb94a8cb22a959ebedb9a3",
+   "sha256": "02v0h60vglkjivwq6n0xbg6pyf7dd9ndfmywk0amxq9gg0szybbl"
   }
  },
  {
@@ -62907,11 +62992,11 @@
   "repo": "joostkremers/nswbuff",
   "unstable": {
    "version": [
-    20190320,
-    740
+    20191013,
+    2037
    ],
-   "commit": "362da7f3687e2eb5bb11667347de85f4a9d002bc",
-   "sha256": "0l2xfz8z5qd4hz3kv6zn7h6qq3narkilri8a071y1n8j31jps4ma"
+   "commit": "19c04c1042fa1ff45bf923e9e50271c0bb57268d",
+   "sha256": "15qsc494xl4mwvwfybla45q7l43cxdd827d7nx4wfmbpw0c6cyc5"
   }
  },
  {
@@ -63308,11 +63393,11 @@
   "repo": "nickanderson/ob-cfengine3",
   "unstable": {
    "version": [
-    20190908,
-    1801
+    20191011,
+    1721
    ],
-   "commit": "d16fd0f1585d5f64dfae76498d43c764d81fc3f8",
-   "sha256": "1xv07hc2fcp9kvzmy5vdjwb6iq5mkj5vpxsnik0m68vcb2jnllbi"
+   "commit": "195ba4694a0ec18d3fb89342e8e0988b382a5b1a",
+   "sha256": "0a18fv141s35vh1mza2d6q5japrfjg5g6l7gp6qq4k4im3gmaf86"
   }
  },
  {
@@ -64217,8 +64302,8 @@
     20190726,
     1452
    ],
-   "commit": "3ce84f2d009833883f908669a89a99c5274d01c3",
-   "sha256": "0hx7bfvqh5amsvsxx4qf6575k87n3xfj558a06sbrg0fnvg2vh1i"
+   "commit": "9e26c0a2699b7076cebc04ece59fb354eb84c11c",
+   "sha256": "1dvcl108ir9nqkk4mjm9xhhj4p9dx9bmg8bnms54fizs1x3x8ar3"
   },
   "stable": {
    "version": [
@@ -64226,8 +64311,8 @@
     8,
     1
    ],
-   "commit": "3ce84f2d009833883f908669a89a99c5274d01c3",
-   "sha256": "0hx7bfvqh5amsvsxx4qf6575k87n3xfj558a06sbrg0fnvg2vh1i"
+   "commit": "05bf3e4b39b765658a5be95d1db2a30084d1f564",
+   "sha256": "0h4ysh36q1fxc40inhsdq2swqpfm15lpilqqcafs5ska42pn7s68"
   }
  },
  {
@@ -64291,20 +64376,20 @@
  },
  {
   "ename": "oer-reveal",
-  "commit": "5982e377cd4cc2e72bfe4650c473c9f6b71085e3",
-  "sha256": "1j43in64p0janfr48v2llh888c337cv66yl6xswidnqysndfg6pg",
+  "commit": "7c4e4d7c68548415413d4ad972b2c804e7d867f8",
+  "sha256": "04rwyhq500c8wcgfhg2xmb246az9sc6s2y45ichxhvvhvqgxjib3",
   "fetcher": "gitlab",
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20190916,
-    657
+    20191024,
+    907
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "b30cf2b16b4987152df8355beab8b8fdcbc22c1f",
-   "sha256": "1m6b5cg5rkimp03w1zgxfh2yycifyj89a5rripr2bic1wp6bifzw"
+   "commit": "641c905b7453855bc99ba64441d1346b03d44fae",
+   "sha256": "1awcazkv01ry7430ghsqrk93pvpi79cd8wig3wlcj4fyvy1g9chf"
   }
  },
  {
@@ -64577,8 +64662,8 @@
   "repo": "OmniSharp/omnisharp-emacs",
   "unstable": {
    "version": [
-    20190915,
-    1000
+    20191015,
+    635
    ],
    "deps": [
     "auto-complete",
@@ -64590,8 +64675,8 @@
     "popup",
     "s"
    ],
-   "commit": "c1dab2beae4b1e67f20f3e90cddeba81bd236fe5",
-   "sha256": "1pm8pv3iccpmyg0bs19d28g56gwfbkkp6d4i1qyxkf371d9w7r3w"
+   "commit": "e658a18a762438c3e1737612737b05d02a21ca2a",
+   "sha256": "1m4xqcn586f0gn305kig502480zlnvmrv98nmdkn36fbwgg96hla"
   },
   "stable": {
    "version": [
@@ -65054,20 +65139,20 @@
   "repo": "rksm/clj-org-analyzer",
   "unstable": {
    "version": [
-    20190914,
-    2215
+    20191001,
+    1717
    ],
-   "commit": "576e1fda552af0da4e64070e2b26303a913f17a9",
-   "sha256": "194vk80d2mzfb0fpkj19jhfsq916l9lkxxwaj0q30r3w6p8hplz4"
+   "commit": "19da62aa4dcf1090be8f574f6f2d4c7e116163a8",
+   "sha256": "1zfc93z6w5zvbqiypqvbnyv8ims1wgpcp61z1s152d0nq2y4pf50"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    4
    ],
-   "commit": "576e1fda552af0da4e64070e2b26303a913f17a9",
-   "sha256": "194vk80d2mzfb0fpkj19jhfsq916l9lkxxwaj0q30r3w6p8hplz4"
+   "commit": "19da62aa4dcf1090be8f574f6f2d4c7e116163a8",
+   "sha256": "1zfc93z6w5zvbqiypqvbnyv8ims1wgpcp61z1s152d0nq2y4pf50"
   }
  },
  {
@@ -65222,14 +65307,14 @@
   "repo": "Kungsgeten/org-brain",
   "unstable": {
    "version": [
-    20190922,
-    1414
+    20191018,
+    1325
    ],
    "deps": [
     "org"
    ],
-   "commit": "1f86e92c72cf52b75695c99572eeace7405caf96",
-   "sha256": "0vdpqg7jy60qlhsdbcfs592xfg32ybw71z1hhpabvhfms92sj2bx"
+   "commit": "715fa33f96b57b7cc9dbda7f5a760c0d3a5089a5",
+   "sha256": "1gwjjv9hrqmnyikv69yqi5akbrspc8h1yfb6adl0w95bzlfjfzpq"
   }
  },
  {
@@ -65264,14 +65349,14 @@
   "repo": "dengste/org-caldav",
   "unstable": {
    "version": [
-    20190817,
-    1004
+    20191024,
+    724
    ],
    "deps": [
     "org"
    ],
-   "commit": "a563500c9884f38ce08793e2964f8274adde163d",
-   "sha256": "18qi1iv5dc0gsvkv9ifal3cjpm568nlb907v8a53cnm4439x1l0l"
+   "commit": "f530b94b6f8d8d1f8a207e48986da75227bd78a0",
+   "sha256": "0b5gw1m646fq7xlq8966rlmqs63p5dgrq71cjc943s45mli0vvcs"
   }
  },
  {
@@ -65327,14 +65412,14 @@
   "repo": "Chobbes/org-chef",
   "unstable": {
    "version": [
-    20190815,
-    1459
+    20191017,
+    2015
    ],
    "deps": [
     "org"
    ],
-   "commit": "8715302a16b5dc2cafee732a4e6b10a263d65328",
-   "sha256": "0l656xd2zp7l7xb5qs8fw8qsa8sdw5fp305lwiz66zq041xcpg4w"
+   "commit": "440e0a11b4af85f558aa138de58d347020439f0b",
+   "sha256": "1c30ssi533gi1rp865fkrbxp7igzpwbrxr4hmmpxhs6qsj1f8pwi"
   }
  },
  {
@@ -65595,14 +65680,14 @@
   "repo": "abo-abo/org-download",
   "unstable": {
    "version": [
-    20190830,
-    1448
+    20191016,
+    1227
    ],
    "deps": [
     "async"
    ],
-   "commit": "10c9d7c8eed928c88a896310c882e3af4d8d0f61",
-   "sha256": "0i8wlx1i7y1vn5lqwjifvymvszg28a07vwqcm4jslf1v2ajs1lsl"
+   "commit": "29d919126fac7277261bce96c99744e35d3c193d",
+   "sha256": "0514i261n9lca3dwqn8s9km3f06xcy1y6l355n49ivrh06kikwc7"
   },
   "stable": {
    "version": [
@@ -65874,16 +65959,16 @@
   "repo": "kidd/org-gcal.el",
   "unstable": {
    "version": [
-    20190902,
-    252
+    20191018,
+    921
    ],
    "deps": [
     "alert",
     "request",
     "request-deferred"
    ],
-   "commit": "19ebbc647d8f4098cdda986aff2fea66e6da13ef",
-   "sha256": "1jvdwlqjgqic2v5nwkiz523nry4jphxg3wp9pin4vxw55vzm5ygb"
+   "commit": "36e9933b0238acb245e6d8dc89944583482fee1e",
+   "sha256": "0jvav64yysxf0rvfmkx8mvpx2cw2d3ppq8wyx8bp9vdi027czg3n"
   },
   "stable": {
    "version": [
@@ -66027,16 +66112,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20190712,
-    443
+    20190930,
+    1406
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "d1d2ff6155c6259a066110ed13d1850143618f7b",
-   "sha256": "064pxsf5kkv69bs1f6lhqsvqwxx19jwha3s6vj8rnk8smawv0w9r"
+   "commit": "5123c29867e5da54d80e92f9a5a4259144451404",
+   "sha256": "1j45whlsclwq9v0c98ni4y5p04slmlwgwsbbr7saaxgv9xmv4yfc"
   },
   "stable": {
    "version": [
@@ -66062,11 +66147,11 @@
   "repo": "bastibe/org-journal",
   "unstable": {
    "version": [
-    20190914,
-    1643
+    20191011,
+    1315
    ],
-   "commit": "5481b6c7410cbc68f0966b5b5840c0048edc3fef",
-   "sha256": "1afjz5s7z0lfb67wsdckgsj2h9rr31gm8424v2w243xmz2lzgrjx"
+   "commit": "19e3b4dd07d8b0145896011a2b4522234b62a50c",
+   "sha256": "1bacprp42abk84hg0ha44pq9n15rdrvvd2pvdjw5yhnqansnx8l5"
   },
   "stable": {
    "version": [
@@ -66101,30 +66186,30 @@
   "repo": "gizmomogwai/org-kanban",
   "unstable": {
    "version": [
-    20190821,
-    2107
+    20191003,
+    1455
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "dd259135a4c3a320e020a335ea27fb4a2e488a53",
-   "sha256": "0k62s4kz8qmfq21r2jz7kfcyn6ydwxzfa5s2s2f26jny8flqva1d"
+   "commit": "3007d636f0c7b69d767d7adcca4ab462708f9610",
+   "sha256": "0mqi85gfaq60dxvm5r7rn6mi479fk26dy0nmss7dnqxwm2s39414"
   },
   "stable": {
    "version": [
     0,
     4,
-    13
+    21
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "03387a779167c4acbc04d4970cd33c52a2ca0bcd",
-   "sha256": "0arjx1a7skdlmagyy0bbxwc134dn951y99yv4jg6l64j1f31y0yg"
+   "commit": "3007d636f0c7b69d767d7adcca4ab462708f9610",
+   "sha256": "0mqi85gfaq60dxvm5r7rn6mi479fk26dy0nmss7dnqxwm2s39414"
   }
  },
  {
@@ -66271,29 +66356,30 @@
   "repo": "alphapapa/org-make-toc",
   "unstable": {
    "version": [
-    20190104,
-    512
+    20191014,
+    2307
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "9adeaf9da23fd3f7600821526f7e41f4ed17dd4a",
-   "sha256": "122fvv6waq70qcccgwnmyfmci48k8zc7vzmagadypmw8grgdjdx2"
+   "commit": "d2f61e3c7e995adf0954cd85139842e57d744eb4",
+   "sha256": "042z0l0hhrfm01jj1r0yd120a67xflzgv5fz6kf28202d6apsv9v"
   },
   "stable": {
    "version": [
     0,
-    3
+    3,
+    1
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "f1a51017b0f85e0cb9ae7d0d8240f2115f57886c",
-   "sha256": "0syhj8q4pv33xgl5qa6x27yhwqvfhffw5xqp819hj4qs1ddlc7j5"
+   "commit": "e92fd443c998532ff786361ae72b6981dc1f2ff0",
+   "sha256": "03vgygni5f1qrmchwy0szks47hwhpl21qvk4wlwh2bd79rxnhc1f"
   }
  },
  {
@@ -66463,28 +66549,28 @@
   "repo": "weirdNox/org-noter",
   "unstable": {
    "version": [
-    20190913,
-    1509
+    20191020,
+    1212
    ],
    "deps": [
     "cl-lib",
     "org"
    ],
-   "commit": "a926c1075964f4a972467c01b807d6a01fd5d0b1",
-   "sha256": "0fb5r5aslqkd48h2l502sq3hixwcy64m00p17znnagf699djfhfl"
+   "commit": "d051a5909878e2214422fd275968ab4d7ef9bcab",
+   "sha256": "12v13l4va28abjgcq1q2lzml8cahh5qbbl0wzvbm41y9cmlbgmxq"
   },
   "stable": {
    "version": [
     1,
-    3,
-    0
+    4,
+    1
    ],
    "deps": [
     "cl-lib",
     "org"
    ],
-   "commit": "8fb007c329fee8cceca97338ae0e88aaafcb8535",
-   "sha256": "0qcdw1px07ggnp74gb3hibd69cq8np9bdpcpvlkm5k32qxhsnwjy"
+   "commit": "32900872c82195e757ec6249a329490a0ca2199e",
+   "sha256": "1vwfpdi7hfkxx4vi0cwg7rvqby3i0mymzdkyzrqzv30dazmcjpag"
   }
  },
  {
@@ -66941,34 +67027,41 @@
   "repo": "alphapapa/org-ql",
   "unstable": {
    "version": [
-    20190923,
-    2244
+    20191019,
+    710
    ],
    "deps": [
     "dash",
+    "dash-functional",
+    "f",
     "org",
     "org-super-agenda",
     "ov",
+    "peg",
     "s",
     "ts"
    ],
-   "commit": "d33b2e0129cbf99df209e1a4d975cfa3d6d5c226",
-   "sha256": "02f5n0v3fq25vxhwsn21nv08s5ris5vq6l9ymsnpha6piqkd4h8d"
+   "commit": "0d6523f85b48080582a84b1dc1213f80de40d3c6",
+   "sha256": "0g01yrf5zcpnf6m4q37b3qzkqgs5s97b6l5wdgf9yy8rgj7rbpgr"
   },
   "stable": {
    "version": [
     0,
-    2,
-    1
+    3,
+    2
    ],
    "deps": [
     "dash",
+    "dash-functional",
     "org",
+    "org-super-agenda",
+    "ov",
+    "peg",
     "s",
     "ts"
    ],
-   "commit": "55694f17fce4dc566f533b0b5f8cd60c4dad9670",
-   "sha256": "1xyabg9fhpip6426za6wjrn0msnaf10c5fzzaawwagk7zmjf9b48"
+   "commit": "2274efce077c7cf8b2930a8bfb9980c251d8e737",
+   "sha256": "11bhpi2l28vp8mm9nx18jljbqdnh9vxpv9kp1dn9lpsgivcdbc34"
   }
  },
  {
@@ -67047,28 +67140,28 @@
   "repo": "oer/org-re-reveal",
   "unstable": {
    "version": [
-    20190922,
-    1724
+    20191020,
+    1137
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "db4848b2e24de71cf1c849ef05b36497ce4d40c1",
-   "sha256": "13zyf3mxaqqsdad1mm1cmqadwpm5b54wn3r0r1cavqv1hy104p6b"
+   "commit": "62f0868c4e9b098fb43b62b257bcd924779838c0",
+   "sha256": "0nbbynpgwmw85y90frbkna0s0sxxdhskpijnl41f9l6psll70mq4"
   },
   "stable": {
    "version": [
     2,
-    5,
-    1
+    12,
+    0
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "07d4af7f601fb22d8ed74081c9f69ba9af61e474",
-   "sha256": "1zbz6hbddxbb264ibmhc04cmnpk17kb50jpn5l8878q4hxw5wwy2"
+   "commit": "62f0868c4e9b098fb43b62b257bcd924779838c0",
+   "sha256": "0nbbynpgwmw85y90frbkna0s0sxxdhskpijnl41f9l6psll70mq4"
   }
  },
  {
@@ -67079,15 +67172,15 @@
   "repo": "oer/org-re-reveal-ref",
   "unstable": {
    "version": [
-    20190921,
-    744
+    20191022,
+    1426
    ],
    "deps": [
     "org-re-reveal",
     "org-ref"
    ],
-   "commit": "03aca420afeb6f701d2fae5d2add9eec19c89d10",
-   "sha256": "1r3daccda3km1s7r2bs03wivzczz07iyh8bbjsdf0fss2d8acdrg"
+   "commit": "1f56a1fc9a52f3815bb2115ebeca3c355688d722",
+   "sha256": "1xrswpkr7hgsb9pj991z4m0820f1nksfad184x0j7kir2xcx0myg"
   }
  },
  {
@@ -67166,8 +67259,8 @@
   "repo": "jkitchin/org-ref",
   "unstable": {
    "version": [
-    20190921,
-    2346
+    20191023,
+    117
    ],
    "deps": [
     "dash",
@@ -67181,8 +67274,8 @@
     "pdf-tools",
     "s"
    ],
-   "commit": "0fa807ff6bdfce58bd9abec3d86a242dd76228e4",
-   "sha256": "1805klqzxvarjd499nb5184n60c7nxnnzyddwykvjy1add2jcvxa"
+   "commit": "58ae484729aa2027fcc3283a75f4c2c19cf499a2",
+   "sha256": "1sbjxrs6axfpwiy74dbq9nrax6qyjmypg4dnxy4y1xab24n6q4fk"
   },
   "stable": {
    "version": [
@@ -67345,8 +67438,8 @@
   "repo": "alphapapa/org-sidebar",
   "unstable": {
    "version": [
-    20190923,
-    2231
+    20191012,
+    514
    ],
    "deps": [
     "dash",
@@ -67356,24 +67449,24 @@
     "org-super-agenda",
     "s"
    ],
-   "commit": "12df3c76e35de3e52b59678133e452785454f96b",
-   "sha256": "0vq3h1cnk1l0h66jrll4md3d6hrprjddl9fjx48dbdqq2zbly10b"
+   "commit": "b5eff7195718e6a70a42d36e48800632080aab0c",
+   "sha256": "138hbcmkxmmdcagdv438946cr4qkwklqqwf2b1khi8gimnnivsxm"
   },
   "stable": {
    "version": [
     0,
-    1
+    2
    ],
    "deps": [
     "dash",
+    "dash-functional",
     "org",
     "org-ql",
-    "org-ql-agenda",
     "org-super-agenda",
     "s"
    ],
-   "commit": "d55d0e8ddaba7843880a355daf6b33d6c0ed9bb8",
-   "sha256": "1zpjzlf372z68mqn3zfam1jfslnkx7hysxhpm2d77s63qbik0s21"
+   "commit": "9634320a6f9ab919119e08a14853c31387f38ce3",
+   "sha256": "106h06vjfbqfj761vbxwymd6612ds8c6fk053yzgbrqzm3hn2c03"
   }
  },
  {
@@ -67426,15 +67519,28 @@
   "repo": "akirak/org-starter",
   "unstable": {
    "version": [
-    20190907,
-    1859
+    20191005,
+    413
    ],
    "deps": [
     "dash",
     "dash-functional"
    ],
-   "commit": "ca166579a35dc671ad8f59dbc6dcf2a1eda94a20",
-   "sha256": "02ikg795jny9cddprbd9ipyiyg2gv6i4c6408qp94n3qmr9jcz48"
+   "commit": "c9f0f91437131dbace3299ff5912e85f07bf2b21",
+   "sha256": "0w51jv9jlkl35296g5v2q81mdrncsj2arnrnj8w3hv18dyrx2db2"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    6
+   ],
+   "deps": [
+    "dash",
+    "dash-functional"
+   ],
+   "commit": "7ea72ec530a340af61da215327a7fbb66a07ad2a",
+   "sha256": "0y1i4zpgmk6i2nj5l6dvdvqkp5a8cww8y4vcpps85blj586xgby3"
   }
  },
  {
@@ -67445,15 +67551,28 @@
   "repo": "akirak/org-starter",
   "unstable": {
    "version": [
-    20190817,
-    1823
+    20190929,
+    646
    ],
    "deps": [
     "org-starter",
     "swiper"
    ],
-   "commit": "ca166579a35dc671ad8f59dbc6dcf2a1eda94a20",
-   "sha256": "02ikg795jny9cddprbd9ipyiyg2gv6i4c6408qp94n3qmr9jcz48"
+   "commit": "c9f0f91437131dbace3299ff5912e85f07bf2b21",
+   "sha256": "0w51jv9jlkl35296g5v2q81mdrncsj2arnrnj8w3hv18dyrx2db2"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    6
+   ],
+   "deps": [
+    "org-starter",
+    "swiper"
+   ],
+   "commit": "7ea72ec530a340af61da215327a7fbb66a07ad2a",
+   "sha256": "0y1i4zpgmk6i2nj5l6dvdvqkp5a8cww8y4vcpps85blj586xgby3"
   }
  },
  {
@@ -67464,11 +67583,11 @@
   "repo": "bastibe/org-static-blog",
   "unstable": {
    "version": [
-    20190924,
-    729
+    20191023,
+    633
    ],
-   "commit": "9f1132fbb6f49609b61730e6769ee5c1d6542d82",
-   "sha256": "0pf7dm5yzy8as63sm5s3mn4npn5p39mvygvnz81jv4r922h9cici"
+   "commit": "d8522a7a245a47e850f42d4773e5ceec0fff4e94",
+   "sha256": "1g5x3imrbazxk9rfwaijgsd1wzxd5fm3wa1wg28mifyp873wypk5"
   },
   "stable": {
    "version": [
@@ -67660,11 +67779,11 @@
   "repo": "mtekman/org-tanglesync.el",
   "unstable": {
    "version": [
-    20190924,
-    2040
+    20190926,
+    1345
    ],
-   "commit": "9e6f074bae1ce7579f495b62fc6ee08f47b63e95",
-   "sha256": "0b6cx26fsqkp4r54k724v7klfczm40zn9hsb48wqiwc7v67qnka0"
+   "commit": "d99181f173b4e55b4e835d99fcd415e62beb047f",
+   "sha256": "0x94gy1bgfd1f3p9w2bfrqj11bwy9ql0cpi1gw6srpj7kykx0lml"
   }
  },
  {
@@ -67951,11 +68070,11 @@
   "repo": "cadadr/elisp",
   "unstable": {
    "version": [
-    20190409,
-    1815
+    20190914,
+    2046
    ],
-   "commit": "ebb2778052aeaf737adebc003957cb48cb01135e",
-   "sha256": "0qlvdpa88ic9gnb0qhijfsc9i6l3ba2zrvk4r4li3qrx0i9rpz5c"
+   "commit": "5f3e67448cc98fe2875115163849acae4d9e8526",
+   "sha256": "1w0dhyr4i0nx0g70smgclcfsbv6cfilb7df330njzaqk8j2gdfws"
   }
  },
  {
@@ -68005,8 +68124,8 @@
   "repo": "alphapapa/org-web-tools",
   "unstable": {
    "version": [
-    20190709,
-    1124
+    20191022,
+    337
    ],
    "deps": [
     "dash",
@@ -68015,8 +68134,8 @@
     "request",
     "s"
    ],
-   "commit": "993dca7f8afe7afffa0d62983fb7018481d886fc",
-   "sha256": "1sfa3wb051cv5qj44ldp76fql5sjfhccqgjm96c85i0zn4i19plf"
+   "commit": "3f528c0d2cf6eeb5f0a672d1ed719b7476472136",
+   "sha256": "1gjcfgh53d75slhw1vcn1mcccjbm7qs8qys76n45wl7ral5108nz"
   },
   "stable": {
    "version": [
@@ -68043,8 +68162,8 @@
   "repo": "akhramov/org-wild-notifier.el",
   "unstable": {
    "version": [
-    20190608,
-    410
+    20190930,
+    1912
    ],
    "deps": [
     "alert",
@@ -68052,14 +68171,14 @@
     "dash",
     "dash-functional"
    ],
-   "commit": "6e194d0f0a21b7d2b09ebdef5ffcd5ffe3633339",
-   "sha256": "0vh8hhb0d5y3bgp0i9msk5c6rpn1mzj9bzqmbk6xwl4qr07hgnxx"
+   "commit": "f2ea8a719cf61742def57475400222a498256bb6",
+   "sha256": "0wrr52bryvv1aj2fk5ik71iifh15bzmvrw1ixzs1afcdp2fn0bcm"
   },
   "stable": {
    "version": [
     0,
     3,
-    1
+    2
    ],
    "deps": [
     "alert",
@@ -68067,8 +68186,8 @@
     "dash",
     "dash-functional"
    ],
-   "commit": "6e194d0f0a21b7d2b09ebdef5ffcd5ffe3633339",
-   "sha256": "0vh8hhb0d5y3bgp0i9msk5c6rpn1mzj9bzqmbk6xwl4qr07hgnxx"
+   "commit": "f2ea8a719cf61742def57475400222a498256bb6",
+   "sha256": "0wrr52bryvv1aj2fk5ik71iifh15bzmvrw1ixzs1afcdp2fn0bcm"
   }
  },
  {
@@ -68095,40 +68214,37 @@
  },
  {
   "ename": "org2blog",
-  "commit": "781b2b45602cae8b972e5c8fd2b19bf7ee8133c6",
-  "sha256": "02gw1kjfm5v08bc1iwa029pk5v3jl277jiq62nmisxn8sd646f5s",
+  "commit": "08b47bf72bff18efb3281509fd9f1688d8bb0349",
+  "sha256": "1snrsqpiacmkajmiw12kpglxkrs5ngma7l7r246q0lvf1h4jzbsa",
   "fetcher": "github",
   "repo": "org2blog/org2blog",
   "unstable": {
    "version": [
-    20190309,
-    442
+    20191021,
+    130
    ],
    "deps": [
     "htmlize",
     "hydra",
     "metaweblog",
-    "org",
     "xml-rpc"
    ],
-   "commit": "bd6dd6b1b3ce57a72e7c229d3f035fc7c0d3860b",
-   "sha256": "0c7viqq8cxkd6xxbvq53dbp1slsjjxs2fb2lyi3njfg18v5c6fks"
+   "commit": "b02a056e1fa1a044a5bc5d44cc0fb0b8c62e1442",
+   "sha256": "1vglshyg8i5q17zxs9s5f0r5qwm18rah7qp7rd00pn4qg48zhy2b"
   },
   "stable": {
    "version": [
     1,
-    0,
-    3
+    1,
+    1
    ],
    "deps": [
     "htmlize",
     "hydra",
-    "metaweblog",
-    "org",
     "xml-rpc"
    ],
-   "commit": "55dbed00ebe5c841c43800b39764682759ecf326",
-   "sha256": "1fncgiwyigvmkc40bm1nr4nlkm828a04jv33jsnzjzyi2n00mbgx"
+   "commit": "3cad357cd5c0f7f949fc6c7aa42d76155d036e78",
+   "sha256": "136l0lm8lv7fgpzply241fngxfl3ck11raamqwislyv0nnjwdfdi"
   }
  },
  {
@@ -68139,11 +68255,11 @@
   "repo": "tumashu/org2ctex",
   "unstable": {
    "version": [
-    20181012,
-    151
+    20191024,
+    610
    ],
-   "commit": "2143992462594ce63733305f75f7c7d08123710a",
-   "sha256": "0xrg66yx4xrmkswbapaz21q4i6qm2199zvxqvgaxd8qyk19fc46c"
+   "commit": "d4af170f5190dad3aa31ab1cf4c6f087d56ab111",
+   "sha256": "0m28mxsq1d5ggr8phfn94pb38lj8x3sxykh7hfqbwhphaza3by5q"
   }
  },
  {
@@ -68281,10 +68397,10 @@
  },
  {
   "ename": "organize-imports-java",
-  "commit": "ec27ae185c0308c445e461dc84f398483ca08c5a",
-  "sha256": "1n91qd9il2sq5wkcc2ag8mvgr1jkgwygrw9kpq7j16qch420i3fj",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "0j4fpbzmi0mq2f493hwl94b3xmkhdcjscvbgv4dz31rw10bl4q7h",
   "fetcher": "github",
-  "repo": "elpa-host/organize-imports-java",
+  "repo": "jcs-elpa/organize-imports-java",
   "unstable": {
    "version": [
     20190922,
@@ -69515,8 +69631,8 @@
    "deps": [
     "org"
    ],
-   "commit": "00bef55f26eefb223662664f33f72810df1e8316",
-   "sha256": "0l6kgbfdqzg66c4qif7zablfk5mr0b0gh3jb24gih2ipxh67r76d"
+   "commit": "5fd940e01ae76ba305d46a0c0cfc4d27aa131d33",
+   "sha256": "1m1fl07k1qhcv96cqgwqcwnak3gx9k5z496y43sc48gldkwq69qr"
   }
  },
  {
@@ -69527,14 +69643,14 @@
   "repo": "choppsv1/org-rfc-export",
   "unstable": {
    "version": [
-    20190923,
-    1004
+    20190926,
+    851
    ],
    "deps": [
     "org"
    ],
-   "commit": "8427bc0b680defd4276bfaa222136b9cbe1f96fc",
-   "sha256": "0ic7w7zgd5da487p8zra6vbv586f2rdhd5xqa6r1606cv203imbz"
+   "commit": "b86c9e6f21d99ea657b4f2224f816300485ed73f",
+   "sha256": "1lg4bs0dr4srcgqxv9qi6v53aqq9i8inc1q024ndag4bis2x1q01"
   }
  },
  {
@@ -69545,14 +69661,14 @@
   "repo": "msnoigrs/ox-rst",
   "unstable": {
    "version": [
-    20190813,
-    427
+    20191013,
+    551
    ],
    "deps": [
     "org"
    ],
-   "commit": "25ea7a8a7ff1f57a9cd4f65b53899da3487bad8a",
-   "sha256": "0b7ybvpj1m48s2zdqk3xjyyzqxa9hjcaz29pgbsd9zg8q9mrnmas"
+   "commit": "9158bfd18096c559e0a225ae62ab683f1c98a547",
+   "sha256": "11v1h45ipjh95ksk6cdgp0azfmb7y3i8hdd46m7psmda08x8kqm5"
   }
  },
  {
@@ -69843,22 +69959,26 @@
   "repo": "10sr/pack-el",
   "unstable": {
    "version": [
-    20190613,
-    425
+    20191017,
+    456
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e0ab7ea1115451b229fae663a110854ab998d8c0",
-   "sha256": "1aqpcain6bi96laa3w1hx4jx75lqzvba0jvyj0jnb19zsa6k3xha"
+   "commit": "85cd856fdc00a2365e88b50373b99f1b3d2227be",
+   "sha256": "0v95ni44scn42mm6mwrdi1vbi1n2h4bw961apm7bp6ilamwpbif8"
   },
   "stable": {
    "version": [
     0,
+    1,
     1
    ],
-   "commit": "2aaf19931c508b78edd53e63d9819dd0a6f9b97d",
-   "sha256": "0mqznvisfrar7j5x1plj2xgnbz4znnzikyq3j3gpssq4wv3kqq7g"
+   "deps": [
+    "cl-lib"
+   ],
+   "commit": "85cd856fdc00a2365e88b50373b99f1b3d2227be",
+   "sha256": "0v95ni44scn42mm6mwrdi1vbi1n2h4bw961apm7bp6ilamwpbif8"
   }
  },
  {
@@ -69893,14 +70013,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20190818,
-    1456
+    20191010,
+    616
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "4b71d9a5034953b0beac02b4722f09f43c5e0dbf",
-   "sha256": "1kc20sg0if2g3a2m6pjvwb7ddgcivmqfi104236s04dy4npzkwbm"
+   "commit": "f761c2ffeed0daba9c17ac7571c7b979b6ceed64",
+   "sha256": "05snrl5slkwp8c1vzfndrp132xbjk61a63vbllm77nbm9acibq41"
   },
   "stable": {
    "version": [
@@ -69931,31 +70051,33 @@
  },
  {
   "ename": "package-lint",
-  "commit": "dbfb0250a58b2e31c32ff1496ed66a3c5439bd67",
-  "sha256": "05akg9cgcqbgja966iv2j878y14d5wvky6m9clkfbw5wyg66xpr0",
+  "commit": "e35516a9733d9ba39f7df441346d2624bc6dd5e7",
+  "sha256": "0yy39gywsw48isfgq9k7c5ibgfkaxiig0jbgmmd9s5a0rmrydiwf",
   "fetcher": "github",
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20190923,
-    8
+    20191018,
+    1144
    ],
    "deps": [
-    "cl-lib"
+    "cl-lib",
+    "let-alist"
    ],
-   "commit": "f2899cac84689d687cf62c61ae9ec587febaf225",
-   "sha256": "1qkackrp6ch8p77j5iqh64qbp0kbi13aw26v4lg35dya2z6y6k3k"
+   "commit": "483556c39c4b7929b28723509d0f26cf790b91c4",
+   "sha256": "19qx71vnr8jj2vqxgcr27zjnagg7nj4lr9xc9fgipwisg1x0yxhx"
   },
   "stable": {
    "version": [
     0,
-    7
+    11
    ],
    "deps": [
-    "cl-lib"
+    "cl-lib",
+    "let-alist"
    ],
-   "commit": "4c90df4919f7b96921a939b3bd88bedfd08d041e",
-   "sha256": "0nhznvsl3l3v7w5x2afw0ay31r6jrdvgr1ys9mhcmd1fsk57bj2r"
+   "commit": "197684c60df4902e632aac1fb0f99e2e967dcf12",
+   "sha256": "1sxl3zf733iyw6k5d6hh4isr6gp1qlvhbp2q8jpzcby8gmvy6l3r"
   }
  },
  {
@@ -69972,19 +70094,19 @@
    "deps": [
     "package-lint"
    ],
-   "commit": "f2899cac84689d687cf62c61ae9ec587febaf225",
-   "sha256": "1qkackrp6ch8p77j5iqh64qbp0kbi13aw26v4lg35dya2z6y6k3k"
+   "commit": "483556c39c4b7929b28723509d0f26cf790b91c4",
+   "sha256": "19qx71vnr8jj2vqxgcr27zjnagg7nj4lr9xc9fgipwisg1x0yxhx"
   },
   "stable": {
    "version": [
     0,
-    7
+    11
    ],
    "deps": [
     "package-lint"
    ],
-   "commit": "4c90df4919f7b96921a939b3bd88bedfd08d041e",
-   "sha256": "0nhznvsl3l3v7w5x2afw0ay31r6jrdvgr1ys9mhcmd1fsk57bj2r"
+   "commit": "197684c60df4902e632aac1fb0f99e2e967dcf12",
+   "sha256": "1sxl3zf733iyw6k5d6hh4isr6gp1qlvhbp2q8jpzcby8gmvy6l3r"
   }
  },
  {
@@ -70328,15 +70450,15 @@
   "repo": "joostkremers/pandoc-mode",
   "unstable": {
    "version": [
-    20190925,
-    822
+    20191003,
+    1221
    ],
    "deps": [
     "dash",
     "hydra"
    ],
-   "commit": "5b1275cbf5f6eb5617e1c7775c935fb1ddd6ae68",
-   "sha256": "10lk0f0wxjdyccp881x0j53g73cadjqdhny3qdmzbg8lblgl79gg"
+   "commit": "f4f10a329acd354aa7dda52e7f7bc23ca28366d3",
+   "sha256": "1j4bawr7a4lfhy76nxsivxngs4w7l1xlifzx69hjn157qdhbqawn"
   },
   "stable": {
    "version": [
@@ -70386,8 +70508,8 @@
     20190124,
     1828
    ],
-   "commit": "ebb2778052aeaf737adebc003957cb48cb01135e",
-   "sha256": "0qlvdpa88ic9gnb0qhijfsc9i6l3ba2zrvk4r4li3qrx0i9rpz5c"
+   "commit": "5f3e67448cc98fe2875115163849acae4d9e8526",
+   "sha256": "1w0dhyr4i0nx0g70smgclcfsbv6cfilb7df330njzaqk8j2gdfws"
   }
  },
  {
@@ -70418,8 +70540,8 @@
   "repo": "Malabarba/paradox",
   "unstable": {
    "version": [
-    20190624,
-    41
+    20191011,
+    1111
    ],
    "deps": [
     "hydra",
@@ -70427,8 +70549,8 @@
     "seq",
     "spinner"
    ],
-   "commit": "1b9e4b198e0a02773b52f6fe4fd03a82340c6cbc",
-   "sha256": "0ja7sxnpm71fvmly53hnb08bgdb9c69yfzzsmdh2h9na82qdjvk5"
+   "commit": "339fe3518d1d102b2295670340e75caf4f01a29a",
+   "sha256": "05hwwdhx980jm1y495r8qng029wm02m45mm7w4wxyjhh6385rbzf"
   },
   "stable": {
    "version": [
@@ -70641,20 +70763,20 @@
   "repo": "dp12/parrot",
   "unstable": {
    "version": [
-    20190311,
-    2325
+    20191015,
+    2127
    ],
-   "commit": "4d77eafc6bfacfe45dae805ceca101331d3d08d0",
-   "sha256": "0lqcw0scn2jcs15vybd1x7k7hiykrcsvimqj58s45m2pnaia57ql"
+   "commit": "13757524f1c708b866f4aaab5a9fb3599a1c4f56",
+   "sha256": "02anyi6mhw457pwsna3ycn1yxsavsmp6p96ffpwg1s7qidc44a4s"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     1
    ],
-   "commit": "e9fe686408214884b20c65284a6a595e1c755794",
-   "sha256": "079k4j0lcaj0lff1llp29bj5ah2b59byw9lw3jjw9wkl9px87r0m"
+   "commit": "13757524f1c708b866f4aaab5a9fb3599a1c4f56",
+   "sha256": "02anyi6mhw457pwsna3ycn1yxsavsmp6p96ffpwg1s7qidc44a4s"
   }
  },
  {
@@ -70933,8 +71055,8 @@
   "repo": "zx2c4/password-store",
   "unstable": {
    "version": [
-    20190916,
-    2027
+    20190929,
+    1627
    ],
    "deps": [
     "auth-source-pass",
@@ -70942,8 +71064,8 @@
     "s",
     "with-editor"
    ],
-   "commit": "e74a1c738f7cda65c7a308e30e8d122f853d6f70",
-   "sha256": "07g2w57q9lvgf5wznyg2ybkrw6w1f5w4jqi8zbw9lzkvj4iz3rg7"
+   "commit": "b830119762416fa8706e479e9b01f2453d6f6ad6",
+   "sha256": "0mf59506qa2zrrk18gr5sp9gz8lx03f6c6qccir5cf6s4rmi5x9m"
   },
   "stable": {
    "version": [
@@ -71236,11 +71358,11 @@
   "repo": "ibukanov/pc-bufsw",
   "unstable": {
    "version": [
-    20181221,
-    856
+    20191014,
+    848
    ],
-   "commit": "762d47b2f278c072643cf2a1ddc785516483d74a",
-   "sha256": "1by9p0j6c21y04cc4ls7f87gks631lv1mxk0aqhh41rml5kj4l22"
+   "commit": "a7c7bba4b7d511eceaaa8fee34d598296402555b",
+   "sha256": "0n6ijz86j88jq7w38yfamrqkjx8s1zbw1c0sa3dhpkv1jg87avb1"
   }
  },
  {
@@ -71361,14 +71483,14 @@
   "repo": "thierryvolpiatto/pcomplete-extension",
   "unstable": {
    "version": [
-    20180707,
-    455
+    20190928,
+    519
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "bb941272b54f49f780819f7ce4fd2c802de9a0da",
-   "sha256": "0bwbxnnw760i6mi7h9pyx3gaasrcja7dj3bfrlia07gw8jgl81ad"
+   "commit": "bc5eb204fee659e0980056009409b44bc7655716",
+   "sha256": "06dsfjbwx1iq0f2xism288vh4cgn804hbvi3gv3zknnzcmh6nlxi"
   },
   "stable": {
    "version": [
@@ -71458,15 +71580,15 @@
   "repo": "politza/pdf-tools",
   "unstable": {
    "version": [
-    20190918,
-    1715
+    20191007,
+    1436
    ],
    "deps": [
     "let-alist",
     "tablist"
    ],
-   "commit": "c851df842e05f353e4d249f2653f98418b3345d6",
-   "sha256": "1ij2w7lhwx2f88m35xp56risa29qrhh2p6xnvc3rnbb9iszajs3i"
+   "commit": "3407af25899c9bc0cb7b710e86ba316ab622f2c7",
+   "sha256": "1dhygjq95y57a5f3a2hw1i36mgn0njgllba8i9f8bc0kpb8ykbb0"
   },
   "stable": {
    "version": [
@@ -71558,8 +71680,8 @@
     20160321,
     2237
    ],
-   "commit": "c88a9a3050197840edfe145f11e0bb9488de32f4",
-   "sha256": "1wy5qpnfri1gha2cnl6q20qar8dbl2mimpb43bnhmm2g3wgjyad6"
+   "commit": "1d410a4e48db07a942e54d3b83a85c7a7ec0aab3",
+   "sha256": "1b7csqypqkalkzq6vrbq5ry1gdk0qnhnk43rlj514mph0s1nywdd"
   }
  },
  {
@@ -71883,14 +72005,14 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20190915,
-    2104
+    20191010,
+    1700
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "519838e2647268567c086b77158a55b01feb7f6c",
-   "sha256": "07bak10gy0ziy7zm9ha8sqfl564nxqhcaaicc35l8zk7qk11gj65"
+   "commit": "03061f49aa26e345a0f91ff1a96c6a50977ed22f",
+   "sha256": "00s4vxqzjgb4l8yivv2j7lyzqz03h4vzbcrgjha7kq2wh05yd3ib"
   },
   "stable": {
    "version": [
@@ -72352,23 +72474,20 @@
   "repo": "emacs-php/php-mode",
   "unstable": {
    "version": [
-    20190919,
-    1405
+    20190930,
+    111
    ],
-   "commit": "ba45a54d45fbf0cb8dfcf8aaa62ae42d43d449bb",
-   "sha256": "12wmh5306xr5jl9l2v02bgswvxkn98pfhny2491mivhgsmra1svi"
+   "commit": "5ba2a16e1751446502652021942f59f2e36aea41",
+   "sha256": "1zgqg6i114g8nylyizrcdf68f35klc140x829cbjrkbssj8vck8z"
   },
   "stable": {
    "version": [
     1,
-    21,
-    4
+    22,
+    0
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "a8ee6ce7c1c319b2b641865ebd599cc36d2dc10e",
-   "sha256": "1gqawn8bg9374swxb4bd2z015v16yjr96am1vwsbmgks3lhiw8ja"
+   "commit": "58de9a7db0b8908e047dfe308858ef5dfd464868",
+   "sha256": "17137l24s0nkr77l1dlmnkjpikks30mf5haskbg5i447lbpcm64r"
   }
  },
  {
@@ -72512,11 +72631,11 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20190618,
-    724
+    20190929,
+    612
    ],
-   "commit": "e8d33c75f6ab466ac15406fac5f2db6666d79deb",
-   "sha256": "1n6f4ibjdzrgll5zvikxc5gcfbpypq9nc2dhfxv011kllj22hpyc"
+   "commit": "81bcfa59d1e5708239d8c32d99cd84405449fb64",
+   "sha256": "1m4vk7v3aafj64qqs0aa9m1w8fbjziq0l6c9k4n10yr8dnm5j9aw"
   },
   "stable": {
    "version": [
@@ -73095,6 +73214,24 @@
   }
  },
  {
+  "ename": "plain-org-wiki",
+  "commit": "6b515386c3969b8d79e14b506bc0d9e1ec3097c4",
+  "sha256": "0m0mm0ki92561axm89mwc6vcx9rwdb7ai9hlvgnhf40k94s97lz6",
+  "fetcher": "github",
+  "repo": "abo-abo/plain-org-wiki",
+  "unstable": {
+   "version": [
+    20191013,
+    1833
+   ],
+   "deps": [
+    "ivy"
+   ],
+   "commit": "887717c184fb22dd219c78851303a8e5b917f877",
+   "sha256": "0wqxp46zvwswda644mnr92qxyyvakvl2l8w61sg6hy37pwfznx73"
+  }
+ },
+ {
   "ename": "plain-theme",
   "commit": "d4bd77883375b229e344384e42c3603ca096891c",
   "sha256": "0igncivhnzzirglmz451czx69cwshjkigqvqddj0a77b1cwszfw8",
@@ -73154,14 +73291,14 @@
   "repo": "skuro/plantuml-mode",
   "unstable": {
    "version": [
-    20190905,
-    838
+    20191019,
+    1309
    ],
    "deps": [
     "dash"
    ],
-   "commit": "1590a75da6c3e25b726bc5e3e12656faab968917",
-   "sha256": "0l20vkq4d673a12lf15m7zn2yzkzf0qkqmq35hi6kpy4bd3zar2v"
+   "commit": "fec1d4fb9d3b720f15931308b207cd8ad65f4f75",
+   "sha256": "19lg1lcjysqy0ziyp0y3xx2akgchhvqkxmxxnxjlwqrn9bqgibxh"
   },
   "stable": {
    "version": [
@@ -73679,15 +73816,15 @@
   "repo": "galaunay/poetry.el",
   "unstable": {
    "version": [
-    20190905,
-    959
+    20191022,
+    938
    ],
    "deps": [
     "pyvenv",
     "transient"
    ],
-   "commit": "9fcefd042355a0280b11ac61e45b52b9819e9c2a",
-   "sha256": "07vhgvpz35infidsw6bh0rxmfhyvmqn93vl9456lfhwyhwka366p"
+   "commit": "3f9ac720b423f087797b9e345b575275f2dcd740",
+   "sha256": "0gs8jpihqckijbm5w300mdm5jl4f9j754fkv5mj1ghj78q6bjmmp"
   },
   "stable": {
    "version": [
@@ -74516,11 +74653,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20190924,
-    759
+    20191013,
+    756
    ],
-   "commit": "bb1393383d512d7358549c99f95b45e7d56d7d2c",
-   "sha256": "1xxq1jnzvms053k7n04mx9y7x68j1h9mij056ai31raxm751mr05"
+   "commit": "d75dc1547a6a1cc2b385c736880eee77d7981aec",
+   "sha256": "0ssbpkmanljxw8dqk6ks643x4pacfwfw5xfzv5jnny25ph656r1f"
   },
   "stable": {
    "version": [
@@ -74752,8 +74889,8 @@
     20190921,
     3
    ],
-   "commit": "2f01b640e3a487718dbc481d14406005c0212ed9",
-   "sha256": "1wqk1g8fjpcbpiz32k7arnisncd4n9zs84dn3qn9y8ggjzldqy91"
+   "commit": "6be551816e3d96865e0d187db3e5724eaaa5f248",
+   "sha256": "1ppyqw1hxjx7c1hrndd8afs9pdmqkzj1hn9sdzr5dam6qdff2nqx"
   },
   "stable": {
    "version": [
@@ -74847,8 +74984,8 @@
   "repo": "jerrypnz/major-mode-hydra.el",
   "unstable": {
    "version": [
-    20190715,
-    937
+    20190930,
+    2105
    ],
    "deps": [
     "dash",
@@ -74856,14 +74993,14 @@
     "hydra",
     "s"
    ],
-   "commit": "d9fb688dae3e134bb1ff7f35474c58f33a5bb992",
-   "sha256": "0aq2dk7c9jqq13p3bv0cq1aym00chcr5f9p3v93wl9h6pc3spbnc"
+   "commit": "fd362d2be7ed80889715ed8a30a61780a18ce6ea",
+   "sha256": "0vnmvpsm46izxlh0l0p89rhy6ifzzfpzk7j3kkf2608s6dy8hgcy"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
    "deps": [
     "dash",
@@ -74871,8 +75008,8 @@
     "hydra",
     "s"
    ],
-   "commit": "d9fb688dae3e134bb1ff7f35474c58f33a5bb992",
-   "sha256": "0aq2dk7c9jqq13p3bv0cq1aym00chcr5f9p3v93wl9h6pc3spbnc"
+   "commit": "bba876b86f0b80495004bf185b2b1f6083a1ff3a",
+   "sha256": "08a15knkdq35pzjq82imff016fbfdib5q4glg2xmdy2b5fnk7jqa"
   }
  },
  {
@@ -75180,17 +75317,17 @@
  },
  {
   "ename": "project-abbrev",
-  "commit": "ec27ae185c0308c445e461dc84f398483ca08c5a",
-  "sha256": "12d0w3b9fh7hdi1qwm13s535k574xfh3ck48zpsv3jlxr59q5bqw",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "18nrcds02swr0s15gvvpc2fbjj9rq6ky3dz8qp51g7nfaprk2279",
   "fetcher": "github",
-  "repo": "elpa-host/project-abbrev",
+  "repo": "jcs-elpa/project-abbrev",
   "unstable": {
    "version": [
     20190517,
     521
    ],
-   "commit": "b94f829bb24570782b9f6bbcfdec4b391091b778",
-   "sha256": "0lkliz9hycag1gf5hxvh7mrgl5my2vbkn52g4pkh2x7hsdkxhxjy"
+   "commit": "fc4e9f774cae42a6fe135833774daaecf2b3dac0",
+   "sha256": "07056jd1z9i65db4pcshhdfrk5yb6xc28k3ihq7pixmya71l15pk"
   }
  },
  {
@@ -75283,17 +75420,25 @@
  },
  {
   "ename": "project-root",
-  "commit": "5b7972602399f9df9139cff177e38653bb0f43ed",
-  "sha256": "0xjir204zk254y2x70k9vqwirx2ljmrikpsgn5kn170d1bxvhwmb",
-  "fetcher": "bitbucket",
+  "commit": "bcf69e7e859145cb908e79abf4a2f51050e52ace",
+  "sha256": "0mhc7l6px5q2x13h6nmf4ixsghjlzbxjm2liscwn6485yg4bsmja",
+  "fetcher": "github",
   "repo": "piranha/project-root",
   "unstable": {
    "version": [
     20110206,
     2030
    ],
-   "commit": "843ca1f4ab2bc9c25e0f7cd585ceb1f2693b23f2",
+   "commit": "a49b1be864357683d9489074148b6d667f4ed23b",
    "sha256": "0nw02f5lmbqdfnw93d3383sdxx1d31szk23zvjlrmmdwv2124281"
+  },
+  "stable": {
+   "version": [
+    0,
+    7
+   ],
+   "commit": "fc1d024a497755c1abfa3eaffde1b18bd3c54865",
+   "sha256": "1z0sqdwa8caick2179bj03qbhjmvh2l5gv1ny6aya979vjgsk0g8"
   }
  },
  {
@@ -75322,14 +75467,14 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20190904,
-    1025
+    20191024,
+    721
    ],
    "deps": [
     "pkg-info"
    ],
-   "commit": "0707fc4fd6cb10959bede0d321a915a959c466aa",
-   "sha256": "14bz3jp0qvq36h70jrv7y18zfgrlh258v18r6sr8fm6pa05kchr8"
+   "commit": "cbdd0f071ca5cc2890738f08aa7223101ef2d032",
+   "sha256": "1sqddfnmz8xr1l4r45yir3fb43plj5ha3z94phh69wa67m3f23ja"
   },
   "stable": {
    "version": [
@@ -75391,28 +75536,28 @@
   "repo": "andrmuel/projectile-git-autofetch",
   "unstable": {
    "version": [
-    20190417,
-    1959
+    20191013,
+    1806
    ],
    "deps": [
     "alert",
     "projectile"
    ],
-   "commit": "8d8d090fdff42671e9926f095deb3448d24730b1",
-   "sha256": "1x1x1hn8k6hpj1vljbgmgznvgnky75xg4scy5y57k937pvkmyg6j"
+   "commit": "4a3eba7658a52c6e955d5f7085cd3fd62b53b9c6",
+   "sha256": "01jsj0pv9qqbkdmbykvk4ic40hc1nhaiaqvx17hi7p89hq3nzffr"
   },
   "stable": {
    "version": [
     0,
     1,
-    1
+    2
    ],
    "deps": [
     "alert",
     "projectile"
    ],
-   "commit": "da02069d906e6e7f28ea1dd6a9196529315a5cba",
-   "sha256": "106kj49rxsrdh6awvql3zyr3ramdcn0aaq4rmbmd45hz9ij7x1wh"
+   "commit": "4a3eba7658a52c6e955d5f7085cd3fd62b53b9c6",
+   "sha256": "01jsj0pv9qqbkdmbykvk4ic40hc1nhaiaqvx17hi7p89hq3nzffr"
   }
  },
  {
@@ -75443,8 +75588,8 @@
   "repo": "asok/projectile-rails",
   "unstable": {
    "version": [
-    20190913,
-    1003
+    20191023,
+    621
    ],
    "deps": [
     "f",
@@ -75453,8 +75598,8 @@
     "projectile",
     "rake"
    ],
-   "commit": "d31af287b2228f855e0bfbc5f985f999e5b5f811",
-   "sha256": "1r4ib96kkhy40m5jd63d9qml9k495zcjk12mwxcid8pk0f1s8l7d"
+   "commit": "b127797372af61ca35f5fdea598004c16bfacee6",
+   "sha256": "0n3z88w58ls62pnxibgfhdg8ms9i305kdjzxygs4gqqh0gjykhcm"
   },
   "stable": {
    "version": [
@@ -75754,11 +75899,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20190821,
-    848
+    20191007,
+    1041
    ],
-   "commit": "d53ded580e30d49e7a783280fd9ba96bc9c1c39c",
-   "sha256": "17hf4mxpijvgd2jrffibcz9ps4vv8w2alcgmh78xjlb6mm0p3ls0"
+   "commit": "15ccaec24ce935de366cae08b906c130379758ce",
+   "sha256": "108qijk2r0kgvbkhc3m04g1krx0xrr1zgjmr5ikwxvvvlxvrzkm2"
   },
   "stable": {
    "version": [
@@ -75861,19 +76006,17 @@
     20170526,
     1650
    ],
-   "commit": "b9f405ae46036860a4e73e167bee3800dfe53a9e",
-   "sha256": "0q70rsi012ybyq7akanl2np4x0ajqcmjknwcwrk3issy24l9f9sq"
+   "commit": "2fc88527e0a1db37fca3e949326cdc2d3e0fbc43",
+   "sha256": "1sc82vzamxgnbk0d7sg4pvjwlrpklbkm9af67wjx5q55gb6cy3y0"
   },
   "stable": {
    "version": [
     3,
     10,
-    0,
-    -1,
-    1
+    0
    ],
-   "commit": "ae1bcaad6ffcd04ca5d40f21dc3fab4f965e49cb",
-   "sha256": "0slzayqgda24z24470lx0iv0rqvvj0jg7g8izbgx2l5g04al0ihz"
+   "commit": "6d4e7fd7966c989e38024a8ea693db83758944f1",
+   "sha256": "0cjwfm9v2gv6skzrq4m7w28810p2h3m1jj4kw6df3x8vvg7q842c"
   }
  },
  {
@@ -76208,11 +76351,11 @@
   "repo": "wasamasa/punpun-theme",
   "unstable": {
    "version": [
-    20161103,
-    847
+    20190928,
+    1413
    ],
-   "commit": "cce8b10b2df6f9187a9eaa0c3f21ff0dda175968",
-   "sha256": "1iz1qc9bphl2y2z7abc33fvyaccj733drkl7nzbr1jlpbknkmk2k"
+   "commit": "2f78125609277b2478abdebd8f9d5ee10a823b65",
+   "sha256": "1sgxrj3igzq86h3whfymxf4qzv9kpvcrlhbvjmnp7fwrplys0n7d"
   }
  },
  {
@@ -76685,8 +76828,8 @@
   "repo": "tumashu/pyim",
   "unstable": {
    "version": [
-    20190925,
-    252
+    20191014,
+    333
    ],
    "deps": [
     "async",
@@ -76694,8 +76837,8 @@
     "pyim-basedict",
     "xr"
    ],
-   "commit": "172a099fe1212d560dab72569f3b0091735a8eb8",
-   "sha256": "0bjjphamw6n7fi86k24zx1wdm6i9hirnf100vkaiyjqmf34490dc"
+   "commit": "485cd94dd2a651f7ecd69bdf80200f0d0033754e",
+   "sha256": "1frd6xshhvy0l8h4chf11g46dai757mbmy0ag0h024934agqd4n0"
   },
   "stable": {
    "version": [
@@ -76840,8 +76983,8 @@
     20170402,
     1255
    ],
-   "commit": "fde732e0e9a4f224c5ae48ad942c6d955aa0a8e6",
-   "sha256": "1wz5psdrpxi58vs2wpz9vagxdrzghc839whqvsa2y71ka3z923rk"
+   "commit": "97f4f2ae187df933f072d74fd8347ec14213f5de",
+   "sha256": "08i0likgznkc7xwb4p47cndza0dy4h12l3im47h12vgjl1r5ayna"
   }
  },
  {
@@ -76894,8 +77037,8 @@
     "pythonic",
     "tablist"
    ],
-   "commit": "277f7c623f489fd31c56d6e131c5481a71b6a926",
-   "sha256": "1xpb08m5zjyxpq45mmhfysxgaga2xj9r6nw6zs2rx0zkv6qjklnr"
+   "commit": "05697e881a8b57c4f183344c42ae36662b180663",
+   "sha256": "148dhzpjv5ykakxdyp0fcxjbqjvf4r6sv8jq9jlyqk2q1nxz45fr"
   }
  },
  {
@@ -76924,20 +77067,20 @@
   "repo": "poppyschmo/pytest-pdb-break",
   "unstable": {
    "version": [
-    20190308,
-    655
+    20191016,
+    530
    ],
-   "commit": "ac969ae8cec2e3da250ce454e74f5b28f0e9649b",
-   "sha256": "0agrqlasx8ikvwk5c9rc2d4spj7bkhbwn46k3b8ind4pzzk4rxwd"
+   "commit": "b57705d55a067456c6160489672feddcc6085713",
+   "sha256": "03plhl4z75rvf3llhw8dwmc8r3hwhwd2pwq3r66kbqdvr0yrdl42"
   },
   "stable": {
    "version": [
     0,
     0,
-    4
+    6
    ],
-   "commit": "38840190dfbcb307778d079da5e2373525b3ac18",
-   "sha256": "0887620iq8xn28aajx7z2pkgh19778w494n8icibwlk2mj2m3gxl"
+   "commit": "b57705d55a067456c6160489672feddcc6085713",
+   "sha256": "03plhl4z75rvf3llhw8dwmc8r3hwhwd2pwq3r66kbqdvr0yrdl42"
   }
  },
  {
@@ -77070,11 +77213,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20190912,
-    1653
+    20191018,
+    1735
    ],
-   "commit": "2fc13db9eb7652b3f6619fbd1a96073850ee6175",
-   "sha256": "0mw3hvslvvj6h56nc42my94vjci36k3yr44511635vdmfsmdzafl"
+   "commit": "1e64dd421f1848dd902bf9f39b5bac8d3f33a96d",
+   "sha256": "0wckkg4ykrhfpyz5dankagai8jfbhzi3kjd99ds1j1515jxmawmg"
   },
   "stable": {
    "version": [
@@ -77194,15 +77337,15 @@
   "repo": "pythonic-emacs/pythonic",
   "unstable": {
    "version": [
-    20190725,
-    1258
+    20191021,
+    811
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "29f8049e56141805b0ee1a2c5fc62c3b027aa736",
-   "sha256": "12dhh11q16crhb6dffwx3s7ncgbqsvc2dvpkzgllr58iwd8hs2kk"
+   "commit": "ba9af8ce302579a2b2097b867a35a9fc0bc4bceb",
+   "sha256": "1q43ngd0nj5j9aca71qi0ss137kp46klr6xdlm8ghy55ppym2g5i"
   },
   "stable": {
    "version": [
@@ -77228,19 +77371,19 @@
   "repo": "jorgenschaefer/pyvenv",
   "unstable": {
    "version": [
-    20190916,
-    1037
+    20191006,
+    1304
    ],
-   "commit": "392e28dad42dc6cc9507e496391a32482f9f1881",
-   "sha256": "0kmzqinlv99wpm5q0lzwlzmjsc03m4z24pwz3zixldh76f7c2fmb"
+   "commit": "103d2f158ef2a760741682e18741e44107c68f3f",
+   "sha256": "055sgk8zf4wb5nqsf3qasf5gg861zlb1831733f1qcrd2ij5gzxx"
   },
   "stable": {
    "version": [
     1,
-    20
+    21
    ],
-   "commit": "fa6a028349733b0ecb407c4cfb3a715b71931eec",
-   "sha256": "1x052fsavb94x3scpqd6n9spqgzaahzbdxhg4qa5sy6hqsabn6zh"
+   "commit": "103d2f158ef2a760741682e18741e44107c68f3f",
+   "sha256": "055sgk8zf4wb5nqsf3qasf5gg861zlb1831733f1qcrd2ij5gzxx"
   }
  },
  {
@@ -77402,11 +77545,11 @@
   "url": "https://framagit.org/steckerhalter/quelpa.git",
   "unstable": {
    "version": [
-    20190710,
-    503
+    20191014,
+    628
    ],
-   "commit": "144b71e0f514b96cf19c39853cf08b2d957a8ed5",
-   "sha256": "0dv85f38r5jd369ihmpknbj2zv8wmabfdsjcny0j6mp7x1n37dy1"
+   "commit": "0c4dab17591b15cea7dccf905afac9991f3b4971",
+   "sha256": "18j5hyyssmqi57h3i28dyv5mn0pmqkcydfzgn8yc5c53qvq9ixc9"
   }
  },
  {
@@ -77633,8 +77776,8 @@
   "repo": "racer-rust/emacs-racer",
   "unstable": {
    "version": [
-    20190610,
-    800
+    20191001,
+    2344
    ],
    "deps": [
     "dash",
@@ -77643,8 +77786,8 @@
     "rust-mode",
     "s"
    ],
-   "commit": "ea6a09c16f8ec646195f942c12fe3ed7d65cc971",
-   "sha256": "1r6g9jgbdidivjms62bvxkg0z3jif5j9sxfg51iq8hvc6m1nd352"
+   "commit": "a0bdf778f01e8c4b8a92591447257422ac0b455b",
+   "sha256": "1dzp2l6lcdrcss5xp32yvil4c1din09awnxg0f71fls6kh2g2fcq"
   },
   "stable": {
    "version": [
@@ -77669,14 +77812,14 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20190925,
-    1446
+    20191023,
+    1526
    ],
    "deps": [
     "faceup"
    ],
-   "commit": "bf31305d903b375f2be88d99f87891843a604e5d",
-   "sha256": "0mq6x3sbhs83imj4g1p92739ldkhqv5g3bnnyzp7yhpcpjk1519n"
+   "commit": "5c1b8c8134741b08c51f3dc47741b05f68f5fd68",
+   "sha256": "1g7fmxrbyydci0qz3x3sm4a2nviri19vd8j9x4wbzbxw2s3c73g3"
   }
  },
  {
@@ -77765,20 +77908,20 @@
   "repo": "Fanael/rainbow-delimiters",
   "unstable": {
    "version": [
-    20170929,
-    1132
+    20191018,
+    1233
    ],
-   "commit": "e561cff4abf97d00d9b2b5f10256d417182e2772",
-   "sha256": "0j9wmri4zn72znq406n2j078q2h4f74qpcrqh2pkfw4f3ff3hf7c"
+   "commit": "5125f4e47604ad36c3eb4706310fcafac729ca8c",
+   "sha256": "1jh1gv69cjlrjkmjrkhgc7jffyxlkq9nci5ag4z1alskfp6favir"
   },
   "stable": {
    "version": [
     2,
     1,
-    3
+    4
    ],
-   "commit": "93cd2dc873e7fedca7abc599cd97d46db4376ac7",
-   "sha256": "0vs9pf8lqq5p5qz1770pxgw47ym4xj8axxmwamn66br59mykdhv0"
+   "commit": "455bcee19c92bf85db0ba7e926f0b5a176b69865",
+   "sha256": "1zr2669savnmkc68hiqsq9wccm6bs1j6jbmlac1xqh6nq7xgq36g"
   }
  },
  {
@@ -79020,11 +79163,11 @@
   "repo": "purcell/reformatter.el",
   "unstable": {
    "version": [
-    20190529,
-    2238
+    20191006,
+    2321
    ],
-   "commit": "8372cc425967f055ba8a26f6098649467e776c5e",
-   "sha256": "1fmyqs06rrkyyclrsfrjsxcwkd0c20kimih2x5llhnxmw51i2y5s"
+   "commit": "e15598a0ccbf4866f4939cceaac897924ba7690f",
+   "sha256": "0dfx0k8q3d4bbvndy9nnhwi2rc2jxmjjp3pi1qbd4nqy0aj6yas1"
   },
   "stable": {
    "version": [
@@ -79183,8 +79326,8 @@
   "repo": "proofit404/relative-buffers",
   "unstable": {
    "version": [
-    20190914,
-    1042
+    20191004,
+    1205
    ],
    "deps": [
     "cl-lib",
@@ -79192,8 +79335,8 @@
     "f",
     "s"
    ],
-   "commit": "496fd31530adc455992b2bac535900fd29b9ad51",
-   "sha256": "14nqs14ml33wlrm268dpijs0n2b12yrlysk1qd62fc7k5hvz9wxl"
+   "commit": "6064cd0b3cbd42c4a46c70fc396f05be71f42bd6",
+   "sha256": "0wzxnbbzzjkzrnfdbdn7k172ad6mnhq5y3swcbilnk1w1a1lzyhn"
   }
  },
  {
@@ -79495,11 +79638,11 @@
   "repo": "tkf/emacs-request",
   "unstable": {
    "version": [
-    20190923,
-    1502
+    20191022,
+    615
    ],
-   "commit": "61b29734d7c44a594598a7674f2c6c575462dd4b",
-   "sha256": "1c8giy34pqzcdh3a7afp4308bj0764wk87c3smfkihfl3clc53ys"
+   "commit": "6d170649ae9ef1c7c3d545517f896c03ca12062c",
+   "sha256": "1sc387x1v82i9r0p5r6v2wrwypk0dvkrmpivnyfkvrpg7vhff6yn"
   },
   "stable": {
    "version": [
@@ -79526,8 +79669,8 @@
     "deferred",
     "request"
    ],
-   "commit": "61b29734d7c44a594598a7674f2c6c575462dd4b",
-   "sha256": "1c8giy34pqzcdh3a7afp4308bj0764wk87c3smfkihfl3clc53ys"
+   "commit": "6d170649ae9ef1c7c3d545517f896c03ca12062c",
+   "sha256": "1sc387x1v82i9r0p5r6v2wrwypk0dvkrmpivnyfkvrpg7vhff6yn"
   },
   "stable": {
    "version": [
@@ -79655,11 +79798,11 @@
   "repo": "pashky/restclient.el",
   "unstable": {
    "version": [
-    20190502,
-    2214
+    20191009,
+    1208
    ],
-   "commit": "422ee8d8b077dffe65706a0f027ed700b84746bc",
-   "sha256": "067nin7vxkdpffxa0q61ybv7szihhvpdinivmci9qkbb86rs9kkz"
+   "commit": "e8ca809ace13549a1ddffb4e4aaa5d5fce750f3d",
+   "sha256": "1wdi3c9wczn6vhr5l9mrbhsnw0hj1zfxh3sz53q8v1k684q5jyjk"
   }
  },
  {
@@ -79677,8 +79820,8 @@
     "helm",
     "restclient"
    ],
-   "commit": "422ee8d8b077dffe65706a0f027ed700b84746bc",
-   "sha256": "067nin7vxkdpffxa0q61ybv7szihhvpdinivmci9qkbb86rs9kkz"
+   "commit": "e8ca809ace13549a1ddffb4e4aaa5d5fce750f3d",
+   "sha256": "1wdi3c9wczn6vhr5l9mrbhsnw0hj1zfxh3sz53q8v1k684q5jyjk"
   }
  },
  {
@@ -79840,8 +79983,8 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20190925,
-    543
+    20191017,
+    1843
    ],
    "deps": [
     "cl-lib",
@@ -79849,22 +79992,22 @@
     "transient",
     "wgrep"
    ],
-   "commit": "d948457034527f1ed9d0d3b00ee81d7ff0abfc02",
-   "sha256": "1hqdhrzhr4yyn0n8pd7xxbj76ibzb6zb35yg8c3kwsba7m3sm6vi"
+   "commit": "fcb3c16dc67d22afb5a5eab14f00bebe3a0720a6",
+   "sha256": "1bzd7xfy5hf4jlf5f4yl9csgr188dl9kdv5yd2f67z36miia5h6h"
   },
   "stable": {
    "version": [
     1,
     8,
-    0
+    1
    ],
    "deps": [
     "cl-lib",
     "s",
     "wgrep"
    ],
-   "commit": "df76c35a7c370f34e23f4ad20a22aacce5581165",
-   "sha256": "0p29hcf0gcswlsy4cy68byys459358v14fzdbz38j1diz5g5ac6p"
+   "commit": "3f07304b8a7ee70ac91f3b66e76dc1d621a96bff",
+   "sha256": "0k7x5z7mh9flwih35cqy8chs54rack3nswdcpw5wcpgv6xim227y"
   }
  },
  {
@@ -80137,8 +80280,8 @@
     20190508,
     609
    ],
-   "commit": "fcefc0509dd0a4ec2e02020c83e1c4a1101ef903",
-   "sha256": "1zbpp4ilf9kvjnxc0cgs90l02lmpp6pa905cahi441l2pn71kbld"
+   "commit": "7045b8116a0bf899a51e6d91a373a693faa310e1",
+   "sha256": "1wgp0xb2c5b6hxxwwwlz7kl4namb7r03cpfkraqzgiia13m9pihr"
   }
  },
  {
@@ -80257,11 +80400,11 @@
   "repo": "DerBeutlin/ros.el",
   "unstable": {
    "version": [
-    20190919,
-    1939
+    20190929,
+    1831
    ],
-   "commit": "967963404824052f25913906f506b090ebba221a",
-   "sha256": "09p9dcybkabkrdvv0ss9jgbmn87zilgijpxhd0r18qpb5hipyr8g"
+   "commit": "f02d154ecf9d583bec2d9b85a77e8cbeb0cf32bb",
+   "sha256": "158mclwiqy678xizw7dixcbvzzlwfg89h7r10rls5vclmmr47gv4"
   }
  },
  {
@@ -80389,11 +80532,11 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20190918,
-    505
+    20191002,
+    1643
    ],
-   "commit": "d3d4bc9b7b829d39628a1af96f06eb23ba48670c",
-   "sha256": "0fgxrpqvqs988kjnkcc1lmyqnfc85ivhrarldl7iqgj25fvni6z1"
+   "commit": "f2633f565fc5e7e6958993ef105225f4e68e43ba",
+   "sha256": "1bjgr7wa82ccrc25r7agfaq3iz7xlp1qchvkmkx3xy59jv4yafjz"
   },
   "stable": {
    "version": [
@@ -80758,8 +80901,8 @@
     20180127,
     22
    ],
-   "commit": "893b1a26244ef6ea82833a9afbc13cb82c0cfb53",
-   "sha256": "0lgahv25a9b2dfgkcm9ipyziiqnr3sb9l2dvzm35khwf3m8dwxgq"
+   "commit": "b69a3866e0299cae8c9c805d644e69b2c17b64de",
+   "sha256": "13sm2v7al9658n17dka6dclzsprccrm3zycx6nwsgl99i14cnn99"
   }
  },
  {
@@ -80861,11 +81004,11 @@
   "repo": "rust-lang/rust-mode",
   "unstable": {
    "version": [
-    20190923,
-    2214
+    20191023,
+    918
    ],
-   "commit": "295e234e5ceb62c047c50ff14bd6ab0a39499816",
-   "sha256": "0hm3mii2d6p93jf4ld8rkrk55pklzj7zlsy14rrc6xh02n2lzzi4"
+   "commit": "5ad9b599c6beea43d6262c3ad81d95512a7e53b8",
+   "sha256": "1i1899lclwq2c238jcyz2hixvixwrqgks8xgw5048zpxvdb6vm6a"
   },
   "stable": {
    "version": [
@@ -80908,8 +81051,8 @@
   "repo": "brotzeit/rustic",
   "unstable": {
    "version": [
-    20190922,
-    930
+    20191019,
+    2022
    ],
    "deps": [
     "dash",
@@ -80923,8 +81066,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "911676a82fb561cc59c9e54e87d566c5a23469f5",
-   "sha256": "1nlp7apy7d6dwxhn61awdy2vhckjjsps4wk0ffjrnjnjhypljwqn"
+   "commit": "030e0dc5777ac2c27d2e99ace19c252eb52a50bc",
+   "sha256": "0xs0lyapkp91nhrjhqgsv03zmvmp8mg4jz434w03cwwcbm8k1j55"
   }
  },
  {
@@ -80959,11 +81102,11 @@
   "repo": "Kungsgeten/ryo-modal",
   "unstable": {
    "version": [
-    20190816,
-    1209
+    20191017,
+    1323
    ],
-   "commit": "0bb210f37539e9d0c1e77ae286a0d7db79cf8edf",
-   "sha256": "1x093wq7srgby3608n3q1vkdfvx9b98q7mzfhxwmy3999y7qhsk5"
+   "commit": "3a54312eea7023a86ca3f8eb3c03c872554bff2f",
+   "sha256": "1cyvp3bi6yhckbdnq98xvghmhdzghya5y9wd7hxjawibs75rza95"
   }
  },
  {
@@ -81258,11 +81401,11 @@
   "repo": "nflath/save-visited-files",
   "unstable": {
    "version": [
-    20190430,
-    1508
+    20190927,
+    2153
    ],
-   "commit": "7eb71a6c4f9cb770b387fcef80231d9a9f648188",
-   "sha256": "01ampk085k0rb0bw85imwbs44p4wp20giiwwpbrv6f97bh1065m2"
+   "commit": "0b61c9bd16947bd99ccd61208bd481325e8c5cba",
+   "sha256": "04rrl0nn4mk8h7qyzh3lljagldm5hqhxv8ps6hkh0zz4il7ds018"
   }
  },
  {
@@ -81335,17 +81478,21 @@
  },
  {
   "ename": "sbt-mode",
-  "commit": "364abdc3829fc12e19f00b534565227dbc30baad",
-  "sha256": "0v0n70czgkdijnw5jd4na41vlrmqcshvr8gdpv0bv55ilqhiihc8",
+  "commit": "824a7ac85d5c2b8f1c7643bff4eb5931a4680309",
+  "sha256": "1i0056y27bcjpqrqgjhl14qk53r3ny8zzadsgyw2jqf5jvg561bc",
   "fetcher": "github",
-  "repo": "ensime/emacs-sbt-mode",
+  "repo": "hvesalai/emacs-sbt-mode",
   "unstable": {
    "version": [
-    20180511,
-    1622
+    20190929,
+    1531
    ],
-   "commit": "e658af140547cbef495c33535c7f694a501d318c",
-   "sha256": "0lv9ridzk9x6rkf7lj21srnszypyq04vqg05vl10zhpz1yqlnbjd"
+   "commit": "5d2edadff23fe23e911379d6c2141d55b23e7254",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "warning: unable to download 'https://github.com/hvesalai/emacs-sbt-mode/archive/5d2edadff23fe23e911379d6c2141d55b23e7254.tar.gz': Couldn't connect to server (7); retrying in 344 ms\nwarning: unable to download 'https://github.com/hvesalai/emacs-sbt-mode/archive/5d2edadff23fe23e911379d6c2141d55b23e7254.tar.gz': Couldn't connect to server (7); retrying in 561 ms\nwarning: unable to download 'https://github.com/hvesalai/emacs-sbt-mode/archive/5d2edadff23fe23e911379d6c2141d55b23e7254.tar.gz': Couldn't connect to server (7); retrying in 1072 ms\nwarning: unable to download 'https://github.com/hvesalai/emacs-sbt-mode/archive/5d2edadff23fe23e911379d6c2141d55b23e7254.tar.gz': Couldn't connect to server (7); retrying in 2013 ms\nerror: unable to download 'https://github.com/hvesalai/emacs-sbt-mode/archive/5d2edadff23fe23e911379d6c2141d55b23e7254.tar.gz': Couldn't connect to server (7)\n"
+   ]
   },
   "stable": {
    "version": [
@@ -81368,8 +81515,8 @@
     20190413,
     1246
    ],
-   "commit": "497baa7a4f9e688b7c9eb6f16dd57e645202e041",
-   "sha256": "0ss7wkc46xmwgldhdygx0344zh2c51ny2xbj869sqpky1wi72z4c"
+   "commit": "6ec97fda154b0578688ab98723685c66af7a7a71",
+   "sha256": "0vq85dv6yrglvfrnf3vxrdlh6cwxfcmrxqwfv596jh0l834cbsgg"
   }
  },
  {
@@ -81392,17 +81539,17 @@
  },
  {
   "ename": "scala-mode",
-  "commit": "564aa1637485192a97803af46b3a1f8e0d042c9a",
-  "sha256": "12x377iw085fbkjb034dmcsbi7hma17zkkmbgrhkvfkz8pbgaic8",
+  "commit": "eb0b5735e9d930502ea7346e29d350ba8068440c",
+  "sha256": "1wnl3ily5qsff36z6fkk86m58w591yc3m2nka22vslafj8m8gwl8",
   "fetcher": "github",
-  "repo": "ensime/emacs-scala-mode",
+  "repo": "hvesalai/emacs-scala-mode",
   "unstable": {
    "version": [
-    20170802,
-    1132
+    20190929,
+    1522
    ],
-   "commit": "56cba2903cf6e12c715dbb5c99b34c97b2679379",
-   "sha256": "13miqdn426cw9y1wqaz5smmf0wi3bzls95z6shcxzdz8cg50zmpg"
+   "commit": "44772cbf1e1ade52bc5066555ff0aed68569aaec",
+   "sha256": "0xnsyrsardsmjyj563dkl03f5d6g2syng1x721i0w36qkiqwcqr7"
   },
   "stable": {
    "version": [
@@ -82487,14 +82634,14 @@
   "repo": "wasamasa/shackle",
   "unstable": {
    "version": [
-    20190201,
-    1846
+    20191020,
+    1249
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "842a90b3ca04d9d886543f14ca5f04e8bd2a3d06",
-   "sha256": "08g72adgbhb1cj6897xrjmpbxcxs6pr8xha4868s293kn6dkh4ys"
+   "commit": "7ccbe513852a1d1700b698547efca14b8940319d",
+   "sha256": "0agsp8ia4irr540r898ifhjqp28n1zsq1pilv1kc272spn3qhvp9"
   },
   "stable": {
    "version": [
@@ -82640,11 +82787,11 @@
   "repo": "ieure/shell-here",
   "unstable": {
    "version": [
-    20150728,
-    1704
+    20191011,
+    1959
    ],
-   "commit": "251309141e18978d2b8014345acc6f5afcd4d509",
-   "sha256": "0z04z07r7p5p05zhaka37s48y82hg2dbk0ynap4inph3frn4yyfl"
+   "commit": "88b80deb1337a97b403b20fc467fa2d579b3bfd5",
+   "sha256": "1x9zcxsc6cnh0h051377asbqhcx3mzcarrnj9zmyg6fcszgas5v1"
   }
  },
  {
@@ -82890,11 +83037,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20190826,
-    741
+    20190930,
+    730
    ],
-   "commit": "f5abefa599e63a769b08debf1aa8f13e77a2b1b4",
-   "sha256": "0kr136ya51iw5nv72jrkk2wn6m2zr86b19b93i1pplhvq465a9bm"
+   "commit": "361297e8539770f2f396d30928ebc01de60ca637",
+   "sha256": "1cnzi91mm3mg5x25v7vg86d1ri7ka7cvspb5l7ikmdv6cb9978ll"
   }
  },
  {
@@ -82960,10 +83107,10 @@
  },
  {
   "ename": "show-eol",
-  "commit": "1ae308e8c251b7a6942f7d9f739830986f7315ea",
-  "sha256": "1k0ihimb4acc30qfmjj3hfpxknif3gzj0iikz23gizrsks7n5p1g",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "1lk397a0b2nwdd9v1vk0kpfd0d0slflsvy4h0ycyvcnbc53byni4",
   "fetcher": "github",
-  "repo": "elpa-host/show-eol",
+  "repo": "jcs-elpa/show-eol",
   "unstable": {
    "version": [
     20190924,
@@ -83182,20 +83329,20 @@
   "repo": "riscy/shx-for-emacs",
   "unstable": {
    "version": [
-    20190623,
-    2154
+    20190929,
+    331
    ],
-   "commit": "ef084c66e66651bf93cd0065469e862b627c044b",
-   "sha256": "1alpp27b3mxw9ansfixdcp4kpj1mak1k1gm370b8fv2s45b3sacb"
+   "commit": "42e175378fa78a2a0b7230deea60e29b60a8b312",
+   "sha256": "04f6ldl81p6pd60i0jspiphdypgkl7qy5qq72dh8hzrw9fcfvf9r"
   },
   "stable": {
    "version": [
     1,
-    1,
-    2
+    2,
+    0
    ],
-   "commit": "ef084c66e66651bf93cd0065469e862b627c044b",
-   "sha256": "1alpp27b3mxw9ansfixdcp4kpj1mak1k1gm370b8fv2s45b3sacb"
+   "commit": "42e175378fa78a2a0b7230deea60e29b60a8b312",
+   "sha256": "04f6ldl81p6pd60i0jspiphdypgkl7qy5qq72dh8hzrw9fcfvf9r"
   }
  },
  {
@@ -83317,11 +83464,11 @@
   "repo": "mswift42/silkworm-theme",
   "unstable": {
    "version": [
-    20180301,
-    1437
+    20191005,
+    1903
    ],
-   "commit": "4a297f952401cfe894dcb24174f6eda05e00fada",
-   "sha256": "00kjibpn3ry7j1s6kqmakybialpcx4919344lxks7wij5l6qqxx0"
+   "commit": "6cb44e3bfb095588aa3bdf8d0d45b583521f9e2c",
+   "sha256": "0w5h1gl8npmwmpvhhwchrknd977w4l3vvd2lib7qphinj117fhzv"
   },
   "stable": {
    "version": [
@@ -83402,14 +83549,14 @@
   "repo": "skeeto/emacs-web-server",
   "unstable": {
    "version": [
-    20190110,
-    1505
+    20191006,
+    1956
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "08535d0fad6a32fdc03d725ec74e10a754bb9c7a",
-   "sha256": "14cajlr1a2dx8x511zb20l633xqa0kqx3nn73x4ph2wwb35njk76"
+   "commit": "67f2f1e665fa66d7ef3beed8e82f94962bfa4f3b",
+   "sha256": "0w0psk98qnwnjyispkcahgh7kyp8jz6m6kwy3hwicsbxbiydrivd"
   },
   "stable": {
    "version": [
@@ -83456,8 +83603,8 @@
    "deps": [
     "cl-lib"
    ],
-   "commit": "8b03b71303070b05d5def3c8a2564e4b5e67098a",
-   "sha256": "1g508x8hf8zlvi6kz9r8jxavl11y47y2gjldjnc6z6ijiqisy3dm"
+   "commit": "2d3304af173b657176a1284abecdad2861820119",
+   "sha256": "1ac03h5hmx6qhsscq5n1n75wc5s1nnvpghws3sij6j64ksixi3b6"
   }
  },
  {
@@ -83762,8 +83909,8 @@
   "repo": "yuya373/emacs-slack",
   "unstable": {
    "version": [
-    20190803,
-    1406
+    20191019,
+    1858
    ],
    "deps": [
     "alert",
@@ -83773,8 +83920,8 @@
     "request",
     "websocket"
    ],
-   "commit": "ea89ac4291532a136d02bb8852b5dc641622ab73",
-   "sha256": "0gnmhlv3gzv5n8ydbg84n9m6i9d0akcvn032ipsyss6bqw1vzl1m"
+   "commit": "25df7218ef17c03ddad057a1ba50f99160b71675",
+   "sha256": "11m951hl6ykk7h028nhvzlc7ywdc93z7n5vpf9w4m73jlgy1kcbr"
   }
  },
  {
@@ -83835,15 +83982,15 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20190925,
-    1213
+    20190930,
+    1713
    ],
    "deps": [
     "cl-lib",
     "macrostep"
    ],
-   "commit": "0bd5891373adf44ab453880dc5549ef53ffc9dba",
-   "sha256": "1dpl1xb5psm83ls5nsl34wiw5zz5csmdm6vfqdr7szxncdsfjij1"
+   "commit": "8cb0980160efd63286849eebc5743da8f0ef8a68",
+   "sha256": "0wxghl8r7x1zs5k9dirfi9lqwvbiwmjrmwz93yi3v504y2via2al"
   },
   "stable": {
    "version": [
@@ -84060,11 +84207,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20190709,
-    1511
+    20191023,
+    1144
    ],
-   "commit": "249a94ca9560d7ac07607d9a23cfc5c5f487943a",
-   "sha256": "02snfrgqp9iwprg4was3njhskbvlypggcgzc58alp0nvlvpszs6g"
+   "commit": "fe2a256f85b87d2700c3ec6762c3e2b2f0e54d22",
+   "sha256": "1v62py91rrx917l1jamykbr6gc3d0x842qv1xlrzk0igbill3nlz"
   },
   "stable": {
    "version": [
@@ -84083,14 +84230,14 @@
   "repo": "mmgeorge/sly-asdf",
   "unstable": {
    "version": [
-    20190807,
-    553
+    20191021,
+    718
    ],
    "deps": [
     "sly"
    ],
-   "commit": "c387ba34a75b172e8a75747220c416462ae9de31",
-   "sha256": "1cr6p11vsplb6afh2avwb585q606npp692gb5vqs377nni5vx7km"
+   "commit": "69123fcebe63bb4d6e40e3dcb187299622401b74",
+   "sha256": "0f5ycdh02w6b6jkzw6fhsq9brdld78277cjykpy291112fx0ppny"
   },
   "stable": {
    "version": [
@@ -84113,14 +84260,14 @@
   "repo": "joaotavora/sly-hello-world",
   "unstable": {
    "version": [
-    20190701,
-    1443
+    20191013,
+    2137
    ],
    "deps": [
     "sly"
    ],
-   "commit": "355c94235afa9f79eefff1d22e97fcfa9c31d70c",
-   "sha256": "0aifmfw83bi0f761k1ppham0mc1b59w2bpas59355vrlbg7jm9vg"
+   "commit": "ae8fe0a0ebcce50425a1d411c027db06ddec39ce",
+   "sha256": "0gimlph6pbq0s313gqa85gzc2x2d9ba4yww91apikd6xl32707bg"
   }
  },
  {
@@ -84131,15 +84278,15 @@
   "repo": "joaotavora/sly-macrostep",
   "unstable": {
    "version": [
-    20190701,
-    1532
+    20191013,
+    2138
    ],
    "deps": [
     "macrostep",
     "sly"
    ],
-   "commit": "6c4d8ef7b6d39d6ef10053fb6ac08bfbed519d4f",
-   "sha256": "1z88h5g0j0mxbqh3k56bl40sydy04jsw7cnhasiyrxyk2glsfm57"
+   "commit": "be2d24545092d164be1a91031d8881afd29c9ec0",
+   "sha256": "0v8m3zkccpqd2l8m9340y672l2mm3mrry8422nva5kfvpcwdayqb"
   }
  },
  {
@@ -84150,14 +84297,14 @@
   "repo": "joaotavora/sly-named-readtables",
   "unstable": {
    "version": [
-    20190701,
-    1800
+    20191013,
+    2138
    ],
    "deps": [
     "sly"
    ],
-   "commit": "6b37ed2201174caa86a44e8ac3350dd09e91e606",
-   "sha256": "1if4ssv0s66gcz8pz55gark9imbw1pilxs1h7y094ygnjcm4m0li"
+   "commit": "a5a42674ccffa97ccd5e4e9742beaf3ea719931f",
+   "sha256": "16asd119rzqrlclps2q6yrkis8jy5an5xgzzqvb7jdyq39zxg54q"
   }
  },
  {
@@ -84168,14 +84315,14 @@
   "repo": "joaotavora/sly-quicklisp",
   "unstable": {
    "version": [
-    20190701,
-    1444
+    20191012,
+    2124
    ],
    "deps": [
     "sly"
    ],
-   "commit": "06d7281e70d71b9a37f488c8f63fd199e1fb0f97",
-   "sha256": "0ml3zshd9kkjspykiadi1nlq7mr5sjcmsvbbbcxrj2d2ki2skniv"
+   "commit": "01ebe3976a244309f2e277c09206831135a0b66c",
+   "sha256": "1vfqmvayf35g6y3ljsm3rlzv5jm50qikhh4lv2zkkswj6gkkb1cv"
   }
  },
  {
@@ -84569,15 +84716,15 @@
   "repo": "Fuco1/smartparens",
   "unstable": {
    "version": [
-    20190904,
-    1742
+    20191015,
+    1754
    ],
    "deps": [
     "cl-lib",
     "dash"
    ],
-   "commit": "12856838cf9b0e6a635a6ceb14a22fdc03b04728",
-   "sha256": "1252j96slvipjlixp9gzlsa5za7zx9a7piz661qmbv6pb812ibfr"
+   "commit": "9738360eb2afb58b4c21815f9d5c793b8125f540",
+   "sha256": "1msaggijlladdfpza4qqbdr4ylx3lla3dyjzapj0vs1cv4r30ivg"
   },
   "stable": {
    "version": [
@@ -86445,14 +86592,14 @@
   "repo": "magit/ssh-agency",
   "unstable": {
    "version": [
-    20180508,
-    26
+    20191009,
+    156
    ],
    "deps": [
     "dash"
    ],
-   "commit": "d9dbedd773ad3a831e02e162c47936d6814a850a",
-   "sha256": "0895n7bss4wdydic1gflr03f2cwdyqywl16gvb599lpn288jhwvz"
+   "commit": "89ea87dbfa0aa2fe644f7215aa3628c3008852c5",
+   "sha256": "0mkrn3jildlqyrkbdp31zf24vkzx4ycy49kxqs3vspbbcpanpj7j"
   },
   "stable": {
    "version": [
@@ -86474,11 +86621,11 @@
   "repo": "jhgorrell/ssh-config-mode-el",
   "unstable": {
    "version": [
-    20190712,
-    1840
+    20191001,
+    2041
    ],
-   "commit": "4c1dfa57d452cb5654453bf186c8ff63e1e71b56",
-   "sha256": "0crglfdazzckizbwzmgl2rn6j85avfzkr1q7ijxd17rp2anvr9bd"
+   "commit": "3d3e9af531003d5456e1a3a3b54147755f070eca",
+   "sha256": "184j4ap4yfis55r87g9rycj78zy2m6lkadbwvlha45d478n35lqh"
   }
  },
  {
@@ -86550,11 +86697,11 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20190921,
-    111
+    20191015,
+    2040
    ],
-   "commit": "80930bb4f222b8fa11b1e64ba2f2905c0d3dd228",
-   "sha256": "1sqana7wy8r7l6zy8sjv89a92qqlxn4z1zckbjk2zld68hp6q6cd"
+   "commit": "bcfa6f49ee3a0ec8a808f3b80286db192b34f6c7",
+   "sha256": "1vvyik4yx19qq5jmy3yi1547s06rm2qsdbvdw88m9pqfffp1xllr"
   },
   "stable": {
    "version": [
@@ -86574,15 +86721,15 @@
   "repo": "stan-dev/stan-mode",
   "unstable": {
    "version": [
-    20190921,
-    1827
+    20191015,
+    2040
    ],
    "deps": [
     "stan-mode",
     "yasnippet"
    ],
-   "commit": "80930bb4f222b8fa11b1e64ba2f2905c0d3dd228",
-   "sha256": "1sqana7wy8r7l6zy8sjv89a92qqlxn4z1zckbjk2zld68hp6q6cd"
+   "commit": "bcfa6f49ee3a0ec8a808f3b80286db192b34f6c7",
+   "sha256": "1vvyik4yx19qq5jmy3yi1547s06rm2qsdbvdw88m9pqfffp1xllr"
   },
   "stable": {
    "version": [
@@ -86753,16 +86900,16 @@
     20171130,
     1559
    ],
-   "commit": "43559408e8340e8fac588c5711c40f7cdca48f96",
-   "sha256": "1w576zzb0dzffn59bxf14z32vy7rmdj4k8ms2dy7qn4vhmyr38jx"
+   "commit": "8fc2c5cd1d7d74e59a35699d12907d5d7efac190",
+   "sha256": "110dgbkqn0x1cw99n6z6llc8547ly7zvp9659d13qhiswbifs8vz"
   },
   "stable": {
    "version": [
     0,
-    19
+    20
    ],
-   "commit": "d86a0c1ffd8db519a1e8d56b3d972fdd8a7f4818",
-   "sha256": "1dzl6cnyzwbzysp82x7w1yc03g25kwan3h0zpnzhhfhg6c904sis"
+   "commit": "4f2670ed6da97b731a51e57a01cab581d1b9c52e",
+   "sha256": "17zmxhj5qzhsnaj796szpdsl30v9cfxkvds0vx2hav9f4ix0pl1s"
   }
  },
  {
@@ -87242,11 +87389,11 @@
   "repo": "zevlg/sudoku.el",
   "unstable": {
    "version": [
-    20161111,
-    706
+    20191015,
+    1315
    ],
-   "commit": "77c11b5041b58fc943cf1668b44b40bae039cb5b",
-   "sha256": "18nbs980y6cj6my208i80cb928rnkk5rn3zwc63prk5whjw4y77v"
+   "commit": "b1924fd244a5fa284de9d67b66fbd69164b37318",
+   "sha256": "19i3rrz4qnc9i845j0bbmps69372rry7gadcyj06gvq2hf9dy3nh"
   }
  },
  {
@@ -87598,16 +87745,16 @@
   "repo": "danielmartin/swift-helpful",
   "unstable": {
    "version": [
-    20190923,
-    1022
+    20191013,
+    1658
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "swift-mode"
    ],
-   "commit": "5d07fa0d574a3ef58dfb0341da118e37c86bf6c5",
-   "sha256": "1jf4544jzn75vkxhxaj3xk3284nz94ik1gxk6b5hzy0r643ccklw"
+   "commit": "5b5eee7122803ca405bc68b67d967a1757d4404c",
+   "sha256": "1vz1dd3w978b3k2ix3vjgz8i2xaxqf24qc5cwhar7n1jwjrzgqig"
   }
  },
  {
@@ -87618,14 +87765,14 @@
   "repo": "swift-emacs/swift-mode",
   "unstable": {
    "version": [
-    20190609,
-    507
+    20191013,
+    1451
    ],
    "deps": [
     "seq"
    ],
-   "commit": "be8d7700cdbf47576d7c4e0a7e0855cce0fe9ad8",
-   "sha256": "020jd4byxm8yh651symcs0v8zwrbm7cn9mn5ampjfwf1k43bq1bj"
+   "commit": "b260308e922bd0361779f66a2e5bc1ef0aae4d30",
+   "sha256": "00qabygq71fpnrwrkbgkz5c33b82ni3sxs77nihd00ia2m1524i5"
   },
   "stable": {
    "version": [
@@ -87702,26 +87849,26 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20190822,
-    1708
+    20191021,
+    1015
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "79333e9edfee38ec3b367c33711a68bdf7783259",
-   "sha256": "0dyclc51sprhmr5fi4lylhwsrn8v1jgyblwk9ly60jj84lj6278z"
+   "commit": "3b35b458e138e7e7a51de7d9e0a1ac70b9f54780",
+   "sha256": "15hm9mrcngwk2vw65bxrhnl4dqi8xgi2gfpnj40npswsh868maw9"
   },
   "stable": {
    "version": [
     0,
-    12,
+    13,
     0
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "85d1e2e779ca92e6ef8e47d08f866b13d4d87aee",
-   "sha256": "0xgngn3jhmyn6mlkk9kmgfgh0w5i50b27syr4cgfgarg6p77j05w"
+   "commit": "cd634c6f51458f81898ecf2821ac3169cb65a1eb",
+   "sha256": "0ghcwrg8a6r5q6fw2x8s08cwlmnz2d8qjhisnjwbnc2l4cgqpd9p"
   }
  },
  {
@@ -87940,8 +88087,8 @@
   "repo": "countvajhula/symex.el",
   "unstable": {
    "version": [
-    20190810,
-    432
+    20191010,
+    1915
    ],
    "deps": [
     "cider",
@@ -87958,8 +88105,8 @@
     "slime",
     "smartparens"
    ],
-   "commit": "745dc44bc1569a05ade034981277ee5955677798",
-   "sha256": "0c1sibigy0kvhizxg2198k9kqgb57cmcjx7l0jmar2cgnmndbrgj"
+   "commit": "955c160af27c585d339dee8dd8eda394b253d3cc",
+   "sha256": "1h0n9f19g7i0dw2pz7mrq9frfp5vjb9kzxs2cksk4n37h7pam3kl"
   },
   "stable": {
    "version": [
@@ -88608,11 +88755,11 @@
   "repo": "saf-dmitry/taskpaper-mode",
   "unstable": {
    "version": [
-    20190919,
-    727
+    20191009,
+    1506
    ],
-   "commit": "c95fb2375b0c8d448a347241eb95f160e6880e99",
-   "sha256": "18qdnjxr4p4a2ds4k7sk5kkykyxcfri8zws3bhisfz1kayad1wlg"
+   "commit": "fa0a5e0c4d36a6f007fc3932f7067fb09ba41de8",
+   "sha256": "1346r8r3m4kpmh90bgdxz7h1d0l7lna64xn7lh6788yfm8rl6sdj"
   },
   "stable": {
    "version": [
@@ -88656,8 +88803,8 @@
    "deps": [
     "cider"
    ],
-   "commit": "217ca22fdff89a2bbe23d67afd43c06f928de826",
-   "sha256": "0w16icw1g1naaasvnjaggjvqyfbbwmc4xlw928dnqyfyys2a4j60"
+   "commit": "e704c2cb737db5481a6b085d82b1fb81e9b0fbac",
+   "sha256": "0hn2i7c6msr8i6b6p578qbdikslap41b5adjrmdra591pmia2cqq"
   },
   "stable": {
    "version": [
@@ -88808,14 +88955,14 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20190925,
-    1406
+    20191023,
+    1255
    ],
    "deps": [
     "visual-fill-column"
    ],
-   "commit": "cfb9a581b0832266386f3a6229d3e4f944168652",
-   "sha256": "1s0zg7a737vsd1yxwnlxgh7w19i9w52scm1402fsil3i8sgznr1f"
+   "commit": "045188580c1e161ea0c14e6d4583a661fa534bae",
+   "sha256": "0hkw8dv0xaj9aa6qnnq56ssggaw8fp9yk5d2r6i5fm23g1cgapd0"
   },
   "stable": {
    "version": [
@@ -89260,21 +89407,21 @@
     "cl-lib",
     "json"
    ],
-   "commit": "556f5559255518865456af0b228f86bfabd43e6b",
-   "sha256": "1dvdd4vzdfkgb9blc6f5402kknp3ppxjyd94cn696rlfrya58vmm"
+   "commit": "9353d89f568a7e8c1e8e4191f764f435a63f0df2",
+   "sha256": "0bibcdbjyfskwj28dk2krnvslb5pnqv5q1clgnwimpmyd6ijm9bj"
   },
   "stable": {
    "version": [
     0,
     24,
-    0
+    2
    ],
    "deps": [
     "cl-lib",
     "json"
    ],
-   "commit": "4ba411719279c62d9c0acd1243a03477ada1ac32",
-   "sha256": "1af614di6yb91ychi56i788n1qh3nsc2a8i8jyz1ram122dbf0jj"
+   "commit": "729307d17c08c9f2baf1925a51b7f36d8f035e01",
+   "sha256": "09ziq6l63418z307bcfnyjcbir9vv93qnaapkk65shi6pyj47z30"
   }
  },
  {
@@ -89293,22 +89440,22 @@
     "cl-lib",
     "tern"
    ],
-   "commit": "556f5559255518865456af0b228f86bfabd43e6b",
-   "sha256": "1dvdd4vzdfkgb9blc6f5402kknp3ppxjyd94cn696rlfrya58vmm"
+   "commit": "9353d89f568a7e8c1e8e4191f764f435a63f0df2",
+   "sha256": "0bibcdbjyfskwj28dk2krnvslb5pnqv5q1clgnwimpmyd6ijm9bj"
   },
   "stable": {
    "version": [
     0,
     24,
-    0
+    2
    ],
    "deps": [
     "auto-complete",
     "cl-lib",
     "tern"
    ],
-   "commit": "4ba411719279c62d9c0acd1243a03477ada1ac32",
-   "sha256": "1af614di6yb91ychi56i788n1qh3nsc2a8i8jyz1ram122dbf0jj"
+   "commit": "729307d17c08c9f2baf1925a51b7f36d8f035e01",
+   "sha256": "09ziq6l63418z307bcfnyjcbir9vv93qnaapkk65shi6pyj47z30"
   }
  },
  {
@@ -89818,18 +89965,18 @@
     20180905,
     1050
    ],
-   "commit": "ba36b4665dff17fa3996c114be56c1d0673aca4e",
-   "sha256": "070nd0dxz1gcw3dsf913gs5p8p7xm83l0g52hpq2cg9max5xr07n"
+   "commit": "b0959ec2f99299f1643d9a0cbb5b64d10bbf7629",
+   "sha256": "1p4rs7lc4sldrkffn0z8k5cvv10lfdgs0a81sjgc9qicr31hb9mz"
   },
   "stable": {
    "version": [
     2019,
-    9,
-    23,
+    10,
+    21,
     0
    ],
-   "commit": "2f9839604e2569120cc4876c667388da6d7342f2",
-   "sha256": "13sma0vbm5g90sa8yxw03rna1kx0nv7zimm8nnw13k1swv0zm21l"
+   "commit": "a62d2e395a8ff3dac6400d089064966f84c15b52",
+   "sha256": "19svp3qk6yn3zspv6b8a7j9mfm1y80xfvqyy2jgs0yckl8i03iyn"
   }
  },
  {
@@ -89879,14 +90026,14 @@
   "repo": "tidalcycles/Tidal",
   "unstable": {
    "version": [
-    20190320,
-    2158
+    20191018,
+    2235
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "6c25387d6ba088258c6ae2fe0079936395ff8f8d",
-   "sha256": "1bnva874xw3i8qqh4w1jy16jhmxv3b3n86dsvzcrpmq4nk09m5lh"
+   "commit": "47e2072676bc9fb0e95db172f7f0ad6115de4163",
+   "sha256": "1bixpx0q4f4k1lmxf325qj4lbdsxhf2gali4sqppyqjghg6qda63"
   },
   "stable": {
    "version": [
@@ -89909,8 +90056,8 @@
   "repo": "ananthakumaran/tide",
   "unstable": {
    "version": [
-    20190829,
-    1315
+    20191004,
+    1231
    ],
    "deps": [
     "cl-lib",
@@ -89919,8 +90066,8 @@
     "s",
     "typescript-mode"
    ],
-   "commit": "13f64933c19590ebd02a4b141bb6be88d7aaf2b0",
-   "sha256": "19kl8r426hi93q1nj5mwadx6wiymx0f77db4w51jcf5kp0rr2hs0"
+   "commit": "b8ce1d8c224cf72ccc3491787a1222be63603127",
+   "sha256": "1q4g8w4p43zbblbwf5fsbk0p2ccy3v5yf139b4ivfkkjy7x8aq9g"
   },
   "stable": {
    "version": [
@@ -90024,16 +90171,16 @@
   "repo": "tmarble/timesheet.el",
   "unstable": {
    "version": [
-    20180802,
-    202
+    20191024,
+    151
    ],
    "deps": [
     "auctex",
     "org",
     "s"
    ],
-   "commit": "67ca6a9f6733052066b438301fb2dd81b8b3f6eb",
-   "sha256": "0rmh8lik27pmq95858jbjzgvf6rsfdnpynwcagj1fgkval5kzdbs"
+   "commit": "5098dc87d3d4f289b6c1b6532070dacbfe6de9fd",
+   "sha256": "0wqxlb4a7fzf14629zw021216qyzz56xwr8hfh2fy6kj90m9br4c"
   },
   "stable": {
    "version": [
@@ -90215,14 +90362,14 @@
   "repo": "kuanyui/tldr.el",
   "unstable": {
    "version": [
-    20190425,
-    749
+    20191006,
+    1059
    ],
    "deps": [
     "request"
    ],
-   "commit": "2ff0834bc58590f98bfece3efc5656d1b47c325d",
-   "sha256": "1qwx4hmqj6fbpmv230kgdv2qwv5jfmbf5kvdhcq48p4rak1r30qj"
+   "commit": "b7f3e3e2171eab5707a42641f4470b69777feaea",
+   "sha256": "0gy5vjffw0bqvhv0gsc654imvridmc7pg88b3nwlfxkrwzi48vxc"
   }
  },
  {
@@ -90291,16 +90438,16 @@
   "repo": "abrochard/emacs-todoist",
   "unstable": {
    "version": [
-    20190925,
-    39
+    20191014,
+    2033
    ],
    "deps": [
     "dash",
     "org",
     "transient"
    ],
-   "commit": "9c6b4e6abcd53d323a992181d6b5ac72cc370c72",
-   "sha256": "178wb528lpf5phcw2nqpmb83k86by59kfmp4qhwixgagnwzz89r5"
+   "commit": "5543b75581a559f29f35f2577a304e0f15f87100",
+   "sha256": "0w8d53njk81smdk7vm6mxdrrg1310cyxapjbylv2a51d442hrf5g"
   }
  },
  {
@@ -90326,11 +90473,11 @@
   "repo": "avillafiorita/todotxt-mode",
   "unstable": {
    "version": [
-    20150424,
-    1404
+    20191017,
+    1319
    ],
-   "commit": "dc6ae151edee88f329ba7abc5d39b7440002232f",
-   "sha256": "1k9ywi7cdgb6i600wr04r2l00423l6vr7k93qa7i7svv856nbbc7"
+   "commit": "ec94ac719e2f879c474d29e21dc84353b20258d7",
+   "sha256": "0x5syh0gvkqn3d32baf1r8xnqrpyzy5ywa9vwdbcjrkqfnnap8zb"
   }
  },
  {
@@ -90584,17 +90731,26 @@
  },
  {
   "ename": "toxi-theme",
-  "commit": "5b7972602399f9df9139cff177e38653bb0f43ed",
-  "sha256": "032m3qbxfd0qp81qwayd5g9k7vz55g4yhw0d35qkxzf4qf58x9sd",
-  "fetcher": "bitbucket",
+  "commit": "2e57d7abe1e43101558b27b0995f54f74a620b33",
+  "sha256": "1dyr8mp5p6j4c949dbzi4fqy86ay84yr3822ab8qx25hck1kdrhj",
+  "fetcher": "github",
   "repo": "postspectacular/toxi-theme",
   "unstable": {
    "version": [
     20160424,
     2126
    ],
-   "commit": "b322fc7497a53f102e74f7994da96f2974171c9b",
+   "commit": "90c8828b91025adf5adc96011a35d25682991b8a",
    "sha256": "1pnsky541m8kzcv81w98jkv0hgajh04hxqlmgddc1y0wbvi849j0"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    2
+   ],
+   "commit": "9e572c6e149249b96f64722cf6f86c3aaf5f2ede",
+   "sha256": "0fn8ivq9i48w26c09963chc5v8gnvz0nxgqzzvkk4b7qki1rav2j"
   }
  },
  {
@@ -90665,8 +90821,8 @@
     20171210,
     2102
    ],
-   "commit": "6ccd4b494cbae9d28091217654f052eaea321007",
-   "sha256": "0cr9flk310yn2jgvj4hbqw9nj5wlfi0fazdkqafzidgz6iq150wd"
+   "commit": "e4af7143bd32907d0bf922bee53a96399f0376fa",
+   "sha256": "1ccxin0vp3z8lxcfm9bci06jkwy0nwasdwg95wp9hdnccpr63s38"
   },
   "stable": {
    "version": [
@@ -90751,14 +90907,14 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20190905,
-    1138
+    20191017,
+    1115
    ],
    "deps": [
     "dash"
    ],
-   "commit": "7bf97594a5ec1b9a682ef5a1537a6b0ecc6d9dfb",
-   "sha256": "08crxnha8rwkv0npdb624v3xxy50bcb0s8pwm1vvz7ahpzyp7gza"
+   "commit": "ad7f2553088faf633d32b51894de796e01a1cacf",
+   "sha256": "16ab68jf98hhy061i41271kdgm8mnmvj62j8y9hmjp7wsw3yzxdr"
   },
   "stable": {
    "version": [
@@ -90893,8 +91049,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20190922,
-    1026
+    20191013,
+    1020
    ],
    "deps": [
     "ace-window",
@@ -90906,8 +91062,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "6a0b1fce801bf0791bc3eee7b0dc4bbbcf95e6a7",
-   "sha256": "16axm791cg49mi61wrqdj5mcadh59zvmslmkfb1bwai5v43br8nc"
+   "commit": "6fb45a351b6d888fda44d5fc86b330b3ea54338f",
+   "sha256": "0ks80b9331p81w9sp1dcq2crb0xgdamy6i5hka2slwm01qharg1j"
   },
   "stable": {
    "version": [
@@ -90936,15 +91092,15 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20190619,
-    1516
+    20190927,
+    542
    ],
    "deps": [
     "evil",
     "treemacs"
    ],
-   "commit": "6a0b1fce801bf0791bc3eee7b0dc4bbbcf95e6a7",
-   "sha256": "16axm791cg49mi61wrqdj5mcadh59zvmslmkfb1bwai5v43br8nc"
+   "commit": "6fb45a351b6d888fda44d5fc86b330b3ea54338f",
+   "sha256": "0ks80b9331p81w9sp1dcq2crb0xgdamy6i5hka2slwm01qharg1j"
   },
   "stable": {
    "version": [
@@ -90974,8 +91130,8 @@
     "cl-lib",
     "treemacs"
    ],
-   "commit": "6a0b1fce801bf0791bc3eee7b0dc4bbbcf95e6a7",
-   "sha256": "16axm791cg49mi61wrqdj5mcadh59zvmslmkfb1bwai5v43br8nc"
+   "commit": "6fb45a351b6d888fda44d5fc86b330b3ea54338f",
+   "sha256": "0ks80b9331p81w9sp1dcq2crb0xgdamy6i5hka2slwm01qharg1j"
   },
   "stable": {
    "version": [
@@ -91006,8 +91162,8 @@
     "pfuture",
     "treemacs"
    ],
-   "commit": "6a0b1fce801bf0791bc3eee7b0dc4bbbcf95e6a7",
-   "sha256": "16axm791cg49mi61wrqdj5mcadh59zvmslmkfb1bwai5v43br8nc"
+   "commit": "6fb45a351b6d888fda44d5fc86b330b3ea54338f",
+   "sha256": "0ks80b9331p81w9sp1dcq2crb0xgdamy6i5hka2slwm01qharg1j"
   },
   "stable": {
    "version": [
@@ -91038,8 +91194,8 @@
     "projectile",
     "treemacs"
    ],
-   "commit": "6a0b1fce801bf0791bc3eee7b0dc4bbbcf95e6a7",
-   "sha256": "16axm791cg49mi61wrqdj5mcadh59zvmslmkfb1bwai5v43br8nc"
+   "commit": "6fb45a351b6d888fda44d5fc86b330b3ea54338f",
+   "sha256": "0ks80b9331p81w9sp1dcq2crb0xgdamy6i5hka2slwm01qharg1j"
   },
   "stable": {
    "version": [
@@ -91130,11 +91286,11 @@
   "repo": "kawabata/emacs-trr",
   "unstable": {
    "version": [
-    20170221,
-    842
+    20191019,
+    1403
    ],
-   "commit": "83660d8343ef3367837354dc684dfdde2f95826a",
-   "sha256": "0h12szq1cww3bpsk09m7d2bk9bfjxrmzlw9ccviwhnric40nh67k"
+   "commit": "f841173e11213ac6916b2d3394b28fb202543871",
+   "sha256": "1s1rh1kz0r8cnsbjjsd61lz7wzf8kzhvbqimhglryckzjsn9jfmf"
   },
   "stable": {
    "version": [
@@ -91208,27 +91364,27 @@
   "repo": "alphapapa/ts.el",
   "unstable": {
    "version": [
-    20190918,
-    241
+    20191010,
+    210
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "395649a2f2ba79028331bb1fa9ec08b218950ff6",
-   "sha256": "02603wv66fplsigxd87jy23hrb5g9vigszcpdqrdv0ypaqaxlr3a"
+   "commit": "540f6a5adab5d881cc5f50835c0a3fe70e74b992",
+   "sha256": "0hmzc1ppnkkr0lfq5fhzqr6icv6iqz824a6bnns7zr466hhqp3qb"
   },
   "stable": {
    "version": [
     0,
-    1
+    2
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "abf67b63ca562cb2304dfe445f67ed6c6f7c3c05",
-   "sha256": "1i93dfm6lw63q1r2fnk5yn95pifvpkfy654yg8mfczss1mz00q35"
+   "commit": "540f6a5adab5d881cc5f50835c0a3fe70e74b992",
+   "sha256": "0hmzc1ppnkkr0lfq5fhzqr6icv6iqz824a6bnns7zr466hhqp3qb"
   }
  },
  {
@@ -91370,16 +91526,16 @@
   "repo": "gcr/tumblesocks",
   "unstable": {
    "version": [
-    20140215,
-    2047
+    20191014,
+    356
    ],
    "deps": [
     "htmlize",
     "markdown-mode",
     "oauth"
    ],
-   "commit": "85a6cdc2db3390593fd886c474959b675460b310",
-   "sha256": "1g7y7czan7mcs5lwc5r6cllgksrj3b9lpn1bj7khwkd1ll391jc2"
+   "commit": "0e4c3847e31a59d405b9927107a23dde9531d744",
+   "sha256": "1gns60yj1ylm87456gzwr0gy0kivp5bd290rg6d8xbc86jdcls19"
   }
  },
  {
@@ -91565,11 +91721,11 @@
   "repo": "emacs-typescript/typescript.el",
   "unstable": {
    "version": [
-    20190918,
-    1042
+    20191006,
+    2134
    ],
-   "commit": "2405090403e2907d7751770bab4a40865ef043ff",
-   "sha256": "0lsn4p08ka1jpjcb436bbcdk1cnj09ld8x1cdh67m23hcclbssi1"
+   "commit": "42b366e669385515fe44967f2676787e7dfd654f",
+   "sha256": "1nmc3x2y9nbj942i7w7ch91q497cdw34pd52iqm82i547scajr0h"
   },
   "stable": {
    "version": [
@@ -91888,11 +92044,11 @@
   "repo": "jackkamm/undo-propose-el",
   "unstable": {
    "version": [
-    20190921,
-    1533
+    20191005,
+    512
    ],
-   "commit": "505d79053590a411be6d84e1bcd4ce13485e96f0",
-   "sha256": "1kvpwcry6q28cw0xrzmss0d05kzn1ay4y2c55k3sb2157izxvafn"
+   "commit": "f80baee566807d733fbacbab08a897bcd62579c3",
+   "sha256": "00rqz63bhh66q78l646q3w16gydygj8h4d8np0dpbifgzciak90b"
   }
  },
  {
@@ -91924,8 +92080,8 @@
     20170723,
     146
    ],
-   "commit": "df0c4dee19a3874b11c7c7f04e8a2fba629fda9b",
-   "sha256": "0bdlr8kqzwzi7aggcn7cwwih19585wi6dd9lvwj4i966zr4w84yx"
+   "commit": "e03771f2d1163d04ca75de76fbfbaa2689c6a9aa",
+   "sha256": "148znb55dbh1hzl9gclg858varx0lwbc5f8d31jladj5yf5pffp1"
   },
   "stable": {
    "version": [
@@ -92584,10 +92740,10 @@
  },
  {
   "ename": "use-ttf",
-  "commit": "ec27ae185c0308c445e461dc84f398483ca08c5a",
-  "sha256": "0gxrn05qcnf54c5895nw68088b9mngsf7sij2prwyfw0ghdl9s8k",
+  "commit": "6c2287c7b4c543e92ccfab120388b2c05174d2db",
+  "sha256": "18ry06d6llq86k5awd23jj0qb68k459dc2i5hqrmpjykqzq6bvya",
   "fetcher": "github",
-  "repo": "elpa-host/use-ttf",
+  "repo": "jcs-elpa/use-ttf",
   "unstable": {
    "version": [
     20190823,
@@ -92903,19 +93059,20 @@
   "repo": "muffinmad/emacs-vc-hgcmd",
   "unstable": {
    "version": [
-    20190910,
-    2008
+    20191010,
+    1129
    ],
-   "commit": "1515cd8cca0b749da482fa1af6e0576da98aa1ac",
-   "sha256": "19x2vdij1sd18g9gcx0vd9qyn37nq1p9dmyyskqlzqlbzxvhg0nm"
+   "commit": "0b052a6e38b58a123ab48001473dab1df2eaa4c6",
+   "sha256": "0jc6vjbb43mvy5p2slgb0z0isavwbinqxiacawqprnw9jn218l92"
   },
   "stable": {
    "version": [
     1,
-    8
+    8,
+    1
    ],
-   "commit": "1515cd8cca0b749da482fa1af6e0576da98aa1ac",
-   "sha256": "19x2vdij1sd18g9gcx0vd9qyn37nq1p9dmyyskqlzqlbzxvhg0nm"
+   "commit": "0b052a6e38b58a123ab48001473dab1df2eaa4c6",
+   "sha256": "0jc6vjbb43mvy5p2slgb0z0isavwbinqxiacawqprnw9jn218l92"
   }
  },
  {
@@ -92995,20 +93152,21 @@
   "repo": "stepnem/vcsh-el",
   "unstable": {
    "version": [
-    20190817,
-    2011
+    20191007,
+    1102
    ],
-   "commit": "2051e4ee20709f82ab2396ab2ccfbe887a3c6a67",
-   "sha256": "168rhydrz7h7bhaf885j4lqxz5x50is7gsypj0vypi6xv71zhd03"
+   "commit": "cbb2b387ea035ee4f95455964144d699f573491d",
+   "sha256": "0apqrhdv0mrv52ws4yyd9q3fd5hrp084nvq5ji9gva8rs2qyki2v"
   },
   "stable": {
    "version": [
     0,
     4,
+    2,
     1
    ],
-   "commit": "2051e4ee20709f82ab2396ab2ccfbe887a3c6a67",
-   "sha256": "168rhydrz7h7bhaf885j4lqxz5x50is7gsypj0vypi6xv71zhd03"
+   "commit": "cbb2b387ea035ee4f95455964144d699f573491d",
+   "sha256": "0apqrhdv0mrv52ws4yyd9q3fd5hrp084nvq5ji9gva8rs2qyki2v"
   }
  },
  {
@@ -93279,14 +93437,14 @@
   "repo": "baron42bba/vertica-snippets",
   "unstable": {
    "version": [
-    20190828,
-    1121
+    20191007,
+    1546
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "4869b7da62799e846b17258f6828dee016a991f4",
-   "sha256": "1phhrkk0yyxq4nlrcwad4dvspg6rwda5lzsmch2w64nr5v4ppvl7"
+   "commit": "5750f359de2956f853b131c46cf56726a5a5dfd3",
+   "sha256": "0yhcv006lrd2c8a3q3iganp7zdlacdafjzg97q3q48ihb864bx7p"
   }
  },
  {
@@ -93341,16 +93499,16 @@
   "repo": "csantosb/vhdl-tools",
   "unstable": {
    "version": [
-    20190809,
-    922
+    20190929,
+    1532
    ],
    "deps": [
     "ggtags",
     "helm-rg",
     "outshine"
    ],
-   "commit": "5202db4c6a511a90a950a723293d11d55ec05264",
-   "sha256": "1ygx8g9cxyyhhpcqan1ca4g741s3dd141bcmp6jjqbjfn2gqraz6"
+   "commit": "9cf9ae509afb79c5579f645907387b8253db167a",
+   "sha256": "0s1pw0a6ykny4r4wvq7867aqkx5rkvlbh3s8jxd8ycpjz9j419dj"
   },
   "stable": {
    "version": [
@@ -93703,11 +93861,11 @@
   "repo": "blak3mill3r/vmd-mode",
   "unstable": {
    "version": [
-    20180223,
-    1356
+    20190929,
+    735
    ],
-   "commit": "24e38a20951dfad6e3e985c7cc6286c1e271da5f",
-   "sha256": "00anpbnf0h6iikhpqz4mss507j41xwvv27svw41kpgcwsnrmrqwm"
+   "commit": "aa9b753601ee1ed31b4f717629179ce7a2cacba5",
+   "sha256": "0gc1c5q1krqlbaq0lb7p29biwpl32lgv4c6527c322a21in6a5pb"
   }
  },
  {
@@ -93798,11 +93956,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20190822,
-    1225
+    20191024,
+    1346
    ],
-   "commit": "097d9806ffab9120f078bea22e9b49502807786b",
-   "sha256": "0x402pq4kq8agzbq1imxg3qm2v6agq2ni1x2a6yqrvwy5vq72qxs"
+   "commit": "48b797a183ab83a2a87747474bb1f06177cbce6a",
+   "sha256": "1lyqmg15s8csndn8rqjrdpqhzs7p415ai3h1p42bxid02vlzibbz"
   }
  },
  {
@@ -93926,11 +94084,15 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20190925,
-    2344
+    20191002,
+    427
    ],
-   "commit": "f5abefa599e63a769b08debf1aa8f13e77a2b1b4",
-   "sha256": "0kr136ya51iw5nv72jrkk2wn6m2zr86b19b93i1pplhvq465a9bm"
+   "commit": "361297e8539770f2f396d30928ebc01de60ca637",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "warning: unable to download 'https://github.com/emacs-w3m/emacs-w3m/archive/361297e8539770f2f396d30928ebc01de60ca637.tar.gz': Couldn't connect to server (7); retrying in 309 ms\nwarning: unable to download 'https://github.com/emacs-w3m/emacs-w3m/archive/361297e8539770f2f396d30928ebc01de60ca637.tar.gz': Couldn't connect to server (7); retrying in 621 ms\nwarning: unable to download 'https://github.com/emacs-w3m/emacs-w3m/archive/361297e8539770f2f396d30928ebc01de60ca637.tar.gz': Couldn't connect to server (7); retrying in 1253 ms\nwarning: unable to download 'https://github.com/emacs-w3m/emacs-w3m/archive/361297e8539770f2f396d30928ebc01de60ca637.tar.gz': Couldn't connect to server (7); retrying in 2533 ms\nerror: unable to download 'https://github.com/emacs-w3m/emacs-w3m/archive/361297e8539770f2f396d30928ebc01de60ca637.tar.gz': Couldn't connect to server (7)\n"
+   ]
   }
  },
  {
@@ -94523,14 +94685,18 @@
   "repo": "ahyatt/emacs-websocket",
   "unstable": {
    "version": [
-    20190621,
-    54
+    20191017,
+    30
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d91a9aef5a3ec5af985e5185c3b237fdd24605e0",
-   "sha256": "0b7kblpsh0m6azqbbvx0fzvwmyamxb25rqk5d1kyy5pizm5kg139"
+   "commit": "5be01c6d1a8e87d001916fc40a77d779826fcacf",
+   "error": [
+    "exited abnormally with code 1\n",
+    "",
+    "warning: unable to download 'https://github.com/ahyatt/emacs-websocket/archive/5be01c6d1a8e87d001916fc40a77d779826fcacf.tar.gz': Couldn't connect to server (7); retrying in 279 ms\nwarning: unable to download 'https://github.com/ahyatt/emacs-websocket/archive/5be01c6d1a8e87d001916fc40a77d779826fcacf.tar.gz': Couldn't connect to server (7); retrying in 627 ms\nwarning: unable to download 'https://github.com/ahyatt/emacs-websocket/archive/5be01c6d1a8e87d001916fc40a77d779826fcacf.tar.gz': Couldn't connect to server (7); retrying in 1283 ms\nwarning: unable to download 'https://github.com/ahyatt/emacs-websocket/archive/5be01c6d1a8e87d001916fc40a77d779826fcacf.tar.gz': Couldn't connect to server (7); retrying in 2591 ms\nerror: unable to download 'https://github.com/ahyatt/emacs-websocket/archive/5be01c6d1a8e87d001916fc40a77d779826fcacf.tar.gz': Couldn't connect to server (7)\n"
+   ]
   },
   "stable": {
    "version": [
@@ -95476,14 +95642,14 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20190715,
-    2007
+    20191008,
+    2002
    ],
    "deps": [
     "async"
    ],
-   "commit": "45c29f9bfb7f2df93426ce1571e2f4f41ed4e492",
-   "sha256": "0n91y0m7m382j7dfcqhcfzngb84a41x6diy6lx4l87b48srhcpzc"
+   "commit": "19ebf53f44532b5c31aaa5b6870fbc567e6889a4",
+   "sha256": "08qqj687vj2ghh4ph56qy6b8czbybyf69kq6whzw8mbqync6qzw6"
   },
   "stable": {
    "version": [
@@ -95780,8 +95946,8 @@
   "repo": "abo-abo/worf",
   "unstable": {
    "version": [
-    20190519,
-    1648
+    20190930,
+    1027
    ],
    "deps": [
     "ace-link",
@@ -95789,8 +95955,8 @@
     "swiper",
     "zoutline"
    ],
-   "commit": "00d191b347397bd7ad1f5b95cfe39fa3fce9fc91",
-   "sha256": "0mp5f6hp8pqckfsi4bxcg09kcfndvsbc2nnqbgdw87bidwlzhzmy"
+   "commit": "69790b0405e794c4507882fa944d6dafdcca84d8",
+   "sha256": "1iklq4k3b61ivf1as992mvy27x0b9f71h813r2n06m27p2fmx2br"
   },
   "stable": {
    "version": [
@@ -96079,20 +96245,20 @@
   "repo": "redguardtoo/wucuo",
   "unstable": {
    "version": [
-    20181106,
-    2257
+    20191016,
+    2324
    ],
-   "commit": "4e988c101fe82f2e8c7b3710d15982fe28b8d32d",
-   "sha256": "0g558miz9f4g8jlq532fs9yxj3il62zajgcjfndall2853hn54af"
+   "commit": "2483a797763a9839a5dc942906e65f574dadd502",
+   "sha256": "1y1wprcdbm5iwz7496pbcdq3hbsrf4hfqkplpyminj94f4ac3pcy"
   },
   "stable": {
    "version": [
     0,
     0,
-    4
+    5
    ],
-   "commit": "4e988c101fe82f2e8c7b3710d15982fe28b8d32d",
-   "sha256": "0g558miz9f4g8jlq532fs9yxj3il62zajgcjfndall2853hn54af"
+   "commit": "2483a797763a9839a5dc942906e65f574dadd502",
+   "sha256": "1y1wprcdbm5iwz7496pbcdq3hbsrf4hfqkplpyminj94f4ac3pcy"
   }
  },
  {
@@ -96678,14 +96844,14 @@
   "repo": "atomontage/xterm-color",
   "unstable": {
    "version": [
-    20190816,
-    941
+    20191002,
+    2158
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "44e6df835bd4173ee4ccc7e29842e9dae76f2668",
-   "sha256": "0i9ivc5xhl5y5v0l18kbhfg8s2abb9zaimyx951b8bc0f5as68xm"
+   "commit": "12296bb1f0166a81b7e602493ed81e04d3381989",
+   "sha256": "1vab02yjcycvzkyzxpks048mmda89ssvb9bghigw1h20c7zk9x5j"
   },
   "stable": {
    "version": [
@@ -96858,8 +97024,8 @@
     20171022,
     1412
    ],
-   "commit": "785c36f6a19c011718f45d359609ada6da8bb5f0",
-   "sha256": "1nvlrrb1iyy6ll85kr8bls1l2pfs6rlnzlj122hmv3916d434iya"
+   "commit": "7cea3314ad9f1f00543afb578c97e45acbfc3fa7",
+   "sha256": "1mh0imhk9n6as7rz959r3wak0ivg8cyxpqk0bkx67gc7p6l573zy"
   }
  },
  {
@@ -97145,14 +97311,14 @@
   "repo": "joaotavora/yasnippet",
   "unstable": {
    "version": [
-    20190724,
-    1204
+    20191009,
+    216
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d91dd66f2aed9bbaef32813a68b105ea77e83890",
-   "sha256": "157ja4fki83dzab2ysd74dmbv83xsrccq59x6d8ilby9fzkizybr"
+   "commit": "a66f15e6c975a4370877df272c1ae87490835d28",
+   "sha256": "0ypjl44fr36n4xj3sx51v4z4arslfqdqfqyhmi9dmd3nm5fqr6f7"
   },
   "stable": {
    "version": [
@@ -97193,25 +97359,25 @@
   "repo": "AndreaCrotti/yasnippet-snippets",
   "unstable": {
    "version": [
-    20190925,
-    846
+    20191010,
+    1106
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "221f2c340af36afb4af2edc2cee92568bb3aba6c",
-   "sha256": "0wj97n79qlpkqdg9g5wxh25x6y0dzkclsvsi6j1dp0c5p1n9nylg"
+   "commit": "a34020042ccc1fdf8b30910dfb937462f4349db6",
+   "sha256": "1a2ikwkih1hjmjlvpjffbbnkvdsgpk70v4gjlb0ph14169sja6x4"
   },
   "stable": {
    "version": [
     0,
-    15
+    16
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "221f2c340af36afb4af2edc2cee92568bb3aba6c",
-   "sha256": "0wj97n79qlpkqdg9g5wxh25x6y0dzkclsvsi6j1dp0c5p1n9nylg"
+   "commit": "c5ddec3a3c0ab2eb045e54709f6852467a90d4c3",
+   "sha256": "0k60ll62daszn6pbhldcdngp548kxx2vyrd6j8awzfwi97cjbi8a"
   }
  },
  {
@@ -97251,11 +97417,11 @@
   "url": "https://www.yatex.org/hgrepos/yatex",
   "unstable": {
    "version": [
-    20190911,
-    27
+    20191005,
+    346
    ],
-   "commit": "9e07513fc2efd1e60e00bff1832ca77ec644166c",
-   "sha256": "0bs1kizsn2cp26ssj84pk1xqabrvc5kpl4689sjxc4vihfayzd5l"
+   "commit": "80692d8b8828a36ad44e8fe6b8d2c1d423898e05",
+   "sha256": "1zk5s5w2b4w78ah99j048nskailb1c00h2lm0m8ddvrmxgjl8nwv"
   }
  },
  {
@@ -97575,11 +97741,11 @@
   "repo": "bbatsov/zenburn-emacs",
   "unstable": {
    "version": [
-    20190809,
-    1324
+    20191016,
+    655
    ],
-   "commit": "4db36d32207613340dfc6a48fcf8e57a60d97ba3",
-   "sha256": "0xkchyg3qsv7nwbl8idypr0wc90c9qhw5s1pbg6xwcyvn9751sba"
+   "commit": "2f4f6e7d0bc37f1a99ab14bb4506a0e53d359da5",
+   "sha256": "0zhj7fak79x4n0spz8vapk5njjhc649ys27v81jncsac6877fs56"
   },
   "stable": {
    "version": [
@@ -97700,11 +97866,11 @@
   "repo": "ziglang/zig-mode",
   "unstable": {
    "version": [
-    20190109,
-    217
+    20191023,
+    1551
    ],
-   "commit": "c2deea85dd65c3e73c2771c56a998cbdeb9ff717",
-   "sha256": "10k7i2fj3imbq09fkcgd4kjp7n1dn46119jqrd6kbx5inlkq1782"
+   "commit": "77202ac26ee6091d69d40990fddb1ce6cfcc6dc8",
+   "sha256": "0d2f6nz99dp3yxr7m8i78lc313qzssm7k4783w6kkvcsbpknazlw"
   }
  },
  {


### PR DESCRIPTION
###### Motivation for this change
Update melpa packaes via update script.

Unupdated set fails to build lua-mode:
```
hash mismatch in fixed-output derivation '/nix/store/cphk12y9f03q9a4grly0zgss68a2q9hw-source':
  wanted: sha256:0cawb544qylifkvqads307n0nfqg7lvyphqbpbzr2xvr5iyi4901
  got:    sha256:0i38fkq50g1z1lvvjm1k4qdzjizv8kqm3j3523s9s72vbmal7jy4
cannot build derivation '/nix/store/x193v4qbcw27ns9px6s59pqxkn0rczyy-emacs-lua-mode-20190113.1050.drv': 1 dependencies couldn't be built
```
Works fine after update.

Tested with my emacs package set—works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
