### PR TITLE
pythonPackages.worldengine: disable python2 tests

### DIFF
--- a/pkgs/development/python-modules/worldengine/default.nix
+++ b/pkgs/development/python-modules/worldengine/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , pythonOlder
+, isPy27
 , fetchFromGitHub
 , nose
 , noise
@@ -48,6 +49,7 @@ buildPythonPackage rec {
 
   # with python<3.5, unittest fails to discover tests because of their filenames
   # so nose is used instead.
+  doCheck = !isPy27; # google namespace clash
   checkInputs = stdenv.lib.optional (pythonOlder "3.5") [ nose ];
   postCheck = stdenv.lib.optionalString (pythonOlder "3.5") ''
     nosetests tests


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken while reviewing another package

```
builder for '/nix/store/kiyhf03wc6nd7jmvbrfprsghkxpgqq3g-python2.7-worldengine-0.19.0.drv' failed with exit code 1; last 10 log lines:
    File "/build/source/worldengine/world.py", line 14, in <module>
      import worldengine.protobuf.World_pb2 as Protobuf
    File "/build/source/worldengine/protobuf/World_pb2.py", line 4, in <module>
      from google.protobuf import descriptor as _descriptor
  ImportError: No module named google.protobuf

  ----------------------------------------------------------------------
  Ran 12 tests in 0.006s

  FAILED (errors=6)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
