### PR TITLE
pythonPackages.chardet: fix tests

### DIFF
--- a/pkgs/development/python-modules/chardet/default.nix
+++ b/pkgs/development/python-modules/chardet/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi, fetchpatch
-, pytest, pytestrunner, hypothesis }:
+, pytest_4, pytestrunner, hypothesis }:
 
 buildPythonPackage rec {
   pname = "chardet";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     })
   ];
 
-  checkInputs = [ pytest pytestrunner hypothesis ];
+  checkInputs = [ pytest_4 pytestrunner hypothesis ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/chardet/chardet;


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
