### PR TITLE
all firejail local includes should look in /etc/firejail

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
   # We need to set the directory for the .local override files back to
   # /etc/firejail so we can actually override them
   postInstall = ''
-    sed -E -e 's@^include (.*)(/firejail/.*.local)$@include /etc\2@g' -i $out/etc/firejail/*.profile
+    sed -E -e 's@^include (.*/)?(.*.local)$@include /etc/firejail/\2@g' -i $out/etc/firejail/*.profile
   '';
 
   # At high parallelism, the build sometimes fails with:


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Firejail profiles that ship with Firejail are intended to be overridden by files in /etc/firejail, named like /etc/firejail/chromium.local.  NixOS needs to jump through some extra hoops, since the base profiles end up in /nix/store, but user profiles go in /etc/firejail.

This updates the regex written by @peterhoeg  in https://github.com/NixOS/nixpkgs/commit/04bbb2ab6b7faf595e60fedc4da2cd5010d0d616 to match all included .local files, not only `/firejail/.*.local`

The firejail package does not have any .local files, so it should be
safe to replace all these includes with the absolute path /etc/firejail/*.local.

For reference, I'm adding this local config: https://github.com/bergey/dotfiles/commit/c1b69c9954d8e9c995f5d120f3b1b66b28b7d7b9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c 