### PR TITLE
Allow ffmpeg attributes to be overridden

### DIFF
--- a/pkgs/development/libraries/ffmpeg/2.8.nix
+++ b/pkgs/development/libraries/ffmpeg/2.8.nix
@@ -1,7 +1,7 @@
 { callPackage, ... } @ args:
 
-callPackage ./generic.nix (args // rec {
+callPackage ./generic.nix (rec {
   version = "${branch}.14";
   branch = "2.8";
   sha256 = "1g6x3lyjl1zlfksizj1ys61kj97yg0xf4dlr6sr5acpbja3a26yn";
-})
+} // args)

--- a/pkgs/development/libraries/ffmpeg/3.4.nix
+++ b/pkgs/development/libraries/ffmpeg/3.4.nix
@@ -4,9 +4,9 @@
 , ...
 }@args:
 
-callPackage ./generic.nix (args // rec {
+callPackage ./generic.nix (rec {
   version = branch;
   branch = "3.4.6";
   sha256 = "1s20wzgxxrm56gckyb8cf1lh36hdnkdxvmmnnvdxvia4zb3grf1b";
   darwinFrameworks = [ Cocoa CoreMedia ];
-})
+} // args)

--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -4,9 +4,9 @@
 , ...
 }@args:
 
-callPackage ./generic.nix (args // rec {
+callPackage ./generic.nix (rec {
   version = "4.2.1";
   branch = "4.2";
   sha256 = "090naa6rj46pzkgh03bf51hbqdz356qqckr2pw6pykc6ysiryak8";
   darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
-})
+} // args)


### PR DESCRIPTION
Switch the order in which the version-specific attributes are combined
with args. Otherwise, if args such as 'branch' are overridden by an
overlay or other derivation, the new value is replaced with the
original when the sets are combined with //.

###### Motivation for this change
Overriding e.g. `ffmpeg_4` in an overlay currently doesn't work, because the way the attributes provided by the override are combined with the attributes in `pkgs/development/libraries/ffmpeg/4.nix` results in the original attributes shadowing the overrides.

This change *should* have no effect on existing packages, unless they have "unused" attributes currently being shadowed.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
