### PR TITLE
python3Packages.snuggs: 1.4.3 -> 1.4.7

### DIFF
--- a/pkgs/development/python-modules/snuggs/default.nix
+++ b/pkgs/development/python-modules/snuggs/default.nix
@@ -1,23 +1,23 @@
 { buildPythonPackage, lib, fetchFromGitHub
 , click, numpy, pyparsing
-, pytest
+, pytest, hypothesis
 }:
 
 buildPythonPackage rec {
   pname = "snuggs";
-  version = "1.4.3";
+  version = "1.4.7";
 
   # Pypi doesn't ship the tests, so we fetch directly from GitHub
   src = fetchFromGitHub {
     owner = "mapbox";
     repo = pname;
     rev = version;
-    sha256 = "198nbgkhlg4ik2i1r2cp900iqlairh2hnii2y8v5wy1qk3rv0s9g";
+    sha256 = "1p3lh9s2ylsnrzbs931y2vn7mp2y2xskgqmh767c9l1a33shfgwf";
   };
 
   propagatedBuildInputs = [ click numpy pyparsing ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest hypothesis ];
   checkPhase = "pytest test_snuggs.py";
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken while reviewing another package

```
builder for '/nix/store/6pbqqq6bl1s91kf4yhdnn5q02zaafl4k-python3.7-snuggs-1.4.3.drv' failed with exit code 1; last 10 log lines:
          assert excinfo.value.offset == 3
          exception_options = ['expected a function or operator',
                               'Expected {Forward: ... | Forward: ...}']
  >       assert str(excinfo.value) in exception_options
  E       assert 'Expected {Forward: Group:({{{{Suppress:("(") map | partial} {{{"nil" | : ...} | * | + | / | - | & | | | <= | < | == |... starting with \' ending with \' | quoted string, starting with " ending with "}}]...} Suppress:(")")})}, found \'b\' ' in ['expected a function or operator', 'Expected {Forward: ... | Forward: ...}']
  E        +  where 'Expected {Forward: Group:({{{{Suppress:("(") map | partial} {{{"nil" | : ...} | * | + | / | - | & | | | <= | < | == |... starting with \' ending with \' | quoted string, starting with " ending with "}}]...} Suppress:(")")})}, found \'b\' ' = str(ExpressionError('Expected {Forward: Group:({{{{Suppress:("(") map | partial} {{{"nil" | : ...} | * | + | / | - | & | |...starting with \' ending with \' | quoted string, starting with " ending with "}}]...} Suppress:(")")})}, found \'b\' '))
  E        +    where ExpressionError('Expected {Forward: Group:({{{{Suppress:("(") map | partial} {{{"nil" | : ...} | * | + | / | - | & | |...starting with \' ending with \' | quoted string, starting with " ending with "}}]...} Suppress:(")")})}, found \'b\' ') = <ExceptionInfo ExpressionError tblen=3>.value

  test_snuggs.py:220: AssertionError
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @


```
[6 built, 1 copied (33.3 MiB), 7.2 MiB DL]
https://github.com/NixOS/nixpkgs/pull/72226
6 package were build:
python27Packages.rasterio python27Packages.snuggs python37Packages.rasterio python37Packages.snuggs python38Packages.rasterio python38Packages.snuggs
```