### PR TITLE
coqPackages.coq-extensible-records: support for coq 8.9 and 8.10

### DIFF
--- a/pkgs/development/coq-modules/coq-extensible-records/default.nix
+++ b/pkgs/development/coq-modules/coq-extensible-records/default.nix
@@ -1,13 +1,39 @@
 { stdenv, fetchFromGitHub, coq }:
 
-stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-coq-extensible-records-1.2.0";
+let
+  versions = {
+    pre_8_9 = {
+      owner   = "gmalecha";
+      rev     = "1.2.0";
+      version = "1.2.0";
+      sha256  = "0h5m04flqfk0v577syw0v1dw2wf7xrx6jaxv5gpmqzssf5hxafy4";
+    };
+    post_8_9 = {
+      owner   = "Ptival";
+      rev     = "bd7082a3571ee3c111096ff6b5eb28c8d3a99ce5";
+      version = "1.2.0+8.9-fix";
+      sha256  = "0625qd8pyxi0v704fwnawrfw5fk966vnk120il0g6qv42siyck95";
+    };
+  };
+  params =
+    {
+      "8.5"  = versions.pre_8_9;
+      "8.6"  = versions.pre_8_9;
+      "8.7"  = versions.pre_8_9;
+      "8.8"  = versions.pre_8_9;
+      "8.9"  = versions.post_8_9;
+      "8.10" = versions.post_8_9;
+    };
+  param = params.${coq.coq-version};
+in
+
+stdenv.mkDerivation rec {
+  inherit (param) version;
+  name = "coq${coq.coq-version}-coq-extensible-records-${version}";
 
   src = fetchFromGitHub {
-    owner = "gmalecha";
+    inherit (param) owner rev sha256;
     repo = "coq-extensible-records";
-    rev = "1.2.0";
-    sha256 = "0h5m04flqfk0v577syw0v1dw2wf7xrx6jaxv5gpmqzssf5hxafy4";
   };
 
   buildInputs = [ coq ];
@@ -27,6 +53,6 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" "8.10" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
`coq-extensible-records` can be made to work for recent versions of Coq. Sadly, upstream is not responding to pull requests. This provides support for those Coq versions in the meantime.

###### Things done
- Built on macOS, tested with Coq versions 8.8, 8.9, and 8.10