### PR TITLE
c3d: 2018-10-04 -> unstable-2019-10-22; mark unbroken

### DIFF
--- a/pkgs/applications/graphics/c3d/default.nix
+++ b/pkgs/applications/graphics/c3d/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchgit, cmake, itk, Cocoa }:
+{ stdenv, fetchgit, cmake, itk4, Cocoa }:
 
 stdenv.mkDerivation {
   pname   = "c3d";
-  version = "2018-10-04";
+  version = "unstable-2019-10-22";
 
   src = fetchgit {
-    url = "https://git.code.sf.net/p/c3d/git";
-    rev = "351929a582b2ef68fb9902df0b11d38f44a0ccd0";
-    sha256 = "0mpv4yl6hdnxgvnwrmd182h64n3ppp30ldzm0jz6jglk0nvpzq9w";
+    url    = "https://github.com/pyushkevich/c3d";
+    rev    = "c04e2b84568654665c64d8843378c8bbd58ba9b0";
+    sha256 = "0lzldxvshl9q362mg76byc7s5zc9qx7mxf2wgyij5vysx8mihx3q";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ itk ]
+  buildInputs = [ itk4 ]
     ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
 
   meta = with stdenv.lib; {
@@ -20,6 +20,5 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ bcdarwin ];
     platforms = platforms.unix;
     license = licenses.gpl2;
-    broken = true;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update and unbreak c3d; switch to the ITK 4.x due to unresolved issues with ITK 5 downloading modules at build time (also affecting nixpkgs.ANTS).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [NA] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
