### PR TITLE
lutris: remove gnutls-kdh

### DIFF
--- a/pkgs/applications/misc/lutris/chrootenv.nix
+++ b/pkgs/applications/misc/lutris/chrootenv.nix
@@ -29,7 +29,7 @@ in buildFHSUserEnv {
 
     # Dolphin
     bluez ffmpeg gettext portaudio wxGTK30 miniupnpc mbedtls lzo sfml gsm
-    wavpack gnutls-kdh orc nettle gmp pcre vulkan-loader
+    wavpack orc nettle gmp pcre vulkan-loader
 
     # DOSBox
     SDL_net SDL_sound


### PR DESCRIPTION
###### Motivation for this change
fixes lutris build

closes https://github.com/NixOS/nixpkgs/issues/72123

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
