### PR TITLE
treewide: `set -u` everywhere

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -125,6 +125,13 @@
       <link linkend="opt-networking.interfaces">networking.interfaces.&lt;name&gt;.…</link> options.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      The stdenv now runs all bash with <literal>set -u</literal>, to catch the use of undefined variables.
+      Before, it itself used <literal>set -u</literal> but was careful to unset it so other packages' code ran as before.
+      Now, all bash code is held to the same high standard, and the rather complex stateful manipulation of the options can be discarded.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -111,17 +111,13 @@ stdenv.mkDerivation {
 
   installPhase =
     ''
-      set -u
-
       mkdir -p $out/bin $out/nix-support
 
       wrap() {
         local dst="$1"
         local wrapper="$2"
         export prog="$3"
-        set +u
         substituteAll "$wrapper" "$out/bin/$dst"
-        set -u
         chmod +x "$out/bin/$dst"
       }
     ''
@@ -163,8 +159,6 @@ stdenv.mkDerivation {
         [[ -e "$underlying" ]] || continue
         wrap ${targetPrefix}$variant ${./ld-wrapper.sh} $underlying
       done
-
-      set +u
     '';
 
   emulation = let
@@ -307,7 +301,6 @@ stdenv.mkDerivation {
     ''
 
     + ''
-      set +u
       substituteAll ${./add-flags.sh} $out/nix-support/add-flags.sh
       substituteAll ${./add-hardening.sh} $out/nix-support/add-hardening.sh
       substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash

--- a/pkgs/build-support/build-dotnet-package/default.nix
+++ b/pkgs/build-support/build-dotnet-package/default.nix
@@ -29,9 +29,9 @@ attrsOrig @
       configurePhase = ''
         runHook preConfigure
 
-        [ -z "$dontPlacateNuget" ] && placate-nuget.sh
-        [ -z "$dontPlacatePaket" ] && placate-paket.sh
-        [ -z "$dontPatchFSharpTargets" ] && patch-fsharp-targets.sh
+        [ -z "''${dontPlacateNuget-}" ] && placate-nuget.sh
+        [ -z "''${dontPlacatePaket-}" ] && placate-paket.sh
+        [ -z "''${dontPatchFSharpTargets-}" ] && patch-fsharp-targets.sh
 
         runHook postConfigure
       '';
@@ -69,7 +69,7 @@ attrsOrig @
 
         cp -rv ${arrayToShell outputFiles} "''${outputFilesArray[@]}" "$target"
 
-        if [ -z "$dontRemoveDuplicatedDlls" ]
+        if [ -z "''${dontRemoveDuplicatedDlls-}" ]
         then
           pushd "$out"
           remove-duplicated-dlls.sh

--- a/pkgs/build-support/setup-hooks/audit-tmpdir.sh
+++ b/pkgs/build-support/setup-hooks/audit-tmpdir.sh
@@ -7,7 +7,7 @@
 # the moment that would produce too many spurious errors (e.g. debug
 # info or assertion messages that refer to $TMPDIR).
 
-fixupOutputHooks+=('if [ -z "$noAuditTmpdir" -a -e "$prefix" ]; then auditTmpdir "$prefix"; fi')
+fixupOutputHooks+=('if [[ -z "${noAuditTmpdir-}" && -e "$prefix" ]]; then auditTmpdir "$prefix"; fi')
 
 auditTmpdir() {
     local dir="$1"

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -228,7 +228,7 @@ autoPatchelf() {
 # behaviour as fixupOutputHooks because the setup hook for patchelf is run in
 # fixupOutput and the postFixup hook runs later.
 postFixupHooks+=('
-    if [ -z "$dontAutoPatchelf" ]; then
+    if [ -z "${dontAutoPatchelf-}" ]; then
         autoPatchelf -- $(for output in $outputs; do
             [ -e "${!output}" ] || continue
             echo "${!output}"

--- a/pkgs/build-support/setup-hooks/compress-man-pages.sh
+++ b/pkgs/build-support/setup-hooks/compress-man-pages.sh
@@ -1,4 +1,4 @@
-fixupOutputHooks+=('if [ -z "$dontGzipMan" ]; then compressManPages "$prefix"; fi')
+fixupOutputHooks+=('if [ -z "${dontGzipMan-}" ]; then compressManPages "$prefix"; fi')
 
 compressManPages() {
     local dir="$1"

--- a/pkgs/build-support/setup-hooks/find-xml-catalogs.sh
+++ b/pkgs/build-support/setup-hooks/find-xml-catalogs.sh
@@ -11,12 +11,12 @@ addXMLCatalogs () {
     done
 }
 
-if [ -z "$libxmlHookDone" ]; then
+if [ -z "${libxmlHookDone-}" ]; then
     libxmlHookDone=1
 
     # Set up XML_CATALOG_FILES.  An empty initial value prevents
     # xmllint and xsltproc from looking in /etc/xml/catalog.
-    export XML_CATALOG_FILES
+    export XML_CATALOG_FILES=''
     if [ -z "$XML_CATALOG_FILES" ]; then XML_CATALOG_FILES=" "; fi
     addEnvHooks "$hostOffset" addXMLCatalogs
 fi

--- a/pkgs/build-support/setup-hooks/move-lib64.sh
+++ b/pkgs/build-support/setup-hooks/move-lib64.sh
@@ -8,7 +8,7 @@
 fixupOutputHooks+=(_moveLib64)
 
 _moveLib64() {
-    if [ "$dontMoveLib64" = 1 ]; then return; fi
+    if [ "${dontMoveLib64-}" = 1 ]; then return; fi
     if [ ! -e "$prefix/lib64" -o -L "$prefix/lib64" ]; then return; fi
     echo "moving $prefix/lib64/* to $prefix/lib"
     mkdir -p $prefix/lib

--- a/pkgs/build-support/setup-hooks/move-sbin.sh
+++ b/pkgs/build-support/setup-hooks/move-sbin.sh
@@ -5,7 +5,7 @@
 fixupOutputHooks+=(_moveSbin)
 
 _moveSbin() {
-    if [ "$dontMoveSbin" = 1 ]; then return; fi
+    if [ "${dontMoveSbin-}" = 1 ]; then return; fi
     if [ ! -e "$prefix/sbin" -o -L "$prefix/sbin" ]; then return; fi
     echo "moving $prefix/sbin/* to $prefix/bin"
     mkdir -p $prefix/bin

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -9,8 +9,8 @@ _assignFirst() {
     local varName="$1"
     local REMOVE=REMOVE # slightly hacky - we allow REMOVE (i.e. not a variable name)
     shift
-    while [ $# -ge 1 ]; do
-        if [ -n "${!1}" ]; then eval "${varName}"="$1"; return; fi
+	while (( $# )); do
+        if [ -n "${!1-}" ]; then eval "${varName}"="$1"; return; fi
         shift
     done
     echo "Error: _assignFirst found no valid variant!"
@@ -19,7 +19,7 @@ _assignFirst() {
 
 # Same as _assignFirst, but only if "$1" = ""
 _overrideFirst() {
-    if [ -z "${!1}" ]; then
+    if [ -z "${!1-}" ]; then
         _assignFirst "$@"
     fi
 }

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -9,7 +9,7 @@ _assignFirst() {
     local varName="$1"
     local REMOVE=REMOVE # slightly hacky - we allow REMOVE (i.e. not a variable name)
     shift
-	while (( $# )); do
+    while (( $# )); do
         if [ -n "${!1-}" ]; then eval "${varName}"="$1"; return; fi
         shift
     done

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -105,7 +105,7 @@ patchShebangs() {
 }
 
 patchShebangsAuto () {
-    if [ -z "$dontPatchShebangs" -a -e "$prefix" ]; then
+    if [ -z "${dontPatchShebangs-}" -a -e "$prefix" ]; then
 
         # Dev output will end up being run on the build platform. An
         # example case of this is sdl2-config. Otherwise, we can just

--- a/pkgs/build-support/setup-hooks/prune-libtool-files.sh
+++ b/pkgs/build-support/setup-hooks/prune-libtool-files.sh
@@ -8,7 +8,7 @@
 fixupOutputHooks+=(_pruneLibtoolFiles)
 
 _pruneLibtoolFiles() {
-    if [ "$dontPruneLibtoolFiles" ] || [ ! -e "$prefix" ]; then
+    if [ "${dontPruneLibtoolFiles-}" ] || [ ! -e "$prefix" ]; then
        return
     fi
 

--- a/pkgs/build-support/setup-hooks/strip.sh
+++ b/pkgs/build-support/setup-hooks/strip.sh
@@ -10,7 +10,7 @@ _doStrip() {
     local -ra stripCmds=(STRIP TARGET_STRIP)
 
     # Optimization
-    if [[ "$STRIP" == "$TARGET_STRIP" ]]; then
+    if [[ "${STRIP-}" == "${TARGET_STRIP-}" ]]; then
         dontStripTarget+=1
     fi
 
@@ -20,7 +20,7 @@ _doStrip() {
         local -n stripCmd="${stripCmds[$i]}"
 
         # `dontStrip` disables them all
-        if [[ "$dontStrip" || "$flag" ]] || ! type -f "$stripCmd" 2>/dev/null
+        if [[ "${dontStrip-}" || "${flag-}" ]] || ! type -f "${stripCmd-}" 2>/dev/null
         then continue; fi
 
         stripDebugList=${stripDebugList:-lib lib32 lib64 libexec bin sbin}

--- a/pkgs/build-support/setup-hooks/update-autotools-gnu-config-scripts.sh
+++ b/pkgs/build-support/setup-hooks/update-autotools-gnu-config-scripts.sh
@@ -1,7 +1,7 @@
 preConfigurePhases+=" updateAutotoolsGnuConfigScriptsPhase"
 
 updateAutotoolsGnuConfigScriptsPhase() {
-    if [ -n "$dontUpdateAutotoolsGnuConfigScripts" ]; then return; fi
+    if [ -n "${dontUpdateAutotoolsGnuConfigScripts-}" ]; then return; fi
 
     for script in config.sub config.guess; do
         for f in $(find . -type f -name "$script"); do

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
@@ -15,7 +15,7 @@ wrapGApp() {
     wrapProgram "$program" "${gappsWrapperArgs[@]}" "$@"
 }
 
-# Note: $gappsWrapperArgs still gets defined even if $dontWrapGApps is set.
+# Note: $gappsWrapperArgs still gets defined even if ${dontWrapGApps-} is set.
 wrapGAppsHook() {
   # guard against running multiple times (e.g. due to propagation)
   [ -z "$wrapGAppsHookHasRun" ] || return 0

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -37,7 +37,7 @@ let cpuName = stdenv.hostPlatform.parsed.cpu.name;
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook
-    if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
     EOF
   '';
 

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -54,7 +54,7 @@ let result = stdenv.mkDerivation rec {
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> "$out/nix-support/setup-hook"
-    if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
     EOF
   '';
 

--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -270,7 +270,7 @@ in rec {
       # Set JAVA_HOME automatically.
       mkdir -p $out/nix-support
       cat <<EOF > $out/nix-support/setup-hook
-      if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
       EOF
     '';
     postFixup = openjdk.postFixup or null;

--- a/pkgs/development/compilers/graalvm/enterprise-edition.nix
+++ b/pkgs/development/compilers/graalvm/enterprise-edition.nix
@@ -72,7 +72,7 @@ let
       # Set JAVA_HOME automatically.
       mkdir -p $out/nix-support
       cat <<EOF > $out/nix-support/setup-hook
-      if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -106,7 +106,7 @@ let
       # Set JAVA_HOME automatically.
       mkdir -p $out/nix-support
       cat <<EOF > $out/nix-support/setup-hook
-      if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -231,7 +231,7 @@ let
       # Set JAVA_HOME automatically.
       mkdir -p $out/nix-support
       cat <<EOF > $out/nix-support/setup-hook
-      if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/darwin/11.nix
+++ b/pkgs/development/compilers/openjdk/darwin/11.nix
@@ -44,7 +44,7 @@ let
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook
-      if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -44,7 +44,7 @@ let
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook
-      if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/darwin/default.nix
+++ b/pkgs/development/compilers/openjdk/darwin/default.nix
@@ -44,7 +44,7 @@ let
 
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook
-      if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/default.nix
+++ b/pkgs/development/compilers/openjdk/default.nix
@@ -114,7 +114,7 @@ let
       # Set JAVA_HOME automatically.
       mkdir -p $out/nix-support
       cat <<EOF > $out/nix-support/setup-hook
-      if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -156,7 +156,7 @@ let result = stdenv.mkDerivation rec {
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook
-    if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
     EOF
   '';
 

--- a/pkgs/development/compilers/rust/setup-hook.sh
+++ b/pkgs/development/compilers/rust/setup-hook.sh
@@ -1,4 +1,4 @@
 # Fix 'failed to open: /homeless-shelter/.cargo/.package-cache' in rust 1.36.
-if [[ -z $IN_NIX_SHELL && -z $CARGO_HOME ]]; then
+if [[ -z ${IN_NIX_SHELL-} && -z ${CARGO_HOME-} ]]; then
     export CARGO_HOME=$TMPDIR
 fi

--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -58,7 +58,7 @@ in stdenv.mkDerivation {
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook
-    if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
     EOF
   '';
 

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -55,7 +55,7 @@ in stdenv.mkDerivation {
 
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook
-    if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+    if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
     EOF
   '';
 

--- a/pkgs/development/interpreters/python/hooks/flit-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/flit-build-hook.sh
@@ -9,7 +9,7 @@ flitBuildPhase () {
     echo "Finished executing flitBuildPhase"
 }
 
-if [ -z "${dontUseFlitBuild-}" ] && [ -z "$buildPhase" ]; then
+if [ -z "${dontUseFlitBuild-}" ] && [ -z "${buildPhase-}" ]; then
     echo "Using flitBuildPhase"
     buildPhase=flitBuildPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/flit-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/flit-build-hook.sh
@@ -9,7 +9,7 @@ flitBuildPhase () {
     echo "Finished executing flitBuildPhase"
 }
 
-if [ -z "$dontUseFlitBuild" ] && [ -z "$buildPhase" ]; then
+if [ -z "${dontUseFlitBuild-}" ] && [ -z "$buildPhase" ]; then
     echo "Using flitBuildPhase"
     buildPhase=flitBuildPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/pip-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-build-hook.sh
@@ -31,7 +31,7 @@ pipShellHook() {
     echo "Finished executing pipShellHook"
 }
 
-if [ -z "$dontUsePipBuild" ] && [ -z "$buildPhase" ]; then
+if [ -z "${dontUsePipBuild-}" ] && [ -z "$buildPhase" ]; then
     echo "Using pipBuildPhase"
     buildPhase=pipBuildPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/pip-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-build-hook.sh
@@ -31,7 +31,7 @@ pipShellHook() {
     echo "Finished executing pipShellHook"
 }
 
-if [ -z "${dontUsePipBuild-}" ] && [ -z "$buildPhase" ]; then
+if [ -z "${dontUsePipBuild-}" ] && [ -z "${buildPhase-}" ]; then
     echo "Using pipBuildPhase"
     buildPhase=pipBuildPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -18,7 +18,7 @@ pipInstallPhase() {
     echo "Finished executing pipInstallPhase"
 }
 
-if [ -z "${dontUsePipInstall-}" ] && [ -z "$installPhase" ]; then
+if [ -z "${dontUsePipInstall-}" ] && [ -z "${installPhase-}" ]; then
     echo "Using pipInstallPhase"
     installPhase=pipInstallPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pip-install-hook.sh
@@ -18,7 +18,7 @@ pipInstallPhase() {
     echo "Finished executing pipInstallPhase"
 }
 
-if [ -z "$dontUsePipInstall" ] && [ -z "$installPhase" ]; then
+if [ -z "${dontUsePipInstall-}" ] && [ -z "$installPhase" ]; then
     echo "Using pipInstallPhase"
     installPhase=pipInstallPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -43,7 +43,7 @@ function pytestCheckPhase() {
     echo "Finished executing pytestCheckPhase"
 }
 
-if [ -z "$dontUsePytestCheck" ] && [ -z "$installCheckPhase" ]; then
+if [ -z "${dontUsePytestCheck-}" ] && [ -z "$installCheckPhase" ]; then
     echo "Using pytestCheckPhase"
     preDistPhases+=" pytestCheckPhase"
 fi

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -43,7 +43,7 @@ function pytestCheckPhase() {
     echo "Finished executing pytestCheckPhase"
 }
 
-if [ -z "${dontUsePytestCheck-}" ] && [ -z "$installCheckPhase" ]; then
+if [ -z "${dontUsePytestCheck-}" ] && [ -z "${installCheckPhase-}" ]; then
     echo "Using pytestCheckPhase"
     preDistPhases+=" pytestCheckPhase"
 fi

--- a/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook.sh
@@ -5,6 +5,6 @@ pythonCatchConflictsPhase() {
     @pythonInterpreter@ @catchConflicts@
 }
 
-if [ -z "$dontUsePythonCatchConflicts" ]; then
+if [ -z "${dontUsePythonCatchConflicts-}" ]; then
     preDistPhases+=" pythonCatchConflictsPhase"
 fi

--- a/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-imports-check-hook.sh
@@ -10,7 +10,7 @@ pythonImportsCheckPhase () {
     fi
 }
 
-if [ -z "$dontUsePythonImportsCheck" ]; then
+if [ -z "${dontUsePythonImportsCheck-}" ]; then
     echo "Using pythonImportsCheckPhase"
     preDistPhases+=" pythonImportsCheckPhase"
 fi

--- a/pkgs/development/interpreters/python/hooks/python-remove-bin-bytecode-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/python-remove-bin-bytecode-hook.sh
@@ -12,6 +12,6 @@ pythonRemoveBinBytecodePhase () {
     fi
 }
 
-if [ -z "$dontUsePythonRemoveBinBytecode" ]; then
+if [ -z "${dontUsePythonRemoveBinBytecode-}" ]; then
     preDistPhases+=" pythonRemoveBinBytecodePhase"
 fi

--- a/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
@@ -36,12 +36,12 @@ setuptoolsShellHook() {
     echo "Finished executing setuptoolsShellHook"
 }
 
-if [ -z "$dontUseSetuptoolsBuild" ] && [ -z "$buildPhase" ]; then
+if [ -z "${dontUseSetuptoolsBuild-}" ] && [ -z "$buildPhase" ]; then
     echo "Using setuptoolsBuildPhase"
     buildPhase=setuptoolsBuildPhase
 fi
 
-if [ -z "$dontUseSetuptoolsShellHook" ] && [ -z "$shellHook" ]; then
+if [ -z "${dontUseSetuptoolsShellHook-}" ] && [ -z "$shellHook" ]; then
     echo "Using setuptoolsShellHook"
     shellHook=setuptoolsShellHook
 fi

--- a/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
@@ -36,12 +36,12 @@ setuptoolsShellHook() {
     echo "Finished executing setuptoolsShellHook"
 }
 
-if [ -z "${dontUseSetuptoolsBuild-}" ] && [ -z "$buildPhase" ]; then
+if [ -z "${dontUseSetuptoolsBuild-}" ] && [ -z "${buildPhase-}" ]; then
     echo "Using setuptoolsBuildPhase"
     buildPhase=setuptoolsBuildPhase
 fi
 
-if [ -z "${dontUseSetuptoolsShellHook-}" ] && [ -z "$shellHook" ]; then
+if [ -z "${dontUseSetuptoolsShellHook-}" ] && [ -z "${shellHook-}" ]; then
     echo "Using setuptoolsShellHook"
     shellHook=setuptoolsShellHook
 fi

--- a/pkgs/development/interpreters/python/hooks/setuptools-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-check-hook.sh
@@ -12,7 +12,7 @@ setuptoolsCheckPhase() {
     echo "Finished executing setuptoolsCheckPhase"
 }
 
-if [ -z "$dontUseSetuptoolsCheck" ] && [ -z "$installCheckPhase" ]; then
+if [ -z "${dontUseSetuptoolsCheck-}" ] && [ -z "$installCheckPhase" ]; then
     echo "Using setuptoolsCheckPhase"
     preDistPhases+=" setuptoolsCheckPhase"
 fi

--- a/pkgs/development/interpreters/python/hooks/setuptools-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-check-hook.sh
@@ -12,7 +12,7 @@ setuptoolsCheckPhase() {
     echo "Finished executing setuptoolsCheckPhase"
 }
 
-if [ -z "${dontUseSetuptoolsCheck-}" ] && [ -z "$installCheckPhase" ]; then
+if [ -z "${dontUseSetuptoolsCheck-}" ] && [ -z "${installCheckPhase-}" ]; then
     echo "Using setuptoolsCheckPhase"
     preDistPhases+=" setuptoolsCheckPhase"
 fi

--- a/pkgs/development/interpreters/python/hooks/wheel-unpack-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/wheel-unpack-hook.sh
@@ -12,7 +12,7 @@ wheelUnpackPhase(){
     echo "Finished executing wheelUnpackPhase"
 }
 
-if [ -z "$dontUseWheelUnpack" ] && [ -z "$unpackPhase" ]; then
+if [ -z "${dontUseWheelUnpack-}" ] && [ -z "$unpackPhase" ]; then
     echo "Using wheelUnpackPhase"
     unpackPhase=wheelUnpackPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/wheel-unpack-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/wheel-unpack-hook.sh
@@ -12,7 +12,7 @@ wheelUnpackPhase(){
     echo "Finished executing wheelUnpackPhase"
 }
 
-if [ -z "${dontUseWheelUnpack-}" ] && [ -z "$unpackPhase" ]; then
+if [ -z "${dontUseWheelUnpack-}" ] && [ -z "${unpackPhase-}" ]; then
     echo "Using wheelUnpackPhase"
     unpackPhase=wheelUnpackPhase
 fi

--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -10,7 +10,7 @@ addEnvHooks "$hostOffset" gettextDataDirsHook
 
 # libintl must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
-if [ -n "@gettextNeedsLdflags@" -a -z "$dontAddExtraLibs" ]; then
+if [ -n "@gettextNeedsLdflags@" -a -z "${dontAddExtraLibs-}" ]; then
     # See pkgs/build-support/setup-hooks/role.bash
     getHostRole
     export NIX_${role_pre}LDFLAGS+=" -lintl"

--- a/pkgs/development/libraries/gtk/hooks/drop-icon-theme-cache.sh
+++ b/pkgs/development/libraries/gtk/hooks/drop-icon-theme-cache.sh
@@ -16,4 +16,4 @@ dropIconThemeCache() {
     fi
 }
 
-preFixupPhases="$preFixupPhases dropIconThemeCache"
+preFixupPhases="${preFixupPhases-} dropIconThemeCache"

--- a/pkgs/development/libraries/libiconv/setup-hook.sh
+++ b/pkgs/development/libraries/libiconv/setup-hook.sh
@@ -2,7 +2,7 @@
 # it doesn't hurt to have it in Glibc either though
 
 # See pkgs/build-support/setup-hooks/role.bash
-if [ -z "$dontAddExtraLibs" ]; then
+if [ -z "${dontAddExtraLibs-}" ]; then
     getHostRole
     export NIX_${role_pre}LDFLAGS+=" -liconv"
 fi

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -31,6 +31,6 @@ qmakeConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "${dontUseQmakeConfigure-}" -a -z "$configurePhase" ]; then
+if [ -z "${dontUseQmakeConfigure-}" -a -z "${configurePhase-}" ]; then
     configurePhase=qmakeConfigurePhase
 fi

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -31,6 +31,6 @@ qmakeConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "$dontUseQmakeConfigure" -a -z "$configurePhase" ]; then
+if [ -z "${dontUseQmakeConfigure-}" -a -z "$configurePhase" ]; then
     configurePhase=qmakeConfigurePhase
 fi

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -61,6 +61,6 @@ postPatchMkspecs() {
         fixQtBuiltinPaths "$dev/mkspecs" '*.pr?'
     fi
 }
-if [ -z "$dontPatchMkspecs" ]; then
+if [ -z "${dontPatchMkspecs-}" ]; then
     postPhases="${postPhases}${postPhases:+ }postPatchMkspecs"
 fi

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -62,5 +62,5 @@ postPatchMkspecs() {
     fi
 }
 if [ -z "${dontPatchMkspecs-}" ]; then
-    postPhases="${postPhases}${postPhases:+ }postPatchMkspecs"
+    postPhases="${postPhases-}${postPhases:+ }postPatchMkspecs"
 fi

--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -64,10 +64,10 @@ qtOwnPathsHook() {
 
 preFixupPhases+=" qtOwnPathsHook"
 
-# Note: $qtWrapperArgs still gets defined even if $dontWrapQtApps is set.
+# Note: $qtWrapperArgs still gets defined even if ${dontWrapQtApps-} is set.
 wrapQtAppsHook() {
     # skip this hook when requested
-    [ -z "$dontWrapQtApps" ] || return 0
+    [ -z "${dontWrapQtApps-}" ] || return 0
 
     # guard against running multiple times (e.g. due to propagation)
     [ -z "$wrapQtAppsHookHasRun" ] || return 0

--- a/pkgs/development/node-packages/node-env.nix
+++ b/pkgs/development/node-packages/node-env.nix
@@ -363,7 +363,7 @@ let
 
         npm ${forceOfflineFlag} --nodedir=${nodeSources} ${npmFlags} ${stdenv.lib.optionalString production "--production"} rebuild
 
-        if [ "$dontNpmInstall" != "1" ]
+        if [ "''${dontNpmInstall-}" != "1" ]
         then
             # NPM tries to download packages even when they already exist if npm-shrinkwrap is used.
             rm -f npm-shrinkwrap.json

--- a/pkgs/development/python-modules/pythonnet/default.nix
+++ b/pkgs/development/python-modules/pythonnet/default.nix
@@ -43,8 +43,8 @@ buildPythonPackage rec {
   '';
 
   preConfigure = ''
-    [ -z "$dontPlacateNuget" ] && placate-nuget.sh
-    [ -z "$dontPlacatePaket" ] && placate-paket.sh
+    [ -z "''${dontPlacateNuget-}" ] && placate-nuget.sh
+    [ -z "''${dontPlacatePaket-}" ] && placate-paket.sh
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
     runHook preUnpack
 
     if [[ -f $src && $src == *.gem ]]; then
-      if [[ -z "$dontBuild" ]]; then
+      if [[ -z "''${dontBuild-}" ]]; then
         # we won't know the name of the directory that RubyGems creates,
         # so we'll just use a glob to find it and move it over.
         gempkg="$src"

--- a/pkgs/development/tools/build-managers/apache-ant/1.9.nix
+++ b/pkgs/development/tools/build-managers/apache-ant/1.9.nix
@@ -46,14 +46,14 @@ stdenv.mkDerivation {
       # JRE by looking for java.  The latter allows just the JRE to be
       # used with (say) ECJ as the compiler.  Finally, allow the GNU
       # JVM.
-      if [ -z "\$JAVA_HOME" ]; then
+      if [ -z "\''${JAVA_HOME-}" ]; then
           for i in javac java gij; do
               if p="\$(type -p \$i)"; then
                   export JAVA_HOME="\$(${coreutils}/bin/dirname \$(${coreutils}/bin/dirname \$(${coreutils}/bin/readlink -f \$p)))"
                   break
               fi
           done
-          if [ -z "\$JAVA_HOME" ]; then
+          if [ -z "\''${JAVA_HOME-}" ]; then
               echo "\$0: cannot find the JDK or JRE" >&2
               exit 1
           fi

--- a/pkgs/development/tools/build-managers/apache-ant/default.nix
+++ b/pkgs/development/tools/build-managers/apache-ant/default.nix
@@ -46,14 +46,14 @@ stdenv.mkDerivation {
       # JRE by looking for java.  The latter allows just the JRE to be
       # used with (say) ECJ as the compiler.  Finally, allow the GNU
       # JVM.
-      if [ -z "\$JAVA_HOME" ]; then
+      if [ -z "\''${JAVA_HOME-}" ]; then
           for i in javac java gij; do
               if p="\$(type -p \$i)"; then
                   export JAVA_HOME="\$(${coreutils}/bin/dirname \$(${coreutils}/bin/dirname \$(${coreutils}/bin/readlink -f \$p)))"
                   break
               fi
           done
-          if [ -z "\$JAVA_HOME" ]; then
+          if [ -z "\''${JAVA_HOME-}" ]; then
               echo "\$0: cannot find the JDK or JRE" >&2
               exit 1
           fi

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -20,17 +20,17 @@ cmakeConfigurePhase() {
         export CTEST_PARALLEL_LEVEL=$NIX_BUILD_CORES
     fi
 
-    if [ -z "$dontFixCmake" ]; then
+    if [ -z "${dontFixCmake-}" ]; then
         fixCmakeFiles .
     fi
 
-    if [ -z "$dontUseCmakeBuildDir" ]; then
+    if [ -z "${dontUseCmakeBuildDir-}" ]; then
         mkdir -p build
         cd build
         cmakeDir=${cmakeDir:-..}
     fi
 
-    if [ -z "$dontAddPrefix" ]; then
+    if [ -z "${dontAddPrefix-}" ]; then
         cmakeFlags="-DCMAKE_INSTALL_PREFIX=$prefix $cmakeFlags"
     fi
 
@@ -84,7 +84,7 @@ cmakeConfigurePhase() {
     cmakeFlags="-DCMAKE_INSTALL_LOCALEDIR=${!outputLib}/share/locale $cmakeFlags"
 
     # Don’t build tests when doCheck = false
-    if [ -z "$doCheck" ]; then
+    if [ -z "${doCheck-}" ]; then
         cmakeFlags="-DBUILD_TESTING=OFF $cmakeFlags"
     fi
 
@@ -115,7 +115,7 @@ cmakeConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "$dontUseCmakeConfigure" -a -z "$configurePhase" ]; then
+if [ -z "${dontUseCmakeConfigure-}" -a -z "$configurePhase" ]; then
     setOutputFlags=
     configurePhase=cmakeConfigurePhase
 fi

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -99,7 +99,7 @@ cmakeConfigurePhase() {
     cmakeFlags="-DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON $cmakeFlags"
     cmakeFlags="-DCMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY=ON $cmakeFlags"
 
-    if [ "$buildPhase" = ninjaBuildPhase ]; then
+    if [ "${buildPhase-}" = ninjaBuildPhase ]; then
         cmakeFlags="-GNinja $cmakeFlags"
     fi
 
@@ -115,7 +115,7 @@ cmakeConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "${dontUseCmakeConfigure-}" -a -z "$configurePhase" ]; then
+if [ -z "${dontUseCmakeConfigure-}" -a -z "${configurePhase-}" ]; then
     setOutputFlags=
     configurePhase=cmakeConfigurePhase
 fi

--- a/pkgs/development/tools/build-managers/gn/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/gn/setup-hook.sh
@@ -9,6 +9,6 @@ gnConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "$dontUseGnConfigure" -a -z "$configurePhase" ]; then
+if [ -z "${dontUseGnConfigure-}" -a -z "$configurePhase" ]; then
     configurePhase=gnConfigurePhase
 fi

--- a/pkgs/development/tools/build-managers/gn/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/gn/setup-hook.sh
@@ -9,6 +9,6 @@ gnConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "${dontUseGnConfigure-}" -a -z "$configurePhase" ]; then
+if [ -z "${dontUseGnConfigure-}" -a -z "${configurePhase-}" ]; then
     configurePhase=gnConfigurePhase
 fi

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -1,7 +1,7 @@
 mesonConfigurePhase() {
     runHook preConfigure
 
-    if [ -z "$dontAddPrefix" ]; then
+    if [ -z "${dontAddPrefix-}" ]; then
         mesonFlags="--prefix=$prefix $mesonFlags"
     fi
 
@@ -36,7 +36,7 @@ mesonConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "$dontUseMesonConfigure" -a -z "$configurePhase" ]; then
+if [ -z "${dontUseMesonConfigure-}" -a -z "$configurePhase" ]; then
     setOutputFlags=
     configurePhase=mesonConfigurePhase
 fi

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -36,7 +36,7 @@ mesonConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "${dontUseMesonConfigure-}" -a -z "$configurePhase" ]; then
+if [ -z "${dontUseMesonConfigure-}" -a -z "${configurePhase-}" ]; then
     setOutputFlags=
     configurePhase=mesonConfigurePhase
 fi

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -19,7 +19,7 @@ ninjaBuildPhase() {
     runHook postBuild
 }
 
-if [ -z "${dontUseNinjaBuild-}" -a -z "$buildPhase" ]; then
+if [ -z "${dontUseNinjaBuild-}" -a -z "${buildPhase-}" ]; then
     buildPhase=ninjaBuildPhase
 fi
 
@@ -38,7 +38,7 @@ ninjaInstallPhase() {
     runHook postInstall
 }
 
-if [ -z "${dontUseNinjaInstall-}" -a -z "$installPhase" ]; then
+if [ -z "${dontUseNinjaInstall-}" -a -z "${installPhase-}" ]; then
     installPhase=ninjaInstallPhase
 fi
 
@@ -73,6 +73,6 @@ ninjaCheckPhase() {
     runHook postCheck
 }
 
-if [ -z "${dontUseNinjaCheck-}" -a -z "$checkPhase" ]; then
+if [ -z "${dontUseNinjaCheck-}" -a -z "${checkPhase-}" ]; then
     checkPhase=ninjaCheckPhase
 fi

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -19,7 +19,7 @@ ninjaBuildPhase() {
     runHook postBuild
 }
 
-if [ -z "$dontUseNinjaBuild" -a -z "$buildPhase" ]; then
+if [ -z "${dontUseNinjaBuild-}" -a -z "$buildPhase" ]; then
     buildPhase=ninjaBuildPhase
 fi
 
@@ -38,7 +38,7 @@ ninjaInstallPhase() {
     runHook postInstall
 }
 
-if [ -z "$dontUseNinjaInstall" -a -z "$installPhase" ]; then
+if [ -z "${dontUseNinjaInstall-}" -a -z "$installPhase" ]; then
     installPhase=ninjaInstallPhase
 fi
 
@@ -73,6 +73,6 @@ ninjaCheckPhase() {
     runHook postCheck
 }
 
-if [ -z "$dontUseNinjaCheck" -a -z "$checkPhase" ]; then
+if [ -z "${dontUseNinjaCheck-}" -a -z "$checkPhase" ]; then
     checkPhase=ninjaCheckPhase
 fi

--- a/pkgs/development/tools/build-managers/scons/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/scons/setup-hook.sh
@@ -71,14 +71,14 @@ sconsCheckPhase() {
     runHook postCheck
 }
 
-if [ -z "$buildPhase" ]; then
+if [ -z "${buildPhase-}" ]; then
     buildPhase=sconsBuildPhase
 fi
 
-if [ -z "${dontUseSconsInstall-}" -a -z "$installPhase" ]; then
+if [ -z "${dontUseSconsInstall-}" -a -z "${installPhase-}" ]; then
     installPhase=sconsInstallPhase
 fi
 
-if [ -z "$checkPhase" ]; then
+if [ -z "${checkPhase-}" ]; then
     checkPhase=sconsCheckPhase
 fi

--- a/pkgs/development/tools/build-managers/scons/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/scons/setup-hook.sh
@@ -75,7 +75,7 @@ if [ -z "$buildPhase" ]; then
     buildPhase=sconsBuildPhase
 fi
 
-if [ -z "$dontUseSconsInstall" -a -z "$installPhase" ]; then
+if [ -z "${dontUseSconsInstall-}" -a -z "$installPhase" ]; then
     installPhase=sconsInstallPhase
 fi
 

--- a/pkgs/development/tools/misc/patchelf/setup-hook.sh
+++ b/pkgs/development/tools/misc/patchelf/setup-hook.sh
@@ -2,7 +2,7 @@
 # directories from the RPATH of every library or executable in every
 # output.
 
-fixupOutputHooks+=('if [ -z "$dontPatchELF" ]; then patchELF "$prefix"; fi')
+fixupOutputHooks+=('if [ -z "${dontPatchELF-}" ]; then patchELF "$prefix"; fi')
 
 patchELF() {
     local dir="$1"

--- a/pkgs/development/tools/misc/premake/setup-hook.sh
+++ b/pkgs/development/tools/misc/premake/setup-hook.sh
@@ -14,6 +14,6 @@ premakeConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "$configurePhase" ]; then
+if [ -z "${configurePhase-}" ]; then
     configurePhase=premakeConfigurePhase
 fi

--- a/pkgs/development/tools/ocaml/opam/opam-shebangs.patch
+++ b/pkgs/development/tools/ocaml/opam/opam-shebangs.patch
@@ -64,7 +64,7 @@ index 00000000..3ea84e2d
 +header() { echo "$1"; }
 +stopNest() { true; }
 +
-+fixupOutputHooks+=('if [ -z "$dontPatchShebangs" -a -e "$prefix" ]; then patchShebangs "$prefix"; fi')
++fixupOutputHooks+=('if [ -z "${dontPatchShebangs-}" -a -e "$prefix" ]; then patchShebangs "$prefix"; fi')
 +
 +patchShebangs() {
 +    local dir="$1"

--- a/pkgs/development/tools/xcbuild/setup-hook.sh
+++ b/pkgs/development/tools/xcbuild/setup-hook.sh
@@ -20,7 +20,7 @@ xcbuildInstallPhase () {
 }
 
 buildPhase=xcbuildBuildPhase
-if [ -z "$installPhase" ]; then
+if [ -z "${installPhase-}" ]; then
     installPhase=xcbuildInstallPhase
 fi
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -179,7 +179,7 @@ let
       '' else "") + (if isModular then ''
         mkdir -p $dev
         cp vmlinux $dev/
-        if [ -z "$dontStrip" ]; then
+        if [ -z "''${dontStrip-}" ]; then
           installFlagsArray+=("INSTALL_MOD_STRIP=1")
         fi
         make modules_install $makeFlags "''${makeFlagsArray[@]}" \

--- a/pkgs/servers/x11/xorg/imake-setup-hook.sh
+++ b/pkgs/servers/x11/xorg/imake-setup-hook.sh
@@ -14,6 +14,6 @@ imakeConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "$dontUseImakeConfigure" -a -z "$configurePhase" ]; then
+if [ -z "${dontUseImakeConfigure-}" -a -z "$configurePhase" ]; then
     configurePhase=imakeConfigurePhase
 fi

--- a/pkgs/servers/x11/xorg/imake-setup-hook.sh
+++ b/pkgs/servers/x11/xorg/imake-setup-hook.sh
@@ -14,6 +14,6 @@ imakeConfigurePhase() {
     runHook postConfigure
 }
 
-if [ -z "${dontUseImakeConfigure-}" -a -z "$configurePhase" ]; then
+if [ -z "${dontUseImakeConfigure-}" -a -z "${configurePhase-}" ]; then
     configurePhase=imakeConfigurePhase
 fi

--- a/pkgs/stdenv/cygwin/rebase-i686.sh
+++ b/pkgs/stdenv/cygwin/rebase-i686.sh
@@ -1,7 +1,7 @@
 fixupOutputHooks+=(_cygwinFixAutoImageBase)
 
 _cygwinFixAutoImageBase() {
-    if [ "$dontRebase" == 1 ] || [ ! -d "$prefix" ]; then
+    if [ "${dontRebase-}" == 1 ] || [ ! -d "$prefix" ]; then
         return
     fi
     find "$prefix" -name "*.dll" -type f | while read DLL; do

--- a/pkgs/stdenv/cygwin/rebase-x86_64.sh
+++ b/pkgs/stdenv/cygwin/rebase-x86_64.sh
@@ -1,7 +1,7 @@
 fixupOutputHooks+=(_cygwinFixAutoImageBase)
 
 _cygwinFixAutoImageBase() {
-    if [ "$dontRebase" == 1 ] || [ ! -d "$prefix" ]; then
+    if [ "${dontRebase-}" == 1 ] || [ ! -d "$prefix" ]; then
         return
     fi
     find "$prefix" -name "*.dll" -type f | while read DLL; do

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -17,10 +17,6 @@ fi
 # code). The hooks for <hookName> are the shell function or variable
 # <hookName>, and the values of the shell array ‘<hookName>Hooks’.
 runHook() {
-    local oldOpts="-u"
-    shopt -qo nounset || oldOpts="+u"
-    set -u # May be called from elsewhere, so do `set -u`.
-
     local hookName="$1"
     shift
     local hooksSlice="${hookName%Hook}Hooks[@]"
@@ -30,10 +26,8 @@ runHook() {
     # undefined.
     for hook in "_callImplicitHook 0 $hookName" ${!hooksSlice+"${!hooksSlice}"}; do
         _eval "$hook" "$@"
-        set -u # To balance `_eval`
     done
 
-    set "$oldOpts"
     return 0
 }
 
@@ -41,10 +35,6 @@ runHook() {
 # Run all hooks with the specified name, until one succeeds (returns a
 # zero exit code). If none succeed, return a non-zero exit code.
 runOneHook() {
-    local oldOpts="-u"
-    shopt -qo nounset || oldOpts="+u"
-    set -u # May be called from elsewhere, so do `set -u`.
-
     local hookName="$1"
     shift
     local hooksSlice="${hookName%Hook}Hooks[@]"
@@ -56,10 +46,8 @@ runOneHook() {
             ret=0
             break
         fi
-        set -u # To balance `_eval`
     done
 
-    set "$oldOpts"
     return "$ret"
 }
 
@@ -70,17 +58,13 @@ runOneHook() {
 # environment variables) and from shell scripts (as functions). If you
 # want to allow multiple hooks, use runHook instead.
 _callImplicitHook() {
-    set -u
     local def="$1"
     local hookName="$2"
     if declare -F "$hookName" > /dev/null; then
-        set +u
         "$hookName"
     elif type -p "$hookName" > /dev/null; then
-        set +u
         source "$hookName"
     elif [ -n "${!hookName:-}" ]; then
-        set +u
         eval "${!hookName}"
     else
         return "$def"
@@ -96,13 +80,10 @@ _callImplicitHook() {
 # command can take them
 _eval() {
     if declare -F "$1" > /dev/null 2>&1; then
-        set +u
         "$@" # including args
     else
-        set +u
         eval "$1"
     fi
-    # `run*Hook` reenables `set -u`
 }
 
 
@@ -190,12 +171,12 @@ addToSearchPath() {
 # so it is defined here but tried after the hook.
 _addRpathPrefix() {
     if [ "${NIX_NO_SELF_RPATH:-0}" != 1 ]; then
-        export NIX_LDFLAGS="-rpath $1/lib $NIX_LDFLAGS"
+        export NIX_LDFLAGS="-rpath $1/lib ${NIX_LDFLAGS-}"
         if [ -n "${NIX_LIB64_IN_SELF_RPATH:-}" ]; then
-            export NIX_LDFLAGS="-rpath $1/lib64 $NIX_LDFLAGS"
+            export NIX_LDFLAGS="-rpath $1/lib64 ${NIX_LDFLAGS-}"
         fi
         if [ -n "${NIX_LIB32_IN_SELF_RPATH:-}" ]; then
-            export NIX_LDFLAGS="-rpath $1/lib32 $NIX_LDFLAGS"
+            export NIX_LDFLAGS="-rpath $1/lib32 ${NIX_LDFLAGS-}"
         fi
     fi
 }
@@ -489,11 +470,7 @@ activatePackage() {
     (( "$hostOffset" <= "$targetOffset" )) || exit -1
 
     if [ -f "$pkg" ]; then
-        local oldOpts="-u"
-        shopt -qo nounset || oldOpts="+u"
-        set +u
         source "$pkg"
-        set "$oldOpts"
     fi
 
     # Only dependencies whose host platform is guaranteed to match the
@@ -512,11 +489,7 @@ activatePackage() {
     fi
 
     if [[ -f "$pkg/nix-support/setup-hook" ]]; then
-        local oldOpts="-u"
-        shopt -qo nounset || oldOpts="+u"
-        set +u
         source "$pkg/nix-support/setup-hook"
-        set "$oldOpts"
     fi
 }
 
@@ -1264,19 +1237,11 @@ showPhaseHeader() {
 
 genericBuild() {
     if [ -f "${buildCommandPath:-}" ]; then
-        local oldOpts="-u"
-        shopt -qo nounset || oldOpts="+u"
-        set +u
         source "$buildCommandPath"
-        set "$oldOpts"
         return
     fi
     if [ -n "${buildCommand:-}" ]; then
-        local oldOpts="-u"
-        shopt -qo nounset || oldOpts="+u"
-        set +u
         eval "$buildCommand"
-        set "$oldOpts"
         return
     fi
 
@@ -1306,11 +1271,7 @@ genericBuild() {
 
         # Evaluate the variable named $curPhase if it exists, otherwise the
         # function named $curPhase.
-        local oldOpts="-u"
-        shopt -qo nounset || oldOpts="+u"
-        set +u
         eval "${!curPhase:-$curPhase}"
-        set "$oldOpts"
 
         if [ "$curPhase" = unpackPhase ]; then
             cd "${sourceRoot:-.}"

--- a/pkgs/tools/misc/desktop-file-utils/setup-hook.sh
+++ b/pkgs/tools/misc/desktop-file-utils/setup-hook.sh
@@ -3,4 +3,4 @@ mimeinfoPreFixupPhase() {
     rm -f $out/share/applications/mimeinfo.cache
 }
 
-preFixupPhases="$preFixupPhases mimeinfoPreFixupPhase"
+preFixupPhases="${preFixupPhases-} mimeinfoPreFixupPhase"


### PR DESCRIPTION
2 years or so ago I made stdenv and cc-wrapper use `set -u`, which *enormously* helped with debugging. But I didn't want to change all of nixpkgs so I added lots of temporary `set +u`-ing. 

Well, I think it's now time to bring the benefit to all of nixpkgs. Why? Because we have another big repo-wide refactor going on https://github.com/NixOS/nixpkgs/pull/72074. This will make that much easier to debug, and hopefully get some momentum going for stdenv tech debt fixing. Everyone chip in!

In particular, I think this is the easiest stdenv refactor we'd like to make, Why? This has the nice property that programs that continue to not fail have the same behavior. [Actually, this is  not true with `trap` to catch failures or no `set -e`, but we use `set -e` and still fail after `trap`-ing.] That means it's very easy to debug; no getting a bunch of things working only to find some deeper dependency was built wrong and needing to backtrack, and no needing to debug complex failures.

I swear there was an issue for thus, but I couldn't find it.

Hydra job: https://hydra.nixos.org/jobset/nixpkgs/bash-no-undef-vars#tabs-evaluations

TODO:

- [x] Fix the broken things

- [x] Write release notes
