### PR TITLE
mariadb-connector-c: fix mysql_version.h search error

### DIFF
--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation {
     ln -sv mariadb_config $out/bin/mysql_config
     ln -sv mariadb $out/lib/mysql
     ln -sv mariadb $out/include/mysql
+    ln -sv mariadb_version.h $out/include/mariadb/mysql_version.h
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
This commit fixed this error: (freeradius build with mysql)
```
builder for '/nix/store/14czlkwfbwd4hx7apaqcflanzdsxl434-freeradius-3.0.19.drv' failed with exit code 2; last 10 log lines:
  CC src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
  LINK build/lib/rlm_sql_sqlite.la
  CC src/modules/rlm_sql/drivers/rlm_sql_null/rlm_sql_null.c
  LINK build/lib/rlm_sql_null.la
  CC src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
  src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c:42:12: fatal error: mysql_version.h: No such file or directory
   #  include <mysql_version.h>
              ^~~~~~~~~~~~~~~~~
  compilation terminated.
  make: *** [scripts/boiler.mk:635: build/objs/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.lo] Error 1
[1 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/14czlkwfbwd4hx7apaqcflanzdsxl434-freeradius-3.0.19.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
