### PR TITLE
melonDS: init at 0.8.3

### DIFF
--- a/pkgs/misc/emulators/melonDS/default.nix
+++ b/pkgs/misc/emulators/melonDS/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, SDL2, gtk3, curl, libpcap }:
+
+stdenv.mkDerivation rec {
+  pname = "melonDS";
+  version = "0.8.3";
+
+  src = fetchFromGitHub {
+    owner = "Arisotura";
+    repo = pname;
+    rev = version;
+    sha256 = "1lqmfwjpkdqfkns1aaxlp4yrg6i0r66mxfr4rrj7b5286k44hqwn";
+  };
+
+  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ SDL2 gtk3 curl libpcap ];
+
+  postInstall = ''
+    install -Dm644 romlist.bin "$out/share/melonDS/romlist.bin"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://melonds.kuribo64.net/";
+    description = "Work in progress Nintendo DS emulator";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ artemist ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19633,6 +19633,8 @@ in
 
   meld = callPackage ../applications/version-management/meld { };
 
+  melonDS = callPackage ../misc/emulators/melonDS { };
+
   meme = callPackage ../applications/graphics/meme { };
 
   mcomix = callPackage ../applications/graphics/mcomix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

melonDS is a useful DS emulator. It's still a WIP, but it is compatible with some games. I used the release version, although the git version has better compatibility, I'll update this when the next version comes out

###### Things done

Create a new package for the melonDS emulator

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
That's me