### PR TITLE
bslizr: init at 1.2.0

### DIFF
--- a/pkgs/applications/audio/bslizr/default.nix
+++ b/pkgs/applications/audio/bslizr/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, xorg, cairo, lv2, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "BSlizr";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "sjaehn";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "1xqhpppfj47nzmyksbqgfvvi5j807g96hqla544w2f752zz4yi0s";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    xorg.libX11 cairo lv2
+  ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/sjaehn/BSlizr;
+    description = "Sequenced audio slicing effect LV2 plugin (step sequencer effect)";
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17813,6 +17813,8 @@ in
 
   bs1770gain = callPackage ../applications/audio/bs1770gain { };
 
+  bslizr = callPackage ../applications/audio/bslizr { };
+
   bspwm = callPackage ../applications/window-managers/bspwm { };
 
   btops = callPackage ../applications/window-managers/btops { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
