### PR TITLE
passExtensions.pass-import: 2.3 -> 2.6

### DIFF
--- a/pkgs/tools/security/pass/extensions/import.nix
+++ b/pkgs/tools/security/pass/extensions/import.nix
@@ -1,34 +1,51 @@
-{ stdenv, pass, fetchFromGitHub, pythonPackages, makeWrapper }:
+{ stdenv, pass, fetchFromGitHub, pythonPackages, makeWrapper, fetchpatch }:
 
 let
-  pythonEnv = pythonPackages.python.withPackages (p: [ p.defusedxml ]);
+  pythonEnv = pythonPackages.python.withPackages (p: [
+    p.defusedxml
+    p.setuptools
+    p.pyaml
+  ]);
 
 in stdenv.mkDerivation rec {
   pname = "pass-import";
-  version = "2.3";
+  version = "2.6";
 
   src = fetchFromGitHub {
     owner = "roddhjav";
     repo = "pass-import";
     rev = "v${version}";
-    sha256 = "1209aqkiqqbir5yzwk5jvyk8c1fyrsj9igr3n4banf347rlwmzfv";
+    sha256 = "1q8rln4djh2z8j2ycm654df5y6anm5iv2r19spgy07c3fnisxlac";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ pythonEnv ];
 
-  patchPhase = ''
+  patches = [
+    # https://github.com/roddhjav/pass-import/pull/91
+    (fetchpatch {
+      url = "https://github.com/roddhjav/pass-import/commit/6ccaf639e92df45bd400503757ae4aa2c5c030d7.patch";
+      sha256 = "0lw9vqvbqcy96s7v7nz0i1bdx93x7qr13azymqypcdhjwmq9i63h";
+    })
+  ];
+
+  postPatch = ''
     sed -i -e 's|$0|${pass}/bin/pass|' import.bash
   '';
 
   dontBuild = true;
 
-  installFlags = [ "PREFIX=$(out)" ];
+  installFlags = [
+    "PREFIX=$(out)"
+    "BASHCOMPDIR=$(out)/etc/bash_completion.d"
+  ];
 
   postFixup = ''
+    install -D pass_import.py $out/${pythonPackages.python.sitePackages}/pass_import.py
     wrapProgram $out/lib/password-store/extensions/import.bash \
       --prefix PATH : "${pythonEnv}/bin" \
+      --prefix PYTHONPATH : "$out/${pythonPackages.python.sitePackages}" \
       --run "export PREFIX"
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
