### PR TITLE
pythonPackages.py3buddy: init at unstable-2019-09-29

### DIFF
--- a/pkgs/development/python-modules/py3buddy/default.nix
+++ b/pkgs/development/python-modules/py3buddy/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchFromGitHub
+, python
+, pyusb
+}:
+
+stdenv.mkDerivation rec {
+  pname = "py3buddy";
+  version = "unstable-2019-09-29";
+
+  src = fetchFromGitHub {
+    owner = "armijnhemel";
+    repo = pname;
+    rev = "2b28908454645117368ca56df67548c93f4e0b03";
+    sha256 = "12ar4kbplavndarkrbibxi5i607f5sfia5myscvalqy78lc33798";
+  };
+
+  propagatedBuildInputs = [ pyusb ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontCheck = true;
+
+  installPhase = ''
+    install -D py3buddy.py $out/lib/${python.libPrefix}/site-packages/py3buddy.py
+  '';
+
+  postInstall = ''
+    install -D 99-ibuddy.rules $out/lib/udev/rules.d/99-ibuddy.rules
+  '';
+
+  meta = {
+    description = "Code to work with the iBuddy MSN figurine";
+    homepage = "https://github.com/armijnhemel/py3buddy";
+    license = with stdenv.lib.licenses; [ mit ];
+    maintainers = with stdenv.lib.maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -906,6 +906,8 @@ in {
 
   pybind11 = callPackage ../development/python-modules/pybind11 { };
 
+  py3buddy = callPackage ../development/python-modules/py3buddy { };
+
   pybullet = callPackage ../development/python-modules/pybullet { };
 
   pycairo = callPackage ../development/python-modules/pycairo {


### PR DESCRIPTION
###### Motivation for this change

Add python code to work with MSN iBuddy. Ideal for CI and Hydra notifications.

![photo](https://usb.brando.com/prod_img/zoom/ULIFE018100_01_L.jpg)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
