### PR TITLE
tev: init at 1.13

### DIFF
--- a/pkgs/applications/graphics/tev/default.nix
+++ b/pkgs/applications/graphics/tev/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchFromGitHub
+, cmake, wrapGAppsHook
+, libX11, xorg, libzip, glfw, gnome3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tev";
+  version = "1.13";
+
+  src = fetchFromGitHub {
+    owner = "Tom94";
+    repo = pname;
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "0c8md6yv1q449aszs05xfby6a2aiw8pac7x0zs169i5mpqrrbfa9";
+  };
+
+  nativeBuildInputs = [ cmake wrapGAppsHook ];
+  buildInputs = [ libX11 libzip glfw ]
+    ++ (with xorg; [ libXrandr libXinerama libXcursor libXi libXxf86vm ]);
+
+  dontWrapGApps = true; # We also need zenity (see below)
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "/usr/" "''${out}/"
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/tev \
+      "''${gappsWrapperArgs[@]}" \
+      --prefix PATH ":" "${gnome3.zenity}/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A high dynamic range (HDR) image comparison tool";
+    longDescription = ''
+      A high dynamic range (HDR) image comparison tool for graphics people. tev
+      allows viewing images through various tonemapping operators and inspecting
+      the values of individual pixels. Often, it is important to find exact
+      differences between pairs of images. For this purpose, tev allows rapidly
+      switching between opened images and visualizing various error metrics (L1,
+      L2, and relative versions thereof). To avoid clutter, opened images and
+      their layers can be filtered by keywords.
+      While the predominantly supported file format is OpenEXR certain other
+      types of images can also be loaded.
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21105,6 +21105,8 @@ in
 
   tetraproc = callPackage ../applications/audio/tetraproc { };
 
+  tev = callPackage ../applications/graphics/tev { };
+
   thinkingRock = callPackage ../applications/misc/thinking-rock { };
 
   thonny = callPackage ../applications/editors/thonny { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
