### PR TITLE
fmsynth: change build so it produces sound again

### DIFF
--- a/pkgs/applications/audio/fmsynth/default.nix
+++ b/pkgs/applications/audio/fmsynth/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   buildPhase = ''
     cd lv2
     substituteInPlace GNUmakefile --replace "/usr/lib/lv2" "$out/lib/lv2"
-    make
+    make  SIMD=0
   '';
 
   preInstall = "mkdir -p $out/lib/lv2";


### PR DESCRIPTION
##### Motivation for this change

fixes https://github.com/Themaister/libfmsynth/issues/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

