### PR TITLE
wifite2: init at 2.2.5

### DIFF
--- a/pkgs/tools/networking/wifite2/default.nix
+++ b/pkgs/tools/networking/wifite2/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, lib, fetchFromGitHub, python3, aircrack-ng, wireshark-cli, reaverwps-t6x, cowpatty, hashcat, hcxtools, which }:
+
+python3.pkgs.buildPythonApplication rec {
+  version = "2.2.5";
+  pname = "wifite2";
+
+  src = fetchFromGitHub {
+    owner = "derv82";
+    repo = "wifite2";
+    rev = version;
+    sha256 = "1hfy90wf2bjg0z8rbs8cfhhvz78pzg2c6nj0zksal42mb6b5cjdp";
+  };
+
+  propagatedBuildInputs = [
+    aircrack-ng
+    wireshark-cli
+    reaverwps-t6x
+    cowpatty
+    hashcat
+    hcxtools
+    which
+  ];
+
+  postFixup = let
+    sitePackagesDir = "$out/lib/python3.${lib.versions.minor python3.version}/site-packages";
+  in ''
+    mv ${sitePackagesDir}/wifite/__main__.py ${sitePackagesDir}/wifite/wifite.py
+  '';
+
+  # which is not found
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/derv82/wifite2";
+    description = "Rewrite of the popular wireless network auditor, wifite";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lassulus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6904,6 +6904,8 @@ in
 
   whois = callPackage ../tools/networking/whois { };
 
+  wifite2 = callPackage ../tools/networking/wifite2 { };
+
   wireguard-tools = callPackage ../tools/networking/wireguard-tools { };
 
   woff2 = callPackage ../development/web/woff2 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
