### PR TITLE
nixos/gnupg: fix pinentry in sway (fix a typo in 3c39093c0d1)

### DIFF
--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -14,7 +14,7 @@ let
       "qt"
     else if xserverCfg.desktopManager.xfce.enable then
       "gtk2"
-    else if xserverCfg.enable || cfg.programs.sway.enable then
+    else if xserverCfg.enable || config.programs.sway.enable then
       "gnome3"
     else
       null;


### PR DESCRIPTION
###### Motivation for this change

Fix a typo in 3c39093c0d1: should be `config`, not `cfg`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested on NixOS with `config.programs.sway.enable = true` and `config.services.xserver.enable = false`; it evaluates and builds now.
###### Notify maintainers

cc @globin - the author of 3c39093c0d1
