### PR TITLE
ydotool: init at 0.1.8

### DIFF
--- a/pkgs/development/libraries/libevdevplus/default.nix
+++ b/pkgs/development/libraries/libevdevplus/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "libevdevplus";
+  version = "2019-10-01";
+
+  src  = fetchFromGitHub {
+    owner  = "YukiWorkshop";
+    repo   = "libevdevPlus";
+    rev    = "e863df2ade43e2c7d7748cc33ca27fb3eed325ca";
+    sha256 = "18z6pn4j7fhmwwh0q22ip5nn7sc1hfgwvkdzqhkja60i8cw2cvvj";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Easy-to-use event device library in C++";
+    license = licenses.mit;
+    maintainers = with maintainers; [ willibutz ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/development/libraries/libuinputplus/default.nix
+++ b/pkgs/development/libraries/libuinputplus/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "libuinputplus";
+  version = "2019-10-01";
+
+  src  = fetchFromGitHub {
+    owner  = "YukiWorkshop";
+    repo   = "libuInputPlus";
+    rev    = "962f180b4cc670e1f5cc73c2e4d5d196ae52d630";
+    sha256 = "0jy5i7bmjad7hw1qcyjl4swqribp2027s9g3609zwj7lj8z5x0bg";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Easy-to-use uinput library in C++";
+    license = licenses.mit;
+    maintainers = with maintainers; [ willibutz ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/tools/wayland/ydotool/default.nix
+++ b/pkgs/tools/wayland/ydotool/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, boost, libevdevplus, libuinputplus }:
+
+stdenv.mkDerivation rec {
+  pname = "ydotool";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "ReimuNotMoe";
+    repo = "ydotool";
+    rev = "v${version}";
+    sha256 = "0mx3636p0f8pznmwm4rlbwq7wrmjb2ygkf8b3a6ps96a7j1fw39l";
+  };
+
+  # disable static linking
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace \
+      "-static" \
+      ""
+  '';
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [
+    boost libevdevplus libuinputplus
+  ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Generic Linux command-line automation tool";
+    license = licenses.mit;
+    maintainers = with maintainers; [ willibutz ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12613,6 +12613,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  libuinputplus = callPackage ../development/libraries/libuinputplus { };
+
   libunistring = callPackage ../development/libraries/libunistring { };
 
   libupnp = callPackage ../development/libraries/pupnp { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14376,6 +14376,8 @@ in
 
   yder = callPackage ../development/libraries/yder { };
 
+  ydotool = callPackage ../tools/wayland/ydotool { };
+
   yojimbo = callPackage ../development/libraries/yojimbo { };
 
   yubioath-desktop = libsForQt5.callPackage ../applications/misc/yubioath-desktop { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4598,6 +4598,8 @@ in
 
   libevdev = callPackage ../development/libraries/libevdev { };
 
+  libevdevplus = callPackage ../development/libraries/libevdevplus { };
+
   libfann = callPackage ../development/libraries/libfann { };
 
   libfsm = callPackage ../development/libraries/libfsm { };


### PR DESCRIPTION
###### Motivation for this change
Adds ydotool for wayland.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (x86_64-linux & aarch64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).