### PR TITLE
openexr-2.3.0: patch CVE-2018-18444

### DIFF
--- a/pkgs/development/libraries/ilmbase/default.nix
+++ b/pkgs/development/libraries/ilmbase/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, buildPackages, automake, autoconf, libtool, which }:
+{ stdenv, fetchurl, buildPackages, automake, autoconf, libtool, which,
+  fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "ilmbase";
@@ -21,7 +22,17 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_LINK = [ "-pthread" ];
 
-  patches = [ ./bootstrap.patch ./cross.patch ];
+  patches = [
+    ./bootstrap.patch
+    ./cross.patch
+    (fetchpatch {
+      name = "CVE-2018-18443.patch";
+      url = "https://github.com/kdt3rd/openexr/commit/5fa930b82cff2db386c64ca512af19e60c14d32a.patch";
+      sha256 = "1j6xd0qkx99acc1szycxaj0wwp01yac67jz48hwc4fwwpz8blx4s";
+      stripLen = 1;
+      excludes = [ "CHANGES.md" ];
+    })
+  ];
 
   # fails 1 out of 1 tests with
   # "lt-ImathTest: testBoxAlgo.cpp:892: void {anonymous}::boxMatrixTransform(): Assertion `b21 == b2' failed"

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, buildPackages, fetchurl, autoconf, automake, libtool, pkgconfig, zlib, ilmbase, }:
+{ lib, stdenv, buildPackages, fetchurl, autoconf, automake, libtool, pkgconfig,
+  zlib, ilmbase, fetchpatch }:
 
 let
   # Doesn't really do anything when not crosscompiling
@@ -16,6 +17,12 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./bootstrap.patch
+    (fetchpatch {
+      name = "CVE-2018-18444.patch";
+      url = "https://github.com/openexr/openexr/commit/1b0f1e5d7dcf2e9d6cbb4e005e803808b010b1e0.patch";
+      sha256 = "0f5m4wdwqqg8wfg7azzsz5yfpdrvws314rd4sqfc74j1g6wrcnqj";
+      stripLen = 1;
+    })
   ];
 
   outputs = [ "bin" "dev" "out" "doc" ];


### PR DESCRIPTION
###### Motivation for this change

Include a security fix for CVE-2018-18444 as reported in #51460. Although 2.4.0 has been released, I decided to backport the fix as it is tiny.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) -> _minimal_
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

_no maintainer in default.nix_
