### PR TITLE
pythonPackages.py3buddy: cleanup

### DIFF
--- a/pkgs/development/python-modules/py3buddy/default.nix
+++ b/pkgs/development/python-modules/py3buddy/default.nix
@@ -22,17 +22,17 @@ stdenv.mkDerivation rec {
   dontCheck = true;
 
   installPhase = ''
-    install -D py3buddy.py $out/lib/${python.libPrefix}/site-packages/py3buddy.py
+    install -D py3buddy.py $out/${python.sitePackages}/py3buddy.py
   '';
 
   postInstall = ''
     install -D 99-ibuddy.rules $out/lib/udev/rules.d/99-ibuddy.rules
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Code to work with the iBuddy MSN figurine";
     homepage = "https://github.com/armijnhemel/py3buddy";
-    license = with stdenv.lib.licenses; [ mit ];
-    maintainers = with stdenv.lib.maintainers; [ prusnak ];
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ prusnak ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -906,7 +906,7 @@ in {
 
   pybind11 = callPackage ../development/python-modules/pybind11 { };
 
-  py3buddy = callPackage ../development/python-modules/py3buddy { };
+  py3buddy = toPythonModule (callPackage ../development/python-modules/py3buddy { });
 
   pybullet = callPackage ../development/python-modules/pybullet { };
 


### PR DESCRIPTION
###### Motivation for this change

Small cleanup of the package definition

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
