### PR TITLE
check-nwc-health: fix source URL

### DIFF
--- a/pkgs/servers/monitoring/plugins/labs_consol_de.nix
+++ b/pkgs/servers/monitoring/plugins/labs_consol_de.nix
@@ -14,7 +14,7 @@ let
     inherit pname version;
 
     src = fetchurl {
-      url = "https://labs.consol.de/assets/downloads/nagios/${pname}-${version}.tar.bz";
+      url = "https://labs.consol.de/assets/downloads/nagios/${pname}-${version}.tar.gz";
       inherit sha256;
     };
 


### PR DESCRIPTION
##### Motivation for this change

Upstream URL was wrong.

Fixes check-{mssql,nwc,ups}-health

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
