### PR TITLE
castget: 1.2.4 -> 2.0.0

### DIFF
--- a/pkgs/applications/networking/feedreaders/castget/default.nix
+++ b/pkgs/applications/networking/feedreaders/castget/default.nix
@@ -6,29 +6,37 @@
 , curl
 , id3lib
 , libxml2
+, glibcLocales
 }:
 
 stdenv.mkDerivation rec {
   pname = "castget";
-  version = "1.2.4";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "mlj";
     repo = pname;
-    # Upstream uses `_` instead of `.` for the version, let's hope it will
-    # change in the next release
+    # Upstream uses `_` instead of `.` for the version
     rev = "rel_${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "1pfrjmsikv35cc0praxgim26zq4r7dfp1pkn6n9fz3fm73gxylyv";
+    sha256 = "1129x64rw587q3sdpa3lrgs0gni5f0siwbvmfz8ya4zkbhgi2ik7";
   };
-  # Otherwise, the autoreconfHook fails since Makefile.am requires it
-  preAutoreconf = ''
-    touch NEWS
-    touch README
-    touch ChangeLog
+
+  # without this, the build fails because of an encoding issue with the manual page.
+  # https://stackoverflow.com/a/17031697/4935114
+  # This requires glibcLocales to be present in the build so it will have an impact.
+  # See https://github.com/NixOS/nixpkgs/issues/8398
+  preBuild = ''
+    export LC_ALL="en_US.UTF-8";
   '';
 
   buildInputs = [ glib curl id3lib libxml2 ];
-  nativeBuildInputs = [ ronn autoreconfHook pkgconfig ];
+  nativeBuildInputs = [
+    ronn
+    # See comment on locale above
+    glibcLocales
+    autoreconfHook
+    pkgconfig
+  ];
 
   meta = with stdenv.lib; {
     description = "A simple, command-line based RSS enclosure downloader";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
