### PR TITLE
musl support for polkit, add elogind

### DIFF
--- a/pkgs/applications/misc/elogind/default.nix
+++ b/pkgs/applications/misc/elogind/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, meson
+, ninja
+, m4
+, gperf
+, getent
+, libcap
+, gettext
+, pkgconfig
+, udev
+, eudev
+, libxslt
+, python3Packages
+, docbook5
+, docbook_xsl
+, docbook_xsl_ns
+, docbook_xml_dtd_42
+, docbook_xml_dtd_45
+
+# Defaulting to false because usually the rationale for using elogind is to
+# use it in situation where a systemd dependency does not work (especially
+# when building with musl, which elogind explicitly supports).
+, enableSystemd ? false
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  pname = "elogind";
+  version = "239.5";
+
+  src = fetchFromGitHub {
+    owner = "elogind";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1gdiy4vbx4gs2hnb79x14zi530mlq26glxpzp3c95w8l058wj4ba";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    m4
+    pkgconfig
+    gperf
+    getent
+    libcap
+    gettext
+    libxslt.bin # xsltproc
+    docbook5 docbook_xsl docbook_xsl_ns docbook_xml_dtd_42 docbook_xml_dtd_45 # needed for docbook without Internet
+    python3Packages.lxml # fixes: man/meson.build:111:0: ERROR: Could not execute command "/build/source/tools/xml_helper.py".
+  ];
+
+  buildInputs =
+    if enableSystemd then [udev] else [eudev];
+
+  preConfigure = ''
+    patchShebangs .
+  '';
+
+  mesonFlags = [
+    "-Drootprefix=${placeholder "out"}"
+    "-Dsysconfdir=${placeholder "out"}/etc"
+  ];
+
+  meta = {
+    homepage = https://github.com/elogind/elogind/releases;
+    description = ''The systemd project's "logind", extracted to a standalone package'';
+    platforms = platforms.linux; # probably more
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ nh2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1599,6 +1599,8 @@ in
 
   elm-github-install = callPackage ../tools/package-management/elm-github-install { };
 
+  elogind = callPackage ../applications/misc/elogind { };
+
   enca = callPackage ../tools/text/enca { };
 
   ent = callPackage ../tools/misc/ent { };


### PR DESCRIPTION
###### Motivation for this change

Being able to build musl-based static applications, like for `static-haskell-nix`, that depend on `polkit`.

`systemd` does not build with musl; it depends on a `logind`, and [`elogind`](https://github.com/elogind/elogind) is one that explicitly supports musl.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

no maintainers in file!