### PR TITLE
gtk3: only build docs on linux

### DIFF
--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -36,6 +36,7 @@
 , wayland-protocols
 , xineramaSupport ? stdenv.isLinux
 , cupsSupport ? stdenv.isLinux
+, withGtkDoc ? stdenv.isLinux
 , cups ? null
 , AppKit
 , Cocoa
@@ -49,7 +50,7 @@ stdenv.mkDerivation rec {
   pname = "gtk+3";
   version = "3.24.12";
 
-  outputs = [ "out" "dev" "devdoc" ];
+  outputs = [ "out" "dev" ] ++ optional withGtkDoc "devdoc";
   outputBin = "dev";
 
   setupHooks = [
@@ -81,7 +82,7 @@ stdenv.mkDerivation rec {
   separateDebugInfo = stdenv.isLinux;
 
   mesonFlags = [
-    "-Dgtk_doc=true"
+    "-Dgtk_doc=${boolToString withGtkDoc}"
     "-Dtests=false"
   ];
 
@@ -109,10 +110,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    docbook_xml_dtd_43
-    docbook_xsl
     gettext
-    gtk-doc
     gobject-introspection
     makeWrapper
     meson
@@ -121,6 +119,10 @@ stdenv.mkDerivation rec {
     python3
     sassc
     setupHooks
+  ] ++ optionals withGtkDoc [
+    docbook_xml_dtd_43
+    docbook_xsl
+    gtk-doc
   ];
 
   buildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
cc @jtojnar @FRidh. This will fix the macos build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).