### PR TITLE
thunderbird, thunderbird-bin: 68.1.1 -> 68.2.2 [Critical security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -160,11 +160,15 @@ stdenv.mkDerivation {
       EOF
 
       # SNAP_NAME: https://github.com/NixOS/nixpkgs/pull/61980
+      # MOZ_LEGACY_PROFILES and MOZ_ALLOW_DOWNGRADE:
+      #   commit 87e261843c4236c541ee0113988286f77d2fa1ee
       wrapProgram "$out/bin/thunderbird" \
         --argv0 "$out/bin/.thunderbird-wrapped" \
         --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:" \
         --suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS" \
-        --set SNAP_NAME "thunderbird"
+        --set SNAP_NAME "thunderbird" \
+        --set MOZ_LEGACY_PROFILES 1 \
+        --set MOZ_ALLOW_DOWNGRADE 1
     '';
 
   passthru.updateScript = import ./../../browsers/firefox-bin/update.nix {

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,615 +1,615 @@
 {
-  version = "68.1.1";
+  version = "68.2.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ar/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ar/thunderbird-68.2.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "33accd6fe1f83fc47a34df038f4257571f42281a89f9aab2f54514443856b71aaa2ee81abe98331ecdbbf026a09eea31fb2c5eb72044347c54f51a6ac1e0bfd4";
+      sha512 = "94c10cb04b64bf430bef1c1be558f85b604eabad88f4a8388aa4b4c01ef699ff1aab04472c4d475272893eb555ee74a996f727c87a65054faeac82c9a12028fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ast/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ast/thunderbird-68.2.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "1e32c40cd198b51a5836c2ad9a6331c0b3028e57d62e5e057990a48ab80b9fd5bd1290a268da29dc5a45c61e712bf0345f85d0ca43c18b2236c0f4bac7b9328f";
+      sha512 = "a09104912d28c60adbb098da0932418896124a5901cc9aa89c14f1effe087c556e225664ca44204407de57a3ebc27b342ca880a1f7b01b11254e8173b433741f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/be/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/be/thunderbird-68.2.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "0f86506a7cf72c75712f6b507fda6e39da9520865dea5eb4fbfdb78531dc88116d4e8227dd91e8f1fb4dff9ed3e4eb7e118b5a4dde3860ec00c3bca625478a21";
+      sha512 = "15c631dbb4ea2d70e480a2d57fc47c1c9ee241c869ba664c0c7fc858a8851cc3a57d833641c3a1bb1e9a3b1b937d4227baaa76d9e6adf556076e97ee83e37e45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/bg/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/bg/thunderbird-68.2.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "f25c07ee41767fc1ec9381291662ce5bf269971f3542b4c2427da7240c13cfe44f006b8995e6474309bb6330e21626ca7e3e7463452ddd5d7e0128b799f6f566";
+      sha512 = "6e6150f76726a0ca79cc227f065134d469a0e1c530393a4bbf23f608c3ed9461a3ea1d68c952f41e54d94f64d4ecc029863f144ff7044de31482389f4b6727d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/br/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/br/thunderbird-68.2.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "c57c207922aa0f1534fd6925305effdea2f09ee83ddfe7eed62d30b91494ddbf6ade0c0cba2e7332c876e10e15593ad985deaec769525fd3a19b21d048383690";
+      sha512 = "71f093f81a82cb266b0be75531354994dd7904ab5ad310c7af27ff4ab588fc6cb45eed1c671df643a30bd0288201ace61897b4f43f2abc0fb0ec84a7de52fbca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ca/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ca/thunderbird-68.2.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "4fb66d8e9285cb40cf42f626d38eecabe489fa5311a25ce2e687483b6624819674b0b4a41f486a0ea98edbe27cea2f7f156368516f70afd4f78629aef93cb94f";
+      sha512 = "eef521076fe2530148f8d84bdfdec7b7a268856fbea8f729f4339c398d74ff3a655b59a24099ae568036128e2800a6935fae55547edeb22d834536058f8288b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/cak/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/cak/thunderbird-68.2.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "2c591767d09c3af59dcda7c44937f012cc14695a7744bca49d2b5788cd44953a85b8cc0005efa4db3daeb6c5f553ead9d15239af37b1c7686e5331cf9bb09ee5";
+      sha512 = "911f720e117fef420121b80adf09a01a9c73d7bdcb4c745513c67d33f0e8f43e7f552cfca2552460ca84cbd0573ad6439275760b505816c87f53f4a1ef4a1ea1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/cs/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/cs/thunderbird-68.2.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "62d58fd817b235d8afea65212f527b99cf67d882a3fef592c2499881d659837ed90f5192111edef9b7d00e37ea5b1becc9fed00eb4af063ffa4ece160996a73b";
+      sha512 = "f2152b276d9fb6827940b75fcc05186694eeb5b44e9ed232e4945c711979fae547f863c1da687b6f3c890b29098d5981fcfb2d48dde134caea1a8e1193fc0807";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/cy/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/cy/thunderbird-68.2.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "7df64966340aed43c1411abeef18ade4891c2d64361d3952967529ea487dbccf6ec4d824f85a740ed4d54bda188acf9992ba9623a72c139268f09efaaa27eb89";
+      sha512 = "20a9e350d931e89cea3a80c47a3a0404d3ee907834a42d361b9f59c1561ac9d19f3cf486ec7e3c8696e739b86185225447331f3f681ede51618df88259e4ea8e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/da/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/da/thunderbird-68.2.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "7bc7c0b44e981f74119cb19f4d27e260a2df53b9188364c367752ca4fa461b1c003ea58d4eb14fd9d9b64ab1cec5cbef6e68080da180ca6e904bc6bed0dea924";
+      sha512 = "3410cb8274cb5b2566da29771587010319ad91f0972d08fb9f0dd06077f2cb2f4ff9e71b8dbf628c4ad6930de37220df83a1ca6b8a16096ba04a42488c31eca8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/de/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/de/thunderbird-68.2.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "6879addb03511e1fa18696069251a3649865fa2410b2503f8588d06e3ad8fe9d127ef414cfa977a323468e037f7fa06d7dbf306bb98608ecc21acedb68e2784d";
+      sha512 = "a821df98acbb753a8613477273a9a9afccbeae15859ef322c0df8888009df77efaad6d969907299d6c93c917baed1fb7955412a8105829514b0ce7c92947a9df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/dsb/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/dsb/thunderbird-68.2.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "ab82cc4b35e0bc9bca7611cc9b17cc383e7489f54e976074d34deca5ddf83d380b85ef3db5b35611d59500ba8c421848ca9d0e4e8dc4f8dbbd0b9fabfd13eada";
+      sha512 = "06eeb9fa9672befe101f56a41c39486a1302b30176f8401a9a86202f3091a9a0fc991e388fcce4892018198afb7dea87d9bbd885c4d99317aa12dd2a607f5d67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/el/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/el/thunderbird-68.2.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "b8aba262bd82149ec9213d0a307ca6579c64b7afa084a251f35efb68384df55c220fe71bbef1741514ddd45c284e669fd4062ce5202f9ba91622b88dd48d5304";
+      sha512 = "67b74a425f35af9220d74c29b9c7b4b9a754916b65a41d9eb5d089c396ed3bf5df4f23668ccc82ec2accc11feb0ae46cf836d309c46865b7121dadc27febe18a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/en-GB/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/en-GB/thunderbird-68.2.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "b16a859480d9cc2f2ae2bf644bdff72e5b272a91cd311684012b4f364f7a06742ceac37a1821cd37e5749e6bc7c12b737e35f226c0694710140b154d931d5610";
+      sha512 = "d4f7bf9ef86ffcc81ecfc8d4eff9c0dff20657bc362873fd6ef7cf21150e8fcfa2b0d4d931cad5bbc3253e1d0f9f0794f2dc50485c0523be6483c0b148a3f07a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/en-US/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/en-US/thunderbird-68.2.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "3046e6826e5df839ec1e572784bf333f72c5deb3dd472a17f0fdae5ce33bad3980a7f39eddaf99e680084053d66dfe83dace788c392ef027116f03ef49e05d33";
+      sha512 = "363441693ea13b0888e32d50ab1906d4642ea8b9503ee5a9b2c4542a571e1d9339a6be9775753e1c9df151f326fcb403e0b294aaa0e397b7b586187e43af3bed";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/es-AR/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/es-AR/thunderbird-68.2.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "8e7ddd969487ec21ec2b4ad50e0757595d05f44972427d6c7243da15a433d16b14dcf6128f9ef96711bf8ac5353df3c3fb7a844a8f69ceb3761b023b22728f7e";
+      sha512 = "955d8dd7f863cee295c7852567627d95996597c0cf46de5651cecf51ff25cd19e9e9dce78dd63674ba08f71b81d06759a319532d35460a0468f5423e051d3d30";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/es-ES/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/es-ES/thunderbird-68.2.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "7e59701093cd6c34498b9439d50bb1d03a2089366e793ef3d205dedeb14427d0f2306d18c5c0423a3a7d349006e3986d2c4977a996b3ebe3fed5d79d4a00035d";
+      sha512 = "4fb00dee3d1ba3583797689dc8b41aa93b1c4ed3f22f65e4ec7ab9d9c8af20abf6d6fe95883c80f83e49630f1731737b43744413e055b841182a08024fc4a755";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/et/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/et/thunderbird-68.2.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "851ed5a2289682a658eb69dbc2e5bab05199b08a3ee53a5d57bc8dbf0bc7882170697b1b382c9abc6f8fd6674c132bdf83f2b05aceeb4edeab57eb510f95f64a";
+      sha512 = "2622507510b95ca3d6d4aeba31b7ec38c42f593aec7e7b56b444675a32390e590954ec68a1d919f953ff8fcf29c3636f306e7a03270ac837622edccc2eb95dba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/eu/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/eu/thunderbird-68.2.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "b006a9d2ca2510ce975509fa505200e3ad66dbc21a3e029007b01b60ea0021c34056b5972e7610ffbbd1d083e70745328ad36d7c64d97fab9973ffe2458d7c94";
+      sha512 = "11fd263e4768bf938d8b8010a3abbe9c1518a64d4d939791d4c0ec67bb7058fa77ba4e0ef3f2c5509b0c12fb0379ebcd2b9568f0b6933a1372814f6e69e6fa3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/fi/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/fi/thunderbird-68.2.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "c08b0567e22048a36ed6838464af84867cf6119130a5c1aa01e093bc7b564cc5d12d22bd530de6aab4e247ffdca1a3757b22dbe2be65edf846026733a8ab6cbb";
+      sha512 = "7872e6ba365debe0a70924fb16222f5eb5a3d904123f3225dfdae4b64c4735b008e5c2ef3f5e28926103a2bf8ec0747c1926f101062a5af9aaa7ee2faa98bb29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/fr/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/fr/thunderbird-68.2.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "0dc66c2136f6bdd0d11d450603f13f9c3822f3a50ecfa0d8f0173475243ca145dd1082fac9f8b9a25e7e6d4e0f19cb127510c40c86bc721074b301536aa114df";
+      sha512 = "e1e892247067712faee12229ff99ae76b9a2fb91f82fe801e7faad99310fee0e208e587ee621b5e8bc9ef3cdb060ffc26b2cbee2b15fed6727d25cbf07d192db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/fy-NL/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/fy-NL/thunderbird-68.2.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "685f664ebb6545f85d52604ea9e26477ba7ab6b36b2cb26fa81caccabe42e99c4cf57de40ce0615e830b0199b1317764e90f2d112fde42344606a39eaf454c1c";
+      sha512 = "4258de7c678122abe7cbdda670847c3af7bb21a5b2bf9678d993a671256037b3076ac1b3f90f38203ba812ce8d5383eca50399329ad457f0beb2a23d2cedd173";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ga-IE/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ga-IE/thunderbird-68.2.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "ecc63d373496bbef6992dd619d637956ce9d753f2eeadb0b2d45d11c11b71e9018c33d6deed7bddb1781285949dfa8f245b99d881126a8076db403e9036ac39c";
+      sha512 = "f06482a503926239ca03654de0fe7eb30f9e2f624ae436b8dd7efc8d19545b07dd3cc468d900033426d00d9b824a2a950209241c9450347c3ec69c5a6dcfc2fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/gd/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/gd/thunderbird-68.2.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "9cc2e9a105b2e1d3410fbde8d06c3340ba2d50ef8790b31c928385607baa8735bfe02ff6010315c1068d7585ac94bd9fa002cdc27c30007e6be44b37a6ebb6e1";
+      sha512 = "b5b390157491549499d23d40e7d293d12be70eccddebdf0b78c338b1a0e3d0386cea9957e74b8880d421aa08fcaa76ff1d45aeaf61b194764a044ccf492a3552";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/gl/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/gl/thunderbird-68.2.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "223c36a2ac4b02e991b90134deb0ac6d2a18d77bf0e8b8627b0cc5c0af49e0d9b10b06c05efb31b93aad90a75792ecf4f803a2fc5471595612697f92e1d3aaf0";
+      sha512 = "63da43e0f8d28f7f1b3099823f6a3eccbce0a296b8ef2e814e728dc044d667cbea8b1ce9f5efb034b72cf17e468f4c006f98e897750b546e5f842116c06afdd1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/he/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/he/thunderbird-68.2.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "865fff7acc60d6b4c19bda1ea38e532e96e0cfde18c441970389c34dd1e6f90f635202f4d98457d2373d42cd47cb3462b2ce0a3d7a385593be654edc54f2b756";
+      sha512 = "8945af4410b3ad01c1131351c660abeacc8b12dd3c9ca6259adead008a90df50f749d80398ddccedaa9ca9ec1a94a7e3efd7545cb2a79823a35e8fe99dddfb19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/hr/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/hr/thunderbird-68.2.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "34c410ab7a1b16c2c172a0c45fcf69d9e2b4462f98f926c391b71eacac351162dfb55f29728627ed2fef28ef7ba40530b899d637690926297e797a3a2be5ceb3";
+      sha512 = "fd502b129afcb37860b70b016f604bcfd9be3b7e9308bec794f70840e05c768f94610962ed02ce24141302819382c7c9b30b4feb9297b5088531d6a4e627d855";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/hsb/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/hsb/thunderbird-68.2.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "f885d2b366fdf1806dd8e882fdabf8994e56471cf01cc0c6ef6d1e1d4972186dc8ec5d35b18ceab8f7982d45724544f4f20afb4621499d9543eb98a3d87a9e43";
+      sha512 = "1c445c5fb5d80dde96383ed33c92f8bffb54bac74541f6f3823f84543e46c02c7fd1ea7792d9c907c7cf9f9e2d1648f4ec763c0dfa48bf155ac0595b63fa9e84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/hu/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/hu/thunderbird-68.2.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "e66ac6ad21527936f65e82be605d061b9b93688e94ef35d85699e2ac03d639e00db07d113071af08f11ac1742d811d66048e1d6de4ecfc01e25e325788fdc208";
+      sha512 = "94fb61ab44be683ac24711a47aa4bf9e8835e40fbf407fd785b108be5c964f703a64d19c87189133008b058ec923cc0a5c345eb5ab43ded7a2f9f2849b8e7dc2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/hy-AM/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/hy-AM/thunderbird-68.2.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "fa959b64625773fdca62414269f1b3d0eb369d1e4d3d45b260d4ebfc367a156f70bda5b13d30a0fb4d576ff96bea5712edde51eab62db211fe636340b73999e2";
+      sha512 = "676cc1ac305891904578e261e802cf8048cd7837fcaf030a81296ae7021284dfdca62dc247923e12dca7cf87a6fd2fd792b2c4622e2c6a18425892f4a1573273";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/id/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/id/thunderbird-68.2.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "b20294eb413344fc550200ecf6780c79a919e9d4498bfb97c660cffc14ef18e1d38ad5033b6ecca703467f832c40d4ed4022e335cf3e28e12b43e7c6321fc1a5";
+      sha512 = "3f1316800e86b1b3e85e30c749aac7454dc2ad024066fd4ced06df4ef96d2bba2105e852d243fbb56ccc5d2304a09e6d175f4e668be1b332c9cb7299066d773d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/is/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/is/thunderbird-68.2.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "99c70cf0baed763feaa41799a51a15ecac4190131d74996101b00e99c2b4b674cdcfd0896573bd5fe4e22a25067f6c0dc3c19ecdc2706e010719d19f97aef20f";
+      sha512 = "85a94f55f05df564cd6feae1d05a9d2aa1c34bfdaf39af1c680ddd77e01c8af57f8ffeaea525dca8464b57574c75863b0ab81947832562c2c38e9e73799311a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/it/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/it/thunderbird-68.2.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "b711ad04c405b7cf0796f242bcc08cb5906a8b4fea4b2655251b135347a4539e974606f88626093376ce16a11995d23c6dfb16fbea38842a0b9dbcd8ce2a93a5";
+      sha512 = "a77be5ee24770e3cd0be842f3e4343cd93afcc582af1665c996ef589ab85a9906ad5485f5af644f78b1374d12a89db32d30f1e44dc29678916e14d1f82395ae2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ja/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ja/thunderbird-68.2.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "bad79952ae19ee63892c357ca2e55e0ee220532fa2d28836a15866f7549c82448196ddb51b91eb2abe75d87188fc1139c886c24f66a557f87253c843622fad64";
+      sha512 = "914e66ab518565a02cdafb9a5183d910e69902be8676f78e5b46bcd6af955111cfbaab57739396e58fd6cddb7d3df235408fe3ac35ad2e7217875053ca991d8d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ka/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ka/thunderbird-68.2.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "f129b230d2572b25e289a7b8c1f1b4be71a8f57b639d0264cc50068a2767af8fbb64ffc0c4ae7d50cb489015fe9a810e34682cf351f6711d40a333c2fcbf9493";
+      sha512 = "d90911b809ab83bdd9558e71d5443fcd2da2941273f6df58d9c2d9b995e924c7ddf7ddb001647d1dae619d533da049a242a255729b7c5ddc98cdc2bf422c5837";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/kab/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/kab/thunderbird-68.2.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "2346f5acab924faf1eda887f29777dbdccd4569a3163f385dbd3ff8fd7be9767df4c19496ac7a550426784a04f1cea6a4370288eb8d12e3cb93abf8b0726979d";
+      sha512 = "32476702ad651e53c2124a9295e5ef9d68ecff038dd0f93f8d574ecce3aaea2565a45cbf882072c2c21e160aadd42f07bcffd1c3986266a1080fa7bed2bc68f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/kk/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/kk/thunderbird-68.2.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "12a7dfe909bf22a2a2906cd749aa409e023a777defeab4a28d4456e76e84a24d10c8a6cd1dfe54371b110acbb04c89c3259341ebd6e0ad497d175d1f9eb8c871";
+      sha512 = "3c122537cd92e1b6d19d7806a6297aa88ffb35935bb2add0569ed349bf17e62013630900d125aa159dffa3084ab5f63e30f5c3d1de39647504af154622c7a882";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ko/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ko/thunderbird-68.2.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "7a3ec307a546c9adbf56a0b41c7b900edb76b0e52a773b486997c1f294abfd7262208a9717936e4e6ccdf109d20cdacd4cc5b4aefec30e82e23c6080154174e9";
+      sha512 = "463d758e31cac61c59ae0f3975e3f87557a23aa92aca3e70e52e412f55a9477d250b98018619f30ba2b8db0795f39d9f5a0d15a56e0fb48f7fdab306dbde1381";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/lt/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/lt/thunderbird-68.2.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "3f0cbd3e185594fb16694020788b22aec01c12682aea86ede1052d766da797b24b9b99b8ecb44dee008cfcd7a10ea36e7e1bbd39842fa416b8e69eea0bd831a4";
+      sha512 = "c439559fa3a98b05e87d36a4dd273c53d5e76d20adb12a7123fefb5cf65d0a74aff139287dffbd6afc1058b90f4977513efcc9c0ebc9fb65c851e3946a0d5d7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ms/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ms/thunderbird-68.2.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "cb70f35114b3fb3c0324b80ece639a4bf733abe15b74bf0f04201e272703eecdffe66a2cd50e66d986332b40d3ba7dee04cf7624cea48e9925294437def77853";
+      sha512 = "36aedc74de1e099be9cde9419c2c4ff2455df0d2f937171cd7ea1182f52ebe900cea8f32debe486fd443fe08fec8647ec2e223ccb34a6743e7cb0e334dfb9c8e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/nb-NO/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/nb-NO/thunderbird-68.2.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "3bd4914a8b0cad71622a79e34d182aa7c1aa115780980c29f732454ec219a19ca4d1af3f61693595842b27cac7c64138c094dbb13b0329950d79ef8674ea610d";
+      sha512 = "47c24120846afdd630c5e68caffb0a55ee6e39b49b4cce47fabb7c189dfb71496f15cf813938f6878c4b068ecd6f799fc2bb39419b8893f720d3821a0c16404f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/nl/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/nl/thunderbird-68.2.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "3335baf0974932247e73704a5272d3bb4b182908a76e9e3e0f15bc0c40fca7763a3fe1f4303b3f3374a0f758bb00d6639595b8cfe9c03999f3bfefd8b6f0153c";
+      sha512 = "9203adf919cd9ef4564b838694ce57e1cd00920b7bed9685af204bdd41d75cbce4d332cc310124a1c351872a059f3d9cb08ffb74916ece8227860f1cfada9205";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/nn-NO/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/nn-NO/thunderbird-68.2.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "b9c93af9d330bec6f7182163fc680161a138a99691897263b74e81d9a30c6d892c4639aa28d0b311ac51800b72de9e092065ce03cd7683b86bd571c7e394a49b";
+      sha512 = "a0effbaa634c9fff52a989aca7452641f0680853bcd0679d2f265632283d2c7164504ce31783b4af4ff8a8c22ebac5eeb2d7865206494e6ae8e85595ecb9c759";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/pl/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/pl/thunderbird-68.2.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "3f66d17f0e231c608b1f45dd51cdb231826a3159ce188e9036cae8f45486d38d95d9878429dc1f15a90df3a91069b4c4c5d64ba9d35ca071cc7c1383d6c89239";
+      sha512 = "f9b8a63d3021e568b9ecee6a3741ff1b02d8da023b1f90412003e9353477b230583b734a7f13caf1b6bcc6337bc8c9a43e5f68200958f284c1855ac262e9e141";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/pt-BR/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/pt-BR/thunderbird-68.2.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "dfa439f4decb4bd22945584772d837acc79ac9227763ffe061a551d334b4ab5b8479516ece0c32ae5d7b05c7168c7ab32b390a83edb61f5d33e20cad965e6b75";
+      sha512 = "8f7609695372957a42b3cbd88af1a5fe5ee8b0554d4dbeb895fd33eb0171ff84fe488df296f656ec43f4b5ac8756c702ed437dfd1ecf684d997b1a3f78dbef84";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/pt-PT/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/pt-PT/thunderbird-68.2.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "79dcbab7997b1610a33db0654d5e2a831e63dc1e5be7794105bf3d9739d749b75ee56a9892c112d1da5fa5c5bcd76b945b1fb7532ef2b075f1c09706abe64165";
+      sha512 = "e1f6f3a1f5cd7dc044c34a3ba344ea79ac25ec5f561677fc3f7110ee29ec7611f15d1d488db8fced5c1b030f02ebabf11f02788ffd4d5f487dcc70d4b63fdf67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/rm/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/rm/thunderbird-68.2.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "e79789f61bd59fcad82e25b62e4a324476d48297e826118352f9a8cbfb3b6807cf565fbcdc49fb1c90f22595f5d5e9b41c67b994d83a15f0bfd8b98645552b35";
+      sha512 = "d01abff7971d44f93139c225d582e0e2e8bd37af2f854cd2b69f46ba7f1858eb303f42baa799e508f7e6716671d77e75c8be49e9f8b773dc6e9e14c8806b1c4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ro/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ro/thunderbird-68.2.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "77e7deeb8e0fb2d77e7a672d0ef77acf171b602036fc14f8685c3b247b42d953dc18e816812067d025f17ec64daf1895508c11ce27de1f55cca7474377eadb6d";
+      sha512 = "9c7ea9c09357fc6885e0c60f53be2b4dac490bcf4ed64abb108163603ba0a9c825fe9333ad104a1a458c6c1d89ef421553337595f4cb5df56beb7fbee04d5513";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/ru/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ru/thunderbird-68.2.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "74993af15f9afbe5034966d2c5ed17d1f1d43a47422acd7e671b4cbb8176ad845b1bf26d45d81a05e6cb4e6f7cb1be0dcec38d22ec4ef82aca45db49a22de1f8";
+      sha512 = "6dd992fd318a5f9a4a168d410c76dd9e9cc6d5c4fadf4ba9f2b2f64a3e34f21e104a5c19b1cc7387cbbd75dc90103c1157cf78793679d32fdba5c883d765861f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/si/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/si/thunderbird-68.2.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "a2feda066e1cac0e3d4e9ae5837cae50ec864190b9620694817eb7659a1292b488b820aefc2c3e11393ac52934827c368d379f9a74babe53dcbc48c447cfb538";
+      sha512 = "4d3593d4627d8f9822555505bf0e64a52a7fb111060fff2c11a7aac670b38c670594d5c96a9711d9894cf7bc82310a28c2a5724ba06fcfb96fd9ce4702e64e26";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/sk/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/sk/thunderbird-68.2.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "ecf370133d0fcda81c9caed13f5307bf27b50e85f255a5c13cb37da4466ca60cceceabe8463dbec3b2e4e7349c92c759803eb2ec01448dce1778d2bcfd2d9fac";
+      sha512 = "876edb57d6b3d7f68dbda843eec6e35d5f1e023a5c0e704dcf0fc973afd3cdfea634901d364273b1db6eccb86460d20e5a4ba7391c13b9033a55ae5899726cef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/sl/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/sl/thunderbird-68.2.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "2fd49d0f88c145ab65ba3887363b969da2b6ca141de373fe7b3fe95cb1af27cd4fcc1e21b146e241c312862736aebeb8ddf813548e7e5e133188eaeb94933124";
+      sha512 = "2987b765582b15ee64c5512ba23e7c42c974f376c734713932621dd7c29af10177f9cd4436c6042b87e0101a5326ce82b8c3d62f7cbbcb30e1806188380dc2e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/sq/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/sq/thunderbird-68.2.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "4adb9557d053c8485dd2abb89285c3559004653d4200025205758f54bf349d79f4a1db8229af5a2fbb7598554e47ebd7f6b1823f3a1cd0bff53a6080d17ed363";
+      sha512 = "ea2fd834b8552c504d687bf61727b32ee23729a1a4a271ecb2e0017aabc862ff8c586a365b375b0c271d53de1eaa16744fae43f020685bf40f57177e84a72351";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/sr/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/sr/thunderbird-68.2.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "4132d8b2470b50d3565d4ab32ce23eae77874b6cba8451c06a10cf5e10d0f1d03170004985d61cc9d7ce4f1c5c31f017b7ed8392ac070e63227d996b0d9cabbf";
+      sha512 = "494a4a932d1073003d1b41aa44442b4a4967e49b10d833e07053e3745502d42696137e333933de7d9c14a8284b454bef624db06519ea3d33965a27bb93f1cf36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/sv-SE/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/sv-SE/thunderbird-68.2.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "7d24c7ab6f7cb5fd6cfffa21b1d55040a626109ed2cff7859dc8c28b78b2dfc40b7b3c9a5ed12aafbc15368f294990a35d172bfa69aeddf8b65505f65f38898c";
+      sha512 = "26bfd19d7063611f078d16a660abe23337f2e41c0a379e1a59669ccff1e887169c66d35b9b9f3a65fd2a7921229dd4310e14cec8f28460a4f4bd3153519b566c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/tr/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/tr/thunderbird-68.2.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "17393c5c522cb0fb6de9c9fc13a2ed0743f995cb51d852ebffcaa03e59b39d93c2137e62aadc70131bc8fd61f2d6c3c70baddfae299e2244109f35b4f7443572";
+      sha512 = "4d0c0d348f0e77aca8c53684d008247b16b19a6df9e3a542e5d95c697685823ac47293425d20331c2c5ba84d81fab5a9031586d5b75a05faa185e1a1c18df93e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/uk/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/uk/thunderbird-68.2.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "e8dad1bfa1b118141e65198014cc405a3041fc552cd1bf4186b22877433805357fe39a5adc6cdb9b9afaa86493442bf32ee73bf2c2859f8ad535c7996744f60c";
+      sha512 = "42b6d102d2d2c18c6ff6e1173567038d9b5da99e05cbd46a9b2593467c8845abdccb2a03d16eb843aa72f2432dd65f69efa6f0a20f76b0aa3ea015749860c722";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/uz/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/uz/thunderbird-68.2.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "5a99a2ec1539f452db613f7fef10d180bb57c642e0098ecb234fe03521f1ac9c781cce50eb025d8a5adae280b466dbcdbc08be08a0106c6d8ad99ff250eec4e4";
+      sha512 = "76a1a55daa7034e98cc37625f491190d909c29270f3e9097230c3ddf33a54fc0dbc954cd5d5339ee5e194538fd14a8c1d615feb702006c9cc8c68727a4bcba92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/vi/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/vi/thunderbird-68.2.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "fc39ef4d2bdd5791cd8661a522f74b2a1f9f3b534968f10b3abfaaa287a160d01debc56c9cd416c35e50b38f80d2a1b5ba10f4134e9fac3ac32748e3891f4026";
+      sha512 = "f8a1fe807f83ba411689ec709304e3029ed8e83b330432e33f0799712c3343869ebebd8b151370480d952c8424101f5da13e13da536ae7fd3c29d593a4f1f84f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/zh-CN/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/zh-CN/thunderbird-68.2.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "96e2cb653a93d788a7e721bf6677e7dd50ad67e4e173bcfc23dbf190440a35ec2349241adbe7bb1a74c4732f3990a15636a0563448cd90b7526c06bc106d083b";
+      sha512 = "cf1afbb064aeb8aade6aeab835f584ea828799342d0cfef7209fea92707751a42b0023a4132efa20e9af8474f891a3cbcfe7edc68494411d69efd1d26942da13";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-x86_64/zh-TW/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/zh-TW/thunderbird-68.2.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "c9d720e70d55998343c4d20257a0385e3764da751e57eb992d7ddf2723f565099d6e8c880ec009f9ea71609ddbf172a8ee7f82e603f42529388d0627e882ce79";
+      sha512 = "1ffe49df1e8d4eb7cd59135b18fdbe6dad920e20aa8e072ab72fbafe332721c833419b1b97db09f91413de86b1717c98d19ed06bd242f55cb39d5a1423fd2551";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ar/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ar/thunderbird-68.2.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "79e4d01a88156ddbc1db2afd10b83e6e069a69df8cedfb0e247706aebbb8053ae68bf44b0ab1849e859ae15d8a6332c4e795033ce7e3385210cf9c12e4f3c37b";
+      sha512 = "d00e2b449749cbc92e497a400eb9f3b1da84c3d654e383809d9b053be6bc2a628b69fd2448773ec339fe55e9d966eb002928f8ea38725ec90522242023b51d9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ast/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ast/thunderbird-68.2.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "72f4ac14a13e364e4ab66d9659845abd4be47f07311cc79d71e05dedea1aa796a8e6d5772faef836e2eae410c1f8ea2b7b1bb460ccd60a0cd2bc7d48f511cd2b";
+      sha512 = "c9ef37b9ac5fa44183ace94cf1f461d0b5a71be8fb491720a1454fd42e4ea423577b7b59885c2b75394674860ac264d7347d5de980f86d6370b0bc3ed99c57b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/be/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/be/thunderbird-68.2.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "aaef151a1ac5b0f4adcb1d708925f5d6452f04fe3f73617bd2a5fd0e2a54e48229c9fc27ec48d5d9ebe8db9e1925b2df7542cd543cf9f312ea7e65ece10d44ce";
+      sha512 = "245a67bc13266c6ae193888131284cb330855deb876ab075e3762d142f4d0ad2bd24a6408c6dedb67133b5abc59fbef8829a29555f47a1ece5d401047b525ae4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/bg/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/bg/thunderbird-68.2.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "28c9f71d5674a21785656309f40876917c27d979f082269f8b32f1600664fa10a3689abf856aa391cb42776fd2d2af18731e4af22fb1c5e75f3616c44772e54f";
+      sha512 = "1ff5dd84fc6627331ce7ba686eb9909f67430ebf401dfa55f0fa688d8cc9e09b2ebf20f027ebe44951e35550b5c1274d714590681b78e7995645338d6622d5ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/br/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/br/thunderbird-68.2.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "08d2e1186d18f3dd80282597927c7c747152d13d2511eea5169b2b42eb4318a817261a2518509f8b26ac83d770d0e70e3ca0521fed8c3f253b5e6f211424ef6c";
+      sha512 = "5b490329c95f9ae1f8e326af5542525a84ebff003db16af222a7952a7b3150612033744e3510b1ee88e519c3384e45f9a49be908a94aef4a86bc90317e22e4dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ca/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ca/thunderbird-68.2.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "d6c0a548b4eaee0c0ab8f7f03e3cf329d353f7e0d2403796b7db8f1693afdcb8454715e4d0e0d2e1f074cd816b2c9ec9be5ccc76b4d7f0d00f8615bfce4f193b";
+      sha512 = "3ab4b4552271fc95649a289dd0b53d07bc10c614116aa723884e3875a0d3726eb234f7a5279a0aad4112bc6b0ca403edcfe1c3e1f2e355a058ca19a3b1cd4bc8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/cak/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/cak/thunderbird-68.2.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "3bd32854eccddf411c294bf0dee5f3d945a1016d1ede639ab8c1e2e86ca97b9866f1e4149f1fb0402fe3ebb148e8f34f7b12ede4853c6cd2edb87d9e822d1e27";
+      sha512 = "41b96130d747143e12d975165621fd7dd6b2705e97cebbdaf1de6cd02a94a54b524f818d4b96d752f926bd6defb38a7f05eee1b8440badb8f946300758287ceb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/cs/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/cs/thunderbird-68.2.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "33c87e9a016097991fdee92d5f8813b4cdeab355ddd5d65d25a017640bd50dba94d5936148e0873ea596fdab2e214eb70bafeb5edb6576397ba300eacbd873c0";
+      sha512 = "30fe5fc38f92d6047b5c666a2c7b07a6a5cf3f5d46fd3958cdf77efef172fb7859f3984185a67eed60cd5583d204222344c2acbedbbb5467cec27bbe3735442b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/cy/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/cy/thunderbird-68.2.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "f28f46b5d8004ade5b91e3fa10659ab87c85f33faef90c534a5c4c0680d11dc0f013abc28003b1a7111b4f67040ba54a4616c85cf9c906e52048ceaf6d9de7b2";
+      sha512 = "9d721c39f6777a0e38514a7026fc63f608a88b5d5a4cb498ea27cd55ec9a617bef8456e3fffc476f6c770ea9f26cf7bd05dd4185be4da307e9888b089927bba6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/da/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/da/thunderbird-68.2.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "21eafecbc13e8f63f36386a64fd947ca566ff6878e96a6ccbd124e1020a62ecede74f8578b56c66b13ef63a4197f527d406aaea6559b833017bb3e1931052dfa";
+      sha512 = "398551aca6272eae4e3c230f3df6c4c33ece24c9a1c65d91eb761e2f5a88e88cb00ea76f2aa1a08e09022a5f6f78859a4f47fab9b166e8d985882e5831931748";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/de/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/de/thunderbird-68.2.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "5c7c528fbff84823ffa46300081f2d5352bfc5316af574d39e020ca53e9b61b1c5784ec7b863fb095645d908ca18862610babf31f7e094d1e0280ce8069573bc";
+      sha512 = "e8407674aa3dd2fe2629d026fbefde62ffaafa27d8c108f7f81d939e33c99bd7f800fe46ba85f7fce905cc8a9e04ae45c2ab495e01b7a3536e9dc759ed592b1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/dsb/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/dsb/thunderbird-68.2.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "f18ab27c8bf26e2ee2feb2007cfab28622c9df0f03facb20f0ee581d6bc33c67227a2422f9bda7edd5cec8fc1ce0096764e26d35262559162a3a37481a92ac3f";
+      sha512 = "402242904ab127690b19315ecc4fa05edd8227845714dc2adb48c0a27e4ebcc34a11e88c9226c35cc3f7691d5f7061ad031896312155617696625acf13772715";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/el/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/el/thunderbird-68.2.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "f3fb8cca78a51fa0b855c8e112625af364b59a6ef2c05c7712da6451790a8749f26260aec716943a785c6006582977ebd950f09cfee8ed9041a875f9ffb632f7";
+      sha512 = "4e55a1be8d29271927b96a258b3a63895ec78ef7343792c7e5724161778aff2f675096877db76dc7a7380d529af4c0e07451aa24900a0c110bae7e007219c462";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/en-GB/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/en-GB/thunderbird-68.2.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "5d53ae6575e6f3580dab921cc2ee11c00834fee39cd321c906b81103fa14b82e4e129d48642aa9b857921abb11a6877b774ad685069a921d417fd93d25ab2198";
+      sha512 = "4e760c56ac7d6465846e7e55a841a8cec97a2ea5125240c84b4e6dda6a7f093b21c1c9a6f1918e897d413b6ca53e8ffaf8547799a494c50795524a1e25bcd32c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/en-US/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/en-US/thunderbird-68.2.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "9a4ead1f16785db8778ead96eb4ed21c5d52e9d3669d2d3bbded0d616e6b57d0649347b067d48437b769c51093627b47503408aa109dc899d62ace8fed83f62f";
+      sha512 = "f1eb103ed969484c70d28519072be820014c829140876fea01c944b24730986108ab717e15d41eecfe3e1226d3a4df7e19848c83f32e04a9d1b5a57a3ca1ef36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/es-AR/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/es-AR/thunderbird-68.2.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "15e85f3f51409fac915b095310158a5313dcd82f66470c85874e4306f1efa70e63bc4b39b615dd8e1eeda22b863c6fe0c5ba15bbc6dd94b6fb4a0859f22ceea3";
+      sha512 = "c1cea73c2def763c74fda709a27b194703500dec4383adef39ace9307b972aaeb531730ab821bc1405f1a58d03463179d0985938a67a7c794628efb0ef08bfe1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/es-ES/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/es-ES/thunderbird-68.2.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "b136302034d987594f65e68564eb1e6b1713d79be39e7b90f8ca73c74faba06d97afd60253ca34f15a415575c412be6ec1113598e86b0b7c4d8ddba35301cbe5";
+      sha512 = "d787f85c7987e4ebcd392d07e928ca2decd0ae60dd56260820646c0852415caaf1f432d5ab695c26803ee3a3bdb01ff3de7e4b0b14cfcbdc2c0ce30adad425b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/et/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/et/thunderbird-68.2.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "5a344c70202d884827231d0a7ba06703c7a265fd3ad59f1442b7d4bdb57fed06b8d6aabff4a5d6193a7b62027e243cfd27cbcafcdc1ce97baa7e0f3317f64e49";
+      sha512 = "12cf982522eb1659823b49feaba38ec663525ef512d2c3ffad88810b5577ac8e987f0b3e8c2c1c261b27df8a70f2a61f602f1bcf856ebe8dd82c06e2c4654887";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/eu/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/eu/thunderbird-68.2.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "ae417ccef00a3c5a2fd33ca653d35575126d18cd991ae32e25bbcd8f6d8a85f282929c2f2c78ae0f12ccf85a418cbd9518f6d28f89d6bf38c41d3509801caf45";
+      sha512 = "eb29c61e849b3e5f1255a02efb14eb0b5446e4edc6b92a77452865eda006b1d4c57df0cc14145a81813a3c9f3407cea135811ff6d17fedd9abcf608468db4553";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/fi/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/fi/thunderbird-68.2.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "2046eda267c49edb5bdf268265dd02f638670c8d6f1310fcc496c1acab2c777e39c5a974dedbb7bb1305f7a9ecf11c64303f8857aa7fba66f76a62cb89e45b23";
+      sha512 = "2e25046477f6ccb78a4f5d631a948d898084521451d8841b82dbe448b91cc3311e4f37a7764f22e53c3c0a03c4cdd91816fb7960916d5c2f480ed8fb6ce7aa6c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/fr/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/fr/thunderbird-68.2.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "f483c884064d13d11d4085a72c8805b5c10564f2926182c649c5422c31c8014a75948d2dbaa612f29b1f64b615e6e9bbdb2c4c1c406c8b57f13498ec1f29674d";
+      sha512 = "d377aaa2329d814881f2508a40131acf392e018df4e553958acc6b7be49e5649372f06cca12278161796cde0c1294ae8c045a27fc26900969d55441a96da58fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/fy-NL/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/fy-NL/thunderbird-68.2.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "b8fc327bb911c25be29c8ae5a664a2b000ee08183388dea6b75f56105365f541a5f81f6d00089868ad20037809c2e4a33dfcc988567fbec187f41abf66d4d6d6";
+      sha512 = "83a1afd4c8c621a28e696a347f3b784e97dd73b48edd1ec832ba2c8a3d0ccc0a24e9911c49be1567e1e482116d1ad8763b4f8925b66ca07d95b46dfc8428ad59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ga-IE/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ga-IE/thunderbird-68.2.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "4c456ec8474109c7b136b14ba49ec8b155f6b7194ca4db618a3daa7affb7dab4b757a8536798cd59241425f4b2404a28f6f3d99969beeb9448192a8faf8fa324";
+      sha512 = "b235bc8a7119d6595927173bd4c0222be43edaaca5f94b83094b1d725f95599caaa4c37b98c7d4096c2d491f54d83a5508de56871e9140460ae3a2c02f065caf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/gd/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/gd/thunderbird-68.2.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "d126c7f9c29102392c8bf2643130f7cca7add29e60d540bdd344f54bc7535b10e70b224ff6adb0d1f8eebb86b933f1f232b768ce65cbb0cda68347dccd8fe373";
+      sha512 = "139b42f7353d47e847509b2d0cd612f2f948eebebb40746513c48d8a99fabd592863fa63bc5d25410d79d1233457f457514d0b606bb9185c0b220596aacfa3dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/gl/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/gl/thunderbird-68.2.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "35c855e9d0df8030e455af1fc1c704ef12f598f598f15b2951b412f9147ad5f3dc129c7ce7b4d3757ab67773e9af75459bc4acc07fdd1390c0d080214840d903";
+      sha512 = "7700ae3008f268f6645c1d06f4f26239158c5af8e1d134c8298afc291d7f6f9440c38f0db470a6ee3e5744d58b4d6ab7ec81db20b856a6920ae4776781e17ad3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/he/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/he/thunderbird-68.2.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "361df030e5bd3e876865fe727e41885cc063f1091e0fb6ed71530aaf2cb88b8ed02c6d762939668cc2bd2fc7d861ef0e737dbd7c7ace9a859158c978f87fa6c3";
+      sha512 = "54f13a180c1aafa42e66ea217a53917112d9c8040f76ea2b9c8d47ba0c420be6f38f33965c47f694512f3e50c088187006215a2c1f8f0a23c4a15434f0a38c99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/hr/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/hr/thunderbird-68.2.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "92bc3303a6a0bfde8c287e98593f3a88ed1b44257dd660cfc418beae15780c06919509c48498633ee85fff990ae447f71916bffbdbd1a5eb691fe8d880052c4c";
+      sha512 = "156be5e240bd7997da2d7cb53fd3b823b9d151c0438d22922a0af09b58480846728da25574f828b75911c612ab7533ad296bb83a9ef010e5a1e7e5391198f75d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/hsb/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/hsb/thunderbird-68.2.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "6a18e62fe60fe7694fbe305a65a497987934af299c83ea0410b08fd139cb988640f511595340b4522fa64550616864060df7423bb0e23696a29dcf274c5987af";
+      sha512 = "906e10af409ebc954066876ec74abf8c4bd5d871afc840561d66d45e8a671e21a59946711401ae84e90ca923e470c72dc1fb6fcb354b973b6712a6bda24d12ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/hu/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/hu/thunderbird-68.2.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "f6a4e4844eb10964c95e0cd6a143128e970f40bda283d63ca542ad707c8818c47106e638fe2cd0e5c88420d31fcb7dd86888fa764ccf4d6de009841dd06bef65";
+      sha512 = "cee72ccd9690792af1b58199cc893e6bfa79f1c5fa98cbbf91cd7385f658ba3082253338df28e822ec5d83e5f7288230b1242e4515ae7b36a861fbe07579dfd9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/hy-AM/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/hy-AM/thunderbird-68.2.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "1ab27605d214695d3db36d337ecd33853cad37b2355c5a5a89da995c3fe655f25f3a1f7e01a9903e5628061bd65d0fe43c49e93558939d152449a81cc91916fc";
+      sha512 = "df2ce259de444e913f39e6ff5f7d678a5a51d0db1977d21f564485fc602987e63284a07d1ad5fcd77864f5bbe7aee28c5028707ebea1343122a1f06c5869c900";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/id/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/id/thunderbird-68.2.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "330f0b9b8c854c37250679ce6e9cf3882153dec717b3b0e6a29524967c5e75c6c784547e9055aae232156c6e0aa0cf833060ea9e192746185c472b1289c662cf";
+      sha512 = "27dd9cfe96accabd3a1d383db15ec3c54aed8b3aaee6976223efa0e92da584208edd67d029d8af77053c248938ded23ba6e8d5c2626ff6ecde37fb3f9ad64aaf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/is/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/is/thunderbird-68.2.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "e8856b72d2950238ea82095fe96fb93872ff6ca8da2ccc666386ce08700f7fc137fb3957ac75c90872b7db3b15095892a3bf39d4169d364c93b79abffcec0588";
+      sha512 = "cbd503933ee642cbfb10dfbdf09ad74e4d2980400ab749eec93471283ad7a9025c5f3b765ef03ecf0f7a47a9d8ff81098222caaa54cd43c7a734180bac56ad4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/it/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/it/thunderbird-68.2.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "75c7cbd7659f5b2156ee6ff05fad47f8c0e9e41461a79ec1f9c35bf15d696f9526789a6192e3dc32b36851d17958351f65f76be50ab70309fd8bfedfcf579e64";
+      sha512 = "421d54e523b0e382ca6aa3888e433304e2b31f58a9934488719bfe44e8b52d1b1c4475ea3e04af322fbf89fb766a963ae39ac3813dcefc24fdc84f1ef913d33e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ja/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ja/thunderbird-68.2.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "ad790fdab0bed7a4828e3654999e3c3b04dc51f04ba4ca12e60d9c70b44236e6902b0dfaa70842db661c5fefc28eb7f2045d78ff5df82224d7e0550dca516f95";
+      sha512 = "bbf876ea4f1d1a5f67b4f45f356df3a18be87065bd3d3362a8b54022f4d1ffd931feab8bf860ff690268ae758e13d804b0759b545974df6cba72ded90d953418";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ka/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ka/thunderbird-68.2.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "371fb961b63f170ab0521bd2fd590244966a8ce9935f5352baaa244922425ddd46f40fc6f8d5512fb7b61c12d01e8d050fe53e77bd7c69f7b6a9135bdeb81e3d";
+      sha512 = "5b59da5dd1d32c349bbc9922dda729a147e915d307a9c6f7f3cb51e8670bdb151d550e8f8832df0629391f928fabad58411b2e76aec02afef73e47c7eaa5db35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/kab/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/kab/thunderbird-68.2.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "a1e6fa908913e56e17272545765092f3cb32d6f5807db7b7bf02d3eaceac37a76136cbfdf0c11e274c7a59b8a1db8d8b54ddea6bdda75d0b1e9f869eb62d8fbe";
+      sha512 = "24afbdcdbd762508e10598e102e3019f23099c0db9ed8f36d0d0eb88f93f215511c1056ea3f9281edb4f6d8935273964e5eed89415f022cb85bda902f6e48131";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/kk/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/kk/thunderbird-68.2.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "2953c0e23c7153e96cde831a607e688540522698649bed526066bdd527ab8024e6007842ce8cc2f6681ab6de81250e63f52c3a0bd51f9ce1a495d19f2446b2e0";
+      sha512 = "7143c4daaeaa364538cd1bcc08a80ec42dd82bab539b8a2f2b616cf1277249b4b6e3584bfcbffa512e5512f018d2c477408f60342646aaa69bbfe497c2afba69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ko/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ko/thunderbird-68.2.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "bbae4b68e771c5416285edf8bd5e8d9f117d5bb9b5da4b4d2d4a90e89dc74e0be32b53f123426bf356749dcb3077f3c28fff47037df2a4afde90d08899794e01";
+      sha512 = "1f1a0fe664d77ad19a2e438e2db872b0248a4c4d232a3496d00e27556218ed9633503d47598328b8c4289f1f0485a8076032bbba04450efe215bef32dc2177a8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/lt/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/lt/thunderbird-68.2.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "a074abc38275119652bbd69765fa36d3865253f32ca7efaaf628aea94ba6316fb581d083eb0284eeba530bbbd8f2613ea43ef6cbec6090c377449e16a1cab272";
+      sha512 = "233f54aa2217bf917300bc2a5b0b24dfbcd173da0ed778092558ecdf8c9aa5289fbea1febf2b812b2b45f352c4503ecc24f474e1eae178d5e4f06e04f54b43e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ms/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ms/thunderbird-68.2.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "a956870831e313917eb15e836aa1c3b5f774afce7a1962f0041c07008b627d5dc12821c091e4777181a15de94d62df565caff10c620cf48d08db0fe2391ec8d8";
+      sha512 = "56aeb272382e45c927de40c9543f106a1786b97db987df299525ccc5300195839524b247e792c8165e2dbccfff95f0ffa0718404163ae646fe1f8851f26c49e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/nb-NO/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/nb-NO/thunderbird-68.2.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "425ba2a0e7401d83a4f98389e108eeb85ffafe685a748526012a47c07768278879d0a9795da0bfca5a955f607afdfb5243a4a5980d85d0f827d0253c5f84daa8";
+      sha512 = "565a7b0a9a5afbc7986f7f887c7e69fb7ee9fbfd1854d0b8146af92c9a0ff7911c387b462994c9684fcdd30ec75ab8ab3a6baa279f1f0aa275793b3ce467f50c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/nl/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/nl/thunderbird-68.2.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "dd05524929e09c8459ea9bde675e645af56e516cfe087862d4b869401b54fea9766553de4edf340ae936d9db169861fe655b3e258cb2f824237de68ba087088e";
+      sha512 = "f2159d2f1f6c7898b2043861137cc4635b5375508fd1cb490a561c01f384b3915dcd741c6c5353c749569679928c65ca40b703735205f0665f7b47e79281c139";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/nn-NO/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/nn-NO/thunderbird-68.2.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "5d74324cdc78563e109f0dd151dd90133baa3d93ecd7c24e3ab8d0b36a402f524e97c58889a4d5ad2bbf5ca08d785b45c660099777b9706441bd7fe5b8c508d1";
+      sha512 = "dbe967a11e73e02b9ee04622f1b8f1cb9ed7564076b651668b24301c42a667f1b759a125af30e9dce48abbebb6e1572e2700e404a4684c8a056061eac1f86465";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/pl/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/pl/thunderbird-68.2.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "09521b3fb8f49631c318f6bd1e8bad27f9b75994c3b1e8b57014d9b290cf6cf338ea30ff46c6b07fb2dfd456fbca18cb609696341417bfb39740253be2a9f678";
+      sha512 = "00471c2ab023143639fe91de17b34ebdb21f51c0fda911968bf8d5b8f1c347800c8e45929712578048334a61d5291e29a0d971114e984685fdd370524c05e218";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/pt-BR/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/pt-BR/thunderbird-68.2.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "9a5c096a5e2bf3d3446c0de33fb92995ca71e994e40fb5b66001f7afe5d0e196a7b3b0088b8e51fa8e079af42095c321ebf9acf367408d9c99c33ecdc90dd57b";
+      sha512 = "f58ba451b23c8de5dab0b1aa9512258bd544ef005db8a730f03091e8a1150342063f1d3da3b0f1f7f88d660dee68ba198ec0423ce10d08d011ed9cafa09d9224";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/pt-PT/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/pt-PT/thunderbird-68.2.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "c19d39ace2beb65123f09129545cdddd303726c2efce12b57f5919435cd6d432c592c5fe48f86ede44a949edf1a1a995b3094f26266baf18cabb79188b00ad58";
+      sha512 = "1b59c18712fa3bc4b9cf95b7ef29e52d77abd2caea42b40c6e252841f0f3a3e395460d95c0be1aaeec86148ec36b69fc1ffb00069eed52aba5b2ba26752599af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/rm/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/rm/thunderbird-68.2.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "839f4e56a788762578de09a74ce8974573b575eb0e0f641f36d2d6086eae08e2a0cb6a610f4ee2ce00db0b8f0549c9cdc3ea433ba3e0a1eb5f6a9093542b94d1";
+      sha512 = "9cdb4d7a8936fc8ca33b4537e2c5a84b5ffd1fff3b6a7bcfc12cdbb644de853034453388d6dcb6fb9cb5cbc76a359da8a9545feff3fd76cab5135f17ef3f11fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ro/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ro/thunderbird-68.2.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "0ae5d25b55971b41594676678dfeed2c5f0c89c3f4c8b2649ce2a1ae9183c1518a07410e46b9fa86d5f09f18f53f4a6c37ecf1e4e72d6414b065dbe3f46d0d6e";
+      sha512 = "3e4085ae550792659070f3b903f5dc9141899fc0b9a81662f5dd42f5e94332f5cba11c298bbbf1e288ff21f89c4ab1f08e6cd202c64e562e53f999727142bdab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/ru/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ru/thunderbird-68.2.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "fc00117c0caffb90ee70583692add1a0aadb8a03970c8cf501aeb248bf4abe1d8d8046c2c170b42248d0f1f11241067508e35aeb0db320579882905156827527";
+      sha512 = "e4dc478b5ddd232e1cbacc742f71f6c571011f9a591d23cbe11108ebf59b77a07fbb8dc74b9ae54a22fb31aa12b386dfe2e8870c336e1c7549af4d4ec0e3220e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/si/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/si/thunderbird-68.2.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "6345bfa3abf1ec899320696b10553f0a75b48f2f2dc317c5d6ac10ddaf09a7269353a73aec84ef4d7501d064e409d434054711441da3698f1ed5af653de4970f";
+      sha512 = "c113bc6f7294373e754fa7ce68f2738fdad9d151771df7198da6375710cd774c2793d1769c5863e055e42059a084c2991503e489e598faa001413afda5ecf348";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/sk/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/sk/thunderbird-68.2.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "745514c55e85f71cf07bda02a842c8452c454a80a10bfea20e9c5750f1702809b4c589a2c1d3127c599a91ac0fab458de8c4d66afc8511e64278f02638fff63c";
+      sha512 = "f1e2c8aa8e9d6773142a6a5597c3c9987b28fc792259435b4847cc8031f90ad1148fddec18ea5af56123a7c0bc013fcc16993d80f89350e2ab03b73ebb919ff0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/sl/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/sl/thunderbird-68.2.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "2449333ceec017fd3b6e3bf673c3aa553b9c52c07a09e02e773e42e2c6acec60573183d6a09c5c085ed9389c1d48c4f02acf50d83499421bedb3094823ddb34d";
+      sha512 = "a0cdb0c88c1229fb6320048d857fdb1fdfaea522c64dd9e131a1ede81c621ea405b795e37861e6202b35040c315ad1181b63a18ef4a6de56a0d65e15bb1d63f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/sq/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/sq/thunderbird-68.2.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "7a2ac8f6c04cbdbc222ea1218dcc64928b6d5038381a7655db34cd568717854197fe4b77645b2ea07b4b76a724c2e8196db693c5e367d09367edf1af471f358e";
+      sha512 = "f268882bb75b36531a03361b16478493813f0121120177e823c411896e5af2f649f617010a045da53842a42365d97794a692c6dd976291b58a1f99a42c579a90";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/sr/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/sr/thunderbird-68.2.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "06db22ff1ed32c1311d62d1cb860bb22686d5893985bf16fe2effaff864b4352788889d5e2f2ff6c450edd4be9d9c1f33ddcff513d5eb2cc3e88fe5e50c33485";
+      sha512 = "c638a41e49ae742d972eb8bf86a04831ecdc608e8d971c910e411ba09fda322c98109e93692c0df884382c1daea2435de105f6894618b1c3b5d1daca2ef0cb75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/sv-SE/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/sv-SE/thunderbird-68.2.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "f1a43a44dc155a01cda07041f554eb3474c35621ee8d8c7596aeee2746da12aa934d94f436014218a360b7848888d0e49285ca66cca8209b7b02d044c29571f4";
+      sha512 = "cb49038fc6499e0fae95eec770ac9cb2f900787bd83410a7674ebaef8ab9d4ec840beae1f90bf7cd1145384157af819ab130c5574a530e3db627e07bba940ca7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/tr/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/tr/thunderbird-68.2.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "e430c26852fd2cc3b9afabe9f8c3e1480e3454614bd90c766dce2b2cf652fe526146f79bdc0e25a1ce4979c1e22c0af90540659df5fdae89b0498428a61e0d1b";
+      sha512 = "3e1285c1b3d369800ef349341e5029ad5eab30025a9fe42dbd8c6c7a5849074cd54def4f02d2e29fe2bb647e220e8f77ac424fd1310d7c5a3cf705346eb3f229";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/uk/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/uk/thunderbird-68.2.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "d6717aee4e1367ba031d03a90fc46ef397f9bbe6ef1d2a5537df77dca1d042e83c6fb44baef9ab01dc47de0f481742186220542831bfb6670c7a756a77eddfad";
+      sha512 = "0a5cf64201720421410861023d0f570b009f2bfce58cb9e42e9001777824e51246db5b5c7be513a54a19d3db1514d9f5958dbb6274f1781518083687343f91e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/uz/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/uz/thunderbird-68.2.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "58ba68d642eeb1700c6d0994260bb16028fd15b49697c6e99e61e73d90275e0e4d2e6957c2af60122ca7be8804c1ddeb15dc38090287335a674104da3cd1cb47";
+      sha512 = "9fe8933b2df9896121c592a94d5ac7ccddb12c8ffc457a5b5b7e7ec7baf8166a3d5d63e767b0c16e92dc884643247b1516b95cda1151253fd1000b2b333fb8c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/vi/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/vi/thunderbird-68.2.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "9968cf02fe2b58f21e228b9292b48fcf9df5beb805335e7c77332231690b2bfcea29a4abfe9e834a85c2e4f79fe55df4590a2ec17676712c1b30736f48704bf8";
+      sha512 = "46524bf98c21f480d805ebd92b2fa8d2913f2209d25048b3ea58bb8dfd36916c4d12cd3805ad468b86c6df945b7d974b953b9592ece9ff817a5817adbe6a73e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/zh-CN/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/zh-CN/thunderbird-68.2.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "41369b102e82285050147d0e883fc20c6b7d311a1a8cef2efd31480a6eeee8c3ea5e0a9e9968c3d903d1fd92aeec331ade3cbcedd16cb254a74c6049ec0ab410";
+      sha512 = "0a5b55df46c71dbbd976e2d6917474da6a3d4f3e67f516dad590b3c96f4925a4c47a2bffcceeb34edce043717ee2da6a1463b7be3a47f18bbfb7f92daf1b9310";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.1.1/linux-i686/zh-TW/thunderbird-68.1.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/zh-TW/thunderbird-68.2.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "37e07f78c2ab67d040d6cd4a511fb3e6a641ca00dd659b51d5d320e79251bb2096dd6719da819c22306e10af9fc88389212129d20064ce110d06d49bf01545b5";
+      sha512 = "c66cbf149528a1c2c6cf44f238911f2455c5867d44565cad757dd63f39eb70bee9331fce74c19bd97b5128a9bee89698803c1936dc7239dcfd099cff0f224e9e";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,615 +1,615 @@
 {
-  version = "68.2.0";
+  version = "68.2.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ar/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ar/thunderbird-68.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "94c10cb04b64bf430bef1c1be558f85b604eabad88f4a8388aa4b4c01ef699ff1aab04472c4d475272893eb555ee74a996f727c87a65054faeac82c9a12028fb";
+      sha512 = "1fb9cd8dd5b8b4cae4aef37c2c7bcca6b87562a7f5bbf419982a37c805f45fa12bba3accef9effa80a2c51968afdc37d0c6763fb4aa06f1a2a4448f0b555b43a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ast/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ast/thunderbird-68.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "a09104912d28c60adbb098da0932418896124a5901cc9aa89c14f1effe087c556e225664ca44204407de57a3ebc27b342ca880a1f7b01b11254e8173b433741f";
+      sha512 = "780d3e7513b9ad4f2f263afedd2ff8b09cbfe73613a9b461f913089ff806e6956cb47a37fecec90bed23cf437bb24da95cd720b8221c359feb6aa8e0fdbf45c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/be/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/be/thunderbird-68.2.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "15c631dbb4ea2d70e480a2d57fc47c1c9ee241c869ba664c0c7fc858a8851cc3a57d833641c3a1bb1e9a3b1b937d4227baaa76d9e6adf556076e97ee83e37e45";
+      sha512 = "9b38c3c3887f6be9a3306c876b5a12623b52dec2b4287bcf60990ae14f3e2f5d6911ada2042892e164e8dc48cead50c38cae731fb71176915a4e35ae72ddb3ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/bg/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/bg/thunderbird-68.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "6e6150f76726a0ca79cc227f065134d469a0e1c530393a4bbf23f608c3ed9461a3ea1d68c952f41e54d94f64d4ecc029863f144ff7044de31482389f4b6727d9";
+      sha512 = "8d4ef2ba98ed1f0627c9e209be57342f86914e0f8e9333adf77279d87390f2d96c413e86d241d91590d82d425fecaeb96025285278f52cee385258fa63749538";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/br/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/br/thunderbird-68.2.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "71f093f81a82cb266b0be75531354994dd7904ab5ad310c7af27ff4ab588fc6cb45eed1c671df643a30bd0288201ace61897b4f43f2abc0fb0ec84a7de52fbca";
+      sha512 = "e75a30d6e6710a6a7938061291c4f11698f1b6ed5e7c5798d2992cc78f7b77a9ebeb2e84fed8bc47b9253716b267fd21b758f2e5454edbbb06cd9c9bc7b1e9e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ca/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ca/thunderbird-68.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "eef521076fe2530148f8d84bdfdec7b7a268856fbea8f729f4339c398d74ff3a655b59a24099ae568036128e2800a6935fae55547edeb22d834536058f8288b0";
+      sha512 = "11694e7a2a1984e0d44c45fd98f6cdc45c387250b673b7a24a37d073e7ac29860e8429b5f16fc72183bf3ecf9ee817f6c2db35645bef3a2c857f4b6f3258baad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/cak/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/cak/thunderbird-68.2.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "911f720e117fef420121b80adf09a01a9c73d7bdcb4c745513c67d33f0e8f43e7f552cfca2552460ca84cbd0573ad6439275760b505816c87f53f4a1ef4a1ea1";
+      sha512 = "85a8ebeccdd26055b9226c2e3c6d4596eac3f9db644bcba4f4eb532daa6abebfbd4e9bb4d0cdbf254b6c5d3f3b14d016fb78700df8fbce2a9643d12f0da0c51a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/cs/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/cs/thunderbird-68.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "f2152b276d9fb6827940b75fcc05186694eeb5b44e9ed232e4945c711979fae547f863c1da687b6f3c890b29098d5981fcfb2d48dde134caea1a8e1193fc0807";
+      sha512 = "5b91762ad3a7ea7f5d0a46e4b0ec1d1865661bdf75afa75a2d1b2fc96c98e8c1848c921f3f4e85450caf3643801125b817d40c17c7c2a42b908850e47d7a7197";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/cy/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/cy/thunderbird-68.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "20a9e350d931e89cea3a80c47a3a0404d3ee907834a42d361b9f59c1561ac9d19f3cf486ec7e3c8696e739b86185225447331f3f681ede51618df88259e4ea8e";
+      sha512 = "8fe8c9508e86603b295e267f5e498e80c757b4d800c205bb677db0b83bf268d39522165c199dc94ff259608047414e9862ef6cc275bee520297e2310c155aee1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/da/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/da/thunderbird-68.2.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "3410cb8274cb5b2566da29771587010319ad91f0972d08fb9f0dd06077f2cb2f4ff9e71b8dbf628c4ad6930de37220df83a1ca6b8a16096ba04a42488c31eca8";
+      sha512 = "9f46e8d606670da7e1df2eb5ef5999cd2fcdb6b257e7d5c40fe8e3e5d2ba01709813874173086ccb9b677065b075c355cee42fc6c884dff299d7ea2d55f0ace7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/de/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/de/thunderbird-68.2.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "a821df98acbb753a8613477273a9a9afccbeae15859ef322c0df8888009df77efaad6d969907299d6c93c917baed1fb7955412a8105829514b0ce7c92947a9df";
+      sha512 = "1f4c94b9597557bcf3c6157c69c080a97ee4ce09a2087ac730fa13d432858483e354b8752a83bc3b651038409c5668361300c71e27268735bc7695ba9ab1df7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/dsb/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/dsb/thunderbird-68.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "06eeb9fa9672befe101f56a41c39486a1302b30176f8401a9a86202f3091a9a0fc991e388fcce4892018198afb7dea87d9bbd885c4d99317aa12dd2a607f5d67";
+      sha512 = "0822b5d4f60087eaac3ff400082a2bf46168a6e7d6a2d16adc0c8c9fecf2891a4f5003d57b134b51ee192585a99359e07156f1fa89068c7016b365de8e6749c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/el/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/el/thunderbird-68.2.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "67b74a425f35af9220d74c29b9c7b4b9a754916b65a41d9eb5d089c396ed3bf5df4f23668ccc82ec2accc11feb0ae46cf836d309c46865b7121dadc27febe18a";
+      sha512 = "0d0ed3efaf1a3e751474f0f18eb5e4deae61e14dec444c29835e1fc6579343c366badd32724577e155b750850ab9111899be005c0f36aec7cddb7122c4ca7237";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/en-GB/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/en-GB/thunderbird-68.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "d4f7bf9ef86ffcc81ecfc8d4eff9c0dff20657bc362873fd6ef7cf21150e8fcfa2b0d4d931cad5bbc3253e1d0f9f0794f2dc50485c0523be6483c0b148a3f07a";
+      sha512 = "69d51b0a0c71a7dec36692c5d40d77ac38a81aa46b6cc350bbcdee529ba579c76057f5e98b0b2906df4236e5bf7086c995d33382c502d81c1c878c32c896543d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/en-US/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/en-US/thunderbird-68.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "363441693ea13b0888e32d50ab1906d4642ea8b9503ee5a9b2c4542a571e1d9339a6be9775753e1c9df151f326fcb403e0b294aaa0e397b7b586187e43af3bed";
+      sha512 = "158b888e2e10bad44f7a6fa19e4f986fe75c56a9ff98fe749b1b981fb67bd102e9ee744ed41267b4b327b54ad24ab74cfa033f9f3bd2ccce9d7ea2f440e76c4a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/es-AR/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/es-AR/thunderbird-68.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "955d8dd7f863cee295c7852567627d95996597c0cf46de5651cecf51ff25cd19e9e9dce78dd63674ba08f71b81d06759a319532d35460a0468f5423e051d3d30";
+      sha512 = "0ac1482f79784f8e2140311fdcfa4efd85f944ea3d2d9e82306decba4de8e8b2ce8d3cbddd89fcf2f6613bb9fce7b08145b79e3f8da4f43d596204af8d8f0740";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/es-ES/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/es-ES/thunderbird-68.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "4fb00dee3d1ba3583797689dc8b41aa93b1c4ed3f22f65e4ec7ab9d9c8af20abf6d6fe95883c80f83e49630f1731737b43744413e055b841182a08024fc4a755";
+      sha512 = "2971f64bfe40444826c9e89221eb1ebd9b0e89e0b1ab76796fa2ce2d72161ef8a850f9c687c2a4b370dda4f86830077c603916a9676eaa419e11e4dc7c0c8e3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/et/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/et/thunderbird-68.2.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "2622507510b95ca3d6d4aeba31b7ec38c42f593aec7e7b56b444675a32390e590954ec68a1d919f953ff8fcf29c3636f306e7a03270ac837622edccc2eb95dba";
+      sha512 = "8763ac65259635e24c27b803feb6fbc89d8c7ec191772cd65e0aaa12fd5fc8f6080743c9357871964400470d743b549de82c12eabbd0bee3107fd5fd5af06565";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/eu/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/eu/thunderbird-68.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "11fd263e4768bf938d8b8010a3abbe9c1518a64d4d939791d4c0ec67bb7058fa77ba4e0ef3f2c5509b0c12fb0379ebcd2b9568f0b6933a1372814f6e69e6fa3a";
+      sha512 = "12153c3b32e419ace528c89ba70a0221eadd64f996b49589f3c77ebfdfb75e3c34b3b33448ee2685fb79fb5c713848164949fd2075d68faeb3eda77a4eaacc03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/fi/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/fi/thunderbird-68.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "7872e6ba365debe0a70924fb16222f5eb5a3d904123f3225dfdae4b64c4735b008e5c2ef3f5e28926103a2bf8ec0747c1926f101062a5af9aaa7ee2faa98bb29";
+      sha512 = "fc14805d09712dae2fabe2c78f3c743dff07c3df51f4ec8321ec5229fb70d884a862bdd3f29e3fb5f01eea4fb78b7e989f01f9c720833924a873daab4bc4f9db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/fr/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/fr/thunderbird-68.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "e1e892247067712faee12229ff99ae76b9a2fb91f82fe801e7faad99310fee0e208e587ee621b5e8bc9ef3cdb060ffc26b2cbee2b15fed6727d25cbf07d192db";
+      sha512 = "bec535e59259e6e909ca7ca434a27b021f08b8abfda17dceac40cb03894aa6453758312a758f15d3f4a1cba7dd4ac768382c750db6aa6181d83e3cb4ebfb26ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/fy-NL/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/fy-NL/thunderbird-68.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "4258de7c678122abe7cbdda670847c3af7bb21a5b2bf9678d993a671256037b3076ac1b3f90f38203ba812ce8d5383eca50399329ad457f0beb2a23d2cedd173";
+      sha512 = "d6842e309a9b2edabf591b36df7363a682ad8ffacc2c5ab324a0fe03dc5b442ecd8e3d05db31d603f4dadc419b5808102e49f35451e3054bacad3819afb1c4b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ga-IE/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ga-IE/thunderbird-68.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "f06482a503926239ca03654de0fe7eb30f9e2f624ae436b8dd7efc8d19545b07dd3cc468d900033426d00d9b824a2a950209241c9450347c3ec69c5a6dcfc2fa";
+      sha512 = "df8f8cbad7817fbeec544f1f6b23d4e06359e72502aa4ecb75a9e3819d9087604717ec64357d15cbb8b5f280a850dc05bdfc3bdce0ff1a14b96a608c0f87f813";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/gd/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/gd/thunderbird-68.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "b5b390157491549499d23d40e7d293d12be70eccddebdf0b78c338b1a0e3d0386cea9957e74b8880d421aa08fcaa76ff1d45aeaf61b194764a044ccf492a3552";
+      sha512 = "f8c5c1b17c9ef90db3d39b956978be96801d8196f4f5f3e15cec0f5baa14a5dd94612c09d177425ab4f2bd52c8c5910cc864d8c68b408831fda83338ab1fadcf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/gl/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/gl/thunderbird-68.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "63da43e0f8d28f7f1b3099823f6a3eccbce0a296b8ef2e814e728dc044d667cbea8b1ce9f5efb034b72cf17e468f4c006f98e897750b546e5f842116c06afdd1";
+      sha512 = "32ada11495dd27707b97981b840f4b6d706d86756914b7ab59cf886b170f2c927990a3e201a955bd81734a9e7732b181f6a4c618d9cbef019b494de9b305ba19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/he/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/he/thunderbird-68.2.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "8945af4410b3ad01c1131351c660abeacc8b12dd3c9ca6259adead008a90df50f749d80398ddccedaa9ca9ec1a94a7e3efd7545cb2a79823a35e8fe99dddfb19";
+      sha512 = "69bc763d9c71fa6132ab598357d3527df00e05f7f24d06832c5ce768072cea148c1935ca9eedd78802f29349f1147b71c32bc3fda58dc0d279c44e735ed48847";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/hr/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/hr/thunderbird-68.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "fd502b129afcb37860b70b016f604bcfd9be3b7e9308bec794f70840e05c768f94610962ed02ce24141302819382c7c9b30b4feb9297b5088531d6a4e627d855";
+      sha512 = "8d4e3ff83f636603e4b848a0c5f8f1feda7790b8cb7ee30e74060976e00893ca5b8ed16f35d4e0ca029ccc4b08f0e860df277cd0c091a45c6673f91ae3b69daf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/hsb/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/hsb/thunderbird-68.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "1c445c5fb5d80dde96383ed33c92f8bffb54bac74541f6f3823f84543e46c02c7fd1ea7792d9c907c7cf9f9e2d1648f4ec763c0dfa48bf155ac0595b63fa9e84";
+      sha512 = "2a9cbcc8a1c438a30876f72d974ef9774de08fb2f8d172190d1b292dcebdc0feee4fe58ce67aa7dc047dc3fa0e75fb31c30233ecd53211ae45dbb332ce3ccc93";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/hu/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/hu/thunderbird-68.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "94fb61ab44be683ac24711a47aa4bf9e8835e40fbf407fd785b108be5c964f703a64d19c87189133008b058ec923cc0a5c345eb5ab43ded7a2f9f2849b8e7dc2";
+      sha512 = "04049eec03cf772f424aafce31cd37d3b3953a0a7e67f0cb5e134cda3f1c820aec5a73815a322277359d79641f2001cab2b677617a5c8ea8a3dcd5e8ddbf56d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/hy-AM/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/hy-AM/thunderbird-68.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "676cc1ac305891904578e261e802cf8048cd7837fcaf030a81296ae7021284dfdca62dc247923e12dca7cf87a6fd2fd792b2c4622e2c6a18425892f4a1573273";
+      sha512 = "29f0fb2b351249423353f9fb12888d3f9e70190063896f075a55c23aa8bf9f89075664d2671789fbd2e732217cdc85858de4c0cbf17eab8c646fc0b2d2e8b2af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/id/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/id/thunderbird-68.2.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "3f1316800e86b1b3e85e30c749aac7454dc2ad024066fd4ced06df4ef96d2bba2105e852d243fbb56ccc5d2304a09e6d175f4e668be1b332c9cb7299066d773d";
+      sha512 = "3509f2fc73e9948285bbee15cfaa6575b0e6cdd6b1db847c25670f700502b885f2677cdbc684ca446ee8389a884e8db5d526bc4ce583220ecf5a9bd45aca55c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/is/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/is/thunderbird-68.2.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "85a94f55f05df564cd6feae1d05a9d2aa1c34bfdaf39af1c680ddd77e01c8af57f8ffeaea525dca8464b57574c75863b0ab81947832562c2c38e9e73799311a7";
+      sha512 = "ac407ed944b80d99a7bebe41a8cc53cfd830b2531f0621fcc5cf1de3c6dfffb862f5e8b84c086757caa8b0d397e14c03b7fc1fffa4194d040ec7f0857f6cdfb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/it/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/it/thunderbird-68.2.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "a77be5ee24770e3cd0be842f3e4343cd93afcc582af1665c996ef589ab85a9906ad5485f5af644f78b1374d12a89db32d30f1e44dc29678916e14d1f82395ae2";
+      sha512 = "73a1c4b2a6e739d106935879bcbfd55a8e68c56250dc7fc4b469eafb87e935367bfda27fa9fc07e44e18bcb6437463ac79e90406becce3149b1ed8c107212b64";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ja/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ja/thunderbird-68.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "914e66ab518565a02cdafb9a5183d910e69902be8676f78e5b46bcd6af955111cfbaab57739396e58fd6cddb7d3df235408fe3ac35ad2e7217875053ca991d8d";
+      sha512 = "57f80b88bb07f240db5855b7a2d359f25cd73fec12e6e877462880fa7bbdf2025243890a5cffb183891e0badfafb3b0aa8ecdff2ccba9fb1ea96f555f278b8f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ka/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ka/thunderbird-68.2.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "d90911b809ab83bdd9558e71d5443fcd2da2941273f6df58d9c2d9b995e924c7ddf7ddb001647d1dae619d533da049a242a255729b7c5ddc98cdc2bf422c5837";
+      sha512 = "bebd69f3a4852f8e349915e6f945fdc7ef75a2f67ba42ea5701fb78708387840da488cbab3acd7fd06c1c0319fc2294d837798d04c71b895114276adc70cf730";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/kab/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/kab/thunderbird-68.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "32476702ad651e53c2124a9295e5ef9d68ecff038dd0f93f8d574ecce3aaea2565a45cbf882072c2c21e160aadd42f07bcffd1c3986266a1080fa7bed2bc68f3";
+      sha512 = "c55f78abb7b68931555ea9653dd216bd7ef9406a39788535efe5d3a307bb0b10c1fbcc0721c4381de5ee3c12c99e7ce2d6cd5ec2336bdc4adce9291f6a3f15f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/kk/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/kk/thunderbird-68.2.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "3c122537cd92e1b6d19d7806a6297aa88ffb35935bb2add0569ed349bf17e62013630900d125aa159dffa3084ab5f63e30f5c3d1de39647504af154622c7a882";
+      sha512 = "9fa4987008ff604604892f079b332fab87b73662686b9b991ded9d1512aee7f474dffc184376ce0bd2ca254527509170e3fade9141eb0f09fc075baa5c97158c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ko/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ko/thunderbird-68.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "463d758e31cac61c59ae0f3975e3f87557a23aa92aca3e70e52e412f55a9477d250b98018619f30ba2b8db0795f39d9f5a0d15a56e0fb48f7fdab306dbde1381";
+      sha512 = "c38492085323faa3dcd70d1911423cab736f9298d5bebe8af3b90caf01a2ba0cec83ed9cd12a39d989dd42b0d3f38a984e3d854422193750936384b5cf21adb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/lt/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/lt/thunderbird-68.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "c439559fa3a98b05e87d36a4dd273c53d5e76d20adb12a7123fefb5cf65d0a74aff139287dffbd6afc1058b90f4977513efcc9c0ebc9fb65c851e3946a0d5d7d";
+      sha512 = "6c8f60e7be1c354f094148392841d1aafa0f735bdef491e1ffbb651e445dae6aaf0a053d90a2d39541d590167f73f39cd5df2fd39885b0e5a64b5ac3895146ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ms/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ms/thunderbird-68.2.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "36aedc74de1e099be9cde9419c2c4ff2455df0d2f937171cd7ea1182f52ebe900cea8f32debe486fd443fe08fec8647ec2e223ccb34a6743e7cb0e334dfb9c8e";
+      sha512 = "d08cf6ae853b47f7c97b6f0e7507b58d63f20817e150c343556c840f07e10e26bbc772e72bd922848bc9ab9353cd9c77aaafdd6be2486fe27e134c9b139f3a7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/nb-NO/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/nb-NO/thunderbird-68.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "47c24120846afdd630c5e68caffb0a55ee6e39b49b4cce47fabb7c189dfb71496f15cf813938f6878c4b068ecd6f799fc2bb39419b8893f720d3821a0c16404f";
+      sha512 = "538d757af2692332940b9cbe5937d7115b8bb68b79cc5a8d3e366b531c867d2b5eff1bef14e4bebb7131e6825bee8ff86e816724edc9919cdbcc0ffa35428555";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/nl/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/nl/thunderbird-68.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "9203adf919cd9ef4564b838694ce57e1cd00920b7bed9685af204bdd41d75cbce4d332cc310124a1c351872a059f3d9cb08ffb74916ece8227860f1cfada9205";
+      sha512 = "14142b1aeafc2dd118781ef935865a0694addb4db406e801eab3212cf179d47a72bcd277589fcfc26364e0ab186a8f7ca5dab1c0ac5d4fc0ebd1c9f2d29ce50a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/nn-NO/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/nn-NO/thunderbird-68.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "a0effbaa634c9fff52a989aca7452641f0680853bcd0679d2f265632283d2c7164504ce31783b4af4ff8a8c22ebac5eeb2d7865206494e6ae8e85595ecb9c759";
+      sha512 = "fb4be65a491a7b7bfd94030b25376438c9484e19260108552e5340317b151cc5e7ef575638c570c7c3d50112912c4f57af1430ce2e5df48628fc1dc33fa84f4f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/pl/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/pl/thunderbird-68.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "f9b8a63d3021e568b9ecee6a3741ff1b02d8da023b1f90412003e9353477b230583b734a7f13caf1b6bcc6337bc8c9a43e5f68200958f284c1855ac262e9e141";
+      sha512 = "d169f4510182b3d19e9df32cdbf18e7f5bc6397d1530c6b9a569375b86a79e236c92bfd22ca28e40db2493e30384638665101fa2bcc6386f409bca4baff3e9ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/pt-BR/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/pt-BR/thunderbird-68.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "8f7609695372957a42b3cbd88af1a5fe5ee8b0554d4dbeb895fd33eb0171ff84fe488df296f656ec43f4b5ac8756c702ed437dfd1ecf684d997b1a3f78dbef84";
+      sha512 = "991c600493c05af2ca87af607cc04c4f0c86df80ef2f46decd5a89be11f8cd1dd0592d2dac0a39ecf0184ce58c32a7d4b0bd21908e7ac60f6422fd93deac3500";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/pt-PT/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/pt-PT/thunderbird-68.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "e1f6f3a1f5cd7dc044c34a3ba344ea79ac25ec5f561677fc3f7110ee29ec7611f15d1d488db8fced5c1b030f02ebabf11f02788ffd4d5f487dcc70d4b63fdf67";
+      sha512 = "58fc40746500757d79005d380b2e92bc5cf44aacfe631c1541759b4fbe7a3867c66face9627ea44efd9eecfc5e22c242e04fe130b5817915e105d6adb4a9c7bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/rm/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/rm/thunderbird-68.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "d01abff7971d44f93139c225d582e0e2e8bd37af2f854cd2b69f46ba7f1858eb303f42baa799e508f7e6716671d77e75c8be49e9f8b773dc6e9e14c8806b1c4d";
+      sha512 = "37ca7ccf1dd91fcf9eea3ad8e34a0999eb3ceb7bdf0cf0359aec08a45b91d5f424c0cf74ee048eba628e9e1910e98f5b6169834aeca2e24f4a73d12b8a0fc729";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ro/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ro/thunderbird-68.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "9c7ea9c09357fc6885e0c60f53be2b4dac490bcf4ed64abb108163603ba0a9c825fe9333ad104a1a458c6c1d89ef421553337595f4cb5df56beb7fbee04d5513";
+      sha512 = "bb9ae44008eacd1b56621cc79141afebc3aa8035706d216f647e139d230aaecd00d130042c0e50198d616c64ed266d0a61ded0140c4f8a75cf244da6434915ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/ru/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ru/thunderbird-68.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "6dd992fd318a5f9a4a168d410c76dd9e9cc6d5c4fadf4ba9f2b2f64a3e34f21e104a5c19b1cc7387cbbd75dc90103c1157cf78793679d32fdba5c883d765861f";
+      sha512 = "2adf2a66902090a5c6b35847ffb9d736f00865bae35b865973ebaca211f09a07dab63a9af56ad780223f389332d1b84a0814012d5169cafb9c1ef5bdebe64d1e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/si/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/si/thunderbird-68.2.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "4d3593d4627d8f9822555505bf0e64a52a7fb111060fff2c11a7aac670b38c670594d5c96a9711d9894cf7bc82310a28c2a5724ba06fcfb96fd9ce4702e64e26";
+      sha512 = "4cc7ac4cd39c47c3ff6f8c4a72f784871609b48824284f7ca89eaf03529c1ce88c1baa5994c1ec22386b7ae2ba694ba9ee4c5dc0bcb138ad0d56a45b0ed7830d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/sk/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/sk/thunderbird-68.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "876edb57d6b3d7f68dbda843eec6e35d5f1e023a5c0e704dcf0fc973afd3cdfea634901d364273b1db6eccb86460d20e5a4ba7391c13b9033a55ae5899726cef";
+      sha512 = "ae9df525a94dc404aea648a50be032f7a056201c3d5ff483d7291d4e77feea33aff5fa21b247f85a76fe03fb0a34e3b143b6769adb9d79d06391dba2ff91aab4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/sl/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/sl/thunderbird-68.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "2987b765582b15ee64c5512ba23e7c42c974f376c734713932621dd7c29af10177f9cd4436c6042b87e0101a5326ce82b8c3d62f7cbbcb30e1806188380dc2e2";
+      sha512 = "625a6ba6d35050e6fd2d15327781890b8b207f24abc6b57290383baeb803f48ad881bcb7cc69aeb9bf8d50a58aba7febfd03d048040f78ab6409a94bfde32202";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/sq/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/sq/thunderbird-68.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "ea2fd834b8552c504d687bf61727b32ee23729a1a4a271ecb2e0017aabc862ff8c586a365b375b0c271d53de1eaa16744fae43f020685bf40f57177e84a72351";
+      sha512 = "9a2578fee7a4fa2dda6216958bcb337a03f9e8743206d9bae4e4b9b09e93eacdde4a04a259c7b7f42337f066e6127f6f1d5b58c82c84e0a9b6f12dc93a93447f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/sr/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/sr/thunderbird-68.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "494a4a932d1073003d1b41aa44442b4a4967e49b10d833e07053e3745502d42696137e333933de7d9c14a8284b454bef624db06519ea3d33965a27bb93f1cf36";
+      sha512 = "e00bafb8dd306cf78e9d7a486aed4c1414b2f0a424653415ccd0b0e8a1b77135e1bf04e6f87a7caaf3752171a8c985d9222c9c81473d16b0b73c1e44f952a153";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/sv-SE/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/sv-SE/thunderbird-68.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "26bfd19d7063611f078d16a660abe23337f2e41c0a379e1a59669ccff1e887169c66d35b9b9f3a65fd2a7921229dd4310e14cec8f28460a4f4bd3153519b566c";
+      sha512 = "acccf3ee449b9a9a0ff513f1bec79aa807f40dbc03b9c245f62f5e10bad0f6f0fb60053ec49f3d2187f3ea57794a9210b1931cddade228efff957037a21d1e40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/tr/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/tr/thunderbird-68.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "4d0c0d348f0e77aca8c53684d008247b16b19a6df9e3a542e5d95c697685823ac47293425d20331c2c5ba84d81fab5a9031586d5b75a05faa185e1a1c18df93e";
+      sha512 = "6213f7a347270e7e8a5437285333ab3321c4207a5ee8922ab37c15f23c535ebc38eb7b84db77f47b743addf328a7ceb99ba38b9bf4756c1667e85ff3ca82234f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/uk/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/uk/thunderbird-68.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "42b6d102d2d2c18c6ff6e1173567038d9b5da99e05cbd46a9b2593467c8845abdccb2a03d16eb843aa72f2432dd65f69efa6f0a20f76b0aa3ea015749860c722";
+      sha512 = "71cc097f0d4535cd03b092ac42f32033153ca80ab09a80c71d40bc9549111b322262898da9068e9f51b60bd438e7062de36eb8c4a3b0996e02dc1f997f9e0641";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/uz/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/uz/thunderbird-68.2.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "76a1a55daa7034e98cc37625f491190d909c29270f3e9097230c3ddf33a54fc0dbc954cd5d5339ee5e194538fd14a8c1d615feb702006c9cc8c68727a4bcba92";
+      sha512 = "5fb3ec2119ec1fd0c45d967f00ca54ebc26ff7c4aa5c2ed161d33df58610dd3c04b38ea4364b4e8c20324c6ac16a7ab8167681f02101abffb827223bf0e176e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/vi/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/vi/thunderbird-68.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "f8a1fe807f83ba411689ec709304e3029ed8e83b330432e33f0799712c3343869ebebd8b151370480d952c8424101f5da13e13da536ae7fd3c29d593a4f1f84f";
+      sha512 = "aac19830337a42539a56bc4f4ea9646afba9f09bf0bdc009ce5fb62d85fb68c6fafbf7cfc8239bd6f18ccee68a9e3bbfb0f28bee0b57fa0c2f1b7b32415492cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/zh-CN/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/zh-CN/thunderbird-68.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "cf1afbb064aeb8aade6aeab835f584ea828799342d0cfef7209fea92707751a42b0023a4132efa20e9af8474f891a3cbcfe7edc68494411d69efd1d26942da13";
+      sha512 = "6e0e34c4407c69b484483242f5203386f606fc45929495d91178d8ddf37bfaab343193afedef01807a7cfd5919bc7dea6555c79e64f4daeb4262f44a679ea9b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-x86_64/zh-TW/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/zh-TW/thunderbird-68.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "1ffe49df1e8d4eb7cd59135b18fdbe6dad920e20aa8e072ab72fbafe332721c833419b1b97db09f91413de86b1717c98d19ed06bd242f55cb39d5a1423fd2551";
+      sha512 = "3939194195b7190f0f1dc4e5e77f79349ecc69f1c2791ead9c0eb5416d69061438960a6410fcdf0c8c6a602b93218af397a78f2ebd1c527ab5404cec8e12aafe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ar/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ar/thunderbird-68.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "d00e2b449749cbc92e497a400eb9f3b1da84c3d654e383809d9b053be6bc2a628b69fd2448773ec339fe55e9d966eb002928f8ea38725ec90522242023b51d9d";
+      sha512 = "75dc59fc776b4b7e80508bef3f7d86981b8d45d49ba85d518141b5dbe6a6fa183cb5a65bfff3bee828052040f4037e966823bea8f57e5d1385cfc87eae64c3aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ast/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ast/thunderbird-68.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "c9ef37b9ac5fa44183ace94cf1f461d0b5a71be8fb491720a1454fd42e4ea423577b7b59885c2b75394674860ac264d7347d5de980f86d6370b0bc3ed99c57b6";
+      sha512 = "7ca575d7620065443cbf78dd388aeb24cde4a26277e0f84e7fed2c71a2cc1e0944313c3479f5a5f82e67d3229233186620d5fa2d237a60c23ac938e54b5cecfc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/be/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/be/thunderbird-68.2.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "245a67bc13266c6ae193888131284cb330855deb876ab075e3762d142f4d0ad2bd24a6408c6dedb67133b5abc59fbef8829a29555f47a1ece5d401047b525ae4";
+      sha512 = "cca67c5de846bd8a26ec2e465ad9110eac88a71291a0cee4dbd445c26fc5c96b5fb33e1bacfc15763b007382c6a147950d847128ac7197ab2deb9466cb7dba7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/bg/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/bg/thunderbird-68.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "1ff5dd84fc6627331ce7ba686eb9909f67430ebf401dfa55f0fa688d8cc9e09b2ebf20f027ebe44951e35550b5c1274d714590681b78e7995645338d6622d5ef";
+      sha512 = "e0444f9522350e25eccbe7ca605f6ac6a9c321e242dcc38f0f73e9fea18a78c3dfdad609b7527e8be32a9a9989a4f34dd6838551ac3bf2eaff9596f7bcaf7343";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/br/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/br/thunderbird-68.2.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "5b490329c95f9ae1f8e326af5542525a84ebff003db16af222a7952a7b3150612033744e3510b1ee88e519c3384e45f9a49be908a94aef4a86bc90317e22e4dd";
+      sha512 = "ee0c134de5dfc02238f9c45c0e2c08f2e178b8fe9e94cf509572e99b25ba5923aee47b932123e7d0b4593546a8f6d16254a1d7be99915c9f5a80d6c27c8b9c3c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ca/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ca/thunderbird-68.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "3ab4b4552271fc95649a289dd0b53d07bc10c614116aa723884e3875a0d3726eb234f7a5279a0aad4112bc6b0ca403edcfe1c3e1f2e355a058ca19a3b1cd4bc8";
+      sha512 = "19d9a5fd2dfe8e4eab8bf28ff01bae7b733b8e45dcf8b929a9039488636cb3e1d8f2ea92cf345becb320aa15c2aa237140717960cef4c97ae0a6daa54827cb48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/cak/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/cak/thunderbird-68.2.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "41b96130d747143e12d975165621fd7dd6b2705e97cebbdaf1de6cd02a94a54b524f818d4b96d752f926bd6defb38a7f05eee1b8440badb8f946300758287ceb";
+      sha512 = "da2c3232ab94785e6a29bacf084ebcf87fd6d813c8841b02e276e093df226246a4f7799a18b86bc411a26753d78763048d189e4ae3b177d18301298df7ba9c9e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/cs/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/cs/thunderbird-68.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "30fe5fc38f92d6047b5c666a2c7b07a6a5cf3f5d46fd3958cdf77efef172fb7859f3984185a67eed60cd5583d204222344c2acbedbbb5467cec27bbe3735442b";
+      sha512 = "e607e74a8d6929ac966876a0cff306073592cfc6728826b84b6d1c51a04d0228d21ddfb9c06b3ac7eae100a7a282fd0e43e5d8796d516b1a0367feb6f9fc85d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/cy/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/cy/thunderbird-68.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "9d721c39f6777a0e38514a7026fc63f608a88b5d5a4cb498ea27cd55ec9a617bef8456e3fffc476f6c770ea9f26cf7bd05dd4185be4da307e9888b089927bba6";
+      sha512 = "6098bcb8043eb313454723f2b3b2f78650c38161adac2c05570b98f6d38a6634963b89bae022742a171eaba81962dde6b63ee33322dff130cee2d5465a34931b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/da/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/da/thunderbird-68.2.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "398551aca6272eae4e3c230f3df6c4c33ece24c9a1c65d91eb761e2f5a88e88cb00ea76f2aa1a08e09022a5f6f78859a4f47fab9b166e8d985882e5831931748";
+      sha512 = "3a1835a0739910cb46ac90af86ff24b555d3ab63ff763c79c13d5b6e09af27c82b24ff96beb412a4dd0b7b9b2b66d897f0190cd32b59cc1b65b223eb486e71b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/de/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/de/thunderbird-68.2.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "e8407674aa3dd2fe2629d026fbefde62ffaafa27d8c108f7f81d939e33c99bd7f800fe46ba85f7fce905cc8a9e04ae45c2ab495e01b7a3536e9dc759ed592b1b";
+      sha512 = "3a7ace0c183900831cad7ba0e35ab2f03fcdb381e29086d28a7c6acca165a6f9a7d4d66d77090d1bbb7ccef5c081e09b91c30f3263a244819422ae9bd0d5c000";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/dsb/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/dsb/thunderbird-68.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "402242904ab127690b19315ecc4fa05edd8227845714dc2adb48c0a27e4ebcc34a11e88c9226c35cc3f7691d5f7061ad031896312155617696625acf13772715";
+      sha512 = "1f993b7dc01db345bd4dba5a8d3cfe0343574831ddacc801a96334a13dc1611e81a4c81d21ac231fee7cff15cf3c16f57e6f9f295069cbef10cbbaa0ba3fcd01";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/el/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/el/thunderbird-68.2.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "4e55a1be8d29271927b96a258b3a63895ec78ef7343792c7e5724161778aff2f675096877db76dc7a7380d529af4c0e07451aa24900a0c110bae7e007219c462";
+      sha512 = "6332f6eddbb3953e411f07c70b7834b3511a04a7a290c183b7344e3a14ab7e12ac97c80feb24b01ac7638a0650be4d508e19d8f0bc9e44537448363be9e00077";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/en-GB/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/en-GB/thunderbird-68.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "4e760c56ac7d6465846e7e55a841a8cec97a2ea5125240c84b4e6dda6a7f093b21c1c9a6f1918e897d413b6ca53e8ffaf8547799a494c50795524a1e25bcd32c";
+      sha512 = "69d8db1594be4d77cf0d11bf56207a18a92759f41fcbd8d93a37cf297f4f5611ccfed934a94b1e85aa2cfdfee7f41a217217faaa5bbea892011b951ab911c715";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/en-US/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/en-US/thunderbird-68.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "f1eb103ed969484c70d28519072be820014c829140876fea01c944b24730986108ab717e15d41eecfe3e1226d3a4df7e19848c83f32e04a9d1b5a57a3ca1ef36";
+      sha512 = "07e703940350fc8e644b4ba30ec1e484930919f1a7919184c94a676ce536b284ddc291221b68d644ed38caae92c9035d160dc957995e041905e7bf6a2f0a61dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/es-AR/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/es-AR/thunderbird-68.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "c1cea73c2def763c74fda709a27b194703500dec4383adef39ace9307b972aaeb531730ab821bc1405f1a58d03463179d0985938a67a7c794628efb0ef08bfe1";
+      sha512 = "a89b687a2fe20a5c1d4469fc40af9987b9871c205955d400e98708917e4a4162d53f407b7a343a248c3869858d0e745ad749fd1098dfb8fcd73e1af6b467149c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/es-ES/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/es-ES/thunderbird-68.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "d787f85c7987e4ebcd392d07e928ca2decd0ae60dd56260820646c0852415caaf1f432d5ab695c26803ee3a3bdb01ff3de7e4b0b14cfcbdc2c0ce30adad425b0";
+      sha512 = "fa7dc46680204a50c6cf9db81f7ea52b6b57ea8b46ab7a6039b44c2891dcb53d88f1e083c6ff5fd1babcc5d006bdededf95e847e16629a0c50631def0d7c9675";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/et/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/et/thunderbird-68.2.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "12cf982522eb1659823b49feaba38ec663525ef512d2c3ffad88810b5577ac8e987f0b3e8c2c1c261b27df8a70f2a61f602f1bcf856ebe8dd82c06e2c4654887";
+      sha512 = "fbc30959bcf06ebc19502bc9a242604cdd346b26e675f5bfa3344d86e05dc6bb280f99b87a85dcdc591157445ba408e7bf76fbe83c6ec2d04caad1b90dabb6f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/eu/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/eu/thunderbird-68.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "eb29c61e849b3e5f1255a02efb14eb0b5446e4edc6b92a77452865eda006b1d4c57df0cc14145a81813a3c9f3407cea135811ff6d17fedd9abcf608468db4553";
+      sha512 = "31a68e7d8507e70d5927ca30464339e84903f0da9d0047e5bf9ec1a30585158727e27b4be34e1eb9a0b9ed5d079928a33a9d549a2b0ee941a2d6639edf905a82";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/fi/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/fi/thunderbird-68.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "2e25046477f6ccb78a4f5d631a948d898084521451d8841b82dbe448b91cc3311e4f37a7764f22e53c3c0a03c4cdd91816fb7960916d5c2f480ed8fb6ce7aa6c";
+      sha512 = "f57214774d942b57135659b9431c2a2d339a7583a58dff1f7c67b03aab1a83de2b241ced6f2fe986c65f4b31c8edb85169b6b256f4b6ea174db969b707926e56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/fr/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/fr/thunderbird-68.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "d377aaa2329d814881f2508a40131acf392e018df4e553958acc6b7be49e5649372f06cca12278161796cde0c1294ae8c045a27fc26900969d55441a96da58fc";
+      sha512 = "f951d981814494adfc5856359567493c1c74374415a728281ffd00042f8e90f223c4c5c5e961353c449c5e4216a51803888426271ab4bdf80f1afcd8de993943";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/fy-NL/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/fy-NL/thunderbird-68.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "83a1afd4c8c621a28e696a347f3b784e97dd73b48edd1ec832ba2c8a3d0ccc0a24e9911c49be1567e1e482116d1ad8763b4f8925b66ca07d95b46dfc8428ad59";
+      sha512 = "c901aab55e2afefdfc453b2ac625fb30edfabfc6384516a0373454a272b7bda96fac1d66029a0410f899729c686fa0d2301a025bd35ce88f4200fdef825c21af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ga-IE/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ga-IE/thunderbird-68.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "b235bc8a7119d6595927173bd4c0222be43edaaca5f94b83094b1d725f95599caaa4c37b98c7d4096c2d491f54d83a5508de56871e9140460ae3a2c02f065caf";
+      sha512 = "9c1f1a932d12d38031426d66cdd4e98e08b858d080a918438b31c5d1c73891b9a63f4b9d60f534f3ea3489446637030252d6f29db22c4cef53a0f46e1971bc26";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/gd/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/gd/thunderbird-68.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "139b42f7353d47e847509b2d0cd612f2f948eebebb40746513c48d8a99fabd592863fa63bc5d25410d79d1233457f457514d0b606bb9185c0b220596aacfa3dd";
+      sha512 = "cd9b43001d36f92f4ec438ad88a60dd30ab739f4a5a18894099d53cdea6b58647eeaa2c492f7d6ed275a2219cd4d3ab8893ec2e8055ff04801fe9c88644bd8cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/gl/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/gl/thunderbird-68.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "7700ae3008f268f6645c1d06f4f26239158c5af8e1d134c8298afc291d7f6f9440c38f0db470a6ee3e5744d58b4d6ab7ec81db20b856a6920ae4776781e17ad3";
+      sha512 = "43b05df3e68bdf83b7762179d6c8e2251e3c54f8bb9b531b181216e2e58b6c67401ad58f9d7696a7ebf88a2e839babfe66be355d11ff19e2c85e20d38eca3a58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/he/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/he/thunderbird-68.2.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "54f13a180c1aafa42e66ea217a53917112d9c8040f76ea2b9c8d47ba0c420be6f38f33965c47f694512f3e50c088187006215a2c1f8f0a23c4a15434f0a38c99";
+      sha512 = "bfdabe6d923afb04c6af7667afe5c2584ba5c10d63b55fc6e820e3ddc9c9424efae36c27e193a7cb50c94bc334d7630e2224fe831f0993ed3041724fbfa8653a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/hr/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/hr/thunderbird-68.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "156be5e240bd7997da2d7cb53fd3b823b9d151c0438d22922a0af09b58480846728da25574f828b75911c612ab7533ad296bb83a9ef010e5a1e7e5391198f75d";
+      sha512 = "9359952226dfa15953c13aa3fbb5fd90652da31c74dce4b07265de87d79b887b6604f8045a388a5de20b52408e3155437ecf5e3338082626863171e17c1d0dd2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/hsb/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/hsb/thunderbird-68.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "906e10af409ebc954066876ec74abf8c4bd5d871afc840561d66d45e8a671e21a59946711401ae84e90ca923e470c72dc1fb6fcb354b973b6712a6bda24d12ea";
+      sha512 = "693a401e6f1ca96a862757b85b2158a17161f1385742a8cbadc092f8b04b106aa4ad8126cb7b38232b7cc53329fb8b5ecf7fdf429ed1e6213c1957c8de3d478d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/hu/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/hu/thunderbird-68.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "cee72ccd9690792af1b58199cc893e6bfa79f1c5fa98cbbf91cd7385f658ba3082253338df28e822ec5d83e5f7288230b1242e4515ae7b36a861fbe07579dfd9";
+      sha512 = "3826ba97156fb92dc1b541ffdb242700008c253ae8a43706be347df420ea2b2fe4424049922e2a1aec60cea29f9c06c9da98e1b0dbc7c1886af7f7f7f19d923c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/hy-AM/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/hy-AM/thunderbird-68.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "df2ce259de444e913f39e6ff5f7d678a5a51d0db1977d21f564485fc602987e63284a07d1ad5fcd77864f5bbe7aee28c5028707ebea1343122a1f06c5869c900";
+      sha512 = "14cd6b6c31b7bb1b4d9c5e0178cedd4f04384e8c586f731c853dfc9b4395d4a9ea2f24bc2607e433482a17476b6e6e6924c9999d3b9b577ce06c00016dcb8742";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/id/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/id/thunderbird-68.2.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "27dd9cfe96accabd3a1d383db15ec3c54aed8b3aaee6976223efa0e92da584208edd67d029d8af77053c248938ded23ba6e8d5c2626ff6ecde37fb3f9ad64aaf";
+      sha512 = "f35f5097ffb6970167bdcfd891decebbdbfe0ab9953c7efc824720b543c39967ee92abb1129897d8c19ed9f3ecfd76e5e9b9b579c5074c97575217279155ce53";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/is/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/is/thunderbird-68.2.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "cbd503933ee642cbfb10dfbdf09ad74e4d2980400ab749eec93471283ad7a9025c5f3b765ef03ecf0f7a47a9d8ff81098222caaa54cd43c7a734180bac56ad4b";
+      sha512 = "71189807e26317b2da5b0d401a586f3fd043bebae673f0a973298d85d2e774cef61c9ca8d7a9f58c68fa9ddf84076ae84892f5e58e29366ca4ffcdee45d19bd6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/it/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/it/thunderbird-68.2.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "421d54e523b0e382ca6aa3888e433304e2b31f58a9934488719bfe44e8b52d1b1c4475ea3e04af322fbf89fb766a963ae39ac3813dcefc24fdc84f1ef913d33e";
+      sha512 = "45e0f05fde4de1295f6acb19340f24db3e06ca4c090f958a193c1e0e82a7773ff466781a29b6119f89bc39acdc6e50de69eb9b4c8e4e2ba565bf760021f90a50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ja/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ja/thunderbird-68.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "bbf876ea4f1d1a5f67b4f45f356df3a18be87065bd3d3362a8b54022f4d1ffd931feab8bf860ff690268ae758e13d804b0759b545974df6cba72ded90d953418";
+      sha512 = "11271df03b068db31a4c5944690000642aa4924d9d744358cf23dfeb118e9c0e759ef0907a868d0e3a5234674b696739fa770d095ebed53aca41ce0eedf0a9fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ka/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ka/thunderbird-68.2.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "5b59da5dd1d32c349bbc9922dda729a147e915d307a9c6f7f3cb51e8670bdb151d550e8f8832df0629391f928fabad58411b2e76aec02afef73e47c7eaa5db35";
+      sha512 = "48396e76d8b6be27b295d5bf14b34f8cc3e34a89df6096ee7f63056691deb2fb47ee3385386d103a4c191e6e6b0459c3e9b4f90640dc1518cb327e0c0f6211af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/kab/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/kab/thunderbird-68.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "24afbdcdbd762508e10598e102e3019f23099c0db9ed8f36d0d0eb88f93f215511c1056ea3f9281edb4f6d8935273964e5eed89415f022cb85bda902f6e48131";
+      sha512 = "1dfc58ede0c1619044cc18a7102f683444fa90df28d096e8ea0700203c05f3411d21abd231f347a37ded2bb89cf84127fd7730143833da151dadd90fceecdc81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/kk/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/kk/thunderbird-68.2.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "7143c4daaeaa364538cd1bcc08a80ec42dd82bab539b8a2f2b616cf1277249b4b6e3584bfcbffa512e5512f018d2c477408f60342646aaa69bbfe497c2afba69";
+      sha512 = "0c0e2ef29e7bc2b715eae29da2c8394fdeaaef47683428972360af109fdcd0ee07494ee5f1653511ad665cd88e94875426fde98af8da0a77a433c19e1f40d543";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ko/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ko/thunderbird-68.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "1f1a0fe664d77ad19a2e438e2db872b0248a4c4d232a3496d00e27556218ed9633503d47598328b8c4289f1f0485a8076032bbba04450efe215bef32dc2177a8";
+      sha512 = "1348d1d702ce8dd045462ff7bfa5d7aee48b302a18b674e22ba13ed55e19b024d2e9ca34f573aaf795c7476e6d11d10769a0a4f1e3da60c4675afe1957b9e9e6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/lt/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/lt/thunderbird-68.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "233f54aa2217bf917300bc2a5b0b24dfbcd173da0ed778092558ecdf8c9aa5289fbea1febf2b812b2b45f352c4503ecc24f474e1eae178d5e4f06e04f54b43e4";
+      sha512 = "2155c783337a468a24b3659b8db2df74c6f3557aeb69c256a0e31ce7bf69eefb0afedada7146ef124a6325b48b9c3a6274543851995ca49486366079c942f0cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ms/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ms/thunderbird-68.2.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "56aeb272382e45c927de40c9543f106a1786b97db987df299525ccc5300195839524b247e792c8165e2dbccfff95f0ffa0718404163ae646fe1f8851f26c49e9";
+      sha512 = "7e0b1e9749224a457df5bab5b207ad16bdfc8fa25bc88fa0b3e73b9e6459c5eafd8a97607f2a9d54efcea7f3162311f99a84156ccf812f27438c58291720ea7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/nb-NO/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/nb-NO/thunderbird-68.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "565a7b0a9a5afbc7986f7f887c7e69fb7ee9fbfd1854d0b8146af92c9a0ff7911c387b462994c9684fcdd30ec75ab8ab3a6baa279f1f0aa275793b3ce467f50c";
+      sha512 = "36638159f4a1fefbb77da855538f7aede0efbc15646dc447af0a68caca484f2b8e2ffb47c6d54ba2b469fc7dbcb793144810c9dce180a0302051227504cdb9f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/nl/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/nl/thunderbird-68.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "f2159d2f1f6c7898b2043861137cc4635b5375508fd1cb490a561c01f384b3915dcd741c6c5353c749569679928c65ca40b703735205f0665f7b47e79281c139";
+      sha512 = "a3c1957daaced30a185cd663b083c8aa5ddce05f1eb84c0bc8e3351c7960697d651318dc0cf362b4f9a102f8ca36802e10bd03dca41d76bfba1c87dd93ee8aa7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/nn-NO/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/nn-NO/thunderbird-68.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "dbe967a11e73e02b9ee04622f1b8f1cb9ed7564076b651668b24301c42a667f1b759a125af30e9dce48abbebb6e1572e2700e404a4684c8a056061eac1f86465";
+      sha512 = "9473bff0632a46f537d9e9ed12ff53be90ee1cc92dce52026255bf70bb092040b7abdbeb9ce3b939c45de69ffcf949630406cffec26ec17da3837208843320d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/pl/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/pl/thunderbird-68.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "00471c2ab023143639fe91de17b34ebdb21f51c0fda911968bf8d5b8f1c347800c8e45929712578048334a61d5291e29a0d971114e984685fdd370524c05e218";
+      sha512 = "98e5e82721e733e982593552eb79a1aed7c7fc891ced4c63e7a84e778a3a18d419efd7d2f7bf24f5ec279c971c9c0088b221044a952a817f086dbc8398af291e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/pt-BR/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/pt-BR/thunderbird-68.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "f58ba451b23c8de5dab0b1aa9512258bd544ef005db8a730f03091e8a1150342063f1d3da3b0f1f7f88d660dee68ba198ec0423ce10d08d011ed9cafa09d9224";
+      sha512 = "bb5fa9871650f3732beb97df364d10a2f3972fcd607318df9819be68fc467f47081dec7a9f5ebd3834a35b136a646b3deb137598ccd9b3e870a344983ee9408a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/pt-PT/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/pt-PT/thunderbird-68.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "1b59c18712fa3bc4b9cf95b7ef29e52d77abd2caea42b40c6e252841f0f3a3e395460d95c0be1aaeec86148ec36b69fc1ffb00069eed52aba5b2ba26752599af";
+      sha512 = "39db7d45cfb76ad752e58949be80728b90f39a53cfd2b94b1ef706eb64b29a4ed785bf6ccd7aa9306ffa90e127cf03fe5a5efb75eed71f403d9672b925f23ca5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/rm/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/rm/thunderbird-68.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "9cdb4d7a8936fc8ca33b4537e2c5a84b5ffd1fff3b6a7bcfc12cdbb644de853034453388d6dcb6fb9cb5cbc76a359da8a9545feff3fd76cab5135f17ef3f11fa";
+      sha512 = "a1bad0dd822897b7bf305740baa77e1c079a61447051a7798f62b0af5c47b20be4c63f8cce7d36821ba7eebfe4901809de8d15598a29fce9661b93b5c3aada79";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ro/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ro/thunderbird-68.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "3e4085ae550792659070f3b903f5dc9141899fc0b9a81662f5dd42f5e94332f5cba11c298bbbf1e288ff21f89c4ab1f08e6cd202c64e562e53f999727142bdab";
+      sha512 = "b6c7cabb8e4083b16775e7835f68d8384d6e11fa1d79dab046fcbbce035892aee957ef94f719938e3a684f6297fcf90e39cfe0fdd564f2e975eb1925ef0dc9b9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/ru/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ru/thunderbird-68.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "e4dc478b5ddd232e1cbacc742f71f6c571011f9a591d23cbe11108ebf59b77a07fbb8dc74b9ae54a22fb31aa12b386dfe2e8870c336e1c7549af4d4ec0e3220e";
+      sha512 = "7d21898e5c05a6dba91c14098fa3d977ed6d6db3cf9165817b0021bcfddf9739abd53dc3a7a4b7541029d049c8153c9e235dfd2a00cfb00891a38de499e3eab2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/si/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/si/thunderbird-68.2.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "c113bc6f7294373e754fa7ce68f2738fdad9d151771df7198da6375710cd774c2793d1769c5863e055e42059a084c2991503e489e598faa001413afda5ecf348";
+      sha512 = "38e6221a855ca73f9e3427c5fa2c51816d046cea9a199f58247615307253660d70e0cdb3e2c50217515f57a1e7891252e908785287ea2b13e32f89a1a1f5c111";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/sk/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/sk/thunderbird-68.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "f1e2c8aa8e9d6773142a6a5597c3c9987b28fc792259435b4847cc8031f90ad1148fddec18ea5af56123a7c0bc013fcc16993d80f89350e2ab03b73ebb919ff0";
+      sha512 = "971ce593483f472913a1fb6d55e8b18f9041af7e3dad5507c0070692f4c30d6dd0c17fbc50cd77a9e8be680d81c82ba24498c53b2bd805b154d34001d650b9b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/sl/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/sl/thunderbird-68.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "a0cdb0c88c1229fb6320048d857fdb1fdfaea522c64dd9e131a1ede81c621ea405b795e37861e6202b35040c315ad1181b63a18ef4a6de56a0d65e15bb1d63f0";
+      sha512 = "b2dd0001bcb435d86bcb4460eb8b05882fd4dc4275ca9057086a625e273a092b60d992cbeb634c7316b315048c8f3e771ee1284ffbd029b0903b8b01d3429f52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/sq/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/sq/thunderbird-68.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "f268882bb75b36531a03361b16478493813f0121120177e823c411896e5af2f649f617010a045da53842a42365d97794a692c6dd976291b58a1f99a42c579a90";
+      sha512 = "84e5232ced93dcbf6b72313da2d7f81691302738d83d692d4c9c29dd610a98f0c90cfc5033e0603292803dc8531ce05eda48e7989c85709dc58964edc172773a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/sr/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/sr/thunderbird-68.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "c638a41e49ae742d972eb8bf86a04831ecdc608e8d971c910e411ba09fda322c98109e93692c0df884382c1daea2435de105f6894618b1c3b5d1daca2ef0cb75";
+      sha512 = "d97e2a2522570f6ceaf77536f3eb1bc190a36c8d6c0b33828068891a3e3b4a9492a847b65b40c58ce66ab84ff47f91ba8e0016ef85375078a3d11cb6a56997f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/sv-SE/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/sv-SE/thunderbird-68.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "cb49038fc6499e0fae95eec770ac9cb2f900787bd83410a7674ebaef8ab9d4ec840beae1f90bf7cd1145384157af819ab130c5574a530e3db627e07bba940ca7";
+      sha512 = "bc1ccaf7005a0d09d3b3942e926167130b6a70affa0458e398e20480bca25637a04b2c5e9a6e836da42b6bce756db518989bb928030f6fc2a72d2d86a10e7d03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/tr/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/tr/thunderbird-68.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "3e1285c1b3d369800ef349341e5029ad5eab30025a9fe42dbd8c6c7a5849074cd54def4f02d2e29fe2bb647e220e8f77ac424fd1310d7c5a3cf705346eb3f229";
+      sha512 = "2ec3f139dc9aeeff218113d63d886d0f51da110b7aa096503d5a6b8f57e0e1c9ce6be5d76089612b2bc8c920f5b6972ac17b421bf78548fe44c5d84721dc672d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/uk/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/uk/thunderbird-68.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "0a5cf64201720421410861023d0f570b009f2bfce58cb9e42e9001777824e51246db5b5c7be513a54a19d3db1514d9f5958dbb6274f1781518083687343f91e0";
+      sha512 = "96a1072393854313bce952c791de5bb03ece30fb135860b02cbb53537df0bf4d81635b6a0f34beed4f6f2f93588e11e24574d8392bdc3373002ea1730850ed6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/uz/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/uz/thunderbird-68.2.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "9fe8933b2df9896121c592a94d5ac7ccddb12c8ffc457a5b5b7e7ec7baf8166a3d5d63e767b0c16e92dc884643247b1516b95cda1151253fd1000b2b333fb8c7";
+      sha512 = "3e3d44f5bf8f39a7d2b352eea6df2066225649aa5e2a641ce0a7cffd5f7fa04d1f09ae504a10b495abccbc95659130432f39c15fe517395ee84492e9734bc379";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/vi/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/vi/thunderbird-68.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "46524bf98c21f480d805ebd92b2fa8d2913f2209d25048b3ea58bb8dfd36916c4d12cd3805ad468b86c6df945b7d974b953b9592ece9ff817a5817adbe6a73e6";
+      sha512 = "2ff6c67f630412ab9ad7480b91b6c648a20ac32fd00ec5370f8bf93b159c1ec1e060f2a8c8c13ca877e47430e8b2483cf465a57b2fdfb8060149ce11d2ee0a73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/zh-CN/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/zh-CN/thunderbird-68.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "0a5b55df46c71dbbd976e2d6917474da6a3d4f3e67f516dad590b3c96f4925a4c47a2bffcceeb34edce043717ee2da6a1463b7be3a47f18bbfb7f92daf1b9310";
+      sha512 = "998de4c5ee44d34e1de350d80225ae76e8b839cf441ba71778e11157b75e3332f83c95fed429c74a3ec85597ca9f939a0efd697a64e86957e327334e03534e40";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.0/linux-i686/zh-TW/thunderbird-68.2.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/zh-TW/thunderbird-68.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "c66cbf149528a1c2c6cf44f238911f2455c5867d44565cad757dd63f39eb70bee9331fce74c19bd97b5128a9bee89698803c1936dc7239dcfd099cff0f224e9e";
+      sha512 = "8ea36d5b3835158d6d6191cea42f8b5cfa75817ae9a52a92ed12e7cfe5d7559136ab5ca7d522aee3059769e9ac719ae20f4448206a86e8b3e902cfb63ae700a0";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,615 +1,615 @@
 {
-  version = "68.2.1";
+  version = "68.2.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ar/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/ar/thunderbird-68.2.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "1fb9cd8dd5b8b4cae4aef37c2c7bcca6b87562a7f5bbf419982a37c805f45fa12bba3accef9effa80a2c51968afdc37d0c6763fb4aa06f1a2a4448f0b555b43a";
+      sha512 = "d6773b83366160665db56b41e9a76765927284a005d9440dada3c4d7bb292eee4cb00100951cc133998acc3de4af92d88ac03d797a425b9245bb837be5b20e60";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ast/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/ast/thunderbird-68.2.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "780d3e7513b9ad4f2f263afedd2ff8b09cbfe73613a9b461f913089ff806e6956cb47a37fecec90bed23cf437bb24da95cd720b8221c359feb6aa8e0fdbf45c0";
+      sha512 = "f090f7132239c6f420cdde8d0598ae20983a5f1a7e4ffab6d94760ef04cd5c61f6298c9c89265259972cb8b8eda4ef1ea141111bd25df928f8986903191c8bff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/be/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/be/thunderbird-68.2.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "9b38c3c3887f6be9a3306c876b5a12623b52dec2b4287bcf60990ae14f3e2f5d6911ada2042892e164e8dc48cead50c38cae731fb71176915a4e35ae72ddb3ef";
+      sha512 = "ade743d0fdcbb32d70157d72ff5eebdb8e59cb79fa27a31ad6fb8348a2a0e29f800a44db52e76ab14d8deca0e98df325a63baaed791a9af85fb903d42d710ad4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/bg/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/bg/thunderbird-68.2.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "8d4ef2ba98ed1f0627c9e209be57342f86914e0f8e9333adf77279d87390f2d96c413e86d241d91590d82d425fecaeb96025285278f52cee385258fa63749538";
+      sha512 = "a6922194323ef1eed00034655415d290148c1afe3a094bc819bbbb3691d26852f435f8fe4c989a7d94d3f5c77bae0a812592f532ca542472014da1a5e4d47e4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/br/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/br/thunderbird-68.2.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "e75a30d6e6710a6a7938061291c4f11698f1b6ed5e7c5798d2992cc78f7b77a9ebeb2e84fed8bc47b9253716b267fd21b758f2e5454edbbb06cd9c9bc7b1e9e2";
+      sha512 = "ebc3ff68c8a2d5a4d3b94f8a7a5a8e42717261bd8e71d07b9516d300010131c2c2697a6d5e645dd6fe82e95f30957490b30c884f5dc2408986e2a2e7cca571d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ca/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/ca/thunderbird-68.2.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "11694e7a2a1984e0d44c45fd98f6cdc45c387250b673b7a24a37d073e7ac29860e8429b5f16fc72183bf3ecf9ee817f6c2db35645bef3a2c857f4b6f3258baad";
+      sha512 = "42b7cc965bb8bc8316b2bb9c7c5827261323d29ef95e757f2d105e4728eb06011786a342961453835a93a5dabb7a9f2344efbcd9bb4d28967764579815511fac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/cak/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/cak/thunderbird-68.2.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "85a8ebeccdd26055b9226c2e3c6d4596eac3f9db644bcba4f4eb532daa6abebfbd4e9bb4d0cdbf254b6c5d3f3b14d016fb78700df8fbce2a9643d12f0da0c51a";
+      sha512 = "3285888bf7611ef6fbda6d3c6c2dcf73f49b678532ddee911edaabbc9d7993d6c6fc4d3e57a523e38f152250b558d96df623388298fdbff3dd0fd26a859edf19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/cs/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/cs/thunderbird-68.2.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "5b91762ad3a7ea7f5d0a46e4b0ec1d1865661bdf75afa75a2d1b2fc96c98e8c1848c921f3f4e85450caf3643801125b817d40c17c7c2a42b908850e47d7a7197";
+      sha512 = "4713e1e619c5c83b4eaf2b4501263da34c8d08554584020d521a9129958422495c923741331d9ee75facfd196541346c40490ed2daa5e0b95c4788e8080570cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/cy/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/cy/thunderbird-68.2.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "8fe8c9508e86603b295e267f5e498e80c757b4d800c205bb677db0b83bf268d39522165c199dc94ff259608047414e9862ef6cc275bee520297e2310c155aee1";
+      sha512 = "8c4b234ea415cf0ac30ec36d0273eabb8c2438865ff602cd5af48bdb5bd7d75377f0501c441c3f746c681dd9a9ca458892a4b413f2dc5c7f491322315f3be8c3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/da/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/da/thunderbird-68.2.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "9f46e8d606670da7e1df2eb5ef5999cd2fcdb6b257e7d5c40fe8e3e5d2ba01709813874173086ccb9b677065b075c355cee42fc6c884dff299d7ea2d55f0ace7";
+      sha512 = "5c6bab8669026511b1138bcaa705d1dd497f39bc3a6aed838a05c38ea09a1335fa32b03238ac7d15b0eadbd3af54583830e77691a366d56bbb99f18a95b0acac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/de/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/de/thunderbird-68.2.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "1f4c94b9597557bcf3c6157c69c080a97ee4ce09a2087ac730fa13d432858483e354b8752a83bc3b651038409c5668361300c71e27268735bc7695ba9ab1df7e";
+      sha512 = "7b3196d75d9d932e7518883839eb8e1f228a22938343d575966d29a8cfce960af7e15e4c108c0bd9bddae1a8e96d503b5254373ed8307753f0303088475f3438";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/dsb/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/dsb/thunderbird-68.2.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "0822b5d4f60087eaac3ff400082a2bf46168a6e7d6a2d16adc0c8c9fecf2891a4f5003d57b134b51ee192585a99359e07156f1fa89068c7016b365de8e6749c3";
+      sha512 = "77278dd593c4eb8a3d4064026a3eb04b704e0cfc4e1fcd9fbfcd8fdd43790e8a9a3a7efed382d8d47dff2796a5e353902f89f3d4e7636319b378bc5beb31f9c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/el/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/el/thunderbird-68.2.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "0d0ed3efaf1a3e751474f0f18eb5e4deae61e14dec444c29835e1fc6579343c366badd32724577e155b750850ab9111899be005c0f36aec7cddb7122c4ca7237";
+      sha512 = "693499cdf65aa99786d332719eb029c5a14d1bddc55839973bcfb22c57d55d1ee500d89d1e48b6e1e7f4ae716bfc272f300ff6f47d7a25f208f6ac3e6615ec9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/en-GB/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/en-GB/thunderbird-68.2.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "69d51b0a0c71a7dec36692c5d40d77ac38a81aa46b6cc350bbcdee529ba579c76057f5e98b0b2906df4236e5bf7086c995d33382c502d81c1c878c32c896543d";
+      sha512 = "457b6c5a99d02a8a9200c158d2e959927774d7a64476964040a4a790c0cf2f5c4c3bfc183bd9efa4f74439cce23c5c4bf922ab8166b3dd3f00a5e94445bca2bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/en-US/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/en-US/thunderbird-68.2.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "158b888e2e10bad44f7a6fa19e4f986fe75c56a9ff98fe749b1b981fb67bd102e9ee744ed41267b4b327b54ad24ab74cfa033f9f3bd2ccce9d7ea2f440e76c4a";
+      sha512 = "3c410d90e2157fce862b189f566774dfe141947a562a5e3a5781896ad1d0ba3ef7b978557fadb94f69108aa1e3674339dc0ef2189f6cdf251285fcae04de909c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/es-AR/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/es-AR/thunderbird-68.2.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "0ac1482f79784f8e2140311fdcfa4efd85f944ea3d2d9e82306decba4de8e8b2ce8d3cbddd89fcf2f6613bb9fce7b08145b79e3f8da4f43d596204af8d8f0740";
+      sha512 = "8891a5c876d1bc3cb465bedd59d4956a3961217fe43a20ae2a9aaabce16e8d29e142f03a84fdc91b1d5214a735ba03eb567ea59566cef6948da8b4daba238392";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/es-ES/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/es-ES/thunderbird-68.2.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "2971f64bfe40444826c9e89221eb1ebd9b0e89e0b1ab76796fa2ce2d72161ef8a850f9c687c2a4b370dda4f86830077c603916a9676eaa419e11e4dc7c0c8e3f";
+      sha512 = "03e0d537213de1c325310f5d6012c9a0543d4bf931a6b4315700abc493acd2657784c2f616bc965f796d95710c32e4063ee3cbe481290a9ff6e2655789864742";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/et/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/et/thunderbird-68.2.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "8763ac65259635e24c27b803feb6fbc89d8c7ec191772cd65e0aaa12fd5fc8f6080743c9357871964400470d743b549de82c12eabbd0bee3107fd5fd5af06565";
+      sha512 = "5af54e9b0e5a79312ea3e1b29688ba5046c239b1c5533a25de36826812df5c326279f9619eb9872dcfd5aebf979931e98cf0c01e7f00c0745964ee11aec6e295";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/eu/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/eu/thunderbird-68.2.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "12153c3b32e419ace528c89ba70a0221eadd64f996b49589f3c77ebfdfb75e3c34b3b33448ee2685fb79fb5c713848164949fd2075d68faeb3eda77a4eaacc03";
+      sha512 = "e4804eda2716ca4685197939dbb9ef3237ae2caa4eee8d2b23d612cf1545499112f601a9ecf8627536499b93fff6584c8ee3732ebf548b900f9a2f9c226490a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/fi/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/fi/thunderbird-68.2.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "fc14805d09712dae2fabe2c78f3c743dff07c3df51f4ec8321ec5229fb70d884a862bdd3f29e3fb5f01eea4fb78b7e989f01f9c720833924a873daab4bc4f9db";
+      sha512 = "9c161986b3f36652e76cd3f5ca6dd3c76470e4ead5c22cff041538ca159271f13eb31f81f07b5bde967204705bd0248039ed1f705ed5a6de5a8f9c85651d0803";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/fr/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/fr/thunderbird-68.2.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "bec535e59259e6e909ca7ca434a27b021f08b8abfda17dceac40cb03894aa6453758312a758f15d3f4a1cba7dd4ac768382c750db6aa6181d83e3cb4ebfb26ec";
+      sha512 = "70374ce7f72a18b1ed0083c2a3079e68115f6d0dbd3dd6060137df98bfd8ef0f48feb53f8d36659c119e814a57b9ffbd0d8c4211ad3ff657336c856773c19df3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/fy-NL/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/fy-NL/thunderbird-68.2.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "d6842e309a9b2edabf591b36df7363a682ad8ffacc2c5ab324a0fe03dc5b442ecd8e3d05db31d603f4dadc419b5808102e49f35451e3054bacad3819afb1c4b7";
+      sha512 = "7e01f9b4b7aea9bb5afd019cd9fecb886eb1814fae341c13cb68b70773011f5165d9150b594a9239ebf456245b532129e99b0ee2eb3b9eb9bda72917ea82fb0b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ga-IE/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/ga-IE/thunderbird-68.2.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "df8f8cbad7817fbeec544f1f6b23d4e06359e72502aa4ecb75a9e3819d9087604717ec64357d15cbb8b5f280a850dc05bdfc3bdce0ff1a14b96a608c0f87f813";
+      sha512 = "e60ecbaeac31a81d1b267840f97c8e9a6b4acbfbb221dbf8f1a33ad97f9a20efffb1f62498263ffbc9191b74b56a35b8f1cd94e96ea37037b6c05df616a6fea7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/gd/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/gd/thunderbird-68.2.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "f8c5c1b17c9ef90db3d39b956978be96801d8196f4f5f3e15cec0f5baa14a5dd94612c09d177425ab4f2bd52c8c5910cc864d8c68b408831fda83338ab1fadcf";
+      sha512 = "dc872843cb900c5dfff45b5d4d1b1673e38fb58cb78108b8fe6e3777b6f68dc5bd1e96ba371fa2294ac96a810dec5e2491cd7c50f499000fa89d10dbd2542c62";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/gl/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/gl/thunderbird-68.2.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "32ada11495dd27707b97981b840f4b6d706d86756914b7ab59cf886b170f2c927990a3e201a955bd81734a9e7732b181f6a4c618d9cbef019b494de9b305ba19";
+      sha512 = "317502e4aeae4b3e83107649d84bc91509ea66fa5e4dc17378e520b8515a4d97f089b2dfd2127b5d110ef3f2ec38030950b2d31419aa8fbd79146533f01df6fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/he/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/he/thunderbird-68.2.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "69bc763d9c71fa6132ab598357d3527df00e05f7f24d06832c5ce768072cea148c1935ca9eedd78802f29349f1147b71c32bc3fda58dc0d279c44e735ed48847";
+      sha512 = "7aebd802addb09c05689625026fa5f11cf912f01a411f8acc8cf98cf524b5d5e1dd8f7f6ac957a177cdb48b83fa74c7985a4b63696e61c253967db77d8624ebb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/hr/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/hr/thunderbird-68.2.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "8d4e3ff83f636603e4b848a0c5f8f1feda7790b8cb7ee30e74060976e00893ca5b8ed16f35d4e0ca029ccc4b08f0e860df277cd0c091a45c6673f91ae3b69daf";
+      sha512 = "2703fd856d598b3f9902b59b437e4b35caa497e96db32a2fc0eb482e78913479d36804c23401212ec8197d2825be9ae549f30f88d8ab7ec68602f9e4e0c4ac41";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/hsb/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/hsb/thunderbird-68.2.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "2a9cbcc8a1c438a30876f72d974ef9774de08fb2f8d172190d1b292dcebdc0feee4fe58ce67aa7dc047dc3fa0e75fb31c30233ecd53211ae45dbb332ce3ccc93";
+      sha512 = "afa4a9b99d675948a1acd41fe4ed26d1ea6c60ae1d2dd16622da5dda954d80820099c83bd8b9bf341f282ed861741b1c60e1b645d2d3e6851090573f5652db60";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/hu/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/hu/thunderbird-68.2.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "04049eec03cf772f424aafce31cd37d3b3953a0a7e67f0cb5e134cda3f1c820aec5a73815a322277359d79641f2001cab2b677617a5c8ea8a3dcd5e8ddbf56d7";
+      sha512 = "d5d29f65ea33468067e1e2f756b4ea80c5d1cf7563d17918569de3af4d68b3d78546339be34b76183a60ae225de36fade448f9c28e6344333f9b9f74c7c4ec96";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/hy-AM/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/hy-AM/thunderbird-68.2.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "29f0fb2b351249423353f9fb12888d3f9e70190063896f075a55c23aa8bf9f89075664d2671789fbd2e732217cdc85858de4c0cbf17eab8c646fc0b2d2e8b2af";
+      sha512 = "d566088586dd5bc1d2dfe528e51d52a78832929377c9e5975da088545bd9bd0d8698788b5239806e8f9d3daf0fbcbc4eb576a13b2e8075272c22eb55476a6638";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/id/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/id/thunderbird-68.2.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "3509f2fc73e9948285bbee15cfaa6575b0e6cdd6b1db847c25670f700502b885f2677cdbc684ca446ee8389a884e8db5d526bc4ce583220ecf5a9bd45aca55c1";
+      sha512 = "058d20ea1d7a2aadcebaeb186ae8e7cc315b5a657203070d0747b32b831bd28f2d6f6973cf0b336257801f82f0b87423e969a71d818801258ee61a8e67e07d66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/is/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/is/thunderbird-68.2.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "ac407ed944b80d99a7bebe41a8cc53cfd830b2531f0621fcc5cf1de3c6dfffb862f5e8b84c086757caa8b0d397e14c03b7fc1fffa4194d040ec7f0857f6cdfb0";
+      sha512 = "38ef9f5c2c57200e8922c71698224fd00da814d5c7205c953c68be9e02bb95fadc370eb04654166149156abe7ea0f45787bd9c9b6e952330427051cd3be18c0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/it/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/it/thunderbird-68.2.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "73a1c4b2a6e739d106935879bcbfd55a8e68c56250dc7fc4b469eafb87e935367bfda27fa9fc07e44e18bcb6437463ac79e90406becce3149b1ed8c107212b64";
+      sha512 = "f1e63f4ddb28da50bcaa54bc5d2de4d76162e732e66c6eb2a6a3a1eb388dfb9e911770b13b3995a068c87002d4c7edc4224ed2dcf0f72733d51b66efe4357d32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ja/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/ja/thunderbird-68.2.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "57f80b88bb07f240db5855b7a2d359f25cd73fec12e6e877462880fa7bbdf2025243890a5cffb183891e0badfafb3b0aa8ecdff2ccba9fb1ea96f555f278b8f2";
+      sha512 = "c8ade4b89ea1448941ece48009d103f77877329c54f47b24d7e4f08b2bc6c882f0e445a7320f61211b4efac532aad2e4df1e8533c23797be851be60063f770ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ka/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/ka/thunderbird-68.2.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "bebd69f3a4852f8e349915e6f945fdc7ef75a2f67ba42ea5701fb78708387840da488cbab3acd7fd06c1c0319fc2294d837798d04c71b895114276adc70cf730";
+      sha512 = "27fada4d1f41bc678dd08dc123ad3b181c3ad107318d07b20dd6f0dde1b2f3fbc88c7a0a35c8745f23e144d0468c066044189e71b115f128bda8e11e7c248ba3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/kab/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/kab/thunderbird-68.2.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "c55f78abb7b68931555ea9653dd216bd7ef9406a39788535efe5d3a307bb0b10c1fbcc0721c4381de5ee3c12c99e7ce2d6cd5ec2336bdc4adce9291f6a3f15f2";
+      sha512 = "be9a3a4eee49466b854dd546fb28162fc390f37e78985666ef8120e42019e0f196b66de884fa6fa43ba40aac1af991a966ab8e7baa8879f04c71a51a1e17018b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/kk/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/kk/thunderbird-68.2.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "9fa4987008ff604604892f079b332fab87b73662686b9b991ded9d1512aee7f474dffc184376ce0bd2ca254527509170e3fade9141eb0f09fc075baa5c97158c";
+      sha512 = "30f93b78c35a19f0be4930e7cb5c5015bbc3dd262368c4c2510371e2fa527b67dc5cb43971d344b5601e7a435034adb697a803000f3de8904a39d053e58c8c69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ko/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/ko/thunderbird-68.2.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "c38492085323faa3dcd70d1911423cab736f9298d5bebe8af3b90caf01a2ba0cec83ed9cd12a39d989dd42b0d3f38a984e3d854422193750936384b5cf21adb0";
+      sha512 = "354712e56c22f1bb97bd4d18d9cf06a884f6c4aeadf5fec1ba8509eaaa9ba4d0a34c50408ef9e12b7cba1627481a7d9192d684cb1a5466b9adbc26c6e6fe9026";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/lt/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/lt/thunderbird-68.2.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "6c8f60e7be1c354f094148392841d1aafa0f735bdef491e1ffbb651e445dae6aaf0a053d90a2d39541d590167f73f39cd5df2fd39885b0e5a64b5ac3895146ac";
+      sha512 = "68b5993e861fe2225c8cbf77959fc91ea45728e4c3ffb458b5b465009197d86e914cbeb6bfb83b397ee4ba5979d279e2a698d31ae614dbe3d09f0dfbe396cea4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ms/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/ms/thunderbird-68.2.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "d08cf6ae853b47f7c97b6f0e7507b58d63f20817e150c343556c840f07e10e26bbc772e72bd922848bc9ab9353cd9c77aaafdd6be2486fe27e134c9b139f3a7e";
+      sha512 = "a140c69209dc0e3f3e001fd3df07373babc53e82a817911e7fc037b20c89e9a6ba0ddad9214a001f99232f12b44a16743a6ff601a352789d8177da5635f622ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/nb-NO/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/nb-NO/thunderbird-68.2.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "538d757af2692332940b9cbe5937d7115b8bb68b79cc5a8d3e366b531c867d2b5eff1bef14e4bebb7131e6825bee8ff86e816724edc9919cdbcc0ffa35428555";
+      sha512 = "93d0fea57d0fa47f9b6803891f57d65e281d8eaba1d4b7a8d8e60bce397cc45f49448a46537284b17481c8966bc2e9dc72c1fbd5ec3b7b62566dd519c7357b51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/nl/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/nl/thunderbird-68.2.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "14142b1aeafc2dd118781ef935865a0694addb4db406e801eab3212cf179d47a72bcd277589fcfc26364e0ab186a8f7ca5dab1c0ac5d4fc0ebd1c9f2d29ce50a";
+      sha512 = "a9f8c33710a09459dd0cf64b432de1e20a0743a38feba00b5ccb564645bbccae25216853b4ec79cdea625bcf668287461cbed80f67cf3d38a269f51eb522e762";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/nn-NO/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/nn-NO/thunderbird-68.2.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "fb4be65a491a7b7bfd94030b25376438c9484e19260108552e5340317b151cc5e7ef575638c570c7c3d50112912c4f57af1430ce2e5df48628fc1dc33fa84f4f";
+      sha512 = "88e6ab3efd57de666add7b7fb9af8ebf23a17eb5ad59d2f0d5e22e5efd87aabd5be299eb90a31feb14c44b499219ef5a59abb62f97274d9777739c6fab5afe4a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/pl/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/pl/thunderbird-68.2.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "d169f4510182b3d19e9df32cdbf18e7f5bc6397d1530c6b9a569375b86a79e236c92bfd22ca28e40db2493e30384638665101fa2bcc6386f409bca4baff3e9ea";
+      sha512 = "af45bea64156e8218fdbec80404905f98493aa6b6b583a984d26970f512a0961290776ff1d882ed47e4b77945c4f43f88d24fccb572e66e833707655079c7a63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/pt-BR/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/pt-BR/thunderbird-68.2.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "991c600493c05af2ca87af607cc04c4f0c86df80ef2f46decd5a89be11f8cd1dd0592d2dac0a39ecf0184ce58c32a7d4b0bd21908e7ac60f6422fd93deac3500";
+      sha512 = "ad9190aa83be73dd0d35247db6b7193be82f842f3400c93f68f8c4a2934ecc0c13c3b1fd86170a21e66c651052a1155b3c75c39a7ac4600176e2ef0e72568768";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/pt-PT/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/pt-PT/thunderbird-68.2.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "58fc40746500757d79005d380b2e92bc5cf44aacfe631c1541759b4fbe7a3867c66face9627ea44efd9eecfc5e22c242e04fe130b5817915e105d6adb4a9c7bc";
+      sha512 = "3642265601859912b983e03e819965fcc22f3039c56ea31e9cfb3aad7bb527d9ba3280fbbfddbcaada7366cce6fa048e91e3e3e1d035bd58e05881e5ed93f6d0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/rm/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/rm/thunderbird-68.2.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "37ca7ccf1dd91fcf9eea3ad8e34a0999eb3ceb7bdf0cf0359aec08a45b91d5f424c0cf74ee048eba628e9e1910e98f5b6169834aeca2e24f4a73d12b8a0fc729";
+      sha512 = "0dfe0f295737a9f3c8f94e73d167b6be62d45796b47defb2b346a305371e04e6d7e06e1cd38a93527311f2ca2b0d67ab78df4dc598ecc1c5c1d865ec07d48788";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ro/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/ro/thunderbird-68.2.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "bb9ae44008eacd1b56621cc79141afebc3aa8035706d216f647e139d230aaecd00d130042c0e50198d616c64ed266d0a61ded0140c4f8a75cf244da6434915ef";
+      sha512 = "8aa794148408196d19a240bc3ad198ebd2183b7688d766f922556f248e9f04aa5340d4ea77d3817c7fe99447a9d0211e8d7a66ee368dd5554c2d6861c36624e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/ru/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/ru/thunderbird-68.2.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "2adf2a66902090a5c6b35847ffb9d736f00865bae35b865973ebaca211f09a07dab63a9af56ad780223f389332d1b84a0814012d5169cafb9c1ef5bdebe64d1e";
+      sha512 = "e3d17ef68f01ab15734bdcd0c20c669b1402807f90bafbb2095f65a29becff4c7471ab882fe94e0b98a3e680ed1ceb5790b887f1e1bb4c4841d4ad308b7094ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/si/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/si/thunderbird-68.2.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "4cc7ac4cd39c47c3ff6f8c4a72f784871609b48824284f7ca89eaf03529c1ce88c1baa5994c1ec22386b7ae2ba694ba9ee4c5dc0bcb138ad0d56a45b0ed7830d";
+      sha512 = "bf11428b449938072961801236c8b101c6965de874d61dc59f6e85a2f03fbb688d1c3731e5a0109093459f75662d1e2705e08e872e57f3402483e3cf04df94fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/sk/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/sk/thunderbird-68.2.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "ae9df525a94dc404aea648a50be032f7a056201c3d5ff483d7291d4e77feea33aff5fa21b247f85a76fe03fb0a34e3b143b6769adb9d79d06391dba2ff91aab4";
+      sha512 = "b078e014d8ad5279efb33e5039856125997df85b34c5edfb5a12109c432cd8f7f0ad218ae5d7173f0b4a5c5f805ae259413ec54f4c7b689ee2ef77a78507b066";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/sl/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/sl/thunderbird-68.2.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "625a6ba6d35050e6fd2d15327781890b8b207f24abc6b57290383baeb803f48ad881bcb7cc69aeb9bf8d50a58aba7febfd03d048040f78ab6409a94bfde32202";
+      sha512 = "57b213fd7bb26f8e239979a95fd5991444f372cf1017b40accdc3023a40fb3e9a2ba56fa6c81e3fce98a7e6ba932e322c2d4e45e326dae8fab69529098eb759e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/sq/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/sq/thunderbird-68.2.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "9a2578fee7a4fa2dda6216958bcb337a03f9e8743206d9bae4e4b9b09e93eacdde4a04a259c7b7f42337f066e6127f6f1d5b58c82c84e0a9b6f12dc93a93447f";
+      sha512 = "248c26db9285b691a7236efa15812f1cad68aac908d51f1691a1e92f5412a52251592f91a374456d9df3408f7495e46a69d511dd236f4db744759b8fcbff92f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/sr/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/sr/thunderbird-68.2.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "e00bafb8dd306cf78e9d7a486aed4c1414b2f0a424653415ccd0b0e8a1b77135e1bf04e6f87a7caaf3752171a8c985d9222c9c81473d16b0b73c1e44f952a153";
+      sha512 = "3603237ef4518e097d2de4edd08e25b700c123a48392a818cfa2506eb2296141d1691e518878a831ea9d14c56264f055c33267292e31bd2d03b9d1e93614e473";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/sv-SE/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/sv-SE/thunderbird-68.2.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "acccf3ee449b9a9a0ff513f1bec79aa807f40dbc03b9c245f62f5e10bad0f6f0fb60053ec49f3d2187f3ea57794a9210b1931cddade228efff957037a21d1e40";
+      sha512 = "015dd59aa8383ec7dcf5e080ff568f2bac62b12dbeeefb341d6bca7e845a90c80bc15f240fba299a5ea7181d8b618ad0db86ae913d5583cd11fda62afedf9b04";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/tr/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/tr/thunderbird-68.2.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "6213f7a347270e7e8a5437285333ab3321c4207a5ee8922ab37c15f23c535ebc38eb7b84db77f47b743addf328a7ceb99ba38b9bf4756c1667e85ff3ca82234f";
+      sha512 = "5e39deccb50cd5bc9396343f23c78991e12aa4980be4e54622e8d06b0c84d0696835112b69254b62853461e2981ef2689fec9ba9426d1988ebda966df3a9b176";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/uk/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/uk/thunderbird-68.2.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "71cc097f0d4535cd03b092ac42f32033153ca80ab09a80c71d40bc9549111b322262898da9068e9f51b60bd438e7062de36eb8c4a3b0996e02dc1f997f9e0641";
+      sha512 = "e48bed3f7aa9ba457f4edca86e3a0877abc3bf1a11faaa32ea6ec84944fe0b5d90be55c7ff96b852b12f8773e800eb1044d28baf968a08580ebc67ee86f976ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/uz/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/uz/thunderbird-68.2.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "5fb3ec2119ec1fd0c45d967f00ca54ebc26ff7c4aa5c2ed161d33df58610dd3c04b38ea4364b4e8c20324c6ac16a7ab8167681f02101abffb827223bf0e176e4";
+      sha512 = "92269611f5980ceca0a6dddf4d06ff27eaf1f84323b3a3215825826f460cad8d293c316d54970f3048bba13f478debc1bbbff0599c3a018afad31de482399663";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/vi/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/vi/thunderbird-68.2.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "aac19830337a42539a56bc4f4ea9646afba9f09bf0bdc009ce5fb62d85fb68c6fafbf7cfc8239bd6f18ccee68a9e3bbfb0f28bee0b57fa0c2f1b7b32415492cd";
+      sha512 = "db82fc0630f3a0fef23a857ff47375ff9012151317df669704ca7433b940cc5966a733b8450bfb3b708d3a103e3d670c289afcdba217da217c68399da1ac1076";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/zh-CN/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/zh-CN/thunderbird-68.2.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "6e0e34c4407c69b484483242f5203386f606fc45929495d91178d8ddf37bfaab343193afedef01807a7cfd5919bc7dea6555c79e64f4daeb4262f44a679ea9b5";
+      sha512 = "f56c70d6609d8a4a39b71a1404baf27208971527581a4cd693e1816cf66f391203961fd91f3ba015f874b39c45d64ec02f5f9f5d3edddc890548ab74130460ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-x86_64/zh-TW/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-x86_64/zh-TW/thunderbird-68.2.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "3939194195b7190f0f1dc4e5e77f79349ecc69f1c2791ead9c0eb5416d69061438960a6410fcdf0c8c6a602b93218af397a78f2ebd1c527ab5404cec8e12aafe";
+      sha512 = "40ed9e876594fadaa2d5b322c5463170fe4a978e5162eb6dbafc53aadd1f53b91587f7b56965908401ca339acc62cd94ffa1d241e7f5e20668ce2ebc7e914834";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ar/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/ar/thunderbird-68.2.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "75dc59fc776b4b7e80508bef3f7d86981b8d45d49ba85d518141b5dbe6a6fa183cb5a65bfff3bee828052040f4037e966823bea8f57e5d1385cfc87eae64c3aa";
+      sha512 = "e6aa9c7573d4756732638c59b20c1a72361da0aba1a7c07528c2c291a5531d039f5f30196a00ab4e215a9bee9b3e6c03b7279d48da7ffe9bec5ac8b6e9f2b8e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ast/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/ast/thunderbird-68.2.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "7ca575d7620065443cbf78dd388aeb24cde4a26277e0f84e7fed2c71a2cc1e0944313c3479f5a5f82e67d3229233186620d5fa2d237a60c23ac938e54b5cecfc";
+      sha512 = "762ea8b11ca21d1eb1d3a87803b43e9ba2b6e0cfc76b242948423d94049c2cc34494996bcb4e396adfdcf14471c280b49776f65e0abd6d37abc1353e55099c92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/be/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/be/thunderbird-68.2.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "cca67c5de846bd8a26ec2e465ad9110eac88a71291a0cee4dbd445c26fc5c96b5fb33e1bacfc15763b007382c6a147950d847128ac7197ab2deb9466cb7dba7e";
+      sha512 = "540dce6d0e3f9974b050a6e70c14eeae791deb9dd8a44d91735a95610c9b500767f93c18b1cdcc13e638b564138d774b35839671c06dc51730cd07f26452baaa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/bg/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/bg/thunderbird-68.2.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "e0444f9522350e25eccbe7ca605f6ac6a9c321e242dcc38f0f73e9fea18a78c3dfdad609b7527e8be32a9a9989a4f34dd6838551ac3bf2eaff9596f7bcaf7343";
+      sha512 = "9e8d05d39461e1940d07e68472fc39453e6d24988700cc52566e7adc5902a5ca1143e7f52e9d5bc70ef00f3a9a9d4caae814c060ab5a2cb811b656ac6b3d5e9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/br/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/br/thunderbird-68.2.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "ee0c134de5dfc02238f9c45c0e2c08f2e178b8fe9e94cf509572e99b25ba5923aee47b932123e7d0b4593546a8f6d16254a1d7be99915c9f5a80d6c27c8b9c3c";
+      sha512 = "bcf1196b1f9bf0c4f8f0aca68568fdcc4085d817aa83048b180bfe33da91194ebb55a8ff314110f13bb7d903593e9dcedba637779034c1e279a5cfc5654f94b4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ca/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/ca/thunderbird-68.2.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "19d9a5fd2dfe8e4eab8bf28ff01bae7b733b8e45dcf8b929a9039488636cb3e1d8f2ea92cf345becb320aa15c2aa237140717960cef4c97ae0a6daa54827cb48";
+      sha512 = "f2963f5863ec3cb8c44de84cec24143aa3b2aa17955ba5eb523f7f834a1ff2fe8b6214edd50a83d21b6f67f01f570f2713c3d8ae1b5085f5ba40af1261b171af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/cak/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/cak/thunderbird-68.2.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "da2c3232ab94785e6a29bacf084ebcf87fd6d813c8841b02e276e093df226246a4f7799a18b86bc411a26753d78763048d189e4ae3b177d18301298df7ba9c9e";
+      sha512 = "4873079388e091aa6898d81857ea6fd05a67d91ceff98f31fb0eb3cff1835320f767aa579ec0c3e5f3721bbae893e0fccda95380aa90acc4e5a031c94a360dbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/cs/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/cs/thunderbird-68.2.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "e607e74a8d6929ac966876a0cff306073592cfc6728826b84b6d1c51a04d0228d21ddfb9c06b3ac7eae100a7a282fd0e43e5d8796d516b1a0367feb6f9fc85d1";
+      sha512 = "8ae22364980f210938d957c9a888d392fe4187395952afb7dafc86f5e7537c50e28f19cc46e98ac7830a82cdc0b2df6352566a7300ff14a9365f56386b43425e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/cy/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/cy/thunderbird-68.2.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "6098bcb8043eb313454723f2b3b2f78650c38161adac2c05570b98f6d38a6634963b89bae022742a171eaba81962dde6b63ee33322dff130cee2d5465a34931b";
+      sha512 = "617517a97ec2748c69a832a5c1022c149a2d45a43e738e3e8469e57321648fde33a1325d2d0d97ddf9b24383ba4d503e2d2c43207d5324c1a38b11d59cc9545e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/da/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/da/thunderbird-68.2.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "3a1835a0739910cb46ac90af86ff24b555d3ab63ff763c79c13d5b6e09af27c82b24ff96beb412a4dd0b7b9b2b66d897f0190cd32b59cc1b65b223eb486e71b2";
+      sha512 = "065506b4da1c4798c2c49373073313dfdacd14cea44a3a0dbf24a93ee7fc55e5074d370f1e8a1be5a347eb8cad84d4be140359b6973ceb62fee353508eaec7f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/de/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/de/thunderbird-68.2.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "3a7ace0c183900831cad7ba0e35ab2f03fcdb381e29086d28a7c6acca165a6f9a7d4d66d77090d1bbb7ccef5c081e09b91c30f3263a244819422ae9bd0d5c000";
+      sha512 = "e83d277b8c0e71856e6a7fc61c1c40a87b9b4332b8906a9011b1b1479784cdf8da827799c85cd1576df000e84a0e47056499ae0a9dfd0a90564ac47960ecb1b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/dsb/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/dsb/thunderbird-68.2.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "1f993b7dc01db345bd4dba5a8d3cfe0343574831ddacc801a96334a13dc1611e81a4c81d21ac231fee7cff15cf3c16f57e6f9f295069cbef10cbbaa0ba3fcd01";
+      sha512 = "35df83f2b276c1058b5d433c2ade026d78fbe3261c59ac8fde2ddfd34946eed9bba4cb805d2132c49dfbe087795bd184617641f276be851fa0d56d60eed61b67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/el/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/el/thunderbird-68.2.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "6332f6eddbb3953e411f07c70b7834b3511a04a7a290c183b7344e3a14ab7e12ac97c80feb24b01ac7638a0650be4d508e19d8f0bc9e44537448363be9e00077";
+      sha512 = "4486ec7687e3b9de1186b20637884e634f1b08c7faaf3e4c8f68ec67d7635c2ac69e8cb1c98a771b619b9a60df187d092400c81d8dcf831a3e7233c478721d53";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/en-GB/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/en-GB/thunderbird-68.2.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "69d8db1594be4d77cf0d11bf56207a18a92759f41fcbd8d93a37cf297f4f5611ccfed934a94b1e85aa2cfdfee7f41a217217faaa5bbea892011b951ab911c715";
+      sha512 = "bbe6c601a6cafff609e583ece568536904ac749f9f818e0059a809f46c0860760090573704f589c44e7ee9a89d7e923e4c02100c808cd2abe0a05a1e59695701";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/en-US/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/en-US/thunderbird-68.2.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "07e703940350fc8e644b4ba30ec1e484930919f1a7919184c94a676ce536b284ddc291221b68d644ed38caae92c9035d160dc957995e041905e7bf6a2f0a61dd";
+      sha512 = "cde3ac5e798a9471ea6108a4d4e333eeecede61af22b63723aa849b9a3aaf6fceea5dcd4be73bceab1bef28030fb264573264b93d52caa44105d11b3531d3427";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/es-AR/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/es-AR/thunderbird-68.2.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "a89b687a2fe20a5c1d4469fc40af9987b9871c205955d400e98708917e4a4162d53f407b7a343a248c3869858d0e745ad749fd1098dfb8fcd73e1af6b467149c";
+      sha512 = "6eaad58df92e839c2fe68c2943763889ec866aeabbe5ea58e026f6446645ad73c728fdeff8f4f8db544f576c73df447bcc5ff02b947ac773efae10849383d6c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/es-ES/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/es-ES/thunderbird-68.2.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "fa7dc46680204a50c6cf9db81f7ea52b6b57ea8b46ab7a6039b44c2891dcb53d88f1e083c6ff5fd1babcc5d006bdededf95e847e16629a0c50631def0d7c9675";
+      sha512 = "0ef85cd0c1bf413dc6368d72b51e000adc8764575ad66727f9e5b09d83840e00be05c14a79aec6a8d1d3c83f1be2d50a2bc0bac46390dea2fc603d80eaf8fb12";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/et/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/et/thunderbird-68.2.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "fbc30959bcf06ebc19502bc9a242604cdd346b26e675f5bfa3344d86e05dc6bb280f99b87a85dcdc591157445ba408e7bf76fbe83c6ec2d04caad1b90dabb6f0";
+      sha512 = "61423c65d957f2c932f292a21b18c76fab5f0cbaf915a1380be812e9fd8b0bddc53b0a0c72d2d1c982a488bc3ff93648d7ddfa56f20275324815d18e433cdf9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/eu/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/eu/thunderbird-68.2.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "31a68e7d8507e70d5927ca30464339e84903f0da9d0047e5bf9ec1a30585158727e27b4be34e1eb9a0b9ed5d079928a33a9d549a2b0ee941a2d6639edf905a82";
+      sha512 = "a8b950a206e8032b19f47aa35393b38ebb4e92d79c6251ae51b9cae1eff89192521eb779203aefc1f0193d5224c0679c572540de5a649f785a40117f3ae2e1bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/fi/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/fi/thunderbird-68.2.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "f57214774d942b57135659b9431c2a2d339a7583a58dff1f7c67b03aab1a83de2b241ced6f2fe986c65f4b31c8edb85169b6b256f4b6ea174db969b707926e56";
+      sha512 = "a35c75087d0261e4257f6f0890545854da399072ab57550745bdf2c45b892f2bef125e79e26fc2badb4924d738b703ffa840f9b0c1dd79610a822adcd0905bb0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/fr/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/fr/thunderbird-68.2.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "f951d981814494adfc5856359567493c1c74374415a728281ffd00042f8e90f223c4c5c5e961353c449c5e4216a51803888426271ab4bdf80f1afcd8de993943";
+      sha512 = "a541fe9c16a415798fe4057d56c3676163aed8f10511293be77b3226f950d6876d6552329e2f519f54c534e52f089fb304ca6a6226cbe9d84e90531969343764";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/fy-NL/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/fy-NL/thunderbird-68.2.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "c901aab55e2afefdfc453b2ac625fb30edfabfc6384516a0373454a272b7bda96fac1d66029a0410f899729c686fa0d2301a025bd35ce88f4200fdef825c21af";
+      sha512 = "03b5528f6622402e1d11110f99121690d7441823788ebbda350e6794818bf03fc38784677fe924f34c4171c86bcaf597f024883b6f57d2abf7c21a1b856024f1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ga-IE/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/ga-IE/thunderbird-68.2.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "9c1f1a932d12d38031426d66cdd4e98e08b858d080a918438b31c5d1c73891b9a63f4b9d60f534f3ea3489446637030252d6f29db22c4cef53a0f46e1971bc26";
+      sha512 = "9d5c677f73363d2e256707ed85ad83ee8c63262ea0df208ddfb99eb3de6ae8921e3add30e72b6061fe4fcf90b015648819515d4a4d6e72b9d19704dca88089e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/gd/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/gd/thunderbird-68.2.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "cd9b43001d36f92f4ec438ad88a60dd30ab739f4a5a18894099d53cdea6b58647eeaa2c492f7d6ed275a2219cd4d3ab8893ec2e8055ff04801fe9c88644bd8cc";
+      sha512 = "6ac94f49cdcddee17875097cf6a79de56b37019d678abd540dad9acf876486f3516d82ebeae2f88dd40672c8cff54eb1e79fa375e734fe403950ed58855781ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/gl/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/gl/thunderbird-68.2.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "43b05df3e68bdf83b7762179d6c8e2251e3c54f8bb9b531b181216e2e58b6c67401ad58f9d7696a7ebf88a2e839babfe66be355d11ff19e2c85e20d38eca3a58";
+      sha512 = "05e9c3984cf66d582ea8a46ec4add667379ed2f8986e1b5eacaba64f632fa4dc3201003a121c97f58e779b8ddf90c9065cdf8b7d9425f15971d1aed11e0673fe";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/he/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/he/thunderbird-68.2.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "bfdabe6d923afb04c6af7667afe5c2584ba5c10d63b55fc6e820e3ddc9c9424efae36c27e193a7cb50c94bc334d7630e2224fe831f0993ed3041724fbfa8653a";
+      sha512 = "6877f21ac08c980d230d9367a867d1f34f65f52d31d1fbea1f0e818cbcee3bd488e78bdedb3566d146b15c36fd955e1ac2569fee96d4f6131690bd9193cc3856";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/hr/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/hr/thunderbird-68.2.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "9359952226dfa15953c13aa3fbb5fd90652da31c74dce4b07265de87d79b887b6604f8045a388a5de20b52408e3155437ecf5e3338082626863171e17c1d0dd2";
+      sha512 = "cd782f28ee3d4bfe661800436eebfc3c726382fded8224ecfd85b32bce96b251f8cf9fb8d619786ac9288e13b5f863b2cfdb211f448f64ab4797fa4a999033da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/hsb/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/hsb/thunderbird-68.2.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "693a401e6f1ca96a862757b85b2158a17161f1385742a8cbadc092f8b04b106aa4ad8126cb7b38232b7cc53329fb8b5ecf7fdf429ed1e6213c1957c8de3d478d";
+      sha512 = "05ae5061071fd2075a37618be4a8bdc3c53e986b2b5308dd570b08c57b65b8eead76825c8bfc80ebaeb6b339b578e1221cfad9040909ff5d10c1ef12ec5b98b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/hu/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/hu/thunderbird-68.2.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "3826ba97156fb92dc1b541ffdb242700008c253ae8a43706be347df420ea2b2fe4424049922e2a1aec60cea29f9c06c9da98e1b0dbc7c1886af7f7f7f19d923c";
+      sha512 = "1c84b8ce2cadbf5aad33db4c767ed0dba536107416ef017622215bf1dff780bed20c5e01eb9723d35065aaa1a66cf86e00efae5325a38a5af7a2f1f6271fc0bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/hy-AM/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/hy-AM/thunderbird-68.2.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "14cd6b6c31b7bb1b4d9c5e0178cedd4f04384e8c586f731c853dfc9b4395d4a9ea2f24bc2607e433482a17476b6e6e6924c9999d3b9b577ce06c00016dcb8742";
+      sha512 = "c13118f36f56d76a7e72ba1d43b4d58e3cf7e8d204db61bb1a80d8bdaf03300d6da83e61ef8ebf33db17ccc2aacdb738df058725e9f49441003ae51613d39c98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/id/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/id/thunderbird-68.2.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "f35f5097ffb6970167bdcfd891decebbdbfe0ab9953c7efc824720b543c39967ee92abb1129897d8c19ed9f3ecfd76e5e9b9b579c5074c97575217279155ce53";
+      sha512 = "edc061991bd2f320091905e82e7062c81aa6ed02b705c1d10c9ff18e20cd80589debead4a8dafbc9dd1452d425dd7c112240205ff4a3adcc53243fbd9a109683";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/is/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/is/thunderbird-68.2.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "71189807e26317b2da5b0d401a586f3fd043bebae673f0a973298d85d2e774cef61c9ca8d7a9f58c68fa9ddf84076ae84892f5e58e29366ca4ffcdee45d19bd6";
+      sha512 = "846f37e9f069b264d5c1fc8bc22c85a19d7bcd798541706b75db6b44fb2885cb9dd212c4a71e8c91ac36bec1ab2354061c42b994737796a353fa906b2db69444";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/it/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/it/thunderbird-68.2.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "45e0f05fde4de1295f6acb19340f24db3e06ca4c090f958a193c1e0e82a7773ff466781a29b6119f89bc39acdc6e50de69eb9b4c8e4e2ba565bf760021f90a50";
+      sha512 = "9f598559b0d5b25951f890111c3664769fbf434e96a41df032e120d6f7c0ad3427dd8991127817a10ff78a555b09ccc8d48b045698e84d5121f2b0bff56af376";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ja/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/ja/thunderbird-68.2.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "11271df03b068db31a4c5944690000642aa4924d9d744358cf23dfeb118e9c0e759ef0907a868d0e3a5234674b696739fa770d095ebed53aca41ce0eedf0a9fa";
+      sha512 = "02f3f38adcf27027a262932fc15b615ea60f11316085170876c22d268d472110624b52bc1a0bed44dc1b8f617853626efb9fb42c8a0b1d689bebc6f01278c12c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ka/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/ka/thunderbird-68.2.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "48396e76d8b6be27b295d5bf14b34f8cc3e34a89df6096ee7f63056691deb2fb47ee3385386d103a4c191e6e6b0459c3e9b4f90640dc1518cb327e0c0f6211af";
+      sha512 = "0416109691e441633d530f47e3886e45ef60affedf72fe47bafa93b8eabdf1b48c926b361d2d3bb747ccc20a9e7ea9b3ff5911fa9c3556c701ba0208dc4e9182";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/kab/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/kab/thunderbird-68.2.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "1dfc58ede0c1619044cc18a7102f683444fa90df28d096e8ea0700203c05f3411d21abd231f347a37ded2bb89cf84127fd7730143833da151dadd90fceecdc81";
+      sha512 = "e6b1e52b8eed939da4b96a4de06174f2758f78b773499a3c860de4a890bf5345d69ba521581ed5d1ae767decad0bb0a474fd8476ba9188a74728c0ac92892a56";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/kk/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/kk/thunderbird-68.2.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "0c0e2ef29e7bc2b715eae29da2c8394fdeaaef47683428972360af109fdcd0ee07494ee5f1653511ad665cd88e94875426fde98af8da0a77a433c19e1f40d543";
+      sha512 = "d3c9be93f32e2f9b83c29ce0fd28fc07d95f2173a17590b02e2dc69d2ba4cf4f38fe8fe4ce24f17e232480c25ae1e67457265e46bb3e4392164b85340d7fdba8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ko/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/ko/thunderbird-68.2.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "1348d1d702ce8dd045462ff7bfa5d7aee48b302a18b674e22ba13ed55e19b024d2e9ca34f573aaf795c7476e6d11d10769a0a4f1e3da60c4675afe1957b9e9e6";
+      sha512 = "a3f35fce676bd90c1bca2bb5bf6886d8806da47ab1ecdac24c449070f77f7174292491ed3b826842d9f7ae6f008a10e4548b01b1543adcd9a85f964940c6784f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/lt/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/lt/thunderbird-68.2.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "2155c783337a468a24b3659b8db2df74c6f3557aeb69c256a0e31ce7bf69eefb0afedada7146ef124a6325b48b9c3a6274543851995ca49486366079c942f0cc";
+      sha512 = "416b15047d4884bd41bfd0e9ade075915be84bcf8ce2d13695cf1df66d99f79a31bc5428833efe0ee00b1bbc960085426430721c3ec79c47966b5d8818563cc6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ms/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/ms/thunderbird-68.2.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "7e0b1e9749224a457df5bab5b207ad16bdfc8fa25bc88fa0b3e73b9e6459c5eafd8a97607f2a9d54efcea7f3162311f99a84156ccf812f27438c58291720ea7c";
+      sha512 = "31539a4147fdd8f9f193c012d19dc5998737efecce32e3ac20b5316bb83a04ff0db8023c92c14e72e03fa02b3b94a0f3b5791a606955f361cb59524da692ac6a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/nb-NO/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/nb-NO/thunderbird-68.2.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "36638159f4a1fefbb77da855538f7aede0efbc15646dc447af0a68caca484f2b8e2ffb47c6d54ba2b469fc7dbcb793144810c9dce180a0302051227504cdb9f4";
+      sha512 = "ec73dc47c1c362b40f8c2b41eb565fb5544a749ab40def2188b7620c8ae5ad3bb42152bb1415695b4ca1dea5b64310d909ee87a133bd2c055a71e459f8766056";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/nl/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/nl/thunderbird-68.2.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "a3c1957daaced30a185cd663b083c8aa5ddce05f1eb84c0bc8e3351c7960697d651318dc0cf362b4f9a102f8ca36802e10bd03dca41d76bfba1c87dd93ee8aa7";
+      sha512 = "75e7ded719cd25276853a8ebce5346ff3cc5a44005412c40c097b9c1fdfdbfa5547f3390a36c376ddc4c26a0037347b8c606d66dbc9783a5978ff59a63f60286";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/nn-NO/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/nn-NO/thunderbird-68.2.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "9473bff0632a46f537d9e9ed12ff53be90ee1cc92dce52026255bf70bb092040b7abdbeb9ce3b939c45de69ffcf949630406cffec26ec17da3837208843320d6";
+      sha512 = "38fbd3a7549964dfad40b49eb3dcc9123247d5cefc19af7c0f9ed7cafca96d89d780035d25655a49ca38404ff7ed8f1ff95cf6e0ce40a5a82caf19a7aa58c4e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/pl/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/pl/thunderbird-68.2.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "98e5e82721e733e982593552eb79a1aed7c7fc891ced4c63e7a84e778a3a18d419efd7d2f7bf24f5ec279c971c9c0088b221044a952a817f086dbc8398af291e";
+      sha512 = "ae94be2b7cef429c3eeba0e9c19f42e91b2be694c674c067b93d337fee373d8b6d9084202257320435859a2f65dee7605202f5ad47ed0526e99b82fdf505672a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/pt-BR/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/pt-BR/thunderbird-68.2.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "bb5fa9871650f3732beb97df364d10a2f3972fcd607318df9819be68fc467f47081dec7a9f5ebd3834a35b136a646b3deb137598ccd9b3e870a344983ee9408a";
+      sha512 = "68a1331ae1b25d00a6e0ff17b2965576851188a6083fba98a67712adabe63f326147a52bd4f28c4870ce0e6e55713d28a07558e29875e29a1a87549b627c4a19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/pt-PT/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/pt-PT/thunderbird-68.2.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "39db7d45cfb76ad752e58949be80728b90f39a53cfd2b94b1ef706eb64b29a4ed785bf6ccd7aa9306ffa90e127cf03fe5a5efb75eed71f403d9672b925f23ca5";
+      sha512 = "6e72e69080c703c70f7b2e4340376a0725b23dc188c13ba4784ada1baab6192373e41555ed84f14c8c584aa16dddff8c7780a53587f3e57958eb32dc37b96e32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/rm/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/rm/thunderbird-68.2.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "a1bad0dd822897b7bf305740baa77e1c079a61447051a7798f62b0af5c47b20be4c63f8cce7d36821ba7eebfe4901809de8d15598a29fce9661b93b5c3aada79";
+      sha512 = "c311d16bd09c414b34e5b131385322686a0b46031a24eeaebea37122137136ce0eb84ac51e927595aaf015c4b3789d5545e8f3ebbe98aca14da1ae2747be1b1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ro/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/ro/thunderbird-68.2.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "b6c7cabb8e4083b16775e7835f68d8384d6e11fa1d79dab046fcbbce035892aee957ef94f719938e3a684f6297fcf90e39cfe0fdd564f2e975eb1925ef0dc9b9";
+      sha512 = "e366dc65546d39f7ff181eb3502c29d46e0e7eb15cab0fd9e85b681c03aa9cfe8a1eaba397bac88256efb986a83bd195655fd4b0568f5d26c2f290ba3a075067";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/ru/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/ru/thunderbird-68.2.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "7d21898e5c05a6dba91c14098fa3d977ed6d6db3cf9165817b0021bcfddf9739abd53dc3a7a4b7541029d049c8153c9e235dfd2a00cfb00891a38de499e3eab2";
+      sha512 = "9778767a03164b9450ac287c28e7c93d8335c8c38d4856da6a1e8fd2a041e49c015a9e8d8892403761075e098cb3b37e2bc36205339cb4ecdecd861e860ed973";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/si/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/si/thunderbird-68.2.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "38e6221a855ca73f9e3427c5fa2c51816d046cea9a199f58247615307253660d70e0cdb3e2c50217515f57a1e7891252e908785287ea2b13e32f89a1a1f5c111";
+      sha512 = "53c4e8b4f7f2bacb648cfcfdc6307aba3564b4dd1aea392e4d4fe0d4ea8c882aa13979e63b6a8422dfdce230c4e8cff6a6ae98d8d568fe11ee9b7c4126dbe31c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/sk/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/sk/thunderbird-68.2.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "971ce593483f472913a1fb6d55e8b18f9041af7e3dad5507c0070692f4c30d6dd0c17fbc50cd77a9e8be680d81c82ba24498c53b2bd805b154d34001d650b9b0";
+      sha512 = "ecd7eeb4cd782107612dcea181c490753ae387daef0af2b0b49a97abf2b0f056348b14eb841253a7274ac65e3d17641ccf0eaf64cf2823d66a72c3435124140e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/sl/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/sl/thunderbird-68.2.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "b2dd0001bcb435d86bcb4460eb8b05882fd4dc4275ca9057086a625e273a092b60d992cbeb634c7316b315048c8f3e771ee1284ffbd029b0903b8b01d3429f52";
+      sha512 = "bf8b1e4e6928f2b27ff41b8ec4a58379d8f64ca6cc97bad5b94d63f21ccce3fc375c34333bc0095ea44e5ff0a46e2932112f4b4a730bc4e8672c7cd9671fbe3c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/sq/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/sq/thunderbird-68.2.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "84e5232ced93dcbf6b72313da2d7f81691302738d83d692d4c9c29dd610a98f0c90cfc5033e0603292803dc8531ce05eda48e7989c85709dc58964edc172773a";
+      sha512 = "40e3ae4db210744ee064b1d7a659b602a1c6d2c68019bae625d02a75baa7e5b3a821f0c86c646d5bf244cba2e870c38ee452692143847fc4a14795fee9b40f1a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/sr/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/sr/thunderbird-68.2.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "d97e2a2522570f6ceaf77536f3eb1bc190a36c8d6c0b33828068891a3e3b4a9492a847b65b40c58ce66ab84ff47f91ba8e0016ef85375078a3d11cb6a56997f5";
+      sha512 = "e70ee2b514f504b423885020bada122985588d00dc1dd5a11cd9cf2b41e60ed0f6d6928d54df5fcf98909c768f82038b8de214eb07117ba84026ac3e4ac1ad51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/sv-SE/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/sv-SE/thunderbird-68.2.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "bc1ccaf7005a0d09d3b3942e926167130b6a70affa0458e398e20480bca25637a04b2c5e9a6e836da42b6bce756db518989bb928030f6fc2a72d2d86a10e7d03";
+      sha512 = "abddf117adb3062e86b2ed4c7c120698293ca87c029c4e5652ff279da621cddd38ae35a3893ac51a2f805f33003efe8f1d9527d5c9d9a3e7352bbad2931dd369";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/tr/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/tr/thunderbird-68.2.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "2ec3f139dc9aeeff218113d63d886d0f51da110b7aa096503d5a6b8f57e0e1c9ce6be5d76089612b2bc8c920f5b6972ac17b421bf78548fe44c5d84721dc672d";
+      sha512 = "b245f36985237ecbd6b5876b424fdfa8f5cb259d3421c8857174f0ae49ce606c1e6e95bbd6f88c46aa4f4a30e1a58315f7ac2a2ec2212503b0885588d46f7520";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/uk/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/uk/thunderbird-68.2.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "96a1072393854313bce952c791de5bb03ece30fb135860b02cbb53537df0bf4d81635b6a0f34beed4f6f2f93588e11e24574d8392bdc3373002ea1730850ed6b";
+      sha512 = "c750c4821d5090457640d03819c60faeed9178eae08c596caac5af8b775891bb6fbf311644395e9521d550d1119143ddd100ede437530edc8b6dd2e109124f3c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/uz/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/uz/thunderbird-68.2.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "3e3d44f5bf8f39a7d2b352eea6df2066225649aa5e2a641ce0a7cffd5f7fa04d1f09ae504a10b495abccbc95659130432f39c15fe517395ee84492e9734bc379";
+      sha512 = "e59c19b61a03b9170fec7c12680f136bdda129c72a0901d653279e0c5c0a0d748f1434379b3901ffc7fccd0d4688cd8414171b0f94171cddbc7f249817689b8a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/vi/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/vi/thunderbird-68.2.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "2ff6c67f630412ab9ad7480b91b6c648a20ac32fd00ec5370f8bf93b159c1ec1e060f2a8c8c13ca877e47430e8b2483cf465a57b2fdfb8060149ce11d2ee0a73";
+      sha512 = "9e65b74645b229c92df8844f356034504f185a4ee9a0a504fb8a4c9c253101eb855a9b5ba28e995221da85c6e58aac9f0e7368639202011307d1b2a623b85931";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/zh-CN/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/zh-CN/thunderbird-68.2.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "998de4c5ee44d34e1de350d80225ae76e8b839cf441ba71778e11157b75e3332f83c95fed429c74a3ec85597ca9f939a0efd697a64e86957e327334e03534e40";
+      sha512 = "2cf2d1a12c53e1bfe9f9cfd13449dbb62260fbf7a1548b3b2d76403a2597c286f727341c4bb4ed65b5086391a99a0fdf97a74c967a4ea9f99a0a393b9a87f7be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.1/linux-i686/zh-TW/thunderbird-68.2.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/68.2.2/linux-i686/zh-TW/thunderbird-68.2.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "8ea36d5b3835158d6d6191cea42f8b5cfa75817ae9a52a92ed12e7cfe5d7559136ab5ca7d522aee3059769e9ac719ae20f4448206a86e8b3e902cfb63ae700a0";
+      sha512 = "389a4e08d3a8cef73017e26b5abb4cd21f8237486470fa382ad90f6d1276bb4ee9e35dc66422728de4e8eb35145d898a705e025d04eb406099a275c2afb05623";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -25,11 +25,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.1.1";
+  version = "68.2.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "2ng5wwd7fn9247ggzlxx96scc2nalaahzvxkzvb87mp9fbfcsi3v9dh370cm42px8hrknnsp2lrfk9hqx4287zyn9pl3k9vr6a9cswl";
+    sha512 = "3y4wizamyyr5q73cid5m97x915w7h7sy2vcvvq7gvi39iw4mz972p0sczs9sp8fp1svf87a2kbrsv2rcsr4spf7wfmsmps50a3zr6na";
   };
 
   # from firefox, but without sound libraries
@@ -52,11 +52,6 @@ in stdenv.mkDerivation rec {
   patches = [
     # Remove buildconfig.html to prevent a dependency on clang etc.
     ./no-buildconfig.patch
-    (fetchpatch {
-      # https://phabricator.services.mozilla.com/D47796
-      url = "https://d3kxowhw4s8amj.cloudfront.net/file/data/a54c6fszaol23yh5aa27/PHID-FILE-sql3i57neyrztfdngrwe/D47796.diff";
-      sha256 = "18i1bk6rz875dly2vnkrdgbah8kx0lv4akjzl0i9gxc58hi5q3nq";
-    })
   ]
   ++ lib.optional (lib.versionOlder version "69")
     (fetchpatch { # https://bugzilla.mozilla.org/show_bug.cgi?id=1500436#c29
@@ -141,6 +136,9 @@ in stdenv.mkDerivation rec {
       gappsWrapperArgs+=(
         --argv0 "$target"
         --set MOZ_APP_LAUNCHER thunderbird
+        # See commit 87e261843c4236c541ee0113988286f77d2fa1ee
+        --set MOZ_LEGACY_PROFILES 1
+        --set MOZ_ALLOW_DOWNGRADE 1
         # https://github.com/NixOS/nixpkgs/pull/61980
         --set SNAP_NAME "thunderbird"
       )

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -25,11 +25,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.2.1";
+  version = "68.2.2";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "1ydlwxr6kln4v357nh3b5k33g4d9gsl8lvcqhphzgdhq6ky266xwb5aa1vlhgjhhzfzxif8jw4hvzs8g3zlzr92q5irpw7nhjn1r4id";
+    sha512 = "3mvanjfc35f14lsfa4zjlhsvwij1n9dz9xmisd5s376r5wp9y33sva5ly914b2hmdl85ypdwv90zyi6whj7jb2f2xmqk480havxgjcn";
   };
 
   # from firefox, but without sound libraries

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -25,11 +25,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.2.0";
+  version = "68.2.1";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "3y4wizamyyr5q73cid5m97x915w7h7sy2vcvvq7gvi39iw4mz972p0sczs9sp8fp1svf87a2kbrsv2rcsr4spf7wfmsmps50a3zr6na";
+    sha512 = "1ydlwxr6kln4v357nh3b5k33g4d9gsl8lvcqhphzgdhq6ky266xwb5aa1vlhgjhhzfzxif8jw4hvzs8g3zlzr92q5irpw7nhjn1r4id";
   };
 
   # from firefox, but without sound libraries

--- a/pkgs/applications/networking/mailreaders/thunderbird/no-buildconfig.patch
+++ b/pkgs/applications/networking/mailreaders/thunderbird/no-buildconfig.patch
@@ -21,3 +21,15 @@ diff -ru -x '*~' a/toolkit/content/jar.mn b/toolkit/content/jar.mn
     content/global/buildconfig.css
     content/global/contentAreaUtils.js
     content/global/datepicker.xhtml
+--- a/comm/mail/base/jar.mn
++++ b/comm/mail/base/jar.mn
+@@ -117,9 +117,7 @@
+ % override chrome://mozapps/content/profile/profileDowngrade.js chrome://messenger/content/profileDowngrade.js
+ % override chrome://mozapps/content/profile/profileDowngrade.xul chrome://messenger/content/profileDowngrade.xul
+ 
+-*   content/messenger/buildconfig.html              (content/buildconfig.html)
+     content/messenger/buildconfig.css               (content/buildconfig.css)
+-% override chrome://global/content/buildconfig.html chrome://messenger/content/buildconfig.html
+ % override chrome://global/content/buildconfig.css chrome://messenger/content/buildconfig.css
+ 
+ # L10n resources and overrides.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Critical security fixes
- Other updates

https://www.thunderbird.net/en-US/thunderbird/68.2.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2019-35/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Fuuzetsu, @nbp, @edolstra
