### PR TITLE
add package for pkgdiff

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6340,6 +6340,12 @@
     githubId = 120188;
     name = "Scott W. Dunlop";
   };
+  sweber = {
+    email = "sweber2342+nixpkgs@gmail.com";
+    github = "sweber83";
+    githubId = 19905904;
+    name = "Simon Weber";
+  };
   swflint = {
     email = "swflint@flintfam.org";
     github = "swflint";

--- a/pkgs/tools/misc/pkgdiff/default.nix
+++ b/pkgs/tools/misc/pkgdiff/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper, perl, wdiff }:
+
+stdenv.mkDerivation rec {
+  version = "1.7.2";
+  pname = "pkgdiff";
+
+  src = fetchFromGitHub {
+    owner = "lvc";
+    repo = "pkgdiff";
+    rev = version;
+    sha256 = "1ahknyx0s54frbd3gqh070lkv3j1b344jrs6m6p1s1lgwbd70vnb";
+  };
+
+  buildInputs = [ perl ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/pkgdiff --prefix PATH : ${lib.makeBinPath [ wdiff ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A tool for visualizing changes in Linux software packages";
+    homepage = https://lvc.github.io/pkgdiff/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ sweber ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13231,6 +13231,8 @@ in
 
   pkcs11helper = callPackage ../development/libraries/pkcs11helper { };
 
+  pkgdiff = callPackage ../tools/misc/pkgdiff { };
+
   plib = callPackage ../development/libraries/plib { };
 
   pocketsphinx = callPackage ../development/libraries/pocketsphinx { };


### PR DESCRIPTION
###### Motivation for this change
pkgdiff package is missing

###### Things done
implement pkgdiff package

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
