### PR TITLE
pythonPackages.pycurl: disable flakey memory tests

### DIFF
--- a/pkgs/development/python-modules/pycurl/default.nix
+++ b/pkgs/development/python-modules/pycurl/default.nix
@@ -35,6 +35,7 @@ buildPythonPackage rec {
     flaky
   ];
 
+  # skip impure or flakey tests
   checkPhase = ''
     pytest tests -k "not test_ssl_in_static_libs \
                      and not test_keyfunction \
@@ -42,7 +43,8 @@ buildPythonPackage rec {
                      and not test_libcurl_ssl_gnutls \
                      and not test_libcurl_ssl_nss \
                      and not test_libcurl_ssl_openssl" \
-                 --ignore=tests/getinfo_test.py
+                 --ignore=tests/getinfo_test.py \
+                 --ignore=tests/memory_mgmt_test.py
   '';
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
fixes #71975

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
