### PR TITLE
trezor-udev-rules: init at unstable-2019-07-17

### DIFF
--- a/nixos/modules/services/hardware/trezord.nix
+++ b/nixos/modules/services/hardware/trezord.nix
@@ -44,20 +44,7 @@ in {
   ### implementation
 
   config = mkIf cfg.enable {
-    services.udev.packages = lib.singleton (pkgs.writeTextFile {
-      name = "trezord-udev-rules";
-      destination = "/etc/udev/rules.d/51-trezor.rules";
-      text = ''
-        # TREZOR v1 (One)
-        SUBSYSTEM=="usb", ATTR{idVendor}=="534c", ATTR{idProduct}=="0001", MODE="0660", GROUP="trezord", TAG+="uaccess", SYMLINK+="trezor%n"
-        KERNEL=="hidraw*", ATTRS{idVendor}=="534c", ATTRS{idProduct}=="0001", MODE="0660", GROUP="trezord", TAG+="uaccess"
-
-        # TREZOR v2 (T)
-        SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="53c0", MODE="0660", GROUP="trezord", TAG+="uaccess", SYMLINK+="trezor%n"
-        SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="53c1", MODE="0660", GROUP="trezord", TAG+="uaccess", SYMLINK+="trezor%n"
-        KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="53c1", MODE="0660", GROUP="trezord", TAG+="uaccess"
-      '';
-    });
+    services.udev.packages = [ pkgs.trezor-udev-rules ];
 
     systemd.services.trezord = {
       description = "TREZOR Bridge";

--- a/pkgs/development/python-modules/trezor/default.nix
+++ b/pkgs/development/python-modules/trezor/default.nix
@@ -11,6 +11,7 @@
 , libusb1
 , rlp
 , shamir-mnemonic
+, trezor-udev-rules
 }:
 
 buildPythonPackage rec {
@@ -24,7 +25,7 @@ buildPythonPackage rec {
     sha256 = "cd8aafd70a281daa644c4a3fb021ffac20b7a88e86226ecc8bb3e78e1734a184";
   };
 
-  propagatedBuildInputs = [ typing-extensions protobuf hidapi ecdsa mnemonic requests pyblake2 click construct libusb1 rlp shamir-mnemonic ];
+  propagatedBuildInputs = [ typing-extensions protobuf hidapi ecdsa mnemonic requests pyblake2 click construct libusb1 rlp shamir-mnemonic trezor-udev-rules ];
 
   checkInputs = [
     pytest

--- a/pkgs/os-specific/linux/trezor-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/trezor-udev-rules/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "trezor-udev-rules";
+  version = "unstable-2019-07-17";
+
+  udevRules = fetchurl {
+    # let's pin the latest commit in the repo which touched the udev rules file
+    url = "https://raw.githubusercontent.com/trezor/trezor-firmware/68a3094b0a8e36b588b1bcb58c34a2c9eafc0dca/common/udev/51-trezor.rules";
+    sha256 = "0vlxif89nsqpbnbz1vwfgpl1zayzmq87gw1snskn0qns6x2rpczk";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    cp ${udevRules} 51-trezor.rules
+    mkdir -p $out/lib/udev/rules.d
+    # we use trezord group, not plugdev
+    # we don't need the udev-acl tag
+    substituteInPlace 51-trezor.rules \
+      --replace 'GROUP="plugdev"' 'GROUP="trezord"' \
+      --replace ', TAG+="udev-acl"' ""
+    cp 51-trezor.rules $out/lib/udev/rules.d/51-trezor.rules
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Udev rules for Trezor";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ prusnak ];
+    platforms = platforms.linux;
+    homepage = "https://github.com/trezor/trezor-firmware/tree/master/common/udev";
+  };
+}

--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, trezor-udev-rules }:
 
 buildGoPackage rec {
   pname = "trezord-go";
@@ -12,6 +12,8 @@ buildGoPackage rec {
     rev    = "v${version}";
     sha256 = "00d90qmmk1pays78a2jm8gb7dncvlsjjn4033q1yd1ii3fxc6nh8";
   };
+
+  propagatedBuildInputs = [ trezor-udev-rules ];
 
   meta = with stdenv.lib; {
     description = "TREZOR Communication Daemon aka TREZOR Bridge";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6643,6 +6643,8 @@ in
 
   tpm2-tools = callPackage ../tools/security/tpm2-tools { };
 
+  trezor-udev-rules = callPackage ../os-specific/linux/trezor-udev-rules {};
+
   trezord = callPackage ../servers/trezord { };
 
   tthsum = callPackage ../applications/misc/tthsum { };


### PR DESCRIPTION
#### Motivation for this change

Let's create a separate udev rules package for Trezor so it works when a user installs `pythonPackages.trezor` or `trezord` packages manually and not via enabling the service via `services.trezord.enable`. Currently, the udev rules are installed only when the service is enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
