### PR TITLE
svaba: init at 1.1.0

### DIFF
--- a/pkgs/applications/science/biology/svaba/default.nix
+++ b/pkgs/applications/science/biology/svaba/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, zlib, bzip2, lzma, fetchFromGitHub } :
+
+stdenv.mkDerivation rec {
+  version = "1.1.0";
+  pname = "svaba";
+
+  src = fetchFromGitHub {
+    owner = "walaj";
+    repo = pname;
+    rev = version;
+    sha256 = "1vv5mc9z5d22kgdy7mm27ya5aahnqgkcrskdr2405058ikk9g8kp";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ zlib bzip2 lzma ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 src/svaba/svaba $out/bin/svaba
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Structural variant and INDEL caller for DNA sequencing data, using genome-wide local assembly";
+    license = licenses.gpl3;
+    homepage = "https://github.com/walaj/svaba";
+    maintainers = with maintainers; [ scalavision ];
+    platforms = platforms.linux;
+    longDescription = ''
+      SvABA is a method for detecting structural variants in sequencing data
+      using genome-wide local assembly. Under the hood, SvABA uses a custom
+      implementation of SGA (String Graph Assembler) by Jared Simpson,
+      and BWA-MEM by Heng Li. Contigs are assembled for every 25kb window
+      (with some small overlap) for every region in the genome.
+      The default is to use only clipped, discordant, unmapped and indel reads,
+      although this can be customized to any set of reads at the command line using VariantBam rules.
+      These contigs are then immediately aligned to the reference with BWA-MEM and parsed to identify variants.
+      Sequencing reads are then realigned to the contigs with BWA-MEM, and variants are scored by their read support.
+    '';
+
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23357,6 +23357,8 @@ in
 
   SPAdes = callPackage ../applications/science/biology/spades { };
 
+  svaba = callPackage ../applications/science/biology/svaba { };
+
   trimal = callPackage ../applications/science/biology/trimal { };
 
   truvari = callPackage ../applications/science/biology/truvari { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x] Ensured that relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ vyp
