### PR TITLE
rclone: 1.49.5 -> 1.50.0

### DIFF
--- a/pkgs/applications/networking/sync/rclone/default.nix
+++ b/pkgs/applications/networking/sync/rclone/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   pname = "rclone";
-  version = "1.49.5";
+  version = "1.50.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0firfb2300grfp5fnqaifhp346m4d0x8r1xshs9d8r6jxb160n03";
+    sha256 = "0k4fybz4670cqg1rpx0c1ximf1x6yl1f788hx9raxkwp5wv703kw";
   };
 
   goPackagePath = "github.com/rclone/rclone";


### PR DESCRIPTION
Package bump due to new release: https://github.com/rclone/rclone/releases/tag/v1.50.0