### PR TITLE
fbterm: fix cross-build

### DIFF
--- a/pkgs/os-specific/linux/fbterm/default.nix
+++ b/pkgs/os-specific/linux/fbterm/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     inherit (s) url sha256;
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ncurses ];
   inherit buildInputs;
 
   preConfigure = ''
@@ -31,6 +31,7 @@ stdenv.mkDerivation {
   preBuild = ''
     mkdir -p "$out/share/terminfo"
     tic -a -v2 -o"$out/share/terminfo" terminfo/fbterm
+    makeFlagsArray+=("AR=$AR")
   '';
 
   patches = [
@@ -47,6 +48,7 @@ stdenv.mkDerivation {
       url = "https://raw.githubusercontent.com/glitsj16/fbterm-patched/d1fe03313be4654dd0a1c0bb5f51530732345134/miscoloring-fix.patch";
       sha256 = "1mjszji0jgs2jsagjp671fv0d1983wmxv009ff1jfhi9pbay6jd0";
     })
+    ./select.patch
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/fbterm/select.patch
+++ b/pkgs/os-specific/linux/fbterm/select.patch
@@ -1,0 +1,12 @@
+diff --git a/src/fbio.cpp b/src/fbio.cpp
+index e5afc44..2485227 100644
+--- a/src/fbio.cpp
++++ b/src/fbio.cpp
+@@ -18,6 +18,7 @@
+  *
+  */
+ 
++#include <sys/select.h>
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include "config.h"


### PR DESCRIPTION
###### Motivation for this change
Cross-compilation!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).