### PR TITLE
onefetch: init at 1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3484,6 +3484,16 @@
     github = "klntsky";
     githubId = 18447310;
   };
+  kloenk = {
+    email = "kloenk@kloenk.de";
+    name = "Kloenk";
+    github = "Kloenk";
+    githubId = 12898828;
+    keys = [{
+      longkeyid = "ed25519/0xB92445CFC9546F9D";
+      fingerprint = "6881 5A95 D715 D429 659B  48A4 B924 45CF C954 6F9D";
+    }];
+  };
   kmeakin = {
     email = "karlwfmeakin@gmail.com";
     name = "Karl Meakin";

--- a/pkgs/tools/misc/onefetch/default.nix
+++ b/pkgs/tools/misc/onefetch/default.nix
@@ -1,0 +1,35 @@
+{
+    cargo
+  , makeRustPlatform
+  , fetchFromGitHub
+  , lib
+  , ...
+}:
+
+let
+  rustPlatform = makeRustPlatform {
+    rustc = cargo;
+    cargo = cargo;
+  };
+in
+  rustPlatform.buildRustPackage rec {
+    name = "onefetch-${version}";
+    version = "1.7.0";
+    
+    src = fetchFromGitHub {
+      owner = "o2sh";
+      repo = "onefetch";
+      rev = version;
+      sha256 = "1p16mg4ak9ppx3y11l3r4y6356drwhnmrlxsaqx01n53ii5ij9kg";
+    };
+    cargoSha256 = "0cpfjxn6nqsrnmgvjzr17n6xbbyfl9c91d5kbrmxb6jyig98k6aq";
+    buildInputs = [ ];
+    CARGO_HOME = "$(mktemp -d cargo-home.XXX)";
+
+    meta = with lib; {
+      homepage = https://github.com/o2sh/onefetch;
+      description = ''Displays information about your Git project directly on your terminal'';
+      license = licenses.mit;
+      maintainers = with maintainers; [ kloenk ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5022,6 +5022,8 @@ in
 
   neofetch = callPackage ../tools/misc/neofetch { };
 
+  onefetch = callPackage ../tools/misc/onefetch { };
+
   nerdfonts = callPackage ../data/fonts/nerdfonts { };
 
   nestopia = callPackage ../misc/emulators/nestopia { };


### PR DESCRIPTION
###### Motivation for this change
Adds onefetch for git repos analysis

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).