### PR TITLE
gnome-twitch: init a unstable-2019-05-20

### DIFF
--- a/pkgs/applications/video/gnome-twitch/default.nix
+++ b/pkgs/applications/video/gnome-twitch/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub
+, pkgconfig, meson, cmake, ninja, wrapGAppsHook
+, libpeas, gtk3, libsoup, json-glib, webkitgtk, glib, glib-networking
+, cairo, clutter-gtk, clutter-gst, epoxy, gstreamer, mpv
+, python3, desktop-file-utils
+, substituteAll
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-twitch-unstable";
+  version = "2019-05-20";
+
+  src = fetchFromGitHub {
+    owner = "vinszent";
+    repo = "gnome-twitch";
+    rev = "8e774a04fdd15fa4c9990918bf89295a232d1715";
+    sha256 = "0pvxfwbv4fms2d0sp43jw83kp1i6gq03kg6gwy8b1fhp473gxrfj";
+  };
+
+  nativeBuildInputs = [ pkgconfig meson cmake ninja wrapGAppsHook python3 ];
+  buildInputs = [
+    libpeas gtk3 libsoup json-glib webkitgtk glib glib-networking
+    cairo clutter-gtk clutter-gst epoxy gstreamer mpv
+  ];
+  mesonFlags = [
+    "-Dbuild-player-backends=gstreamer-cairo,gstreamer-opengl,gstreamer-clutter,mpv-opengl"
+  ];
+  postPatch = ''
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
+    substituteInPlace meson_post_install.py \
+      --replace "update-desktop-database" \
+                "${desktop-file-utils}/bin/update-desktop-database" \
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gnome Twitch: enjoy Twitch on your GNU/Linux desktop";
+    homepage = "https://gnome-twitch.vinszent.com";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19110,6 +19110,8 @@ in
 
   gnome_mplayer = callPackage ../applications/video/gnome-mplayer { };
 
+  gnome-twitch = callPackage ../applications/video/gnome-twitch { };
+
   gnumeric = callPackage ../applications/office/gnumeric { };
 
   gnunet = callPackage ../applications/networking/p2p/gnunet { };


### PR DESCRIPTION
I need some help with this. The app builds but fails at the end due to the python post install script:

```
these derivations will be built:
  /nix/store/m4a14p327qcrphw2vzr3y9np76cm5dwx-gnome-twitch-unstable-2019-05-20.drv
building '/nix/store/m4a14p327qcrphw2vzr3y9np76cm5dwx-gnome-twitch-unstable-2019-05-20.drv'...
unpacking sources
unpacking source archive /nix/store/jszyj3njb7k9wl7hnqwkicsvfmj0a5ii-source
source root is source
patching sources
configuring
meson flags: --buildtype=plain         --libdir=/nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/lib --libexecdir=/nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/libexec         --bindir=/nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/bin --sbindir=/nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/sbin         --includedir=/nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/include         --mandir=/nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/man --infodir=/nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/info         --localedir=/nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale         -Dauto_features=enabled         -Dwrap_mode=nodownload         --prefix=/nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20
The Meson build system
Version: 0.51.2
Source dir: /build/source
Build dir: /build/source/build
Build type: native build
DEPRECATION: Duplicated values in array option is deprecated. This will become a hard error in the future.
DEPRECATION: Duplicated values in array option is deprecated. This will become a hard error in the future.
DEPRECATION: Duplicated values in array option is deprecated. This will become a hard error in the future.
Project name: gnome-twitch
Project version: 0.4.1
C compiler for the host machine: /nix/store/5yyx688q9qxhb4ypawq7v80fm3ix27dm-gcc-wrapper-8.3.0/bin/cc (gcc 8.3.0 "gcc (GCC) 8.3.0")
DEPRECATION: Duplicated values in array option is deprecated. This will become a hard error in the future.
Build machine cpu family: x86_64
Build machine cpu: x86_64
Compiler for C supports arguments -Wno-unused-variable -Wunused-variable: YES
Compiler for C supports arguments -Wno-unused-parameter -Wunused-parameter: YES
Compiler for C supports arguments -Wno-missing-field-initializers -Wmissing-field-initializers: YES
Found pkg-config: /nix/store/i81brxnf72l8dzvckr9c0g2d1hs7b6fs-pkg-config-0.29.2/bin/pkg-config (0.29.2)
Run-time dependency gtk+-3.0 found: YES 3.24.12
Run-time dependency libpeas-1.0 found: YES 1.24.0
Configuring config.h using configuration
Run-time dependency libsoup-2.4 found: YES 2.68.2
Run-time dependency json-glib-1.0 found: YES 1.4.4
Run-time dependency libpeas-gtk-1.0 found: YES 1.24.0
Run-time dependency webkit2gtk-4.0 found: YES 2.26.1
Run-time dependency x11 found: YES 1.6.8
Library m found: YES
Found pkg-config: /nix/store/i81brxnf72l8dzvckr9c0g2d1hs7b6fs-pkg-config-0.29.2/bin/pkg-config (0.29.2)
Program meson_post_install.py found: YES (/build/source/meson_post_install.py)
Build targets in project: 12
Found ninja-1.9.0 at /nix/store/jd70qlnjjgkjarqq3xc5a5rlhq7xlm0p-ninja-1.9.0/bin/ninja
meson: enabled parallel building
building
build flags: -j8 -l8
[36/50] Compiling C object 'src/25a6634@@gnome-twitch@exe/gt-twitch-login-dlg.c.o'.[K[KK[K
In file included from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/glist.h:32,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/ghash.h:33,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib.h:50,
                 from /nix/store/fhm00qmclykk2m4za8q3f361gxcva7l9-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdkconfig.h:8,
                 from /nix/store/fhm00qmclykk2m4za8q3f361gxcva7l9-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdk.h:30,
                 from /nix/store/fhm00qmclykk2m4za8q3f361gxcva7l9-gtk+3-3.24.12-dev/include/gtk-3.0/gtk/gtk.h:30,
                 from ../src/gt-twitch-login-dlg.h:22,
                 from ../src/gt-twitch-login-dlg.c:19:
../src/gt-twitch-login-dlg.c: In function 'dispose':
../src/gt-twitch-login-dlg.c:72:50: warning: function called through a non-compatible type
     g_clear_pointer(&priv->token_redirect_regex, (GDestroyNotify) g_regex_unref);
/nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gmem.h:121:8: note: in definition of macro 'g_clear_pointer'
       (destroy) (_ptr);                                                        \
        ^~~~~~~
[38/50] Compiling C object 'src/25a6634@@gnome-twitch@exe/gt-follows-manager.c.o'.c.o'.
In file included from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/glist.h:32,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/ghash.h:33,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib.h:50,
                 from /nix/store/fhm00qmclykk2m4za8q3f361gxcva7l9-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdkconfig.h:8,
                 from /nix/store/fhm00qmclykk2m4za8q3f361gxcva7l9-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdk.h:30,
                 from /nix/store/fhm00qmclykk2m4za8q3f361gxcva7l9-gtk+3-3.24.12-dev/include/gtk-3.0/gtk/gtk.h:30,
                 from ../src/gt-follows-manager.h:22,
                 from ../src/gt-follows-manager.c:19:
../src/gt-follows-manager.c: In function 'gt_follows_manager_load_from_file':
../src/gt-follows-manager.c:833:9: warning: function called through a non-compatible type
         (GDestroyNotify) gt_channel_list_free);
/nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gmem.h:121:8: note: in definition of macro 'g_clear_pointer'
       (destroy) (_ptr);                                                        \
        ^~~~~~~
[47/50] Generating GnomeTwitch-0.4.1.gir with a custom command.-file.c.o'..c.o'.
g-ir-scanner: link: gcc -o /build/source/build/tmp-introspectpin5zuoi/GnomeTwitch-0.4.1 /build/source/build/tmp-introspectpin5zuoi/GnomeTwitch-0.4.1.o -L. -Wl,-rpath,. -Wl,--no-as-needed -L/build/source/build/src -Wl,-rpath,/build/source/build/src -L/nix/store/pkz5q19jgsipp613lw99nj07a2vv1sfr-glib-2.62.1/lib -Wl,-rpath,/nix/store/pkz5q19jgsipp613lw99nj07a2vv1sfr-glib-2.62.1/lib -L/nix/store/56l5j98xscpjjaiqdq29ilhzw87q38qi-gtk+3-3.24.12/lib -Wl,-rpath,/nix/store/56l5j98xscpjjaiqdq29ilhzw87q38qi-gtk+3-3.24.12/lib -L/nix/store/f8g5k930w7wab7cigypg25zi134gy4l7-atk-2.34.1/lib -Wl,-rpath,/nix/store/f8g5k930w7wab7cigypg25zi134gy4l7-atk-2.34.1/lib -L/nix/store/f7i6nlx4dn55a9k1cmmam1amrd4z5aqd-cairo-1.16.0/lib -Wl,-rpath,/nix/store/f7i6nlx4dn55a9k1cmmam1amrd4z5aqd-cairo-1.16.0/lib -L/nix/store/16pgw4s7zipczka51c9qm5inw94wb30g-gdk-pixbuf-2.40.0/lib -Wl,-rpath,/nix/store/16pgw4s7zipczka51c9qm5inw94wb30g-gdk-pixbuf-2.40.0/lib -L/nix/store/i7cziwjkqczsgfc7j8i16qnkvfxjvy3j-pango-1.43.0/lib -Wl,-rpath,/nix/store/i7cziwjkqczsgfc7j8i16qnkvfxjvy3j-pango-1.43.0/lib -L/nix/store/f151jrr2731q6xjv0wq5h76s73hs0rzr-libpeas-1.24.0//lib -Wl,-rpath,/nix/store/f151jrr2731q6xjv0wq5h76s73hs0rzr-libpeas-1.24.0//lib -L/nix/store/mj8imkaskc5fa552iakw4f4mwsbnpq8k-gobject-introspection-1.62.0/lib -Wl,-rpath,/nix/store/mj8imkaskc5fa552iakw4f4mwsbnpq8k-gobject-introspection-1.62.0/lib -lgnome-twitch -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lpeas-1.0 -lgmodule-2.0 -lgirepository-1.0 -L/nix/store/pkz5q19jgsipp613lw99nj07a2vv1sfr-glib-2.62.1/lib -lgio-2.0 -lgobject-2.0 -Wl,--export-dynamic -pthread -lgmodule-2.0 -lglib-2.0
[48/50] Compiling C object 'src/25a6634@@gnome-twitch@exe/utils.c.o'.
../src/utils.c: In function 'utils_timestamp_filename':
../src/utils.c:67:9: warning: 'GTimeVal' is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
         GTimeVal time;
         ^~~~~~~~
In file included from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/galloca.h:32,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib.h:30,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gprintf.h:21,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gstdio.h:22,
                 from ../src/utils.c:19:
/nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gtypes.h:551:8: note: declared here
 struct _GTimeVal
        ^~~~~~~~~
../src/utils.c: In function 'utils_timestamp_file':
../src/utils.c:83:5: warning: 'GTimeVal' is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
     GTimeVal time;
     ^~~~~~~~
In file included from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/galloca.h:32,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib.h:30,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gprintf.h:21,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gstdio.h:22,
                 from ../src/utils.c:19:
/nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gtypes.h:551:8: note: declared here
 struct _GTimeVal
        ^~~~~~~~~
../src/utils.c:94:5: warning: 'g_file_info_get_modification_time' is deprecated: Use 'g_file_info_get_modification_date_time' instead [-Wdeprecated-declarations]
     g_file_info_get_modification_time(info, &time);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/gio/gio.h:71,
                 from /nix/store/fhm00qmclykk2m4za8q3f361gxcva7l9-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdkapplaunchcontext.h:28,
                 from /nix/store/fhm00qmclykk2m4za8q3f361gxcva7l9-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdk.h:32,
                 from /nix/store/fhm00qmclykk2m4za8q3f361gxcva7l9-gtk+3-3.24.12-dev/include/gtk-3.0/gtk/gtk.h:30,
                 from ../src/gt-channel.h:22,
                 from ../src/utils.h:22,
                 from ../src/utils.c:23:
/nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/gio/gfileinfo.h:1051:19: note: declared here
 void              g_file_info_get_modification_time  (GFileInfo         *info,
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/utils.c: In function 'utils_parse_vod_from_json':
../src/utils.c:556:5: warning: 'GTimeVal' is deprecated: Use 'GDateTime' instead [-Wdeprecated-declarations]
     GTimeVal time;
     ^~~~~~~~
In file included from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/galloca.h:32,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib.h:30,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gprintf.h:21,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gstdio.h:22,
                 from ../src/utils.c:19:
/nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gtypes.h:551:8: note: declared here
 struct _GTimeVal
        ^~~~~~~~~
../src/utils.c:578:5: warning: 'g_time_val_from_iso8601' is deprecated: Use 'g_date_time_new_from_iso8601' instead [-Wdeprecated-declarations]
     if (!g_time_val_from_iso8601(json_reader_get_string_value(reader), &time))
     ^~
In file included from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib.h:88,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gprintf.h:21,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gstdio.h:22,
                 from ../src/utils.c:19:
/nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gtimer.h:70:10: note: declared here
 gboolean g_time_val_from_iso8601 (const gchar *iso_date,
          ^~~~~~~~~~~~~~~~~~~~~~~
../src/utils.c:584:5: warning: 'g_date_time_new_from_timeval_utc' is deprecated: Use 'g_date_time_new_from_unix_utc' instead [-Wdeprecated-declarations]
     data->created_at = g_date_time_new_from_timeval_utc(&time);
     ^~~~
In file included from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib.h:44,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gprintf.h:21,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gstdio.h:22,
                 from ../src/utils.c:19:
/nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gdatetime.h:120:25: note: declared here
 GDateTime *             g_date_time_new_from_timeval_utc                (const GTimeVal *tv);
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/utils.c:588:5: warning: 'g_time_val_from_iso8601' is deprecated: Use 'g_date_time_new_from_iso8601' instead [-Wdeprecated-declarations]
     if (!g_time_val_from_iso8601(json_reader_get_string_value(reader), &time))
     ^~
In file included from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib.h:88,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gprintf.h:21,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gstdio.h:22,
                 from ../src/utils.c:19:
/nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gtimer.h:70:10: note: declared here
 gboolean g_time_val_from_iso8601 (const gchar *iso_date,
          ^~~~~~~~~~~~~~~~~~~~~~~
../src/utils.c:594:5: warning: 'g_date_time_new_from_timeval_utc' is deprecated: Use 'g_date_time_new_from_unix_utc' instead [-Wdeprecated-declarations]
     data->published_at = g_date_time_new_from_timeval_utc(&time);
     ^~~~
In file included from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib.h:44,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gprintf.h:21,
                 from /nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gstdio.h:22,
                 from ../src/utils.c:19:
/nix/store/ffpa6rmdg9cn07la0asrhx2qb52agna2-glib-2.62.1-dev/include/glib-2.0/glib/gdatetime.h:120:25: note: declared here
 GDateTime *             g_date_time_new_from_timeval_utc                (const GTimeVal *tv);
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[50/50] Generating GnomeTwitch-0.4.1.typelib with a custom command.
glibPreInstallPhase
installing
install flags: install
[1/2] Installing files. with a custom command.
Installing data/com.vinszent.GnomeTwitch.desktop to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/applications
Installing data/com.vinszent.GnomeTwitch.appdata.xml to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/metainfo
Installing src/libgnome-twitch.so.0.4.1 to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/lib
Installing src/GnomeTwitch-0.4.1.gir to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/gir-1.0
Installing src/GnomeTwitch-0.4.1.typelib to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/lib/girepository-1.0
Installing src/gnome-twitch to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/bin
Installing /build/source/include/gnome-twitch/gt-player-backend.h to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/include/gnome-twitch
Installing /build/source/include/gnome-twitch/gt-log.h to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/include/gnome-twitch
Installing /build/source/data/icons/hicolor/16x16/apps/com.vinszent.GnomeTwitch.png to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/icons/hicolor/16x16/apps
Installing /build/source/data/icons/hicolor/24x24/apps/com.vinszent.GnomeTwitch.png to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/icons/hicolor/24x24/apps
Installing /build/source/data/icons/hicolor/32x32/apps/com.vinszent.GnomeTwitch.png to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/icons/hicolor/32x32/apps
Installing /build/source/data/icons/hicolor/48x48/apps/com.vinszent.GnomeTwitch.png to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/icons/hicolor/48x48/apps
Installing /build/source/data/icons/hicolor/256x256/apps/com.vinszent.GnomeTwitch.png to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/icons/hicolor/256x256/apps
Installing /build/source/data/icons/hicolor/512x512/apps/com.vinszent.GnomeTwitch.png to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/icons/hicolor/512x512/apps
Installing /build/source/data/icons/hicolor/scalable/apps/com.vinszent.GnomeTwitch.svg to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/icons/hicolor/scalable/apps
Installing /build/source/data/icons/hicolor/scalable/apps/com.vinszent.GnomeTwitch-symbolic.svg to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/icons/hicolor/symbolic/apps
Installing /build/source/data/com.vinszent.GnomeTwitch.gschema.xml to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/glib-2.0/schemas
Installing /build/source/build/meson-private/gnome-twitch.pc to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/lib/pkgconfig
Running custom install script '/nix/store/f6782xkn0xwkw4jmxr96r7f8zzglqbli-meson-0.51.2/bin/meson --internal gettext install --subdir=po --localedir=share/locale --pkgname=gnome-twitch'
Installing /build/source/build/po/cs.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/cs/LC_MESSAGES/gnome-twitch.mo
Installing /build/source/build/po/de.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/de/LC_MESSAGES/gnome-twitch.mo
Installing /build/source/build/po/es.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/es/LC_MESSAGES/gnome-twitch.mo
Installing /build/source/build/po/fr.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/fr/LC_MESSAGES/gnome-twitch.mo
Installing /build/source/build/po/hu.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/hu/LC_MESSAGES/gnome-twitch.mo
Installing /build/source/build/po/nl.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/nl/LC_MESSAGES/gnome-twitch.mo
Installing /build/source/build/po/pl.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/pl/LC_MESSAGES/gnome-twitch.mo
Installing /build/source/build/po/pt.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/pt/LC_MESSAGES/gnome-twitch.mo
Installing /build/source/build/po/ru.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/ru/LC_MESSAGES/gnome-twitch.mo
Installing /build/source/build/po/sr.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/sr/LC_MESSAGES/gnome-twitch.mo
Installing /build/source/build/po/sv.gmo to /nix/store/3mjwpvlkjpmrny6qg3q5px74nj4b8kh0-gnome-twitch-unstable-2019-05-20/share/locale/sv/LC_MESSAGES/gnome-twitch.mo
Running custom install script '/build/source/meson_post_install.py'
Failed to run install script '/build/source/meson_post_install.py'
FAILED: meson-install
/nix/store/f6782xkn0xwkw4jmxr96r7f8zzglqbli-meson-0.51.2/bin/meson install --no-rebuild
ninja: build stopped: subcommand failed.
builder for '/nix/store/m4a14p327qcrphw2vzr3y9np76cm5dwx-gnome-twitch-unstable-2019-05-20.drv' failed with exit code 1
error: build of '/nix/store/m4a14p327qcrphw2vzr3y9np76cm5dwx-gnome-twitch-unstable-2019-05-20.drv' failed

```