### PR TITLE
fzf-zsh: init at unstable-2019-09-09

### DIFF
--- a/pkgs/shells/zsh/fzf-zsh/default.nix
+++ b/pkgs/shells/zsh/fzf-zsh/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, fzf }:
+
+stdenv.mkDerivation rec {
+  pname = "fzf-zsh-unstable";
+  version = "2019-09-09";
+
+  src = fetchFromGitHub {
+    owner = "Wyntau";
+    repo = "fzf-zsh";
+    rev = "829d7e40cc437dce8a6e234e259bbd4065e87124";
+    sha256 = "1irjmxhcg1fm4g8p3psjqk7sz5qhj5kw73pyhv91njvpdhn9l26z";
+  };
+
+  postPatch = ''
+    substituteInPlace fzf-zsh.plugin.zsh \
+      --replace \
+        'fzf_path="$( cd "$fzf_zsh_path/../fzf/" && pwd )"' \
+        "fzf_path=${fzf}" \
+      --replace \
+        '$fzf_path/shell' \
+        '${fzf}/share/fzf'
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm0644 fzf-zsh.plugin.zsh $out/share/zsh/plugins/fzf-zsh/fzf-zsh.plugin.zsh
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/wyntau/fzf-zsh;
+    description = "wrap fzf to use in oh-my-zsh";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ma27 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1677,6 +1677,8 @@ in
 
   fzf = callPackage ../tools/misc/fzf { };
 
+  fzf-zsh = callPackage ../shells/zsh/fzf-zsh { };
+
   fzy = callPackage ../tools/misc/fzy { };
 
   g2o = callPackage ../development/libraries/g2o { };


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Simple `fzf` wrapper which provides a way nicer interface for ZSH's
<C-r> search. When using oh-my-zsh it can be enabled like this:

``` nix
{ pkgs, ... }: {
  programs.zsh = {
    enable = true;
    ohMyZsh = {
      enable = true;
      customPkgs = [ pkgs.fzf-zsh ];
      plugins = [ "fzf-zsh" ];
    };
  };
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
