### PR TITLE
uhd: fix outdated python module (Mako)

### DIFF
--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig
-, python, pythonPackages, orc, libusb1, boost }:
+, python, orc, libusb1, boost }:
 
 # You need these udev rules to not have to run as root (copied from
 # ${uhd}/share/uhd/utils/uhd-usrp.rules):
@@ -40,7 +40,12 @@ in stdenv.mkDerivation {
                [ (stdenv.lib.optionalString stdenv.isAarch32 "-DCMAKE_CXX_FLAGS=-Wno-psabi") ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ python pythonPackages.pyramid_mako orc libusb1 boost ];
+  buildInputs = [
+    (python.withPackages (ps: with ps; [ Mako six requests ]))
+    orc
+    libusb1
+    boost
+  ];
 
   # Build only the host software
   preConfigure = "cd host";


### PR DESCRIPTION
###### Motivation for this change
The UHD build is currently broken.
`pyramid_mako` does not work anymore with python-2.7. According to `http://files.ettus.com/manual/page_build_guide.html` the module python.Mako is required. Replacing it in the input seems to make it work again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fpletz @tomberek @bjornfor 
