### PR TITLE
symlinkJoin: fix cross

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -71,7 +71,7 @@ let
 
   trivialBuilders = self: super:
     import ../build-support/trivial-builders.nix {
-      inherit lib; inherit (self) stdenv stdenvNoCC; inherit (self.xorg) lndir;
+      inherit lib; inherit (self) stdenv stdenvNoCC; inherit (self.pkgsBuildHost.xorg) lndir;
       inherit (self) runtimeShell;
     };
 


### PR DESCRIPTION
I’m a bit confused by this — I don’t understand how it could have been broken all this time with nobody noticing! But apparently it was…