### PR TITLE
wt: 3.4.1 -> 3.4.2, 4.1.1 -> 4.1.2

### DIFF
--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -49,8 +49,8 @@ let
     };
 in {
   wt3 = generic {
-    version = "3.4.1";
-    sha256 = "1bsx7hmy6g2x9p3vl5xw9lv1xk891pnvs93a87s15g257gznkjmj";
+    version = "3.4.2";
+    sha256 = "03mwr4yv3705y74pdh19lmh8szad6gk2x2m23f4pr0wrmqg73307";
   };
 
   wt4 = generic {

--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -54,7 +54,7 @@ in {
   };
 
   wt4 = generic {
-    version = "4.1.1";
-    sha256 = "1f1imx5kbpqlysrqx5h75hf2f8pkq972rz42x0pl6cxbnsyzngid";
+    version = "4.1.2";
+    sha256 = "06bnadpgflg8inikzynnz4l4r6w1bphjwlva4pzf51w648vpkknl";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
New patch releases for [wt3](https://github.com/emweb/wt/releases/tag/3.4.2) and [wt4](https://github.com/emweb/wt/releases/tag/4.1.2).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).