### PR TITLE
polysemy-plugin: fix tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1272,8 +1272,21 @@ self: super: {
   # upstream issue: https://github.com/vmchale/atspkg/issues/12
   language-ats = dontCheck super.language-ats;
 
-  # polysemy has occasional test failures from what looks like buggy async tests.
-  # We think this will probably be fixed when updating to the polysemy version in LTS-15.
-  polysemy = dontCheck super.polysemy;
+  # polysemy-plugin requires polysemy >= 1.2.0.0
+  polysemy = self.polysemy_1_2_2_0;
+
+  # The polysemy-plugin tests failed because it couldn't find
+  # the polysemy-plugin package in the doctests:
+  # https://github.com/NixOS/nixpkgs/issues/71164
+  # I've addressed this with a PR upstream:
+  # https://github.com/polysemy-research/polysemy/pull/265
+  # the patch of which is applied here.
+  polysemy-plugin = appendPatch (addSetupDepend super.polysemy-plugin self.cabal-doctest) (pkgs.fetchpatch {
+    url = "https://github.com/polysemy-research/polysemy/pull/265.patch";
+    sha256 = "19237js70chq84w7vqgvj49n6bs9lp95k13ia3xzbr1r9yyrfkhq";
+    stripLen = 1;
+  });
+
+  polysemy-zoo = self.polysemy-zoo_0_6_0_1;
 
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3096,7 +3096,6 @@ broken-packages:
   - aws-sign4
   - aws-simple
   - aws-sns
-  - axel
   - axiom
   - azubi
   - azure-service-api
@@ -6606,7 +6605,6 @@ broken-packages:
   - kmp-dfa
   - knead
   - knead-arithmetic
-  - knit-haskell
   - knots
   - koellner-phonetic
   - kontra-config
@@ -7960,9 +7958,6 @@ broken-packages:
   - polydata
   - polydata-core
   - polynomial
-  - polysemy-plugin
-  - polysemy-RandomFu
-  - polysemy-zoo
   - polyseq
   - polysoup
   - polytypeable


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
polysemy-plugin is broken due to failing tests.

###### Things done

- polysemy-plugin was broken due to failing doctests:
  https://github.com/NixOS/nixpkgs/issues/71164.
- I submitted a PR upstream to fix this:
  https://github.com/polysemy-research/polysemy/pull/265.
- I've applied the patch of the PR here and moved the default polysemy
  attribute to "polysemy_1_2_0_0" because polysemy-plugin requires
  "polysemy >= 1.2.0.0".
- Move default "polysemy-zoo" attribute to "polysemy-zoo_0_6_0_1"
  because it is fixed by the polysemy-plugin changes and fixes issues
  with building "polysemy-RandomFu" and "knit-haskell".

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti 
