### PR TITLE
ocamlPackages.checkseum: 0.0.3 → 0.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/checkseum/default.nix
+++ b/pkgs/development/ocaml-modules/checkseum/default.nix
@@ -1,41 +1,28 @@
-{ stdenv, fetchurl, ocaml, findlib, dune, alcotest, cmdliner, fmt, optint, rresult }:
+{ lib, fetchurl, buildDunePackage
+, bigarray-compat, optint
+, cmdliner, fmt, rresult
+, alcotest
+}:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
-then throw "checkseum is not available for OCaml ${ocaml.version}"
-else
+buildDunePackage rec {
+  version = "0.1.1";
+  pname = "checkseum";
 
-# The C implementation is not portable: x86 only
-let hasC = stdenv.isi686 || stdenv.isx86_64; in
-
-stdenv.mkDerivation rec {
-  version = "0.0.3";
-  name = "ocaml${ocaml.version}-checkseum-${version}";
   src = fetchurl {
-    url = "https://github.com/mirage/checkseum/releases/download/v0.0.3/checkseum-v0.0.3.tbz";
-    sha256 = "12j45zsvil1ynwx1x8fbddhqacc8r1zf7f6h576y3f3yvbg7l1fm";
+    url = "https://github.com/mirage/checkseum/releases/download/v${version}/checkseum-v${version}.tbz";
+    sha256 = "0aa2r1l65a5hcgciw6n8r5ij4gpgg0cf9k24isybxiaiz63k94d3";
   };
 
-  postPatch = stdenv.lib.optionalString (!hasC) ''
-    rm -r bin src-c
-  '';
+  buildInputs = [ cmdliner fmt rresult ];
+  propagatedBuildInputs = [ bigarray-compat optint ];
+  checkInputs = lib.optionals doCheck [ alcotest ];
 
-  buildInputs = [ ocaml findlib dune alcotest cmdliner fmt rresult ];
-  propagatedBuildInputs = [ optint ];
-
-  buildPhase = "dune build";
-
-  doCheck = hasC;
-  checkPhase = "dune runtest";
-
-  inherit (dune) installPhase;
-
-  passthru = { inherit hasC; };
+  doCheck = true;
 
   meta = {
     homepage = "https://github.com/mirage/checkseum";
     description = "ADLER-32 and CRC32C Cyclic Redundancy Check";
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/decompress/default.nix
+++ b/pkgs/development/ocaml-modules/decompress/default.nix
@@ -22,6 +22,5 @@ buildDunePackage rec {
 		license = lib.licenses.mit;
 		maintainers = [ lib.maintainers.vbgl ];
 		homepage = "https://github.com/mirage/decompress";
-		broken = !checkseum.hasC;
 	};
 }


### PR DESCRIPTION
###### Motivation for this change

This fixes the “decompress” library on non-x86_64 platforms

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
