### PR TITLE
Znapzend improvements

### DIFF
--- a/nixos/modules/services/backup/znapzend.nix
+++ b/nixos/modules/services/backup/znapzend.nix
@@ -399,6 +399,14 @@ in
         '';
 
         serviceConfig = {
+          # znapzendzetup --import apparently tries to connect to the backup
+          # host 3 times with a timeout of 30 seconds, leading to a startup
+          # delay of >90s when the host is down, which is just above the default
+          # service timeout of 90 seconds. Increase the timeout so it doesn't
+          # make the service fail in that case.
+          TimeoutStartSec = 180;
+          # Needs to have write access to ZFS
+          User = "root";
           ExecStart = let
             args = concatStringsSep " " [
               "--logto=${cfg.logTo}"


### PR DESCRIPTION
###### Motivation for this change
- Adds options `features.compressed` to use `-Lce` for sending and `features.recvu` to allow destination filesystems to be unmounted. See `man znapzend` for info on these features.
- Fixes the service timing out when starting when a destination host is offline.

Ping @lheckemann 

###### Things done

- [x] Made sure both commits have the intended changes in my local system