### PR TITLE
libbacktrace: init at 2018-06-05

### DIFF
--- a/pkgs/development/libraries/libbacktrace/default.nix
+++ b/pkgs/development/libraries/libbacktrace/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, callPackage, fetchFromGitHub, enableStatic ? false, enableShared ? true }:
+let
+  yesno = b: if b then "yes" else "no";
+in stdenv.mkDerivation rec {
+  pname = "libbacktrace";
+  version = "2018-06-05";
+  src = fetchFromGitHub {
+    owner = "ianlancetaylor";
+    repo = pname;
+    rev = "5a99ff7fed66b8ea8f09c9805c138524a7035ece";
+    sha256 = "0mb81x76k335iz3h5nqxsj4z3cz2a13i33bkhpk6iffrjz9i4dhz";
+  };
+  configureFlags = [
+    "--enable-static=${yesno enableStatic}"
+    "--enable-shared=${yesno enableShared}"
+  ];
+  meta = with stdenv.lib; {
+    description = "A C library that may be linked into a C/C++ program to produce symbolic backtraces";
+    homepage = https://github.com/ianlancetaylor/libbacktrace;
+    maintainers = with maintainers; [ twey ];
+    license = with licenses; [ bsd3 ];
+  };
+}

--- a/pkgs/development/libraries/libbacktrace/default.nix
+++ b/pkgs/development/libraries/libbacktrace/default.nix
@@ -3,12 +3,12 @@ let
   yesno = b: if b then "yes" else "no";
 in stdenv.mkDerivation rec {
   pname = "libbacktrace";
-  version = "2018-06-05";
+  version = "2020-05-13";
   src = fetchFromGitHub {
     owner = "ianlancetaylor";
     repo = pname;
-    rev = "5a99ff7fed66b8ea8f09c9805c138524a7035ece";
-    sha256 = "0mb81x76k335iz3h5nqxsj4z3cz2a13i33bkhpk6iffrjz9i4dhz";
+    rev = "9b7f216e867916594d81e8b6118f092ac3fcf704";
+    sha256 = "0qr624v954gnfkmpdlfk66sxz3acyfmv805rybsaggw5gz5sd1nh";
   };
   configureFlags = [
     "--enable-static=${yesno enableStatic}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12658,6 +12658,8 @@ in
 
   libb2 = callPackage ../development/libraries/libb2 { };
 
+  libbacktrace = callPackage ../development/libraries/libbacktrace { };
+
   libbap = callPackage ../development/libraries/libbap {
     inherit (ocaml-ng.ocamlPackages_4_06) bap ocaml findlib ctypes;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers