### PR TITLE
buildLazyBinaries: init build support helper

### DIFF
--- a/pkgs/build-support/build-lazy-binaries.nix
+++ b/pkgs/build-support/build-lazy-binaries.nix
@@ -1,0 +1,78 @@
+# Build up a directory of binaries, that will transparently install from <nixpkgs> and call into their real package
+# This is for binaries, that you want on your path, but not necessarily wait for, on system update
+
+# The approach is to build a busybox-like bin-folder, soft linking to
+# a single dispatcher/installer/launcher script
+
+## TODOS
+# - Mechanism to prefetch packages making out the lazy path. Possibly with priorities
+# - Mechanism to keep using previous versions, until the most recent version has been downloaded / built
+# - Support for generating the catalog on hydra (right now requires manual management)
+# - Detect collisions / offer options to prioritize, or even handle (zenity) on call
+# - Support for renaming binaries
+# - Progress report (zenity), while downloading / building a package
+# - provide proper shell environments per package (maybe go through nix-shell -p)
+
+{ stdenv, lib, writeScript, runCommand, nix, coreutils }:
+
+## NOTE about <nixpkgs> `toString <nixpkgs>` will lazy bind: updating
+# <nixpkgs>'s content should immediately reflect in lazy binaries.  To
+# achieve a static binding, where lazy-packages needs to be rebuilt,
+# in order to see changes, just pass <nixpkgs>
+{ nixpkgs ? toString <nixpkgs>
+, catalog ? { } # package = [ binary binary .. ]; eg { \"utillinux\" = [ \"addpart\" \"agetty\" ... ]; ... }"
+, installed ? throw "Please set commands to install lazily; eg [ \"addpart\" \"ionice\" \"lscpu\" ... ]"
+}:
+
+with lib;
+let
+  binaryCatalog = listToAttrs
+    (concatLists
+      (mapAttrsToList
+        (value: bins:
+          map (name: { inherit name value; })
+            bins)
+        catalog));
+in
+
+# Here the dispatcher/installer/launcher script is built
+# it has a case "$0" in cmd) ... esac
+# and builds the package via nix, before calling the binary
+
+# TODO base case should suggest package to install, based on catalog
+
+runCommand "lazy-binaries" {
+  inherit installed;
+  launcher = writeScript "lazy-binaries-launcher" ''
+    #!${stdenv.shell} -e
+    execBinary () {
+      p="$1"
+      bin="$2"
+      shift; shift
+      exec "$("${nix}/bin/nix-build" --no-out-link "${nixpkgs}" -A "$p")/bin/$bin" "$@"
+    }
+    case "$(exec ${coreutils}/bin/basename "$0")" in
+    ${concatStrings
+      (map
+        (bin: ''
+          "${bin}") execBinary "${binaryCatalog.${bin} or bin}" "${bin}" "$@" ;;
+        '')
+        installed)
+     }*)
+      echo "Uninstalled: '$0'" >&2
+      exit 1
+      ;;
+    esac
+  '';
+
+  # Here the link farm is built
+
+  # TODO package names providing same binary are random, r/n
+} ''
+  mkdir -p $out/bin
+  cd $out/bin
+  for p in ''${installed[@]}
+  do
+    ln -s $launcher $p
+  done
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -147,6 +147,8 @@ in
 
   buildFHSUserEnv = callPackage ../build-support/build-fhs-userenv { };
 
+  buildLazyBinaries = callPackage ../build-support/build-lazy-binaries.nix { };
+
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
   castget = callPackage ../applications/networking/feedreaders/castget { };


### PR DESCRIPTION
This helps create shell binaries, which build their corresponding
packages, only when run.

By default, it uses package names identical to command
names. Binaries, contained by packages with different name, can be
listed in a catalog.

###### Motivation for this change

I often want to update my system, but I also want to have access to many packages on my system path. This creates a tension: installing many packages means lots of download volume and / or build time (especially if you're on master).

Considering the pervasive laziness of nix, wouldn't it be nice, if there was a sort of lazy nix-shell, that would build packages only at the last second, before calling into binaries from them?

###### Things done

This is a proof of concept, mainly for personal use and to gauge interest.
It might already be a workable prototype, please have a look at the code comments, to get a sense of the direction, I can see this going.

I'm open to suggestions for the interface, especially on collision-detection/prioritization/runtime-dispatch and renames.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

not sure who to cc this to, in particular. I need feedback about having the catalog built on hydra and other integrations. I think, right now, this should already be of interest to everybody doing nixos development, but a nixos module for it could also benefit infrequent users of heavy packages, replacing `nix-shell -p`.