### PR TITLE
clightning: 0.7.2.1 -> 0.7.3

### DIFF
--- a/pkgs/applications/blockchains/clightning.nix
+++ b/pkgs/applications/blockchains/clightning.nix
@@ -1,19 +1,19 @@
 { stdenv, python3, pkgconfig, which, libtool, autoconf, automake,
-  autogen, sqlite, gmp, zlib, fetchurl, unzip, fetchpatch }:
+  autogen, sqlite, gmp, zlib, fetchurl, unzip, fetchpatch, gettext }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "clightning";
-  version = "0.7.2.1";
+  version = "0.7.3";
 
   src = fetchurl {
     url = "https://github.com/ElementsProject/lightning/releases/download/v${version}/clightning-v${version}.zip";
-    sha256 = "3be716948efc1208b5e6a41e3034e4e4eecc5abbdac769fd1d999a104ac3a2ec";
+    sha256 = "ef2193940146d1b8ff0cc03602842c4d81db9ca6a5e73927e4f8932715e931a4";
   };
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ autoconf autogen automake libtool pkgconfig which unzip ];
+  nativeBuildInputs = [ autoconf autogen automake libtool pkgconfig which unzip gettext ];
   buildInputs =
     let py3 = python3.withPackages (p: [ p.Mako ]);
     in [ sqlite gmp zlib py3 ];
@@ -28,7 +28,8 @@ stdenv.mkDerivation rec {
     patchShebangs \
       tools/generate-wire.py \
       tools/update-mocks.sh \
-      tools/mockup.sh
+      tools/mockup.sh \
+      devtools/sql-rewrite.py
   '';
 
   doCheck = false;


### PR DESCRIPTION
##### Motivation for this change
New release. Requires `gettext` to build as mentioned in the changelog (https://github.com/ElementsProject/lightning/blob/v0.7.3/CHANGELOG.md).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (ArchLinux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jb55 
