### PR TITLE
welle-io: 1.0 -> 2.0

### DIFF
--- a/pkgs/applications/radio/welle-io/default.nix
+++ b/pkgs/applications/radio/welle-io/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig
+{ mkDerivation, lib, fetchFromGitHub, cmake, pkgconfig
 , qtbase, qtcharts, qtmultimedia, qtquickcontrols, qtquickcontrols2
-, faad2, rtl-sdr, soapysdr-with-plugins, libusb, fftwSinglePrec }:
+, faad2, rtl-sdr, soapysdr-with-plugins, libusb, fftwSinglePrec, lame, mpg123 }:
 let
 
-  version = "1.0";
+  version = "2.0";
 
-in stdenv.mkDerivation {
+in mkDerivation {
 
   pname = "welle-io";
   inherit version;
@@ -13,8 +13,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "AlbrechtL";
     repo = "welle.io";
-    rev = "V${version}";
-    sha256 = "1fsr0c2w16z45mcr85sqmllw1xf2gn6hp6f6fmgx2zfprq8gdmcr";
+    rev = "v${version}";
+    sha256 = "0cp8dyswgwidabaj9bvkkc6hl3160096j6myckd5bw00zxnbfiqn";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
@@ -22,7 +22,9 @@ in stdenv.mkDerivation {
   buildInputs = [
     faad2
     fftwSinglePrec
+    lame
     libusb
+    mpg123
     qtbase
     qtcharts
     qtmultimedia
@@ -38,7 +40,7 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A DAB/DAB+ Software Radio";
     homepage = https://www.welle.io/;
     maintainers = with maintainers; [ ck3d markuskowa ];


### PR DESCRIPTION
###### Motivation for this change
New major version.

###### Things done
* Update version
* Fix Qt mkDerivation
* Tested with RTL-SDR device

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ck3d 
