### PR TITLE
mariadb-connector-c: fix crypt_libs

### DIFF
--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake
+{ stdenv, fetchurl, cmake, fetchpatch
 , curl, openssl, zlib
 , libiconv
 , version, sha256, ...
@@ -17,6 +17,13 @@ stdenv.mkDerivation {
     ];
     inherit sha256;
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/MariaDB/mariadb-connector-c/commit/ee91b2c98a63acb787114dee4f2694e154630928.patch";
+      sha256 = "05mlyv20kzn9bax4byv2ph1cf42541fcl1zcqzbfwqmynnisvdah";
+    })
+  ];
 
   cmakeFlags = [
     "-DMARIADB_UNIX_ADDR=/run/mysqld/mysqld.sock"


### PR DESCRIPTION
###### Motivation for this change
Fixed this error in Darwin
```
[ 37%] Linking C shared module sha256_password.so
Undefined symbols for architecture x86_64:
  "_BIO_free", referenced from:
      _auth_sha256_client in sha256_pw.c.o
  "_BIO_new_mem_buf", referenced from:
      _auth_sha256_client in sha256_pw.c.o
  "_ERR_clear_error", referenced from:
      _auth_sha256_client in sha256_pw.c.o
  "_PEM_read_bio_RSA_PUBKEY", referenced from:
      _auth_sha256_client in sha256_pw.c.o
  "_RSA_free", referenced from:
      _auth_sha256_client in sha256_pw.c.o
  "_RSA_public_encrypt", referenced from:
      _auth_sha256_client in sha256_pw.c.o
  "_RSA_size", referenced from:
      _auth_sha256_client in sha256_pw.c.o
ld: symbol(s) not found for architecture x86_64
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [CMakeFiles/sha256_password.dir/build.make:84: sha256_password.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:237: CMakeFiles/sha256_password.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
builder for '/nix/store/npxzwxwzvyx7rk9jpamdpaggp556m8vd-mariadb-connector-c-3.1.4.drv' failed with exit code 2
error: build of '/nix/store/npxzwxwzvyx7rk9jpamdpaggp556m8vd-mariadb-connector-c-3.1.4.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
