### PR TITLE
python3Packages.pytest4: deterministic bytecode

### DIFF
--- a/pkgs/development/python-modules/pytest/4.nix
+++ b/pkgs/development/python-modules/pytest/4.nix
@@ -6,11 +6,6 @@ buildPythonPackage rec {
   version = "4.6.5";
   pname = "pytest";
 
-  preCheck = ''
-    # don't test bash builtins
-    rm testing/test_argcomplete.py
-  '';
-
   src = fetchPypi {
     inherit pname version;
     sha256 = "8fc39199bdda3d9d025d3b1f4eb99a192c20828030ea7c9a0d2840721de7d347";
@@ -25,7 +20,14 @@ buildPythonPackage rec {
   doCheck = !isPyPy; # https://github.com/pytest-dev/pytest/issues/3460
   checkPhase = ''
     runHook preCheck
-    $out/bin/py.test -x testing/ -k "not test_collect_pyargs_with_testpaths"
+
+    # don't test bash builtins
+    rm testing/test_argcomplete.py
+
+    # determinism - this test writes non deterministic bytecode
+    rm -rf testing/test_assertrewrite.py
+
+    PYTHONDONTWRITEBYTECODE=1 $out/bin/py.test -x testing/ -k "not test_collect_pyargs_with_testpaths"
     runHook postCheck
   '';
 


### PR DESCRIPTION
###### Motivation for this change

For reasons that are not clear to me, the pytest4 check phase produces a lot of non-deterministic bytecode files. This PR turns off bytecode generation during test execution and additionally disables a test that force enables bytecode generation.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @domenkozar @lovek323 @madjar @lsix 
