### PR TITLE
scaff: init at 0.1.1

### DIFF
--- a/pkgs/development/tools/scaff/default.nix
+++ b/pkgs/development/tools/scaff/default.nix
@@ -1,0 +1,26 @@
+{ lib, rustPlatform, fetchFromGitLab, pkgconfig, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "scaff";
+  version = "0.1.1";
+
+  src = fetchFromGitLab {
+    owner = "jD91mZM2";
+    repo = pname;
+    rev = version;
+
+    sha256 = "1s5v50205l2h33pccyafrjv3a6lpb62inhm8z81hkvx53bqifvd7";
+  };
+
+  cargoSha256 = "17rnzwlgrpr6isbajaccxa83msvvskxyqrc4cirgjmc7aqa0ilbh";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openssl ];
+
+  meta = with lib; {
+    description = "Painless and powerful scaffolding of projects";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jD91mZM2 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10124,6 +10124,8 @@ in
 
   sauce-connect = callPackage ../development/tools/sauce-connect { };
 
+  scaff = callPackage ../development/tools/scaff { };
+
   selenium-server-standalone = callPackage ../development/tools/selenium/server { };
 
   selendroid = callPackage ../development/tools/selenium/selendroid { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).