### PR TITLE
Fix handling of lists in whitelistedLicenses and blacklistedLicenses

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -36,10 +36,10 @@ let
     attrs ? meta.license;
 
   hasWhitelistedLicense = assert areLicenseListsValid; attrs:
-    hasLicense attrs && builtins.elem attrs.meta.license whitelist;
+    hasLicense attrs && lib.lists.any (l: builtins.elem l whitelist) (lib.lists.toList attrs.meta.license);
 
   hasBlacklistedLicense = assert areLicenseListsValid; attrs:
-    hasLicense attrs && builtins.elem attrs.meta.license blacklist;
+    hasLicense attrs && lib.lists.any (l: builtins.elem l blacklist) (lib.lists.toList attrs.meta.license);
 
   allowBroken = config.allowBroken or false
     || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
@@ -75,7 +75,7 @@ let
     allowInsecurePredicate attrs ||
     builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
 
-  showLicense = license: license.shortName or "unknown";
+  showLicense = license: toString (map (l: l.shortName or "unknown") (lib.lists.toList license));
 
   pos_str = meta: meta.position or "«unknown-file»";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A package's meta.license can either be a single license or a list.  The
code to check config.whitelistedLicenses and config.blackListedLicenses
wasn't handling this, nor was the showLicense function.

Tested as per below:
```
$ rg blacklistedLicenses ~/.config/nixpkgs/config.nix                                                                                                                                                                                                         
5:  blacklistedLicenses = with pkgs.stdenv.lib.licenses; [ agpl3Plus ];                                                                                                                                                                                       

# k6 has meta.license = agpl3Plus                                                                                                                                                                                                                                                              
nix-repl> :p k6.meta.license                                                                                                                                                                                                                                  
{ fullName = "GNU Affero General Public License v3.0 or later"; shortName = "agpl3Plus"; spdxId = "AGPL-3.0-or-later"; url = "http://spdx.org/licenses/AGPL-3.0-or-later.html"; }
$ nix-env -i k6                                                                                                                                                                                                                                               
installing 'k6-0.24.0'                                                                                                                                                                                                                                        
error: Package ‘k6-0.24.0’ in /nix/store/57m3mhl53m862in5mralzxhmpfwzzq29-nixos-19.09.907.f6dac808387/nixos/pkgs/development/tools/k6/default.nix:20 has a blacklisted license (‘agpl3Plus’), refusing to evaluate.                                           

# ripgrep-all has meta.license = [ agpl3Plus ]
nix-repl> :p ripgrep-all.meta.license                                                                                                                                                                                                                         
[ { fullName = "GNU Affero General Public License v3.0 or later"; shortName = "agpl3Plus"; spdxId = "AGPL-3.0-or-later"; url = "http://spdx.org/licenses/AGPL-3.0-or-later.html"; } ]
$ nix-env -i ripgrep-all                                                                                                                                                                                                                                      
replacing old 'ripgrep-all-0.9.2'                                                                                                                                                                                                                             
installing 'ripgrep-all-0.9.2'                                                                                                                                                                                                                                
building '/nix/store/xrv8j6kpy8vvw19msrpg0kj0hgd0nfzf-user-environment.drv'...                                                                                                                                                                                
created 1045 symlinks in user environment

# with this PR, ripgrep is now correctly rejected:
$ nix-env -f . -i ripgrep-all                                                                                                                                                                                                                                 
replacing old 'ripgrep-all-0.9.2'                                                                                                                                                                                                                             
installing 'ripgrep-all-0.9.2'                                                                                                                                                                                                                                
error: Package ‘ripgrep-all-0.9.2’ in /home/graham/git/graham33/nixpkgs/pkgs/tools/text/ripgrep-all/default.nix:26 has a blacklisted license (‘agpl3Plus’), refusing to evaluate.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
