### PR TITLE
prometheus-postgres-exporter: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/postgres-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postgres-exporter.nix
@@ -1,10 +1,8 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
-
-with stdenv.lib;
+{ lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   pname = "postgres_exporter";
-  version = "0.5.1";
+  version = "0.6.0";
 
   goPackagePath = "github.com/wrouesnel/postgres_exporter";
 
@@ -12,13 +10,13 @@ buildGoPackage rec {
     owner = "wrouesnel";
     repo = "postgres_exporter";
     rev = "v${version}";
-    sha256 = "1awcqhiak56nrsaa49lkw6mcbrlm86ls14sp9v69h3a0brc1q7bn";
+    sha256 = "0a903mklp3aardlbz5fkslisav9khd1w3akcf9xkc5nfinr6xnqb";
   };
 
-  meta = {
+  meta = with lib; {
     inherit (src.meta) homepage;
     description = "A Prometheus exporter for PostgreSQL";
     license = licenses.asl20;
-    maintainers = with maintainers; [ fpletz globin ];
+    maintainers = with maintainers; [ fpletz globin willibutz ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
New [release](https://github.com/wrouesnel/postgres_exporter/releases/tag/v0.6.0).

###### Things done
Added myself as maintainer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).