### PR TITLE
nixos/acme: Fix allowKeysForGroup not applying immediately

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -210,6 +210,12 @@ in
                   environment.REQUESTS_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt";
                   serviceConfig = {
                     Type = "oneshot";
+                    # With RemainAfterExit the service is considered active even
+                    # after the main process having exited, which means when it
+                    # gets changed, the activation phase restarts it, meaning
+                    # the permissions of the StateDirectory get adjusted
+                    # according to the specified group
+                    RemainAfterExit = true;
                     SuccessExitStatus = [ "0" "1" ];
                     User = data.user;
                     Group = data.group;


### PR DESCRIPTION
###### Motivation for this change
Previously setting `allowKeysForGroup = true; group = "foo"` would not
apply the group permission change of the certificates until the service
gets restarted. This commit fixes this by making systemd restart the
service every time it changes.

Note that applying this commit to a system with an already running acme
systemd service doesn't fix this immediately and you still need to wait
for the next refresh (or call `systemctl restart acme-<domain>`). Once
everybody's service has restarted once this should be a problem of the
past.

Fixes https://github.com/NixOS/nixpkgs/issues/48845, which I think has been broken since the introduction of the option in https://github.com/NixOS/nixpkgs/pull/12283

Ping @tmplt @arianvp @abbradar 

###### Things done

- [x] Tested it by first using `enableACME` on a new domain without `allowKeysForGroup`. Then rebuilding with the option and checking that the directory has the correct group permissions.