### PR TITLE
k9s: 0.8.4 -> 0.9.3

### DIFF
--- a/pkgs/applications/networking/cluster/k9s/default.nix
+++ b/pkgs/applications/networking/cluster/k9s/default.nix
@@ -2,16 +2,25 @@
 
 buildGoModule rec {
   pname = "k9s";
-  version = "0.8.4";
+  version = "0.9.3";
+  # rev is the release commit, mainly for version command output
+  rev = "1a9a83b34cdd0c9b4e793ed6b4b5c16ea1a949a0";
 
   src = fetchFromGitHub {
     owner  = "derailed";
     repo   = "k9s";
     rev    = version;
-    sha256 = "0wsj6wc2qi5708cg47l2qblq1cg8fcwxdygpkayib9hapx6lc6f8";
+    sha256 = "0k27mfccz563r18zlbaxll305vrmrx19ym6znsikvqxlmhy86g36";
   };
 
-  modSha256 = "1ia9wx6yd9mdr981lcw58xv39iqzz25r03bmn1c6byxmq2xpcjq8";
+  buildFlagsArray = ''
+    -ldflags=
+      -s -w
+      -X github.com/derailed/k9s/cmd.version=${version}
+      -X github.com/derailed/k9s/cmd.commit=${rev}
+  '';
+
+  modSha256 = "09rwbl8zd06ax5hidm5l1schwqvsr5ndlqh09w1rq9fqjijy649y";
 
   meta = with stdenv.lib; {
     description = "Kubernetes CLI To Manage Your Clusters In Style.";


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update and add missed build flags

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Gonzih
