### PR TITLE
vivaldi: fix patched paths

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -51,8 +51,7 @@ in stdenv.mkDerivation rec {
       --set-rpath "${libPath}" \
       opt/${vivaldiName}/vivaldi-bin
   '' + stdenv.lib.optionalString proprietaryCodecs ''
-    sed -i '/^if \[ "$VIVALDI_FFMPEG_FOUND/i \
-      VIVALDI_FFMPEG_FOUND=YES\nCACHED_FFMPEG=${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so' opt/${vivaldiName}/${vivaldiName}
+    ln -s ${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so opt/${vivaldiName}/libffmpeg.so.''${version%\.*\.*}
   '' + ''
     echo "Finished patching Vivaldi binaries"
   '';
@@ -82,7 +81,7 @@ in stdenv.mkDerivation rec {
       --suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}/ \
       ${stdenv.lib.optionalString enableWidevine "--suffix LD_LIBRARY_PATH : ${libPath}"}
   '' + stdenv.lib.optionalString enableWidevine ''
-    ln -sf ${vivaldi-widevine}/lib/libwidevinecdm.so $out/opt/${vivaldiName}/libwidevinecdm.so
+    ln -sf ${vivaldi-widevine}/share/google/chrome/WidevineCdm $out/opt/${vivaldiName}/WidevineCdm
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "chromium-codecs-ffmpeg";
-  version = "74.0.3729.169";
+  version = "78.0.3904.70";
 
   src = fetchurl {
-    url = "https://launchpadlibrarian.net/424938057/${name}-extra_${version}-0ubuntu0.16.04.1_amd64.deb";
-    sha256 = "1ls2fshfk08hqsfvbd7p6rp2gv3n0xdy86rdh00wiz5qgl3skfzc";
+    url = "https://launchpadlibrarian.net/449403909/${name}-extra_${version}-0ubuntu0.16.04.2_amd64.deb";
+    sha256 = "00j604nm49z6hbyw7xsxcvmdjf7117kb478plkpizzvmm3w72b9v";
   };
 
   buildInputs = [ dpkg ];

--- a/pkgs/applications/networking/browsers/vivaldi/widevine.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/widevine.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "widevine";
-  version = "4.10.1196.0";
+  version = "4.10.1582.1";
 
   src = fetchurl {
     url = "https://dl.google.com/widevine-cdm/${version}-linux-x64.zip";
-    sha256 = "01c7nr7d2xs718jymicbk4ipzfx6q253109qv3lk4lryrrhvw14y";
+    sha256 = "0l743f2yyaq1vvc3iicajgnfpjxjsfvjcqvanndbxs23skgjcv6r";
   };
 
   buildInputs = [ unzip ];
@@ -17,12 +17,10 @@ stdenv.mkDerivation rec {
     unzip $src
   '';
 
-  installPhase = let
-    installDir = "$out/share/google/chrome/WidevineCdm/_platform_specific/linux_x64";
-  in ''
-    install -vD libwidevinecdm.so ${installDir}/libwidevinecdm.so
-    install -vD manifest.json ${installDir}/manifest.json
-    install -vD LICENSE.txt ${installDir}/LICENSE.txt
+  installPhase = ''
+    install -vD manifest.json $out/share/google/chrome/WidevineCdm/manifest.json
+    install -vD LICENSE.txt $out/share/google/chrome/WidevineCdm/LICENSE.txt
+    install -vD libwidevinecdm.so $out/share/google/chrome/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/browsers/vivaldi/widevine.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/widevine.nix
@@ -14,12 +14,15 @@ stdenv.mkDerivation rec {
   buildInputs = [ unzip ];
 
   unpackPhase = ''
-    unzip $src libwidevinecdm.so
-    find .
+    unzip $src
   '';
 
-  installPhase = ''
-    install -vD libwidevinecdm.so $out/lib/libwidevinecdm.so
+  installPhase = let
+    installDir = "$out/share/google/chrome/WidevineCdm/_platform_specific/linux_x64";
+  in ''
+    install -vD libwidevinecdm.so ${installDir}/libwidevinecdm.so
+    install -vD manifest.json ${installDir}/manifest.json
+    install -vD LICENSE.txt ${installDir}/LICENSE.txt
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
Doesn't align with the stable version but it's looking like these changes are needed for when 2.9 is released.
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
