### PR TITLE
wofi: init at 2019-10-28

### DIFF
--- a/pkgs/applications/misc/wofi/default.nix
+++ b/pkgs/applications/misc/wofi/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, fetchhg, pkg-config, wayland, gtk3 }:
+
+stdenv.mkDerivation rec {
+  pname = "wofi";
+  version = "2019-10-28";
+
+  src = fetchhg {
+    url = "https://hg.sr.ht/~scoopta/wofi";
+    rev = "3fac708b2b541bb9927ec1b2389c4eb294e1b35b";
+    sha256 = "0sp9hqm1lv9wyxj8z7vazs25nvl6yznd5vfhmwb51axwkr79s2ym";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ wayland gtk3 ];
+
+  sourceRoot = "hg-archive/Release";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp wofi $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "A launcher/menu program for wlroots based wayland compositors such as sway";
+    homepage = "https://hg.sr.ht/~scoopta/wofi";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ erictapen ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21599,6 +21599,8 @@ in
 
   wmii_hg = callPackage ../applications/window-managers/wmii-hg { };
 
+  wofi = callPackage ../applications/misc/wofi { };
+
   wordnet = callPackage ../applications/misc/wordnet { };
 
   wordgrinder = callPackage ../applications/office/wordgrinder { };


### PR DESCRIPTION
###### Motivation for this change

Package `wofi`, which is [a launcher for Wayland compositors such as sway](https://github.com/swaywm/sway/wiki#program-launchers).

Related to #57602.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @


