### PR TITLE
tracecmd: 2.8.3 -> 2.9-dev & kernelshark: 0.9.8 -> 1.1.0

### DIFF
--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, asciidoc, docbook_xsl, libxslt }:
 stdenv.mkDerivation {
   pname = "trace-cmd";
-  version = "2.8.3";
+  version = "2.9-dev";
 
   src = fetchgit (import ./src.nix);
 
@@ -17,18 +17,14 @@ stdenv.mkDerivation {
 
   buildPhase = "make trace-cmd libs doc";
 
-  installTargets = [ "install_cmd" "install_libs" "install_man" ];
+  installTargets = [ "install_cmd" "install_libs" "install_doc" ];
   installFlags = [
     "bindir=${placeholder "out"}/bin"
     "man_dir=${placeholder "man"}/share/man"
     "libdir=${placeholder "lib"}/lib"
-    "includedir=${placeholder "dev"}/include/trace-cmd"
+    "includedir=${placeholder "dev"}/include"
     "BASH_COMPLETE_DIR=${placeholder "out"}/etc/bash_completion.d"
   ];
-
-  postInstall = ''
-    mv $dev/include/trace-cmd/traceevent $dev/include/traceevent
-  '';
 
   meta = with stdenv.lib; {
     description = "User-space tools for the Linux kernel ftrace subsystem";

--- a/pkgs/os-specific/linux/trace-cmd/fix-Makefiles.patch
+++ b/pkgs/os-specific/linux/trace-cmd/fix-Makefiles.patch
@@ -1,52 +1,35 @@
-diff --git a/Documentation/Makefile b/Documentation/Makefile
-index 21e42fd..826361d 100644
---- a/Documentation/Makefile
-+++ b/Documentation/Makefile
-@@ -108,7 +108,11 @@ $(IMGS_INSTALL): %.png.install : %.png force
- 
- GUI_INSTALL = $(HTML_INSTALL) $(IMGS_INSTALL)
- 
--install: $(MAN1_INSTALL) $(MAN5_INSTALL) $(GUI_INSTALL)
-+install_man: $(MAN1_INSTALL) $(MAN5_INSTALL)
-+
-+install_gui: $(GUI_INSTALL)
-+
-+install: install_man install_gui
- 
- clean:
- 	(cd $(obj); \
 diff --git a/Makefile b/Makefile
-index 2bcc383..107ead0 100644
+index bbdf15e..deb8ef7 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -289,7 +289,7 @@ libtraceevent.a: $(LIBTRACEEVENT_STATIC)
+@@ -288,7 +288,7 @@ libtraceevent.a: $(LIBTRACEEVENT_STATIC)
  libtracecmd.a: $(LIBTRACECMD_STATIC)
  libtracecmd.so: $(LIBTRACECMD_SHARED)
  
 -libs: $(LIBTRACECMD_SHARED) $(LIBTRACEEVENT_SHARED)
 +libs: $(LIBTRACECMD_SHARED) $(LIBTRACEEVENT_SHARED) $(LIBTRACECMD_STATIC) $(LIBTRACEEVENT_STATIC)
  
- plugins: force $(obj)/plugins/trace_plugin_dir $(obj)/plugins/trace_python_dir
- 	$(Q)$(MAKE) -C $(src)/plugins
-@@ -345,6 +345,8 @@ install_gui: install_cmd gui
+ plugins: force $(obj)/lib/traceevent/plugins/traceevent_plugin_dir $(obj)/lib/traceevent/plugins/trace_python_dir
+ 	$(Q)$(MAKE) -C $(src)/lib/traceevent/plugins
+@@ -344,6 +344,8 @@ install_gui: install_cmd gui
  install_libs: libs
- 	$(Q)$(call do_install,$(LIBTRACECMD_SHARED),$(libdir_SQ))
- 	$(Q)$(call do_install,$(LIBTRACEEVENT_SHARED),$(libdir_SQ))
-+	$(Q)$(call do_install,$(LIBTRACECMD_STATIC),$(libdir_SQ))
-+	$(Q)$(call do_install,$(LIBTRACEEVENT_STATIC),$(libdir_SQ))
+ 	$(Q)$(call do_install,$(LIBTRACECMD_SHARED),$(libdir_SQ)/trace-cmd)
+ 	$(Q)$(call do_install,$(LIBTRACEEVENT_SHARED),$(libdir_SQ)/traceevent)
++	$(Q)$(call do_install,$(LIBTRACECMD_STATIC),$(libdir_SQ)/trace-cmd)
++	$(Q)$(call do_install,$(LIBTRACEEVENT_STATIC),$(libdir_SQ)/traceevent)
  	$(Q)$(call do_install,$(src)/include/traceevent/event-parse.h,$(includedir_SQ)/traceevent)
  	$(Q)$(call do_install,$(src)/include/traceevent/trace-seq.h,$(includedir_SQ)/traceevent)
- 	$(Q)$(call do_install,$(src)/include/trace-cmd/trace-cmd.h,$(includedir_SQ))
-@@ -356,6 +358,12 @@ doc:
- doc_clean:
- 	$(MAKE) -C $(src)/Documentation clean
+ 	$(Q)$(call do_install,$(src)/include/trace-cmd/trace-cmd.h,$(includedir_SQ)/trace-cmd)
+diff --git a/kernel-shark/src/CMakeLists.txt b/kernel-shark/src/CMakeLists.txt
+index e20a030..7fce165 100644
+--- a/kernel-shark/src/CMakeLists.txt
++++ b/kernel-shark/src/CMakeLists.txt
+@@ -93,7 +93,7 @@ if (Qt5Widgets_FOUND AND Qt5Network_FOUND)
+             DESTINATION ${_INSTALL_PREFIX}/share/icons/${KS_APP_NAME})
  
-+install_man:
-+	$(MAKE) -C $(src)/Documentation install_man
-+
-+install_gui_docs:
-+	$(MAKE) -C $(src)/Documentation install_gui
-+
- install_doc:
- 	$(MAKE) -C $(src)/Documentation install
+     install(FILES "${KS_DIR}/org.freedesktop.kshark-record.policy"
+-            DESTINATION /usr/share/polkit-1/actions/)
++            DESTINATION ${_INSTALL_PREFIX}/share/polkit-1/actions/)
  
+     install(PROGRAMS "${KS_DIR}/bin/kshark-su-record"
+             DESTINATION ${_INSTALL_PREFIX}/bin/)

--- a/pkgs/os-specific/linux/trace-cmd/kernelshark.nix
+++ b/pkgs/os-specific/linux/trace-cmd/kernelshark.nix
@@ -1,7 +1,7 @@
-{ stdenv, mkDerivation, fetchgit, qtbase, cmake, json_c, mesa_glu, freeglut, trace-cmd, pkg-config }:
+{ stdenv, mkDerivation, fetchgit, qtbase, cmake, asciidoc, docbook_xsl, json_c, mesa_glu, freeglut, trace-cmd, pkg-config }:
 mkDerivation {
   pname = "kernelshark";
-  version = "0.9.8";
+  version = "1.1.0";
 
   src = fetchgit (import ./src.nix);
 
@@ -11,21 +11,22 @@ mkDerivation {
 
   preConfigure = "pushd kernel-shark";
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ pkg-config cmake asciidoc ];
 
-  buildInputs = [ qtbase json_c mesa_glu freeglut pkg-config ];
+  buildInputs = [ qtbase json_c mesa_glu freeglut ];
 
   cmakeFlags = [
     "-D_INSTALL_PREFIX=${placeholder "out"}"
     "-DTRACECMD_BIN_DIR=${trace-cmd}/bin"
     "-DTRACECMD_INCLUDE_DIR=${trace-cmd.dev}/include"
-    "-DTRACECMD_LIBRARY=${trace-cmd.lib}/lib/libtracecmd.a"
-    "-DTRACEEVENT_LIBRARY=${trace-cmd.lib}/lib/libtraceevent.a"
+    "-DTRACECMD_LIBRARY=${trace-cmd.lib}/lib/trace-cmd/libtracecmd.a"
+    "-DTRACEEVENT_LIBRARY=${trace-cmd.lib}/lib/traceevent/libtraceevent.a"
   ];
 
   preInstall = ''
     popd
-    make install_gui_docs prefix=$doc
+    make install_doc_gui prefix=$doc \
+      FIND_MANPAGE_DOCBOOK_XSL=${docbook_xsl}/share/xml/docbook-xsl-nons/manpages/docbook.xsl
     pushd kernel-shark/build
   '';
 

--- a/pkgs/os-specific/linux/trace-cmd/src.nix
+++ b/pkgs/os-specific/linux/trace-cmd/src.nix
@@ -1,5 +1,5 @@
 {
   url    = "git://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/";
-  rev    = "138c70106835ee0f05879e7f2f46bca8dae7ca99"; # branch: trace-cmd-stable-v2.8
-  sha256 = "1grpip7lywf98nsm7ql1d6bgc0ky0672savr8jz3a8hf9ny265nx";
+  rev    = "ab370b78b9278fe16657742d46cb95c0a65b47d5"; # branch: kernelshark-v1.1
+  sha256 = "0qngwc4qgadrkwlwpz73f12prdkx94kl0bg7g9hib95ipvsdmk1c";
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
