### PR TITLE
slimThemes: use sane name and description

### DIFF
--- a/pkgs/applications/display-managers/slim/themes.nix
+++ b/pkgs/applications/display-managers/slim/themes.nix
@@ -7,7 +7,7 @@ let
     {fullName, src, version ? "testing"}:
 
     stdenv. mkDerivation rec {
-      name = "${fullName}-${version}";
+      name = "${fullName}-slim-theme-${version}";
 
       inherit src;
 
@@ -16,12 +16,12 @@ let
       dontBuild = true;
 
       installPhase = ''
-        install -dm755 $out/share/slim/themes/${name}
-        install -m644 * $out/share/slim/themes/${name}
+        install -dm755 $out/share/slim/themes/${fullName}
+        install -m644 * $out/share/slim/themes/${fullName}
       '';
 
       meta = {
-        description = "Slim theme for ${fullName}";
+        description = "A theme for SLiM (Simple Login Manager)";
         platforms = stdenv.lib.platforms.linux;
       };
     };
@@ -174,7 +174,7 @@ in {
   };
 
   nixosSlim = buildTheme {
-    fullName = "nixos-slim";
+    fullName = "nixos";
     src = fetchurl {
       url = "https://github.com/jagajaga/nixos-slim-theme/archive/2.0.tar.gz";
       sha256 = "0lldizhigx7bjhxkipii87y432hlf5wdvamnfxrryf9z7zkfypc8";


### PR DESCRIPTION
###### Motivation for this change

Currently, the package name of SLiM themes is just it's name. That leads to some problems:

- this name appears in installed packages (nix-env -q) and repolory
- it can get confused with other programs of the same name (e.g. https://repology.org/project/lunar/versions)
- it is not obvious that it is a theme
- naming is not consistent. other themes use the scheme `numix-gtk-theme`, `adapta-kde-theme`, `deepin-sound-theme`, see https://nixos.org/nixos/packages.html?channel=nixos-19.09&page=2&query=theme

So i propose to change the name to `${fullName}-slim-theme-${version}`, e.g. `nixos-slim-theme-testing`.

I also changed the install directory name to just the fullName:

```
$ tree /nix/store/pfd6wi7n6l3k4r75a4i3dmr32dfqd8yv-nixos-slim-theme-testing
/nix/store/pfd6wi7n6l3k4r75a4i3dmr32dfqd8yv-nixos-slim-theme-testing
└── share
    └── slim
        └── themes
            └── nixos
                ├── background.png
                ├── LICENSE
                ├── panel.png
                ├── preview.png
                ├── README.md
                └── slim.theme
```

The Attribute name was not changed, so it should not break anything.

I don't use SLiM, so i would like to have at least one user test this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jagajaga, @AndersonTorres
