### PR TITLE
arrayfire: update

### DIFF
--- a/pkgs/development/libraries/arrayfire/default.nix
+++ b/pkgs/development/libraries/arrayfire/default.nix
@@ -1,36 +1,16 @@
 { stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig
 , cudatoolkit, opencl-clhpp, ocl-icd, fftw, fftwFloat, mkl
 , blas, openblas, boost, mesa, libGLU_combined
-, freeimage, python
+, freeimage, python, clfft, clblas
+, doxygen, buildDocs ? false
 }:
 
 let
-  version = "3.6.4";
+  strOnLinux = stdenv.lib.optionalString stdenv.isLinux;
 
-  clfftSource = fetchFromGitHub {
-    owner = "arrayfire";
-    repo = "clFFT";
-    rev = "16925fb93338b3cac66490b5cf764953d6a5dac7";
-    sha256 = "0y35nrdz7w4n1l17myhkni3hwm37z775xn6f76xmf1ph7dbkslsc";
-    fetchSubmodules = true;
-  };
-
-  clblasSource = fetchFromGitHub {
-    owner = "arrayfire";
-    repo = "clBLAS";
-    rev = "1f3de2ae5582972f665c685b18ef0df43c1792bb";
-    sha256 = "154mz52r5hm0jrp5fqrirzzbki14c1jkacj75flplnykbl36ibjs";
-    fetchSubmodules = true;
-  };
-
-  cl2hppSource = fetchurl {
-    url = "https://github.com/KhronosGroup/OpenCL-CLHPP/releases/download/v2.0.10/cl2.hpp";
-    sha256 = "1v4q0g6b6mwwsi0kn7kbjn749j3qafb9r4ld3zdq1163ln9cwnvw";
-  };
-
-in stdenv.mkDerivation {
+in stdenv.mkDerivation rec {
   pname = "arrayfire";
-  inherit version;
+  version = "3.6.4";
 
   src = fetchurl {
     url = "http://arrayfire.com/arrayfire_source/arrayfire-full-${version}.tar.bz2";
@@ -41,21 +21,21 @@ in stdenv.mkDerivation {
     "-DAF_BUILD_OPENCL=OFF"
     "-DAF_BUILD_EXAMPLES=OFF"
     "-DBUILD_TESTING=OFF"
-    "-DCMAKE_LIBRARY_PATH=${cudatoolkit}/lib/stubs"
+    (strOnLinux "-DCMAKE_LIBRARY_PATH=${cudatoolkit}/lib/stubs")
   ];
 
   patches = [ ./no-download.patch ];
 
   postPatch = ''
     mkdir -p ./build/third_party/clFFT/src
-    cp -R --no-preserve=mode,ownership ${clfftSource}/ ./build/third_party/clFFT/src/clFFT-ext/
+    cp -R --no-preserve=mode,ownership ${clfft.src}/ ./build/third_party/clFFT/src/clFFT-ext/
     mkdir -p ./build/third_party/clBLAS/src
-    cp -R --no-preserve=mode,ownership ${clblasSource}/ ./build/third_party/clBLAS/src/clBLAS-ext/
+    cp -R --no-preserve=mode,ownership ${clblas.src}/ ./build/third_party/clBLAS/src/clBLAS-ext/
     mkdir -p ./build/include/CL
-    cp -R --no-preserve=mode,ownership ${cl2hppSource} ./build/include/CL/cl2.hpp
+    cp -R --no-preserve=mode,ownership ${opencl-clhpp}/include/CL/cl2.hpp ./build/include/CL/cl2.hpp
   '';
 
-  preBuild = ''
+  preBuild = strOnLinux ''
     export CUDA_PATH="${cudatoolkit}"
   '';
 
@@ -64,6 +44,7 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     pkgconfig
+    python
   ];
 
   buildInputs = [
@@ -72,15 +53,18 @@ in stdenv.mkDerivation {
     openblas
     libGLU_combined
     mesa freeimage
-    boost.out boost.dev python
-  ] ++ (stdenv.lib.optional stdenv.isLinux [ cudatoolkit ocl-icd ]);
+    boost.out boost.dev
+  ] ++ (stdenv.lib.optional stdenv.isLinux [ cudatoolkit ocl-icd ])
+    ++ (stdenv.lib.optional buildDocs [ doxygen ]);
 
   meta = with stdenv.lib; {
-    description = "A general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices";
+    description = "A general-purpose library for parallel and massively-parallel computations";
+    longDescription = ''
+      A general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.";
+    '';
     license = licenses.bsd3;
-    homepage = https://arrayfire.com/ ;
+    homepage = "https://arrayfire.com/";
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with stdenv.lib.maintainers; [ chessai ];
-    inherit version;
+    maintainers = with maintainers; [ chessai ];
   };
 }


### PR DESCRIPTION
- Depend on `clfft`, `clblas`, and `opencl-clhpp` from nixpkgs (do not
fetch their sources)
- Add `buildDocs` flag. When set to true, arrayfire's docs will be
built using `doxygen`.
- Ensure that `cudatoolkit` is not evaluated on darwin.
- Move `python` from `buildInputs` to `nativeBuildInputs`.
- Meta: Shrink `description` and add `longDescription`.
- Meta: `homepage` formatting now adheres to nixpkgs manual.
- A few minour syntactic-only changes.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
