### PR TITLE
spotify-tui: 0.6.2 -> 0.8.0

### DIFF
--- a/pkgs/applications/audio/spotify-tui/default.nix
+++ b/pkgs/applications/audio/spotify-tui/default.nix
@@ -2,16 +2,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "spotify-tui";
-  version = "0.6.2";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "Rigellute";
     repo = "spotify-tui";
     rev = "v${version}";
-    sha256 = "0ksrdavnvjpph7h0lcc2hvxhygfbn0dmsabq2ilslvpa80ph2c53";
+    sha256 = "0pgmcld48sd34jpsc4lr8dbqs8iwk0xp9aa3b15m61mv3lf04qc6";
   };
 
-  cargoSha256 = "029g80mcqvmckszpbzm4hxs5w63n41ah4rc1b93i9c1nzvncd811";
+  cargoSha256 = "1rb4dl9zn3xx2yrapx5cfsli93ggmdq8w9fqi8cy8giyja1mnqfl";
+
+  cargoPatches = [ ./fix-cargo-lock-version.patch ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ]

--- a/pkgs/applications/audio/spotify-tui/fix-cargo-lock-version.patch
+++ b/pkgs/applications/audio/spotify-tui/fix-cargo-lock-version.patch
@@ -1,0 +1,13 @@
+diff --git i/Cargo.lock w/Cargo.lock
+index e1eae72..e004898 100644
+--- i/Cargo.lock
++++ w/Cargo.lock
+@@ -1310,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "spotify-tui"
+-version = "0.7.5"
++version = "0.8.0"
+ dependencies = [
+  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jwijenbergh
