### PR TITLE
firecracker: update, aarch64 support

### DIFF
--- a/pkgs/applications/virtualization/firecracker/default.nix
+++ b/pkgs/applications/virtualization/firecracker/default.nix
@@ -2,15 +2,28 @@
 
 let
   version = "0.19.0";
-  baseurl = "https://github.com/firecracker-microvm/firecracker/releases/download";
 
+  suffix = {
+    x86_64-linux  = "";
+    aarch64-linux = "-aarch64";
+  }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  baseurl = "https://github.com/firecracker-microvm/firecracker/releases/download";
   fetchbin = name: sha256: fetchurl {
-    url    = "${baseurl}/v${version}/${name}-v${version}";
-    inherit sha256;
+    url    = "${baseurl}/v${version}/${name}-v${version}${suffix}";
+    sha256 = sha256."${stdenv.hostPlatform.system}";
   };
 
-  firecracker-bin = fetchbin "firecracker" "0yjhw77xc2nc96p36jhf0va95gf6hwi9n270g4iiwakycdy048mx";
-  jailer-bin      = fetchbin "jailer"      "1q792b4bl1q3ach8nc8l0fbcil44knv3wa542xrskndzdz28lhsp";
+  firecracker-bin = fetchbin "firecracker" {
+    x86_64-linux  = "0yjhw77xc2nc96p36jhf0va95gf6hwi9n270g4iiwakycdy048mx";
+    aarch64-linux = "165yca7pcwpqw3x6dihcjz1xcwjh37sdi9qrrjk9zasxx7xcniym";
+  };
+
+  jailer-bin = fetchbin "jailer" {
+    x86_64-linux  = "1q792b4bl1q3ach8nc8l0fbcil44knv3wa542xrskndzdz28lhsp";
+    aarch64-linux = "1cnwlpy5bswjprk7fcjgf6lxidhp7z00qx691nkwhzjkby80j490";
+  };
+
 in
 stdenv.mkDerivation {
   pname = "firecracker";
@@ -42,7 +55,7 @@ stdenv.mkDerivation {
     description = "Secure, fast, minimal micro-container virtualization";
     homepage    = http://firecracker-microvm.io;
     license     = licenses.asl20;
-    platforms   = [ "x86_64-linux" ];
+    platforms   = [ "x86_64-linux" "aarch64-linux" ];
     maintainers = with maintainers; [ thoughtpolice ];
   };
 }

--- a/pkgs/applications/virtualization/firecracker/default.nix
+++ b/pkgs/applications/virtualization/firecracker/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv }:
 
 let
-  version = "0.18.0";
+  version = "0.19.0";
   baseurl = "https://github.com/firecracker-microvm/firecracker/releases/download";
 
   fetchbin = name: sha256: fetchurl {
@@ -9,20 +9,33 @@ let
     inherit sha256;
   };
 
-  firecracker-bin = fetchbin "firecracker" "140g93z0k8yd9lr049ps4dj0psb9ac1v7g5zs7lzpws9rj8shmgh";
-  jailer-bin      = fetchbin "jailer"      "0sk1zm1fx0zdy5il8vyygzads72ni2lcil42wv59j8b2bg8p7fwd";
+  firecracker-bin = fetchbin "firecracker" "0yjhw77xc2nc96p36jhf0va95gf6hwi9n270g4iiwakycdy048mx";
+  jailer-bin      = fetchbin "jailer"      "1q792b4bl1q3ach8nc8l0fbcil44knv3wa542xrskndzdz28lhsp";
 in
 stdenv.mkDerivation {
-  name = "firecracker-${version}";
+  pname = "firecracker";
   inherit version;
-
   srcs = [ firecracker-bin jailer-bin ];
-  phases = [ "installPhase" ];
+
+  unpackPhase    = ":";
+  configurePhase = ":";
+
+  buildPhase     = ''
+    cp ${firecracker-bin} firecracker
+    cp ${jailer-bin}      jailer
+    chmod +x firecracker jailer
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    ./firecracker --version
+    ./jailer --version
+  '';
 
   installPhase = ''
     mkdir -p $out/bin
-    install -D ${firecracker-bin} $out/bin/firecracker
-    install -D ${jailer-bin}      $out/bin/jailer
+    install -D firecracker $out/bin/firecracker
+    install -D jailer      $out/bin/jailer
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).