### PR TITLE
graalvm8: 19.1.1 -> 19.2.1

### DIFF
--- a/pkgs/development/compilers/graalvm/001_mx.py.patch
+++ b/pkgs/development/compilers/graalvm/001_mx.py.patch
@@ -1,57 +1,31 @@
 diff --git a/mx.py b/mx.py
-index af7a9c2..08c0ea8 100755
+index a0b9315..b7d67a0 100755
 --- a/mx.py
 +++ b/mx.py
-@@ -4976,30 +4976,6 @@ class PackedResourceLibrary(ResourceLibrary):
+@@ -238,21 +238,7 @@ def _check_file_with_sha1(path, sha1, sha1path, mustExist=True, newFile=False, l
+             f.write(value or sha1OfFile(path))
  
-     def get_path(self, resolve):
-         extract_path = _make_absolute(self.extract_path, self.suite.dir)
--        download_path = super(PackedResourceLibrary, self).get_path(resolve)
--        if resolve and self._check_extract_needed(extract_path, download_path):
--            extract_path_tmp = tempfile.mkdtemp(suffix=basename(extract_path), dir=dirname(extract_path))
--            try:
--                # extract archive
--                Extractor.create(download_path).extract(extract_path_tmp)
--                # ensure modification time is up to date
--                os.utime(extract_path_tmp, None)
--                logv("Moving temporary directory {} to {}".format(extract_path_tmp, extract_path))
--                try:
--                    # attempt atomic overwrite
--                    os.rename(extract_path_tmp, extract_path)
--                except OSError:
--                    # clean destination & re-try for cases where atomic overwrite doesn't work
--                    rmtree(extract_path, ignore_errors=True)
--                    os.rename(extract_path_tmp, extract_path)
--            except OSError as ose:
--                # Rename failed. Race with other process?
--                if self._check_extract_needed(extract_path, download_path):
--                    # ok something really went wrong
--                    abort("Extracting {} failed!".format(download_path), context=ose)
--            finally:
--                rmtree(extract_path_tmp, ignore_errors=True)
+     if exists(path):
+-        if sha1Check and sha1:
+-            if not _sha1CachedValid() or (newFile and sha1 != _sha1Cached()):
+-                logv('Create/update SHA1 cache file ' + sha1path)
+-                _writeSha1Cached()
 -
-         return extract_path
- 
-     def _check_download_needed(self):
-@@ -5900,7 +5876,7 @@ class HgConfig(VC):
- 
-     def update_to_branch(self, vcdir, branch, abortOnError=True):
-         cmd = ['update', branch]
--        self.hg_command(vcdir, cmd, abortOnError=abortOnError)
-+        self.run(['hg', vcdir] + cmd)
- 
-     def add(self, vcdir, path, abortOnError=True):
-         return self.run(['hg', '-q', '-R', vcdir, 'add', path]) == 0
-@@ -5937,7 +5913,7 @@ class HgConfig(VC):
-                 return None
- 
-     def parent_info(self, vcdir, abortOnError=True):
--        out = self.hg_command(vcdir, ["log", "-r", ".", "--template", "{author}|||{date|hgdate}"], abortOnError=abortOnError)
-+        out = _check_output_str(["hg", '-R', vcdir, "log", "-r", ".", "--template", "{author}|||{date|hgdate}"])
-         author, date = out.split("|||")
-         ts, _ = date.split(" ")
-         return self._sanitize_parent_info({
-@@ -8301,46 +8277,8 @@ class SuiteImport:
+-            if sha1 != _sha1Cached():
+-                computedSha1 = sha1OfFile(path)
+-                if sha1 == computedSha1:
+-                    warn('Fixing corrupt SHA1 cache file ' + sha1path)
+-                    _writeSha1Cached(computedSha1)
+-                    return True
+-                if logErrors:
+-                    size = os.path.getsize(path)
+-                    log_error('SHA1 of {} [size: {}] ({}) does not match expected value ({})'.format(TimeStampFile(path), size, computedSha1, sha1))
+-                return False
++        return True
+     elif mustExist:
+         if logErrors:
+             log_error("'{}' does not exist".format(path))
+@@ -1057,46 +1043,8 @@ class SuiteImport:
          version = import_dict.get("version")
          suite_dir = None
          version_from = import_dict.get("versionFrom")
@@ -100,7 +74,7 @@ index af7a9c2..08c0ea8 100755
  
      @staticmethod
      def get_source_urls(source, kind=None):
-@@ -8381,8 +8319,6 @@ class Suite(object):
+@@ -1467,8 +1415,6 @@ class Suite(object):
      :type dists: list[Distribution]
      """
      def __init__(self, mxDir, primary, internal, importing_suite, load, vc, vc_dir, dynamicallyImported=False):
@@ -109,7 +83,7 @@ index af7a9c2..08c0ea8 100755
          self.imported_by = [] if primary else [importing_suite]
          self.mxDir = mxDir
          self.dir = dirname(mxDir)
-@@ -8410,7 +8346,7 @@ class Suite(object):
+@@ -1496,7 +1442,7 @@ class Suite(object):
          self._outputRoot = None
          self._preloaded_suite_dict = None
          self.vc = vc
@@ -118,7 +92,7 @@ index af7a9c2..08c0ea8 100755
          self._preload_suite_dict()
          self._init_imports()
          if load:
-@@ -9310,7 +9246,9 @@ def get_dynamic_imports():
+@@ -2405,7 +2351,9 @@ class Repository(SuiteConstituent):
  class SourceSuite(Suite):
      """A source suite"""
      def __init__(self, mxDir, primary=False, load=True, internal=False, importing_suite=None, dynamicallyImported=False):
@@ -129,7 +103,7 @@ index af7a9c2..08c0ea8 100755
          Suite.__init__(self, mxDir, primary, internal, importing_suite, load, vc, vc_dir, dynamicallyImported=dynamicallyImported)
          logvv("SourceSuite.__init__({}), got vc={}, vc_dir={}".format(mxDir, self.vc, self.vc_dir))
          self.projects = []
-@@ -9359,17 +9297,7 @@ class SourceSuite(Suite):
+@@ -2454,17 +2402,7 @@ class SourceSuite(Suite):
          """
          Gets the release tag from VC or create a time based once if VC is unavailable
          """
@@ -148,73 +122,7 @@ index af7a9c2..08c0ea8 100755
  
      def scm_metadata(self, abortOnError=False):
          scm = self.scm
-@@ -12541,55 +12469,8 @@ def _attempt_download(url, path, jarEntryName=None):
-     return False
- 
- def download(path, urls, verbose=False, abortOnError=True, verifyOnly=False):
--    """
--    Attempts to downloads content for each URL in a list, stopping after the first successful download.
--    If the content cannot be retrieved from any URL, the program is aborted, unless abortOnError=False.
--    The downloaded content is written to the file indicated by `path`.
--    """
--    if not verifyOnly:
--        ensure_dirname_exists(path)
--        assert not path.endswith(os.sep)
--
--    # https://docs.oracle.com/javase/7/docs/api/java/net/JarURLConnection.html
--    jarURLPattern = re.compile('jar:(.*)!/(.*)')
--    verify_errors = {}
--    for url in urls:
--        if not verifyOnly or verbose:
--            log('Downloading ' + url + ' to ' + path)
--        m = jarURLPattern.match(url)
--        jarEntryName = None
--        if m:
--            url = m.group(1)
--            jarEntryName = m.group(2)
--
--        if verifyOnly:
--            try:
--                conn = _urlopen(url, timeout=10)
--                conn.close()
--                return True
--            except (IOError, socket.timeout) as e:
--                _suggest_tlsv1_error(e)
--                verify_errors[url] = e
--            continue
--
--        for i in range(4):
--            if i != 0:
--                time.sleep(1)
--                warn('Retry {} to download from {}'.format(i, url))
--            res = _attempt_download(url, path, jarEntryName)
--            if res is True:
--                return True
--            if res is False:
--                break
--
--    if abortOnError:
--        msg = 'Could not download to ' + path + ' from any of the following URLs: ' + ', '.join(urls)
--        if verifyOnly:
--            for url, e in verify_errors.items():
--                msg += '\n  ' + url + ': ' + str(e)
--        abort(msg)
--    else:
--        return False
-+    print("FAKE download(path={} urls={} verbose={} abortOnError={} verifyOnly={})".format(path, urls, verbose, abortOnError, verifyOnly))
-+    return True
- 
- def update_file(path, content, showDiff=False):
-     """
-@@ -13393,6 +13274,7 @@ class Archiver(SafeFileCreation):
- 
-     def _add_zip(self, filename, archive_name, provenance):
-         self._add_provenance(archive_name, provenance)
-+        os.utime(filename, (315532800, 315532800))
-         self.zf.write(filename, archive_name)
- 
-     def _add_str_zip(self, data, archive_name, provenance):
-@@ -18541,12 +18423,35 @@ def _find_suite_import(importing_suite, suite_import, fatalIfMissing=True, load=
+@@ -2993,12 +2931,35 @@ def _find_suite_import(importing_suite, suite_import, fatalIfMissing=True, load=
          Attempts to locate an existing suite in the local context
          Returns the path to the mx.name dir if found else None
          """
@@ -255,3 +163,129 @@ index af7a9c2..08c0ea8 100755
  
      def _get_import_dir(url, mode):
          """Return directory where the suite will be cloned to"""
+@@ -3816,7 +3777,7 @@ def getmtime(name):
+     """
+     Wrapper for builtin open function that handles long path names on Windows.
+     """
+-    return os.path.getmtime(_safe_path(name))
++    return 315532800
+ 
+ 
+ def stat(name):
+@@ -4062,57 +4023,8 @@ def _attempt_download(url, path, jarEntryName=None):
+     return False
+ 
+ def download(path, urls, verbose=False, abortOnError=True, verifyOnly=False):
+-    """
+-    Attempts to downloads content for each URL in a list, stopping after the first successful download.
+-    If the content cannot be retrieved from any URL, the program is aborted, unless abortOnError=False.
+-    The downloaded content is written to the file indicated by `path`.
+-    """
+-    if not verifyOnly:
+-        ensure_dirname_exists(path)
+-        assert not path.endswith(os.sep)
+-
+-    # https://docs.oracle.com/javase/7/docs/api/java/net/JarURLConnection.html
+-    jarURLPattern = re.compile('jar:(.*)!/(.*)')
+-    verify_errors = {}
+-    for url in urls:
+-        if not verifyOnly or verbose:
+-            log('Downloading ' + url + ' to ' + path)
+-        m = jarURLPattern.match(url)
+-        jarEntryName = None
+-        if m:
+-            url = m.group(1)
+-            jarEntryName = m.group(2)
+-
+-        if not _opts.trust_http and (url.lower().startswith('http://') or url.lower().startswith('ftp://')):
+-            warn('Downloading from non-https URL {}. Use --trust-http mx option to suppress this warning.'.format(url))
+-
+-        if verifyOnly:
+-            try:
+-                conn = _urlopen(url, timeout=10)
+-                conn.close()
+-            except (IOError, socket.timeout) as e:
+-                _suggest_tlsv1_error(e)
+-                verify_errors[url] = e
+-        else:
+-            for i in range(4):
+-                if i != 0:
+-                    time.sleep(1)
+-                    warn('Retry {} to download from {}'.format(i, url))
+-                if _attempt_download(url, path, jarEntryName):
+-                    return True # Download was successful
+-
+-    if verifyOnly and len(verify_errors) < len(urls): # verify-mode at least one success -> success
+-        return True
+-    else: # Either verification error or no download was successful
+-        msg = 'Could not download to ' + path + ' from any of the following URLs: ' + ', '.join(urls)
+-        if verifyOnly: # verify-mode -> print error details
+-            for url, e in verify_errors.items():
+-                msg += '\n  ' + url + ': ' + str(e)
+-        if abortOnError:
+-            abort(msg)
+-        else:
+-            warn(msg)
+-            return False
++    print("FAKE download(path={} urls={} verbose={} abortOnError={} verifyOnly={})".format(path, urls, verbose, abortOnError, verifyOnly))
++    return True
+ 
+ def update_file(path, content, showDiff=False):
+     """
+@@ -7887,30 +7799,6 @@ class PackedResourceLibrary(ResourceLibrary):
+ 
+     def get_path(self, resolve):
+         extract_path = _make_absolute(self.extract_path, self.suite.dir)
+-        download_path = super(PackedResourceLibrary, self).get_path(resolve)
+-        if resolve and self._check_extract_needed(extract_path, download_path):
+-            extract_path_tmp = tempfile.mkdtemp(suffix=basename(extract_path), dir=dirname(extract_path))
+-            try:
+-                # extract archive
+-                Extractor.create(download_path).extract(extract_path_tmp)
+-                # ensure modification time is up to date
+-                os.utime(extract_path_tmp, None)
+-                logv("Moving temporary directory {} to {}".format(extract_path_tmp, extract_path))
+-                try:
+-                    # attempt atomic overwrite
+-                    os.rename(extract_path_tmp, extract_path)
+-                except OSError:
+-                    # clean destination & re-try for cases where atomic overwrite doesn't work
+-                    rmtree(extract_path, ignore_errors=True)
+-                    os.rename(extract_path_tmp, extract_path)
+-            except OSError as ose:
+-                # Rename failed. Race with other process?
+-                if self._check_extract_needed(extract_path, download_path):
+-                    # ok something really went wrong
+-                    abort("Extracting {} failed!".format(download_path), context=ose)
+-            finally:
+-                rmtree(extract_path_tmp, ignore_errors=True)
+-
+         return extract_path
+ 
+     def _check_download_needed(self):
+@@ -8430,7 +8318,7 @@ class VC(_with_metaclass(ABCMeta, object)):
+         :param str branch: a branch name
+         :param bool abortOnError: if True abort on error
+         """
+-        abort(self.kind + " update_to_branch is not implemented")
++        self.run(['hg', vcdir] + cmd)
+ 
+     def is_release_from_tags(self, vcdir, prefix):
+         """
+@@ -8831,7 +8719,7 @@ class HgConfig(VC):
+                 return None
+ 
+     def parent_info(self, vcdir, abortOnError=True):
+-        out = self.hg_command(vcdir, ["log", "-r", ".", "--template", "{author}|||{date|hgdate}"], abortOnError=abortOnError)
++        out = _check_output_str(["hg", '-R', vcdir, "log", "-r", ".", "--template", "{author}|||{date|hgdate}"])
+         author, date = out.split("|||")
+         ts, _ = date.split(" ")
+         return self._sanitize_parent_info({
+@@ -14069,6 +13957,7 @@ class Archiver(SafeFileCreation):
+ 
+     def _add_zip(self, filename, archive_name, provenance):
+         self._add_provenance(archive_name, provenance)
++        os.utime(filename, (315532800, 315532800))
+         self.zf.write(filename, archive_name)
+ 
+     def _add_str_zip(self, data, archive_name, provenance):

--- a/pkgs/development/compilers/graalvm/005_tool_jt.rb.patch
+++ b/pkgs/development/compilers/graalvm/005_tool_jt.rb.patch
@@ -1,0 +1,46 @@
+diff --git a/tool/jt.rb b/tool/jt.rb
+index 870d88edcb..0a6e4c367b 100755
+--- a/tool/jt.rb
++++ b/tool/jt.rb
+@@ -152,13 +152,16 @@ module Utilities
+   end
+ 
+   def find_mx
+-    if which('mx')
+-      'mx'
++    if ENV.key?("MX_GIT_CACHE_DIR")
++      "mx-internal"
+     else
+-      mx_repo = find_or_clone_repo("https://github.com/graalvm/mx.git")
+-      "#{mx_repo}/mx"
++      if which('mx')
++        'mx'
++      else
++        mx_repo = find_or_clone_repo("https://github.com/graalvm/mx.git")
++        "#{mx_repo}/mx"
++      end
+     end
+-  end
+ 
+   def find_launcher(use_native)
+     if use_native
+@@ -444,8 +447,8 @@ module Commands
+           --no-sforceimports                         do not run sforceimports before building
+           parser                                     build the parser
+           options                                    build the options
+-          graalvm                                    build a minimal JVM-only GraalVM containing only TruffleRuby, 
+-                                                     available by default in mxbuild/truffleruby-jvm, 
++          graalvm                                    build a minimal JVM-only GraalVM containing only TruffleRuby,
++                                                     available by default in mxbuild/truffleruby-jvm,
+                                                      the Ruby is symlinked into rbenv or chruby if available
+               --graal      include the GraalVM Compiler in the build
+               --native     build native ruby image as well, available in mxbuild/truffleruby-native
+@@ -491,7 +494,7 @@ module Commands
+       jt test compiler                               run compiler tests
+       jt test integration [TESTS]                    run integration tests
+       jt test bundle [--jdebug]                      tests using bundler
+-      jt test gems [TESTS]                           tests using gems 
++      jt test gems [TESTS]                           tests using gems
+       jt test ecosystem [TESTS]                      tests using the wider ecosystem such as bundler, Rails, etc
+       jt test cexts [--no-openssl] [--no-gems] [test_names...]
+                                                      run C extension tests (set GEM_HOME)

--- a/pkgs/development/compilers/graalvm/006_mx_copylib.py.patch
+++ b/pkgs/development/compilers/graalvm/006_mx_copylib.py.patch
@@ -1,0 +1,14 @@
+diff --git a/mx.fastr/mx_copylib.py b/mx.fastr/mx_copylib.py
+index 4f57e1954..db45220d9 100644
+--- a/mx.fastr/mx_copylib.py
++++ b/mx.fastr/mx_copylib.py
+@@ -54,6 +54,9 @@ def _copylib(lib, libpath, plain_libpath_base, target):
+     else:
+         try:
+             if platform.system() == 'Linux':
++                # https://github.com/oracle/fastr/issues/110
++                if libpath.endswith("libgcc_s.so"):
++                    libpath = libpath + ".1"
+                 output = subprocess.check_output(['objdump', '-p', libpath])
+             elif platform.system() == 'SunOS':
+                 output = subprocess.check_output(['elfdump', '-d', libpath])

--- a/pkgs/development/compilers/graalvm/007_unimplemented.c.patch
+++ b/pkgs/development/compilers/graalvm/007_unimplemented.c.patch
@@ -1,0 +1,85 @@
+diff --git a/com.oracle.truffle.r.native/fficall/src/common/unimplemented.c b/com.oracle.truffle.r.native/fficall/src/common/unimplemented.c
+index dcf081316..c2cb4879b 100644
+--- a/com.oracle.truffle.r.native/fficall/src/common/unimplemented.c
++++ b/com.oracle.truffle.r.native/fficall/src/common/unimplemented.c
+@@ -20,8 +20,10 @@
+ 
+ #include <Rinternals.h>
+ #include <stdlib.h>
++#include <rlocale.h>
+ 
+ #include <R_ext/eventloop.h>
++#include <R_ext/GraphicsEngine.h>
+ #include <Defn.h>
+ 
+ Rboolean known_to_be_latin1 = FALSE;
+@@ -166,3 +168,69 @@ int Scollate(SEXP a, SEXP b) {
+ void z_prec_r(Rcomplex *r, Rcomplex *x, double digits) {
+     unimplemented("z_prec_r");
+ }
++
++int Rf_AdobeSymbol2ucs2(int n) {
++  unimplemented("Rf_AdobeSymbol2ucs2");
++  return 0;
++}
++
++size_t Mbrtowc(wchar_t *wc, const char *s, size_t n, mbstate_t *ps) {
++  unimplemented("Mbrtowc");
++  return 0;
++}
++
++double R_GE_VStrHeight(const char *s, cetype_t enc, const pGEcontext gc, pGEDevDesc dd) {
++  unimplemented("R_GE_VStrHeight");
++  return 0;
++}
++
++void R_GE_VText(double x, double y, const char * const s, cetype_t enc,
++		double x_justify, double y_justify, double rotation,
++		const pGEcontext gc, pGEDevDesc dd) {
++  unimplemented("R_GE_VText");
++}
++
++double R_GE_VStrWidth(const char *s, cetype_t enc, const pGEcontext gc, pGEDevDesc dd) {
++  unimplemented("R_GE_VStrWidth");
++}
++
++void setulb(int n, int m, double *x, double *l, double *u, int *nbd,
++	    double *f, double *g, double factr, double *pgtol,
++	    double *wa, int * iwa, char *task, int iprint, int *isave) {
++  unimplemented("setulb");
++}
++
++void genptry(int n, double *p, double *ptry, double scale, void *ex) {
++  unimplemented("genptry");
++}
++
++double EXP(double x) {
++  unimplemented("EXP");
++  return 0;
++}
++
++double LOG(double x) {
++  unimplemented("LOG");
++  return 0;
++}
++
++Rwchar_t Rf_utf8toucs32(wchar_t high, const char *s) {
++  unimplemented("Rf_utf8toucs32");
++  return 0;
++}
++
++size_t mbtoucs(unsigned int *wc, const char *s, size_t n) {
++  unimplemented("mbtoucs");
++  return (size_t) 0;
++}
++
++
++int DispatchOrEval(SEXP call, SEXP op, const char *generic, SEXP args,
++		   SEXP rho, SEXP *ans, int dropmissing, int argsevald) {
++  unimplemented("DispatchOrEval");
++  return 0;
++}
++
++void ENSURE_NAMEDMAX (SEXP x) {
++  unimplemented("ENSURE_NAMEDMAX");
++}

--- a/pkgs/development/compilers/graalvm/008_remove_jfr.patch
+++ b/pkgs/development/compilers/graalvm/008_remove_jfr.patch
@@ -1,0 +1,33 @@
+diff --git a/mx.jvmci/suite.py b/mx.jvmci/suite.py
+index 9690c0a38f..fa1d36b7e1 100644
+--- a/mx.jvmci/suite.py
++++ b/mx.jvmci/suite.py
+@@ -241,18 +241,7 @@ suite = {
+       "workingSets" : "JVMCI,HotSpot,SPARC",
+     },
+ 
+-    "jdk.vm.ci.hotspot.jfr" : {
+-      "subDir" : "jvmci",
+-      "sourceDirs" : ["src"],
+-      "dependencies" : [
+-        "jdk.vm.ci.hotspot",
+-        "JFR",
+-      ],
+-      "checkstyle" : "jdk.vm.ci.hotspot",
+-      "javaCompliance" : "1.8",
+-      "profile" : "",
+-      "workingSets" : "JVMCI,HotSpot",
+-    },
++
+ 
+     "hotspot" : {
+       "native" : True,
+@@ -354,7 +343,7 @@ suite = {
+         "jdk.vm.ci.hotspot.aarch64",
+         "jdk.vm.ci.hotspot.amd64",
+         "jdk.vm.ci.hotspot.sparc",
+-        "jdk.vm.ci.hotspot.jfr",
++
+       ],
+       "distDependencies" : [
+         "JVMCI_SERVICES",

--- a/pkgs/development/compilers/graalvm/009_remove_signedness_verifier.patch
+++ b/pkgs/development/compilers/graalvm/009_remove_signedness_verifier.patch
@@ -1,0 +1,21 @@
+diff --git a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/query/SizeAndSignednessVerifier.java b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/query/SizeAndSignednessVerifier.java
+index 23a76357fd2..f13694b6ed7 100644
+--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/query/SizeAndSignednessVerifier.java
++++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/query/SizeAndSignednessVerifier.java
+@@ -249,15 +249,6 @@ public final class SizeAndSignednessVerifier extends NativeInfoTreeVisitor {
+     }
+ 
+     private void checkSignedness(boolean isUnsigned, ResolvedJavaType type, ResolvedJavaMethod method) {
+-        if (isSigned(type)) {
+-            if (isUnsigned) {
+-                addError("Type " + type.toJavaName(false) + " is signed, but accessed C value is unsigned", method);
+-            }
+-        } else if (nativeLibs.isWordBase(type)) {
+-            /* every Word type other than Signed is assumed to be unsigned. */
+-            if (!isUnsigned) {
+-                addError("Type " + type.toJavaName(false) + " is unsigned, but accessed C value is signed", method);
+-            }
+-        }
++
+     }
+ }

--- a/pkgs/development/compilers/graalvm/010_mx_substratevm.py
+++ b/pkgs/development/compilers/graalvm/010_mx_substratevm.py
@@ -1,0 +1,13 @@
+diff --git a/substratevm/mx.substratevm/mx_substratevm.py b/substratevm/mx.substratevm/mx_substratevm.py
+index b89163ef983..0fd0138b336 100644
+--- a/substratevm/mx.substratevm/mx_substratevm.py
++++ b/substratevm/mx.substratevm/mx_substratevm.py
+@@ -189,7 +189,7 @@ if str(svm_java_compliance().value) not in GRAAL_COMPILER_FLAGS_MAP:
+     mx.abort("Substrate VM does not support this Java version: " + str(svm_java_compliance()))
+ GRAAL_COMPILER_FLAGS = GRAAL_COMPILER_FLAGS_BASE + GRAAL_COMPILER_FLAGS_MAP[str(svm_java_compliance().value)]
+ 
+-IMAGE_ASSERTION_FLAGS = ['-H:+VerifyGraalGraphs', '-H:+VerifyPhases']
++IMAGE_ASSERTION_FLAGS = ['-H:+VerifyGraalGraphs', '-H:+VerifyPhases', '-H:+ReportExceptionStackTraces']
+ suite = mx.suite('substratevm')
+ svmSuites = [suite]
+ clibraryDists = ['SVM_HOSTED_NATIVE']

--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -1,10 +1,11 @@
 { stdenv, lib, fetchFromGitHub, fetchurl, fetchzip, fetchgit, mercurial_4, python27, setJavaClassPath,
-  zlib, makeWrapper, openjdk, unzip, git, clang, llvm, which, icu, ruby, bzip2, glibc
-  # gfortran, readline, bzip2, lzma, pcre, curl, ed, tree ## WIP: fastr deps
+  which, zlib, makeWrapper, openjdk, unzip, git, clang, llvm, icu, ruby, glibc, bash, gcc, libobjc,
+  xcodebuild, gfortran, readline, bzip2, lzma, pcre, curl, ed, libresolv, libiconv, writeScriptBin,
+  openssl, perl, CoreFoundation, Foundation, JavaNativeFoundation, JavaRuntimeSupport, JavaVM, Cocoa
 }:
 
 let
-  version = "19.1.1";
+  version = "19.2.1";
   mercurial = mercurial_4;
   truffleMake = ./truffle.make;
   makeMxGitCache = list: out: ''
@@ -24,6 +25,57 @@ let
     # patch the shebang in python script runner
     chmod -R +rw ${out}/graaljs/graal-nodejs/mx.graal-nodejs/python2
     patchShebangs ${out}/graaljs/graal-nodejs/mx.graal-nodejs/python2/python
+
+    # # TUFFLE-RUBY # #
+    (cd ${out}/truffleruby && git apply ${./005_tool_jt.rb.patch})
+    patchShebangs ${out}/truffleruby/tool/query-versions-json.rb
+
+    substituteInPlace ${out}/truffleruby/src/main/c/Makefile \
+      --replace '(MX_HOME)/mx' '(MX_HOME)/mx-internal'
+
+    substituteInPlace ${out}/truffleruby/src/processor/java/org/truffleruby/processor/BuildInformationProcessor.java \
+      --replace 'trufflerubyHome = findHome();' \
+                'trufflerubyHome = new File(System.getenv("MX_GIT_CACHE_DIR"), "truffleruby");' \
+      --replace tool/query-versions-json.rb 'ruby tool/query-versions-json.rb' \
+      --replace 'revision = runCommand("git rev-parse --short=8 HEAD");' \
+                'revision = "${version}";' \
+      --replace 'compileDate = runCommand("git log -1 --date=short --pretty=format:%cd");' \
+                'compileDate = "1970-01-01";'
+
+    substituteInPlace ${out}/truffleruby/mx.truffleruby/mx_truffleruby.py \
+      --replace "mx_binary = join(mx._mx_home, 'mx')" "mx_binary = join(mx._mx_home, 'mx-internal')"
+
+    # # FASTR # #
+    (cd ${out}/fastr && git apply ${ ./006_mx_copylib.py.patch })
+    (cd ${out}/fastr && git apply ${ ./007_unimplemented.c.patch })
+    substituteInPlace ${out}/fastr/com.oracle.truffle.r.parser.processor/src/com/oracle/truffle/r/parser/processor/GenerateRParserProcessor.java \
+      --replace 'File suiteRoot = srcGenDir.getCanonicalFile().getParentFile().getParentFile().getParentFile();' \
+                'File suiteRoot = new File(System.getenv("MX_GIT_CACHE_DIR"), "fastr");'
+
+    substituteInPlace ${out}/fastr/com.oracle.truffle.r.native/gnur/Makefile.libs \
+      --replace 'mx -p' 'mx-internal -p'
+
+    substituteInPlace ${out}/fastr/com.oracle.truffle.r.native/include/Makefile \
+      --replace 'mx -p' 'mx-internal -p'
+
+    substituteInPlace ${out}/fastr/com.oracle.truffle.r.native/fficall/Makefile \
+      --replace 'mx -p' 'mx-internal -p'
+
+    substituteInPlace ${out}/fastr/com.oracle.truffle.r.native.recommended/Makefile \
+      --replace 'mx -p' 'mx-internal -p'
+
+    # Make sure that the logs aren't hidden when compiling gnur
+    substituteInPlace ${out}/fastr/com.oracle.truffle.r.native/gnur/Makefile.gnur \
+      --replace '> gnur_configure.log 2>&1' "" \
+      --replace '> gnur_make.log 2>&1' ""
+
+    substituteInPlace ${out}/fastr/com.oracle.truffle.r.native/run/Linux/Renviron \
+      --replace /bin/ "" \
+      --replace /usr/bin/ ""
+
+    sed -i "s|exec \$mx|exec mx-internal|g" ${out}/fastr/com.oracle.truffle.r.native/run/*.sh
+    chmod +x ${out}/fastr/com.oracle.truffle.r.native/run/*.sh
+    patchShebangs ${out}/fastr/com.oracle.truffle.r.native/run/*.sh
 
     cd ${out}
     hg init
@@ -50,14 +102,15 @@ let
                 unzip "$out/${name}" -d "$out/$BASENAME.extracted"
 
                 # Ninja is called later in the build process
-                if [ -f $out/$BASENAME.extracted/ninja ]; then
-                  patchelf --set-interpreter \
-                    "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-                    --set-rpath "${stdenv.cc.cc.lib}/lib64" \
-                    $out/$BASENAME.extracted/ninja
-                fi
-              ''
-            else ""}
+               ${lib.optionalString stdenv.isLinux ''
+                 if [ -f $out/$BASENAME.extracted/ninja ]; then
+                   patchelf --set-interpreter \
+                     "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+                     --set-rpath "${stdenv.cc.cc.lib}/lib64" \
+                     $out/$BASENAME.extracted/ninja
+                 fi''}
+                ''
+              else ""}
          '') list}
       '';
     };
@@ -89,30 +142,32 @@ let
     rec { sha1 = "42a25dc3219429f0e5d060061f71acb49bf010a0"; name = "HAMCREST_${sha1}/hamcrest.jar";                                                   url = mirror://maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar; }
     rec { sha1 = "1dc37250fbc78e23a65a67fbbaf71d2e9cbc3c0b"; name = "HAMCREST_${sha1}/hamcrest.sources.jar";                                           url = mirror://maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar; }
     rec { sha1 = "0d031013db9a80d6c88330c42c983fbfa7053193"; name = "hsdis_${sha1}/hsdis.so";                                                          url = "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/hsdis/intel/hsdis-amd64-linux-${sha1}.so"; }
-  ];
+] ++ lib.optionals stdenv.isLinux [
+  rec { sha1 = "0d031013db9a80d6c88330c42c983fbfa7053193"; name = "hsdis_${sha1}/hsdis.so";                                                          url = "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/hsdis/intel/hsdis-amd64-linux-${sha1}.so"; }
+                                                                          ]
+++ lib.optionals stdenv.isDarwin [
+  rec { sha1 = "67f6d23cbebd8998450a88b5bef362171f66f11a"; name = "hsdis_${sha1}/hsdis.dylib";                                                       url = "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/hsdis/intel/hsdis-amd64-darwin-${sha1}.dylib"; }
+                                                                          ];
 
   graal-mxcache = jvmci8-mxcache ++ [
+    # rec { sha1 = "5001adab652fc4eb35e30cdefbb0765442f8b7db"; name = "LLVM_ORG_LIBCXX_SRC_${sha1}/llvm-org-libcxx-src.tar.gz";                          url = https://lafo.ssw.uni-linz.ac.at/pub/llvm-org/compiler-rt-llvmorg-8.0.0-4-gd563e33a79-bgae3b177eaa-linux-amd64.tar.gz; }
+    rec { sha1 = "5001adab652fc4eb35e30cdefbb0765442f8b7db"; name = "LLVM_ORG_COMPILER_RT_LINUX_${sha1}/llvm-org-compiler-rt-linux.tar.gz";            url = https://lafo.ssw.uni-linz.ac.at/pub/llvm-org/compiler-rt-llvmorg-8.0.0-4-gd563e33a79-bgae3b177eaa-linux-amd64.tar.gz; }
     rec { sha1 = "a990b2dba1c706f5c43c56fedfe70bad9a695852"; name = "LLVM_WRAPPER_${sha1}/llvm-wrapper.jar";                                           url = mirror://maven/org/bytedeco/javacpp-presets/llvm/6.0.1-1.4.2/llvm-6.0.1-1.4.2.jar; }
     rec { sha1 = "decbd95d46092fa9afaf2523b5b23d07ad7ad6bc"; name = "LLVM_WRAPPER_${sha1}/llvm-wrapper.sources.jar";                                   url = mirror://maven/org/bytedeco/javacpp-presets/llvm/6.0.1-1.4.2/llvm-6.0.1-1.4.2-sources.jar; }
-    rec { sha1 = "344483aefa15147c121a8fb6fb35a2406768cc5c"; name = "LLVM_PLATFORM_SPECIFIC_${sha1}/llvm-platform-specific.jar";                       url = mirror://maven/org/bytedeco/javacpp-presets/llvm/6.0.1-1.4.2/llvm-6.0.1-1.4.2-linux-x86_64.jar; }
-    rec { sha1 = "503402aa0cf80fd95ede043c0011152c2b4556fd"; name = "LLVM_PLATFORM_${sha1}/llvm-platform.jar";                                         url = mirror://maven/org/bytedeco/javacpp-presets/llvm-platform/6.0.1-1.4.2/llvm-platform-6.0.1-1.4.2.jar; }
     rec { sha1 = "cfa6a0259d98bff5aa8d41ba11b4d1dad648fbaa"; name = "JAVACPP_${sha1}/javacpp.jar";                                                     url = mirror://maven/org/bytedeco/javacpp/1.4.2/javacpp-1.4.2.jar; }
     rec { sha1 = "fdb2d2c17f6b91cdd5421554396da8905f0dfed2"; name = "JAVACPP_${sha1}/javacpp.sources.jar";                                             url = mirror://maven/org/bytedeco/javacpp/1.4.2/javacpp-1.4.2-sources.jar; }
     rec { sha1 = "702ca2d0ae93841c5ab75e4d119b29780ec0b7d9"; name = "NINJA_SYNTAX_${sha1}/ninja-syntax.tar.gz";                                        url = "https://pypi.org/packages/source/n/ninja_syntax/ninja_syntax-1.7.2.tar.gz"; }
-    rec { sha1 = "987234c4ce45505c21302e097c24efef4873325c"; name = "NINJA_${sha1}/ninja.zip";                                                         url = "https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip";
-          isNinja = true; }
     rec { sha1 = "f2cfb09cee12469ff64f0d698b13de19903bb4f7"; name = "NanoHTTPD-WebSocket_${sha1}/nanohttpd-websocket.jar";                             url = mirror://maven/org/nanohttpd/nanohttpd-websocket/2.3.1/nanohttpd-websocket-2.3.1.jar; }
     rec { sha1 = "a8d54d1ca554a77f377eff6bf9e16ca8383c8f6c"; name = "NanoHTTPD_${sha1}/nanohttpd.jar";                                                 url = mirror://maven/org/nanohttpd/nanohttpd/2.3.1/nanohttpd-2.3.1.jar; }
     rec { sha1 = "946f8aa9daa917dd81a8b818111bec7e288f821a"; name = "ANTLR4_${sha1}/antlr4.jar";                                                       url = mirror://maven/org/antlr/antlr4-runtime/4.7.1/antlr4-runtime-4.7.1.jar; }
     rec { sha1 = "c3aeac59c022bdc497c8c48ed86fa50450e4896a"; name = "JLINE_${sha1}/jline.jar";                                                         url = mirror://maven/jline/jline/2.14.6/jline-2.14.6.jar; }
     rec { sha1 = "d0bdc21c5e6404726b102998e44c66a738897905"; name = "JAVA_ALLOCATION_INSTRUMENTER_${sha1}/java-allocation-instrumenter.jar";           url = mirror://maven/com/google/code/java-allocation-instrumenter/java-allocation-instrumenter/3.1.0/java-allocation-instrumenter-3.1.0.jar; }
-    rec { sha1 = "0da08b8cce7bbf903602a25a3a163ae252435795"; name = "ASM5_${sha1}/asm5.jar";                                                        url = mirror://maven/org/ow2/asm/asm/5.0.4/asm-5.0.4.jar; }
+    rec { sha1 = "0da08b8cce7bbf903602a25a3a163ae252435795"; name = "ASM5_${sha1}/asm5.jar";                                                           url = mirror://maven/org/ow2/asm/asm/5.0.4/asm-5.0.4.jar; }
     rec { sha1 = "396ce0c07ba2b481f25a70195c7c94922f0d1b0b"; name = "ASM_TREE5_${sha1}/asm-tree5.jar";                                                 url = mirror://maven/org/ow2/asm/asm-tree/5.0.4/asm-tree-5.0.4.jar; }
     rec { sha1 = "280c265b789e041c02e5c97815793dfc283fb1e6"; name = "LIBFFI_SOURCES_${sha1}/libffi-sources.tar.gz";                                    url = https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/libffi-3.2.1.tar.gz; }
     rec { sha1 = "8819cea8bfe22c9c63f55465e296b3855ea41786"; name = "TruffleJSON_${sha1}/trufflejson.jar";                                             url = https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/trufflejson-20180130.jar; }
     rec { sha1 = "9712a8124c40298015f04a74f61b3d81a51513af"; name = "CHECKSTYLE_8.8_${sha1}/checkstyle-8.8.jar";                                       url = https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/checkstyle-8.8-all.jar; }
-    rec { sha1 = "158ba6f2b346469b5f8083d1700c3f55b8b9082c"; name = "VISUALVM_COMMON_${sha1}/visualvm-common.tar.gz";                                  url = https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/visualvm/visualvm-19_0_0-11.tar.gz; }
-    rec { sha1 = "eb5ffa476ed2f6fac0ecd4bb2ae32741f9646932"; name = "VISUALVM_PLATFORM_SPECIFIC_${sha1}/visualvm-platform-specific.tar.gz";            url = https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/visualvm/visualvm-19_0_0-11-linux-amd64.tar.gz; }
+    rec { sha1 = "8dc5a90bed5f51d7538d05b8c31c31b7dfddbd66"; name = "VISUALVM_COMMON_${sha1}/visualvm-common.tar.gz";                                  url = https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/visualvm/visualvm-19_0_0-20.tar.gz; }
     rec { sha1 = "e6e60889b7211a80b21052a249bd7e0f88f79fee"; name = "Java-WebSocket_${sha1}/java-websocket.jar";                                       url = mirror://maven/org/java-websocket/Java-WebSocket/1.3.9/Java-WebSocket-1.3.9.jar; }
     rec { sha1 = "7a4d00d5ec5febd252a6182e8b6e87a0a9821f81"; name = "ICU4J_${sha1}/icu4j.jar";                                                         url = mirror://maven/com/ibm/icu/icu4j/62.1/icu4j-62.1.jar; }
     # This duplication of asm with underscore and minus is totally weird
@@ -138,15 +193,25 @@ let
     rec { sha1 = "505a09064f6e2209616f38724f6d97d8d889aa92"; name = "JONI_${sha1}/joni.sources.jar";                                                   url = mirror://maven/org/jruby/joni/joni/2.1.25/joni-2.1.25-sources.jar; }
     rec { sha1 = "c4f7d054303948eb6a4066194253886c8af07128"; name = "XZ-1.8_${sha1}/xz-1.8.jar";                                                       url = mirror://maven/org/tukaani/xz/1.8/xz-1.8.jar; }
     rec { sha1 = "9314d3d372b05546a33791fbc8dd579c92ebd16b"; name = "GNUR_${sha1}/gnur.tar.gz";                                                        url = http://cran.rstudio.com/src/base/R-3/R-3.5.1.tar.gz; }
-    rec { sha1 = "90aa8308da72ae610207d8f6ca27736921be692a"; name = "ANTLR4_COMPLETE_${sha1}/antlr4-complete.jar";                                     url = https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/antlr-4.7.1-complete.jar; }
-  ];
+    rec { sha1 = "90aa8308da72ae610207d8f6ca27736921be692a"; name = "ANTLR4_COMPLETE_${sha1}/antlr4-complete.jar";                                     url = https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/antlr-4.7.1-complete.jar; }] ++
+  lib.optionals stdenv.isLinux [
+    rec { sha1 = "df4c1f784294d02a82d78664064248283bfcc297"; name = "LLVM_ORG_${sha1}/llvm-org.tar.gz";                                                url = https://lafo.ssw.uni-linz.ac.at/pub/llvm-org/llvm-llvmorg-8.0.0-4-gd563e33a79-bgae3b177eaa-linux-amd64.tar.gz; }
+    rec { sha1 = "344483aefa15147c121a8fb6fb35a2406768cc5c"; name = "LLVM_PLATFORM_SPECIFIC_${sha1}/llvm-platform-specific.jar";                       url = mirror://maven/org/bytedeco/javacpp-presets/llvm/6.0.1-1.4.2/llvm-6.0.1-1.4.2-linux-x86_64.jar; }
+    rec { sha1 = "fd1a723d62cbbc591041d303e8b151d89f131643"; name = "VISUALVM_PLATFORM_SPECIFIC_${sha1}/visualvm-platform-specific.tar.gz";            url = https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/visualvm/visualvm-19_0_0-20-linux-amd64.tar.gz; }
+    rec { sha1 = "987234c4ce45505c21302e097c24efef4873325c"; name = "NINJA_${sha1}/ninja.zip";                                                         url = "https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip";
+          isNinja = true; }] ++
+  lib.optionals stdenv.isDarwin [
+    rec { sha1 = "0fa1af180755fa4cc018ee9be33f2d7d827593c4"; name = "LLVM_ORG_${sha1}/llvm-org.tar.gz";                                                url = https://lafo.ssw.uni-linz.ac.at/pub/llvm-org/llvm-llvmorg-8.0.0-4-gd563e33a79-bgae3b177eaa-darwin-amd64.tar.gz; }
+    rec { sha1 = "57bc74574104a9e0a2dc4d7a71ffcc5731909e57"; name = "LLVM_PLATFORM_SPECIFIC_${sha1}/llvm-platform-specific.jar";                       url = mirror://maven/org/bytedeco/javacpp-presets/llvm/6.0.1-1.4.2/llvm-6.0.1-1.4.2-macosx-x86_64.jar; }
+    rec { sha1 = "ae23bb365930f720acc88c62640bae6852a37d67"; name = "VISUALVM_PLATFORM_SPECIFIC_${sha1}/visualvm-platform-specific.tar.gz";            url = https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/visualvm/visualvm-19_0_0-20-macosx-x86_64.tar.gz; }
+    rec { sha1 = "8142c497f7dfbdb052a1e31960fdfe2c6f9a5ca2"; name = "NINJA_${sha1}/ninja.zip";                                                         url = "https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip";
+          isNinja = true; }];
 
   graal-mxcachegit = [
-    { sha256 = "05z2830ng71bhgsxc0zyc74l1bz7hg54la8j1r99993fhhch4y36"; name = "graaljs";     url = "https://github.com/graalvm/graaljs.git";     rev = "vm-${version}"; }
-    { sha256 = "0ai5x4n1c2lcfkfpp29zn1bcmp3khc5hvssyw1qr1l2zy79fxwjp"; name = "truffleruby"; url = "https://github.com/oracle/truffleruby.git";  rev = "vm-${version}"; }
-    { sha256 = "010079qsl6dff3yca8vlzcahq9z1ppyr758shjkm1f7izwphjv7p"; name = "fastr";       url = "https://github.com/oracle/fastr.git";        rev = "vm-${version}"; }
-    { sha256 = "0hcqbasqs0yb7p1sal63qbxqxh942gh5vzl95pfdlflmc2g82v4q"; name = "graalpython"; url = "https://github.com/graalvm/graalpython.git"; rev = "vm-${version}"; }
-  ];
+    { sha256 = "01w39ms39gl3cw7c2fgcacr2yjg94im9x2x7p5g94l6xlcgqvcnr"; name = "graaljs";     url = "https://github.com/graalvm/graaljs.git";     rev = "vm-${version}"; }
+    { sha256 = "1dps9n5b9c80pbg1fmlwpffy6ina0f0h27di24kafc8isxrdggia"; name = "truffleruby"; url = "https://github.com/oracle/truffleruby.git";  rev = "vm-${version}"; }
+    { sha256 = "0jdpdqm3ld1wsasmi8ka26qf19cibjac8lrqm040h5vh0iqzxizy"; name = "fastr";       url = "https://github.com/oracle/fastr.git";        rev = "vm-${version}"; }
+    { sha256 = "1gv8vafwrafjzvgv4gwk4kcsb3bnvsx07qa5inc0bdyxy5shl381"; name = "graalpython"; url = "https://github.com/graalvm/graalpython.git"; rev = "vm-${version}"; }];
 
   ninja-syntax = python27.pkgs.buildPythonPackage rec {
     version = "1.7.2";
@@ -169,13 +234,13 @@ let
 in rec {
 
   mx = stdenv.mkDerivation rec {
-    version = "5.223.0";
+    version = "5.247.1";
     pname = "mx";
     src = fetchFromGitHub {
       owner  = "graalvm";
       repo   = "mx";
       rev    = version;
-      sha256 = "0q51dnm6n1472p93dxr4jh8d7cv09a70pq89cdgxwh42vapykrn9";
+      sha256 = "038qr49rqzkhj76nqd27h8fysssnlpdhmy23ks2y81xlxhlzkc59";
     };
     nativeBuildInputs = [ makeWrapper ];
     prePatch = ''
@@ -214,15 +279,17 @@ in rec {
   };
 
   jvmci8 = stdenv.mkDerivation rec {
-    version = "19.2-b01";
+    version = "19.3-b05";
     pname = "jvmci";
     src = fetchFromGitHub {
       owner  = "graalvm";
       repo   = "graal-jvmci-8";
       rev    = "jvmci-${version}";
-      sha256 = "0maipj871vaxvap4576m0pzblzqxfjjzmwap3ndd84ny8d6vbqaa";
+      sha256 =  "0j7my76vldbrvki9x1gn9ics3x2z96j05jdy4nflbpik8i396114";
     };
-    buildInputs = [ mx mercurial openjdk ];
+    buildInputs = [ mx mercurial openjdk ] ++ lib.optional stdenv.isDarwin [
+      libobjc CoreFoundation Foundation JavaNativeFoundation JavaRuntimeSupport JavaVM xcodebuild Cocoa
+    ];
     postUnpack = ''
       # a fake mercurial dir to prevent mx crash and supply the version to mx
       ( cd $sourceRoot
@@ -233,17 +300,27 @@ in rec {
         hg checkout ${lib.escapeShellArg src.rev}
       )
     '';
-    patches = [ ./004_mx_jvmci.py.patch ];
+    patches = [ ./004_mx_jvmci.py.patch ] ++
+              lib.optional stdenv.isDarwin [
+                ./008_remove_jfr.patch ];
     postPatch =''
       # The hotspot version name regex fix
       substituteInPlace mx.jvmci/mx_jvmci.py \
-        --replace "\\d+.\\d+-b\\d+" "\\d+.\\d+-bga"
-      substituteInPlace src/share/vm/jvmci/jvmciCompilerToVM.cpp \
-        --replace 'method->name_and_sig_as_C_string(), method->native_function(), entry' \
-                  'method->name_and_sig_as_C_string(), p2i(method->native_function()), p2i(entry)' || exit -1
+        --replace "\\d+.\\d+-b\\d+" "\\d+.\\d+-b[g\\d][a\\d]"
+      # darwin: https://github.com/oracle/graal/issues/1816
+      substituteInPlace src/share/vm/code/compiledIC.cpp \
+        --replace 'entry == false' '*entry == false'
     '';
     hardeningDisable = [ "fortify" ];
-    NIX_CFLAGS_COMPILE = "-Wno-error=format-overflow -Wno-error=nonnull";
+    NIX_CFLAGS_COMPILE = toString (lib.optional stdenv.isDarwin [
+      "-Wno-reserved-user-defined-literal"
+      "-Wno-c++11-narrowing"
+    ] ++
+    lib.optional stdenv.isLinux [
+      "-Wno-error=format-overflow" # newly detected by gcc7
+      "-Wno-error=nonnull"
+    ]);
+
     buildPhase = ''
       export MX_ALT_OUTPUT_ROOT=$NIX_BUILD_TOP/mxbuild
       export MX_CACHE_DIR=${makeMxCache jvmci8-mxcache}
@@ -254,7 +331,9 @@ in rec {
     '';
     installPhase = ''
       mkdir -p $out
-      mv openjdk1.8.0_*/linux-amd64/product/* $out
+      ${if stdenv.isDarwin
+        then "mv openjdk1.8.0_*/darwin-amd64/product/* $out"
+        else "mv openjdk1.8.0_*/linux-amd64/product/* $out"}
       install -v -m0555 -D $MX_CACHE_DIR/hsdis*/hsdis.so $out/jre/lib/amd64/hsdis-amd64.so
     '';
     # copy-paste openjdk's preFixup
@@ -276,25 +355,36 @@ in rec {
     inherit (openjdk) meta;
   };
 
-  graalvm8 = stdenv.mkDerivation rec {
+  graalvm8 = 	stdenv.mkDerivation rec {
     inherit version;
     pname = "graal";
     src = fetchFromGitHub {
       owner  = "oracle";
       repo   = "graal";
       rev    = "vm-${version}";
-      sha256 = "0abx6adk91yzaf1md4qbidxykpqcgphh6j4hj01ry57s4if0j66f";
+      sha256 = "0v8zkmzkyhmmmvra5pp876d4i4ijrrw15j98ipayc7is02kwiwmq";
     };
-    patches = [ ./002_setjmp.c.patch ./003_mx_truffle.py.patch ];
-    buildInputs = [ mx zlib mercurial jvmci8 git clang llvm
-                    python27withPackages which icu ruby bzip2
-                    # gfortran readline bzip2 lzma pcre.dev curl ed ## WIP: fastr dependencies
+
+    patches = [ ./002_setjmp.c.patch ./003_mx_truffle.py.patch ] ++
+              lib.optional stdenv.isDarwin [
+                ./009_remove_signedness_verifier.patch ./010_mx_substratevm.py
+              ];
+
+    buildInputs = [ mx zlib.dev mercurial jvmci8 git llvm clang
+                    python27withPackages icu ruby bzip2 which
+                    readline bzip2 lzma pcre curl ed gfortran
+                  ]  ++ lib.optional stdenv.isDarwin [
+                    CoreFoundation gcc.cc.lib libiconv perl openssl
                   ];
+
     postUnpack = ''
-      cp ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc}/stdlib.h \
-        $sourceRoot/sulong/projects/com.oracle.truffle.llvm.libraries.bitcode/include
-      cp ${truffleMake} $TMP && mv *truffle.make truffle.make
+      ${lib.optionalString stdenv.isLinux ''
+        cp ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc}/stdlib.h \
+          $sourceRoot/sulong/projects/com.oracle.truffle.llvm.libraries.bitcode/include
+      ''}
+      cp ${truffleMake} $TMPDIR/truffle.make
       rm $sourceRoot/truffle/src/libffi/patches/others/0001-Add-mx-bootstrap-Makefile.patch
+
       # a fake mercurial dir to prevent mx crash and supply the version to mx
       ( cd $sourceRoot
         hg init
@@ -303,57 +393,93 @@ in rec {
         hg tag      ${lib.escapeShellArg src.rev}
         hg checkout ${lib.escapeShellArg src.rev}
       )
+
+      # make a copy of jvmci8
+      mkdir $NIX_BUILD_TOP/jvmci8
+      cp -dpR ${jvmci8}/* $NIX_BUILD_TOP/jvmci8
+      chmod +w -R $NIX_BUILD_TOP/jvmci8
+      export MX_CACHE_DIR=${makeMxCache graal-mxcache}
+      export MX_GIT_CACHE_DIR=$NIX_BUILD_TOP/mxgitcache
+      ${makeMxGitCache graal-mxcachegit "$MX_GIT_CACHE_DIR"}
+      cd $TMPDIR
     '';
+
     postPatch = ''
       substituteInPlace substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/PosixDirectives.java \
         --replace '<zlib.h>' '<${zlib.dev}/include/zlib.h>'
       substituteInPlace substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/CCLinkerInvocation.java \
         --replace 'cmd.add("-v");' 'cmd.add("-v"); cmd.add("-L${zlib}/lib");'
-      substituteInPlace substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java \
-        --replace 'command.add(Platform.includedIn(Platform.WINDOWS.class) ? "CL" : "gcc");' \
-          'command.add(Platform.includedIn(Platform.WINDOWS.class) ? "CL" : "${stdenv.cc}/bin/gcc");'
+
+      # For debugging native-image build, add this replace statement on CCompilerInvoker.java
+      # --replace '(String line : lines) {' '(String line : lines) {System.out.println("DEBUG: " + line);'
+      ${if stdenv.isLinux then ''
+          substituteInPlace substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java \
+            --replace 'command.add(Platform.includedIn(Platform.WINDOWS.class) ? "CL" : "gcc");' \
+                      'command.add(Platform.includedIn(Platform.WINDOWS.class) ? "CL" : "${stdenv.cc}/bin/gcc");' ''
+        else ''
+          substituteInPlace substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java \
+            --replace 'command.add(Platform.includedIn(Platform.WINDOWS.class) ? "CL" : "gcc");' \
+                      'command.add(Platform.includedIn(Platform.WINDOWS.class) ? "CL" : "${gcc.cc}/bin/gcc");
+                       command.add("-F"); command.add("${CoreFoundation}/Library/Frameworks");
+                       command.add("-framework"); command.add("CoreFoundation");'
+       ''}
+
+      # prevent cyclical imports caused by identical <include> names
       substituteInPlace substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/CCLinkerInvocation.java \
         --replace 'protected String compilerCommand = "cc";' 'protected String compilerCommand = "${stdenv.cc}/bin/cc";'
-      # prevent cyclical imports caused by identical <include> names
-      substituteInPlace sulong/projects/com.oracle.truffle.llvm.libraries.bitcode/include/stdlib.h \
-        --replace '# include <cstdlib>' '# include "${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc}/cstdlib"'
       # dragonegg can't seem to compile on nix, so let's not require it
       substituteInPlace sulong/mx.sulong/suite.py \
         --replace '"requireDragonegg" : True,' '"requireDragonegg" : False,'
       substituteInPlace truffle/mx.truffle/mx_truffle.py \
         --replace 'os.path.relpath(self.subject.delegate.dir, self.subject.suite.vc_dir)' \
                   'self.subject.delegate.dir'
-
+      substituteInPlace sulong/projects/bootstrap-toolchain-launchers/Makefile \
+        --replace /bin/bash ${bash}/bin/bash
       # Patch the native-image template, as it will be run during build
       chmod +x vm/mx.vm/launcher_template.sh && patchShebangs vm/mx.vm
       # Prevent random errors from too low maxRuntimecompilemethods
       substituteInPlace truffle/mx.truffle/macro-truffle.properties \
         --replace '-H:MaxRuntimeCompileMethods=1400' \
                   '-H:MaxRuntimeCompileMethods=28000'
+      ${lib.optionalString stdenv.isDarwin ''
+        substituteInPlace truffle/src/com.oracle.truffle.nfi.test.native/src/object.cc \
+          --replace '#include <stdlib.h>' ""
+      ''}
+      ${lib.optionalString stdenv.isLinux ''
+        substituteInPlace sulong/projects/com.oracle.truffle.llvm.libraries.bitcode/include/stdlib.h \
+          --replace '# include <cstdlib>' '# include "${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc}/cstdlib"'
+      ''}
     '';
 
     buildPhase = ''
-      # make a copy of jvmci8
-      mkdir $NIX_BUILD_TOP/jvmci8
-      cp -dpR ${jvmci8}/* $NIX_BUILD_TOP/jvmci8
-      chmod +w -R $NIX_BUILD_TOP/jvmci8
-
       export MX_ALT_OUTPUT_ROOT=$NIX_BUILD_TOP/mxbuild
-      export MX_CACHE_DIR=${makeMxCache graal-mxcache}
       export MX_GIT_CACHE='refcache'
-      export MX_GIT_CACHE_DIR=$NIX_BUILD_TOP/mxgitcache
       export JVMCI_VERSION_CHECK='ignore'
       export JAVA_HOME=$NIX_BUILD_TOP/jvmci8
-      # export FASTR_RELEASE=true ## WIP
-      ${makeMxGitCache graal-mxcachegit "$MX_GIT_CACHE_DIR"}
-      cd $NIX_BUILD_TOP/source
-
+      export FASTR_RELEASE=true
+      export PKG_LDFLAGS_OVERRIDE="-L${pcre.out}/lib -L${zlib}/lib -L${gfortran.cc.lib}/lib64"
+      ${lib.optionalString stdenv.isDarwin ''
+        export CC="gcc"
+        export CPP="gcc -E"
+        export NIX_CXXSTDLIB_LINK=""
+        export NIX_TARGET_CXXSTDLIB_LINK=""
+        export OPENSSL_PREFIX=$(realpath openssl)
+        # this fixes error: impure path 'LibFFIHeaderDirectives' used in link
+        export NIX_ENFORCE_PURITY=0
+      ''}
       ( cd vm
-        mx-internal -v --dynamicimports /substratevm,/tools,sulong,/graal-nodejs,graalpython build
+        mx-internal -v --suite sdk --suite compiler --suite vm --suite tools --suite regex --suite truffle \
+                       --dynamicimports /substratevm,/sulong,graal-js,graalpython,fastr,truffleruby build
       )
     '';
 
-    installPhase = ''
+    installPhase =
+      (if stdenv.isDarwin then ''
+      mkdir -p $out
+      rm -rf $MX_ALT_OUTPUT_ROOT/vm/darwin-amd64/GRAALVM_*STAGE1*
+      cp -rf $MX_ALT_OUTPUT_ROOT/vm/darwin-amd64/GRAALVM*/graalvm-unknown-${version}/* $out
+      ''
+       else ''
       mkdir -p $out
       rm -rf $MX_ALT_OUTPUT_ROOT/vm/linux-amd64/GRAALVM_*STAGE1*
       cp -rf $MX_ALT_OUTPUT_ROOT/vm/linux-amd64/GRAALVM*/graalvm-unknown-${version}/* $out
@@ -366,7 +492,7 @@ in rec {
       cp -rf ${glibc}/lib/* $out/jre/lib/svm/clibraries/linux-amd64/
       cp ${glibc.static}/lib/* $out/jre/lib/svm/clibraries/linux-amd64/
       cp ${zlib.static}/lib/libz.a $out/jre/lib/svm/clibraries/linux-amd64/libz.a
-    '';
+    '');
 
     inherit (jvmci8) preFixup;
     dontStrip = true; # stripped javac crashes with "segmentaion fault"
@@ -390,12 +516,14 @@ in rec {
       ./helloworld
       ./helloworld | fgrep 'Hello World'
 
-      # Ahead-Of-Time compilation with --static
-      $out/bin/native-image --no-server --static HelloWorld
-      ./helloworld
-      ./helloworld | fgrep 'Hello World'
-    '';
-
+      ${lib.optionalString stdenv.isLinux
+        ''
+          # Ahead-Of-Time compilation with --static (supported on linux only)
+          $out/bin/native-image --no-server --static HelloWorld
+          ./helloworld
+          ./helloworld | fgrep 'Hello World'
+        ''}
+         '';
     enableParallelBuilding = true;
     passthru.home = graalvm8;
 
@@ -404,7 +532,7 @@ in rec {
       description = "High-Performance Polyglot VM";
       license = licenses.gpl2;
       maintainers = with maintainers; [ volth hlolli ];
-      platforms = [ "x86_64-linux" /*"aarch64-linux" "x86_64-darwin"*/ ];
+      platforms = [ "x86_64-linux" "x86_64-darwin" /*"aarch64-linux"*/ ];
     };
   };
 }

--- a/pkgs/development/compilers/graalvm/truffle.make
+++ b/pkgs/development/compilers/graalvm/truffle.make
@@ -2,13 +2,15 @@
 
 # `make MX_VERBOSE=y` will report all lines executed. The actual value doesn't
 # matter as long as it's not empty.
+
 QUIETLY$(MX_VERBOSE) = @
 
 .PHONY: default
 
 default:
+	sed -i "s|-print-multi-os-directory||g" ../$(SOURCES)/configure
 	$(QUIETLY) echo CONFIGURE libffi
 	$(QUIETLY) mkdir ../$(OUTPUT)
-	$(QUIETLY) cd ../$(OUTPUT) && ../$(SOURCES)/configure $(CONFIGURE_ARGS) > ../libffi.configure.log
+	$(QUIETLY) cd ../$(OUTPUT) && ../$(SOURCES)/configure $(CONFIGURE_ARGS)
 	$(QUIETLY) echo MAKE libffi
-	$(QUIETLY) $(MAKE) -C ../$(OUTPUT) > ../libffi.build.log
+	$(QUIETLY) $(MAKE) -C ../$(OUTPUT)

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -7,11 +7,14 @@ let
   };
 
   jdk = stdenv.mkDerivation {
-    name = "zulu1.8.0_222-8.40.0.25-ca-fx";
+    # @hlolli: Later version than 1.8.0_202 throws error when building jvmci.
+    # dyld: lazy symbol binding failed: Symbol not found: _JVM_BeforeHalt
+    # Referenced from: ../libjava.dylib Expected in: .../libjvm.dylib
+    name = "zulu1.8.0_202-8.36.0.1";
 
     src = fetchurl {
-      url = "http://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-fx-jdk8.0.222-macosx_x64.zip";
-      sha256 = "1mal8bdc94q7ahx7p3xggy3qpxr6h83g2y01wzgvnqjd8n5i3qr1";
+      url = "https://cdn.azul.com/zulu/bin/zulu8.36.0.1-ca-jdk8.0.202-macosx_x64.zip";
+      sha256 = "0s92l1wlf02vjx8dvrsla2kq7qwxnmgh325b38mgqy872016jm9p";
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-linux/";
     };
 

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -61,9 +61,16 @@ let
     installPhase = ''
       linkFramework() {
         local path="$1"
+        local nested_path="$1"
         local dest="$out/Library/Frameworks/$path"
+        if [ "$path" == "JavaNativeFoundation.framework" ]; then
+          local nested_path="JavaVM.framework/Versions/A/Frameworks/JavaNativeFoundation.framework"
+        fi
+        if [ "$path" == "JavaRuntimeSupport.framework" ]; then
+          local nested_path="JavaVM.framework/Versions/A/Frameworks/JavaRuntimeSupport.framework"
+        fi
         local name="$(basename "$path" .framework)"
-        local current="$(readlink "/System/Library/Frameworks/$path/Versions/Current")"
+        local current="$(readlink "/System/Library/Frameworks/$nested_path/Versions/Current")"
         if [ -z "$current" ]; then
           current=A
         fi
@@ -75,25 +82,21 @@ let
         # ApplicationServices in the 10.9 SDK
         local isChild=0
 
-        if [ -d "${sdk.out}/Library/Frameworks/$path/Versions/$current/Headers" ]; then
+        if [ -d "${sdk.out}/Library/Frameworks/$nested_path/Versions/$current/Headers" ]; then
           isChild=1
-          cp -R "${sdk.out}/Library/Frameworks/$path/Versions/$current/Headers" .
+          cp -R "${sdk.out}/Library/Frameworks/$nested_path/Versions/$current/Headers" .
         elif [ -d "${sdk.out}/Library/Frameworks/$name.framework/Versions/$current/Headers" ]; then
           current="$(readlink "/System/Library/Frameworks/$name.framework/Versions/Current")"
           cp -R "${sdk.out}/Library/Frameworks/$name.framework/Versions/$current/Headers" .
         fi
-        ln -s -L "/System/Library/Frameworks/$path/Versions/$current/$name"
-        ln -s -L "/System/Library/Frameworks/$path/Versions/$current/Resources"
+        ln -s -L "/System/Library/Frameworks/$nested_path/Versions/$current/$name"
+        ln -s -L "/System/Library/Frameworks/$nested_path/Versions/$current/Resources"
 
-        if [ -f "/System/Library/Frameworks/$path/module.map" ]; then
-          ln -s "/System/Library/Frameworks/$path/module.map"
+        if [ -f "/System/Library/Frameworks/$nested_path/module.map" ]; then
+          ln -s "/System/Library/Frameworks/$nested_path/module.map"
         fi
 
-        if [ $isChild -eq 1 ]; then
-          pushd "${sdk.out}/Library/Frameworks/$path/Versions/$current" >/dev/null
-        else
-          pushd "${sdk.out}/Library/Frameworks/$name.framework/Versions/$current" >/dev/null
-        fi
+        pushd "${sdk.out}/Library/Frameworks/$nested_path/Versions/$current" >/dev/null
         local children=$(echo Frameworks/*.framework)
         popd >/dev/null
 
@@ -108,7 +111,6 @@ let
 
         popd >/dev/null
       }
-
 
       linkFramework "${name}.framework"
     '';

--- a/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
@@ -65,6 +65,8 @@ with frameworks; with libs; {
   InstallerPlugins        = [];
   InstantMessage          = [];
   JavaFrameEmbedding      = [];
+  JavaNativeFoundation    = [];
+  JavaRuntimeSupport      = [];
   JavaScriptCore          = [];
   Kerberos                = [];
   Kernel                  = [ IOKit ];

--- a/pkgs/os-specific/darwin/apple-source-releases/libdispatch/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libdispatch/default.nix
@@ -12,5 +12,14 @@ appleDerivation {
 
     cp -r dispatch/*.h $out/include/dispatch
     cp -r os/object*.h  $out/include/os
+
+    # gcc compatability. Source: https://stackoverflow.com/a/28014302/3714556
+    substituteInPlace $out/include/dispatch/object.h \
+      --replace 'typedef void (^dispatch_block_t)(void);' \
+                '#ifdef __clang__
+                 typedef void (^dispatch_block_t)(void);
+                 #else
+                 typedef void* dispatch_block_t;
+                 #endif'
   '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8384,7 +8384,13 @@ in
   jre = jre8;
   jre_headless = jre8_headless;
 
-  inherit (callPackages ../development/compilers/graalvm { }) mx jvmci8 graalvm8;
+  inherit (callPackages ../development/compilers/graalvm {
+    gcc = if stdenv.targetPlatform.isDarwin then gcc8 else gcc;
+    inherit (darwin.apple_sdk.frameworks)
+      CoreFoundation Foundation JavaNativeFoundation
+      JavaVM JavaRuntimeSupport Cocoa;
+    inherit (darwin) libiconv libobjc libresolv;
+  }) mx jvmci8 graalvm8;
 
   graalvm8-ee = callPackage ../development/compilers/graalvm/enterprise-edition.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
Bumping graalvm8

###### Things done

I fixed fastr and truffleruby so these are now included. I was planing to make it work for darwin, but I'll have to find time later for that, next weekend or next week. I refactored the cache generation into the postUnpack phase. I guess I could refactor some of the patching from the mxgitcaches into the postPatch phase later on.

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x ] NixOS
   - [ x ] macOS
   - [ ] other Linux distributions
- [ x ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @volth 
