### PR TITLE
Fix sage dependencies

### DIFF
--- a/pkgs/development/python-modules/ipython/5.nix
+++ b/pkgs/development/python-modules/ipython/5.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+# Build dependencies
+, glibcLocales
+# Test dependencies
+, nose
+, pygments
+, testpath
+, isPy27
+, mock
+# Runtime dependencies
+, backports_shutil_get_terminal_size
+, decorator
+, pathlib2
+, pickleshare
+, requests
+, simplegeneric
+, traitlets
+, prompt_toolkit
+, pexpect
+, appnope
+}:
+
+buildPythonPackage rec {
+  pname = "ipython";
+  version = "5.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4bac649857611baaaf76bc82c173aa542f7486446c335fe1a6c05d0d491c8906";
+  };
+
+  prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace setup.py --replace "'gnureadline'" " "
+  '';
+
+  buildInputs = [ glibcLocales ];
+
+  checkInputs = [ nose pygments testpath ] ++ lib.optional isPy27 mock;
+
+  propagatedBuildInputs = [
+    backports_shutil_get_terminal_size decorator pickleshare prompt_toolkit
+    simplegeneric traitlets requests pathlib2 pexpect
+  ] ++ lib.optionals stdenv.isDarwin [ appnope ];
+
+  LC_ALL="en_US.UTF-8";
+
+  doCheck = false; # Circular dependency with ipykernel
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = {
+    description = "IPython: Productive Interactive Computing";
+    homepage = http://ipython.org/;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ bjornfor orivej lnl7 ];
+  };
+}

--- a/pkgs/development/python-modules/notebook/2.nix
+++ b/pkgs/development/python-modules/notebook/2.nix
@@ -25,11 +25,11 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "6.0.1";
+  version = "5.7.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "660976fe4fe45c7aa55e04bf4bccb9f9566749ff637e9020af3422f9921f9a5d";
+    sha256 = "573e0ae650c5d76b18b6e564ba6d21bf321d00847de1d215b418acb64f056eb8";
   };
 
   LC_ALL = "en_US.utf8";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3535,7 +3535,10 @@ in {
 
   ipyparallel = callPackage ../development/python-modules/ipyparallel { };
 
-  ipython = callPackage ../development/python-modules/ipython { };
+  ipython = if pythonOlder "3.5" then
+      callPackage ../development/python-modules/ipython/5.nix { }
+    else
+      callPackage ../development/python-modules/ipython { };
 
   ipython_genutils = callPackage ../development/python-modules/ipython_genutils { };
 


### PR DESCRIPTION
###### Motivation for this change

Two recent commits, ad53cf0a829dee15a6a01568b7af3b63e08717b2 and 0ccf10b955910dd511208720f3bbf49a2ffe9fbb, broke dependencies that are needed for the sage build. Both look like they can be reverted without negative consequences. I think the first one was made by mistake (probably some automation issue, cc @FRidh), while the second one was premature (cc @jonringer).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
