### PR TITLE
gnutls-kdh: fix build

### DIFF
--- a/pkgs/development/libraries/nettle/3.4.nix
+++ b/pkgs/development/libraries/nettle/3.4.nix
@@ -1,0 +1,10 @@
+{ callPackage, fetchurl, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "3.4.1";
+
+  src = fetchurl {
+    url = "mirror://gnu/nettle/nettle-${version}.tar.gz";
+    sha256 = "1bcji95n1iz9p9vsgdgr26v6s7zhpsxfbjjwpqcihpfd6lawyhgr";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12958,6 +12958,8 @@ in
 
   nettle = callPackage ../development/libraries/nettle { };
 
+  nettle_3_4 = callPackage ../development/libraries/nettle/3.4.nix { };
+
   newt = callPackage ../development/libraries/newt { };
 
   nghttp2 = callPackage ../development/libraries/nghttp2 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11267,6 +11267,7 @@ in
 
   gnutls-kdh = callPackage ../development/libraries/gnutls-kdh/3.5.nix {
     gperf = gperf_3_0;
+    nettle = nettle_3_4; # https://github.com/arpa2/gnutls-kdh/issues/2
   };
 
   gpac = callPackage ../applications/video/gpac { };


### PR DESCRIPTION
###### Motivation for this change
closes #72123

gnutls-kdh doesn't build with nettle 3.5.1, this pretty much reverts the bump for gnutls-kdh only

also fixes lutris build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
