### PR TITLE
itstool: Don't use Python 3 yet

### DIFF
--- a/pkgs/development/tools/misc/itstool/default.nix
+++ b/pkgs/development/tools/misc/itstool/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python3 }:
+{ stdenv, fetchurl, python2 }:
 
 stdenv.mkDerivation rec {
   # 2.0.3+ breaks the build of gnome3.gnome-desktop
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "bf909fb59b11a646681a8534d5700fec99be83bb2c57badf8c1844512227033a";
   };
 
-  buildInputs = [ (python3.withPackages(ps: with ps; [ libxml2 ])) ];
+  buildInputs = [ (python2.withPackages(ps: with ps; [ libxml2 ])) ];
 
   meta = {
     homepage = http://itstool.org/;


### PR DESCRIPTION
##### Motivation for this change
Fix NixOS tests on staging, which broke after #63174 was merged.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh 
