### PR TITLE
emacs-cmake-mode: do not run `configure`

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -16,7 +16,7 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
 
   dontConfigure = pkg: if pkg != null then pkg.override (args: {
     melpaBuild = drv: args.melpaBuild (drv // {
-      configureScript = "true";
+      dontConfigure = true;
     });
   }) else null;
 
@@ -52,14 +52,9 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
         # part of a larger package
         caml = dontConfigure super.caml;
 
-        cmake-mode = super.cmake-mode.overrideAttrs (attrs: {
-          buildInputs = (attrs.buildInputs or []) ++ [
-            external.openssl
-          ];
-          nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ [
-            external.pkgconfig
-          ];
-        });
+        # part of a larger package
+        # upstream issue: missing package version
+        cmake-mode = dontConfigure super.cmake-mode;
 
         # Expects bash to be at /bin/bash
         company-rtags = markBroken super.company-rtags;
@@ -285,10 +280,6 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
 
         # upstream issue: missing file header
         bufshow = markBroken super.bufshow;
-
-        # part of a larger package
-        # upstream issue: missing package version
-        cmake-mode = dontConfigure super.cmake-mode;
 
         # upstream issue: missing file header
         connection = markBroken super.connection;


### PR DESCRIPTION
Before this patch, the stable version did not run configure, and the
unstable version added `openssl` and `pkgconfig` to
dependencies.

Also, `dontConfigure = true` seems more readable than `configureScript
= "true"`.

###### Motivation for this change

Save compile time, reduce compile time dependencies.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] NO BINARIES Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
