### PR TITLE
Vscode extensions

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -131,8 +131,8 @@ in
     mktplcRef = {
       name = "vim";
       publisher = "vscodevim";
-      version = "1.3.0";
-      sha256 = "18z24w7smjjnv945f8qyy6dl95xckyqa6gg3gijfcigvq5sgyawc";
+      version = "1.11.3";
+      sha256 = "1smzsgcrkhghbnpy51gp28kh74l7y4s2m8pfxabb4ffb751254j0";
     };
     meta = {
       license = stdenv.lib.licenses.mit;

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -64,7 +64,7 @@ in
     mktplcRef = {
       name = "latex-workshop";
       publisher = "James-Yu";
-      version = "8.2.0"; 
+      version = "8.2.0";
       sha256 = "1ai16aam4v5jzhxgms589q0l24kyk1a9in6z4i7g05b3sahyxab2";
     };
     meta = with stdenv.lib; {
@@ -81,6 +81,18 @@ in
     };
     meta = {
       license = stdenv.lib.licenses.bsd3;
+    };
+  };
+
+  ms-azuretools.vscode-docker = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "vscode-docker";
+      publisher = "ms-azuretools";
+      version = "0.8.1";
+      sha256 = "0n59whmcrx8946xix6skvc50f2vsc85ckvn8cs06w9mqmymm1q0s";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
     };
   };
 

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -90,6 +90,19 @@ in
     extractNuGet = callPackage ./python/extract-nuget.nix { };
   };
 
+  redhat.vscode-yaml = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "vscode-yaml";
+      publisher = "redhat";
+      version = "0.5.3";
+      sha256 = "03swlsp906rqlrx6jf3ibh7pk36sm0zdr8jfy6sr3w5lqjg27gka";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
+
   skyapps.fish-vscode = buildVscodeMarketplaceExtension {
     mktplcRef = {
       name = "fish-vscode";

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -108,6 +108,18 @@ in
     };
   };
 
+  ms-vscode.Go = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "Go";
+      publisher = "ms-vscode";
+      version = "0.11.7";
+      sha256 = "1l6jjdfivw1pn9y4d4i7zf80ls1k1b0ap1d828ah57ad3bgmyqfi";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   ms-vscode.cpptools = callPackage ./cpptools {};
 
   ms-python.python = callPackage ./python {

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -96,6 +96,18 @@ in
     };
   };
 
+  ms-kubernetes-tools.vscode-kubernetes-tools = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "vscode-kubernetes-tools";
+      publisher = "ms-kubernetes-tools";
+      version = "1.0.6";
+      sha256 = "12a4phl1pddsajy3n0ld6rp607iy0pif6pqrs6ljbg2x97fyra28";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   ms-vscode.cpptools = callPackage ./cpptools {};
 
   ms-python.python = callPackage ./python {


### PR DESCRIPTION
###### Motivation for this change
Wanted to add a few more vscode extensions

you can test with
```
$ nix-shell --pure -p "with import ./. {}; vscode-with-extensions.override {vscodeExtensions = with vscode-extensions; [ ms-kubernetes-tools.vscode-kubernetes-tools redhat.vscode-yaml ms-azuretools.vscode-docker ms-vscode.Go vscodevim.vim ];}"
$ code

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
