### PR TITLE
Update pypi2nix

### DIFF
--- a/pkgs/development/python-modules/nix-prefetch-github/default.nix
+++ b/pkgs/development/python-modules/nix-prefetch-github/default.nix
@@ -1,0 +1,32 @@
+{ fetchPypi
+, lib
+, buildPythonPackage
+, attrs
+, click
+, effect
+, jinja2
+}:
+
+buildPythonPackage rec {
+  pname = "nix-prefetch-github";
+  version = "2.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1jkvmj33xinff0sb47yg33n131yi93pyq86skqc78xd38j6c8q9s";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    click
+    effect
+    jinja2
+  ];
+
+  meta = with lib; {
+    description = "Prefetch sources from github";
+    homepage = https://github.com/seppeljordan/nix-prefetch-github;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ seppeljordan ];
+  };
+}

--- a/pkgs/development/python-modules/parsley/default.nix
+++ b/pkgs/development/python-modules/parsley/default.nix
@@ -1,0 +1,22 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "Parsley";
+  version = "1.3";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hcd41bl07a8sx7nmx12p16xprnblc4phxkawwmmy78n8y6jfi4l";
+  };
+  # Tests fail although the package works just fine.  Unfortunately
+  # the tests as run by the upstream CI server travis.org are broken.
+  doCheck = false;
+  meta = with lib; {
+    license = licenses.mit;
+    homepage = "https://launchpad.net/parsley";
+    description = "A parser generator library based on OMeta, and other useful parsing tools.";
+    maintainers = with maintainers; [ seppeljordan ];
+  };
+}

--- a/pkgs/development/tools/pypi2nix/default.nix
+++ b/pkgs/development/tools/pypi2nix/default.nix
@@ -1,107 +1,24 @@
-{ stdenv, fetchFromGitHub, fetchurl, pythonPackages, zip, makeWrapper, nix, nix-prefetch-git
-, nix-prefetch-hg
+{ python3
 }:
+with python3;
 
-let
-
-  version = "1.8.1";
-
-  src = fetchFromGitHub {
-    owner = "garbas";
-    repo = "pypi2nix";
-    rev = "v${version}";
-    sha256 = "039a2ys7ijzi2sa2haa6a8lbhncvd1wfsi6gcy9vm02gi31ghzyb";
-  };
-
-  click = fetchurl {
-    url = "https://pypi.python.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz";
-    sha256 = "02qkfpykbq35id8glfgwc38yc430427yd05z1wc5cnld8zgicmgi";
-  };
-
-  requests = fetchurl {
-    url = "https://pypi.python.org/packages/16/09/37b69de7c924d318e51ece1c4ceb679bf93be9d05973bb30c35babd596e2/requests-2.13.0.tar.gz";
-    sha256 = "1s0wg4any4dsv5l3hqjxqk2zgb7pdbqhy9rhc8kh3aigfq4ws8jp";
-  };
-
-in stdenv.mkDerivation rec {
+pkgs.buildPythonApplication rec {
   pname = "pypi2nix";
-  inherit version;
-  srcs = [
-    src
-    click
-    requests
-  ];
-  buildInputs = [
-    pythonPackages.python pythonPackages.flake8 pythonPackages.setuptools
-    zip makeWrapper nix.out nix-prefetch-git nix-prefetch-hg
-  ];
-
-  sourceRoot = ".";
-
-  postUnpack = ''
-    mkdir -p $out/pkgs
-
-    mv click-*/click                    $out/pkgs/click
-    mv requests-*/requests              $out/pkgs/
-
-    if [ -z "$IN_NIX_SHELL" ]; then
-      if [ -e git-export ]; then
-        mv git-export/src/pypi2nix      $out/pkgs/pypi2nix
-      else
-        mv source/src/pypi2nix          $out/pkgs/pypi2nix
-      fi
-    fi
-  '';
-
-  patchPhase = ''
-    sed -i -e "s|default='nix-shell',|default='${nix.out}/bin/nix-shell',|" $out/pkgs/pypi2nix/cli.py
-    sed -i -e "s|nix-prefetch-git|${nix-prefetch-git}/bin/nix-prefetch-git|" $out/pkgs/pypi2nix/stage2.py
-    sed -i -e "s|nix-prefetch-hg|${nix-prefetch-hg}/bin/nix-prefetch-hg|" $out/pkgs/pypi2nix/stage2.py
-  '';
-
-  commonPhase = ''
-    mkdir -p $out/bin
-
-    echo "#!${pythonPackages.python.interpreter}" >  $out/bin/pypi2nix
-    echo "import pypi2nix.cli" >> $out/bin/pypi2nix
-    echo "pypi2nix.cli.main()" >> $out/bin/pypi2nix
-
-    chmod +x $out/bin/pypi2nix
-
-    export PYTHONPATH=$out/pkgs:$PYTHONPATH
-  '';
-
-  # flake8 doesn't run on python3
-  doCheck = false;
-  checkPhase = ''
-    flake8 ${src}/src
-  '';
-
-  installPhase = commonPhase + ''
-    wrapProgram $out/bin/pypi2nix \
-        --prefix PYTHONPATH : "$PYTHONPATH" \
-        --prefix PATH : "${nix-prefetch-git}/bin:${nix-prefetch-hg}/bin"
-  '';
-
-  shellHook = ''
-    export home=`pwd`
-    export out=/tmp/`pwd | md5sum | cut -f 1 -d " "`-$name
-
-    rm -rf $out
-    mkdir -p $out
-
-    cd $out
-    runHook unpackPhase
-    runHook commonPhase
-    cd $home
-
-    export PATH=$out/bin:$PATH
-    export PYTHONPATH=`pwd`/src:$PYTHONPATH
-  '';
-
-  meta = {
-    homepage = https://github.com/garbas/pypi2nix;
-    description = "A tool that generates nix expressions for your python packages, so you don't have to.";
-    maintainers = with stdenv.lib.maintainers; [ ];
+  version = "2.0.0";
+  src = pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "0w9z07kdnfs96230jag8xgz4wx337bb3q3bvqxn3r31x8fsmz6rr";
   };
+  checkInputs = with pkgs; [ pytest ];
+  propagatedBuildInputs = with pkgs; [
+    attrs
+    click
+    jinja2
+    nix-prefetch-github
+    packaging
+    parsley
+    setuptools
+    toml
+  ];
+  checkPhase = "${python3.interpreter} -m pytest unittests -m 'not nix'";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8991,9 +8991,7 @@ in
 
   pythonDocs = recurseIntoAttrs (callPackage ../development/interpreters/python/cpython/docs {});
 
-  pypi2nix = callPackage ../development/tools/pypi2nix {
-    pythonPackages = python3Packages;
-  };
+  pypi2nix = callPackage ../development/tools/pypi2nix {};
 
   setupcfg2nix = python3Packages.callPackage ../development/tools/setupcfg2nix {};
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -793,6 +793,8 @@ in {
     inherit python;
   };
 
+  nix-prefetch-github = callPackage ../development/python-modules/nix-prefetch-github { };
+
   nixpart = callPackage ../tools/filesystems/nixpart { };
 
   # This is used for NixOps to make sure we won't break it with the next major

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -830,6 +830,8 @@ in {
 
   palettable = callPackage ../development/python-modules/palettable { };
 
+  parsley = callPackage ../development/python-modules/parsley { };
+
   pastel = callPackage ../development/python-modules/pastel { };
 
   pathlib = callPackage ../development/python-modules/pathlib { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
*NOTE*: This PR should reviewable by commit since each should make sense on its own and now break anything.

###### Motivation for this change
I want to update `pypi2nix`.

###### Things done
* Update nix expression for `pypi2nix` since it can now easily be packages via the default `python.pkgs.buildPythonApplication`
* Initialize `pythonPackages.nix-prefetch-github` at version 2.3.1 since it is a dependency of `pypi2nix`
* Initialize `pythonPackages.parsley` at version 1.3 since it is a dependency of `pypi2nix`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
