### PR TITLE
pidgin-opensteamworks: git-2018-08-02 -> 1.7

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks/default.nix
@@ -1,23 +1,33 @@
-{ stdenv, fetchFromGitHub, pidgin, glib, json-glib, nss, nspr, libgnome-keyring } :
+{ stdenv, fetchFromGitHub, pkgconfig, pidgin, glib, json-glib, nss, nspr
+, libsecret
+} :
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "pidgin-opensteamworks";
-  version = "unstable-2018-08-02";
+  version = "1.7";
 
   src = fetchFromGitHub {
     owner = "EionRobb";
     repo = "pidgin-opensteamworks";
-    rev = "b16a636d177f4a8862abdfbdb2c0994712ea0cd3";
-    sha256 = "0qyxfrfzsm43f1gmbg350znwxld1fqr9a9yziqs322bx2vglzgfh";
+    rev = version;
+    sha256 = "0zxd45g9ycw5kmm4i0800jnqg1ms2gbqcld6gkyv6n3ac1wxizpj";
   };
 
-  preConfigure = "cd steam-mobile";
+  preConfigure = ''
+    cd steam-mobile
+  '';
+
   installFlags = [
     "PLUGIN_DIR_PURPLE=${placeholder "out"}/lib/purple-2"
     "DATA_ROOT_DIR_PURPLE=${placeholder "out"}/share"
   ];
 
-  buildInputs = [ pidgin glib json-glib nss nspr libgnome-keyring ];
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+  buildInputs = [
+    pidgin glib json-glib nss nspr libsecret
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/EionRobb/pidgin-opensteamworks;

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/pidgin-opensteamworks/default.nix
@@ -13,9 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0zxd45g9ycw5kmm4i0800jnqg1ms2gbqcld6gkyv6n3ac1wxizpj";
   };
 
-  preConfigure = ''
-    cd steam-mobile
-  '';
+  sourceRoot = "source/steam-mobile";
 
   installFlags = [
     "PLUGIN_DIR_PURPLE=${placeholder "out"}/lib/purple-2"


### PR DESCRIPTION
###### Motivation for this change
pidgin-opensteamworks finally did a new versioned release last month (since 1.6.1 in 2015), so it seemed like a good time to update the expression again :).

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] ~~Ensured that relevant documentation is up to date~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).