### PR TITLE
WIP: Windows cross compilation via LLVM

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -29,7 +29,7 @@ rec {
       # Derived meta-data
       libc =
         /**/ if final.isDarwin              then "libSystem"
-        else if final.isMinGW               then "msvcrt"
+        else if final.isWindows             then "msvcrt"
         else if final.isWasi                then "wasilibc"
         else if final.isRedox               then "relibc"
         else if final.isMusl                then "musl"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -248,6 +248,16 @@ rec {
     libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
   };
 
+  windowsLlvm32 = {
+    config = "i686-pc-windows-msvc";
+    useLLVM = true;
+  };
+
+  windowsLlvm64 = {
+    config = "x86_64-pc-windows-msvc";
+    useLLVM = true;
+  };
+
   # BSDs
 
   amd64-netbsd = lib.warn "The amd64-netbsd system example is deprecated. Use x86_64-netbsd instead." x86_64-netbsd;

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -156,9 +156,11 @@ stdenv.mkDerivation {
       wrap "$ldInner" ${./macos-sierra-reexport-hack.bash} ''${ld:-$ldPath/${targetPrefix}ld}
       wrap "${targetPrefix}ld" ${./ld-wrapper.sh} "$out/bin/$ldInner"
       unset ldInner
-    '') + ''
+    '')
+    # TODO make list below easier to customize without mass rebuild
+    + ''
 
-      for variant in ld.gold ld.bfd ld.lld; do
+      for variant in ld.gold ld.bfd ld.lld${optionalString (targetPlatform.useLLVM or false) " ld64.ldd"}; do
         local underlying=$ldPath/${targetPrefix}$variant
         [[ -e "$underlying" ]] || continue
         wrap ${targetPrefix}$variant ${./ld-wrapper.sh} $underlying

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -293,7 +293,7 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" pic"
     ''
 
-    + optionalString targetPlatform.isAvr ''
+    + optionalString (targetPlatform.isAvr || targetPlatform.isWindows && targetPlatform.useLLVM or false) ''
       hardening_unsupported_flags+=" relro bindnow"
     ''
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -465,6 +465,8 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" pic"
     '' + optionalString targetPlatform.isMinGW ''
       hardening_unsupported_flags+=" stackprotector"
+    '' + optionalString targetPlatform.isWindows ''
+      hardening_unsupported_flags+=" pic"
     '' + optionalString targetPlatform.isAvr ''
       hardening_unsupported_flags+=" stackprotector pic"
     '' + optionalString (targetPlatform.libc == "newlib") ''

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -453,16 +453,17 @@ rec {
    *   sha256 = "ffffffffffffffffffffffffffffffffffffffffffffffffffff";
    * }
    */
-  requireFile = { name ? null
+  requireFile = { name ? throw "unreachable"
+                , pname ? throw "unreachable"
+                , version ? throw "unreachable"
                 , sha256 ? null
                 , sha1 ? null
                 , url ? null
                 , message ? null
                 , hashMode ? "flat"
-                } :
+                } @ args:
     assert (message != null) || (url != null);
     assert (sha256 != null) || (sha1 != null);
-    assert (name != null) || (url != null);
     let msg =
       if message != null then message
       else ''
@@ -477,8 +478,11 @@ rec {
       hash = if sha256 != null then sha256 else sha1;
       name_ = if name == null then baseNameOf (toString url) else name;
     in
-    stdenvNoCC.mkDerivation {
-      name = name_;
+    stdenvNoCC.mkDerivation (builtins.intersectAttrs {
+      name = throw "unreachable";
+      pname = throw "unreachable";
+      version = throw "unreachable";
+    } args // {
       outputHashMode = hashMode;
       outputHashAlgo = hashAlgo;
       outputHash = hash;
@@ -495,7 +499,7 @@ rec {
         _EOF_
         exit 1
       '';
-    };
+    });
 
 
   # Copy a path to the Nix store.

--- a/pkgs/development/compilers/llvm/8/bintools.nix
+++ b/pkgs/development/compilers/llvm/8/bintools.nix
@@ -1,6 +1,30 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ fetchFromGitHub, runCommand, stdenv, llvm, lld, version }:
 
 let
+  # Wrappers that implement some functionality before upstream has it.
+  llvm-mingw = stdenv.mkDerivation rec {
+    name = "llvm-mingw";
+    version = "git-${src.rev}";
+    src = fetchFromGitHub {
+      repo = "llvm-mingw";
+      owner = "mstorsjo";
+      rev = "5d764329d80fe6f0ae3f067d0b606062eb466712";
+      sha256 = "0q3vmjjjrmlpdnqg9b81x4797kvhdbn6yhlambfjnvk4pzi7hglv";
+    };
+    postUnpack = ''
+      sourceRoot=''${sourceRoot}/wrappers;
+    '';
+    buildPhase = ''
+      $CC -iquote . windres-wrapper.c -o llvm-windres
+    '';
+    #buildPhase = ''
+    #  $CC -iquote . windres-wrapper.c -DLLVM_PATH=\"${llvm}/bin/\" -o llvm-windres
+    #'';
+    installPhase = ''
+      mkdir -p "$out/bin"
+      install -m 755 llvm-windres "$out/bin"
+    '';
+  };
   prefix =
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
@@ -10,7 +34,7 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)
    done
-   for prog in ${llvm}/bin/*; do
+   for prog in ${llvm}/bin/* ${llvm-mingw}/bin/*; do
      ln -sf $prog $out/bin/${prefix}$(basename $prog)
    done
 

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -53,6 +53,8 @@ let
       ./compiler-rt-baremetal.patch
       # make clang -xhip use $PATH to find executables
       ./HIP-use-PATH-8.patch
+      # https://reviews.llvm.org/D69769
+      ./msvc-lld.patch
     ];
 
     postPatch = ''

--- a/pkgs/development/compilers/llvm/8/clang/msvc-lld.patch
+++ b/pkgs/development/compilers/llvm/8/clang/msvc-lld.patch
@@ -1,0 +1,89 @@
+commit 418f133acf9724564ddc30f9ac79c04648e3eb20
+Author: John Ericson <git@JohnEricson.me>
+Date:   Sun Nov 3 13:04:53 2019 -0500
+
+    [Clang][Driver] Don't pun -fuse-ld=lld as -fuse-ld=lld-link with msvc
+    
+    Summary:
+    Besides the Mingw toolchain, there is also the CrossWindows toolchain,
+    which means GNU-style cli but genuine windows headers + libraries. LLD's
+    MinGW driver is as good a fit as binutil's ld, but there is no easy way
+    to select it when lld was being rewritten to lld-link.
+    
+    This makes lld always be the GNU-style one, consistent with the non-msvc
+    case. It's a small breaking change for Windows, but the only
+    straightforward way.
+    
+    It may seem silly to worry about the gnu-style flags, but it is useful
+    for mixing software designed with MinGW in mind with "real" windows
+    software that needs a MSVC C++ ABI, C++ threads, etc.
+    
+    Testing in conjunction with https://github.com/NixOS/nixpkgs/pull/72366,
+    which might be the first fully automated way to cross compile to
+    Windows.  I haven't taught Nixpkgs to wrap clang-cl like it wraps clang,
+    so even for some packages that have separate MSVC and MinGW builds
+    systems (e.g. zlib, opensll), I seem to be having better luck with the
+    MinGW-style builds so am going with that.
+    
+    Backport of D69760 for release 8
+    
+    Subscribers: mstorsjo, cfe-commits
+    
+    Tags: #clang
+    
+    Differential Revision: https://reviews.llvm.org/D69769
+
+diff --git a/lib/Driver/Driver.cpp b/lib/Driver/Driver.cpp
+index a784e218f1..8185836c65 100644
+--- a/lib/Driver/Driver.cpp
++++ b/lib/Driver/Driver.cpp
+@@ -4592,8 +4592,8 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
+         break;
+       case llvm::Triple::MSVC:
+       case llvm::Triple::UnknownEnvironment:
+-        if (Args.getLastArgValue(options::OPT_fuse_ld_EQ)
+-                .startswith_lower("bfd"))
++        auto linkerFlavor = Args.getLastArgValue(options::OPT_fuse_ld_EQ);
++        if (linkerFlavor.startswith_lower("bfd") || linkerFlavor.equals_lower("lld"))
+           TC = llvm::make_unique<toolchains::CrossWindowsToolChain>(
+               *this, Target, Args);
+         else
+diff --git a/lib/Driver/ToolChains/MSVC.cpp b/lib/Driver/ToolChains/MSVC.cpp
+index a164fd68e2..1a0da36d06 100644
+--- a/lib/Driver/ToolChains/MSVC.cpp
++++ b/lib/Driver/ToolChains/MSVC.cpp
+@@ -475,13 +475,10 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+ 
+   std::vector<const char *> Environment;
+ 
+-  // We need to special case some linker paths.  In the case of lld, we need to
+-  // translate 'lld' into 'lld-link', and in the case of the regular msvc
++  // We need to special case some linker paths.  In the case of the regular msvc
+   // linker, we need to use a special search algorithm.
+   llvm::SmallString<128> linkPath;
+   StringRef Linker = Args.getLastArgValue(options::OPT_fuse_ld_EQ, "link");
+-  if (Linker.equals_lower("lld"))
+-    Linker = "lld-link";
+ 
+   if (Linker.equals_lower("link")) {
+     // If we're using the MSVC linker, it's not sufficient to just use link
+diff --git a/test/Driver/fuse-ld.c b/test/Driver/fuse-ld.c
+index b043ce624e..9444a33aa7 100644
+--- a/test/Driver/fuse-ld.c
++++ b/test/Driver/fuse-ld.c
+@@ -78,8 +78,13 @@
+ // RUN: %clang %s -### -fuse-ld=lld \
+ // RUN:     -target i686-unknown-windows-msvc 2>&1 \
+ // RUN:   | FileCheck %s --check-prefix CHECK-WINDOWS-MSVC-LLD
+-// CHECK-WINDOWS-MSVC-LLD: "{{.*}}lld-link"
+-// CHECK-WINDOWS-MSVC-LLD-SAME: "-out:{{.*}}"
++// CHECK-WINDOWS-MSVC-LLD: "{{.*}}ld.lld"
++// CHECK-WINDOWS-MSVC-LLD-SAME: "-o"
++
++// RUN: %clang-cl %s -### -fuse-ld=lld \
++// RUN:   | FileCheck %s --check-prefix CHECK-WINDOWS-MSVC-LLD
++// CHECK-cl-WINDOWS-MSVC-LLD: "{{.*}}ld.lld"
++// CHECK-cl-WINDOWS-MSVC-LLD-SAME: "-o"
+ 
+ // RUN: %clang %s -### -fuse-ld=lld-link \
+ // RUN:     -target i686-unknown-windows-msvc 2>&1 \

--- a/pkgs/development/compilers/llvm/8/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation {
   ] ++ lib.optionals (useLLVM) [
     "-DCOMPILER_RT_BUILD_BUILTINS=ON"
     "-DCMAKE_C_FLAGS=-nodefaultlibs"
+    "-DCMAKE_C_FLAGS=-ffreestanding"
     #https://stackoverflow.com/questions/53633705/cmake-the-c-compiler-is-not-able-to-compile-a-simple-test-program
     "-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY"
   ] ++ lib.optionals (bareMetal) [
@@ -55,7 +56,7 @@ stdenv.mkDerivation {
     ../../common/compiler-rt/glibc.patch
     ./codesign.patch # Revert compiler-rt commit that makes codesign mandatory
   ]# ++ lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
-    ++ lib.optional (useLLVM) ./crtbegin-and-end.patch
+    ++ lib.optional (useLLVM && !stdenv.hostPlatform.isWindows) ./crtbegin-and-end.patch
     ++ lib.optional stdenv.hostPlatform.isAarch32 ./armv7l.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -25,6 +25,8 @@ let
       ln -s "${cc}/lib/clang/${release_version}/include" "$rsrc"
       ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
       echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+    '' + stdenv.lib.optionalString (stdenv.targetPlatform.isWindows) ''
+      echo "-fuse-ld=lld" >> $out/nix-support/cc-cflags
     '';
   in {
 
@@ -55,12 +57,22 @@ let
 
     libclang = tools.clang-unwrapped.lib;
 
-    clang = if stdenv.cc.isGNU then tools.libstdcxxClang else tools.libcxxClang;
+    clang = if stdenv.cc.isGNU then tools.libstdcxxClang
+      else  if stdenv.targetPlatform.isWindows then tools.msvcxxrtClang
+      else tools.libcxxClang;
 
     libstdcxxClang = wrapCCWith rec {
       cc = tools.clang-unwrapped;
       # libstdcxx is taken from gcc in an ad-hoc way in cc-wrapper.
       libcxx = null;
+      extraPackages = [
+        targetLlvmLibraries.compiler-rt
+      ];
+      extraBuildCommands = mkExtraBuildCommands cc;
+    };
+
+    msvcxxrtClang = wrapCCWith rec {
+      cc = tools.clang-unwrapped;
       extraPackages = [
         targetLlvmLibraries.compiler-rt
       ];
@@ -92,20 +104,21 @@ let
 
     lldClang = wrapCCWith rec {
       cc = tools.clang-unwrapped;
-      libcxx = targetLlvmLibraries.libcxx;
+      libcxx = if stdenv.targetPlatform.isWindows then null else targetLlvmLibraries.libcxx;
       bintools = wrapBintoolsWith {
         inherit (tools) bintools;
       };
-      extraPackages = [
+      extraPackages = stdenv.lib.optionals (!stdenv.targetPlatform.isWindows) [
         targetLlvmLibraries.libcxxabi
+      ] ++ [
         targetLlvmLibraries.compiler-rt
-      ] ++ lib.optionals (!stdenv.targetPlatform.isWasm) [
+      ] ++ lib.optionals (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isWindows) [
         targetLlvmLibraries.libunwind
       ];
       extraBuildCommands = ''
         echo "-rtlib=compiler-rt -Wno-unused-command-line-argument" >> $out/nix-support/cc-cflags
         echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
-      '' + lib.optionalString (!stdenv.targetPlatform.isWasm) ''
+      '' + lib.optionalString (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isWindows) ''
         echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
       '' + lib.optionalString stdenv.targetPlatform.isWasm ''
         echo "-fno-exceptions" >> $out/nix-support/cc-cflags

--- a/pkgs/development/compilers/llvm/8/libunwind.nix
+++ b/pkgs/development/compilers/llvm/8/libunwind.nix
@@ -1,0 +1,35 @@
+{ stdenv, version, fetch, cmake, fetchpatch, enableShared ? true }:
+
+stdenv.mkDerivation {
+  pname = "libunwind";
+  inherit version;
+
+  src = fetch "libunwind" "0vhgcgzsb33l83qaikrkj87ypqb48mi607rccczccwiiv8ficw0q";
+
+  nativeBuildInputs = [ cmake ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/llvm-mirror/libunwind/commit/34a45c630d4c79af403661d267db42fbe7de1178.patch";
+      sha256 = "0n0pv6jvcky8pn3srhrf9x5kbnd0d2kia9xlx2g590f5q0bgwfhv";
+    })
+    (fetchpatch {
+      url = "https://github.com/llvm-mirror/libunwind/commit/e050272d2eb57eb4e56a37b429a61df2ebb8aa3e.patch";
+      sha256 = "1sxyx5xnax8k713jjcxgq3jq3cpnxygs2rcdf5vfja0f2k9jzldl";
+    })
+  ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = stdenv.lib.optionals stdenv.hostPlatform.isMinGW [
+    # Taken from https://github.com/mstorsjo/llvm-mingw/blob/master/build-libcxx.sh
+    "-DCXX_SUPPORTS_CXX11=TRUE"
+    "-DCXX_SUPPORTS_CXX_STD=TRUE"
+    "-DLIBUNWIND_USE_COMPILER_RT=TRUE"
+    "-DLIBUNWIND_ENABLE_THREADS=TRUE"
+    "-DLIBUNWIND_ENABLE_CROSS_UNWINDING=FALSE"
+    "-DCMAKE_CXX_FLAGS=-Wno-dll-attribute-on-redeclaration"
+    "-DCMAKE_C_FLAGS=-Wno-dll-attribute-on-redeclaration"
+    "-DCMAKE_SHARED_LINKER_FLAGS=-lpsapi"
+  ] ++ stdenv.lib.optional (!enableShared) "-DLIBUNWIND_ENABLE_SHARED=OFF";
+}

--- a/pkgs/development/compilers/llvm/8/lld-mingw-multiple.patch
+++ b/pkgs/development/compilers/llvm/8/lld-mingw-multiple.patch
@@ -1,0 +1,73 @@
+commit e043d67f365d01401d6bd8cf3d49926e922c9c93
+Author: John Ericson <git@JohnEricson.me>
+Date:   Sun Nov 3 12:26:55 2019 -0500
+
+    [MinGW] Support --allow-multiple-definition
+    
+    Summary:
+    We want the Clang CrossWindows toolchain to work with ld.lld and ld.bfd
+    alike, and it uses this, so we need to support this.
+    
+    Backport of D69767
+    
+    Subscribers: llvm-commits, mstorsjo
+    
+    Tags: #llvm
+    
+    Differential Revision: https://reviews.llvm.org/D69768
+
+diff --git a/MinGW/Driver.cpp b/MinGW/Driver.cpp
+index def769bb9..2b2af1839 100644
+--- a/MinGW/Driver.cpp
++++ b/MinGW/Driver.cpp
+@@ -146,6 +146,8 @@ bool mingw::link(ArrayRef<const char *> ArgsArr, raw_ostream &Diag) {
+ 
+   if (auto *A = Args.getLastArg(OPT_subs))
+     Add("-subsystem:" + StringRef(A->getValue()));
++  if (Args.hasFlag(OPT_allow_multiple_definition, OPT_no_allow_multiple_definition, false))
++    Add("-force:multiple");
+   if (auto *A = Args.getLastArg(OPT_out_implib))
+     Add("-implib:" + StringRef(A->getValue()));
+   if (auto *A = Args.getLastArg(OPT_stack))
+diff --git a/MinGW/Options.td b/MinGW/Options.td
+index 0cda2447e..0cac9b6ec 100644
+--- a/MinGW/Options.td
++++ b/MinGW/Options.td
+@@ -4,8 +4,18 @@ class F<string name>: Flag<["--", "-"], name>;
+ class J<string name>: Joined<["--", "-"], name>;
+ class S<string name>: Separate<["--", "-"], name>;
+ 
++multiclass B<string name, string help1, string help2> {
++  def NAME: Flag<["--", "-"], name>, HelpText<help1>;
++  def no_ # NAME: Flag<["--", "-"], "no-" # name>, HelpText<help2>;
++}
++
+ def L: JoinedOrSeparate<["-"], "L">, MetaVarName<"<dir>">,
+   HelpText<"Add a directory to the library search path">;
++
++defm allow_multiple_definition: B<"allow-multiple-definition",
++    "Allow multiple definitions",
++    "Do not allow multiple definitions (default)">;
++
+ def dynamicbase: F<"dynamicbase">, HelpText<"Enable ASLR">;
+ def entry: S<"entry">, MetaVarName<"<entry>">,
+   HelpText<"Name of entry point symbol">;
+diff --git a/test/MinGW/driver.test b/test/MinGW/driver.test
+index 3222bb111..3426d6461 100644
+--- a/test/MinGW/driver.test
++++ b/test/MinGW/driver.test
+@@ -37,6 +37,14 @@ RUN: ld.lld -### foo.o -m i386pep -obar.exe | FileCheck -check-prefix=OUT %s
+ RUN: ld.lld -### foo.o -m i386pep -o bar.exe | FileCheck -check-prefix=OUT %s
+ OUT: -out:bar.exe
+ 
++RUN: ld.lld -### foo.o -m i386pep --allow-multiple-definitions | FileCheck -check-prefix=FORCE_MULTIPLE %s
++RUN: ld.lld -### foo.o -m i386pep --no-allow-multiple-definitions --allow-multiple-definitions | FileCheck -check-prefix=FORCE_MULTIPLE %s
++FORCE_MULTIPLE: -force:multiple
++
++RUN: ld.lld -### foo.o -m i386pep --no-allow-multiple-definitions | FileCheck -check-prefix=NO_FORCE_MULTIPLE %s
++RUN: ld.lld -### foo.o -m i386pep --allow-multiple-definitions --no-allow-multiple-definitions | FileCheck -check-prefix=NO_FORCE_MULTIPLE %s
++NO_FORCE_MULTIPLE-NOT: -force:multiple
++
+ RUN: ld.lld -### foo.o -m i386pep --out-implib bar | FileCheck -check-prefix=IMPLIB %s
+ RUN: ld.lld -### foo.o -m i386pep --out-implib=bar | FileCheck -check-prefix=IMPLIB %s
+ IMPLIB: -implib:bar

--- a/pkgs/development/compilers/llvm/8/lld-mingw-search-harder.patch
+++ b/pkgs/development/compilers/llvm/8/lld-mingw-search-harder.patch
@@ -1,0 +1,76 @@
+commit 447022647c36a64e710165a41a19443b10f74327
+Author: Martin Storsjo <martin@martin.st>
+Date:   Thu Oct 10 08:52:39 2019 +0000
+
+    [LLD] [MinGW] Look for other library patterns with -l
+    
+    GNU ld looks for a number of other patterns than just lib<name>.dll.a
+    and lib<name>.a.
+    
+    GNU ld does support linking directly against a DLL without using an
+    import library. If that's the only match for a -l argument, point out
+    that the user needs to use an import library, instead of leaving the
+    user with a puzzling message about the -l argument not being found
+    at all.
+    
+    Also convert an existing case of fatal() into error().
+    
+    Differential Revision: https://reviews.llvm.org/D68689
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/lld/trunk@374292 91177308-0d34-0410-b5e6-96231b3b80d8
+    
+    (cherry-pick of 5cd168d52a1de34c2a08ba8b58d1e6002e72885b)
+
+diff --git a/MinGW/Driver.cpp b/MinGW/Driver.cpp
+index 2b2af1839..866ef2084 100644
+--- a/MinGW/Driver.cpp
++++ b/MinGW/Driver.cpp
+@@ -115,11 +115,26 @@ searchLibrary(StringRef Name, ArrayRef<StringRef> SearchPaths, bool BStatic) {
+   }
+ 
+   for (StringRef Dir : SearchPaths) {
+-    if (!BStatic)
++    if (!BStatic) {
+       if (Optional<std::string> S = findFile(Dir, "lib" + Name + ".dll.a"))
+         return *S;
++      if (Optional<std::string> S = findFile(Dir, Name + ".dll.a"))
++        return *S;
++    }
+     if (Optional<std::string> S = findFile(Dir, "lib" + Name + ".a"))
+       return *S;
++    if (!BStatic) {
++      if (Optional<std::string> S = findFile(Dir, Name + ".lib"))
++        return *S;
++      if (Optional<std::string> S = findFile(Dir, "lib" + Name + ".dll")) {
++        fatal("lld doesn't support linking directly against " + *S +
++              ", use an import library");
++      }
++      if (Optional<std::string> S = findFile(Dir, Name + ".dll")) {
++        fatal("lld doesn't support linking directly against " + *S +
++              ", use an import library");
++      }
++    }
+   }
+   fatal("unable to find library -l" + Name);
+ }
+diff --git a/test/MinGW/lib.test b/test/MinGW/lib.test
+index 56104d6d9..7342aa3a1 100644
+--- a/test/MinGW/lib.test
++++ b/test/MinGW/lib.test
+@@ -19,3 +19,16 @@ RUN: echo > %t/lib/libbar.a
+ RUN: ld.lld -### -m i386pep -Bstatic -lfoo -Bdynamic -lbar -L%t/lib | FileCheck -check-prefix=LIB5 %s
+ LIB5:      libfoo.a
+ LIB5-SAME: libbar.dll.a
++
++RUN: echo > %t/lib/noprefix.dll.a
++RUN: echo > %t/lib/msvcstyle.lib
++RUN: ld.lld -### -m i386pep -L%t/lib -lnoprefix -lmsvcstyle | FileCheck -check-prefix=OTHERSTYLES %s
++OTHERSTYLES: noprefix.dll.a
++OTHERSTYLES-SAME: msvcstyle.lib
++
++RUN: echo > %t/lib/libnoimplib.dll
++RUN: echo > %t/lib/noprefix_noimplib.dll
++RUN: not ld.lld -### -m i386pep -L%t/lib -lnoimplib 2>&1 | FileCheck -check-prefix=UNSUPPORTED-DLL1 %s
++RUN: not ld.lld -### -m i386pep -L%t/lib -lnoprefix_noimplib 2>&1 | FileCheck -check-prefix=UNSUPPORTED-DLL2 %s
++UNSUPPORTED-DLL1: lld doesn't support linking directly against {{.*}}libnoimplib.dll, use an import library
++UNSUPPORTED-DLL2: lld doesn't support linking directly against {{.*}}noprefix_noimplib.dll, use an import library

--- a/pkgs/development/compilers/llvm/8/lld/default.nix
+++ b/pkgs/development/compilers/llvm/8/lld/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation {
   src = fetch "lld" "121xhxrlvwy3k5nf6p1wv31whxlb635ssfkci8z93mwv4ja1xflz";
 
   patches = [
+    # https://reviews.llvm.org/D68689 backport
+    ./lld-mingw-search-harder.patch
     # https://reviews.llvm.org/D69768
     ./lld-mingw-multiple.patch
   ];

--- a/pkgs/development/compilers/llvm/8/lld/default.nix
+++ b/pkgs/development/compilers/llvm/8/lld/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation {
 
   src = fetch "lld" "121xhxrlvwy3k5nf6p1wv31whxlb635ssfkci8z93mwv4ja1xflz";
 
+  patches = [
+    # https://reviews.llvm.org/D69768
+    ./lld-mingw-multiple.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];
 

--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -15,6 +15,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-NH66WAOqAaMm/IIu8L5R7CUFhX56yTLH7mPY1Q4jDC4=";
   };
 
+  # It disables it with MSVC, but CMake doesn't realize that clang for windows,
+  # even with gcc-style flags, has the same semantic restrictions.
+  patches = stdenv.lib.optional
+    (stdenv.hostPlatform.isWindows && stdenv.hostPlatform.useLLVM or false)
+    ./no-fpic.patch;
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [
@@ -31,7 +37,7 @@ stdenv.mkDerivation rec {
     description = "AWS SDK for C common core";
     homepage = "https://github.com/awslabs/aws-c-common";
     license = licenses.asl20;
-    platforms = platforms.unix;
+    platforms = platforms.all;
     maintainers = with maintainers; [ orivej eelco r-burns ];
   };
 }

--- a/pkgs/development/libraries/aws-c-common/no-fpic.patch
+++ b/pkgs/development/libraries/aws-c-common/no-fpic.patch
@@ -1,0 +1,14 @@
+diff --git a/nix/store/b1hnbvv9zn3fh1iyhb5xmhw8jpjj241x-source/cmake/AwsCFlags.cmake b/AwsCFlags.cmake
+index 5ceb11cf106..c2ba65546d8 100644
+--- a/cmake/AwsCFlags.cmake
++++ b/cmake/AwsCFlags.cmake
+@@ -64,9 +64,6 @@ function(aws_set_common_properties target)
+         # Avoid exporting symbols we don't intend to export
+         list(APPEND AWS_C_FLAGS -fvisibility=hidden)
+ 
+-        # Always enable position independent code, since this code will always end up in a shared lib
+-        list(APPEND AWS_C_FLAGS -fPIC)
+-
+     endif()
+ 
+     check_include_file(stdint.h HAS_STDINT)

--- a/pkgs/development/libraries/aws-c-event-stream/default.nix
+++ b/pkgs/development/libraries/aws-c-event-stream/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     description = "C99 implementation of the vnd.amazon.eventstream content-type";
     homepage = "https://github.com/awslabs/aws-c-event-stream";
     license = licenses.asl20;
-    platforms = platforms.unix;
+    platforms = platforms.all;
     maintainers = with maintainers; [ orivej eelco ];
   };
 }

--- a/pkgs/development/libraries/aws-checksums/default.nix
+++ b/pkgs/development/libraries/aws-checksums/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-fXu7GI2UR9QiBGP2n2pEFRjz9ZwA+BAK9zxhNnoYWt4=";
   };
 
+  # It disables it with MSVC, but CMake doesn't realize that clang for windows,
+  # even with gcc-style flags, has the same semantic restrictions.
+  patches = stdenv.lib.optional
+    (stdenv.hostPlatform.isWindows && stdenv.hostPlatform.useLLVM or false)
+    ./no-fpic.patch;
+
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ aws-c-common ];
@@ -24,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "HW accelerated CRC32c and CRC32";
     homepage = "https://github.com/awslabs/aws-checksums";
     license = licenses.asl20;
-    platforms = platforms.unix;
+    platforms = platforms.all;
     maintainers = with maintainers; [ orivej eelco ];
   };
 }

--- a/pkgs/development/libraries/aws-checksums/no-fpic.patch
+++ b/pkgs/development/libraries/aws-checksums/no-fpic.patch
@@ -1,0 +1,15 @@
+diff --git a/nix/store/z3yg9mxc3dhnqrkbz3vwk36b9n52wixz-source/CMakeLists.txt b/CMakeLists.txt
+index 32e11f5c1d7..a7b6f0ed5b6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -83,10 +83,6 @@ if(BUILD_SHARED_LIBS AND WIN32)
+     target_compile_definitions(aws-checksums PRIVATE "-DAWS_CHECKSUMS_EXPORTS")    
+ endif()
+ 
+-if(NOT MSVC)
+-    target_compile_options(aws-checksums PRIVATE -fPIC)
+-endif()
+-
+ if(BUILD_JNI_BINDINGS)
+     find_package(JNI)
+     include_directories(${JNI_INCLUDE_DIRS})

--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     description = "A C++ interface for Amazon Web Services";
     homepage = "https://github.com/awslabs/aws-sdk-cpp";
     license = licenses.asl20;
-    platforms = platforms.unix;
+    platforms = platforms.all;
     maintainers = with maintainers; [ eelco orivej ];
   };
 }

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -80,7 +80,7 @@ let
           then "./Configure BSD-x86" + lib.optionalString (stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf") "-elf"
         else if stdenv.hostPlatform.isBSD
           then "./Configure BSD-generic${toString stdenv.hostPlatform.parsed.cpu.bits}"
-        else if stdenv.hostPlatform.isMinGW
+        else if with stdenv.hostPlatform; isMinGW || (isWindows && stdenv.hostPlatform.useLLVM or false)
           then "./Configure mingw${optionalString
                                      (stdenv.hostPlatform.parsed.cpu.bits != 32)
                                      (toString stdenv.hostPlatform.parsed.cpu.bits)}"

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -108,8 +108,17 @@ stdenv.mkDerivation (rec {
 
   makeFlags = [
     "PREFIX=${stdenv.cc.targetPrefix}"
-  ] ++ lib.optionals (stdenv.hostPlatform.libc == "msvcrt") [
+  ] ++ lib.optionals (stdenv.hostPlatform.isWindows) [
     "-f" "win32/Makefile.gcc"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "RC=${stdenv.cc.targetPrefix}windres"
+  ] ++ lib.optionals (stdenv.hostPlatform.isWindows && (! stdenv.hostPlatform.isMinGW) && stdenv.hostPlatform.useLLVM or false) [
+    "LDFLAGS=-loldnames" # so POSIX names work
+  ] ++ lib.optionals (false /* stdenv.hostPlatform.isWindows && stdenv.hostPlatform.useLLVM */) [
+    "-f" "win32/Makefile.msc"
+    "CC=${stdenv.cc.targetPrefix}clang-cl"
+    "AR=${stdenv.cc.bintools.targetPrefix}llvm-lib"
+    "RC=${stdenv.cc.bintools.targetPrefix}llvm-rc"
   ] ++ lib.optionals shared [
     # Note that as of writing (zlib 1.2.11), this flag only has an effect
     # for Windows as it is specific to `win32/Makefile.gcc`.

--- a/pkgs/os-specific/windows/default.nix
+++ b/pkgs/os-specific/windows/default.nix
@@ -42,4 +42,6 @@ lib.makeScope newScope (self: with self; {
   wxMSW = callPackage ./wxMSW-2.8 { };
 
   libgnurx = callPackage ./libgnurx { };
+
+  sdks = callPackage ./sdks { };
 })

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, windows, fetchurl }:
+{ lib, stdenv, windows, fetchurl, fetchpatch }:
 
 let
   version = "6.0.0";
@@ -23,6 +23,13 @@ in stdenv.mkDerivation {
   buildInputs = [ windows.mingw_w64_headers ];
   dontStrip = true;
   hardeningDisable = [ "stackprotector" "fortify" ];
+  patches = [
+    # Clang support https://github.com/mstorsjo/llvm-mingw/issues/3
+    (fetchpatch {
+      url = "https://github.com/mirror/mingw-w64/commit/25d51481e344be35d93524965309f514486395c0.diff";
+      sha256 = "09rgzyg95kp5sh1zikcjh0h616ni38n8vzf03x6s8hqj07692y4i";
+    })
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -24,6 +24,8 @@ in stdenv.mkDerivation {
   dontStrip = true;
   hardeningDisable = [ "stackprotector" "fortify" ];
 
+  enableParallelBuilding = true;
+
   meta = {
     platforms = lib.platforms.windows;
   };

--- a/pkgs/os-specific/windows/sdks/default.nix
+++ b/pkgs/os-specific/windows/sdks/default.nix
@@ -49,6 +49,15 @@ let
     else if platform.isAarch64 then "ARM64"
     else throw "missing platform";
 
+  # TODO(@Ericson2314): Need a better solution for case-insensativity.
+  forceLower = dir: ''
+    for file in "${dir}"/*; do
+      if [[ "''${file}" != "''${file,,}" ]]; then
+        mv "''${file}" "''${file,,}"
+      fi
+    done
+  '';
+
   mkCrt = variant: let
     versionShort = "14.16";
     version = "${versionShort}.27023";
@@ -122,6 +131,10 @@ in lib.makeExtensible (self: {
       mv Contents/VC/Auxiliary "$aux"
       mv Contents/Common7 "$common7"
     '';
+    preFixup = ''
+      ${forceLower "$out/lib"}
+      ${forceLower "$dev/include"}
+    '';
   };
 
   inherit manifest manifestFile;
@@ -154,6 +167,9 @@ in lib.makeExtensible (self: {
       ${extractMsi "$msi" "$srcs" "$msiTemp"}
       mkdir "$out"
       mv "$msiTemp/Program Files/Windows Kits/10/Lib/${version}/um/${convArchLower stdenvNoCC.hostPlatform}" "$out/lib"
+    '';
+    preFixup = ''
+      ${forceLower "$out/lib"}
     '';
   };
 
@@ -196,6 +212,10 @@ in lib.makeExtensible (self: {
       mkdir "$dev"
       mv "$msiTempHeaders/Program Files/Windows Kits/10/Include/${version}/${shortName}" "$dev/include"
     '';
+    preFixup = ''
+      ${forceLower "$out/lib"}
+      ${forceLower "$dev/include"}
+    '';
   };
 
   ucrt = let
@@ -233,6 +253,10 @@ in lib.makeExtensible (self: {
       mv "$msiTemp/Program Files/Windows Kits/10/Lib/${version}/${shortName}/${convArchLower stdenvNoCC.hostPlatform}" "$out/lib"
     '' + lib.optionalString (!static) ''
       mv "$msiTemp/Program Files/Windows Kits/10/bin/${version}/${convArchLower stdenvNoCC.hostPlatform}/${shortName}"/* "$out/lib/"
+    '';
+    preFixup = ''
+      ${forceLower "$out/lib"}
+      ${forceLower "$dev/include"}
     '';
   };
 })

--- a/pkgs/os-specific/windows/sdks/default.nix
+++ b/pkgs/os-specific/windows/sdks/default.nix
@@ -1,0 +1,238 @@
+{ stdenvNoCC, fetchurl, lib, config, msitools, unzip, static ? false }:
+
+#if !(config.microsoftVisualStudioLicenseAccepted or false)
+if false
+then throw ''
+  Please read
+
+    https://www.visualstudio.com/license-terms/mt644918/
+
+  and change the argument above to `true` if you accept it.
+''
+else
+
+# How to maintain this.
+#
+# The root manifest is at https://aka.ms/vs/<version>/release/channel .
+# Versions 15 and 16 (2017 and 2019) are confirmed at this time.
+#
+#   jq '."channelItems" | .[] | select(.id == "Microsoft.VisualStudio.Manifests.VisualStudio") | .payloads | map (. + {"name": .fileName} | del(.fileName) | del(.size))'jq '."channelItems" | .[] | select(.id == "Microsoft.VisualStudio.Manifests.VisualStudio") | .[0]' < VisualStudio.<version>.Release.chman
+#
+# With the above command, we pull out the main manifest (in a form for fetchgit), which in tern has everything else we need.
+#
+# TODO(@Ericson2314): automate more.
+
+let
+  manifestFile = builtins.fetchurl {
+    name = "VisualStudio.vsman";
+    url = "https://download.visualstudio.microsoft.com/download/pr/d1553812-31d4-46b0-a480-e6b965eb1125/2d369814247879bf68e8de25fab0b635093ab56a329993f1b9d0c3cc01f001ef/VisualStudio.vsman";
+    sha256 = "0lrz0p69p1zznq4xyzjmnp0gy967rb6vh4jckcyzay3gp2567knl";
+    # TODO(@Ericson2314): MS claims this hash but it doesn't work. Hashes within
+    # are fine. Is something compromised??!?!
+    #sha256 = "2d369814247879bf68e8de25fab0b635093ab56a329993f1b9d0c3cc01f001ef";
+  };
+  manifestUnindexed = builtins.fromJSON (builtins.readFile manifestFile);
+  manifest = lib.listToAttrs (map (v: lib.nameValuePair v.id v) manifestUnindexed.packages);
+
+  fetchManifest = id: fetchurl {
+    inherit
+      (builtins.head manifest.${id}.payloads)
+      sha256 url;
+  };
+
+  convArchLower = platform: lib.toLower (convArchUpper platform);
+
+  convArchUpper = platform:
+         if platform.isx86_64 then "X64"
+    else if platform.isx86_32 then "X86"
+    else if platform.isAarch32 then "ARM"
+    else if platform.isAarch64 then "ARM64"
+    else throw "missing platform";
+
+  mkCrt = variant: let
+    versionShort = "14.16";
+    version = "${versionShort}.27023";
+    idLibs    = "Microsoft.VisualC.${versionShort}.CRT.${convArchLower stdenvNoCC.hostPlatform}.${variant}";
+    idHeaders = "Microsoft.VisualC.${versionShort}.CRT.Headers";
+    srcLibs = fetchManifest idLibs;
+    srcHeaders = fetchManifest idHeaders;
+  in stdenvNoCC.mkDerivation {
+    pname = "${stdenvNoCC.targetPlatform.config}-microsoft-visual-c-crt-${lib.toLower variant}";
+    inherit version;
+    inherit srcLibs srcHeaders;
+    outputs = [ "out" "dev" ];
+    nativeBuildInputs = [ unzip ];
+    unpackPhase = "true";
+    dontConfigure = true;
+    dontBuild = true;
+    installPhase = ''
+      unzip "$srcLibs" 'Contents/*'
+      mkdir "$out"
+      mv Contents/VC/Tools/MSVC/${version}/lib/${convArchLower stdenvNoCC.hostPlatform} "$out/lib"
+      unzip "$srcHeaders" 'Contents/*'
+      mkdir "$dev"
+      mv Contents/VC/Tools/MSVC/${version}/include "$dev"
+    '';
+  };
+
+  windowsSdkVersionMinor = "18362";
+  windowsSdkVersion = "10.0.${windowsSdkVersionMinor}.0";
+
+  windowsSdkMetaInstaller = manifest.${"Win10SDK_10.0.${windowsSdkVersionMinor}"};
+  windowsSdk = lib.listToAttrs (map (v: lib.nameValuePair v.fileName v) windowsSdkMetaInstaller.payloads);
+
+  fetchWindowsSdk = fileName: fetchurl {
+    inherit
+      (windowsSdk.${fileName})
+      url sha256;
+    name = lib.replaceStrings [ " " "%20" ] [ "_" "_" ] (lib.last (lib.splitString "\\" fileName));
+  };
+
+  fetchWindowsSdkInstaller = fileName: fetchWindowsSdk ("Installers\\" + fileName);
+
+  extractMsi = msi: srcs: destination: ''
+    srcs=(${srcs})
+    printLines "''${srcs[@]}"
+    for x in "''${srcs[@]}"; do
+      cp $x $(echo $x | cut -d- -f2)
+    done
+    cp "${msi}" ./
+    msiextract -C "${destination}" ./*.msi
+    rm *.msi
+  '';
+
+in lib.makeExtensible (self: {
+  msvcTools = let
+    version = "14.23.28105";
+    id = "Microsoft.VisualCpp.Tools.Host${convArchUpper stdenvNoCC.hostPlatform}.Target${convArchUpper stdenvNoCC.targetPlatform}";
+    src = fetchManifest id;
+  in stdenvNoCC.mkDerivation {
+    pname = "${stdenvNoCC.targetPlatform.config}-microsoft-visual-c-tools";
+    inherit version;
+    inherit src;
+    outputs = [ "out" "aux" "common7" ];
+    nativeBuildInputs = [ unzip ];
+    unpackPhase = "true";
+    dontConfigure = true;
+    dontBuild = true;
+    installPhase = ''
+      unzip "$src" 'Contents/*'
+      mkdir -p "$out"
+      mv Contents/VC/Tools/MSVC/${version}/bin/Host${convArchLower stdenvNoCC.hostPlatform}/${convArchLower stdenvNoCC.targetPlatform} "$out/bin"
+      mv Contents/VC/Auxiliary "$aux"
+      mv Contents/Common7 "$common7"
+    '';
+  };
+
+  inherit manifest manifestFile;
+
+  crtDesktop = mkCrt "Desktop";
+
+  crtStore = mkCrt "Store";
+
+  windowsSdkDesktopLibs = let
+    shortName = "um";
+    version = windowsSdkVersion;
+  in stdenvNoCC.mkDerivation {
+    pname = "windows-sdk-store-desktop-libs";
+    version = windowsSdkVersion;
+    msi = fetchWindowsSdkInstaller "Windows SDK Desktop Libs ${convArchLower stdenvNoCC.hostPlatform}-x86_en-us.msi";
+    srcs = map fetchWindowsSdkInstaller {
+      x64 = [
+        "58314d0646d7e1a25e97c902166c3155.cab"
+      ];
+      x86 = [
+        "53174a8154da07099db041b9caffeaee.cab"
+      ];
+    }.${convArchLower stdenvNoCC.hostPlatform};
+    nativeBuildInputs = [ msitools ];
+    unpackPhase = "true";
+    dontConfigure = true;
+    dontBuild = true;
+    installPhase = ''
+      msiTemp=$(mktemp -d)
+      ${extractMsi "$msi" "$srcs" "$msiTemp"}
+      mkdir "$out"
+      mv "$msiTemp/Program Files/Windows Kits/10/Lib/${version}/um/${convArchLower stdenvNoCC.hostPlatform}" "$out/lib"
+    '';
+  };
+
+  windowsSdkStoreAppLibs = let
+    shortName = "um";
+    version = windowsSdkVersion;
+  in stdenvNoCC.mkDerivation {
+    pname = "windows-sdk-store-app-libs";
+    inherit version;
+    msiLibs = fetchWindowsSdkInstaller "Windows SDK for Windows Store Apps Libs-x86_en-us.msi";
+    srcsLibs = map fetchWindowsSdkInstaller [
+      "05047a45609f311645eebcac2739fc4c.cab"
+      "0b2a4987421d95d0cb37640889aa9e9b.cab"
+      "13d68b8a7b6678a368e2d13ff4027521.cab"
+      "463ad1b0783ebda908fd6c16a4abfe93.cab"
+      "5a22e5cde814b041749fb271547f4dd5.cab"
+      "ba60f891debd633ae9c26e1372703e3c.cab"
+      "e10768bb6e9d0ea730280336b697da66.cab"
+      "f9b24c8280986c0683fbceca5326d806.cab"
+    ];
+    msiHeaders = fetchWindowsSdkInstaller "Windows SDK for Windows Store Apps Headers-x86_en-us.msi";
+    srcsHeaders = map fetchWindowsSdkInstaller [
+      "766c0ffd568bbb31bf7fb6793383e24a.cab"
+      "8125ee239710f33ea485965f76fae646.cab"
+      "c0aa6d435b0851bf34365aadabd0c20f.cab"
+      "c1c7e442409c0adbf81ae43aa0e4351f.cab"
+    ];
+    nativeBuildInputs = [ msitools ];
+    outputs = [ "out" "dev" ];
+    unpackPhase = "true";
+    dontConfigure = true;
+    dontBuild = true;
+    installPhase = ''
+      msiTempLibs=$(mktemp -d)
+      ${extractMsi "$msiLibs" "$srcsLibs" "$msiTempLibs"}
+      mkdir "$out"
+      mv "$msiTempLibs/Program Files/Windows Kits/10/Lib/${version}/${shortName}/${convArchLower stdenvNoCC.hostPlatform}" "$out/lib"
+      msiTempHeaders=$(mktemp -d)
+      ${extractMsi "$msiHeaders" "$srcsHeaders" "$msiTempHeaders"}
+      mkdir "$dev"
+      mv "$msiTempHeaders/Program Files/Windows Kits/10/Include/${version}/${shortName}" "$dev/include"
+    '';
+  };
+
+  ucrt = let
+    shortName = "ucrt";
+    version = windowsSdkVersion;
+  in stdenvNoCC.mkDerivation {
+    pname = "windows-sdk-${shortName}";
+    inherit version;
+    msi = fetchWindowsSdkInstaller "Universal CRT Headers Libraries and Sources-x86_en-us.msi";
+    srcs = map fetchWindowsSdkInstaller [
+      "eca0aa33de85194cd50ed6e0aae0156f.cab"
+      "16ab2ea2187acffa6435e334796c8c89.cab"
+      "2868a02217691d527e42fe0520627bfa.cab"
+      "6ee7bbee8435130a869cf971694fd9e2.cab"
+      "78fa3c824c2c48bd4a49ab5969adaaf7.cab"
+      "7afc7b670accd8e3cc94cfffd516f5cb.cab"
+      "80dcdb79b8a5960a384abe5a217a7e3a.cab"
+      "96076045170fe5db6d5dcf14b6f6688e.cab"
+      "a1e2a83aa8a71c48c742eeaff6e71928.cab"
+      "beb5360d2daaa3167dea7ad16c28f996.cab"
+      "f9ff50431335056fb4fbac05b8268204.cab"
+      "b2f03f34ff83ec013b9e45c7cd8e8a73.cab"
+    ];
+    nativeBuildInputs = [ msitools ];
+    outputs = [ "out" "dev" "src" ];
+    unpackPhase = "true";
+    dontConfigure = true;
+    dontBuild = true;
+    installPhase = ''
+      msiTemp=$(mktemp -d)
+      ${extractMsi "$msi" "$srcs" "$msiTemp"}
+      mkdir "$out" "$dev"
+      mv "$msiTemp/Program Files/Windows Kits/10/Include/${version}/${shortName}" "$dev/include"
+      mv "$msiTemp/Program Files/Windows Kits/10/Source/${version}/${shortName}" "$src"
+      mv "$msiTemp/Program Files/Windows Kits/10/Lib/${version}/${shortName}/${convArchLower stdenvNoCC.hostPlatform}" "$out/lib"
+    '' + lib.optionalString (!static) ''
+      mv "$msiTemp/Program Files/Windows Kits/10/bin/${version}/${convArchLower stdenvNoCC.hostPlatform}/${shortName}"/* "$out/lib/"
+    '';
+  };
+})

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -74,7 +74,7 @@ in lib.init bootStages ++ [
              (hostPlatform.isLinux && !buildPlatform.isLinux)
              [ buildPackages.patchelf ]
         ++ lib.optional
-             (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS || p.isGenode;
+             (let f = p: !p.isx86 || builtins.elem p.libc [ "musl" "wasilibc" "relibc" ] || p.isiOS || p.isGenode || p.isWindows;
                in f hostPlatform && !(f buildPlatform) )
              buildPackages.updateAutotoolsGnuConfigScriptsHook
            # without proper `file` command, libtool sometimes fails

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -282,7 +282,11 @@ in rec {
           ++ lib.optional (stdenv.hostPlatform.isDarwin) "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"
           ++ lib.optional (stdenv.buildPlatform.uname.system != null) "-DCMAKE_HOST_SYSTEM_NAME=${stdenv.buildPlatform.uname.system}"
           ++ lib.optional (stdenv.buildPlatform.uname.processor != null) "-DCMAKE_HOST_SYSTEM_PROCESSOR=${stdenv.buildPlatform.uname.processor}"
-          ++ lib.optional (stdenv.buildPlatform.uname.release != null) "-DCMAKE_HOST_SYSTEM_VERSION=${stdenv.buildPlatform.uname.release}";
+          ++ lib.optional (stdenv.buildPlatform.uname.release != null) "-DCMAKE_HOST_SYSTEM_VERSION=${stdenv.buildPlatform.uname.release}"
+          ++ lib.optional (stdenv.hostPlatform.parsed.kernel.name == "windows")
+            # TODO(@Ericson2314): probably bettter in the setup hook
+            "-DCMAKE_RC_COMPILER=${stdenv.hostPlatform.config}-llvm-rc"
+          ;
 
           mesonFlags = if mesonFlags == null then null else let
             # See https://mesonbuild.com/Reference-tables.html#cpu-families

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14610,7 +14610,28 @@ in
     else if name == "newlib" && stdenv.targetPlatform.isOr1k then targetPackages.or1k-newlib or or1k-newlib
     else if name == "newlib" then targetPackages.newlibCross or newlibCross
     else if name == "musl" then targetPackages.muslCross or muslCross
-    else if name == "msvcrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64
+    else if name == "msvcrt" then
+      if targetPackages.hostPlatform.isMinGW
+      then
+        targetPackages.windows.mingw_w64 or windows.mingw_w64
+      else
+        # Real Windows headers + libs
+        (pkgs.buildEnv {
+          name = "windows-crt-combined";
+          extraOutputsToInstall = [ "out" "dev" ];
+          paths = with targetPackages.windows.sdks; [
+            crtDesktop
+            crtStore
+            ucrt
+            windowsSdkStoreAppLibs
+            windowsSdkDesktopLibs
+          ];
+          postBuild = ''
+            moveToOutput include "$dev"
+          '';
+        }).overrideAttrs (_: {
+          outputs = [ "out" "dev" ];
+        })
     else if stdenv.targetPlatform.useiOSPrebuilt then targetPackages.darwin.iosSdkPkgs.libraries or darwin.iosSdkPkgs.libraries
     else if name == "libSystem" then targetPackages.darwin.xcode
     else if name == "nblibc" then targetPackages.netbsdCross.libc
@@ -15876,7 +15897,9 @@ in
 
   libspnav = callPackage ../development/libraries/libspnav { };
 
-  libgsf = callPackage ../development/libraries/libgsf { };
+  libgsf = callPackage ../development/libraries/libgsf {
+    inherit (buildPackages) perl; # TODO figure out what is broken with splicing
+  };
 
   # GNU libc provides libiconv so systems with glibc don't need to build
   # libiconv separately. Additionally, Apple forked/repackaged libiconv so we

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20994,7 +20994,7 @@ in
 
   vndr = callPackage ../development/tools/vndr { };
 
-  windows = callPackages ../os-specific/windows {};
+  windows = callPackage ../os-specific/windows {};
 
   wirelesstools = callPackage ../os-specific/linux/wireless-tools { };
 


### PR DESCRIPTION
###### Motivation for this change

LLVM can do a much better job than GCC via MinGW. In particular, it can do abi-compatable C++ with MSVC, and has more features implemented such proper C++ threads.

I want this because I want Nix to run on Windows, and am continuing @volth's port to make it do so (https://github.com/NixOS/nix/pull/3185). However, I think it's important that we can purely build Nix for all supported platforms, and not ask developers to set up arcane stuff to test their PRs. Therefore I am making this as a self-imposed prerequisite. I need this to do so because Nix uses C++ threads.

Some of this stuff is rather rougher / and more patch heavy than I like my portability initiatives to be, and so I'll hold off trying to port many more packages until the far far future when the requisite tech debt is cleaned up and the portability is maintainable. But I can't do any less than this if I am to build Nix.

The base branch is very intentional, because I will want to merge to 19.09 in addition to master so Nix can use it from there in its CI.

This supports MinGW and Visual Studio headers and libs:
 - MinGW: `{ config = "x86_64-pc-mingw32"; useLLVM = true; }`
 - MSVC: `{ config = "x86_64-pc-windows-msvc"; useLLVM = true; }`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @angerman 
