### PR TITLE
python3Packages.nototools: make compatible with python3, unblock channel

### DIFF
--- a/nixos/tests/fontconfig-default-fonts.nix
+++ b/nixos/tests/fontconfig-default-fonts.nix
@@ -7,7 +7,7 @@ import ./make-test.nix ({ lib, ... }:
     fonts.fonts = with pkgs; [
       noto-fonts-emoji
       cantarell-fonts
-      twitter-color-emoji
+      #twitter-color-emoji # Can't be generated with Python 3 version of nototools
       source-code-pro
       gentium
     ];

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -89,15 +89,17 @@ in
       maintainers = with maintainers; [ mathnerd314 ];
     };
   };
-  noto-fonts-emoji = let version = "2018-08-10-unicode11"; in stdenv.mkDerivation {
+  noto-fonts-emoji = let
+    version = "unstable-2019-10-22";
+  in stdenv.mkDerivation {
     pname = "noto-fonts-emoji";
     inherit version;
 
     src = fetchFromGitHub {
       owner = "googlei18n";
       repo = "noto-emoji";
-      rev = "v${version}";
-      sha256 = "1y54zsvwf5pqhcd9cl2zz5l52qyswn6kycvrq03zm5kqqsngbw3p";
+      rev = "018aa149d622a4fea11f01c61a7207079da301bc";
+      sha256 = "0qmnnjpp5lza6g5m3ki6hj46p891h9vl42k3acd0qw8i0jj5yn2c";
     };
 
     buildInputs = [ cairo ];

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, fetchFromGitHub, optipng, cairo, pythonPackages, pkgconfig, pngquant, which, imagemagick }:
+{ stdenv, fetchzip, fetchFromGitHub, optipng, cairo, python3Packages, pkgconfig, pngquant, which, imagemagick }:
 
 let
   mkNoto = { name, weights, sha256, }:
@@ -102,7 +102,7 @@ in
 
     buildInputs = [ cairo ];
     nativeBuildInputs = [ pngquant optipng which cairo pkgconfig imagemagick ]
-                     ++ (with pythonPackages; [ python fonttools nototools ]);
+                     ++ (with python3Packages; [ python fonttools nototools ]);
 
     postPatch = ''
       sed -i 's,^PNGQUANT :=.*,PNGQUANT := ${pngquant}/bin/pngquant,' Makefile

--- a/pkgs/data/fonts/noto-fonts/tools.nix
+++ b/pkgs/data/fonts/noto-fonts/tools.nix
@@ -1,27 +1,44 @@
-{ fetchFromGitHub, pythonPackages, lib }:
+{ fetchFromGitHub, lib, fetchpatch, buildPythonPackage, isPy3k, fonttools, numpy, pillow, six, bash }:
 
-pythonPackages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "nototools";
-  version = "unstable-2019-03-20";
+  version = "unstable-2019-10-21";
 
   src = fetchFromGitHub {
     owner = "googlefonts";
     repo = "nototools";
-    rev = "9c4375f07c9adc00c700c5d252df6a25d7425870";
-    sha256 = "0z9i23vl6xar4kvbqbc8nznq3s690mqc5zfv280l1c02l5n41smc";
+    rev = "cae92ce958bee37748bf0602f5d7d97bb6db98ca";
+    sha256 = "1jqr0dz23rjqiyxw1w69l6ry16dwdcf3c6cysiy793g2v7pir2yi";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ fonttools numpy ];
+  propagatedBuildInputs = [ fonttools numpy ];
+
+  patches = lib.optionals isPy3k [
+    # Additional Python 3 compat https://github.com/googlefonts/nototools/pull/497
+    (fetchpatch {
+      url = https://github.com/googlefonts/nototools/commit/ded1f311b3260f015b5c5b80f05f7185392c4eff.patch;
+      sha256 = "0bn0rlbddxicw0h1dnl0cibgj6xjalja2qcm563y7kk3z5cdwhgq";
+    })
+  ];
 
   postPatch = ''
     sed -ie "s^join(_DATA_DIR_PATH,^join(\"$out/third_party/ucd\",^" nototools/unicode_data.py
   '';
 
+  checkInputs = [
+    pillow six bash
+  ];
+
+  checkPhase = ''
+    patchShebangs tests/
+    cd tests
+    rm gpos_diff_test.py # needs ttxn?
+    ./run_tests
+  '';
+
   postInstall = ''
     cp -r third_party $out
   '';
-
-  disabled = pythonPackages.isPy3k;
 
   meta = {
     description = "Noto fonts support tools and scripts plus web site generation";

--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -118,5 +118,6 @@ stdenv.mkDerivation rec {
     ## Non-artwork is MIT
     license = with licenses; [ asl20 ofl cc-by-40 mit ];
     maintainers = with maintainers; [ jtojnar ];
+    broken = true; # Can't be build using the current Python 3 version of nototools
   };
 }

--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -7,7 +7,7 @@
 , imagemagick
 , pkg-config
 , pngquant
-, python2
+, python3
 , which
 , zopfli
 }:
@@ -33,7 +33,7 @@ let
     sha256 = "0vzmlp83vnk4njcfkn03jcc1vkg2rf12zf5kj3p3a373xr4ds1zn";
   };
 
-  python = python2.withPackages (pp: with pp; [
+  python = python3.withPackages (pp: with pp; [
     nototools
   ]);
 in


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The latest version of the Python package fonttools is no longer Python 2 compatible, breaking nototools and thus certain font generation.

By updating nototools and applying patches it is now (mostly) Python 3 compatible.

Note we could also add an older Python 2 version of fonttools, but longer-term we should get rid of Python 2.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
