### PR TITLE
python3.pkgs.cherrypy: 18.1.2 -> 18.3.0 and fix tests

### DIFF
--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -7,29 +7,24 @@
 
 buildPythonPackage rec {
   pname = "cherrypy";
-  version = "18.1.2";
+  version = "18.3.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     pname = "CherryPy";
     inherit version;
-    sha256 = "1w3hpsg7q8shdmscmbqk00w90lcw3brary7wl1a56k5h7nx33pj8";
+    sha256 = "0q6cs4vrv0rwim4byxfizrlp4h6hmwg3n4baz0ga66vvgiz6hgk8";
   };
 
-  # Remove patches once 96b34df and 14c12d2
+  # Remove patches once 88d2163 and 713f672
   # become part of a release - they're currently only present in master.
-  # ref: https://github.com/cherrypy/cherrypy/pull/1791
+  # ref: https://github.com/cherrypy/cherrypy/pull/1820
   patches = [
     (fetchpatch {
-      name = "pytest5-1.patch";
-      url = "https://github.com/cherrypy/cherrypy/commit/96b34dfea7853b0189bc0a3878b6ddff0d4e505c.patch";
-      sha256 = "0zy53mahffgkpd844118b42lsk5lkjmig70d60x1i46w6gnr61mi";
-    })
-    (fetchpatch {
-      name = "pytest5-2.patch";
-      url = "https://github.com/cherrypy/cherrypy/commit/14c12d2420a4b3765bb241250bd186e93b2f25eb.patch";
-      sha256 = "0ihcz7b5myn923rq5665b98pz52hnf6fcys2y2inf23r3i07scyz";
+      name = "test_HTTP11_Timeout.patch";
+      url = "https://github.com/cherrypy/cherrypy/commit/88d21630f68090c56d07000cabb6df4f1b612a71.patch";
+      sha256 = "1i6a3qs3ijyd9rgsxb8axigkzdlmr5sl3ljif9rvn0d90211bzwh";
     })
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes #72154.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @username1001101
