### PR TITLE
Ansible: Fix connection plugins and add support for NETCONF

### DIFF
--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -6,7 +6,6 @@
 , jinja2
 , pyyaml
 , httplib2
-, boto
 , six
 , netaddr
 , dnspython
@@ -29,8 +28,6 @@ buildPythonPackage rec {
   };
 
   prePatch = ''
-    sed -i "s,/usr/,$out," lib/ansible/constants.py
-
     # ansible-connection is wrapped, so make sure it's not passed
     # through the python interpreter.
     sed -i "s/\[python, /[/" lib/ansible/executor/task_executor.py

--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -29,6 +29,10 @@ buildPythonPackage rec {
 
   prePatch = ''
     sed -i "s,/usr/,$out," lib/ansible/constants.py
+
+    # ansible-connection is wrapped, so make sure it's not passed
+    # through the python interpreter.
+    sed -i "s/\[python, /[/" lib/ansible/executor/task_executor.py
   '';
 
   postInstall = ''

--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -12,6 +12,7 @@
 , dnspython
 , jmespath
 , dopy
+, ncclient
 , windowsSupport ? false
 , pywinrm
 }:
@@ -43,7 +44,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     pycrypto paramiko jinja2 pyyaml httplib2
-    six netaddr dnspython jmespath dopy
+    six netaddr dnspython jmespath dopy ncclient
   ] ++ lib.optional windowsSupport pywinrm;
 
   # dificult to test


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

1. Patches Ansible to use the unwrapped version of `ansible-connection`, as it executes it through a python interpreter, which currently results in a SyntaxError. Fixes #71342 

2. Includes `ncclient` to add support for netconf connections to configure network hardware.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - Before: `/nix/store/8hz5c81n1cfgwczn267y1prdizhw55q8-python3.7-ansible-2.8.4	 220.9M`
  - After: `/nix/store/azxh8l7bvkga12yk10zm0qscc5ai6cah-python3.7-ansible-2.8.4	 228.4M`
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @joamaki @costrouc 
