### PR TITLE
pythonPackages.qscintilla-qt5: fix build

### DIFF
--- a/pkgs/development/python-modules/qscintilla-qt5/default.nix
+++ b/pkgs/development/python-modules/qscintilla-qt5/default.nix
@@ -20,6 +20,8 @@ buildPythonPackage {
     lndir ${pyqt5} $out
     rm -rf "$out/nix-support"
     cd Python
+    substituteInPlace configure.py \
+      --replace "qmake = {'CONFIG': 'qscintilla2'}" "qmake = {'CONFIG': 'qscintilla2', 'QT': 'widgets printsupport'}"
     ${python.executable} ./configure.py \
       --pyqt=PyQt5 \
       --destdir=$out/${python.sitePackages}/PyQt5 \
@@ -37,6 +39,5 @@ buildPythonPackage {
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ lsix ];
     homepage = https://www.riverbankcomputing.com/software/qscintilla/;
-    broken = true;
   };
 }


### PR DESCRIPTION
(cherry picked from commit 9209dcf0303d6e85ae5741943d009aa54a579173)

###### Motivation for this change

Backport #71641 to make QGIS (and other applications depending on `pythonPackages.qscintilla-qt5`, if any) available on NixOS 19.09. See also https://github.com/NixOS/nixpkgs/pull/71646#issuecomment-545883615

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip -b release-19.09"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lsix

### results of running executable files in `./results/*/bin/` produced by `nix-review ...`:

#### looking fine:

(at least as far as I can tell)

<details><summary>qscintilla-qt5 executables (click to expand)</summary>

- ```bash
  results/python27Packages.qscintilla-qt5/bin/pylupdate5 -version
  ```
  ```
  pylupdate5 v5.13.0
  ```
- ```bash
  results/python27Packages.qscintilla-qt5/bin/pyrcc5 -version
  ```
  ```
  pyrcc5 v5.13.0
  ```
- ```bash
  results/python27Packages.qscintilla-qt5/bin/pyuic5 --version
  ```
  ```
  Python User Interface Compiler 5.13.0 for Qt version 5.12.3
  ```
- ```bash
  results/python37Packages.qscintilla-qt5/bin/pylupdate5 -version
  ```
  ```
  pylupdate5 v5.13.0
  ```
- ```bash
  results/python37Packages.qscintilla-qt5/bin/pyrcc5 -version
  ```
  ```
  pyrcc5 v5.13.0
  ```
- ```bash
  results/python37Packages.qscintilla-qt5/bin/pyuic5 --version
  ```
  ```
  Python User Interface Compiler 5.13.0 for Qt version 5.12.3
  ```

</details>

#### not working out of the box:

- ```bash
  results/qgis/bin/qgis_bench
  ```
  ```
  Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
  qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
  This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

  Aborted (core dumped)
  ```
- ```bash
  results/qgis/bin/qgis
  ```
  ```
  Info: Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
  Warning: Could not find the Qt platform plugin "xcb" in ""
  Fatal: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

  QGIS died on signal -1Aborted (core dumped)
  ```

<details><summary>... and the same for qgis-unwrapped (click to expand)</summary>

- ```bash
  results/qgis-unwrapped/bin/qgis_bench
  ```
  ```
  Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
  qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
  This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

  Aborted (core dumped)
  ```
- ```bash
  results/qgis-unwrapped/bin/qgis
  ```
  ```
  Info: Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
  Warning: Could not find the Qt platform plugin "xcb" in ""
  Fatal: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

  QGIS died on signal -1Aborted (core dumped)
  ```

</details>