### PR TITLE
gdal: add patch for CVE-2019-17545

### DIFF
--- a/pkgs/development/libraries/gdal/2.4.0.nix
+++ b/pkgs/development/libraries/gdal/2.4.0.nix
@@ -16,6 +16,15 @@ stdenv.mkDerivation rec {
     sha256 = "09qgy36z0jc9w05373m4n0vm4j54almdzql6z9p9zr9pdp61syf3";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-17545.patch";
+      url = "https://github.com/OSGeo/gdal/commit/8cd2d2eb6327cf782a74dae263ffa6f89f46c93d.patch";
+      stripLen = 1;
+      sha256 = "06h88a659jcqf6ps1m91qy78s6s9krbkwnz28f5qh7032vlp6qpw";
+    })
+  ];
+
   buildInputs = [ unzip libjpeg libtiff libgeotiff libpng proj openssl sqlite
     libspatialite poppler hdf4 qhull giflib expat libxml2 proj ]
   ++ (with pythonPackages; [ python numpy wrapPython ])

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -20,7 +20,15 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "source/gdal";
 
-  patches = [ ./001.3_0_1.darwin.patch ];
+  patches = [
+    ./001.3_0_1.darwin.patch
+    (fetchpatch {
+      name = "CVE-2019-17545.patch";
+      url = "https://github.com/OSGeo/gdal/commit/148115fcc40f1651a5d15fa34c9a8c528e7147bb.patch";
+      stripLen = 1;
+      sha256 = "0hai59hhvrci9xwjw4lp3wc1brn00imngmqrbbs8v9yr3b0fzbgs";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-17545

Patches added for 3.0.1 and 2.4.0 variants - it does look like the patch would apply fine to 1.11 too, but I'm not quite confident enough the result would be correct.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
