### PR TITLE
keepalived: 1.4.2 -> 1.4.5, patch CVE-2018-19115

### DIFF
--- a/pkgs/tools/networking/keepalived/default.nix
+++ b/pkgs/tools/networking/keepalived/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libnfnetlink, libnl, net_snmp, openssl, pkgconfig }:
+{ stdenv, fetchFromGitHub, fetchpatch, libnfnetlink, libnl, net_snmp, openssl, pkgconfig }:
 
 stdenv.mkDerivation rec {
   pname = "keepalived";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "12r80rcfxrys826flaqcdlfhcr7q4ccsd62ra1svy9545vf02qmx";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2018-19115.patch";
+      url = "https://github.com/acassen/keepalived/pull/961/commits/f28015671a4b04785859d1b4b1327b367b6a10e9.patch";
+      sha256 = "1jnwk7x4qdgv7fb4jzw6sihv62n8wv04myhgwm2vxn8nfkcgd1mm";
+    })
+  ];
 
   buildInputs = [
     libnfnetlink

--- a/pkgs/tools/networking/keepalived/default.nix
+++ b/pkgs/tools/networking/keepalived/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "keepalived";
-  version = "1.4.2";
+  version = "1.4.5";
 
   src = fetchFromGitHub {
     owner = "acassen";
     repo = "keepalived";
     rev = "v${version}";
-    sha256 = "154yxs6kwpi9yc4pa45ba3z3bfwzgmmmja5nk3d9mxq6w6s1swcy";
+    sha256 = "12r80rcfxrys826flaqcdlfhcr7q4ccsd62ra1svy9545vf02qmx";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Patches https://nvd.nist.gov/vuln/detail/CVE-2018-19115

Also bumped to last release of 1.4.x series. Why not the newer 2.x series? I have never used keepalived and this package has no maintainer listed, so I'm being conservative, not wanting to break anything...

Will probably backport the patch without the bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
