### PR TITLE
uw-ttyp0: init at 1.3

### DIFF
--- a/pkgs/data/fonts/uw-ttyp0/default.nix
+++ b/pkgs/data/fonts/uw-ttyp0/default.nix
@@ -1,0 +1,78 @@
+{ stdenv, fetchurl, perl
+, bdftopcf, bdf2psf, mkfontdir
+, fonttosfnt
+, targetsDat  ? null
+, variantsDat ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "uw-ttyp0";
+  version = "1.3";
+
+  src = fetchurl {
+    url = "https://people.mpi-inf.mpg.de/~uwe/misc/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1vp053bwv8sr40p3pn4sjaiq570zp7knh99z9ynk30v7ml4cz2i8";
+  };
+
+  # remove for version >1.3
+  patches = [ ./determinism.patch ];
+
+  nativeBuildInputs = [ perl bdftopcf bdf2psf fonttosfnt mkfontdir ];
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash     = "0hzhaakbbcnz5ksi5p8mavw9578rsqlqadkrirrkhfnyqqlrii4j";
+
+  # configure sizes, encodings and variants
+  preConfigure =
+    (if targetsDat == null
+      then ''
+        cat << EOF > TARGETS.dat
+        SIZES = 11 12 13 14 15 16 17 18 22 \
+        11b 12b 13b 14b 15b 16b 17b 18b 22b 15i 16i 17i 18i
+        ENCODINGS = uni
+        EOF
+      ''
+      else ''cp "${targetsDat}" TARGETS.dat'') +
+    (if variantsDat == null
+      then ''
+        cat << EOF > VARIANTS.dat
+        COPYTO AccStress PApostropheAscii
+        COPYTO PAmComma AccGraveAscii
+        COPYTO Digit0Slashed Digit0
+        EOF
+      ''
+      else ''cp "${variantsDat}" VARIANTS.dat'');
+
+  postBuild = ''
+    # convert bdf to psf and otb fonts
+    build=$(pwd)
+    mkdir {psf,otb}
+    cd ${bdf2psf}/share/bdf2psf
+    for i in $build/genbdf/*.bdf; do
+      name="$(basename $i .bdf)"
+      bdf2psf \
+        --fb "$i" standard.equivalents \
+        ascii.set+useful.set+linux.set 512 \
+        "$build/psf/$name.psf"
+      fonttosfnt -v -o "$build/otb/$name.otb" "$i"
+    done
+    cd $build
+  '';
+
+  postInstall = ''
+    # install psf fonts
+    fontDir="$out/share/consolefonts"
+    mkdir -p "$fontDir"
+    mv -t "$fontDir" psf/*.psf
+    mv -t "$out/share/fonts/X11/misc" otb/*.otb
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Monospace bitmap screen fonts for X11";
+    homepage = https://people.mpi-inf.mpg.de/~uwe/misc/uw-ttyp0/;
+    license = with licenses; [ free mit ];
+    maintainers = with maintainers; [ rnhmjoj ];
+  };
+
+}

--- a/pkgs/data/fonts/uw-ttyp0/determinism.patch
+++ b/pkgs/data/fonts/uw-ttyp0/determinism.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index b9736cd..5740412 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -76,7 +76,7 @@ bdf : $(bdf)
+ 
+ genpcf/%.pcf.gz : genbdf/%.bdf
+ 	$(BDFTOPCF) $< > $(@:.pcf.gz=.pcf)
+-	gzip -9 -f $(@:.pcf.gz=.pcf)
++	gzip -n -9 -f $(@:.pcf.gz=.pcf)
+ 
+ genbdf/t0-11-uni.bdf : bdf/t0-11.bdf bdf/t0-12.bdf VARIANTS.dat mgl/unicode.mgl
+ 	$(MKSHALLOW) bdf/t0-12.bdf | cat - bdf/t0-11.bdf | $(BDFMANGLE) - VARIANTS.dat mgl/unicode.mgl > $@

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17756,6 +17756,8 @@ in
 
   unscii = callPackage ../data/fonts/unscii { };
 
+  uw-ttyp0 = callPackage ../data/fonts/uw-ttyp0 { inherit (xorg) fonttosfnt mkfontdir; };
+
   vanilla-dmz = callPackage ../data/icons/vanilla-dmz { };
 
   vdrsymbols = callPackage ../data/fonts/vdrsymbols { };


### PR DESCRIPTION
###### Motivation for this change

A nice bitmap font with good unicode support.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested in xterm and linux virtual console
- [x] Tested execution of all binary files (none)
- [x] Determined the impact on package closure size (n/a)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).