### PR TITLE
communi: fix build

### DIFF
--- a/pkgs/applications/networking/irc/communi/default.nix
+++ b/pkgs/applications/networking/irc/communi/default.nix
@@ -19,15 +19,17 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     export QMAKEFEATURES=${libcommuni}/features
-    qmakeFlags="$qmakeFlags \
-      COMMUNI_INSTALL_PREFIX=$out \
-      COMMUNI_INSTALL_BINS=$out/bin \
-      COMMUNI_INSTALL_PLUGINS=$out/lib/communi/plugins \
-      COMMUNI_INSTALL_ICONS=$out/share/icons/hicolor \
-      COMMUNI_INSTALL_DESKTOP=$out/share/applications \
-      COMMUNI_INSTALL_THEMES=$out/share/communi/themes
-    "
   '';
+
+  qmakeFlags = [
+    "COMMUNI_INSTALL_PREFIX=$out"
+    "COMMUNI_INSTALL_BINS=$out/bin"
+    "COMMUNI_INSTALL_PLUGINS=$out/lib/communi/plugins"
+    "COMMUNI_INSTALL_ICONS=$out/share/icons/hicolor"
+    "COMMUNI_INSTALL_DESKTOP=$out/share/applications"
+    "COMMUNI_INSTALL_THEMES=$out/share/communi/themes"
+  ];
+
 
   postInstall = stdenv.lib.optionalString stdenv.isLinux ''
     substituteInPlace "$out/share/applications/communi.desktop" \


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing anotoher package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
