### PR TITLE
python3Packages.html2text: fix build

### DIFF
--- a/pkgs/development/python-modules/html2text/default.nix
+++ b/pkgs/development/python-modules/html2text/default.nix
@@ -1,21 +1,28 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, pytest
 }:
 
 buildPythonPackage rec {
   pname = "html2text";
   version = "2019.9.26";
+  disabled = pythonOlder "3.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "6f56057c5c2993b5cc5b347cb099bdf6d095828fef1b53ef4e2a2bf2a1be9b4f";
+  src = fetchFromGitHub {
+    owner = "Alir3z4";
+    repo = pname;
+    rev = version;
+    sha256 = "1gzcx4n6q71plq4zvb1z0fy3brrln0qqrd6jc89iiqn7r1ix8h87";
   };
 
-  meta = with stdenv.lib; {
+  # python setup.py test is broken, use pytest
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
     description = "Turn HTML into equivalent Markdown-structured text";
     homepage = https://github.com/Alir3z4/html2text/;
     license = licenses.gpl3;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change
noticed the python3 build was broken while reviewing #72211

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @


```
[4 built, 2 copied (0.4 MiB), 0.4 MiB DL]
https://github.com/NixOS/nixpkgs/pull/72213
4 package were build:
fanficfare python37Packages.html2text python38Packages.html2text rss2email
```