### PR TITLE
stop using hardeningDisable = [ "fortify" ]; for Go packages

### DIFF
--- a/pkgs/applications/blockchains/go-ethereum.nix
+++ b/pkgs/applications/blockchains/go-ethereum.nix
@@ -10,9 +10,6 @@ buildGoPackage rec {
   propagatedBuildInputs =
     stdenv.lib.optionals stdenv.isDarwin [ libobjc IOKit ];
 
-  # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
-  hardeningDisable = [ "fortify" ];
-
   src = fetchFromGitHub {
     owner = "ethereum";
     repo = pname;

--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -16,8 +16,6 @@ buildGoPackage rec {
   goPackagePath = "github.com/containerd/containerd";
   outputs = [ "bin" "out" "man" ];
 
-  hardeningDisable = [ "fortify" ];
-
   buildInputs = [ btrfs-progs go-md2man utillinux ];
   buildFlags = "VERSION=v${version}";
 

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -37,8 +37,6 @@ rec {
         rev = containerdRev;
         sha256 = containerdSha256;
       };
-
-      hardeningDisable = [ "fortify" ];
     });
 
     docker-tini = tini.overrideAttrs  (oldAttrs: {
@@ -81,9 +79,6 @@ rec {
       rev = "v${version}";
       sha256 = sha256;
     };
-
-    # Optimizations break compilation of libseccomp c bindings
-    hardeningDisable = [ "fortify" ];
 
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -18,8 +18,6 @@ buildGoPackage rec {
 
   outputs = [ "bin" "out" "man" ];
 
-  # Optimizations break compilation of libseccomp c bindings
-  hardeningDisable = [ "fortify" ];
   nativeBuildInputs = [ pkgconfig go-md2man ];
 
   buildInputs = [ btrfs-progs libseccomp gpgme lvm2 systemd ];

--- a/pkgs/servers/livepeer/default.nix
+++ b/pkgs/servers/livepeer/default.nix
@@ -18,11 +18,6 @@ buildGoPackage rec {
 
   buildInputs = [ pkgconfig ffmpeg ];
 
-  # XXX This removes the -O2 flag, to avoid errors like:
-  #   cgo-dwarf-inference:2:8: error: enumerator value for '__cgo_enum__0' is not an integer constant
-  # This is a workaround for nixpkgs+golang BUG https://github.com/NixOS/nixpkgs/issues/25959
-  hardeningDisable = [ "fortify" ];
-
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -4,9 +4,6 @@ buildGoPackage rec {
   pname = "trezord-go";
   version = "2.0.27";
 
-  # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
-  hardeningDisable = [ "fortify" ];
-
   goPackagePath = "github.com/trezor/trezord-go";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/networking/flannel/default.nix
+++ b/pkgs/tools/networking/flannel/default.nix
@@ -9,8 +9,6 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/coreos/flannel";
 
-  hardeningDisable = [ "fortify" ];
-
   src = fetchFromGitHub {
     inherit rev;
     owner = "coreos";


### PR DESCRIPTION
###### Motivation for this change

it seems that the issue #25959 is not present anymore. Let's get rid of the workarounds.

The following got built just fine:
```
$ nix-shell -I nixpkgs=. -p go-ethereum containerd docker podman livepeer trezord flannel
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

go-ethereum: @adisbladis @asymmetric @lionello @xrelkd
containerd: @offline @vdemeester
docker: @nequissimus @offline @tailhook @vdemeester @periklis
podman: @vdemeester @saschagrunert
livepeer: @elitak
flannel: @johanot @offline