### PR TITLE
librecad: fix missing app name and icon on Wayland

### DIFF
--- a/pkgs/applications/misc/librecad/default.nix
+++ b/pkgs/applications/misc/librecad/default.nix
@@ -1,5 +1,6 @@
 { boost
 , fetchFromGitHub
+, fetchpatch
 , installShellFiles
 , mkDerivationWith
 , muparser
@@ -16,7 +17,7 @@ let
   stdenv = gcc8Stdenv;
 in
 
-# Doesn't build with gcc9
+  # Doesn't build with gcc9
 mkDerivationWith stdenv.mkDerivation rec {
   pname = "librecad";
   version = "2.2.0-rc1";
@@ -30,6 +31,13 @@ mkDerivationWith stdenv.mkDerivation rec {
 
   patches = [
     ./fix_qt_5_11_build.patch
+    (
+      fetchpatch {
+        # Fix missing app name and icon on Wayland.
+        url = "https://github.com/LibreCAD/LibreCAD/commit/a17f8281093403f0c7c36996232665ed21906688.patch";
+        sha256 = "1x46psh4bcx2hxck4l83ki43g1252vb033i2x94h4rpai9hww4d5";
+      }
+    )
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Wayland uses the .desktop file to find the app name and icon. Without it being specified the correct icon is not shown. This was broken in the recent update to Qt5 (#69077).

Tested on Gnome/Wayland.

References:

  - https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon
  - https://doc.qt.io/qt-5/qguiapplication.html#desktopFileName-prop

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @viric 
