### PR TITLE
pythonPackages.isort: Add explicit setuptools dep and bin test

### DIFF
--- a/pkgs/development/python-modules/isort/default.nix
+++ b/pkgs/development/python-modules/isort/default.nix
@@ -1,4 +1,6 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, futures, backports_functools_lru_cache, mock, pytest }:
+{ lib, buildPythonPackage, fetchPypi, setuptools, isPy27, futures
+, backports_functools_lru_cache, mock, pytest
+}:
 
 let
   skipTests = [ "test_requirements_finder" "test_pipfile_finder" ] ++ lib.optional isPy27 "test_standard_library_deprecates_user_issue_778";
@@ -12,13 +14,24 @@ in buildPythonPackage rec {
     sha256 = "c40744b6bc5162bbb39c1257fe298b7a393861d50978b565f3ccd9cb9de0182a";
   };
 
-  propagatedBuildInputs = lib.optionals isPy27 [ futures backports_functools_lru_cache ];
+  propagatedBuildInputs = [
+    setuptools
+  ] ++ lib.optionals isPy27 [ futures backports_functools_lru_cache ];
 
   checkInputs = [ mock pytest ];
 
-  # isort excludes paths that contain /build/, so test fixtures don't work with TMPDIR=/build/
   checkPhase = ''
+    # isort excludes paths that contain /build/, so test fixtures don't work
+    # with TMPDIR=/build/
     PATH=$out/bin:$PATH TMPDIR=/tmp/ pytest ${testOpts}
+
+    # Confirm that the produced executable script is wrapped correctly and runs
+    # OK, by launching it in a subshell without PYTHONPATH
+    (
+      unset PYTHONPATH
+      echo "Testing that `isort --version-number` returns OK..."
+      $out/bin/isort --version-number
+    )
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
isort's executable script has a dependency on `setuptools` (although this dependency doesn't appear to be expressed in the pyproject for it), which was not previously present. This issue wasn't originally exposed, but f7e28bf5d818192 resulted in it surfacing somehow (I assume by effectively removing `setuptools` from implicitly being in `propagatedBuildInputs` in some respect...?).

This makes the dependency explicit, and also adds a minimal test of the executable script to catch future issues of this nature.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~~Ensured that relevant documentation is up to date~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh I suspect there's a few other packages around that will turn out to have implicit dependencies on `setuptools`.
