### PR TITLE
pythonPackages.pydocumentdb: fix build

### DIFF
--- a/pkgs/development/python-modules/pydocumentdb/default.nix
+++ b/pkgs/development/python-modules/pydocumentdb/default.nix
@@ -14,6 +14,11 @@ buildPythonPackage rec {
     sha256 = "1e6f072ae516fc061c9442f8ca470463b53dc626f0f6a86ff3a803293f4b50dd";
   };
 
+  # https://github.com/Azure/azure-cosmos-python/issues/183
+  preBuild = ''
+    touch changelog.md
+  '';
+
   propagatedBuildInputs = [ six requests ];
 
   # requires an active Azure Cosmos service


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when I rebased #71797

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
