### PR TITLE
tpm2-abrmd: init at 2.2.0

### DIFF
--- a/pkgs/tools/security/tpm2-abrmd/default.nix
+++ b/pkgs/tools/security/tpm2-abrmd/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, lib
+, tpm2-tss, pkgconfig, glib, which, dbus, cmocka }:
+
+stdenv.mkDerivation rec {
+  pname = "tpm2-abrmd";
+  version = "2.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/tpm2-software/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
+    sha256 = "1lbfhyyh9k54r8s1h8ca2czxv4hg0yq984kdh3vqh3990aca0x9a";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    tpm2-tss glib which dbus cmocka
+  ];
+
+  # Unit tests are currently broken as the check phase attempts to start a dbus daemon etc.
+  #configureFlags = [ "--enable-unit" ];
+  doCheck = false;
+
+  meta = with lib; {
+    description = "TPM2 resource manager, accessible via D-Bus";
+    homepage = https://github.com/tpm2-software/tpm2-tools;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lschuermann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6621,6 +6621,8 @@ in
 
   tpm-luks = callPackage ../tools/security/tpm-luks { };
 
+  tpm2-abrmd = callPackage ../tools/security/tpm2-abrmd { };
+
   tpm2-tools = callPackage ../tools/security/tpm2-tools { };
 
   trezord = callPackage ../servers/trezord { };


### PR DESCRIPTION
###### Motivation for this change
TPM2 requires a resource manager if multiple applications (or sometimes even one) want to access the same physical device. Recently, the kernel received its own TPM resource manager, however some applications rely on being able to talk to the `tpm2-abrmd` via D-Bus.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I'm using the package locally and it appears to work. I'll create a NixOS module for installing and using the resource manager separately.

@lassulus
