### PR TITLE
Fix build of obs-linuxbrowser

### DIFF
--- a/pkgs/applications/video/obs-studio/linuxbrowser.nix
+++ b/pkgs/applications/video/obs-studio/linuxbrowser.nix
@@ -5,18 +5,19 @@
 # mkdir -p ~/.config/obs-studio/plugins
 # ln -s ~/.nix-profile/share/obs/obs-plugins/obs-linuxbrowser ~/.config/obs-studio/plugins/
 
-{ stdenv, fetchFromGitHub, obs-studio, cmake, libcef
-}:
+{ stdenv, fetchFromGitHub, obs-studio, cmake, libcef }:
 
 stdenv.mkDerivation rec {
   pname = "obs-linuxbrowser";
-  version = "0.6.1";
+  version = "0.6.1-6-gf86dba6";
+
   src = fetchFromGitHub {
     owner = "bazukas";
     repo = "obs-linuxbrowser";
     rev = version;
-    sha256 = "1mi9pchy07ipnx1m2767n29d53v822yajcf6c3705dhz882z21zq";
+    sha256 = "08d7qz0721va88bcyia8p0ycw50f6x3yk97s3vzhsc9xpq691kpi";
   };
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ obs-studio ];
   postUnpack = ''
@@ -44,6 +45,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ puffnfresh ];
     license = licenses.gpl2;
     platforms = with platforms; linux;
-    broken = true;
   };
 }

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, cmake, alsaLib, atk, cairo, cups, dbus, expat, fontconfig
 , GConf, gdk-pixbuf, glib, gtk2, libX11, libxcb, libXcomposite, libXcursor
 , libXdamage, libXext, libXfixes, libXi, libXrandr, libXrender, libXScrnSaver
-, libXtst, nspr, nss, pango, libpulseaudio, systemd }:
+, libXtst, nspr, nss, pango, libpulseaudio, systemd, at-spi2-atk, at-spi2-core
+}:
 
 let
   libPath =
@@ -9,20 +10,24 @@ let
       alsaLib atk cairo cups dbus expat fontconfig GConf gdk-pixbuf glib gtk2
       libX11 libxcb libXcomposite libXcursor libXdamage libXext libXfixes libXi
       libXrandr libXrender libXScrnSaver libXtst nspr nss pango libpulseaudio
-      systemd
+      systemd at-spi2-core at-spi2-atk
     ];
 in
 stdenv.mkDerivation rec {
   pname = "cef-binary";
-  version = "3.3497.1833.g13f506f";
+  version = "74.1.14-g50c3c5c";
+
   src = fetchurl {
-    url = "http://opensource.spotify.com/cefbuilds/cef_binary_${version}_linux64.tar.bz2";
-    sha256 = "02v22yx1ga2yxagjblzkfw0ax7zkrdpc959l1a15m8nah3y7xf9p";
+    name = "cef_binary_74.1.14+g50c3c5c+chromium-74.0.3729.131_linux64_minimal.tar.bz2";
+    url = "http://opensource.spotify.com/cefbuilds/cef_binary_74.1.19%2Bgb62bacf%2Bchromium-74.0.3729.157_linux64_minimal.tar.bz2";
+    sha256 = "0v3540kq4y68gq7mb4d8a9issm363lm5ngrd6d96pcc7vckkw4wn";
   };
+
   nativeBuildInputs = [ cmake ];
   makeFlags = "libcef_dll_wrapper";
   dontStrip = true;
   dontPatchELF = true;
+
   installPhase = ''
     mkdir -p $out/lib/ $out/share/cef/
     cp libcef_dll_wrapper/libcef_dll_wrapper.a $out/lib/
@@ -39,6 +44,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ puffnfresh ];
     license = licenses.bsd3;
     platforms = with platforms; linux;
-    broken = true;
   };
 }


### PR DESCRIPTION
I would like to fix the build of `obs-linuxbrowser`, but it seems like I'll need some help along the way. Hopefully, there's someone who knows a bit about cmake and/or CEF to help me figure out why these builds are failing right now.

Anyhow, I updated CEF to `cef_binary_75.0.11+gf50b3c2+chromium-75.0.3770.100`, which seems to build fine. Then I updated `obs-linuxbrowser` to the latest version from https://github.com/bazukas/obs-linuxbrowser, but unfortunately that build fails as follows:

~~~
[ 63%] Linking C shared module build/obs-linuxbrowser/bin/64bit/libobs-linuxbrowser.so
[ 63%] Built target obs-linuxbrowser
In file included from /build/source/src/browser/browser-app.cpp:29:
/build/source/src/browser/browser-app.hpp:76:15: error: 'virtual bool BrowserApp::OnProcessMessageReceived(CefRefPtr<CefBrowser>, CefProcessId, CefRefPtr<CefProcessMessage>)' marked 'override', but does not override
  virtual bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
               ^~~~~~~~~~~~~~~~~~~~~~~~
/build/source/src/browser/browser-app.cpp: In member function 'virtual void BrowserApp::OnContextInitialized()':
/build/source/src/browser/browser-app.cpp:316:91: error: no matching function for call to 'CefBrowserHost::CreateBrowserSync(CefWindowInfo&, BrowserClient*, const char [45], CefBrowserSettings&, std::nullptr_t)'
      info, client.get(), "https://github.com/bazukas/obs-linuxbrowser/", settings, nullptr);
                                                                                           ^
In file included from /build/cef/include/../include/cef_print_handler.h:42,
                 from /build/cef/include/../include/cef_browser_process_handler.h:43,
                 from /build/cef/include/cef_app.h:42,
                 from /build/source/src/browser/browser-app.hpp:23,
                 from /build/source/src/browser/browser-app.cpp:29:
/build/cef/include/../include/cef_browser.h:305:32: note: candidate: 'static CefRefPtr<CefBrowser> CefBrowserHost::CreateBrowserSync(const CefWindowInfo&, CefRefPtr<CefClient>, const CefString&, const CefBrowserSettings&, CefRefPtr<CefDictionaryValue>, CefRefPtr<CefRequestContext>)'
   static CefRefPtr<CefBrowser> CreateBrowserSync(
                                ^~~~~~~~~~~~~~~~~
/build/cef/include/../include/cef_browser.h:305:32: note:   candidate expects 6 arguments, 5 provided
/build/source/src/browser/browser-app.cpp: In member function 'void BrowserApp::UpdateActiveStateJS(bool)':
/build/source/src/browser/browser-app.cpp:387:17: error: 'class CefBrowser' has no member named 'SendProcessMessage'
  this->browser->SendProcessMessage(PID_BROWSER, msg);
                 ^~~~~~~~~~~~~~~~~~
/build/source/src/browser/browser-app.cpp: In member function 'void BrowserApp::UpdateVisibilityStateJS(bool)':
/build/source/src/browser/browser-app.cpp:395:17: error: 'class CefBrowser' has no member named 'SendProcessMessage'
  this->browser->SendProcessMessage(PID_BROWSER, msg);
                 ^~~~~~~~~~~~~~~~~~
/build/source/src/browser/browser-app.cpp: In function 'void {anonymous}::file_changed(int)':
/build/source/src/browser/browser-app.cpp:42:7: warning: ignoring return value of 'ssize_t read(int, void*, size_t)', declared with attribute warn_unused_result [-Wunused-result]
   read(static_in_fd, (void*) &event, sizeof(inotify_event));
   ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/browser_shared.dir/build.make:76: CMakeFiles/browser_shared.dir/src/browser/browser-app.cpp.o] Error 1
~~~

Does anyone have an idea what to do about this compiler error?

Cc: @puffnfresh 