### PR TITLE
Introduce NixOPS plugin structure

### DIFF
--- a/pkgs/tools/package-management/nixops/core.nix
+++ b/pkgs/tools/package-management/nixops/core.nix
@@ -1,0 +1,14 @@
+{ fetchurl, callPackage, nixopsPlugins }: rec {
+  nixopsWithPlugins = { plugins }:
+    callPackage ./wrapper.nix (rec {
+      version = "1.8pre2870_2434bf2";
+      src = fetchurl {
+        url = "https://hydra.nixos.org/build/104709722/download/2/nixops-${version}.tar.bz2";
+        sha256 = "sha256:1bz561m7clhrick4wnff3y92iw222bd1cn4fz6ln1a2jhvjmrxrv";
+      };
+      inherit plugins;
+    });
+
+  nixopsCore =
+    nixopsWithPlugins { plugins = with nixopsPlugins; [ nixops-aws ]; };
+}

--- a/pkgs/tools/package-management/nixops/plugins.nix
+++ b/pkgs/tools/package-management/nixops/plugins.nix
@@ -1,0 +1,92 @@
+{ lib, python2Packages, fetchFromGitHub }: rec {
+  buildNixOpsPlugin =
+    { pluginName, name ? "nixops-${pluginName}", src, version, ... }@attrs:
+    python2Packages.buildPythonPackage (rec {
+      inherit name src;
+      prePatch = ''
+        substituteInPlace setup.py --subst-var-by version ${version}
+      '';
+      postInstall = ''
+        mkdir -p $out/share/nix/nixops-${pluginName}
+        cp -av nix/* $out/share/nix/nixops-${pluginName}
+      '';
+    } // attrs);
+
+  # Core Plugins
+  nixops-aws = buildNixOpsPlugin {
+    pluginName = "aws";
+    src = fetchFromGitHub {
+      owner = "nixos";
+      repo = "nixops-aws";
+      rev = "c61356ff7337a2df7a24fcc28a11091d255a2665";
+      sha256 = "2811ecb981261b5639fce4b757733c27a20573cc8a9a714b16d19ca33c90e74d";
+    };
+    version = "pre1823_c61356f";
+    doCheck = false;
+    propagatedBuildInputs = with python2Packages; [ boto boto3 ];
+    meta.maintainers = with lib.maintainers; [
+      aminechikhaoui
+      eelco
+      rob
+      domenkozar
+    ];
+  };
+
+  nixops-hetzner = buildNixOpsPlugin {
+    pluginName = "hetzner";
+    src = fetchFromGitHub {
+      owner = "nixos";
+      repo = "nixops-hetzner";
+      rev = "6245ca44f3682e45d6d82cee7d873f76b51ff693";
+      sha256 = "d980c41bef38ce398ba32bc388d6405cf861b6de723259f0afd401d57bbff2fa";
+    };
+    version = "pre1402_6245ca4";
+    doCheck = false;
+    propagatedBuildInputs = with python2Packages; [ hetzner ];
+    meta.maintainers = with lib.maintainers; [
+      aminechikhaoui
+      eelco
+      rob
+      domenkozar
+    ];
+  };
+
+  # Community Plugins
+  nixops-libvirtd = buildNixOpsPlugin {
+    pluginName = "libvirtd";
+    src = fetchFromGitHub {
+      owner = "nix-community";
+      repo = "nixops-libvirtd";
+      rev = "1c29f6c716dad9ad58aa863ebc9575422459bf95";
+      sha256 = "155131e2f64f51441af60a0550e57d90053d09749b214ce0d0bce7072b794a3c";
+    };
+    version = "pre730_1c29f6c";
+    propagatedBuildInputs = with python2Packages; [ libvirt ];
+    meta.maintainers = with lib.maintainers; [ aminechikhaoui ];
+  };
+
+  nixops-vbox = buildNixOpsPlugin {
+    pluginName = "vbox";
+    src = fetchFromGitHub {
+      owner = "nix-community";
+      repo = "nixops-vbox";
+      rev = "bff6054ce9e7f5f9aa830617577f1a511a461063";
+      sha256 = "b128943107648782eaa1846ee56314062cba2949f01f33a23c81579c515c1448";
+    };
+    version = "pre896_bff6054";
+    meta.maintainers = with lib.maintainers; [ aminechikhaoui ];
+  };
+
+  nixops-datadog = buildNixOpsPlugin {
+    pluginName = "datadog";
+    src = fetchFromGitHub {
+      owner = "nix-community";
+      repo = "nixops-datadog";
+      rev = "3637478b8103658dd9404792cafabe50342a9d72";
+      sha256 = "e11fc9ae73ea24ffb86c66aced0436e5a50a5be6f9613ad247a207bdb9cad6d5";
+    };
+    version = "pre714_3637478";
+    propagatedBuildInputs = [ python2Packages.datadog ];
+    meta.maintainers = with lib.maintainers; [ aminechikhaoui ];
+  };
+}

--- a/pkgs/tools/package-management/nixops/wrapper.nix
+++ b/pkgs/tools/package-management/nixops/wrapper.nix
@@ -1,0 +1,49 @@
+{ lib, python2Packages, libxslt, docbook_xsl_ns, openssh, cacert
+# version args
+, src, version
+, plugins ? []
+, meta ? {}
+}:
+
+python2Packages.buildPythonApplication {
+  name = "nixops-${version}";
+  inherit version src;
+
+  buildInputs = [ libxslt ];
+
+  pythonPath = with python2Packages;
+    [ prettytable
+      # Go back to sqlite once Python 2.7.13 is released
+      pysqlite
+      typing
+      pluggy
+    ] ++ plugins;
+
+  checkPhase =
+  # Ensure, that there are no (python) import errors
+  ''
+    SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt \
+    HOME=$(pwd) \
+      $out/bin/nixops --version
+  '';
+
+  postInstall = ''
+    make -C doc/manual install nixops.1 docbookxsl=${docbook_xsl_ns}/xml/xsl/docbook \
+      docdir=$out/share/doc/nixops mandir=$out/share/man
+
+    mkdir -p $out/share/nix/nixops
+    cp -av "nix/"* $out/share/nix/nixops
+
+    # Add openssh to nixops' PATH. On some platforms, e.g. CentOS and RHEL
+    # the version of openssh is causing errors when have big networks (40+)
+    wrapProgram $out/bin/nixops --prefix PATH : "${openssh}/bin"
+  '';
+
+  meta = {
+    homepage = https://github.com/NixOS/nixops;
+    description = "NixOS cloud provisioning and deployment tool";
+    maintainers = with lib.maintainers; [ aminechikhaoui eelco rob domenkozar ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.lgpl3;
+  } // meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24326,6 +24326,10 @@ in
 
   nixopsUnstable = lowPrio (callPackage ../tools/package-management/nixops/unstable.nix { });
 
+  nixopsPlugins = recurseIntoAttrs (callPackage ../tools/package-management/nixops/plugins.nix {});
+
+  inherit (callPackage ../tools/package-management/nixops/core.nix {}) nixopsCore nixopsWithPlugins;
+
   nixops-dns = callPackage ../tools/package-management/nixops/nixops-dns.nix { };
 
   /* Evaluate a NixOS configuration using this evaluation of Nixpkgs.


### PR DESCRIPTION
pkgs.nixopsCore now contains only the None/AWS/Hetzner backends,
other backends are available through pkgs.nixopsPlugins such as
pkgs.nixopsPlugins.nixops-vbox for VirtualBox.

There is also a convenience pkgs.nixopsWithPlugins which makes it
possible to quickly package a NixOPS with additional backends e.g:

```Nix
let
  nixopsGCE = nixopsPlugins.buildNixOpsPlugin rec {
    pluginName = "gce";
    src = builtins.fetchGit "https://github.com/AmineChikhaoui/nixops-gce";
    version = "pre853_aca0173";
    propagatedBuildInputs = [ python2Packages.libcloud ];
  };
in nixopsWithPlugins {
  plugins = with nixopsPlugins;
    [ nixops-aws nixops-hetzner nixops-libvirtd nixops-datadog nixops-vbox ]
    ++ [ nixopsGCE ];
}
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @disassembler @edolstra @rbvermaa 
