### PR TITLE
vimwiki-markdown: init at 0.2.0

### DIFF
--- a/pkgs/tools/misc/vimwiki-markdown/default.nix
+++ b/pkgs/tools/misc/vimwiki-markdown/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonApplication
+, fetchPypi
+, markdown
+, pygments
+}:
+
+buildPythonApplication rec {
+  version = "0.2.0";
+  pname = "vimwiki-markdown";
+
+  src = fetchPypi {
+    inherit version pname;
+    sha256 = "0k7srlglhq4bm85kgd5ismslrk1fk8v16mm41a8k0kmcr9k4vi4a";
+  };
+
+  propagatedBuildInputs= [
+    markdown
+    pygments
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Vimwiki markdown plugin";
+    homepage = https://github.com/WnP/vimwiki_markdown;
+    license = licenses.mit;
+    maintainers = with maintainers; [ seqizz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6807,6 +6807,8 @@ in
   vimpager = callPackage ../tools/misc/vimpager { };
   vimpager-latest = callPackage ../tools/misc/vimpager/latest.nix { };
 
+  vimwiki-markdown = python3Packages.callPackage ../tools/misc/vimwiki-markdown { };
+
   visidata = (newScope python3Packages) ../applications/misc/visidata {
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A nice application which is useful for users of vimwiki

I've locally installed and I guess categorized the package by somewhat sane way

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
