### PR TITLE
nixpkgs manual: document staging-next branch

### DIFF
--- a/doc/contributing/submitting-changes.xml
+++ b/doc/contributing/submitting-changes.xml
@@ -375,31 +375,32 @@ Additional information.
 
   <section xml:id="submitting-changes-master-branch">
    <title>Master branch</title>
-
-   <itemizedlist>
-    <listitem>
-     <para>
-      It should only see non-breaking commits that do not cause mass rebuilds.
-     </para>
-    </listitem>
-   </itemizedlist>
+   <para>
+    The <literal>master</literal> branch is the main development branch. 
+    It should only see non-breaking commits that do not cause mass rebuilds.
+   </para>
   </section>
 
   <section xml:id="submitting-changes-staging-branch">
    <title>Staging branch</title>
+   <para>
+    The <literal>staging</literal> branch is a development branch where mass-rebuilds go. 
+    It should only see non-breaking mass-rebuild commits. 
+    That means it is not to be used for testing, and changes must have been well tested already.
+    If the branch is already in a broken state, please refrain from adding extra new breakages.
+   </para>
+  </section>
 
-   <itemizedlist>
-    <listitem>
-     <para>
-      It's only for non-breaking mass-rebuild commits. That means it's not to be used for testing, and changes must have been well tested already. <link xlink:href="https://web.archive.org/web/20160528180406/http://comments.gmane.org/gmane.linux.distributions.nixos/13447">Read policy here</link>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      If the branch is already in a broken state, please refrain from adding extra new breakages. Stabilize it for a few days, merge into master, then resume development on staging. <link xlink:href="http://hydra.nixos.org/jobset/nixpkgs/staging#tabs-evaluations">Keep an eye on the staging evaluations here</link>. If any fixes for staging happen to be already in master, then master can be merged into staging.
-     </para>
-    </listitem>
-   </itemizedlist>
+  <section xml:id="submitting-changes-staging-next-branch">
+   <title>Staging-next branch</title>
+   <para>
+    The <literal>staging-next</literal> branch is for stabilizing mass-rebuilds submitted to the <literal>staging</literal> branch prior to merging them into <literal>master</literal>. 
+    Mass-rebuilds should go via the <literal>staging</literal> branch. 
+    It should only see non-breaking commits that are fixing issues blocking it from being merged into the <literal>master </literal> branch.
+   </para>  
+   <para>
+    If the branch is already in a broken state, please refrain from adding extra new breakages. Stabilize it for a few days and then merge into master.
+   </para>
   </section>
 
   <section xml:id="submitting-changes-stable-release-branches">


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
