### PR TITLE
python3packages.stytra: init at 0.8.26

### DIFF
--- a/pkgs/development/python-modules/arrayqueues/default.nix
+++ b/pkgs/development/python-modules/arrayqueues/default.nix
@@ -1,0 +1,25 @@
+{ lib, pkgs, buildPythonPackage, fetchPypi, isPy3k
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "arrayqueues";
+  version = "1.2.0b0";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gvrxb2rw0dk469wq5azylar7hhanfp07gl5mc6ajdbgz9gsd6ln";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  meta = {
+    homepage = "https://github.com/portugueslab/arrayqueues";
+    description = "Multiprocessing queues for numpy arrays using shared memory";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/colorspacious/default.nix
+++ b/pkgs/development/python-modules/colorspacious/default.nix
@@ -1,0 +1,24 @@
+{ lib, pkgs, buildPythonPackage, fetchPypi, isPy3k
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "colorspacious";
+  version = "1.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "065n24zbm9ymy2gvf03vx5cggk1258vcjdaw8jn9v26arpl7542y";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  meta = {
+    homepage = "https://github.com/njsmith/colorspacious";
+    description = "A powerful, accurate, and easy-to-use Python library for doing colorspace conversions ";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/flammkuchen/default.nix
+++ b/pkgs/development/python-modules/flammkuchen/default.nix
@@ -1,9 +1,10 @@
-{ lib, pkgs, buildPythonPackage, fetchPypi, isPy3k
+{ lib, pkgs, buildPythonPackage, fetchPypi, isPy27
 , numpy
 , scipy
 , tables
 , pandas
 , nose
+, configparser
 }:
 
 buildPythonPackage rec {
@@ -24,7 +25,7 @@ buildPythonPackage rec {
     scipy
     tables
     pandas
-  ];
+  ] ++ lib.optionals isPy27 [ configparser ];
 
   meta = {
     homepage = "https://github.com/portugueslab/flammkuchen";

--- a/pkgs/development/python-modules/flammkuchen/default.nix
+++ b/pkgs/development/python-modules/flammkuchen/default.nix
@@ -1,0 +1,35 @@
+{ lib, pkgs, buildPythonPackage, fetchPypi, isPy3k
+, numpy
+, scipy
+, tables
+, pandas
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "flammkuchen";
+  version = "0.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e9aab9b229ace70d879b85618a9ce0e88dd6ce35d4dbcdfd60c6b61c33a1b4fb";
+  };
+
+  checkInputs = [
+    nose
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    tables
+    pandas
+  ];
+
+  meta = {
+    homepage = "https://github.com/portugueslab/flammkuchen";
+    description = "Flexible HDF5 saving/loading library forked from deepdish (University of Chicago) and maintained by the Portugues lab";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/lightparam/default.nix
+++ b/pkgs/development/python-modules/lightparam/default.nix
@@ -1,0 +1,28 @@
+{ lib, pkgs, buildPythonPackage, fetchPypi, isPy3k
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "lightparam";
+  version = "0.3.7";
+  disabled = !isPy3k;
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version;
+    format = "wheel";
+    python = "py3";
+    sha256 = "53d5d5b225bac27bc14929c9ad4e51ece4f692813dd367f317fb1586145d93f1";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  meta = {
+    homepage = "https://github.com/portugueslab/lightparam";
+    description = "Another attempt at parameters in Python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/qimage2ndarray/default.nix
+++ b/pkgs/development/python-modules/qimage2ndarray/default.nix
@@ -1,0 +1,32 @@
+{ lib, pkgs, buildPythonPackage, fetchPypi, isPy3k
+, numpy
+, pyqt5
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "qimage2ndarray";
+  version = "1.8";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7b9eb08a9be27f5439289d90d7d5a5942aad403d5634fe336eb915678c65db48";
+  };
+
+  checkInputs = [
+    nose
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    pyqt5
+  ];
+
+  meta = {
+    homepage = "https://github.com/hmeine/qimage2ndarray";
+    description = "A small python extension for quickly converting between QImages and numpy.ndarrays (in both directions)";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/stytra/default.nix
+++ b/pkgs/development/python-modules/stytra/default.nix
@@ -1,0 +1,81 @@
+{ lib, pkgs, buildPythonPackage, fetchPypi, isPy3k, callPackage
+, opencv3
+, pyqt5
+, pyqtgraph
+, numpy
+, scipy
+, numba
+, pandas
+, tables
+, git
+, ffmpeg
+, scikitimage
+, matplotlib
+, qdarkstyle
+, GitPython
+, anytree
+, pims
+, imageio
+, imageio-ffmpeg
+, av
+, nose
+, pytest
+, pyserial
+, arrayqueues
+, colorspacious
+, qimage2ndarray
+, flammkuchen
+, lightparam
+}:
+
+buildPythonPackage rec {
+  pname = "stytra";
+  version = "0.8.26";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "81842a957e3114230c2d628f64325cd89d166913b68c3f802c89282f40918587";
+  };
+  doCheck = false;
+  checkInputs = [
+    nose
+    pytest
+    pyserial
+  ];
+
+
+  propagatedBuildInputs = [
+    opencv3
+    pyqt5
+    pyqtgraph
+    numpy
+    scipy
+    numba
+    pandas
+    tables
+    git
+    ffmpeg
+    scikitimage
+    matplotlib
+    qdarkstyle
+    GitPython
+    anytree
+    qimage2ndarray
+    flammkuchen
+    pims
+    colorspacious
+    lightparam
+    imageio
+    imageio-ffmpeg
+    arrayqueues
+    av
+  ];
+
+  meta = {
+    homepage = "https://github.com/portugueslab/stytra";
+    description = "A modular package to control stimulation and track behaviour";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5240,6 +5240,8 @@ in {
 
   structlog = callPackage ../development/python-modules/structlog { };
 
+  stytra = callPackage ../development/python-modules/stytra { };
+
   sybil = callPackage ../development/python-modules/sybil { };
 
   # legacy alias

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -179,6 +179,8 @@ in {
 
   apprise = callPackage ../development/python-modules/apprise { };
 
+  arrayqueues = callPackage ../development/python-modules/arrayqueues { };
+
   aresponses = callPackage ../development/python-modules/aresponses { };
 
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2690,6 +2690,8 @@ in {
 
   lightning = callPackage ../development/python-modules/lightning { };
 
+  lightparam = callPackage ../development/python-modules/lightparam { };
+
   jupyter = callPackage ../development/python-modules/jupyter { };
 
   jupyter_console = if pythonOlder "3.5" then

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2455,6 +2455,8 @@ in {
 
   filetype = callPackage ../development/python-modules/filetype { };
 
+  flammkuchen = callPackage ../development/python-modules/flammkuchen { };
+
   flexmock = callPackage ../development/python-modules/flexmock { };
 
   flit = callPackage ../development/python-modules/flit { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1716,6 +1716,8 @@ in {
 
   colorlog = callPackage ../development/python-modules/colorlog { };
 
+  colorspacious = callPackage ../development/python-modules/colorspacious { };
+
   colour = callPackage ../development/python-modules/colour {};
 
   configshell = callPackage ../development/python-modules/configshell { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4924,6 +4924,8 @@ in {
 
   qds_sdk = callPackage ../development/python-modules/qds_sdk { };
 
+  qimage2ndarray = callPackage ../development/python-modules/qimage2ndarray { };
+
   quamash = callPackage ../development/python-modules/quamash { };
 
   quandl = callPackage ../development/python-modules/quandl { };


### PR DESCRIPTION
WIP - wanted to get feedback on help as this is my first time packing using wheel.

It seems like `propogatedBuildInputs` is not behaving the same way--if I only have a package here I get failures like:

```Processing ./stytra-0.8.26-py3-none-any.whl
ERROR: Could not find a version that satisfies the requirement pyqtgraph>=0.10.0 (from stytra==0.8.26) (from versions: none)
ERROR: No matching distribution found for pyqtgraph>=0.10.0 (from stytra==0.8.26)
builder for '/nix/store/brscmbwx2nzr56f8wdh3n8vnjq2ih58p-python3.7-stytra-0.8.26.drv' failed with exit code 1
```
As a result, I'm including in both `buildInputs`, and `propogatedBuildInputs`, which feels wrong. It does build, but when I try open a shell the following happens:
```
> python
>>> import stytra
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nix/store/prr2jha833ix3qa30w0cbfgcr1zxh75s-python3-3.7.5-env/lib/python3.7/site-packages/stytra/__init__.py", line 3, in <module>
    from stytra.experiments import VisualExperiment
  File "/nix/store/prr2jha833ix3qa30w0cbfgcr1zxh75s-python3-3.7.5-env/lib/python3.7/site-packages/stytra/experiments/__init__.py", line 5, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
>>> import numpy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'numpy'
```

This seems very odd, as in any other derivation I test, I can import from `propogatedBuildInputs` in python shell. To debug, I switched back to using the tar.gz file, and found an unexpected error:

```
these derivations will be built:
  /nix/store/25sy04zv5h91a02nkbdxy5lkf73ibn33-python3-3.7.5-env.drv
building '/nix/store/25sy04zv5h91a02nkbdxy5lkf73ibn33-python3-3.7.5-env.drv'...
collision between `/nix/store/10b0xgqaqacaxiwlvcklp9nbl20y5wcx-python3.7-sip-4.19.18/bin/sip' and `/nix/store/nqa4rbzhi6aj0ry54dwc82r2900zlnmr-python3.7-PyQt5.sip-4.19.18/bin/sip'
builder for '/nix/store/25sy04zv5h91a02nkbdxy5lkf73ibn33-python3-3.7.5-env.drv' failed with exit code 255
error: build of '/nix/store/25sy04zv5h91a02nkbdxy5lkf73ibn33-python3-3.7.5-env.drv' failed
```

Any thoughts or tips? Thanks!

###### Motivation for this change
Add module for closed-loop experiments for larval zebrafish.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
