### PR TITLE
shotgun: init at 2.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3911,6 +3911,11 @@
     githubId = 13791;
     name = "Luke Gorrie";
   };
+  lumi = {
+    email = "lumi@pew.im";
+    github = "lumi-me-not";
+    name = "lumi";
+  };
   luz = {
     email = "luz666@daum.net";
     github = "Luz";

--- a/pkgs/tools/graphics/shotgun/default.nix
+++ b/pkgs/tools/graphics/shotgun/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, rustPlatform, pkg-config, libXrandr, libX11 }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "shotgun";
+  version = "2.2.0";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libXrandr libX11 ];
+
+  src = fetchFromGitHub {
+    owner = "neXromancers";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "tJnF1X+NI1hP0J/n3rGy8TD/yIveqRPVlJvJvn0C7Do=";
+  };
+
+  cargoSha256 = "TL2WehcCwygLMVVrBHOX1HgVtDhgVsIgUeiadEjCj1o=";
+
+  meta = with lib; {
+    description = "Minimal X screenshot utility";
+    homepage = "https://github.com/neXromancers/shotgun";
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ lumi ];
+    platforms = platforms.linux;
+    badPlatforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20712,6 +20712,8 @@ in
 
   shfmt = callPackage ../tools/text/shfmt { };
 
+  shotgun = callPackage ../tools/graphics/shotgun {};
+
   shutter = callPackage ../applications/graphics/shutter { };
 
   simple-scan = gnome3.simple-scan;


### PR DESCRIPTION
###### Motivation for this change

Adding the `shotgun` package. This is an X11 screen capture tool.

Repository: https://github.com/neXromancers/shotgun

I've also added myself to `maintainers`.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
