### PR TITLE
go-license-detector: init at 3.0.2

### DIFF
--- a/pkgs/development/tools/misc/go-license-detector/default.nix
+++ b/pkgs/development/tools/misc/go-license-detector/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-license-detector";
+  version = "3.0.2";
+
+  src = fetchFromGitHub {
+    owner = "src-d";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0gp7na2hqn5crr5x4khllsq7ka9h7rx8b4y10yzxmi0wpmxr53sw";
+  };
+
+  modSha256 = "163f1kiy7kqrnaazb8ydaaiz57lv30jyjkvv6i7pczvcg9yfhmdb";
+
+  meta = with lib; {
+    description = "Reliable project licenses detector";
+    homepage = "https://github.com/src-d/go-license-detector";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25947,4 +25947,5 @@ in
 
   quartus-prime-lite = callPackage ../applications/editors/quartus-prime {};
 
+  go-license-detector = callPackage ../development/tools/misc/go-license-detector { };
 }


### PR DESCRIPTION
###### Motivation for this change

Another utility for detecting licenses under which source files are
licensed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).