### PR TITLE
vector: init at 0.5.0

### DIFF
--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, fetchFromGitHub, rustPlatform
+, openssl, pkgconfig, protobuf
+, Security, libiconv
+
+, features ?
+    (if stdenv.isAarch64
+     then [ "jemallocator" ]
+     else [ "leveldb" "jemallocator" ])
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "vector";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner  = "timberio";
+    repo   = pname;
+    rev    = "refs/tags/v${version}";
+    sha256 = "0niyxlvphn3awrpfh1hbqy767cckgjzyjrkqjxj844czxhh1hhff";
+  };
+
+  cargoSha256 = "0bdgan891hrah54g6aaysqizkxrfsbidnxihai0i7h7knzq9gsk5";
+  buildInputs = [ openssl pkgconfig protobuf ]
+                ++ stdenv.lib.optional stdenv.isDarwin [ Security libiconv ];
+
+  # needed for internal protobuf c wrapper library
+  PROTOC="${protobuf}/bin/protoc";
+  PROTOC_INCLUDE="${protobuf}/include";
+
+  # rdkafka fails to build, for some reason...
+  cargoBuildFlags = [ "--no-default-features" "--features" "${lib.concatStringsSep "," features}" ];
+  checkPhase = ":"; # skip tests, too -- they don't respect the rdkafka flag...
+
+  meta = with stdenv.lib; {
+    description = "A high-performance logs, metrics, and events router";
+    homepage    = "https://github.com/timberio/vector";
+    license     = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ thoughtpolice ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24201,6 +24201,10 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  vector = callPackage ../tools/misc/vector {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   epkowa = callPackage ../misc/drivers/epkowa { };
 
   utsushi = callPackage ../misc/drivers/utsushi { };


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).