### PR TITLE
twitter-color-emoji: use noto-fonts-emoji’s src

### DIFF
--- a/pkgs/data/fonts/twitter-color-emoji/default.nix
+++ b/pkgs/data/fonts/twitter-color-emoji/default.nix
@@ -3,6 +3,7 @@
 
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , cairo
 , graphicsmagick
 , pkg-config
@@ -10,21 +11,11 @@
 , python3
 , which
 , zopfli
-, fetchpatch
+, noto-fonts-emoji
 }:
 
 let
   version = "12.1.2";
-
-  # Cannot use noto-fonts-emoji.src since it is too old
-  # and still tries to use vendored pngquant.
-  notoSrc = fetchFromGitHub {
-    name = "noto";
-    owner = "googlefonts";
-    repo = "noto-emoji";
-    rev = "833a43d03246a9325e748a2d783006454d76ff66";
-    sha256 = "1g6ikzk8banm3ihqm9g27ggjq2mn1b1hq3zhpl13lxid6mp60s4a";
-  };
 
   twemojiSrc = fetchFromGitHub {
     name = "twemoji";
@@ -34,24 +25,21 @@ let
     sha256 = "0vzmlp83vnk4njcfkn03jcc1vkg2rf12zf5kj3p3a373xr4ds1zn";
   };
 
-  python = python3.withPackages (pp: with pp; [
-    nototools
-  ]);
 in
 stdenv.mkDerivation rec {
   pname = "twitter-color-emoji";
   inherit version;
 
   srcs = [
-    notoSrc
+    noto-fonts-emoji.src
     twemojiSrc
   ];
 
-  sourceRoot = notoSrc.name;
+  sourceRoot = noto-fonts-emoji.src.name;
 
   postUnpack = ''
     chmod -R +w ${twemojiSrc.name}
-    mv ${twemojiSrc.name} ${notoSrc.name}
+    mv ${twemojiSrc.name} ${noto-fonts-emoji.src.name}
   '';
 
   nativeBuildInputs = [
@@ -59,21 +47,14 @@ stdenv.mkDerivation rec {
     graphicsmagick
     pkg-config
     pngquant
-    python
+    python3
+    python3.pkgs.nototools
     which
     zopfli
   ];
 
   patches = [
-    # Port to python3
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/raw/3bc176c10ced2824fe03da5ff561e22a36bf8ccd/f/noto-emoji-port-to-python3.patch";
-      sha256 = "1b91abd050phxlxq7322i74nkx16fkhpw14yh97r2j4c7fqarr2q";
-    })
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/raw/3bc176c10ced2824fe03da5ff561e22a36bf8ccd/f/noto-emoji-python3.patch";
-      sha256 = "0mw2c748izb6h9a19jwc0qxlb6l1kj6k8gc345lpf7lfcxfl7l59";
-    })
+    # ImageMagick -> GrahphicsMagick
     (fetchpatch {
       url = "https://src.fedoraproject.org/rpms/twitter-twemoji-fonts/raw/3bc176c10ced2824fe03da5ff561e22a36bf8ccd/f/noto-emoji-use-gm.patch";
       sha256 = "0yfmfzaaiq5163c06172g4r734aysiqyv1s28siv642vqzsqh4i2";

--- a/pkgs/tools/misc/scfbuild/default.nix
+++ b/pkgs/tools/misc/scfbuild/default.nix
@@ -4,26 +4,36 @@ buildPythonApplication {
   pname = "scfbuild";
   version = "1.0.3";
 
+  format = "other";
+
   src = fetchFromGitHub {
-    owner = "eosrei";
+    owner = "13rac1";
     repo = "scfbuild";
     rev = "9acc7fc5fedbf48683d8932dd5bd7583bf922bae";
     sha256 = "1zlqsxkpg7zvmhdjgbqwwc9qgac2b8amzq8c5kwyh5cv95zcp6qn";
   };
 
-  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+  patches = [
+    # Convert to Python 3
+    # https://github.com/13rac1/scfbuild/pull/19
+    ./python-3.patch
+  ];
 
   propagatedBuildInputs = [ pyyaml fonttools fontforge ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/${python.sitePackages}
     cp -r scfbuild $out/${python.sitePackages}
     cp -r bin $out
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "SVGinOT color font builder";
-    homepage = https://github.com/eosrei/scfbuild;
+    homepage = https://github.com/13rac1/scfbuild;
     license = licenses.gpl3;
     maintainers = with maintainers; [ abbradar ];
   };

--- a/pkgs/tools/misc/scfbuild/python-3.patch
+++ b/pkgs/tools/misc/scfbuild/python-3.patch
@@ -1,0 +1,46 @@
+--- a/bin/scfbuild
++++ b/bin/scfbuild
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python2
++#!/usr/bin/env python3
+ # -*- coding: utf-8 -*-
+ 
+ from __future__ import (absolute_import, division, print_function,
+--- a/scfbuild/builder.py
++++ b/scfbuild/builder.py
+@@ -287,8 +287,8 @@ def _add_name_record(self, text, name_id, platform_id, plat_enc_id, lang_id):
+         # TODO: The installed version of fontTools doesn't have
+         # table__n_a_m_e.setName().
+         record = NameRecord()
+-        # PyYAML creates strings, force to Unicode
+-        record.string = unicode(text)
++        # PyYAML creates strings, which are unicode as of Python3
++        record.string = text
+         record.nameID = name_id
+         record.platformID = platform_id
+         record.platEncID = plat_enc_id
+--- a/scfbuild/fforge.py
++++ b/scfbuild/fforge.py
+@@ -84,7 +84,7 @@ def add_glyphs(font, svg_filepaths, conf):
+             u_ids = [int(u_id, 16) for u_id in filename.split("-")]
+             # Example: (0x1f441, 0x1f5e8)
+ 
+-            u_str = ''.join(map(unichr, u_ids))
++            u_str = ''.join(map(chr, u_ids))
+             # Example: "U\0001f441U\0001f5e8"
+ 
+             # Replace sequences with correct ZWJ/VS16 versions as needed
+--- a/scfbuild/main.py
++++ b/scfbuild/main.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python2
++#!/usr/bin/env python3
+ # -*- coding: utf-8 -*-
+ 
+ # SCFBuild is released under the GNU General Public License v3.
+index 0000000..99418b5
+--- /dev/null
++++ b/scfbuild/requirements.txt
+@@ -0,0 +1,2 @@
++fonttools>=3.41.2
++PyYAML>=5.1

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6111,7 +6111,7 @@ in
     qtbase = qt4;
   };
 
-  scfbuild = python2.pkgs.callPackage ../tools/misc/scfbuild { };
+  scfbuild = python3.pkgs.callPackage ../tools/misc/scfbuild { };
 
   scriptaculous = callPackage ../development/libraries/scriptaculous { };
 


### PR DESCRIPTION
###### Motivation for this change
* Clean up `twitter-color-emoji`
* Fix #72164 for `emojione` and `twemoji-color-font`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
