### PR TITLE
nixfmt test

### DIFF
--- a/pkgs/tools/misc/txr-copy/default.nix
+++ b/pkgs/tools/misc/txr-copy/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, bison, flex, libffi }:
+
+stdenv.mkDerivation rec {
+  pname = "txr";
+  version = "225";
+
+  src = fetchurl {
+    url = "http://www.kylheku.com/cgit/txr/snapshot/${pname}-${version}.tar.bz2"; sha256 = "07vh0rmvjr2sir15l3ppp2pnp2d849dg17rzykkzqyk3d5rwfxyj";
+  };
+
+  nativeBuildInputs = [ bison flex ];
+  buildInputs = [ libffi ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+  checkTarget = "tests";
+
+  # Remove failing test-- mentions 'usr/bin' so probably related :)
+  preCheck = "rm -rf tests/017";
+
+  postInstall = ''
+    d=$out/share/vim-plugins/txr
+    mkdir -p $d/{syntax,ftdetect}
+
+    cp {tl,txr}.vim $d/syntax/
+
+    cat > $d/ftdetect/txr.vim <<EOF
+      au BufRead,BufNewFile *.txr set filetype=txr | set lisp
+      au BufRead,BufNewFile *.tl,*.tlo set filetype=tl | set lisp
+    EOF
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Programming language for convenient data munging";
+    license = licenses.bsd2;
+    homepage = http://nongnu.org/txr;
+    maintainers = with stdenv.lib.maintainers; [ dtzWill ];
+    platforms = platforms.linux; # Darwin fails although it should work AFAIK
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6692,6 +6692,8 @@ in
 
   txr = callPackage ../tools/misc/txr { stdenv = clangStdenv; };
 
+  txr-copy = callPackage ../tools/misc/txr-copy { stdenv=clangStdenv; };
+
   txt2man = callPackage ../tools/misc/txt2man { };
 
   txt2tags = callPackage ../tools/text/txt2tags { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
