### PR TITLE
mu-repo: init at 1.8.0

### DIFF
--- a/pkgs/applications/misc/mu-repo/default.nix
+++ b/pkgs/applications/misc/mu-repo/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub, buildPythonApplication, pytest, git }:
+
+buildPythonApplication rec {
+  pname = "mu-repo";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "fabioz";
+    repo = pname;
+    rev = with lib;
+      "mu_repo_" + concatStringsSep "_" (splitVersion version);
+    sha256 = "1dxfggzbhiips0ww2s93yba9842ycp0i3x2i8vvcx0vgicv3rv6f";
+  };
+
+  checkInputs = [ pytest git ];
+  # disable test which assumes it's a git repo
+  checkPhase = "py.test mu_repo --ignore=mu_repo/tests/test_checkout.py";
+
+  meta = with lib; {
+    description = "Tool to help in dealing with multiple git repositories";
+    homepage = "http://fabioz.github.io/mu-repo/";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19808,6 +19808,8 @@ in
 
   mtpaint = callPackage ../applications/graphics/mtpaint { };
 
+  mu-repo = python3Packages.callPackage ../applications/misc/mu-repo { };
+
   mucommander = callPackage ../applications/misc/mucommander { };
 
   multimarkdown = callPackage ../tools/typesetting/multimarkdown { };


### PR DESCRIPTION
###### Motivation for this change

**mu-repo** - a tool to help in dealing with multiple git repositories.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/nc014syiz00283yl7v13jaz0r217a5ff-mu-repo-1.8.0
/nix/store/nc014syiz00283yl7v13jaz0r217a5ff-mu-repo-1.8.0	  96.6M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
