### PR TITLE
onnxruntime: 0.5.0 -> 1.0.0

### DIFF
--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "onnxruntime";
-  version = "0.5.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "onnxruntime";
     rev = "v${version}";
-    sha256 = "0s8ylc5xr55490hbz7zn3hnp9dnyp92d320ln8xw5hqkw3mgyr3p";
+    sha256 = "1d28lzrjnq69yl8j9ncxlsxl0bniacn3hnsr9van10zgp527436v";
     # TODO: use nix-versions of grpc, onnx, eigen, googletest, etc.
     # submodules increase src size and compile times significantly
     # not currently feasible due to how integrated cmake build is with git
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
     rm -r $out/bin   # ctest runner
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     description = "Cross-platform, high performance scoring engine for ML models";
     longDescription = ''
@@ -55,6 +57,9 @@ stdenv.mkDerivation rec {
       compatibility.
     '';
     homepage = "https://github.com/microsoft/onnxruntime";
+    changelog = "https://github.com/microsoft/onnxruntime/releases";
+    # https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#architectures
+    platforms = platforms.unix;
     license = licenses.mit;
     maintainers = with maintainers; [ jonringer ];
   };


### PR DESCRIPTION
###### Motivation for this change
just had a release ~12 hrs ago

https://github.com/microsoft/onnxruntime/releases

updated some of the metadata, and enabled parallel-building

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[11:28:31] jon@jon-workstation ~/projects/nixpkgs (bump-onnxruntime)
$ nix path-info -Sh ./result
/nix/store/nh33kjq4nlx9zi6rv6yk5h3px766w5pw-onnxruntime-1.0.0     42.1M
$ nix path-info -Sh ./result-dev
/nix/store/p4dj9jdfzyi2rj0d0zfh5c9ql08vfwj3-onnxruntime-1.0.0-dev         42.4M
```