### PR TITLE
systemd.network.dhcpNetworks: init nixos option

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -890,6 +890,14 @@ in
       '';
     };
 
+    systemd.network.dhcpNetworks = mkOption {
+      default = [ "en*" "wl*" ];
+      type = types.listOf types.str;
+      description = ''
+        List of interface names (wildcards), for whit to enable DHCP.
+      '';
+    };
+
     systemd.network.links = mkOption {
       default = {};
       type = with types; attrsOf (submodule [ { options = linkOptions; } ]);
@@ -959,5 +967,14 @@ in
     };
 
     services.resolved.enable = mkDefault true;
+
+    systemd.network.networks = listToAttrs
+      (map
+        (name: nameValuePair
+          "10-dhcp-${(replaceStrings ["*"] ["+"] name)}" {
+            matchConfig.Name = name;
+            DHCP = "yes";
+          })
+        config.systemd.network.dhcpNetworks);
   };
 }


### PR DESCRIPTION
this allows to configures common physical interfaces (en*, wl*) with dhcp

###### Motivation for this change

After [switching to networkd](https://github.com/NixOS/nixpkgs/issues/10001), we should still provide a plug-and-play experience for common physical device and make it easy to configure a non-standard interface with dhcp.

###### Things done

This allows to set `systemd.network.dhcpNetworks` as a list of `systemd.network.networks.matchConfig.Name`s for being configured by DHCP.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested compilation
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### TODO

This PR is a suggestion, based on my current solution, using networkd on a Desktop and Laptop.

Maybe this should be derived from network.useDHCP instead, but I think it's good to have a central switch for that behavior.

###### Notify maintainers

cc @fpletz @arianvp @flokli 
