### PR TITLE
[needs help] mindustry-bin: init at 5.0 v99

### DIFF
--- a/pkgs/games/mindustry-bin/default.nix
+++ b/pkgs/games/mindustry-bin/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, makeWrapper, makeDesktopItem, jdk, jre, openal, libpulseaudio }:
+
+stdenv.mkDerivation rec {
+  version = "99";
+  pname = "mindustry-bin";
+
+  src = fetchurl {
+    url = "https://github.com/Anuken/Mindustry/releases/download/v${version}/Mindustry.jar";
+    sha256 = "07fhcfhw6fvxdx191rzapkpy1nhgim6k9ps6zq6iwa30gpz5685l";
+  };
+
+  desktopItem = makeDesktopItem {
+    comment =  meta.description;
+    name = "mindustry";
+    desktopName = "Mindustry";
+    genericName = "Tower Defense Game";
+    categories = "Application;Games";
+    icon = "mindustry";
+    exec = "mindustry";
+  };
+
+  buildInputs = [ makeWrapper jdk ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/java $out/share/icons
+
+    cp -r ${desktopItem}/share/applications $out/share/
+
+    jar xf $src icons/icon_64.png
+    cp icons/icon_64.png $out/share/icons/mindustry.png
+
+    ln -s $src $out/share/java/mindustry.jar
+    makeWrapper ${jre}/bin/java $out/bin/mindustry \
+      --add-flags "-jar $out/share/java/mindustry.jar"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "a sandbox tower defense game written in Java";
+    homepage = https://mindustrygame.github.io/;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22492,6 +22492,9 @@ in
 
   minetest = minetestclient_5;
 
+  mindustry = mindustry-bin;
+  mindustry-bin = callPackage ../games/mindustry-bin { };
+
   mnemosyne = callPackage ../games/mnemosyne {
     python = python3;
   };


### PR DESCRIPTION
Note: Game launches but sound does not work yet (some OpenAL issue).

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/72001

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
