### PR TITLE
lib: delay/remove 4 deprecation warnings

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -473,10 +473,4 @@ rec {
   /* Pick the outputs of packages to place in buildInputs */
   chooseDevOutputs = drvs: builtins.map getDev drvs;
 
-  /*** deprecated stuff ***/
-
-  zipWithNames = zipAttrsWithNames;
-  zip = builtins.trace
-    "lib.zip is deprecated, use lib.zipAttrsWith instead" zipAttrsWith;
-
 }

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -178,7 +178,7 @@ rec {
           + "for your uses (`lib.concat(Map)StringsSep`)." )
     (lib.concatStringsSep "; " (map (x: "${x}=") (attrNames a)));
 
-  showVal = with lib;
+  showVal = xx: with lib;
     trace ( "Warning: `showVal` is deprecated "
           + "and will be removed in the next release, "
           + "please use `traceSeqN`" )
@@ -196,7 +196,7 @@ rec {
       go = x: generators.toPretty
         { allowPrettyValues = true; }
         (modify x);
-    in go);
+    in go) xx;
 
   traceXMLVal = x:
     trace ( "Warning: `traceXMLVal` is deprecated "

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -59,7 +59,7 @@ let
       stringLength sub substring tail;
     inherit (trivial) id const pipe concat or and bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell min max
-      importJSON warn info showWarnings nixpkgsVersion version mod compare
+      importJSON warn info showWarnings version mod compare
       splitByAndCompare functionArgs setFunctionArgs isFunction;
     inherit (fixedPoints) fix fix' converge extends composeExtensions
       makeExtensible makeExtensibleWithCustomName;
@@ -70,7 +70,7 @@ let
       genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin
-      getLib getDev chooseDevOutputs zipWithNames zip;
+      getLib getDev chooseDevOutputs;
     inherit (lists) singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range partition zipListsWith zipLists
@@ -133,7 +133,7 @@ let
       mergeAttrsNoOverride mergeAttrByFunc mergeAttrsByFuncDefaults
       mergeAttrsByFuncDefaultsClean mergeAttrBy
       fakeSha256 fakeSha512
-      nixType imap;
+      nixType imap nixpkgsVersion zipWithNames zip;
     inherit (versions)
       splitVersion;
   });

--- a/lib/deprecated.nix
+++ b/lib/deprecated.nix
@@ -274,4 +274,12 @@ rec {
   # Fake hashes. Can be used as hash placeholders, when computing hash ahead isn't trivial
   fakeSha256 = "0000000000000000000000000000000000000000000000000000000000000000";
   fakeSha512 = "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+  # deprecated in favor for 'lib.version'. See 9274ea390348e17f766732e7fbd335e3bc164954
+  nixpkgsVersion = lib.trivial.version;
+
+  zipWithNames = zipAttrsWithNames;
+  zip = x: builtins.trace
+    "'lib.zip' is deprecated, use 'lib.zipAttrsWith' instead" zipAttrsWith x;
+
 }

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -520,7 +520,7 @@ rec {
   mkForce = mkOverride 50;
   mkVMOverride = mkOverride 10; # used by ‘nixos-rebuild build-vm’
 
-  mkStrict = builtins.trace "`mkStrict' is obsolete; use `mkOverride 0' instead." (mkOverride 0);
+  mkStrict = x: mkOverride 0 (builtins.trace "'mkStrict' is obsolete; use 'mkOverride 0' instead." x);
 
   mkFixStrictness = id; # obsolete, no-op
 

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -196,8 +196,6 @@ rec {
        else if lib.pathExists revisionFile then lib.fileContents revisionFile
        else default;
 
-  nixpkgsVersion = builtins.trace "`lib.nixpkgsVersion` is deprecated, use `lib.version` instead!" version;
-
   /* Determine whether the function is being called from inside a Nix
      shell.
 


### PR DESCRIPTION
This issue was seen when, for example, I've tried to nix-shell into docs:

```
$ nix-shell nixpkgs/doc
trace: `mkStrict' is obsolete; use `mkOverride 0' instead.
trace: `lib.nixpkgsVersion` is deprecated, use `lib.version` instead!
trace: Warning: `showVal` is deprecated and will be removed in the next release, please use `traceSeqN`
trace: lib.zip is deprecated, use lib.zipAttrsWith instead

nix-shell $
```

IMO it is clutter, so I did a few adjustments:

1. For multi-arity functions I've moved deprecation warning deeper, so
    shallow function evaluation doesn't trigger warning message, only deep evaluation does that.
2. Move function to `lib/deprecated.nix`.
   a) for 0-arity functions (lib.nixpkgsVersion) I've also removed deprecation
      message, as there is no way to silence it other way.

The worst thing is deprecation message removed for `lib.nixpkgsVersion`, but
I hope future linters will be able to scan `lib/deprecated.nix` and report deprecated
stuff before evaluation.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
