### PR TITLE
nats: update versions, rename gnatsd, add libnats

### DIFF
--- a/pkgs/development/libraries/libnats-c/default.nix
+++ b/pkgs/development/libraries/libnats-c/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub
+, cmake, protobuf, protobufc
+, libsodium, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname   = "libnats";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner  = "nats-io";
+    repo   = "nats.c";
+    rev    = "refs/tags/v${version}";
+    sha256 = "16a0f0gvrmyrqvmh6vinqny3qhm6wyzw5ijnn3r82b1gqlpws0fz";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libsodium openssl protobuf protobufc ];
+
+  separateDebugInfo = true;
+  enableParallelBuilding = true;
+  outputs = [ "out" "dev" ];
+
+  meta = with stdenv.lib; {
+    description = "C API for the NATS messaging system";
+    homepage    = "https://github.com/nats-io/nats.c";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/servers/nats-server/default.nix
+++ b/pkgs/servers/nats-server/default.nix
@@ -3,17 +3,16 @@
 with lib;
 
 buildGoPackage rec {
-  pname = "gnatsd";
-  version = "1.4.0";
-  rev = "v${version}";
+  pname   = "nats-server";
+  version = "2.1.0";
 
-  goPackagePath = "github.com/nats-io/gnatsd";
+  goPackagePath = "github.com/nats-io/${pname}";
 
   src = fetchFromGitHub {
-    inherit rev;
-    owner = "nats-io";
-    repo = "gnatsd";
-    sha256 = "0wxdvaxl273kd3wcas634hx1wx5piljgbfr6vhf669b1frkgrh2b";
+    rev    = "v${version}";
+    owner  = "nats-io";
+    repo   = pname;
+    sha256 = "1zp43v69cawbp6bpby1vx51z6nyv8gxnnl2qkhwr9zrgnhlcflnl";
   };
 
   meta = {

--- a/pkgs/servers/nats-streaming-server/default.nix
+++ b/pkgs/servers/nats-streaming-server/default.nix
@@ -3,17 +3,15 @@
 with lib;
 
 buildGoPackage rec {
-  pname = "nats-streaming-server";
-  version = "0.11.2";
-  rev = "v${version}";
-
-  goPackagePath = "github.com/nats-io/nats-streaming-server";
+  pname   = "nats-streaming-server";
+  version = "0.16.2";
+  goPackagePath = "github.com/nats-io/${pname}";
 
   src = fetchFromGitHub {
-    inherit rev;
-    owner = "nats-io";
-    repo = "nats-streaming-server";
-    sha256 = "1jd9c5yw3xxp5hln1g8w48l4cslhxbv0k2af47g6pya09kwknqkq";
+    rev    = "v${version}";
+    owner  = "nats-io";
+    repo   = pname;
+    sha256 = "0xrgwsw4xrn6fjy1ra4ycam50kdhyqqsms4yxblj5c5z7w4hnlmk";
   };
 
   meta = {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -463,4 +463,8 @@ mapAliases ({
   ocaml_4_01_0 = ocamlPackages_4_01_0.ocaml;
   ocaml_4_02   = ocamlPackages_4_02.ocaml;
   ocaml_4_03   = ocamlPackages_4_03.ocaml;
-}))
+}) // {
+
+  # added 2019-10-28
+  gnatsd = nats-server;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12025,6 +12025,10 @@ in
 
   libinjection = callPackage ../development/libraries/libinjection { };
 
+  libnats-c = callPackage ../development/libraries/libnats-c {
+    openssl = openssl_1_0_2;
+  };
+
   liburing = callPackage ../development/libraries/liburing { };
 
   librseq = callPackage ../development/libraries/librseq { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14843,7 +14843,7 @@ in
 
   glabels = callPackage ../applications/graphics/glabels { };
 
-  gnatsd = callPackage ../servers/gnatsd { };
+  nats-server = callPackage ../servers/nats-server { };
 
   gofish = callPackage ../servers/gopher/gofish { };
 


### PR DESCRIPTION
###### Motivation for this change

This updates `nats-server` (previously known as `gnatsd`), `nats-streaming-server`, and adds the `nats.c` library as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).