### PR TITLE
stress-ng: 0.10.05 -> 0.10.08

### DIFF
--- a/pkgs/tools/system/stress-ng/default.nix
+++ b/pkgs/tools/system/stress-ng/default.nix
@@ -1,25 +1,32 @@
 { stdenv, fetchurl
-, attr, keyutils, libaio, libapparmor, libbsd, libcap, libgcrypt, lksctp-tools, zlib
+, attr, judy, keyutils, libaio, libapparmor, libbsd, libcap, libgcrypt, lksctp-tools, zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "stress-ng";
-  version = "0.10.05";
+  version = "0.10.08";
 
   src = fetchurl {
     url = "https://kernel.ubuntu.com/~cking/tarballs/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0hkghs99fl8kzg3lkkd4w6cj5133zr9a415py0ng60kzrfffmgdy";
+    sha256 = "1kkmznn0y5wxi7x9nlhzyfy933bv66113in4rf0raw6brymympaa";
   };
 
+  postPatch = ''
+    sed -i '/\#include <bsd\/string.h>/i #undef HAVE_STRLCAT\n#undef HAVE_STRLCPY' stress-ng.h
+  ''; # needed because of Darwin patch on libbsd
+
   # All platforms inputs then Linux-only ones
-  buildInputs = [ libbsd libgcrypt zlib ]
+  buildInputs = [ judy libbsd libgcrypt zlib ]
     ++ stdenv.lib.optionals stdenv.hostPlatform.isLinux [
       attr keyutils libaio libapparmor libcap lksctp-tools
     ];
 
-  postPatch = ''
-    substituteInPlace Makefile --replace "/usr" ""
-  '';
+  makeFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "MANDIR=${placeholder "out"}/share/man/man1"
+    "JOBDIR=${placeholder "out"}/share/stress-ng/example-jobs"
+    "BASHDIR=${placeholder "out"}/share/bash-completion/completions"
+  ];
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optional stdenv.hostPlatform.isMusl "-D_LINUX_SYSINFO_H=1";
 
@@ -28,8 +35,6 @@ stdenv.mkDerivation rec {
   # triggering the rebuild. Why this only happens on i686 remains a
   # mystery, though. :-(
   enableParallelBuilding = (!stdenv.isi686);
-
-  installFlags = [ "DESTDIR=${placeholder "out"}" ];
 
   meta = with stdenv.lib; {
     description = "Stress test a computer system";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version update
\+ fixes #72292

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
