### PR TITLE
wdisplays: init at 2019-10-26-unstable

### DIFF
--- a/pkgs/tools/graphics/wdisplays/default.nix
+++ b/pkgs/tools/graphics/wdisplays/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, gtk3, epoxy, wayland }:
+stdenv.mkDerivation {
+  pname = "wdisplays";
+  version = "2019-10-26-unstable";
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+
+  buildInputs = [ gtk3 epoxy wayland ];
+
+  src = fetchFromGitHub {
+    owner = "cyclopsian";
+    repo = "wdisplays";
+    rev = "22669edadb8ff3478bdb51ddc140ef6e61e3d9ef";
+    sha256 = "127k5i98km6mh8yw4vf8n44b29kc3n0169xpkdh7yr0rhv6n9cdl";
+  };
+
+  meta = let inherit (stdenv) lib; in {
+    description = "A graphical application for configuring displays in Wayland compositors";
+    homepage = "https://github.com/cyclopsian/wdisplays";
+    maintainers = [ lib.maintainers.lheckemann ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7123,6 +7123,8 @@ in
 
   wdiff = callPackage ../tools/text/wdiff { };
 
+  wdisplays = callPackage ../tools/graphics/wdisplays { };
+
   webalizer = callPackage ../tools/networking/webalizer { };
 
   weighttp = callPackage ../tools/networking/weighttp { };


### PR DESCRIPTION
##### Motivation for this change
Switched to sway and don't like configuring monitor resolutions and offsets as plain numbers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Built on x86_64-linux (Nixos)
- [x] Tested with sway from nixos-19.09
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).