### PR TITLE
qt5ct: qtsvg, qmakeFlags nixification

### DIFF
--- a/pkgs/tools/misc/qt5ct/default.nix
+++ b/pkgs/tools/misc/qt5ct/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchurl, qtbase, qttools, qmake }:
+{ mkDerivation, lib, fetchurl, qtbase, qtsvg, qttools, qmake }:
 
 let inherit (lib) getDev; in
 
@@ -13,15 +13,12 @@ mkDerivation rec {
 
   nativeBuildInputs = [ qmake qttools ];
 
-  buildInputs = [ qtbase ];
+  buildInputs = [ qtbase qtsvg ];
 
   qmakeFlags = [
     "LRELEASE_EXECUTABLE=${getDev qttools}/bin/lrelease"
+    "PLUGINDIR=${placeholder "out"}/${qtbase.qtPluginPrefix}"
   ];
-
-  preConfigure = ''
-    qmakeFlags+=" PLUGINDIR=$out/$qtPluginPrefix"
-  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

As discussed in #71463, qt5ct cannot be built for unstable. @dtzWill mentioned a commit solving this situation, but the commit does not appear on any active branch. This PR picks it up for the master.

Fixes: #71463.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ralith @dtzWill 