### PR TITLE
treewide: replace make/build/configure/patchFlags with nix lists

### DIFF
--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -94,7 +94,7 @@ deis = buildGoPackage rec {
 
   goDeps = ./deps.nix; <co xml:id='ex-buildGoPackage-3' />
 
-  buildFlags = "--tags release"; <co xml:id='ex-buildGoPackage-4' />
+  buildFlags = [ "--tags" "release" ]; <co xml:id='ex-buildGoPackage-4' />
 }
 </programlisting>
   </example>

--- a/nixos/modules/services/x11/extra-layouts.nix
+++ b/nixos/modules/services/x11/extra-layouts.nix
@@ -141,7 +141,7 @@ in
         });
 
         xkbcomp = super.xorg.xkbcomp.overrideAttrs (old: {
-          configureFlags = "--with-xkb-config-root=${self.xkb_patched}/share/X11/xkb";
+          configureFlags = [ "--with-xkb-config-root=${self.xkb_patched}/share/X11/xkb" ];
         });
 
       };

--- a/pkgs/applications/audio/aeolus/default.nix
+++ b/pkgs/applications/audio/aeolus/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   preBuild = "cd source";
 
-  makeFlags = "DESTDIR= PREFIX=$(out)";
+  makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
 
   meta = {
     description = "Synthetized (not sampled) pipe organ emulator";

--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -62,7 +62,7 @@ multiStdenv.mkDerivation {
   # Cf. https://github.com/phantom-code/airwave/issues/57
   hardeningDisable = [ "format" ];
 
-  cmakeFlags = "-DVSTSDK_PATH=${vst-sdk}/VST2_SDK";
+  cmakeFlags = [ "-DVSTSDK_PATH=${vst-sdk}/VST2_SDK" ];
 
   postInstall = ''
     mv $out/bin $out/libexec

--- a/pkgs/applications/audio/distrho/default.nix
+++ b/pkgs/applications/audio/distrho/default.nix
@@ -37,7 +37,7 @@ in stdenv.mkDerivation rec {
     libXinerama libXrender ladspa-sdk
   ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = http://distrho.sourceforge.net;

--- a/pkgs/applications/audio/foo-yc20/default.nix
+++ b/pkgs/applications/audio/foo-yc20/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libjack2 gtk2 lv2 faust ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   # remove lv2 until https://github.com/sampov2/foo-yc20/issues/6 is resolved
   postInstallFixup = "rm -rf $out/lib/lv2";

--- a/pkgs/applications/audio/lsp-plugins/default.nix
+++ b/pkgs/applications/audio/lsp-plugins/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  buildFlags = "release";
+  buildFlags = [ "release" ];
 
   meta = with stdenv.lib;
     { description = "Collection of open-source audio plugins";

--- a/pkgs/applications/audio/sndpeek/default.nix
+++ b/pkgs/applications/audio/sndpeek/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     libXext
     libXi
   ];
-  buildFlags = "linux-alsa";
+  buildFlags = [ "linux-alsa" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -60,7 +60,7 @@ with stdenv.lib; stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper pkgconfig ];
   buildInputs = [ glfw-git alsaLib curl glew gtk2-x11 jansson libjack2 libzip rtaudio rtmidi speex libsamplerate ];
 
-  buildFlags = "Rack";
+  buildFlags = [ "Rack" ];
 
   installPhase = ''
     install -D -m755 -t $out/bin Rack

--- a/pkgs/applications/editors/bviplus/default.nix
+++ b/pkgs/applications/editors/bviplus/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     ncurses
   ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   buildFlags = [ "CFLAGS=-fgnu89-inline" ];
 

--- a/pkgs/applications/editors/edbrowse/default.nix
+++ b/pkgs/applications/editors/edbrowse/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  makeFlags = "-C src prefix=$(out)";
+  makeFlags = [ "-C" "src" "prefix=$(out)" ];
 
   src = fetchFromGitHub {
     owner = "CMB";

--- a/pkgs/applications/editors/fte/default.nix
+++ b/pkgs/applications/editors/fte/default.nix
@@ -15,9 +15,9 @@ stdenv.mkDerivation rec {
   };
   src = [ ftesrc ftecommon ];
 
-  buildFlags = "PREFIX=$(out)";
+  buildFlags = [ "PREFIX=$(out)" ];
 
-  installFlags = "PREFIX=$(out) INSTALL_NONROOT=1";
+  installFlags = [ "PREFIX=$(out) INSTALL_NONROOT=1" ];
 
   meta = with stdenv.lib; {
     description = "A free text editor for developers";

--- a/pkgs/applications/editors/jucipp/default.nix
+++ b/pkgs/applications/editors/jucipp/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     sed -i 's|liblldb LIBLLDB_LIBRARIES|liblldb LIBNOTHING|g' CMakeLists.txt
     sed -i 's|> arguments;|> arguments; ${lintIncludes}|g' src/source_clang.cc
   '';
-  cmakeFlags = "-DLIBLLDB_LIBRARIES=${stdenv.lib.makeLibraryPath [ llvmPackages.lldb ]}/liblldb.so";
+  cmakeFlags = [ "-DLIBLLDB_LIBRARIES=${stdenv.lib.makeLibraryPath [ llvmPackages.lldb ]}/liblldb.so" ];
   postInstall = ''
     mv $out/bin/juci $out/bin/.juci
     makeWrapper "$out/bin/.juci" "$out/bin/juci" \

--- a/pkgs/applications/graphics/seg3d/default.nix
+++ b/pkgs/applications/graphics/seg3d/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   ];
 
 
-  makeFlags = "VERBOSE=1";
+  makeFlags = [ "VERBOSE=1" ];
 
   preBuild = ''
     export LD_LIBRARY_PATH=`pwd`/lib

--- a/pkgs/applications/graphics/smartdeblur/default.nix
+++ b/pkgs/applications/graphics/smartdeblur/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake qt4 fftw ];
 
-  cmakeFlags = "-DUSE_SYSTEM_FFTW=ON";
+  cmakeFlags = [ "-DUSE_SYSTEM_FFTW=ON" ];
 
   meta = {
     homepage = https://github.com/Y-Vladimir/SmartDeblur;

--- a/pkgs/applications/graphics/zgv/default.nix
+++ b/pkgs/applications/graphics/zgv/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     ./switch.patch
   ];
 
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/applications/misc/bibletime/default.nix
+++ b/pkgs/applications/misc/bibletime/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake sword qt4 boost clucene_core ];
 
-  cmakeFlags = "-DUSE_QT_WEBKIT=ON -DCMAKE_BUILD_TYPE=Debug";
+  cmakeFlags = [ "-DUSE_QT_WEBKIT=ON" "-DCMAKE_BUILD_TYPE=Debug" ];
 
   meta = {
     description = "A Qt4 Bible study tool";

--- a/pkgs/applications/misc/cbatticon/default.nix
+++ b/pkgs/applications/misc/cbatticon/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sed -i -e 's/ -Wno-format//g' Makefile
   '';
 
-  makeFlags = "PREFIX=${placeholder "out"}";
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   meta = with stdenv.lib; {
     description = "Lightweight and fast battery icon that sits in the system tray";

--- a/pkgs/applications/misc/ddgr/default.nix
+++ b/pkgs/applications/misc/ddgr/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ python3 ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   preBuild = ''
     # Version 1.7 was released as 1.6

--- a/pkgs/applications/misc/fbreader/default.nix
+++ b/pkgs/applications/misc/fbreader/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
   ++ optional (uiType == "gtk") gtk2
   ++ optionals (uiType == "cocoa") [ AppKit Cocoa ];
 
-  makeFlags = "INSTALLDIR=$(out)";
+  makeFlags = [ "INSTALLDIR=$(out)" ];
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=narrowing" ]; # since gcc-6
 

--- a/pkgs/applications/misc/googler/default.nix
+++ b/pkgs/applications/misc/googler/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ python ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/jarun/googler;

--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   modSha256 = "0d6zc7hxb246zsvwsjz4ds6gdd2m95x6l3djh3mmciwfg9cd7prx";
 
-  buildFlags = "-tags extended";
+  buildFlags = [ "-tags" "extended" ];
 
   subPackages = [ "." ];
 

--- a/pkgs/applications/misc/jp2a/default.nix
+++ b/pkgs/applications/misc/jp2a/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "12a1z9ba2j16y67f41y8ax5sgv1wdjd71pg7circdxkj263n78ql";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ libjpeg ];

--- a/pkgs/applications/misc/notify-osd-customizable/default.nix
+++ b/pkgs/applications/misc/notify-osd-customizable/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     libtool
   ];
 
-  configureFlags = "--libexecdir=$(out)/bin";
+  configureFlags = [ "--libexecdir=$(out)/bin" ];
 
   preFixup = ''
     wrapProgram "$out/bin/notify-osd" \

--- a/pkgs/applications/misc/stupidterm/default.nix
+++ b/pkgs/applications/misc/stupidterm/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     sha256 = "1f73wvqqvj5pr3fvb7jjc4bi1iwgkkknz24k8n69mdb75jnfjipp";
   };
 
-  makeFlags = "PKGCONFIG=${pkgconfig}/bin/pkg-config binary=stupidterm";
+  makeFlags = [ "PKGCONFIG=${pkgconfig}/bin/pkg-config" "binary=stupidterm" ];
 
   installPhase = ''
     install -D stupidterm $out/bin/stupidterm

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-latex/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-latex/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [pkgconfig];
   buildInputs = [gtk2 glib pidgin];
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   postPatch = ''
     sed -e 's/-Wl,-soname//' -i Makefile

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     sed -i -e 's|DESTINATION.*PURPLE_PLUGIN_DIR}|DESTINATION lib/purple-2|' CMakeLists.txt
   '';
 
-  cmakeFlags = "-DCMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT=1";
+  cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT=1" ];
 
   meta = {
     homepage = https://bitbucket.org/olegoandreev/purple-vk-plugin;

--- a/pkgs/applications/networking/irc/sic/default.nix
+++ b/pkgs/applications/networking/irc/sic/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "sic";
   version = "1.2";
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
   src = fetchurl {
     url = "https://dl.suckless.org/tools/sic-${version}.tar.gz";
     sha256 = "ac07f905995e13ba2c43912d7a035fbbe78a628d7ba1c256f4ca1372fb565185";

--- a/pkgs/applications/networking/mailreaders/mblaze/default.nix
+++ b/pkgs/applications/networking/mailreaders/mblaze/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   postInstall = ''
     install -Dm644 -t $out/share/zsh/site-functions contrib/_mblaze

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -245,7 +245,7 @@ in stdenv.mkDerivation rec {
     find -name "*.cmd" -exec sed -i s,/lib:/usr/lib,, {} \;
     '';
 
-  makeFlags = "SHELL=${bash}/bin/bash";
+  makeFlags = [ "SHELL=${bash}/bin/bash" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -245,7 +245,7 @@ in stdenv.mkDerivation rec {
     find -name "*.cmd" -exec sed -i s,/lib:/usr/lib,, {} \;
     '';
 
-  makeFlags = "SHELL=${bash}/bin/bash";
+  makeFlags = [ "SHELL=${bash}/bin/bash" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/radio/dmrconfig/default.nix
+++ b/pkgs/applications/radio/dmrconfig/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       --replace /usr/local/bin/dmrconfig $out/bin/dmrconfig
   '';
 
-  makeFlags = "VERSION=${version} GITCOUNT=0";
+  makeFlags = [ "VERSION=${version}" "GITCOUNT=0" ];
 
   installPhase = ''
     mkdir -p $out/bin $out/lib/udev/rules.d

--- a/pkgs/applications/science/biology/sumatools/default.nix
+++ b/pkgs/applications/science/biology/sumatools/default.nix
@@ -22,7 +22,7 @@ in rec {
       rev = "sumalib_v${version}";
       sha256 = "0hwkrxzfz7m5wdjvmrhkjg8kis378iaqr5n4nhdhkwwhn8x1jn5a";
     };
-    makeFlags = "PREFIX=$(out)";
+    makeFlags = [ "PREFIX=$(out)" ];
     inherit meta;
   };
 

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -141,7 +141,7 @@ self = stdenv.mkDerivation {
 
   prefixKey = "-prefix ";
 
-  buildFlags = "revision coq coqide bin/votour";
+  buildFlags = [ "revision" "coq" "coqide" "bin/votour" ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/applications/science/logic/prover9/default.nix
+++ b/pkgs/applications/science/logic/prover9/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     done
   '';
 
-  buildFlags = "all";
+  buildFlags = [ "all" ];
 
   checkPhase = "make test1";
 

--- a/pkgs/applications/science/math/msieve/default.nix
+++ b/pkgs/applications/science/math/msieve/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   ECM = if ecm == null then "0" else "1";
 
   # Doesn't hurt Linux but lets clang-based platforms like Darwin work fine too
-  makeFlags = "CC=cc all";
+  makeFlags = [ "CC=cc" "all" ];
 
   installPhase = ''
     mkdir -p $out/bin/

--- a/pkgs/applications/science/math/ries/default.nix
+++ b/pkgs/applications/science/math/ries/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1h2wvd4k7f0l0i1vm9niz453xdbcs3nxccmri50qyrzzzc1b0842";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = https://mrob.com/pub/ries/;

--- a/pkgs/applications/science/math/scilab/default.nix
+++ b/pkgs/applications/science/math/scilab/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional (!withXaw3d) "--with-local-xaw"
   ;
 
-  makeFlags = "all";
+  makeFlags = [ "all" ];
 
   meta = {
     homepage = http://www.scilab.org/;

--- a/pkgs/applications/science/misc/megam/default.nix
+++ b/pkgs/applications/science/misc/megam/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  makeFlags = "CAML_INCLUDES=${ocaml}/lib/ocaml/caml";
+  makeFlags = [ "CAML_INCLUDES=${ocaml}/lib/ocaml/caml" ];
 
   # see https://bugzilla.redhat.com/show_bug.cgi?id=435559
   dontStrip = true;

--- a/pkgs/applications/version-management/git-and-tools/git-imerge/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-imerge/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pythonPackages.python pythonPackages.wrapPython ];
 
-  makeFlags = "PREFIX= DESTDIR=$(out)" ; 
+  makeFlags = [ "PREFIX=" "DESTDIR=$(out)" ] ; 
  
   meta = with stdenv.lib; {
     homepage = https://github.com/mhagger/git-imerge;

--- a/pkgs/applications/version-management/git-and-tools/stgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/stgit/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ python2 git ];
 
-  makeFlags = "prefix=$$out";
+  makeFlags = [ "prefix=$$out" ];
 
   postInstall = ''
     mkdir -p "$out/etc/bash_completion.d/"

--- a/pkgs/applications/version-management/gogs/default.nix
+++ b/pkgs/applications/version-management/gogs/default.nix
@@ -27,7 +27,7 @@ buildGoPackage rec {
   nativeBuildInputs = [ makeWrapper ]
     ++ optional pamSupport pam;
 
-  buildFlags = "-tags";
+  buildFlags = [ "-tags" ];
 
   buildFlagsArray =
     (  optional sqliteSupport "sqlite"

--- a/pkgs/applications/version-management/mr/default.nix
+++ b/pkgs/applications/version-management/mr/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ perl ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = {
     description = "Multiple Repository management tool";

--- a/pkgs/applications/video/xawtv/default.nix
+++ b/pkgs/applications/video/xawtv/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   NIX_LDFLAGS = "-lgcc_s";
 
-  makeFlags = "SUID_ROOT= DESTDIR=\$(out) PREFIX=";
+  makeFlags = [ "SUID_ROOT=" "DESTDIR=\$(out)" "PREFIX=" ];
 
   buildInputs = [ncurses libjpeg libX11 libXt libXft xorgproto libFS perl alsaLib aalib
                  libXaw libXpm libXext libSM libICE libv4l];

--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
   hardeningDisable = [ "fortify" ];
 
   buildInputs = [ btrfs-progs go-md2man utillinux ];
-  buildFlags = "VERSION=v${version}";
+  buildFlags = [ "VERSION=v${version}" ];
 
   BUILDTAGS = []
     ++ optional (btrfs-progs == null) "no_btrfs";

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -187,11 +187,11 @@ stdenv.mkDerivation (rec {
   '';
 
   # TODO: Flask needs more testing before enabling it by default.
-  #makeFlags = "XSM_ENABLE=y FLASK_ENABLE=y PREFIX=$(out) CONFIG_DIR=/etc XEN_EXTFILES_URL=\\$(XEN_ROOT)/xen_ext_files ";
+  #makeFlags = [ "XSM_ENABLE=y" "FLASK_ENABLE=y" "PREFIX=$(out)"" ""CONFIG_DIR=/etc XEN_EXTFILES_URL=\\$(XEN_ROOT)/xen_ext_files " ];
   makeFlags = [ "PREFIX=$(out) CONFIG_DIR=/etc" "XEN_SCRIPT_DIR=/etc/xen/scripts" ]
            ++ (config.makeFlags or []);
 
-  buildFlags = "xen tools";
+  buildFlags = [ "xen" "tools" ];
 
   postBuild = ''
     make -C docs man-pages

--- a/pkgs/applications/window-managers/i3/blocks-gaps.nix
+++ b/pkgs/applications/window-managers/i3/blocks-gaps.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
     sha256 = "0v9307ij8xzwdaxay3r75sd2cp453s3qb6q7dy9fks2p6wwqpazi";
   };
 
-  makeFlags = "all";
-  installFlags = "PREFIX=\${out} VERSION=${version}";
+  makeFlags = [ "all" ];
+  installFlags = [ "PREFIX=\${out} VERSION=${version}" ];
 
   buildInputs = optional (contains_any scripts perlscripts) perl;
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ libxcb xcbutilkeysyms xcbutilimage pam libX11
     libev cairo libxkbcommon libxkbfile libjpeg_turbo xcbutilxrm ];
 
-  makeFlags = "all";
+  makeFlags = [ "all" ];
   preInstall = ''
     mkdir -p $out/share/man/man1
   '';
-  installFlags = "PREFIX=\${out} SYSCONFDIR=\${out}/etc MANDIR=\${out}/share/man";
+  installFlags = [ "PREFIX=\${out} SYSCONFDIR=\${out}/etc MANDIR=\${out}/share/man" ];
   postInstall = ''
     mv $out/bin/i3lock $out/bin/i3lock-color
     mv $out/share/man/man1/i3lock.1 $out/share/man/man1/i3lock-color.1

--- a/pkgs/applications/window-managers/i3/lock.nix
+++ b/pkgs/applications/window-managers/i3/lock.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ which libxcb xcbutilkeysyms xcbutilimage xcbutilxrm
     pam libX11 libev cairo libxkbcommon libxkbfile ];
 
-  makeFlags = "all";
-  installFlags = "PREFIX=\${out} SYSCONFDIR=\${out}/etc";
+  makeFlags = [ "all" ];
+  installFlags = [ "PREFIX=\${out} SYSCONFDIR=\${out}/etc" ];
   postInstall = ''
     mkdir -p $out/share/man/man1
     cp *.1 $out/share/man/man1

--- a/pkgs/applications/window-managers/ion-3/default.nix
+++ b/pkgs/applications/window-managers/ion-3/default.nix
@@ -13,6 +13,6 @@ stdenv.mkDerivation {
     sha256 = "1nkks5a95986nyfkxvg2rik6zmwx0lh7szd5fji7yizccwzc9xns";
   };
   buildInputs = [ xlibsWrapper lua gettext groff ];
-  buildFlags = "LUA_DIR=${lua} X11_PREFIX=/no-such-path PREFIX=\${out}";
-  installFlags = "PREFIX=\${out}";
+  buildFlags = [ "LUA_DIR=${lua}" "X11_PREFIX=/no-such-path" "PREFIX=\${out}" ];
+  installFlags = [ "PREFIX=\${out}" ];
 }

--- a/pkgs/applications/window-managers/notion/default.nix
+++ b/pkgs/applications/window-managers/notion/default.nix
@@ -35,8 +35,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [makeWrapper xlibsWrapper lua gettext mandoc which libXinerama libXrandr libX11 ] ++ stdenv.lib.optional enableXft libXft;
 
-  buildFlags = "LUA_DIR=${lua} X11_PREFIX=/no-such-path PREFIX=\${out}";
-  installFlags = "PREFIX=\${out}";
+  buildFlags = [ "LUA_DIR=${lua}" "X11_PREFIX=/no-such-path" "PREFIX=\${out}" ];
+  installFlags = [ "PREFIX=\${out}" ];
 
   postInstall = ''
     wrapProgram $out/bin/notion \

--- a/pkgs/applications/window-managers/wmii-hg/default.nix
+++ b/pkgs/applications/window-managers/wmii-hg/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
                   libX11 libXrender libXext libXinerama libXrandr libXft ];
 
   # For some reason including mercurial in buildInputs did not help
-  makeFlags = "WMII_HGVERSION=hg${rev}";
+  makeFlags = [ "WMII_HGVERSION=hg${rev}" ];
 
   meta = {
     homepage = https://suckless.org/; # https://wmii.suckless.org/ does not exist anymore

--- a/pkgs/desktops/gnome-2/desktop/mail-notification/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/mail-notification/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     ./patches/mail-notification-dont-link-against-bsd-compat.patch
   ];
 
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
   NIX_CFLAGS_COMPILE = "-Wno-error";
 
   preConfigure = "./jb configure prefix=$out";

--- a/pkgs/desktops/mate/mate-screensaver/default.nix
+++ b/pkgs/desktops/mate/mate-screensaver/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--without-console-kit" ];
 
-  makeFlags = "DBUS_SESSION_SERVICE_DIR=$(out)/etc";
+  makeFlags = [ "DBUS_SESSION_SERVICE_DIR=$(out)/etc" ];
 
   meta = with stdenv.lib; {
     description = "Screen saver and locker for the MATE desktop";

--- a/pkgs/desktops/rox/rox-filer/default.nix
+++ b/pkgs/desktops/rox/rox-filer/default.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation {
   setSourceRoot = "export sourceRoot=rox-filer-${version}/ROX-Filer/";
 
   # patch source with defined patches
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
 
   # patch the main.c to disable the lookup of the APP_DIR environment variable,
   # which is used to lookup the location for certain images when rox-filer

--- a/pkgs/desktops/xfce/core/xfce4-panel.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [ ./xfce4-panel-datadir.patch ];
-  patchFlags = "-p1";
+  patchFlags = [ "-p1" ];
 
   postPatch = ''
     for f in $(find . -name \*.sh); do

--- a/pkgs/desktops/xfce4-14/xfce4-panel/default.nix
+++ b/pkgs/desktops/xfce4-14/xfce4-panel/default.nix
@@ -11,7 +11,7 @@ mkXfceDerivation {
   buildInputs = [ exo garcon gtk2 gtk3 glib glib-networking libxfce4ui libxfce4util libwnck3 xfconf ];
 
   patches = [ ../../xfce/core/xfce4-panel-datadir.patch ];
-  patchFlags = "-p1";
+  patchFlags = [ "-p1" ];
 
   postPatch = ''
     for f in $(find . -name \*.sh); do

--- a/pkgs/development/compilers/chicken/4/chicken.nix
+++ b/pkgs/development/compilers/chicken/4/chicken.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation {
 
   setupHook = lib.ifEnable (bootstrap-chicken != null) ./setup-hook.sh;
 
-  buildFlags = "PLATFORM=${platform} PREFIX=$(out) VARDIR=$(out)/var/lib";
-  installFlags = "PLATFORM=${platform} PREFIX=$(out) VARDIR=$(out)/var/lib";
+  buildFlags = [ "PLATFORM=${platform}" "PREFIX=$(out)" "VARDIR=$(out)/var/lib" ];
+  installFlags = [ "PLATFORM=${platform}" "PREFIX=$(out)" "VARDIR=$(out)/var/lib" ];
 
   # We need a bootstrap-chicken to regenerate the c-files after
   # applying a patch to add support for CHICKEN_REPOSITORY_EXTRA

--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation {
 
   setupHook = lib.ifEnable (bootstrap-chicken != null) ./setup-hook.sh;
 
-  buildFlags = "PLATFORM=${platform} PREFIX=$(out)";
-  installFlags = "PLATFORM=${platform} PREFIX=$(out)";
+  buildFlags = [ "PLATFORM=${platform}" "PREFIX=$(out)" ];
+  installFlags = [ "PLATFORM=${platform}" "PREFIX=$(out)" ];
 
   buildInputs = [
     makeWrapper

--- a/pkgs/development/compilers/cmdstan/default.nix
+++ b/pkgs/development/compilers/cmdstan/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1vq1cnrkvrvbfl40j6ajc60jdrjcxag1fi6kff5pqmadfdz9564j";
   };
 
-  buildFlags = "build";
+  buildFlags = [ "build" ];
   enableParallelBuilding = true;
 
   doCheck = true;

--- a/pkgs/development/compilers/dev86/default.nix
+++ b/pkgs/development/compilers/dev86/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = {
     description = "Linux 8086 development environment";

--- a/pkgs/development/compilers/eli/default.nix
+++ b/pkgs/development/compilers/eli/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
   ];
 
   # skip interactive browser check
-  buildFlags = "nobrowsers";
+  buildFlags = [ "nobrowsers" ];
 
 
   preConfigure=''

--- a/pkgs/development/compilers/fpc/default.nix
+++ b/pkgs/development/compilers/fpc/default.nix
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
       sed -e "s@'/lib64/ld-linux[^']*'@'''@" -i fpcsrc/compiler/systems/t_linux.pas
     '' else "";
 
-  makeFlags = "NOGDB=1 FPC=${startFPC}/bin/fpc";
+  makeFlags = [ "NOGDB=1" "FPC=${startFPC}/bin/fpc" ];
 
-  installFlags = "INSTALL_PREFIX=\${out}";
+  installFlags = [ "INSTALL_PREFIX=\${out}" ];
 
   postInstall = ''
     for i in $out/lib/fpc/*/ppc*; do

--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -25,12 +25,12 @@ stdenv.mkDerivation rec {
     patchShebangs src/tools
     patchShebangs bin
   '';
-  buildFlags = "-C src/ocaml-output";
+  buildFlags = [ "-C" "src/ocaml-output" ];
 
   preInstall = ''
     mkdir -p $out/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib/fstarlib
   '';
-  installFlags = "-C src/ocaml-output";
+  installFlags = [ "-C" "src/ocaml-output" ];
   postInstall = ''
     wrapProgram $out/bin/fstar.exe --prefix PATH ":" "${z3}/bin"
   '';

--- a/pkgs/development/compilers/hhvm/default.nix
+++ b/pkgs/development/compilers/hhvm/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   # the cmake package does not handle absolute CMAKE_INSTALL_INCLUDEDIR correctly
   # (setting it to an absolute path causes include files to go to $out/$out/include,
   #  because the absolute path is interpreted with root at $out).
-  cmakeFlags = "-DCMAKE_INSTALL_INCLUDEDIR=include";
+  cmakeFlags = [ "-DCMAKE_INSTALL_INCLUDEDIR=include" ];
 
   prePatch = ''
     substituteInPlace ./configure \

--- a/pkgs/development/compilers/iasl/default.nix
+++ b/pkgs/development/compilers/iasl/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     "-O3"
   ];
 
-  buildFlags = "iasl";
+  buildFlags = [ "iasl" ];
 
   buildInputs = [ bison flex ];
 

--- a/pkgs/development/compilers/ocaml/3.10.0.nix
+++ b/pkgs/development/compilers/ocaml/3.10.0.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (rec {
 
   prefixKey = "-prefix ";
   configureFlags = ["-no-tk" "-x11lib" xlibsWrapper];
-  buildFlags = "world bootstrap world.opt";
+  buildFlags = [ "world" "bootstrap" "world.opt" ];
   buildInputs = [xlibsWrapper ncurses];
   installTargets = "install installopt";
   patchPhase = ''

--- a/pkgs/development/compilers/ocaml/3.11.2.nix
+++ b/pkgs/development/compilers/ocaml/3.11.2.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   prefixKey = "-prefix ";
   configureFlags = ["-no-tk"] ++ optionals useX11 [ "-x11lib" xlibsWrapper ];
-  buildFlags = "world" + optionalString useNativeCompilers " bootstrap world.opt";
+  buildFlags = [ "world" + optionalString useNativeCompilers " bootstrap world.opt" ];
   buildInputs = [ncurses] ++ optionals useX11 [ xlibsWrapper ];
   installTargets = "install" + optionalString useNativeCompilers " installopt";
   prePatch = ''

--- a/pkgs/development/compilers/ocaml/3.12.1.nix
+++ b/pkgs/development/compilers/ocaml/3.12.1.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   prefixKey = "-prefix ";
   configureFlags = ["-no-tk"] ++ optionals useX11 [ "-x11lib" xlibsWrapper ];
-  buildFlags = "world" + optionalString useNativeCompilers " bootstrap world.opt";
+  buildFlags = [ "world" + optionalString useNativeCompilers " bootstrap world.opt" ];
   buildInputs = [ncurses] ++ optionals useX11 [ xlibsWrapper ];
   installTargets = "install" + optionalString useNativeCompilers " installopt";
   patches = optionals stdenv.isDarwin [ ./3.12.1-darwin-fix-configure.patch ];

--- a/pkgs/development/compilers/ocaml/4.00.1.nix
+++ b/pkgs/development/compilers/ocaml/4.00.1.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   prefixKey = "-prefix ";
   configureFlags = ["-no-tk"] ++ optionals useX11 [ "-x11lib" xlibsWrapper ];
-  buildFlags = "world" + optionalString useNativeCompilers " bootstrap world.opt";
+  buildFlags = [ "world" + optionalString useNativeCompilers " bootstrap world.opt" ];
   buildInputs = [ncurses] ++ optionals useX11 [ xlibsWrapper ];
   installTargets = "install" + optionalString useNativeCompilers " installopt";
   preConfigure = ''

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (args // {
   ++ optional flambdaSupport "-flambda"
   ;
 
-  buildFlags = "world" + optionalString useNativeCompilers " bootstrap world.opt";
+  buildFlags = [ "world" + optionalString useNativeCompilers " bootstrap world.opt" ];
   buildInputs = optional (!stdenv.lib.versionAtLeast version "4.07") ncurses
     ++ optionals useX11 [ libX11 xorgproto ];
   installTargets = "install" + optionalString useNativeCompilers " installopt";

--- a/pkgs/development/compilers/ocaml/metaocaml-3.09.nix
+++ b/pkgs/development/compilers/ocaml/metaocaml-3.09.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation ({
 
   prefixKey = "-prefix ";
   configureFlags = ["-no-tk" "-x11lib" xlibsWrapper];
-  buildFlags = "world bootstrap world.opt";
+  buildFlags = [ "world" "bootstrap" "world.opt" ];
   buildInputs = [xlibsWrapper ncurses];
   installTargets = "install installopt";
   patchPhase = ''

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -745,7 +745,7 @@ self: super: {
           substituteInPlace conf.py --replace "'.md': CommonMarkParser," ""
         '';
         nativeBuildInputs = with pkgs.buildPackages.pythonPackages; [ sphinx recommonmark sphinx_rtd_theme ];
-        makeFlags = "html";
+        makeFlags = [ "html" ];
         installPhase = ''
           mv _build/html $out
         '';

--- a/pkgs/development/interpreters/kona/default.nix
+++ b/pkgs/development/interpreters/kona/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0c1yf3idqkfq593xgqb25r2ykmfmp83zzh3q7kb8095a069gvri3";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
   preInstall = ''mkdir -p "$out/bin"'';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/interpreters/spidermonkey/1.8.5.nix
+++ b/pkgs/development/interpreters/spidermonkey/1.8.5.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
     ./1.8.5-arm-flags.patch
   ];
 
-  patchFlags = "-p3";
+  patchFlags = [ "-p3" ];
 
   # fixes build on gcc8
   postPatch = ''

--- a/pkgs/development/libraries/blitz/default.nix
+++ b/pkgs/development/libraries/blitz/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  buildFlags = "lib info pdf html";
+  buildFlags = [ "lib" "info" "pdf" "html" ];
   installTargets = [ "install" "install-info" "install-pdf" "install-html" ];
 
   inherit doCheck;

--- a/pkgs/development/libraries/cfitsio/default.nix
+++ b/pkgs/development/libraries/cfitsio/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   # Shared-only build
-  buildFlags = "shared";
+  buildFlags = [ "shared" ];
   postPatch = '' sed -e '/^install:/s/libcfitsio.a //' -e 's@/bin/@@g' -i Makefile.in
    '';
 

--- a/pkgs/development/libraries/cutee/default.nix
+++ b/pkgs/development/libraries/cutee/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "18bzvhzx8k24mpcim5669n3wg9hd0sfsxj8zjpbr24hywrlppgc2";
   };
 
-  buildFlags = "cutee";
+  buildFlags = [ "cutee" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/development/libraries/filter-audio/default.nix
+++ b/pkgs/development/libraries/filter-audio/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Lightweight audio filtering library made from webrtc code";

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -106,5 +106,5 @@ stdenv.mkDerivation rec {
 }
 
 // stdenv.lib.optionalAttrs stdenv.isDarwin {
-  makeFlags = "CFLAGS=-D_FORTIFY_SOURCE=0";
+  makeFlags = [ "CFLAGS=-D_FORTIFY_SOURCE=0" ];
 }

--- a/pkgs/development/libraries/hspell/dicts.nix
+++ b/pkgs/development/libraries/hspell/dicts.nix
@@ -15,7 +15,7 @@ in
   aspell = dict {
     name = "aspell-dict-he-${hspell.version}";
 
-    buildFlags = "aspell";
+    buildFlags = [ "aspell" ];
 
     installPhase = ''
       mkdir -p $out/lib/aspell
@@ -25,7 +25,7 @@ in
   myspell = dict {
     name = "myspell-dict-he-${hspell.version}";
 
-    buildFlags = "myspell";
+    buildFlags = [ "myspell" ];
 
     installPhase = ''
       mkdir -p $out/lib/myspell
@@ -35,7 +35,7 @@ in
   hunspell = dict {
     name = "hunspell-dict-he-${hspell.version}";
 
-    buildFlags = "hunspell";
+    buildFlags = [ "hunspell" ];
 
     installPhase = ''
       mkdir -p $out/lib

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -103,7 +103,7 @@ let
     setOutputFlags = false;
 
     # alltools to build smaller tools, incl. aviocat, ismindex, qt-faststart, etc.
-    buildFlags = "all alltools install-man";
+    buildFlags = [ "all" "alltools" "install-man" ];
 
 
     postInstall = ''

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sha256 = "02v22yx1ga2yxagjblzkfw0ax7zkrdpc959l1a15m8nah3y7xf9p";
   };
   nativeBuildInputs = [ cmake ];
-  makeFlags = "libcef_dll_wrapper";
+  makeFlags = [ "libcef_dll_wrapper" ];
   dontStrip = true;
   dontPatchELF = true;
   installPhase = ''

--- a/pkgs/development/libraries/libcouchbase/default.nix
+++ b/pkgs/development/libraries/libcouchbase/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1yfmcx65aqd5l87scha6kmm2s38n85ci3gg0h6qfs16s3jfi6bw7";
   };
 
-  cmakeFlags = "-DLCB_NO_MOCK=ON";
+  cmakeFlags = [ "-DLCB_NO_MOCK=ON" ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ libevent openssl ];

--- a/pkgs/development/libraries/libexecinfo/default.nix
+++ b/pkgs/development/libraries/libexecinfo/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "CC:=$(CC)" "AR:=$(AR)" ];
 
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
 
   installPhase = ''
     install -Dm644 execinfo.h stacktraverse.h -t $out/include

--- a/pkgs/development/libraries/libf2c/default.nix
+++ b/pkgs/development/libraries/libf2c/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     unzip ${src}
   '';
 
-  makeFlags = "-f makefile.u";
+  makeFlags = [ "-f" "makefile.u" ];
 
   installPhase = ''
     mkdir -p $out/include $out/lib

--- a/pkgs/development/libraries/libowfat/default.nix
+++ b/pkgs/development/libraries/libowfat/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       'install -m 644 $(INCLUDES) $(DESTDIR)$(INCLUDEDIR)'
   '';
 
-  makeFlags = "prefix=$(out)";
+  makeFlags = [ "prefix=$(out)" ];
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libyaml-cpp/default.nix
+++ b/pkgs/development/libraries/libyaml-cpp/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = "-DBUILD_SHARED_LIBS=ON -DYAML_CPP_BUILD_TESTS=OFF";
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" "-DYAML_CPP_BUILD_TESTS=OFF" ];
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/development/libraries/lmdb/default.nix
+++ b/pkgs/development/libraries/lmdb/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   postUnpack = "sourceRoot=\${sourceRoot}/libraries/liblmdb";
 
   patches = [ ./hardcoded-compiler.patch ];
-  patchFlags = "-p3";
+  patchFlags = [ "-p3" ];
 
   outputs = [ "bin" "out" "dev" ];
 

--- a/pkgs/development/libraries/ois/default.nix
+++ b/pkgs/development/libraries/ois/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
 
   buildInputs = [
     autoconf automake libtool libX11 xorgproto libXi libXaw

--- a/pkgs/development/libraries/readline/6.2.nix
+++ b/pkgs/development/libraries/readline/6.2.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (rec {
 
   propagatedBuildInputs = [ncurses];
 
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
   patches =
     [ ./link-against-ncurses.patch
       ./no-arch_only.patch

--- a/pkgs/development/libraries/readline/8.0.nix
+++ b/pkgs/development/libraries/readline/8.0.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ncurses];
 
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
 
   upstreamPatches =
     (let

--- a/pkgs/development/libraries/science/biology/mirtk/default.nix
+++ b/pkgs/development/libraries/science/biology/mirtk/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  cmakeFlags = "-DWITH_VTK=ON -DBUILD_ALL_MODULES=ON";
+  cmakeFlags = [ "-DWITH_VTK=ON" "-DBUILD_ALL_MODULES=ON" ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/science/math/fenics/default.nix
+++ b/pkgs/development/libraries/science/math/fenics/default.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation {
     numpy pkgconfig six sphinx suitesparse sympy ufl vtk zlib
     ] ++ stdenv.lib.optionals pythonBindings [ ply python numpy swig ];
   patches = [ ./unicode.patch ];
-  cmakeFlags = "-DDOLFIN_CXX_FLAGS=-std=c++11"
+  cmakeFlags = [ "-DDOLFIN_CXX_FLAGS=-std=c++11" ]
     + " -DDOLFIN_AUTO_DETECT_MPI=OFF"
     + " -DDOLFIN_ENABLE_CHOLMOD=" + (if suitesparse != null then "ON" else "OFF")
     + " -DDOLFIN_ENABLE_DOCS=" + (if docs then "ON" else "OFF")

--- a/pkgs/development/libraries/t1lib/default.nix
+++ b/pkgs/development/libraries/t1lib/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   inherit patches;
 
   buildInputs = [ libX11 libXaw ];
-  buildFlags = "without_doc";
+  buildFlags = [ "without_doc" ];
 
   postInstall = stdenv.lib.optional (!stdenv.isDarwin) "chmod +x $out/lib/*.so.*"; # ??
 

--- a/pkgs/development/libraries/vxl/default.nix
+++ b/pkgs/development/libraries/vxl/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   # BUILD_OUL wants old linux headers for videodev.h, not available
   # in stdenv linux headers
   # BUILD_BRL fails to find open()
-  cmakeFlags = "-DBUILD_OUL=OFF -DBUILD_BRL=OFF -DBUILD_CONTRIB=OFF "
+  cmakeFlags = [ "-DBUILD_OUL=OFF" "-DBUILD_BRL=OFF" "-DBUILD_CONTRIB=OFF" "" ]
     + (if stdenv.hostPlatform.system == "x86_64-linux" then
       "-DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_C_FLAGS=-fPIC"
     else

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -253,7 +253,7 @@ with super;
     # Upstreams:
     # 5.1: http://webserver2.tecgraf.puc-rio.br/~lhf/ftp/lua/5.1/luuid.tar.gz
     # 5.2: http://webserver2.tecgraf.puc-rio.br/~lhf/ftp/lua/5.2/luuid.tar.gz
-    patchFlags = "-p2";
+    patchFlags = [ "-p2" ];
     patches = [
       ./luuid.patch
     ];

--- a/pkgs/development/misc/amdapp-sdk/default.nix
+++ b/pkgs/development/misc/amdapp-sdk/default.nix
@@ -46,7 +46,7 @@ in stdenv.mkDerivation {
 
   patches = stdenv.lib.attrByPath [version "patches"] [] src_info;
 
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
   buildInputs = [ makeWrapper perl libGLU_combined xorg.libX11 xorg.libXext xorg.libXaw xorg.libXi xorg.libXxf86vm ];
   propagatedBuildInputs = [ stdenv.cc ];
   NIX_LDFLAGS = "-lX11 -lXext -lXmu -lXi -lXxf86vm";

--- a/pkgs/development/misc/qmk_firmware/default.nix
+++ b/pkgs/development/misc/qmk_firmware/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation {
       --replace arm-none-eabi arm-none-eabihf
     rm keyboards/handwired/frenchdev/rules.mk keyboards/dk60/rules.mk
   '';
-  buildFlags = "all:default";
+  buildFlags = [ "all:default" ];
   doCheck = true;
   checkTarget = "test:all";
   installPhase = ''

--- a/pkgs/development/ocaml-modules/biniou/1.0.nix
+++ b/pkgs/development/ocaml-modules/biniou/1.0.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   preBuild = ''
     mkdir $out/bin

--- a/pkgs/development/ocaml-modules/bolt/default.nix
+++ b/pkgs/development/ocaml-modules/bolt/default.nix
@@ -45,7 +45,7 @@ EOF
 
   createFindlibDestdir = true;
 
-  buildFlags = "all";
+  buildFlags = [ "all" ];
 
   doCheck = true;
   checkTarget = "tests";

--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
       --subst-var-by ZLIB_INCLUDE "${zlib.dev}/include"
   '';
 
-  buildFlags = "all allopt";
+  buildFlags = [ "all" "allopt" ];
 
   inherit (param) installTargets;
 

--- a/pkgs/development/ocaml-modules/cohttp/0.19.3.nix
+++ b/pkgs/development/ocaml-modules/cohttp/0.19.3.nix
@@ -19,7 +19,7 @@ buildOcaml rec {
   ++ stdenv.lib.optionals asyncSupport [ async_p4 async_ssl_p4 ];
   propagatedBuildInputs = [ re stringext uri_p4 fieldslib_p4 sexplib_p4 base64 ];
 
-  buildFlags = "PREFIX=$(out)";
+  buildFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/mirage/ocaml-cohttp;

--- a/pkgs/development/ocaml-modules/cryptokit/default.nix
+++ b/pkgs/development/ocaml-modules/cryptokit/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   buildInputs = [ zlib ocaml findlib ocamlbuild ncurses ];
   propagatedBuildInputs = [ param.zarith ];
 
-  buildFlags = "setup.data build";
+  buildFlags = [ "setup.data" "build" ];
 
   preBuild = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs";
 

--- a/pkgs/development/ocaml-modules/dolmen/default.nix
+++ b/pkgs/development/ocaml-modules/dolmen/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 	buildInputs = [ ocaml findlib ocamlbuild ];
 	propagatedBuildInputs = [ menhir ];
 
-	makeFlags = "-C src";
+	makeFlags = [ "-C" "src" ];
 
 	createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/dypgen/default.nix
+++ b/pkgs/development/ocaml-modules/dypgen/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     make
   '';
 
-  makeFlags = "BINDIR=$(out)/bin  MANDIR=$(out)/usr/share/man/man1 DYPGENLIBDIR=$(out)/lib/ocaml/${ocaml.version}/site-lib";
+  makeFlags = [ "BINDIR=$(out)/bin" "MANDIR=$(out)/usr/share/man/man1" "DYPGENLIBDIR=$(out)/lib/ocaml/${ocaml.version}/site-lib" ];
 
   meta = {
     homepage = http://dypgen.free.fr;

--- a/pkgs/development/ocaml-modules/fontconfig/default.nix
+++ b/pkgs/development/ocaml-modules/fontconfig/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ocaml fontconfig ];
-  makeFlags = "OCAML_STDLIB_DIR=$(out)/lib/ocaml/${stdenv.lib.getVersion ocaml}/site-lib/ OCAML_HAVE_OCAMLOPT=yes";
+  makeFlags = [ "OCAML_STDLIB_DIR=$(out)/lib/ocaml/${stdenv.lib.getVersion" "ocaml}/site-lib/" "OCAML_HAVE_OCAMLOPT=yes" ];
 
   meta = {
     description = "Fontconfig bindings for OCaml";

--- a/pkgs/development/ocaml-modules/frontc/default.nix
+++ b/pkgs/development/ocaml-modules/frontc/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  makeFlags = "PREFIX=$(out) OCAML_SITE=$(OCAMLFIND_DESTDIR)";
+  makeFlags = [ "PREFIX=$(out)" "OCAML_SITE=$(OCAMLFIND_DESTDIR)" ];
 
   postInstall = "cp ${meta_file} $OCAMLFIND_DESTDIR/FrontC/META";
 }

--- a/pkgs/development/ocaml-modules/lablgl/default.nix
+++ b/pkgs/development/ocaml-modules/lablgl/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  buildFlags = "lib libopt glut glutopt";
+  buildFlags = [ "lib" "libopt" "glut" "glutopt" ];
 
   postInstall = ''
     cp ./META $out/lib/ocaml/${ocaml.version}/site-lib/lablgl

--- a/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (rec {
   buildInputs = [ ocaml findlib gtk2 libgnomecanvas libglade gtksourceview camlp4 ];
 
   configureFlags = [ "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib" ];
-  buildFlags = "world";
+  buildFlags = [ "world" ];
 
   preInstall = ''
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib gtk2 libgnomecanvas libglade gtksourceview ];
 
   configureFlags = [ "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib" ];
-  buildFlags = "world";
+  buildFlags = [ "world" ];
 
   preInstall = ''
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib

--- a/pkgs/development/ocaml-modules/llvm/default.nix
+++ b/pkgs/development/ocaml-modules/llvm/default.nix
@@ -22,9 +22,9 @@ stdenv.mkDerivation {
     "-DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR=${stdenv.lib.getLib llvm}/lib"
   ];
 
-  buildFlags = "ocaml_all";
+  buildFlags = [ "ocaml_all" ];
 
-  installFlags = "-C bindings/ocaml";
+  installFlags = [ "-C bindings/ocaml" ];
 
   postInstall = ''
     mkdir -p $OCAMLFIND_DESTDIR/

--- a/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     cp META $out/lib/ocaml/${ocaml.version}/site-lib/cairo/
   '';
 
-  makeFlags = "INSTALLDIR=$(out)/lib/ocaml/${ocaml.version}/site-lib/cairo";
+  makeFlags = [ "INSTALLDIR=$(out)/lib/ocaml/${ocaml.version}/site-lib/cairo" ];
 
   meta = {
     homepage = http://cairographics.org/cairo-ocaml;

--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [ camlp4 ];
 
-  buildFlags = "all all.opt";
+  buildFlags = [ "all" "all.opt" ];
 
   meta = {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/yojson/default.nix
+++ b/pkgs/development/ocaml-modules/yojson/default.nix
@@ -15,7 +15,7 @@ let
     extra = {
       createFindlibDestdir = true;
 
-      makeFlags = "PREFIX=$(out)";
+      makeFlags = [ "PREFIX=$(out)" ];
 
       preBuild = "mkdir $out/bin";
     };

--- a/pkgs/development/pure-modules/audio/default.nix
+++ b/pkgs/development/pure-modules/audio/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure portaudio fftw libsndfile libsamplerate ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/avahi/default.nix
+++ b/pkgs/development/pure-modules/avahi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure avahi ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/csv/default.nix
+++ b/pkgs/development/pure-modules/csv/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/doc/default.nix
+++ b/pkgs/development/pure-modules/doc/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ pure ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
 
   meta = {
     description = "A simple utility for literate programming and documenting source code written in the Pure programming language";

--- a/pkgs/development/pure-modules/fastcgi/default.nix
+++ b/pkgs/development/pure-modules/fastcgi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure fcgi ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/faust/default.nix
+++ b/pkgs/development/pure-modules/faust/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure faust libtool ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/ffi/default.nix
+++ b/pkgs/development/pure-modules/ffi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure libffi ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/gen/default.nix
+++ b/pkgs/development/pure-modules/gen/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   hsEnv = haskellPackages.ghcWithPackages (hsPkgs : [hsPkgs.language-c]);
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ hsEnv pure ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
 
   meta = {
     description = "Pure interface generator";

--- a/pkgs/development/pure-modules/gl/default.nix
+++ b/pkgs/development/pure-modules/gl/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure freeglut libGLU_combined xlibsWrapper ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/glpk/default.nix
+++ b/pkgs/development/pure-modules/glpk/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure glpkWithExtras ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/gplot/default.nix
+++ b/pkgs/development/pure-modules/gplot/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure gnuplot ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/gsl/default.nix
+++ b/pkgs/development/pure-modules/gsl/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure gsl ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/gtk/default.nix
+++ b/pkgs/development/pure-modules/gtk/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure pure-ffi gtk2 ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/liblo/default.nix
+++ b/pkgs/development/pure-modules/liblo/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure liblo ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/lilv/default.nix
+++ b/pkgs/development/pure-modules/lilv/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure lilv lv2 serd sord sratom ];
-  makeFlags = "CFLAGS=-I${lilv}/include/lilv-0 libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "CFLAGS=-I${lilv}/include/lilv-0" "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/lv2/default.nix
+++ b/pkgs/development/pure-modules/lv2/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure lv2 ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/midi/default.nix
+++ b/pkgs/development/pure-modules/midi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure portmidi ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/mpfr/default.nix
+++ b/pkgs/development/pure-modules/mpfr/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/octave/default.nix
+++ b/pkgs/development/pure-modules/octave/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure octave ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/odbc/default.nix
+++ b/pkgs/development/pure-modules/odbc/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure libiodbc ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/pandoc/default.nix
+++ b/pkgs/development/pure-modules/pandoc/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ pure ];
   propagatedBuildInputs = [ pandoc gawk getopt ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   preInstall = ''
     mkdir -p $out/bin
     mkdir -p $out/share/man/man1

--- a/pkgs/development/pure-modules/rational/default.nix
+++ b/pkgs/development/pure-modules/rational/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/readline/default.nix
+++ b/pkgs/development/pure-modules/readline/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure readline ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/sockets/default.nix
+++ b/pkgs/development/pure-modules/sockets/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/sql3/default.nix
+++ b/pkgs/development/pure-modules/sql3/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure sqlite ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/stldict/default.nix
+++ b/pkgs/development/pure-modules/stldict/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/stllib/default.nix
+++ b/pkgs/development/pure-modules/stllib/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/tk/default.nix
+++ b/pkgs/development/pure-modules/tk/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure tcl tk xlibsWrapper ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/pure-modules/xml/default.nix
+++ b/pkgs/development/pure-modules/xml/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ pure libxml2 libxslt ];
-  makeFlags = "libdir=$(out)/lib prefix=$(out)/";
+  makeFlags = [ "libdir=$(out)/lib" "prefix=$(out)/" ];
   setupHook = ../generic-setup-hook.sh;
 
   meta = {

--- a/pkgs/development/python-modules/ephem/default.nix
+++ b/pkgs/development/python-modules/ephem/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "0dj4kk325b01s7q1zkwpm9rrzl7n1jf7fr92wcajjhc5kx14hwb0";
   };
 
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
   checkInputs = [ pytest glibcLocales ];
   # JPLTest uses assets not distributed in package
   checkPhase = ''

--- a/pkgs/development/python-modules/koji/default.nix
+++ b/pkgs/development/python-modules/koji/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   # Judging from SyntaxError
   #disabled = isPy3k;
 
-  makeFlags = "DESTDIR=$(out)";
+  makeFlags = [ "DESTDIR=$(out)" ];
 
   postInstall = ''
     mv $out/usr/* $out/

--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
       sha256 = "0z5qnkndg6ma5f5qqrid5m95i9kybsr000v3fdy1ab562kf65a27";
     })
   ];
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
 
   nativeBuildInputs = [ swig2 ];
   buildInputs = [ swig2 openssl ];

--- a/pkgs/development/python-modules/purepng/default.nix
+++ b/pkgs/development/python-modules/purepng/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage {
       sha256 = "1ag0pji3p012hmj8kadcd0vydv9702188c0isizsi964qcl4va6m";
     })
   ];
-  patchFlags = "-p1 -d code";
+  patchFlags = [ "-p1" "-d" "code" ];
 
   # cython is optional - if not supplied, the "pure python" implementation will be used
   nativeBuildInputs = [ cython ];

--- a/pkgs/development/python-modules/pyside/default.nix
+++ b/pkgs/development/python-modules/pyside/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   buildInputs = [ mesa ];
 
-  makeFlags = "QT_PLUGIN_PATH=" + pysideShiboken + "/lib/generatorrunner";
+  makeFlags = [ "QT_PLUGIN_PATH=" + pysideShiboken + "/lib/generatorrunner" ];
 
   meta = {
     description = "LGPL-licensed Python bindings for the Qt cross-platform application and UI framework";

--- a/pkgs/development/python-modules/pythonirclib/default.nix
+++ b/pkgs/development/python-modules/pythonirclib/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     sha256 = "5fb8d95d6c95c93eaa400b38447c63e7a176b9502bc49b2f9b788c9905f4ec5e";
   })];
 
-  patchFlags = "irclib.py";
+  patchFlags = [ "irclib.py" ];
 
   propagatedBuildInputs = [ paver ];
 

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -509,7 +509,7 @@ in
     '';
   } // (if stdenv.isDarwin then {
     # https://github.com/NixOS/nixpkgs/issues/19098
-    buildFlags = "--disable-lto";
+    buildFlags = [ "--disable-lto" ];
   } else {});
 
   scrypt = attrs:

--- a/pkgs/development/tools/analysis/ikos/default.nix
+++ b/pkgs/development/tools/analysis/ikos/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake boost gmp clang llvm sqlite python
                   ocamlPackages.apron mpfr ppl doxygen graphviz ];
 
-  cmakeFlags = "-DAPRON_ROOT=${ocamlPackages.apron}";
+  cmakeFlags = [ "-DAPRON_ROOT=${ocamlPackages.apron}" ];
 
   postBuild = "make doc";
 

--- a/pkgs/development/tools/erlang/cuter/default.nix
+++ b/pkgs/development/tools/erlang/cuter/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook makeWrapper which ];
   buildInputs = [ python python.pkgs.setuptools z3.python erlang ];
 
-  buildFlags = "PWD=$(out)/lib/erlang/lib/cuter-${version} cuter_target";
+  buildFlags = [ "PWD=$(out)/lib/erlang/lib/cuter-${version}" "cuter_target" ];
   configurePhase = ''
     autoconf
     ./configure --prefix $out

--- a/pkgs/development/tools/misc/doclifter/default.nix
+++ b/pkgs/development/tools/misc/doclifter/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   };
   buildInputs = [ python ];
   
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
   
   preInstall = ''
     mkdir -p $out/bin

--- a/pkgs/development/tools/misc/sloccount/default.nix
+++ b/pkgs/development/tools/misc/sloccount/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  makeFlags = "PREFIX=$(out) CC=cc";
+  makeFlags = [ "PREFIX=$(out)" "CC=cc" ];
 
   doCheck = true;
   checkPhase = ''HOME="$TMPDIR" PATH="$PWD:$PATH" make test'';

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     --replace +camlp4 $out/lib/ocaml/${ocaml.version}/site-lib/camlp4
   '';
 
-  makeFlags = "all";
+  makeFlags = [ "all" ];
 
   installTargets = "install install-META";
 

--- a/pkgs/development/tools/ocaml/camlp5/default.nix
+++ b/pkgs/development/tools/ocaml/camlp5/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   preConfigure = "configureFlagsArray=(--strict" +
                   " --libdir $out/lib/ocaml/${ocaml.version}/site-lib)";
 
-  buildFlags = "world.opt";
+  buildFlags = [ "world.opt" ];
 
   dontStrip = true;
 

--- a/pkgs/development/tools/ocaml/cppo/default.nix
+++ b/pkgs/development/tools/ocaml/cppo/default.nix
@@ -18,7 +18,7 @@ let param =
     sha256 = "1xqldjz9risndnabvadw41fdbi5sa2hl4fnqls7j9xfbby1izbg8";
     extra = {
       createFindlibDestdir = true;
-      makeFlags = "PREFIX=$(out)";
+      makeFlags = [ "PREFIX=$(out)" ];
       preBuild = ''
         mkdir $out/bin
       '';

--- a/pkgs/development/tools/ocaml/dune/default.nix
+++ b/pkgs/development/tools/ocaml/dune/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib ];
 
-  buildFlags = "release";
+  buildFlags = [ "release" ];
 
   dontAddPrefix = true;
 

--- a/pkgs/development/tools/ocaml/ocamlscript/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlscript/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
 
   patches = [ ./Makefile.patch ];
 
-  buildFlags = "PREFIX=$(out)";
-  installFlags = "PREFIX=$(out)";
+  buildFlags = [ "PREFIX=$(out)" ];
+  installFlags = [ "PREFIX=$(out)" ];
 
   preInstall = "mkdir $out/bin";
   createFindlibDestdir = true;

--- a/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
+++ b/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     url = "https://src.fedoraproject.org/repo/pkgs/ocaml-omake/${pname}-${version}.tar.gz/fe39a476ef4e33b7ba2ca77a6bcaded2/${pname}-${version}.tar.gz";
     sha256 = "1sas02pbj56m7wi5vf3vqrrpr4ynxymw2a8ybvfj2dkjf7q9ii13";
   };
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
   patches = [ ./warn.patch ];
 
   buildInputs = [ ocaml makeWrapper ncurses ];
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
 #
 #  configureFlags = if transitional then "--transitional" else "--strict";
 #
-#  buildFlags = "world.opt";		
+#  buildFlags = [ "world.opt" ];		
 
   meta = {
     description = "Omake build system";

--- a/pkgs/development/tools/sslmate/default.nix
+++ b/pkgs/development/tools/sslmate/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0vhppvy5vphipbycfilzxdly7nw12brscz4biawf3bl376yp7ljm";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   buildInputs = [ perlPackages.perl makeWrapper ];
 

--- a/pkgs/development/tools/stagit/default.nix
+++ b/pkgs/development/tools/stagit/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0gh28spkry9wbmdj0hmvz3680fvbyzab9cifhj1p76f4fz27rnv9";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   buildInputs = [ libgit2 ];
 

--- a/pkgs/development/tools/tychus/default.nix
+++ b/pkgs/development/tools/tychus/default.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
 
   buildInputs = stdenv.lib.optionals stdenv.hostPlatform.isDarwin [ CoreFoundation ];
 
-  buildFlags = "--tags release";
+  buildFlags = [ "--tags" "release" ];
 
   meta = {
     description = "Command line utility to live-reload your application.";

--- a/pkgs/games/gmad/default.nix
+++ b/pkgs/games/gmad/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     else if stdenv.isDarwin then "gmad_osx"
     else "gmad";
 
-  premakeFlags = "--bootil_lib=${bootil}/lib --bootil_inc=${bootil}/include";
+  premakeFlags = [ "--bootil_lib=${bootil}/lib" "--bootil_inc=${bootil}/include" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/games/openra/common.nix
+++ b/pkgs/games/openra/common.nix
@@ -69,7 +69,7 @@ in {
       python
     ];
 
-    makeFlags = "prefix=$(out)";
+    makeFlags = [ "prefix=$(out)" ];
 
     doCheck = true;
 

--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     "--without-liblzo2"
   ];
 
-  makeFlags = "INSTALL_PERSONAL_DIR=";
+  makeFlags = [ "INSTALL_PERSONAL_DIR=" ];
 
   postInstall = ''
     mv $out/games/ $out/bin

--- a/pkgs/games/pingus/default.nix
+++ b/pkgs/games/pingus/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
       sha256 = "0nqyhznnnvpgfa6rfv8rapjfpw99b67n97jfqp9r3hpib1b3ja6p";
     })
   ];
-  makeFlags = "PREFIX=${placeholder "out"}";
+  makeFlags = [ "PREFIX=${placeholder" ""out"}" ];
   dontUseSconsInstall = true;
   meta = {
     inherit (s) version;

--- a/pkgs/games/stockfish/default.nix
+++ b/pkgs/games/stockfish/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   postUnpack = "sourceRoot+=/src";
   makeFlags = [ "PREFIX=$(out)" "ARCH=${arch}" ];
-  buildFlags = "build ";
+  buildFlags = [ "build" "" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/games/tremulous/default.nix
+++ b/pkgs/games/tremulous/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     cd ..
   '';
   patches = [ ./parse.patch ];
-  patchFlags = "-p 0";
+  patchFlags = [ "-p" "0" ];
   NIX_LD_FLAGS = ''
     -rpath ${stdenv.cc}/lib
     -rpath ${stdenv.cc}/lib64

--- a/pkgs/games/vitetris/default.nix
+++ b/pkgs/games/vitetris/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  makeFlags = "INSTALL=install";
+  makeFlags = [ "INSTALL=install" ];
 
   meta = {
     description = "Terminal-based Tetris clone by Victor Nilsson";

--- a/pkgs/misc/beep/default.nix
+++ b/pkgs/misc/beep/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "0bgch6jq5cahakk3kbr9549iysf2dik09afixxy5brbxk1xfzb2r";
   };
 
-  makeFlags = "INSTALL_DIR=\${out}/bin/ MAN_DIR=\${out}/man/man1/";
+  makeFlags = [ "INSTALL_DIR=\${out}/bin/" "MAN_DIR=\${out}/man/man1/" ];
 
   preInstall = ''
     mkdir -p $out/bin

--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -245,7 +245,7 @@ stdenv.mkDerivation rec {
     })
     ./firmware_location.patch
     ];
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
 
   configureFlags = [ "--enable-dependency-reduction" "--disable-frontend"];
 

--- a/pkgs/misc/drivers/xboxdrv/default.nix
+++ b/pkgs/misc/drivers/xboxdrv/default.nix
@@ -12,7 +12,7 @@ in stdenv.mkDerivation {
     sha256 = "0jx2wqmc7602dxyj19n3h8x0cpy929h7c0h39vcc5rf0q74fh3id";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ scons libX11 libusb1 boost glib dbus-glib ];
   dontUseSconsInstall = true;

--- a/pkgs/misc/emulators/blastem/default.nix
+++ b/pkgs/misc/emulators/blastem/default.nix
@@ -11,7 +11,7 @@ let
         rev = "244f8bbbdf64ae603f9f6c09a3067943837459ec";
         sha256 = "0x4y5q7ygxfjfy2wxijkps9khsjjfb169sbda410vaw0m88wqj5p";
       };
-      makeFlags = "CPU=m68k SYNTAX=mot";
+      makeFlags = [ "CPU=m68k" "SYNTAX=mot" ];
       installPhase = ''
         mkdir -p $out/bin
         cp vasmm68k_mot $out/bin

--- a/pkgs/misc/emulators/dlx/default.nix
+++ b/pkgs/misc/emulators/dlx/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ unzip ];
 
-  makeFlags = "LINK=gcc CFLAGS=-O2";
+  makeFlags = [ "LINK=gcc" "CFLAGS=-O2" ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/misc/emulators/hatari/default.nix
+++ b/pkgs/misc/emulators/hatari/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   # For pthread_cancel
-  cmakeFlags = "-DCMAKE_EXE_LINKER_FLAGS=-lgcc_s";
+  cmakeFlags = [ "-DCMAKE_EXE_LINKER_FLAGS=-lgcc_s" ];
 
   buildInputs = [ zlib SDL cmake ];
 

--- a/pkgs/misc/emulators/mess/default.nix
+++ b/pkgs/misc/emulators/mess/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
       unzip -o ${messSrc}
     '';
 
-  makeFlags = "TARGET=mess BUILD_EXPAT= BUILD_ZLIB= NOWERROR=1";
+  makeFlags = [ "TARGET=mess" "BUILD_EXPAT=" "BUILD_ZLIB=" "NOWERROR=1" ];
 
   buildInputs =
     [ unzip pkgconfig SDL gtk2 GConf libGLU_combined expat zlib ];

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -268,7 +268,7 @@ in {
     defconfig = "cm_fx6_defconfig";
     extraMeta.platforms = ["armv7l-linux"];
     filesToInstall = ["u-boot-with-nand-spl.imx"];
-    buildFlags = "u-boot-with-nand-spl.imx";
+    buildFlags = [ "u-boot-with-nand-spl.imx" ];
     extraConfig = ''
       CONFIG_CMD_SETEXPR=y
     '';

--- a/pkgs/os-specific/darwin/apple-source-releases/PowerManagement/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/PowerManagement/default.nix
@@ -3,7 +3,7 @@
 appleDerivation {
   nativeBuildInputs = [ xcbuildHook ];
   buildInputs = [ IOKit ];
-  xcbuildFlags = "-target caffeinate";
+  xcbuildFlags = [ "-target" "caffeinate" ];
   installPhase = ''
     install -D Products/Deployment/caffeinate $out/bin/caffeinate
   '';

--- a/pkgs/os-specific/darwin/apple-source-releases/Security/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Security/default.nix
@@ -5,7 +5,7 @@ appleDerivation {
   # buildInputs = [ Foundation xpc darling ];
   buildInputs = [ xpc xnu ];
 
-  xcbuildFlags = "-target Security_frameworks_osx";
+  xcbuildFlags = [ "-target" "Security_frameworks_osx" ];
 
   # NIX_CFLAGS_COMPILE = "-Wno-error -I${xnu}/include/libkern -DPRIVATE -I${xnu}/Library/Frameworks/System.framework/Headers";
 

--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/default.nix
@@ -6,7 +6,7 @@ appleDerivation {
   buildInputs = [ CoreSymbolication darling xnu ];
   NIX_CFLAGS_COMPILE = "-DCTF_OLD_VERSIONS -DPRIVATE -DYYDEBUG=1 -I${xnu}/Library/Frameworks/System.framework/Headers -Wno-error=implicit-function-declaration";
   NIX_LDFLAGS = "-L./Products/Release";
-  xcbuildFlags = "-target dtrace_frameworks -target dtrace";
+  xcbuildFlags = [ "-target" "dtrace_frameworks" "-target"" ""dtrace" ];
 
   doCheck = false;
   checkPhase = "xcodebuild -target dtrace_tests";

--- a/pkgs/os-specific/darwin/apple-source-releases/libutil/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libutil/default.nix
@@ -11,7 +11,7 @@ appleDerivation {
       --replace '#include <xpc/xpc.h>' ""
   '';
 
-  xcbuildFlags = "-target util";
+  xcbuildFlags = [ "-target" "util" ];
 
   installPhase = ''
     mkdir -p $out/include

--- a/pkgs/os-specific/darwin/libtapi/default.nix
+++ b/pkgs/os-specific/darwin/libtapi/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   cmakeFlags = [ "-DLLVM_INCLUDE_TESTS=OFF" ];
 
-  buildFlags = "libtapi";
+  buildFlags = [ "libtapi" ];
 
   installTarget = "install-libtapi";
 

--- a/pkgs/os-specific/darwin/reattach-to-user-namespace/default.nix
+++ b/pkgs/os-specific/darwin/reattach-to-user-namespace/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "00mjyj8yicrpnlm46rlbkvxgl5381l8xawh7rmjk10p3zrm56jbv";
   };
 
-  buildFlags = "ARCHES=x86_64";
+  buildFlags = [ "ARCHES=x86_64" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/os-specific/linux/alienfx/default.nix
+++ b/pkgs/os-specific/linux/alienfx/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
 
   patches = [./unistd.patch];
   buildInputs = [ libusb1 ];
-  makeFlags = "build";
+  makeFlags = [ "build" ];
   preInstall = ''
     mkdir -p $out/bin
     mkdir -p $out/man/man1

--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     ./gcc.patch
   ];
 
-  makeFlags = "KBASE=${kernel.dev}/lib/modules/${kernel.modDirVersion}";
+  makeFlags = [ "KBASE=${kernel.dev}/lib/modules/${kernel.modDirVersion}" ];
 
   unpackPhase = ''
     sourceRoot=broadcom-sta

--- a/pkgs/os-specific/linux/cifs-utils/default.nix
+++ b/pkgs/os-specific/linux/cifs-utils/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ kerberos keyutils pam talloc ];
 
-  makeFlags = "root_sbindir=$(out)/sbin";
+  makeFlags = [ "root_sbindir=$(out)/sbin" ];
 
   meta = with stdenv.lib; {
     homepage = http://www.samba.org/linux-cifs/cifs-utils/;

--- a/pkgs/os-specific/linux/dmidecode/default.nix
+++ b/pkgs/os-specific/linux/dmidecode/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1pcfhcgs2ifdjwp7amnsr3lq95pgxpr150bjhdinvl505px0cw07";
   };
 
-  makeFlags = "prefix=$(out)";
+  makeFlags = [ "prefix=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = https://www.nongnu.org/dmidecode/;

--- a/pkgs/os-specific/linux/drbd/default.nix
+++ b/pkgs/os-specific/linux/drbd/default.nix
@@ -31,9 +31,9 @@ stdenv.mkDerivation rec {
       substituteInPlace scripts/drbd.rules --replace /usr/sbin/drbdadm $out/sbin/drbdadm
     '';
 
-  makeFlags = "SHELL=${stdenv.shell}";
+  makeFlags = [ "SHELL=${stdenv.shell}" ];
 
-  installFlags = "localstatedir=$(TMPDIR)/var sysconfdir=$(out)/etc INITDIR=$(out)/etc/init.d";
+  installFlags = [ "localstatedir=$(TMPDIR)/var sysconfdir=$(out)/etc INITDIR=$(out)/etc/init.d" ];
 
   meta = with stdenv.lib; {
     homepage = http://www.drbd.org/;

--- a/pkgs/os-specific/linux/extrace/default.nix
+++ b/pkgs/os-specific/linux/extrace/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0acspj3djspfvgr3ng5b61qws6v2md6b0lc5qkby10mqnfpkvq85";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   postInstall = ''
     install -dm755 "$out/share/licenses/extrace/"

--- a/pkgs/os-specific/linux/jool/cli.nix
+++ b/pkgs/os-specific/linux/jool/cli.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ libnl iptables ];
 
-  makeFlags = "-C src/usr";
+  makeFlags = [ "-C" "src/usr" ];
 
   prePatch = ''
     sed -e 's%^XTABLES_SO_DIR = .*%XTABLES_SO_DIR = '"$out"'/lib/xtables%g' -i src/usr/iptables/Makefile

--- a/pkgs/os-specific/linux/ldm/default.nix
+++ b/pkgs/os-specific/linux/ldm/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     sed '16i#include <sys/stat.h>' -i ldm.c
   '';
 
-  buildFlags = "ldm";
+  buildFlags = [ "ldm" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/os-specific/linux/mmc-utils/default.nix
+++ b/pkgs/os-specific/linux/mmc-utils/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "1mak9rqjp6yvqk2h5hfil5a9gfx138h62n3cryckfbhr6fmaylm7";
   };
 
-  makeFlags = "CC=${stdenv.cc.targetPrefix}cc";
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installPhase = ''
     make install prefix=$out

--- a/pkgs/os-specific/linux/numad/default.nix
+++ b/pkgs/os-specific/linux/numad/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace "install -m" "install -Dm"
   '';
 
-  makeFlags = "prefix=$(out)";
+  makeFlags = [ "prefix=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "A user-level daemon that monitors NUMA topology and processes resource consumption to facilitate good NUMA resource access";

--- a/pkgs/os-specific/linux/pam_mount/default.nix
+++ b/pkgs/os-specific/linux/pam_mount/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sh autogen.sh --prefix=$out
     '';
 
-  makeFlags = "DESTDIR=$(out)";
+  makeFlags = [ "DESTDIR=$(out)" ];
 
   # Probably a hack, but using DESTDIR and PREFIX makes everything work!
   postInstall = ''

--- a/pkgs/os-specific/linux/pcmciautils/default.nix
+++ b/pkgs/os-specific/linux/pcmciautils/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     ln -sf ${configOpts} ./config/config.opts'')
   ;
 
-  makeFlags = "LEX=flex";
+  makeFlags = [ "LEX=flex" ];
   installFlags = ''INSTALL=install DESTDIR=''${out}'';
   postInstall =
     lib.concatMapStrings (path: ''

--- a/pkgs/os-specific/linux/rfkill/default.nix
+++ b/pkgs/os-specific/linux/rfkill/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "01zs7p9kd92pxgcgwl5w46h3iyx4acfg6m1j5fgnflsaa350q5iy";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = http://wireless.kernel.org/en/users/Documentation/rfkill;

--- a/pkgs/os-specific/linux/rtl8192eu/default.nix
+++ b/pkgs/os-specific/linux/rtl8192eu/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  makeFlags = [ "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/rtlwifi_new/default.nix
+++ b/pkgs/os-specific/linux/rtlwifi_new/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  makeFlags = [ "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/sysstat/default.nix
+++ b/pkgs/os-specific/linux/sysstat/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     export SYSTEMCTL=systemctl
   '';
 
-  makeFlags = "SYSCONFIG_DIR=$(out)/etc IGNORE_FILE_ATTRIBUTES=y CHOWN=true";
+  makeFlags = [ "SYSCONFIG_DIR=$(out)/etc" "IGNORE_FILE_ATTRIBUTES=y" "CHOWN=true" ];
   installTargets = "install_base install_nls install_man";
 
   patches = [ ./install.patch ];

--- a/pkgs/os-specific/linux/untie/default.nix
+++ b/pkgs/os-specific/linux/untie/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1334ngvbi4arcch462mzi5vxvxck4sy1nf0m58116d9xmx83ak0m";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "A tool to run processes untied from some of the namespaces";

--- a/pkgs/os-specific/windows/jom/default.nix
+++ b/pkgs/os-specific/windows/jom/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   QTDIR = qt48;
 
-  # cmakeFlags = "-DWIN32=1 -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_RC_COMPILER=${stdenv.cc.targetPrefix}windres";
+  # cmakeFlags = [ "-DWIN32=1" "-DCMAKE_SYSTEM_NAME=Windows" "-DCMAKE_RC_COMPILER=${stdenv.cc.targetPrefix}windres" ];
 
   preBuild = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     export NIX_CROSS_CFLAGS_COMPILE=-fpermissive

--- a/pkgs/servers/fileshare/default.nix
+++ b/pkgs/servers/fileshare/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig git ];
   buildInputs = [ libmicrohttpd ];
 
-  makeFlags = "BUILD=release";
+  makeFlags = [ "BUILD=release" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/servers/mail/postfix/pfixtools.nix
+++ b/pkgs/servers/mail/postfix/pfixtools.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     "-Wno-error=format-truncation"
   ];
 
-  makeFlags = "DESTDIR=$(out) prefix=";
+  makeFlags = [ "DESTDIR=$(out)" "prefix=" ];
 
   meta = {
     description = "A collection of postfix-related tools";

--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -17,9 +17,9 @@ perlPackages.buildPerlPackage rec {
 
   # Enabling 'taint' mode is desirable, but that flag disables support
   # for the PERL5LIB environment variable. Needs further investigation.
-  makeFlags = "PERL_BIN=${perlPackages.perl}/bin/perl PERL_TAINT=no";
+  makeFlags = [ "PERL_BIN=${perlPackages.perl}/bin/perl" "PERL_TAINT=no" ];
 
-  makeMakerFlags = "CONFDIR=/homeless/shelter LOCALSTATEDIR=/var/lib/spamassassin";
+  makeMakerFlags = [ "CONFDIR=/homeless/shelter" "LOCALSTATEDIR=/var/lib/spamassassin" ];
 
   doCheck = false;
 

--- a/pkgs/servers/monitoring/nagios/default.nix
+++ b/pkgs/servers/monitoring/nagios/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ php perl gd libpng zlib unzip ];
 
   configureFlags = [ "--localstatedir=/var/lib/nagios" ];
-  buildFlags = "all";
+  buildFlags = [ "all" ];
 
   # Do not create /var directories
   preInstall = ''

--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   # Note: this enables libc malloc as a temporary fix for cross-compiling.
   # Due to hardcoded configure flags in jemalloc, we can't cross-compile vendored jemalloc properly, and so we're forced to use libc allocator.
   # It's weird that the build isn't failing because of failure to compile dependencies, it's from failure to link them!
-  makeFlags = "PREFIX=$(out)" + stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) " AR=${stdenv.cc.targetPrefix}ar RANLIB=${stdenv.cc.targetPrefix}ranlib MALLOC=libc";
+  makeFlags = [ "PREFIX=$(out)" + stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) " AR=${stdenv.cc.targetPrefix}ar RANLIB=${stdenv.cc.targetPrefix}ranlib MALLOC=libc" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -19,7 +19,7 @@ let
         pcre libxslt groff ncurses readline libedit makeWrapper python
       ];
 
-      buildFlags = "localstatedir=/var/spool";
+      buildFlags = [ "localstatedir=/var/spool" ];
 
       postInstall = ''
         wrapProgram "$out/sbin/varnishd" --prefix PATH : "${stdenv.lib.makeBinPath [ stdenv.cc ]}"

--- a/pkgs/shells/bash/5.0.nix
+++ b/pkgs/shells/bash/5.0.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     -DSSH_SOURCE_BASHRC
   '';
 
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
 
   patches = upstreamPatches;
 

--- a/pkgs/tools/X11/hsetroot/default.nix
+++ b/pkgs/tools/X11/hsetroot/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   patches = [ underlinkingPatch ];
 
-  patchFlags = "-p0";
+  patchFlags = [ "-p0" ];
 
   preConfigure = "./autogen.sh";
 

--- a/pkgs/tools/X11/setroot/default.nix
+++ b/pkgs/tools/X11/setroot/default.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ libX11 imlib2 ]
     ++ stdenv.lib.optional enableXinerama libXinerama;
 
-  buildFlags = "CC=cc " + (if enableXinerama then "xinerama=1" else "xinerama=0");
+  buildFlags = [ "CC=cc" (if enableXinerama then "xinerama=1" else "xinerama=0") ] ;
 
-  installFlags = "DESTDIR=$(out) PREFIX=";
+  installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 
   meta = with stdenv.lib; {
     description = "Simple X background setter inspired by imlibsetroot and feh";

--- a/pkgs/tools/X11/srandrd/default.nix
+++ b/pkgs/tools/X11/srandrd/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libX11 libXrandr libXinerama ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/jceb/srandrd";

--- a/pkgs/tools/X11/xcwd/default.nix
+++ b/pkgs/tools/X11/xcwd/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ libX11 ];
 
-  makeFlags = "prefix=$(out)";
+  makeFlags = [ "prefix=$(out)" ];
 
   installPhase = ''
     install -D xcwd "$out/bin/xcwd"

--- a/pkgs/tools/X11/xdotool/default.nix
+++ b/pkgs/tools/X11/xdotool/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib
   '';
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = {
     homepage = https://www.semicomplete.com/projects/xdotool/;

--- a/pkgs/tools/X11/xnee/default.nix
+++ b/pkgs/tools/X11/xnee/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   # `cnee' is linked without `-lXi' and as a consequence has a RUNPATH that
   # lacks libXi.
-  makeFlags = "LDFLAGS=-lXi";
+  makeFlags = [ "LDFLAGS=-lXi" ];
 
   # XXX: Actually tests require an X server.
   doCheck = true;

--- a/pkgs/tools/X11/xpointerbarrier/default.nix
+++ b/pkgs/tools/X11/xpointerbarrier/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ xorg.libX11 xorg.libXfixes xorg.libXrandr ];
 
-  makeFlags = "prefix=$(out)";
+  makeFlags = [ "prefix=$(out)" ];
 
   meta = {
     homepage = https://uninformativ.de/git/xpointerbarrier;

--- a/pkgs/tools/archivers/undmg/default.nix
+++ b/pkgs/tools/archivers/undmg/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/matthewbauer/undmg;

--- a/pkgs/tools/cd-dvd/cdrdao/default.nix
+++ b/pkgs/tools/cd-dvd/cdrdao/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "0pmpgx91j984snrsxbq1dgf3ximks2dfh1sqqmic72lrls7wp4w1";
   };
 
-  makeFlags = "RM=rm LN=ln MV=mv";
+  makeFlags = [ "RM=rm" "LN=ln" "MV=mv" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libvorbis libmad libao ];

--- a/pkgs/tools/cd-dvd/cdrkit/default.nix
+++ b/pkgs/tools/cd-dvd/cdrkit/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     ln -s $out/bin/wodim $out/bin/cdrecord
   '';
 
-  makeFlags = "PREFIX=\$(out)";
+  makeFlags = [ "PREFIX=\$(out)" ];
 
   meta = {
     description = "Portable command-line CD/DVD recorder software, mostly compatible with cdrtools";

--- a/pkgs/tools/filesystems/ciopfs/default.nix
+++ b/pkgs/tools/filesystems/ciopfs/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ fuse glib attr ];
 
-  makeFlags = "DESTDIR=$(out) PREFIX=";
+  makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 
   meta = {
     homepage = http://www.brain-dump.org/projects/ciopfs/;

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation
     ''--localstatedir=/var''
     ];
 
-  makeFlags = "DESTDIR=$(out)";
+  makeFlags = [ "DESTDIR=$(out)" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/graphics/dpic/default.nix
+++ b/pkgs/tools/graphics/dpic/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   phases = [ "unpackPhase" "buildPhase" "installPhase" ];
 
-  makeFlags = "CC=${stdenv.cc.outPath}/bin/cc";
+  makeFlags = [ "CC=${stdenv.cc.outPath}/bin/cc" ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/tools/graphics/kst/default.nix
+++ b/pkgs/tools/graphics/kst/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ qtbase gsl getdata netcdf muparser matio ];
 
-  cmakeFlags = "-Dkst_qt5=1 -Dkst_release=1";
+  cmakeFlags = [ "-Dkst_qt5=1" "-Dkst_release=1" ];
 
   postInstall = ''
     mkdir -p $out

--- a/pkgs/tools/graphics/pngcheck/default.nix
+++ b/pkgs/tools/graphics/pngcheck/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   makefile = "Makefile.unx";
-  makeFlags = "ZPATH=${zlib.static}/lib";
+  makeFlags = [ "ZPATH=${zlib.static}/lib" ];
 
   buildInputs = [ zlib ];
 

--- a/pkgs/tools/graphics/quirc/default.nix
+++ b/pkgs/tools/graphics/quirc/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     mkdir -p "$out"/{bin,lib,include}
     find . -maxdepth 1 -type f -perm -0100 -exec cp '{}' "$out"/bin ';'
   '';
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
   meta = {
     inherit (s) version;
     description = ''A small QR code decoding library'';

--- a/pkgs/tools/misc/dylibbundler/default.nix
+++ b/pkgs/tools/misc/dylibbundler/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "1mpd43hvpfp7pskfrjnd6vcmfii9v3p97q0ws50krkdvshp0bv2h";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Small command-line program that aims to make bundling .dylibs as easy as possible";

--- a/pkgs/tools/misc/fdupes/default.nix
+++ b/pkgs/tools/misc/fdupes/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "19b6vqblddaw8ccw4sn0qsqzbswlhrz8ia6n4m3hymvcxn8skpz9";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Identifies duplicate files residing within specified directories";

--- a/pkgs/tools/misc/fondu/default.nix
+++ b/pkgs/tools/misc/fondu/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "152prqad9jszjmm4wwqrq83zk13ypsz09n02nrk1gg0fcxfm7fr2";
   };
 
-  makeFlags = "DESTDIR=$(out)";
+  makeFlags = [ "DESTDIR=$(out)" ];
 
   hardeningDisable = [ "fortify" ];
 

--- a/pkgs/tools/misc/fzy/default.nix
+++ b/pkgs/tools/misc/fzy/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1gkzdvj73f71388jvym47075l9zw61v6l8wdv2lnc0mns6dxig0k";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "A better fuzzy finder";

--- a/pkgs/tools/misc/lf/default.nix
+++ b/pkgs/tools/misc/lf/default.nix
@@ -15,8 +15,8 @@ buildGoModule rec {
 
   # TODO: Setting buildFlags probably isn't working properly. I've tried a few
   # variants, e.g.:
-  # - buildFlags = "-ldflags \"-s -w -X 'main.gVersion=${version}'\"";
-  # - buildFlags = "-ldflags \\\"-X ${goPackagePath}/main.gVersion=${version}\\\"";
+  # - buildFlags = [ "-ldflags" "\"-s" "-w"" ""-X 'main.gVersion=${version}'\"" ];
+  # - buildFlags = [ "-ldflags" "\\\"-X" "${goPackagePath}/main.gVersion=${version}\\\"" ];
   # Override the build phase (to set buildFlags):
   buildPhase = ''
     runHook preBuild

--- a/pkgs/tools/misc/memtest86+/default.nix
+++ b/pkgs/tools/misc/memtest86+/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "all" ];
 
-  buildFlags = "memtest.bin";
+  buildFlags = [ "memtest.bin" ];
 
   doCheck = false; # fails
 

--- a/pkgs/tools/misc/mktorrent/default.nix
+++ b/pkgs/tools/misc/mktorrent/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "17pdc5mandl739f8q26n5is8ga56s83aqcrwhlnnplbxwx2inidr";
   };
 
-  makeFlags = "USE_PTHREADS=1 USE_OPENSSL=1 USE_LONG_OPTIONS=1"
+  makeFlags = [ "USE_PTHREADS=1" "USE_OPENSSL=1" "USE_LONG_OPTIONS=1" ]
     + stdenv.lib.optionalString stdenv.isi686 " USE_LARGE_FILES=1"
     + stdenv.lib.optionalString stdenv.isLinux "CFLAGS=-lgcc_s";
 

--- a/pkgs/tools/misc/moreutils/default.nix
+++ b/pkgs/tools/misc/moreutils/default.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = with perlPackages; [ perl IPCRun TimeDate TimeDuration ];
 
-  buildFlags = "CC=cc";
-  installFlags = "PREFIX=$(out)";
+  buildFlags = [ "CC=cc" ];
+  installFlags = [ "PREFIX=$(out)" ];
 
   postInstall = ''
     wrapProgram $out/bin/chronic --prefix PERL5LIB : $PERL5LIB

--- a/pkgs/tools/misc/pal/default.nix
+++ b/pkgs/tools/misc/pal/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sed -i -e 's,/etc/pal\.conf,'$out/etc/pal.conf, src/input.c
   '';
 
-  makeFlags = "prefix=$(out)";
+  makeFlags = [ "prefix=$(out)" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib gettext readline ];

--- a/pkgs/tools/misc/svtplay-dl/default.nix
+++ b/pkgs/tools/misc/svtplay-dl/default.nix
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
       --replace 'PYTHONPATH=lib' 'PYTHONPATH=lib:$PYTHONPATH'
   '';
 
-  makeFlags = "PREFIX=$(out) SYSCONFDIR=$(out)/etc PYTHON=${python.interpreter}";
+  makeFlags = [ "PREFIX=$(out)" "SYSCONFDIR=$(out)/etc" "PYTHON=${python.interpreter}" ];
 
   postInstall = ''
     wrapProgram "$out/bin/svtplay-dl" \

--- a/pkgs/tools/misc/teleconsole/default.nix
+++ b/pkgs/tools/misc/teleconsole/default.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   CGO_ENABLED = 1;
-  buildFlags = "-ldflags";
+  buildFlags = [ "-ldflags" ];
 
   meta = with stdenv.lib; {
     homepage = "https://www.teleconsole.com/";

--- a/pkgs/tools/misc/tty-clock/default.nix
+++ b/pkgs/tools/misc/tty-clock/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ncurses ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/xorg62/tty-clock;

--- a/pkgs/tools/misc/vmtouch/default.nix
+++ b/pkgs/tools/misc/vmtouch/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [perl];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = {
     description = "Portable file system cache diagnostics and control";

--- a/pkgs/tools/misc/xdo/default.nix
+++ b/pkgs/tools/misc/xdo/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
      sha256 = "1h3jrygcjjbavdbkpx2hscsf0yf97gk487lzjdlvymd7dxdv9hy9";
    };
 
-   makeFlags = "PREFIX=$(out)";
+   makeFlags = [ "PREFIX=$(out)" ];
 
    buildInputs = [ libxcb xcbutilwm xcbutil ];
 

--- a/pkgs/tools/networking/ratools/default.nix
+++ b/pkgs/tools/networking/ratools/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "07m45bn9lzgbfihmxic23wqp73nxg5ihrvkigr450jq6gzvgwawq";
   };
 
-  makeFlags = "-C src";
+  makeFlags = [ "-C" "src" ];
 
   installPhase = ''
     install -vD bin/* -t $out/bin

--- a/pkgs/tools/networking/shadowfox/default.nix
+++ b/pkgs/tools/networking/shadowfox/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   modSha256 = "0hcc87mzacqwbw10l49kx0sxl4mivdr88c40wh6hdfvrbam2w86r";
 
-  buildFlags = "--tags release";
+  buildFlags = [ "--tags" "release" ];
 
   meta = with stdenv.lib; {
     description = ''

--- a/pkgs/tools/networking/traceroute/default.nix
+++ b/pkgs/tools/networking/traceroute/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "3669d22a34d3f38ed50caba18cd525ba55c5c00d5465f2d20d7472e5d81603b6";
   };
 
-  makeFlags = "prefix=$(out) LDFLAGS=-lm";
+  makeFlags = [ "prefix=$(out)" "LDFLAGS=-lm" ];
 
   preConfigure = ''
     sed -i 's@LIBS := \(.*\) -lm \(.*\)@LIBS := \1 \2@' Make.rules

--- a/pkgs/tools/package-management/clib/default.nix
+++ b/pkgs/tools/package-management/clib/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "fortify" ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   buildInputs = [ curl ];
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -94,9 +94,9 @@ common =
            # RISC-V support in progress https://github.com/seccomp/libseccomp/pull/50
         ++ lib.optional (!withLibseccomp) "--disable-seccomp-sandboxing";
 
-      makeFlags = "profiledir=$(out)/etc/profile.d";
+      makeFlags = [ "profiledir=$(out)/etc/profile.d" ];
 
-      installFlags = "sysconfdir=$(out)/etc";
+      installFlags = [ "sysconfdir=$(out)/etc" ];
 
       doInstallCheck = true; # not cross
 

--- a/pkgs/tools/security/aws-okta/default.nix
+++ b/pkgs/tools/security/aws-okta/default.nix
@@ -15,7 +15,7 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  buildFlags = "--tags release";
+  buildFlags = [ "--tags" "release" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libusb1 ];

--- a/pkgs/tools/security/crunch/default.nix
+++ b/pkgs/tools/security/crunch/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation  rec {
       --replace 'sudo ' ""
   '';
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Wordlist generator";

--- a/pkgs/tools/security/meo/default.nix
+++ b/pkgs/tools/security/meo/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "0ifg7y28s89i9gwda6fyj1jbrykbcvq8bf1m6rxmdcv5afi3arbq";
   };
 
-  buildFlags = "QMAKE=qmake";
+  buildFlags = [ "QMAKE=qmake" ];
 
   buildInputs = [ openssl pcre-cpp qt4 boost pkcs11helper ];
 

--- a/pkgs/tools/security/nitrokey-app/default.nix
+++ b/pkgs/tools/security/nitrokey-app/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     wrapQtAppsHook
   ];
-  cmakeFlags = "-DCMAKE_BUILD_TYPE=Release";
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
 
   meta = with stdenv.lib; {
     description      = "Provides extra functionality for the Nitrokey Pro and Storage";

--- a/pkgs/tools/security/phrasendrescher/default.nix
+++ b/pkgs/tools/security/phrasendrescher/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl libssh2 gpgme ];
 
-  configureFlags = "--with-plugins";
+  configureFlags = [ "--with-plugins" ];
 
   meta = with stdenv.lib; {
     description = "A modular and multi processing pass phrase cracking tool";

--- a/pkgs/tools/system/daemon/default.nix
+++ b/pkgs/tools/system/daemon/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
     url = http://libslack.org/daemon/download/daemon-0.6.4.tar.gz;
     sha256 = "18aw0f8k3j30xqwv4z03962kdpqd10nf1w9liihylmadlx5fmff4";
   };
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
   buildInputs = [ perl ];
 
   meta = {

--- a/pkgs/tools/system/ioping/default.nix
+++ b/pkgs/tools/system/ioping/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0cv2496jplka55yqdcf3ln78r8yggy4lgmgf06l6fbljjrdx7pgq";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "Disk I/O latency measuring tool";

--- a/pkgs/tools/system/lr/default.nix
+++ b/pkgs/tools/system/lr/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mpaqn0zfhxdf9wzs1wgdd29bjcyl3rgfdlqbwhiwcy2h3vy2h8s";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/chneukirchen/lr;

--- a/pkgs/tools/system/nq/default.nix
+++ b/pkgs/tools/system/nq/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1db96ykz35r273jyhf7cdknqk4p2jj9l8gbz7pjy1hq4pb6ffk99";
   };
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
   postPatch = ''
     sed -i tq \
       -e 's|\bfq\b|'$out'/bin/fq|g' \

--- a/pkgs/tools/system/xe/default.nix
+++ b/pkgs/tools/system/xe/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "04jr8f6jcijr0bsmn8ajm0aj35qh9my3xjsaq64h8lwg5bpyn29x";
   };
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
     description = "Simple xargs and apply replacement";

--- a/pkgs/tools/text/ansifilter/default.nix
+++ b/pkgs/tools/text/ansifilter/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ boost lua ];
 
-  makeFlags = "PREFIX=$(out) conf_dir=/etc/ansifilter";
+  makeFlags = [ "PREFIX=$(out)" "conf_dir=/etc/ansifilter" ];
 
   meta = with stdenv.lib; {
     description = "Tool to convert ANSI to other formats";

--- a/pkgs/tools/text/replace/default.nix
+++ b/pkgs/tools/text/replace/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "man" ];
 
-  makeFlags = "TREE=\$(out) MANTREE=\$(TREE)/share/man";
+  makeFlags = [ "TREE=\$(out)" "MANTREE=\$(TREE)/share/man" ];
 
   preBuild = ''
     sed -e "s@/bin/mv@$(type -P mv)@" -i replace.h

--- a/pkgs/tools/text/zimreader/default.nix
+++ b/pkgs/tools/text/zimreader/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     sha256 = "0x529137rxy6ld64xqa6xmn93121ripxvkf3sc7hv3wg6km182sw";
   };
 
-  patchFlags = "-p2";
+  patchFlags = [ "-p2" ];
   patches = [
     (fetchpatch {
       name = "zimreader_tntnet221.patch";

--- a/pkgs/tools/typesetting/hevea/default.nix
+++ b/pkgs/tools/typesetting/hevea/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = with ocamlPackages; [ ocaml ocamlbuild ];
 
-  makeFlags = "PREFIX=$(out)";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "A quite complete and fast LATEX to HTML translator";

--- a/pkgs/tools/video/yamdi/default.nix
+++ b/pkgs/tools/video/yamdi/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "4a6630f27f6c22bcd95982bf3357747d19f40bd98297a569e9c77468b756f715";
   };
 
-  buildFlags = "CC=cc";
+  buildFlags = [ "CC=cc" ];
 
   installPhase = ''
     install -D {,$out/bin/}yamdi


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @globin Contribution from Nixcon Hackathon.

This commit wasn't even compiled, so will likely have syntax errors. It was made by running a crude sequence of sed steps, after discussing with @globin at Nixcon. These were the sed steps for example for one set of flags:
```
rg -l 'configureFlags = "' | xargs -n 1 sed -i 's/Flags = "\([^ ]*\) \(.*\)"/Flags = "\1" "\2"/'
rg -l 'configureFlags = "' | xargs -n 1 sed -i 's/Flags = "\([^ ]*\)" "\([^ ]*\) \(.*\)"/Flags = "\1" "\2" "\3"/' 
rg -l 'configureFlags = "' | xargs -n 1 sed -i 's/Flags = "\([^ ]*\)" "\([^ ]*\)" "\([^ ]*\) \(.*\)"/Flags = "\1" "\2" "\3" "\4"/' 
rg -l 'configureFlags = "[^ ]*"' | xargs -n 1 sed -i 's/Flags = "\(.*\)"/Flags = \[ "\1" \]/'
```

This gets quite a few constructs wrong, I've fixed the ones I've noticed wrong. It will get legitimate spaces inside the strings wrong, or if there is an if else on the same line. 

I'll make a small python program that will work better, so other flags can be changed by @globin when he comes across more.
