### PR TITLE
Fix QGIS in release-19.09

### DIFF
--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -10,7 +10,7 @@ let
     [ qscintilla-qt5 gdal jinja2 numpy psycopg2
       chardet dateutil pyyaml pytz requests urllib3 pygments pyqt5 sip owslib six ];
 in mkDerivation rec {
-  version = "3.8.3";
+  version = "3.10.0";
   pname = "qgis";
   name = "${pname}-unwrapped-${version}";
 
@@ -18,7 +18,7 @@ in mkDerivation rec {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "16axjih48qn8ri3p71d8f7k0y3rd05wghmg1fcbyda871b45b2f8";
+    sha256 = "0qq4dznxxbpj8b4ypkz7dixc0b0v6rmf3c5hs4m3ka3rzck8jsqc";
   };
 
   passthru = {

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake, ninja, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
+{ mkDerivation, lib, fetchFromGitHub, cmake, ninja, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
 , qwt, fcgi, python3Packages, libspatialindex, libspatialite, postgresql
 , txt2tags, openssl, libzip, hdf5, netcdf, exiv2
 , qtbase, qtwebkit, qtsensors, qca-qt5, qtkeychain, qscintilla, qtserialport, qtxmlpatterns
@@ -9,8 +9,8 @@ let
   pythonBuildInputs = with python3Packages;
     [ qscintilla-qt5 gdal jinja2 numpy psycopg2
       chardet dateutil pyyaml pytz requests urllib3 pygments pyqt5 sip owslib six ];
-in stdenv.mkDerivation rec {
-  version = "3.8.0";
+in mkDerivation rec {
+  version = "3.8.3";
   pname = "qgis";
   name = "${pname}-unwrapped-${version}";
 
@@ -18,7 +18,7 @@ in stdenv.mkDerivation rec {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "11jqj6lavpw9piv0rm8vvbgd99zhcxl6yfjg699wlrjlyf71xac5";
+    sha256 = "16axjih48qn8ri3p71d8f7k0y3rd05wghmg1fcbyda871b45b2f8";
   };
 
   passthru = {
@@ -29,7 +29,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [ openssl proj geos xlibsWrapper sqlite gsl qwt exiv2
     fcgi libspatialindex libspatialite postgresql txt2tags libzip hdf5 netcdf
     qtbase qtwebkit qtsensors qca-qt5 qtkeychain qscintilla qtserialport qtxmlpatterns] ++
-    (stdenv.lib.optional withGrass grass) ++ pythonBuildInputs;
+    (lib.optional withGrass grass) ++ pythonBuildInputs;
 
   nativeBuildInputs = [ cmake flex bison ninja ];
 
@@ -45,13 +45,13 @@ in stdenv.mkDerivation rec {
   cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=OFF"
                  "-DPYQT5_SIP_DIR=${python3Packages.pyqt5}/share/sip/PyQt5"
                  "-DQSCI_SIP_DIR=${python3Packages.qscintilla-qt5}/share/sip/PyQt5" ] ++
-                 stdenv.lib.optional withGrass "-DGRASS_PREFIX7=${grass}/${grass.name}";
+                 lib.optional withGrass "-DGRASS_PREFIX7=${grass}/${grass.name}";
 
   meta = {
     description = "A Free and Open Source Geographic Information System";
     homepage = http://www.qgis.org;
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = with stdenv.lib.platforms; linux;
-    maintainers = with stdenv.lib.maintainers; [ lsix ];
+    license = lib.licenses.gpl2Plus;
+    platforms = with lib.platforms; linux;
+    maintainers = with lib.maintainers; [ lsix ];
   };
 }

--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -35,15 +35,16 @@ in stdenv.mkDerivation rec {
   patches = (lib.optional (stdenv.isDarwin && withQt5) xcodePatch) ++
             (lib.optional (!withQt5) ./fix-qt4-build.patch );
 
+  # Make sure that libqscintilla2.so is available in $out/lib since it is expected
+  # by some packages such as sqlitebrowser
+  postFixup = ''
+    ln -s $out/lib/libqscintilla2_qt?.so $out/lib/libqscintilla2.so
+  '';
+
   enableParallelBuilding = true;
 
-  # By default qscintilla will name the library with a qt version suffix which
-  # confuses the crap out of sqlitebrowser and possibly others so we simply
-  # strip the suffix as we don't need it and the various FindQScintilla.cmake
-  # files floating around *should* look for the un-suffixed version.
   postPatch = ''
     substituteInPlace qscintilla.pro \
-      --replace '_qt$''${QT_MAJOR_VERSION}'   "" \
       --replace '$$[QT_INSTALL_LIBS]'         $out/lib \
       --replace '$$[QT_INSTALL_HEADERS]'      $out/include \
       --replace '$$[QT_INSTALL_TRANSLATIONS]' $out/translations \

--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -4,21 +4,25 @@
 , fixDarwinDylibNames
 }:
 
-# Fix Xcode 8 compilation problem
-let xcodePatch =
-  fetchurl { url = "https://raw.githubusercontent.com/Homebrew/formula-patches/a651d71/qscintilla2/xcode-8.patch";
-             sha256 = "1a88309fdfd421f4458550b710a562c622d72d6e6fdd697107e4a43161d69bc9"; };
-in
-stdenv.mkDerivation rec {
-  pname = "qscintilla";
-  version = "2.9.4";
+let
+  # Fix Xcode 8 compilation problem
+  xcodePatch = fetchurl {
+    url = "https://raw.githubusercontent.com/Homebrew/formula-patches/a651d71/qscintilla2/xcode-8.patch";
+    sha256 = "1a88309fdfd421f4458550b710a562c622d72d6e6fdd697107e4a43161d69bc9";
+  };
 
-  name = "${pname}-${if withQt5 then "qt5" else "qt4"}-${version}";
+  pname = "qscintilla-qt${if withQt5 then "5" else "4"}";
+  version = "2.11.2";
+
+in stdenv.mkDerivation rec {
+  inherit pname version;
 
   src = fetchurl {
-    url = "mirror://sourceforge/pyqt/QScintilla2/QScintilla-${version}/QScintilla_gpl-${version}.zip";
-    sha256 = "04678skipydx68zf52vznsfmll2v9aahr66g50lcqbr6xsmgr1yi";
+    url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/${version}/QScintilla_gpl-${version}.tar.gz";
+    sha256 = "18glb2v07mwfz6p8qmwhzcaaczyc36x3gn9wx8ndm7q6d93xr6q2";
   };
+
+  sourceRoot = "QScintilla_gpl-${version}/Qt4Qt5";
 
   buildInputs = [ (if withQt5 then qtbase else qt4) ];
 
@@ -28,25 +32,24 @@ stdenv.mkDerivation rec {
     ++ (if withQt5 then [ qmake ] else [ qmake4Hook ])
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-
   patches = (lib.optional (stdenv.isDarwin && withQt5) xcodePatch) ++
             (lib.optional (!withQt5) ./fix-qt4-build.patch );
 
   enableParallelBuilding = true;
 
-  preConfigure = ''
-    cd Qt4Qt5
-    sed -i qscintilla.pro \
-      -e "s,\$\$\\[QT_INSTALL_LIBS\\],$out/lib," \
-      -e "s,\$\$\\[QT_INSTALL_HEADERS\\],$out/include/," \
-      -e "s,\$\$\\[QT_INSTALL_TRANSLATIONS\\],$out/translations," \
-    ${if withQt5 then ''
-      -e "s,\$\$\\[QT_HOST_DATA\\]/mkspecs,$out/mkspecs," \
-      -e "s,\$\$\\[QT_INSTALL_DATA\\]/mkspecs,$out/mkspecs," \
-      -e "s,\$\$\\[QT_INSTALL_DATA\\],$out/share,"
-    '' else ''
-      -e "s,\$\$\\[QT_INSTALL_DATA\\],$out/share/qt,"
-    ''}
+  # By default qscintilla will name the library with a qt version suffix which
+  # confuses the crap out of sqlitebrowser and possibly others so we simply
+  # strip the suffix as we don't need it and the various FindQScintilla.cmake
+  # files floating around *should* look for the un-suffixed version.
+  postPatch = ''
+    substituteInPlace qscintilla.pro \
+      --replace '_qt$''${QT_MAJOR_VERSION}'   "" \
+      --replace '$$[QT_INSTALL_LIBS]'         $out/lib \
+      --replace '$$[QT_INSTALL_HEADERS]'      $out/include \
+      --replace '$$[QT_INSTALL_TRANSLATIONS]' $out/translations \
+      --replace '$$[QT_HOST_DATA]/mkspecs'    $out/mkspecs \
+      --replace '$$[QT_INSTALL_DATA]/mkspecs' $out/mkspecs \
+      --replace '$$[QT_INSTALL_DATA]'         $out/share${lib.optionalString (! withQt5) "/qt"}
   '';
 
   meta = with stdenv.lib; {
@@ -65,9 +68,10 @@ stdenv.mkDerivation rec {
       proportional fonts, bold and italics, multiple foreground and
       background colours and multiple fonts.
     '';
-    homepage = http://www.riverbankcomputing.com/software/qscintilla/intro;
+    homepage = https://www.riverbankcomputing.com/software/qscintilla/intro;
     license = with licenses; [ gpl2 gpl3 ]; # and commercial
-    platforms = platforms.unix;
     maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.unix;
+    broken = !withQt5;
   };
 }

--- a/pkgs/development/python-modules/qscintilla-qt5/default.nix
+++ b/pkgs/development/python-modules/qscintilla-qt5/default.nix
@@ -15,6 +15,13 @@ buildPythonPackage {
   buildInputs = [ qscintilla ];
   propagatedBuildInputs = [ pyqt5 ];
 
+  postPatch = ''
+    substituteInPlace Python/configure.py \
+      --replace \
+      "target_config.py_module_dir" \
+      "'$out/${python.sitePackages}'"
+  '';
+
   preConfigure = ''
     mkdir -p $out
     lndir ${pyqt5} $out
@@ -28,6 +35,7 @@ buildPythonPackage {
       --stubsdir=$out/${python.sitePackages}/PyQt5 \
       --apidir=$out/api/${python.libPrefix} \
       --qsci-incdir=${qscintilla}/include \
+      --qsci-featuresdir=${qscintilla}/mkspecs/features \
       --qsci-libdir=${qscintilla}/lib \
       --pyqt-sipdir=${pyqt5}/share/sip/PyQt5 \
       --qsci-sipdir=$out/share/sip/PyQt5 \

--- a/pkgs/development/python-modules/qscintilla-qt5/default.nix
+++ b/pkgs/development/python-modules/qscintilla-qt5/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage {
     lndir ${pyqt5} $out
     rm -rf "$out/nix-support"
     cd Python
+    substituteInPlace configure.py \
+      --replace "qmake = {'CONFIG': 'qscintilla2'}" "qmake = {'CONFIG': 'qscintilla2', 'QT': 'widgets printsupport'}"
     ${python.executable} ./configure.py \
       --pyqt=PyQt5 \
       --destdir=$out/${python.sitePackages}/PyQt5 \
@@ -37,6 +39,5 @@ buildPythonPackage {
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ lsix ];
     homepage = https://www.riverbankcomputing.com/software/qscintilla/;
-    broken = true;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

qgis is currently broken on release-19.09.

This PR backports all necessary fixes to have it up to date and running.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
