### PR TITLE
xapian: 1.4.12 -> 1.4.13

### DIFF
--- a/pkgs/development/libraries/xapian/default.nix
+++ b/pkgs/development/libraries/xapian/default.nix
@@ -37,5 +37,5 @@ let
     };
   };
 in {
-  xapian_1_4 = generic "1.4.12" "0z5c1y9vp519h2x2igjq39v6j615nppry0wasd0xn4hphgd3d2jg";
+  xapian_1_4 = generic "1.4.13" "0z0k8902bz2ckdggikj5yz11ik2n8krmdwzvpqv60phcm3zzzy4k";
 }

--- a/pkgs/development/libraries/xapian/skip-flaky-darwin-test.patch
+++ b/pkgs/development/libraries/xapian/skip-flaky-darwin-test.patch
@@ -1,14 +1,14 @@
 diff -Naur xapian-core.old/tests/api_db.cc xapian-core.new/tests/api_db.cc
 --- xapian-core.old/tests/api_db.cc
 +++ xapian-core.new/tests/api_db.cc
-@@ -998,6 +998,7 @@
+@@ -1020,6 +1020,7 @@
  
  // test for keepalives
  DEFINE_TESTCASE(keepalive1, remote) {
 +    SKIP_TEST("Fails in darwin nix build environment");
-     Xapian::Database db(get_remote_database("apitest_simpledata", 5000));
+     XFAIL_FOR_BACKEND("multi_glass_remoteprog_glass",
+ 		      "Multi remote databases are currently buggy");
  
-     /* Test that keep-alives work */
 diff -Naur xapian-core.old/tests/api_scalability.cc xapian-core.new/tests/api_scalability.cc
 --- xapian-core.old/tests/api_scalability.cc
 +++ xapian-core.new/tests/api_scalability.cc


### PR DESCRIPTION
###### Motivation for this change
Supersedes #71939 simply including an updated darwin patch. And rebased for good measure.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
