### PR TITLE
nvidia-texture-tools: 2.1.0 -> unstable-2019-10-27

### DIFF
--- a/pkgs/development/libraries/nvidia-texture-tools/default.nix
+++ b/pkgs/development/libraries/nvidia-texture-tools/default.nix
@@ -37,5 +37,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/castano/nvidia-texture-tools;
     license = licenses.mit;
     platforms = platforms.unix;
+    broken = stdenv.isAarch64;
   };
 }

--- a/pkgs/development/libraries/nvidia-texture-tools/default.nix
+++ b/pkgs/development/libraries/nvidia-texture-tools/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nvidia-texture-tools";
-  version = "2.1.0";
+  version = "unstable-2019-10-27";
 
   src = fetchFromGitHub {
     owner = "castano";
     repo = "nvidia-texture-tools";
-    rev = version;
-    sha256 = "0p8ja0k323nkgm07z0qlslg6743vimy9rf3wad2968az0vwzjjyx";
+    rev = "a131e4c6b0b7c9c73ccc3c9e6f1c7e165be86bcc";
+    sha256 = "1qzyr3ib5dpxyq1y33lq02qv4cww075sm9bm4f651d34q5x38sk3";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

Updating to latest unstable that fixes build on darwin, but sadly is still failing on aarch64. Reported to upsteam as noted in the previous pull request.

Closes #41109.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).