### PR TITLE
minecraft: 2.1.5965 -> 2.1.7658

### DIFF
--- a/pkgs/games/minecraft/default.nix
+++ b/pkgs/games/minecraft/default.nix
@@ -15,6 +15,7 @@
 , cups
 , dbus
 , atk
+, gtk3-x11
 , gtk2-x11
 , gdk-pixbuf
 , glib
@@ -58,6 +59,7 @@ let
     glib
     gnome2.GConf
     gnome2.pango
+    gtk3-x11
     gtk2-x11
     nspr
     nss
@@ -82,11 +84,11 @@ in
  stdenv.mkDerivation rec {
   pname = "minecraft-launcher";
 
-  version = "2.1.5965";
+  version = "2.1.7658";
 
   src = fetchurl {
     url = "https://launcher.mojang.com/download/linux/x86_64/minecraft-launcher_${version}.tar.gz";
-    sha256 = "0wlc49s541li4cbxdmlw8fp34hp1q9m6ngr7l5hfdhv1i13s5845";
+    sha256 = "10sng7l0q9r98zwifjmy50nyh65ny4djmacz8158hffcsfcx93px";
   };
 
   icon = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
tried playing with friends, noticed it was out of date

used strace to determine that it needs both gtk2 and gtk3 in runtime path for it to work

gtk3 addition to closure:
```
$ nix path-info -Sh ./result
/nix/store/ibxwz2456xmjspnd85z8bqa9iwv99fai-minecraft-launcher-2.1.5965  622.5M
$ nix path-info -Sh ./result
/nix/store/y8fbsmql9nvpzlc76cyccfp7ggxcg1n4-minecraft-launcher-2.1.7658  675.2M
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
