### PR TITLE
enlightenment.efl: 1.22.5 -> 1.23.1

### DIFF
--- a/pkgs/desktops/enlightenment/econnman.nix
+++ b/pkgs/desktops/enlightenment/econnman.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A user interface for the connman network connection manager";
     homepage = https://enlightenment.org/;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
-    platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.lgpl3;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx romildo ];
   };
 }

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -152,8 +152,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Enlightenment foundation libraries";
     homepage = https://enlightenment.org/;
-    platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.lgpl3;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx romildo ];
   };
 }

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, SDL, SDL2, alsaLib, bullet, curl, dbus,
+{ stdenv, fetchurl, meson, ninja, pkgconfig, SDL, SDL2, alsaLib, avahi, bullet, check, curl, dbus,
   doxygen, expat, fontconfig, freetype, fribidi, ghostscript, giflib,
-  glib, gst_all_1, gtk3, harfbuzz, jbig2dec, libGL, libdrm, libinput,
+  glib, gst_all_1, gtk3, harfbuzz, ibus, jbig2dec, libGL, libdrm, libinput,
   libjpeg, libpng, libpulseaudio, libraw, librsvg, libsndfile,
   libspectre, libtiff, libwebp, libxkbcommon, luajit, lz4, mesa,
   openjpeg, openssl, poppler, python27Packages, systemd, udev,
@@ -9,20 +9,24 @@
 
 stdenv.mkDerivation rec {
   pname = "efl";
-  version = "1.22.5";
+  version = "1.23.1";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "1cjk56z0whpzcqwg3xdq23kyp1g83xa67m9dlp7ywmb36bn4ca59";
+    sha256 = "0q9g4j7k10s1a8rv2ca9v9lydh7ml3zsrqvgncc4qhvdl76208nn";
   };
 
   nativeBuildInputs = [
+    meson
+    ninja
     gtk3
     pkgconfig
+    check
   ];
 
   buildInputs = [
     SDL
+    avahi
     fontconfig
     freetype
     giflib
@@ -31,6 +35,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
     gst_all_1.gstreamer
+    ibus
     libGL
     libpng
     libpulseaudio
@@ -90,30 +95,25 @@ stdenv.mkDerivation rec {
     xorg.xcbutilkeysyms
   ];
 
-  # ac_ct_CXX must be set to random value, because then it skips some magic which does alternative searching for g++
-  configureFlags = [
-    "--enable-sdl"
-    "--enable-drm"
-    "--enable-elput"
-    "--with-opengl=full"
-    "--enable-image-loader-jp2k"
-    "--enable-xinput22"
-    "--enable-multisense"
-    "--enable-liblz4"
-    "--enable-systemd"
-    "--enable-image-loader-webp"
-    "--enable-harfbuzz"
-    "--enable-xine"
-    "--enable-fb"
-    "--disable-tslib"
-    "--with-systemdunitdir=$out/systemd/user"
-    "ac_ct_CXX=foo"
+  mesonFlags = [
+    "--buildtype=release"
+    "-D build-tests=false" # disable build tests, which are not working
+    "-D drm=true"
+    "-D embedded-lz4=false"
+    "-D evas-loaders-disabler=json"
+    "-D fb=true"
+    "-D opengl=full"
+    "-D sdl=true"
   ];
 
   patches = [ ./efl-elua.patch ];
 
   postPatch = ''
     patchShebangs src/lib/elementary/config_embed
+
+    # fix destination of systemd unit and dbus service
+    substituteInPlace systemd-services/meson.build --replace "dep.get_pkgconfig_variable('systemduserunitdir')" "'$out/systemd/user'"
+    substituteInPlace dbus-services/meson.build --replace "dep.get_pkgconfig_variable('session_bus_services_dir')" "'$out/share/dbus-1/services'"
   '';
 
   # bin/edje_cc creates $HOME/.run, which would break build of reverse dependencies.
@@ -122,29 +122,32 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    export LD_LIBRARY_PATH="$(pwd)/src/lib/eina/.libs:$LD_LIBRARY_PATH"
+    # allow ecore_con to find libcurl.so, which is a runtime dependency (it is dlopened)
+    export LD_LIBRARY_PATH="${curl.out}/lib:$LD_LIBRARY_PATH"
+
     source "$setupHook"
   '';
 
   NIX_CFLAGS_COMPILE = [ "-DluaL_reg=luaL_Reg" ]; # needed since luajit-2.1.0-beta3
 
   postInstall = ''
+    # fix use of $out variable
     substituteInPlace "$out/share/elua/core/util.lua" --replace '$out' "$out"
+
+    # add all module include dirs to the Cflags field in efl.pc
     modules=$(for i in "$out/include/"*/; do printf ' -I''${includedir}/'`basename $i`; done)
-    substituteInPlace "$out/lib/pkgconfig/efl.pc" --replace 'Cflags: -I''${includedir}/efl-1' \
-      'Cflags: -I''${includedir}/eina-1/eina'"$modules"
+    substituteInPlace "$out/lib/pkgconfig/efl.pc" \
+      --replace 'Cflags: -I''${includedir}/efl-1' \
+                'Cflags: -I''${includedir}/eina-1/eina'"$modules"
 
     # build icon cache
     gtk-update-icon-cache "$out"/share/icons/Enlightenment-X
   '';
 
-  # EFL applications depend on libcurl, although it is linked at
-  # runtime by hand in code (it is dlopened).
   postFixup = ''
+    # EFL applications depend on libcurl, which is linked at runtime by hand in code (it is dlopened)
     patchelf --add-needed ${curl.out}/lib/libcurl.so $out/lib/libecore_con.so
   '';
-
-  enableParallelBuilding = true;
 
   meta = {
     description = "Enlightenment foundation libraries";

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -4,7 +4,7 @@
   libjpeg, libpng, libpulseaudio, libraw, librsvg, libsndfile,
   libspectre, libtiff, libwebp, libxkbcommon, luajit, lz4, mesa,
   openjpeg, openssl, poppler, python27Packages, systemd, udev,
-  utillinux, writeText, xineLib, xorg, zlib
+  utillinux, writeText, xorg, zlib
 }:
 
 stdenv.mkDerivation rec {
@@ -78,7 +78,6 @@ stdenv.mkDerivation rec {
     poppler
     python27Packages.dbus-python
     utillinux
-    xineLib
     xorg.libXScrnSaver
     xorg.libXcomposite
     xorg.libXdamage

--- a/pkgs/desktops/enlightenment/enlightenment.nix
+++ b/pkgs/desktops/enlightenment/enlightenment.nix
@@ -17,10 +17,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    (pkgconfig.override { vanilla = true; })
     gettext
     meson
     ninja
+    pkgconfig
   ];
 
   buildInputs = [

--- a/pkgs/desktops/enlightenment/ephoto.nix
+++ b/pkgs/desktops/enlightenment/ephoto.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    (pkgconfig.override { vanilla = true; })
+    pkgconfig
     mesa.dev # otherwise pkg-config does not find gbm
     makeWrapper
   ];

--- a/pkgs/desktops/enlightenment/rage.nix
+++ b/pkgs/desktops/enlightenment/rage.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson
     ninja
-    (pkgconfig.override { vanilla = true; })
+    pkgconfig
     mesa.dev
     wrapGAppsHook
   ];

--- a/pkgs/desktops/enlightenment/terminology.nix
+++ b/pkgs/desktops/enlightenment/terminology.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Powerful terminal emulator based on EFL";
     homepage = https://www.enlightenment.org/about-terminology;
-    platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.bsd2;
-    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx ];
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ matejc tstrobel ftrvxmtrx romildo ];
   };
 }

--- a/pkgs/desktops/enlightenment/terminology.nix
+++ b/pkgs/desktops/enlightenment/terminology.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson
     ninja
-    (pkgconfig.override { vanilla = true; })
+    pkgconfig
     makeWrapper
   ];
 

--- a/pkgs/development/python-modules/python-efl/default.nix
+++ b/pkgs/development/python-modules/python-efl/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "python-efl";
-  version = "1.22.0";
+  version = "1.23.0";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/bindings/python/${pname}-${version}.tar.xz";
-    sha256 = "1qhy63c3fs2bxkx2np5z14hyxbr12ii030crsjnhpbyw3mic0s63";
+    sha256 = "16yn6a1b9167nfmryyi44ma40m20ansfpwgrvqzfvwix7qaz9pib";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/python-modules/python-efl/default.nix
+++ b/pkgs/development/python-modules/python-efl/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     homepage = https://phab.enlightenment.org/w/projects/python_bindings_for_efl/;
     platforms = platforms.linux;
     license = with licenses; [ gpl3 lgpl3 ];
-    maintainers = with maintainers; [ matejc tstrobel ftrvxmtrx ];
+    maintainers = with maintainers; [ matejc tstrobel ftrvxmtrx romildo ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- enlightenment.efl: 1.22.5 -> [1.23.1](https://www.enlightenment.org/news/efl-1.23.1)
- pythonPackage.python-efl: 1.22.0 -> [1.23.0](https://sourceforge.net/p/enlightenment/mailman/message/36779150/)
- enlightenment.{enlightenment,ephoto,rage,terminology}: use default pkgconfig
- enlightenment.{econnman,efl,terminology}, pythonPackages.python-efl: add romildo as maintainer
- _Edited_: enlightenment.efl: remove dependence on xineLib 

Tested on a VM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matejc @ftrvxmtrx 
