### PR TITLE
pythonPackages.python-nomad: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/python-nomad/default.nix
+++ b/pkgs/development/python-modules/python-nomad/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, requests }:
+
+buildPythonPackage rec {
+  pname = "python-nomad";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1rf6ad35vg3yi1p4l383xwx0ammdvr1k71bxg93bgcvljypx4cyn";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # Tests require nomad agent
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python client library for Hashicorp Nomad";
+    homepage = "https://github.com/jrxFive/python-nomad";
+    license = licenses.mit;
+    maintainers = with maintainers; [ xbreak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5837,6 +5837,8 @@ in {
 
   pyregion = callPackage ../development/python-modules/pyregion {};
 
+  python-nomad = callPackage ../development/python-modules/python-nomad { };
+
   python-u2flib-host = callPackage ../development/python-modules/python-u2flib-host { };
 
   python-xmp-toolkit = callPackage ../development/python-modules/python-xmp-toolkit { };


### PR DESCRIPTION
Python client library for Hashicorp Nomad

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Useful library for interfacing Nomad from Python.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

*Edit:*
Note: Tests are disabled because they are more like integration tests in that it requires a nomad agent running.

###### Notify maintainers
