### PR TITLE
mindustry: init at 99 (and updates)

### DIFF
--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -19,14 +19,14 @@ let
   # Note: when raising the version, ensure that all SNAPSHOT versions in
   # build.gradle are replaced by a fixed version
   # (the current one at the time of release) (see postPatch).
-  version = "100";
+  version = "101";
   buildVersion = makeBuildVersion version;
 
   src = fetchFromGitHub {
     owner = "Anuken";
     repo = "Mindustry";
     rev = "v${version}";
-    sha256 = "1m3nz2z98c1jsqca3mv1ybv2z2f844wa4b2d5pnrididaxdbn42v";
+    sha256 = "0ynrc5g3iyflz1bkc6q8n5yk30cl4jdqnzlkvh408l7p7k6adz0d";
   };
 
   desktopItem = makeDesktopItem {
@@ -65,7 +65,7 @@ let
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "11a9h9gf69nn86z4w1v6wb0k7ann4wzwxp4f4ylc87dk8xpvsalw";
+    outputHash = "06kcanp4bvzq3d8svl1l3f8r04fw6azrfzxs2vc2nxgi8p2x2v4y";
   };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -19,14 +19,14 @@ let
   # Note: when raising the version, ensure that all SNAPSHOT versions in
   # build.gradle are replaced by a fixed version
   # (the current one at the time of release) (see postPatch).
-  version = "101.1";
+  version = "102";
   buildVersion = makeBuildVersion version;
 
   src = fetchFromGitHub {
     owner = "Anuken";
     repo = "Mindustry";
     rev = "v${version}";
-    sha256 = "1rbsc8srg2a0mjhi3w6p3q94f7nifqp3w4x565g4g9fq5ksfrsmi";
+    sha256 = "0g4zy2zlynv6f427pq1ngnl0zpr6nnih10wd2l8vl9bxwzjygwdr";
   };
 
   desktopItem = makeDesktopItem {
@@ -65,7 +65,7 @@ let
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "1ydkpj48vy7pnhhmhbjr8kbf71dm6zzb45mc18xfamaji4jc3m38";
+    outputHash = "1sscxrr32f2agwz34pm491xqkz7m4bwdc1p3g64kcnl3p6rg7r7k";
   };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -19,14 +19,14 @@ let
   # Note: when raising the version, ensure that all SNAPSHOT versions in
   # build.gradle are replaced by a fixed version
   # (the current one at the time of release) (see postPatch).
-  version = "101";
+  version = "101.1";
   buildVersion = makeBuildVersion version;
 
   src = fetchFromGitHub {
     owner = "Anuken";
     repo = "Mindustry";
     rev = "v${version}";
-    sha256 = "0ynrc5g3iyflz1bkc6q8n5yk30cl4jdqnzlkvh408l7p7k6adz0d";
+    sha256 = "1rbsc8srg2a0mjhi3w6p3q94f7nifqp3w4x565g4g9fq5ksfrsmi";
   };
 
   desktopItem = makeDesktopItem {
@@ -65,7 +65,7 @@ let
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "06kcanp4bvzq3d8svl1l3f8r04fw6azrfzxs2vc2nxgi8p2x2v4y";
+    outputHash = "1ydkpj48vy7pnhhmhbjr8kbf71dm6zzb45mc18xfamaji4jc3m38";
   };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -1,0 +1,106 @@
+{ stdenv
+, makeWrapper
+, makeDesktopItem
+, fetchFromGitHub
+, gradle_5
+, perl
+, jre
+, libpulseaudio
+
+# Make the build version easily overridable.
+# Server and client build versions must match, and an empty build version means
+# any build is allowed, so this parameter acts as a simple whitelist.
+# Takes the package version and returns the build version.
+, makeBuildVersion ? (v: v)
+}:
+
+let
+  pname = "mindustry";
+  # Note: when raising the version, ensure that all SNAPSHOT versions in
+  # build.gradle are replaced by a fixed version
+  # (the current one at the time of release) (see postPatch).
+  version = "99";
+  buildVersion = makeBuildVersion version;
+
+  src = fetchFromGitHub {
+    owner = "Anuken";
+    repo = "Mindustry";
+    rev = "v${version}";
+    sha256 = "14zxmqfzn1va0im7846cfilhglzcbxd46nn9ilahkqi6lyl4c1fm";
+  };
+
+  desktopItem = makeDesktopItem {
+    type = "Application";
+    name = "Mindustry";
+    desktopName = "Mindustry";
+    exec = "mindustry";
+    icon = "mindustry";
+  };
+
+  postPatch = ''
+    # Remove unbuildable iOS stuff
+    sed -i '/^project(":ios"){/,/^}/d' build.gradle
+    sed -i '/robo(vm|VM)/d' build.gradle
+    rm ios/build.gradle
+
+    # Pin 'SNAPSHOT' versions
+    sed -i 's/com.github.anuken:packr:-SNAPSHOT/com.github.anuken:packr:034efe51781d2d8faa90370492133241bfb0283c/' build.gradle
+  '';
+
+  # fake build to pre-download deps into fixed-output derivation
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit version src postPatch;
+    nativeBuildInputs = [ gradle_5 perl ];
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d)
+      gradle --no-daemon desktop:dist -Pbuildversion=${buildVersion}
+      gradle --no-daemon server:dist -Pbuildversion=${buildVersion}
+    '';
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "0drx1y35za07bm7xwsl9va9kbz87qa4i5w462lywzmc08aissv04";
+  };
+
+in stdenv.mkDerivation rec {
+  inherit pname version src postPatch;
+
+  nativeBuildInputs = [ gradle_5 makeWrapper ];
+
+  buildPhase = ''
+    export GRADLE_USER_HOME=$(mktemp -d)
+    # point to offline repo
+    sed -ie "s#mavenLocal()#mavenLocal(); maven { url '${deps}' }#g" build.gradle
+    gradle --offline --no-daemon desktop:dist -Pbuildversion=${buildVersion}
+    gradle --offline --no-daemon server:dist -Pbuildversion=${buildVersion}
+  '';
+
+  installPhase = ''
+    install -Dm644 desktop/build/libs/Mindustry.jar $out/share/mindustry.jar
+    install -Dm644 server/build/libs/server-release.jar $out/share/mindustry-server.jar
+    mkdir $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/mindustry \
+      --prefix LD_LIBRARY_PATH : ${libpulseaudio}/lib \
+      --add-flags "-jar $out/share/mindustry.jar"
+    makeWrapper ${jre}/bin/java $out/bin/mindustry-server \
+      --add-flags "-jar $out/share/mindustry-server.jar"
+    install -Dm644 core/assets/icons/icon_64.png $out/share/icons/hicolor/64x64/apps/mindustry.png
+    install -Dm644 ${desktopItem}/share/applications/Mindustry.desktop $out/share/applications/Mindustry.desktop
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://mindustrygame.github.io/";
+    downloadPage = "https://github.com/Anuken/Mindustry/releases";
+    description = "A sandbox tower defense game";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/games/mindustry/default.nix
+++ b/pkgs/games/mindustry/default.nix
@@ -19,14 +19,14 @@ let
   # Note: when raising the version, ensure that all SNAPSHOT versions in
   # build.gradle are replaced by a fixed version
   # (the current one at the time of release) (see postPatch).
-  version = "99";
+  version = "100";
   buildVersion = makeBuildVersion version;
 
   src = fetchFromGitHub {
     owner = "Anuken";
     repo = "Mindustry";
     rev = "v${version}";
-    sha256 = "14zxmqfzn1va0im7846cfilhglzcbxd46nn9ilahkqi6lyl4c1fm";
+    sha256 = "1m3nz2z98c1jsqca3mv1ybv2z2f844wa4b2d5pnrididaxdbn42v";
   };
 
   desktopItem = makeDesktopItem {
@@ -65,7 +65,7 @@ let
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "0drx1y35za07bm7xwsl9va9kbz87qa4i5w462lywzmc08aissv04";
+    outputHash = "11a9h9gf69nn86z4w1v6wb0k7ann4wzwxp4f4ylc87dk8xpvsalw";
   };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22950,6 +22950,8 @@ in
 
   megaglest = callPackage ../games/megaglest {};
 
+  mindustry = callPackage ../games/mindustry { };
+
   minecraft = callPackage ../games/minecraft { };
 
   minecraft-server = callPackage ../games/minecraft-server { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
