### PR TITLE
ripasso-cursive: unstable-2019-08-27 -> 0.3.0

### DIFF
--- a/pkgs/tools/security/ripasso/cursive.nix
+++ b/pkgs/tools/security/ripasso/cursive.nix
@@ -1,30 +1,37 @@
-{ stdenv, lib, rustPlatform, fetchFromGitHub, pkgconfig, ncurses, python3, openssl, libgpgerror, gpgme, xorg }:
+{ stdenv, lib, rustPlatform, fetchFromGitHub, pkgconfig, ncurses, python3, openssl, libgpgerror, gpgme, xorg, AppKit, Security }:
 
 with rustPlatform;
 buildRustPackage rec {
-  version = "unstable-2019-08-27";
+  version = "0.3.0";
   pname = "ripasso-cursive";
 
   src = fetchFromGitHub {
     owner = "cortex";
     repo = "ripasso";
-    rev  = "1b5ef4ae19f95f1422ba5cb09e9e689880599c40";
-    sha256 = "1lh1in8knpqz4vbsmdyd4hh8y4bfhxjciysfbq3qzdpdpihgj0nn";
+    rev  = "release-${version}";
+    sha256 = "1rkb23i9gcfmifcl31s8w86k7aza6nxrh3w33fvhv1ins1gxxk7w";
   };
 
-  cargoSha256 = "0dwaa106vj7jbgshhqpjabsr0zmkg1a5syzky7jcaasvc7r7njwl";
-  cargoBuildFlags = [ "-p ripasso-cursive" ];
+  cargoSha256 = "1p0bsl4h2w257vfjbpqiga693gaslfq34g30dghpqb5n4kl416zp";
+
+  cargoBuildFlags = [ "-p ripasso-cursive -p ripasso-man" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     ncurses python3 openssl libgpgerror gpgme xorg.libxcb
-  ];
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ AppKit Security ];
+
+  preFixup = ''
+    mkdir -p "$out/man/man1"
+    $out/bin/ripasso-man > $out/man/man1/ripasso-cursive.1
+    rm $out/bin/ripasso-man
+  '';
 
   meta = with stdenv.lib; {
     description = "A simple password manager written in Rust";
     homepage = "https://github.com/cortex/ripasso";
     license = licenses.gpl3;
     maintainers = with maintainers; [ sgo ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2032,7 +2032,9 @@ in
     conf = config.riot-web.conf or null;
   };
 
-  ripasso-cursive = callPackage ../tools/security/ripasso/cursive.nix {};
+  ripasso-cursive = callPackage ../tools/security/ripasso/cursive.nix {
+    inherit (darwin.apple_sdk.frameworks) AppKit Security;
+  };
 
   roundcube = callPackage ../servers/roundcube { };
 


### PR DESCRIPTION
###### Motivation for this change

Updates ripasso-cursive to the latest release. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

