### PR TITLE
pythonPackages.pylint: add setuptools

### DIFF
--- a/pkgs/development/python-modules/pylint/1.9.nix
+++ b/pkgs/development/python-modules/pylint/1.9.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, buildPythonPackage, fetchPypi, astroid, six, isort,
   mccabe, configparser, backports_functools_lru_cache, singledispatch,
-  pytest, pytestrunner, pyenchant }:
+  pytest, pytestrunner, pyenchant, setuptools }:
 
 buildPythonPackage rec {
   pname = "pylint";
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest pytestrunner pyenchant ];
 
-  propagatedBuildInputs = [ astroid six isort mccabe configparser backports_functools_lru_cache singledispatch ];
+  propagatedBuildInputs = [ astroid six isort mccabe configparser backports_functools_lru_cache singledispatch setuptools ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
     # Remove broken darwin test


### PR DESCRIPTION
Previously it was missing a runtime dependency on setuptools:

    [kier@saelli:~/checkouts/nixpkgs]$ $(nix-build -A python27Packages.pylint --no-out-link)/bin/pylint
    Traceback (most recent call last):
      File "/nix/store/0k8h6n6nxjcs2j5jp54mfppjbx37hrrg-python2.7-pylint-1.9.5/bin/.pylint-wrapped", line 6, in <module>
        from pylint import run_pylint
      File "/nix/store/0k8h6n6nxjcs2j5jp54mfppjbx37hrrg-python2.7-pylint-1.9.5/lib/python2.7/site-packages/pylint/__init__.py", line 11, in <module>
        from .__pkginfo__ import version as __version__
      File "/nix/store/0k8h6n6nxjcs2j5jp54mfppjbx37hrrg-python2.7-pylint-1.9.5/lib/python2.7/site-packages/pylint/__pkginfo__.py", line 25, in <module>
        from pkg_resources import parse_version
    ImportError: No module named pkg_resources

With this change, the same command now correctly prints pylint's help text.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
