### PR TITLE
minc2_simple: init at unstable-2019-11-12

### DIFF
--- a/pkgs/development/libraries/minc2-simple/default.nix
+++ b/pkgs/development/libraries/minc2-simple/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, cmake, libminc }:
+
+stdenv.mkDerivation {
+  version = "unstable-2019-11-12";
+  name    = "minc2-simple";
+
+  src = fetchFromGitHub {
+    owner  = "vfonov";
+    repo   = "minc2-simple";
+    rev    = "5cb5c0e8242885f6f6866cbfa9e1a16de5a9e6b6";
+    sha256 = "sha256:1fmj237mq1vzbn8px4x9ddv9fspzff11na9ird9gaynhp0k9w9s5";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libminc ];
+
+  cmakeFlags = [ "-DBUILD_TESTING=OFF" "-DLIBMINC_DIR=${libminc}/lib/" ];
+
+  # tests don't actually run automatically, e.g., missing input files
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/vfonov/minc2-simple";
+    description = "Simple interface to the libminc medical imaging library";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = [ "x86_64-linux" ];
+    license   = licenses.free;
+  };
+}

--- a/pkgs/development/python-modules/minc2-simple/default.nix
+++ b/pkgs/development/python-modules/minc2-simple/default.nix
@@ -1,0 +1,22 @@
+{ buildPythonPackage, fetchFromGitHub, stdenv, cmake,
+  hdf5, libminc, minc2_simple, minc_tools, mni_autoreg,
+  cffi, six, numpy, scipy, pytest }:
+
+buildPythonPackage {
+  pname   = "minc2-simple";
+
+  inherit (minc2_simple) version src;
+
+  sourceRoot = "source/python";
+
+  buildInputs = [ cffi six numpy scipy hdf5 libminc minc2_simple ];
+  checkInputs = [ pytest minc_tools mni_autoreg ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/vfonov/minc2-simple";
+    description = "Simple interface to the libminc medical imaging library";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = platforms.linux;
+    license   = licenses.free;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23214,6 +23214,8 @@ in
 
   migrate = callPackage ../applications/science/biology/migrate { };
 
+  minc2_simple = callPackage ../development/libraries/minc2-simple { };
+
   mirtk = callPackage ../development/libraries/science/biology/mirtk { };
 
   muscle = callPackage ../applications/science/biology/muscle { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1705,6 +1705,10 @@ in {
 
   pyepsg = callPackage ../development/python-modules/pyepsg { };
 
+  minc2_simple = callPackage ../development/python-modules/minc2-simple {
+    inherit (pkgs) minc2_simple;
+  };
+
   pyezminc = callPackage ../development/python-modules/pyezminc { };
 
   billiard = callPackage ../development/python-modules/billiard { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a package.  Fresh version of #51094.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [NA] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
