### PR TITLE
cloud-custodian: init at 0.8.45.1

### DIFF
--- a/pkgs/tools/networking/cloud-custodian/default.nix
+++ b/pkgs/tools/networking/cloud-custodian/default.nix
@@ -1,0 +1,48 @@
+{ lib, buildPythonApplication, fetchPypi
+, argcomplete
+, boto3
+, botocore
+, certifi
+, dateutil
+, jsonpatch
+, jsonschema
+, pyyaml
+, tabulate
+, urllib3
+}:
+
+buildPythonApplication rec {
+  pname = "cloud-custodian";
+  version = "0.8.45.1";
+
+  src = fetchPypi {
+    pname = "c7n";
+    inherit version;
+    sha256 = "0c199gdmpm83xfghrbzp02xliyxiygsnx2fvb35j9qpf37wzzp3z";
+  };
+
+  propagatedBuildInputs = [
+    argcomplete
+    boto3
+    botocore
+    certifi
+    dateutil
+    jsonpatch
+    jsonschema
+    pyyaml
+    tabulate
+    urllib3
+  ];
+
+  # Requires tox, many packages, and network access
+  checkPhase = ''
+    $out/bin/custodian --help
+  '';
+
+  meta = with lib; {
+    description = "Rules engine for cloud security, cost optimization, and governance";
+    homepage = "https://cloudcustodian.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -807,6 +807,8 @@ in
 
   claws = callPackage ../tools/misc/claws { };
 
+  cloud-custodian = python3Packages.callPackage ../tools/networking/cloud-custodian  { };
+
   codespell = with python3Packages; toPythonApplication codespell;
 
   cozy = callPackage ../applications/audio/cozy-audiobooks { };


### PR DESCRIPTION
###### Motivation for this change
Tool for managing cloud cluster security/cost/etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
