### PR TITLE
pazi: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/tools/misc/pazi/cargo-lock.patch
+++ b/pkgs/tools/misc/pazi/cargo-lock.patch
@@ -1,13 +1,13 @@
-diff --git a/Cargo.lock b/Cargo.lock
-index 074b0ca..22f3bc5 100644
---- a/Cargo.lock
-+++ b/Cargo.lock
-@@ -286,7 +286,7 @@ dependencies = [
+diff --git i/Cargo.lock w/Cargo.lock
+index b39a076..03a2757 100644
+--- i/Cargo.lock
++++ w/Cargo.lock
+@@ -281,7 +281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  
  [[package]]
  name = "pazi"
--version = "0.2.0"
-+version = "0.3.0"
+-version = "0.3.0"
++version = "0.4.0"
  dependencies = [
   "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
-  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkgs/tools/misc/pazi/default.nix
+++ b/pkgs/tools/misc/pazi/default.nix
@@ -2,18 +2,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "pazi";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "euank";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1gnh6047hacavcb9bhps9d1zjns66rdbd158fw20kjp1lln5srrn";
+    sha256 = "1bbci7bvrwl7lsslf302jham1pcw32fi7nwgqyjpfjyzvnpfgndz";
   };
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
-  cargoSha256 = "15s03vwgl6562n5h9r4d5kp2r168jakn5nwnyibmrs8r5q0idmjs";
+  cargoSha256 = "0nqcp54nwv4ic5jc3cgg15rh8dgkixfgkwb5q47rv8ding4cd0j5";
 
   cargoPatches = [ ./cargo-lock.patch ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/euank/pazi/releases/tag/v0.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bbigras
