### PR TITLE
gtranslator: 3.32.1 → 3.34.0

### DIFF
--- a/pkgs/tools/text/gtranslator/default.nix
+++ b/pkgs/tools/text/gtranslator/default.nix
@@ -9,6 +9,8 @@
 , wrapGAppsHook
 , libxml2
 , libgda
+, libsoup
+, json-glib
 , gspell
 , glib
 , gtk3
@@ -19,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gtranslator";
-  version = "3.32.1";
+  version = "3.34.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1nmlj41wm02lbgrxdlpqpcgdab5cxsvggvqnk43v6kk86q27pcz1";
+    sha256 = "05zvpx330h9k7b12p07bhcy47vq66260fmiph2b6h97xpl15rwmj";
   };
 
   nativeBuildInputs = [
@@ -42,6 +44,8 @@ stdenv.mkDerivation rec {
     gtk3
     gtksourceview4
     libgda
+    libsoup
+    json-glib
     gettext
     gspell
     gsettings-desktop-schemas


### PR DESCRIPTION
There is like ton of warnings:

```
(gtranslator:635): GtkSourceView-CRITICAL **: 03:25:48.702: gtk_source_buffer_new_with_language: assertion 'GTK_SOURCE_IS_LANGUAGE (language)' failed

(gtranslator:635): GtkSourceView-CRITICAL **: 03:25:48.702: gtk_source_buffer_set_highlight_syntax: assertion 'GTK_SOURCE_IS_BUFFER (buffer)' failed

(gtranslator:635): GtkSourceView-WARNING **: 03:25:48.702: Failed to load '/nix/store/b3ksa6kz93q8ymbl0ipba5aji4wvvjaz-gtranslator-3.34.0/share/gtranslator/sourceview/gtranslator.lang': could not find the RelaxNG schema file
```

most likely caused by this weird thing:

https://gitlab.gnome.org/GNOME/gtranslator/commit/11b7fb5a7ac361133f7c895b74a083f4925131a6#526d558dcb822f9947243577ed64fa2c60980044_346_349

but it appears to work otherwise.