### PR TITLE
ocamlPackages.ocp-indent: 1.7.0 → 1.8.1

### DIFF
--- a/pkgs/development/tools/ocaml/ocp-indent/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-indent/default.nix
@@ -1,12 +1,12 @@
 { lib, fetchzip, buildDunePackage, cmdliner }:
 
 buildDunePackage rec {
-  version = "1.7.0";
+  version = "1.8.1";
   pname = "ocp-indent";
 
   src = fetchzip {
     url = "https://github.com/OCamlPro/ocp-indent/archive/${version}.tar.gz";
-    sha256 = "006x3fsd61vxnxj4chlakyk3b2s10pb0bdl46g0ghf3j8h33x7hc";
+    sha256 = "0h4ysh36q1fxc40inhsdq2swqpfm15lpilqqcafs5ska42pn7s68";
   };
 
   minimumOCamlVersion = "4.02";


### PR DESCRIPTION
###### Motivation for this change

Fixes & compat with OCaml 4.08

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jirkamarsik 
