### PR TITLE
ghostscript: 9.27 -> 9.50

### DIFF
--- a/pkgs/development/libraries/jbig2dec/default.nix
+++ b/pkgs/development/libraries/jbig2dec/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, python, autoconf }:
 
 stdenv.mkDerivation rec {
-  name = "jbig2dec-0.16";
+  pname = "jbig2dec";
+  version = "0.17";
 
   src = fetchurl {
-    url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs927/${name}.tar.gz";
-    sha256 = "00h61y7bh3z6mqfzxyb318gyh0f8jwarg4hvlrm83rqps8avzxm4";
+    url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs950/${pname}-${version}.tar.gz";
+    sha256 = "0wpvslmwazia3z8gyk343kbq6yj47pxr4x5yjvx332v309qssazp";
   };
 
   postPatch = ''
@@ -17,10 +18,10 @@ stdenv.mkDerivation rec {
   checkInputs = [ python ];
   doCheck = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://www.jbig2dec.com/;
     description = "Decoder implementation of the JBIG2 image compression format";
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -9,9 +9,9 @@ assert x11Support -> xlibsWrapper != null;
 assert cupsSupport -> cups != null;
 
 let
-  version = "9.${ver_min}";
-  ver_min = "27";
-  sha512 = "00m8pfvvg4dzvrzk66myr8kid76x44sgqk84m9562g4viv9zbw759l8q9qg64mgvbajzn78zpqfgdlgz9nwgcdb1vpwc08gm12ssrsy";
+  version = "9.50";
+  ver_min = lib.versions.minor version;
+  sha512 = "3p46kzn6kh7z4qqnqydmmvdlgzy5730z3yyvyxv6i4yb22mgihzrwqmhmvfn3b7lypwf6fdkkndarzv7ly3zndqpyvg89x436sms7iw";
 
   fonts = stdenv.mkDerivation {
     name = "ghostscript-fonts";
@@ -47,24 +47,6 @@ stdenv.mkDerivation rec {
   patches = [
     ./urw-font-files.patch
     ./doc-no-ref.diff
-    (fetchpatch {
-        name = "CVE-2019-10216.patch";
-        url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=5b85ddd19a8420a1bd2d5529325be35d78e94234";
-        sha256 = "165svml4knq1xlysfvj7vc07h68bhv3rgvl83xrhxsxdzs1ign31";
-    })
-    (fetchpatch {
-        name = "CVE-2019-14811.CVE-2019-14812.CVE-2019-14813.patch";
-        url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=885444fcbe10dc42787ecb76686c8ee4dd33bf33";
-        sha256 = "19928sr7xpx7iibk9gn127g0r1yv2lcfpwgk2ipzz4wgrs3f5j70";
-    })
-    (fetchpatch {
-        name = "CVE-2019-14817-partial.patch";
-        url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=cd1b1cacadac2479e291efe611979bdc1b3bdb19";
-        # patch doesn't apply cleanly to all files, but at least partially applying it fixes
-        # *most* of the problematic sites.
-        excludes = ["Resource/Init/pdf_font.ps"];
-        sha256 = "0f8qgdqpv7bldc9akvjj10af2h2876cvnz4q3nvg4a00rk5i05wn";
-    })
   ];
 
   outputs = [ "out" "man" "doc" ];
@@ -73,7 +55,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoconf ];
   buildInputs =
-    [ zlib expat openssl
+    [ zlib expat openssl jbig2dec
       libjpeg libpng libtiff freetype fontconfig libpaper jbig2dec
       libiconv ijs lcms2
     ]


### PR DESCRIPTION
###### Motivation for this change
broken on master, bumped it

closes #68562 #70091 #59154
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
