### PR TITLE
lib: Add lib.maintainer-groups

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -24,6 +24,7 @@ let
     # packaging
     customisation = callLibs ./customisation.nix;
     maintainers = import ../maintainers/maintainer-list.nix;
+    teams = callLibs ../maintainers/team-list.nix;
     meta = callLibs ./meta.nix;
     sources = callLibs ./sources.nix;
     versions = callLibs ./versions.nix;

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1,0 +1,24 @@
+/* List of maintainer teams.
+    name = {
+      # Required
+      members = [ maintainer1 maintainer2 ];
+      scope = "Maintain foo packages.";
+    };
+
+  where
+
+  - `members` is the list of maintainers belonging to the group,
+  - `scope` describes the scope of the group.
+
+  More fields may be added in the future.
+
+  Please keep the list alphabetically sorted.
+  */
+
+{ lib }:
+with lib.maintainers; {
+  freedesktop = {
+    members = [ jtojnar worldofpeace ];
+    scope = "Maintain Freedesktop.org packages for graphical desktop.";
+  };
+}

--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
     description = "System service to manage, install and generate color profiles to accurately color manage input and output devices";
     homepage = https://www.freedesktop.org/software/colord/;
     license = licenses.lgpl2Plus;
-    maintainers = [ maintainers.marcweber ];
+    maintainers = [ maintainers.marcweber ] ++ teams.freedesktop.members;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
There are many people interested in being responsible for core desktop packages but adding themselves to each one of them is a chore. This PR adds an indirection simplifying this use case. 