### PR TITLE
twitter-color-emoji: build with python3 

### DIFF
--- a/nixos/tests/fontconfig-default-fonts.nix
+++ b/nixos/tests/fontconfig-default-fonts.nix
@@ -7,7 +7,7 @@ import ./make-test.nix ({ lib, ... }:
     fonts.fonts = with pkgs; [
       noto-fonts-emoji
       cantarell-fonts
-      #twitter-color-emoji # Can't be generated with Python 3 version of nototools
+      twitter-color-emoji
       source-code-pro
       gentium
     ];

--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -4,12 +4,13 @@
 { stdenv
 , fetchFromGitHub
 , cairo
-, imagemagick
+, graphicsmagick
 , pkg-config
 , pngquant
 , python3
 , which
 , zopfli
+, fetchpatch
 }:
 
 let
@@ -55,12 +56,28 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cairo
-    imagemagick
+    graphicsmagick
     pkg-config
     pngquant
     python
     which
     zopfli
+  ];
+
+  patches = [
+    # Port to python3
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/raw/3bc176c10ced2824fe03da5ff561e22a36bf8ccd/f/noto-emoji-port-to-python3.patch";
+      sha256 = "1b91abd050phxlxq7322i74nkx16fkhpw14yh97r2j4c7fqarr2q";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/raw/3bc176c10ced2824fe03da5ff561e22a36bf8ccd/f/noto-emoji-python3.patch";
+      sha256 = "0mw2c748izb6h9a19jwc0qxlb6l1kj6k8gc345lpf7lfcxfl7l59";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/raw/3bc176c10ced2824fe03da5ff561e22a36bf8ccd/f/noto-emoji-use-gm.patch";
+      sha256 = "0yfmfzaaiq5163c06172g4r734aysiqyv1s28siv642vqzsqh4i2";
+    })
   ];
 
   postPatch = let
@@ -118,6 +135,5 @@ stdenv.mkDerivation rec {
     ## Non-artwork is MIT
     license = with licenses; [ asl20 ofl cc-by-40 mit ];
     maintainers = with maintainers; [ jtojnar ];
-    broken = true; # Can't be build using the current Python 3 version of nototools
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This can now be marked as un-broken.

See comments on https://github.com/NixOS/nixpkgs/commit/980d658fbd15591b71f967b60759c03ce7cd0137. 

###### Things done

Viewed in font-manager. Ran fontconfig-default-fonts test with success.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
