### PR TITLE
berglas: 0.2.0 → 0.2.1

### DIFF
--- a/pkgs/tools/admin/berglas/default.nix
+++ b/pkgs/tools/admin/berglas/default.nix
@@ -3,16 +3,16 @@
 buildGoModule rec {
 
   name = "berglas-${version}";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "berglas";
-    rev = "v0.2.0";
-    sha256 = "1d75x0n1d1ry2xmy6h64qqc0dlnivipycv3p0aihyp3l810gpdbk";
+    rev = "v0.2.1";
+    sha256 = "1m34rxiynmgsris1avjn7am50b8sds77515zlnna9qvsrywbzljc";
   };
 
-  modSha256 = "0fvgvrvdpdwjx51wmbf0rdwnr9l1l212qbvznvif3xsi5nnlkx6r";
+  modSha256 = "0lfcrsb4r5hxxd652cxff23fnbrphp3lgwp5anpaddzcjcd2qyj8";
 
   meta = with stdenv.lib; {
     description = "A tool for managing secrets on Google Cloud";


### PR DESCRIPTION
###### Motivation for this change

`berglas` was improved!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify reviewers

cc @Ekleog @andir 
