### PR TITLE
sage: ignore attrs deprecation warning

### DIFF
--- a/pkgs/applications/science/math/sage/patches/ignore-cmp-deprecation.patch
+++ b/pkgs/applications/science/math/sage/patches/ignore-cmp-deprecation.patch
@@ -1,0 +1,13 @@
+diff --git a/src/sage/tests/cmdline.py b/src/sage/tests/cmdline.py
+index bd6b76ab82..f8340a8c66 100644
+--- a/src/sage/tests/cmdline.py
++++ b/src/sage/tests/cmdline.py
+@@ -872,7 +872,7 @@ def test_executable(args, input="", timeout=100.0, **kwds):
+         sage: with open(input, 'w') as F:
+         ....:     _ = F.write(s)
+         sage: test_executable(["sage", "--rst2sws", input, output]) # py2
+-        ('', '', 0)
++        ('', '...', 0)
+         sage: import tarfile # py2
+         sage: f = tarfile.open(output, 'r') # py2
+         sage: print(f.extractfile('sage_worksheet/worksheet.html').read()) # py2

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -104,6 +104,9 @@ stdenv.mkDerivation rec {
       url = "https://git.sagemath.org/sage.git/patch?id=d27dc479a5772d59e4bc85d805b6ffd595284f1d";
       sha256 = "1nf1s9y7n30lhlbdnam7sghgaq9nasmv96415gl5jlcf7a3hlxk3";
     })
+
+    # ignore a deprecation warning for usage of `cmp` in the attrs library in the doctests
+    ./patches/ignore-cmp-deprecation.patch
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

cmp is deprecated since attrs 19.2.0:
http://www.attrs.org/en/19.2.0/changelog.html

The deprecation warning breaks the doctests.  Fortunately they have a
rather long deprecation window, so we can just wait until upstream(s)
fix this.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
