### PR TITLE
xzoom: fix version

### DIFF
--- a/pkgs/tools/X11/xzoom/default.nix
+++ b/pkgs/tools/X11/xzoom/default.nix
@@ -3,19 +3,17 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "xzoom";
-  major = "0";
-  minor = "3";
+  version = "0.3";
   patch = "24";
-  version = "${major}.${minor}.${patch}";
 
   # or fetchFromGitHub(owner,repo,rev) or fetchgit(rev)
   src = fetchurl {
-    url = "http://www.ibiblio.org/pub/linux/libs/X/${pname}-${major}.${minor}.tgz";
+    url = "http://www.ibiblio.org/pub/linux/libs/X/${pname}-${version}.tgz";
     sha256 = "0jzl5py4ny4n4i58lxx2hdwq9zphqf7h3m14spl3079y5mlzssxj";
   };
   patches = [
     (fetchurl {
-       url = "http://http.debian.net/debian/pool/main/x/xzoom/xzoom_${major}.${minor}-${patch}.diff.gz";
+       url = "http://http.debian.net/debian/pool/main/x/xzoom/xzoom_${version}-${patch}.diff.gz";
        sha256 = "0zhc06whbvaz987bzzzi2bz6h9jp6rv812qs7b71drivvd820qbh";
     })
   ];


### PR DESCRIPTION
###### Motivation for this change

After https://github.com/NixOS/nixpkgs/pull/71528 the error disappeared, but we have a different version than everyone else.

That is because we had the patch version applied to the version. The patch comes from debian, but even they use the official release version. So we should too.

https://repology.org/project/xzoom/versions

![Screenshot from 2019-10-28 17-34-18](https://user-images.githubusercontent.com/91113/67697664-34ac3100-f9a9-11e9-8c9c-16ebd18ae67f.png)

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c
