### PR TITLE
nixos/qemu-vm: Option to use squashfs Nix store closure instead of virtfs access to host's store

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -284,6 +284,7 @@ in
   prosodyMysql = handleTest ./xmpp/prosody-mysql.nix {};
   proxy = handleTest ./proxy.nix {};
   qboot = handleTestOn ["x86_64-linux" "i686-linux"] ./qboot.nix {};
+  qemu-private-store = handleTest ./qemu-private-store.nix {};
   quagga = handleTest ./quagga.nix {};
   quorum = handleTest ./quorum.nix {};
   rabbitmq = handleTest ./rabbitmq.nix {};

--- a/nixos/tests/qemu-private-store.nix
+++ b/nixos/tests/qemu-private-store.nix
@@ -1,0 +1,24 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+{
+  name = "qemu-private-store";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ chkno ];
+  };
+
+  nodes = {
+    shared = _: { };
+    private = _: {
+      virtualisation.shareNixStore = false;
+      virtualisation.shareExchangeDir = false;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    shared.wait_for_unit("multi-user.target")
+    private.wait_for_unit("multi-user.target")
+
+    shared.succeed("[[ $(mount | grep -c virt) -gt 0 ]]")
+    private.succeed("[[ $(mount | grep -c virt) -eq 0 ]]")
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change
Allow VMs built with `nixos-rebuild build-vm` to work without any virtfs mounts into the host.  In particular, allow them to use a nix store closure in a squashfs like the installer uses.

This allows better isolation of guests.  A host that runs multiple VMs may not wish the guests to be able to see each others' derivations.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review rev --branch staging HEAD"` -- It's zero packages, but this refactoring touches all the NixOS tests.  I ran a handful of existing ones.
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after) -- N/A?
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
