### PR TITLE
aerc: Fix store references in default config

### DIFF
--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -18,6 +18,10 @@ buildGoModule rec {
     python3.pkgs.wrapPython
   ];
 
+  patches = [
+    ./runtime-sharedir.patch
+  ];
+
   pythonPath = [
     python3.pkgs.colorama
   ];

--- a/pkgs/applications/networking/mailreaders/aerc/runtime-sharedir.patch
+++ b/pkgs/applications/networking/mailreaders/aerc/runtime-sharedir.patch
@@ -1,0 +1,43 @@
+From 7ea68a2eef026723903d72f54ca54b629881ec06 Mon Sep 17 00:00:00 2001
+From: Tadeo Kondrak <me@tadeo.ca>
+Date: Mon, 28 Oct 2019 08:36:36 -0600
+Subject: [PATCH] Fix aerc breaking every time the package is rebuilt.
+
+On NixOS, the SHAREDIR changes on every rebuild to the package, but aerc
+fills it in as part of the default config. Fix this by not substituting
+@SHAREDIR@ in the default config until runtime.
+---
+ Makefile         | 2 +-
+ config/config.go | 3 +++
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index d3072d3..17ca0be 100644
+--- a/Makefile
++++ b/Makefile
+@@ -24,7 +24,7 @@ aerc: $(GOSRC)
+ 		-o $@
+ 
+ aerc.conf: config/aerc.conf.in
+-	sed -e 's:@SHAREDIR@:$(SHAREDIR):g' > $@ < config/aerc.conf.in
++	cat config/aerc.conf.in > $@
+ 
+ DOCS := \
+ 	aerc.1 \
+diff --git a/config/config.go b/config/config.go
+index bfcbecf..2f4e703 100644
+--- a/config/config.go
++++ b/config/config.go
+@@ -377,6 +377,9 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
+ 	if err = config.LoadConfig(file); err != nil {
+ 		return nil, err
+ 	}
++	for i, filter := range config.Filters {
++		config.Filters[i].Command = strings.ReplaceAll(filter.Command, "@SHAREDIR@", sharedir)
++	}
+ 	if ui, err := file.GetSection("general"); err == nil {
+ 		if err := ui.MapTo(&config.General); err != nil {
+ 			return nil, err
+-- 
+2.23.0
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#63499

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

Fixes #63499