### PR TITLE
yacreader: 9.5.0 -> 9.6.2

### DIFF
--- a/pkgs/applications/graphics/yacreader/default.nix
+++ b/pkgs/applications/graphics/yacreader/default.nix
@@ -1,14 +1,17 @@
-{ stdenv, fetchurl, qmake, poppler, pkgconfig, libunarr, libGLU
-, qtdeclarative, qtgraphicaleffects, qtmultimedia, qtquickcontrols, qtscript
+{ mkDerivation, lib, fetchFromGitHub, qmake, poppler, pkgconfig, libunarr
+, libGLU, qtdeclarative, qtgraphicaleffects, qtmultimedia, qtquickcontrols
+, qtscript
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "yacreader";
-  version = "9.5.0";
+  version = "9.6.2";
 
-  src = fetchurl {
-    url = "https://github.com/YACReader/yacreader/releases/download/${version}/${pname}-${version}-src.tar.xz";
-    sha256 = "0cv5y76kjvsqsv4fp99j8np5pm4m76868i1nn40q6hy573dmxwm6";
+  src = fetchFromGitHub {
+    owner = "YACReader";
+    repo = pname;
+    rev = version;
+    sha256 = "1s7kb72skhr364kq8wr2i012jjmaz2vzcz526h0b2bch8921wrnf";
   };
 
   nativeBuildInputs = [ qmake pkgconfig ];
@@ -19,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A comic reader for cross-platform reading and managing your digital comic collection";
-    homepage = http://www.yacreader.com;
-    license = stdenv.lib.licenses.gpl3;
+    homepage = "http://www.yacreader.com";
+    license = lib.licenses.gpl3;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Simple version upgrade, and also the usual #65399 fix which is also needed in 19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
