### PR TITLE
ocamlPackages.ocamlearlybird: init at 0.1.5; ocamlPackages.angstrom: 0.10.0 -> 0.12.1

### DIFF
--- a/pkgs/development/ocaml-modules/angstrom-async/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-async/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, angstrom, async }:
+
+buildDunePackage rec {
+  pname = "angstrom-async";
+
+  inherit (angstrom) version src;
+
+  minimumOCamlVersion = "4.04.1";
+
+  propagatedBuildInputs = [ angstrom async ];
+
+  doCheck = true;
+
+  meta = {
+    inherit (angstrom.meta) homepage license;
+    description = "Async support for Angstrom";
+    maintainers = with stdenv.lib.maintainers; [ romildo ];
+  };
+}

--- a/pkgs/development/ocaml-modules/angstrom-lwt-unix/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-lwt-unix/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, angstrom, ocaml_lwt }:
+
+buildDunePackage rec {
+  pname = "angstrom-lwt-unix";
+
+  inherit (angstrom) version src;
+
+  minimumOCamlVersion = "4.03";
+
+  propagatedBuildInputs = [ angstrom ocaml_lwt ];
+
+  doCheck = true;
+
+  meta = {
+    inherit (angstrom.meta) homepage license;
+    description = "Lwt_unix support for Angstrom";
+    maintainers = with stdenv.lib.maintainers; [ romildo ];
+  };
+}

--- a/pkgs/development/ocaml-modules/angstrom-unix/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom-unix/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, angstrom }:
+
+buildDunePackage rec {
+  pname = "angstrom-unix";
+
+  inherit (angstrom) version src;
+
+  minimumOCamlVersion = "4.03";
+
+  propagatedBuildInputs = [ angstrom ];
+
+  doCheck = true;
+
+  meta = {
+    inherit (angstrom.meta) homepage license;
+    description = "Unix support for Angstrom";
+    maintainers = with stdenv.lib.maintainers; [ romildo ];
+  };
+}

--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -2,7 +2,7 @@
 
 buildDunePackage rec {
   pname = "angstrom";
-  version = "0.10.0";
+  version = "0.12.1";
 
   minimumOCamlVersion = "4.03";
 
@@ -10,7 +10,7 @@ buildDunePackage rec {
     owner  = "inhabitedtype";
     repo   = pname;
     rev    = version;
-    sha256 = "0lh6024yf9ds0nh9i93r9m6p5psi8nvrqxl5x7jwl13zb0r9xfpw";
+    sha256 = "0w0wavqzdy2hrh7cjyl9w72ad4vndhwhknwvyacvkwkja5wys5b2";
   };
 
   buildInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/earlybird/default.nix
+++ b/pkgs/development/ocaml-modules/earlybird/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchurl, buildDunePackage, angstrom, angstrom-lwt-unix,
+  batteries, cmdliner, lwt_ppx, ocaml_lwt, ppx_deriving_yojson,
+  ppx_tools_versioned, yojson }:
+
+buildDunePackage rec {
+  pname = "earlybird";
+  version = "0.1.5";
+
+  minimumOCamlVersion = "4.04";
+
+  src = fetchurl {
+    url = "https://github.com/hackwaly/ocamlearlybird/releases/download/${version}/${pname}-${version}.tbz";
+    sha256 = "10yflmsicw4sdmm075zjpbmxpwm9fvibnl3sl18zjpwnm6l9sv7d";
+  };
+
+  buildInputs = [ angstrom angstrom-lwt-unix batteries cmdliner lwt_ppx ocaml_lwt ppx_deriving_yojson ppx_tools_versioned yojson ];
+
+  meta = {
+    homepage = "https://github.com/hackwaly/ocamlearlybird";
+    description = "OCaml debug adapter";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -22,6 +22,8 @@ let
 
     angstrom-async = callPackage ../development/ocaml-modules/angstrom-async { };
 
+    angstrom-lwt-unix = callPackage ../development/ocaml-modules/angstrom-lwt-unix { };
+
     ansiterminal = callPackage ../development/ocaml-modules/ansiterminal { };
 
     apron = callPackage ../development/ocaml-modules/apron { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -20,6 +20,8 @@ let
 
     angstrom = callPackage ../development/ocaml-modules/angstrom { };
 
+    angstrom-async = callPackage ../development/ocaml-modules/angstrom-async { };
+
     ansiterminal = callPackage ../development/ocaml-modules/ansiterminal { };
 
     apron = callPackage ../development/ocaml-modules/apron { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -24,6 +24,8 @@ let
 
     angstrom-lwt-unix = callPackage ../development/ocaml-modules/angstrom-lwt-unix { };
 
+    angstrom-unix = callPackage ../development/ocaml-modules/angstrom-unix { };
+
     ansiterminal = callPackage ../development/ocaml-modules/ansiterminal { };
 
     apron = callPackage ../development/ocaml-modules/apron { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -231,6 +231,8 @@ let
 
     earley = callPackage ../development/ocaml-modules/earley { };
 
+    earlybird = callPackage ../development/ocaml-modules/earlybird { };
+
     easy-format = callPackage ../development/ocaml-modules/easy-format { };
 
     elina = callPackage ../development/ocaml-modules/elina { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- ocamlPackages.angstrom: 0.10.0 -> [0.12.1](https://github.com/inhabitedtype/angstrom/releases)
- ocamlPackages.angstrom-async: init at 0.12.1
- ocamlPackages.angstrom-lwt-unix: init at 0.12.1
- ocamlPackages.angstrom-unix: init at 0.12.1
- ocamlPackages.[ocamlearlybird](https://github.com/hackwaly/ocamlearlybird): init at 0.1.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).