### PR TITLE
Doc: various improvements NixOS and Nixpkgs manuals

### DIFF
--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -5,7 +5,7 @@
   <subtitle>Version <xi:include href=".version" parse="text" />
   </subtitle>
  </info>
- <xi:include href="introduction.chapter.xml" />
+ <xi:include href="preface.chapter.xml" />
  <part>
   <title>Using Nixpkgs</title>
   <xi:include href="configuration.xml" />

--- a/doc/preface.chapter.md
+++ b/doc/preface.chapter.md
@@ -1,44 +1,45 @@
 ---
-title: Introduction
+title: Preface
 author: Frederik Rietdijk
 date: 2015-11-25
 ---
 
-# Introduction
+# Preface
 
 The Nix Packages collection (Nixpkgs) is a set of thousands of packages for the
-[Nix package manager](http://nixos.org/nix/), released under a
+[Nix package manager](https://nixos.org/nix/), released under a
 [permissive MIT/X11 license](https://github.com/NixOS/nixpkgs/blob/master/COPYING).
 Packages are available for several platforms, and can be used with the Nix
-package manager on most GNU/Linux distributions as well as NixOS.
+package manager on most GNU/Linux distributions as well as [NixOS](https://nixos.org/nixos).
 
 This manual primarily describes how to write packages for the Nix Packages collection
 (Nixpkgs). Thus it’s mainly for packagers and developers who want to add packages to
 Nixpkgs. If you like to learn more about the Nix package manager and the Nix
-expression language, then you are kindly referred to the [Nix manual](http://nixos.org/nix/manual/).
+expression language, then you are kindly referred to the [Nix manual](https://nixos.org/nix/manual/).
+The NixOS distribution is documented in the [NixOS manual](https://nixos.org/nixos/manual/).
 
 ## Overview of Nixpkgs
 
 Nix expressions describe how to build packages from source and are collected in
 the [nixpkgs repository](https://github.com/NixOS/nixpkgs). Also included in the
 collection are Nix expressions for
-[NixOS modules](http://nixos.org/nixos/manual/index.html#sec-writing-modules).
+[NixOS modules](https://nixos.org/nixos/manual/index.html#sec-writing-modules).
 With these expressions the Nix package manager can build binary packages.
 
 Packages, including the Nix packages collection, are distributed through
-[channels](http://nixos.org/nix/manual/#sec-channels). The collection is
+[channels](https://nixos.org/nix/manual/#sec-channels). The collection is
 distributed for users of Nix on non-NixOS distributions through the channel
 `nixpkgs`. Users of NixOS generally use one of the `nixos-*` channels, e.g.
-`nixos-16.03`, which includes all packages and modules for the stable NixOS
-16.03. Stable NixOS releases are generally only given
+`nixos-19.09`, which includes all packages and modules for the stable NixOS
+19.09. Stable NixOS releases are generally only given
 security updates. More up to date packages and modules are available via the
 `nixos-unstable` channel.
 
 Both `nixos-unstable` and `nixpkgs` follow the `master` branch of the Nixpkgs
 repository, although both do lag the `master` branch by generally
-[a couple of days](http://howoldis.herokuapp.com/). Updates to a channel are
+[a couple of days](https://howoldis.herokuapp.com/). Updates to a channel are
 distributed as soon as all tests for that channel pass, e.g.
-[this table](http://hydra.nixos.org/job/nixpkgs/trunk/unstable#tabs-constituents)
+[this table](https://hydra.nixos.org/job/nixpkgs/trunk/unstable#tabs-constituents)
 shows the status of tests for the `nixpkgs` channel.
 
 The tests are conducted by a cluster called [Hydra](http://nixos.org/hydra/),

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -62,7 +62,7 @@ let
     "--stringparam html.stylesheet 'style.css overrides.css highlightjs/mono-blue.css'"
     "--stringparam html.script './highlightjs/highlight.pack.js ./highlightjs/loader.js'"
     "--param xref.with.number.and.title 1"
-    "--param toc.section.depth 3"
+    "--param toc.section.depth 0"
     "--stringparam admon.style ''"
     "--stringparam callout.graphics.extension .svg"
     "--stringparam current.docid manual"

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -69,7 +69,6 @@ let
     "--param chunk.section.depth 0"
     "--param chunk.first.sections 1"
     "--param use.id.as.filename 1"
-    "--stringparam generate.toc 'book toc appendix toc'"
     "--stringparam chunk.toc ${toc}"
   ];
 

--- a/nixos/doc/manual/manual.xml
+++ b/nixos/doc/manual/manual.xml
@@ -8,32 +8,7 @@
   <subtitle>Version <xi:include href="./generated/version" parse="text" />
   </subtitle>
  </info>
- <preface xml:id="preface">
-  <title>Preface</title>
-  <para>
-   This manual describes how to install, use and extend NixOS, a Linux
-   distribution based on the purely functional package management system Nix.
-  </para>
-  <para>
-   If you encounter problems, please report them on the
-   <literal
-    xlink:href="https://discourse.nixos.org">Discourse</literal> or
-   on the <link
-    xlink:href="irc://irc.freenode.net/#nixos">
-   <literal>#nixos</literal> channel on Freenode</link>. Bugs should be
-   reported in
-   <link
-    xlink:href="https://github.com/NixOS/nixpkgs/issues">NixOS’
-   GitHub issue tracker</link>.
-  </para>
-  <note>
-   <para>
-    Commands prefixed with <literal>#</literal> have to be run as root, either
-    requiring to login as root user or temporarily switching to it using
-    <literal>sudo</literal> for example.
-   </para>
-  </note>
- </preface>
+ <xi:include href="preface.xml" />
  <xi:include href="installation/installation.xml" />
  <xi:include href="configuration/configuration.xml" />
  <xi:include href="administration/running.xml" />

--- a/nixos/doc/manual/preface.xml
+++ b/nixos/doc/manual/preface.xml
@@ -1,0 +1,29 @@
+<preface xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="preface">
+ <title>Preface</title>
+ <para>
+  This manual describes how to install, use and extend NixOS, a Linux
+  distribution based on the purely functional package management system
+  <link xlink:href="https://nixos.org/nix">Nix</link>.
+ </para>
+ <para>
+  If you encounter problems, please report them on the
+  <literal
+   xlink:href="https://discourse.nixos.org">Discourse</literal> or
+  on the <link
+   xlink:href="irc://irc.freenode.net/#nixos">
+  <literal>#nixos</literal> channel on Freenode</link>. Bugs should be
+  reported in
+  <link
+   xlink:href="https://github.com/NixOS/nixpkgs/issues">NixOS’
+  GitHub issue tracker</link>.
+ </para>
+ <note>
+  <para>
+   Commands prefixed with <literal>#</literal> have to be run as root, either
+   requiring to login as root user or temporarily switching to it using
+   <literal>sudo</literal> for example.
+  </para>
+ </note>
+</preface>

--- a/nixos/doc/manual/preface.xml
+++ b/nixos/doc/manual/preface.xml
@@ -5,7 +5,15 @@
  <para>
   This manual describes how to install, use and extend NixOS, a Linux
   distribution based on the purely functional package management system
-  <link xlink:href="https://nixos.org/nix">Nix</link>.
+  <link xlink:href="https://nixos.org/nix">Nix</link>, that is composed
+  using modules and packages defined in the
+  <link xlink:href="https://nixos.org/nixpkgs">Nixpkgs</link> project.
+ </para>
+ <para>
+  Additional information regarding the Nix package manager and the Nixpkgs
+  project can be found in respectively the
+  <link xlink:href="https://nixos.org/nix/manual">Nix manual</link> and the
+  <link xlink:href="https://nixos.org/nixpkgs/manual">Nixpkgs manual</link>.
  </para>
  <para>
   If you encounter problems, please report them on the


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
