### PR TITLE
pulumi: install providers and add update script

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,0 +1,51 @@
+# DO NOT EDIT! This file is generated automatically by update.sh
+{ }:
+{
+  version = "1.4.0";
+  pulumiPkgs = {
+    x86_64-linux = [
+      {
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.4.0-linux-x64.tar.gz";
+        sha256 = "00ywy2ba4xha6gwd42i3fdrk1myivkd1r6ijdr2vkianmg524k6f";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v0.2.0-linux-amd64.tar.gz";
+        sha256 = "1hj4gysjipd091f106a7xz02g9cail5d11rn6j08m0xphg9cf3fn";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v1.4.1-linux-amd64.tar.gz";
+        sha256 = "0r6xpsb2riqmxwxw28lbi3xd7w4ds510gw99j1rr57h5b9bq19jj";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.2.3-linux-amd64.tar.gz";
+        sha256 = "0m7fajy3cy1agsz787ak548khwj8rwahs1ibaswqfyyw092iyzb9";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.7.0-linux-amd64.tar.gz";
+        sha256 = "1qw90l7h8yn06bz2l2995nbrc3svs223dm3ys1807amj4n2jyfwb";
+      }
+    ];
+    x86_64-darwin = [
+      {
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.4.0-darwin-x64.tar.gz";
+        sha256 = "02vqw9gn17dy3rfh0j00k9f827l42g3nl3rhlcbc8jbgx3n9c9qy";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v0.2.0-darwin-amd64.tar.gz";
+        sha256 = "077j9fp8ix00rcqrq8qxk3kvz6gz6sknzb2iv3qjvkh6yh292mz3";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v1.4.1-darwin-amd64.tar.gz";
+        sha256 = "1i2vf3bxwf8awvw183hq9bbnmznda1jpv1zqghgz2ybx4s0915nx";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.2.3-darwin-amd64.tar.gz";
+        sha256 = "123czx1c31r5r91k2jhdgmnffypnl8w1a6h9mr2rdhwgbx8hzq40";
+      }
+      {
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.7.0-darwin-amd64.tar.gz";
+        sha256 = "0cl0vakppxi0v8ym8b4fzhzb10nl84wd0vfik8gpfwsg7zwdzhlp";
+      }
+    ];
+  };
+}

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -3,26 +3,16 @@
 with lib;
 
 let
-
-  version = "1.4.0";
-
-  # switch the dropdown to “manual” on https://pulumi.io/quickstart/install.html # TODO: update script
-  pulumiArchPackage = {
-    x86_64-linux = {
-      url = "https://get.pulumi.com/releases/sdk/pulumi-v${version}-linux-x64.tar.gz";
-      sha256 = "00ywy2ba4xha6gwd42i3fdrk1myivkd1r6ijdr2vkianmg524k6f";
-    };
-    x86_64-darwin = {
-      url = "https://get.pulumi.com/releases/sdk/pulumi-v${version}-darwin-x64.tar.gz";
-      sha256 = "02vqw9gn17dy3rfh0j00k9f827l42g3nl3rhlcbc8jbgx3n9c9qy";
-    };
-  };
-
+  data = import ./data.nix {};
 in stdenv.mkDerivation {
-  inherit version;
   pname = "pulumi";
+  version = data.version;
 
-  src = fetchurl pulumiArchPackage.${stdenv.hostPlatform.system};
+  postUnpack = ''
+    mv pulumi-* pulumi
+  '';
+
+  srcs = map (x: fetchurl x) data.pulumiPkgs.${stdenv.hostPlatform.system};
 
   installPhase = ''
     mkdir -p $out/bin
@@ -35,9 +25,10 @@ in stdenv.mkDerivation {
     homepage = https://pulumi.io/;
     description = "Pulumi is a cloud development platform that makes creating cloud programs easy and productive";
     license = with licenses; [ asl20 ];
-    platforms = builtins.attrNames pulumiArchPackage;
+    platforms = builtins.attrNames data.pulumiPkgs;
     maintainers = with maintainers; [
       peterromfeldhk
+      jlesquembre
     ];
   };
 }

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+VERSION="1.4.0"
+
+declare -A plugins
+plugins=(
+    ["aws"]="1.7.0"
+    ["gcp"]="1.4.1"
+    ["kubernetes"]="1.2.3"
+    ["random"]="0.2.0"
+)
+
+function genMainSrc() {
+    local url="https://get.pulumi.com/releases/sdk/pulumi-v${VERSION}-$1-x64.tar.gz"
+    local sha256
+    sha256=$(nix-prefetch-url "$url")
+    echo "      {"
+    echo "        url = \"${url}\";"
+    echo "        sha256 = \"$sha256\";"
+    echo "      }"
+}
+
+function genSrcs() {
+    for plug in "${!plugins[@]}"; do
+        local version=${plugins[$plug]}
+        # url as defined here
+        # https://github.com/pulumi/pulumi/blob/06d4dde8898b2a0de2c3c7ff8e45f97495b89d82/pkg/workspace/plugins.go#L197
+        local url="https://api.pulumi.com/releases/plugins/pulumi-resource-${plug}-v${version}-$1-amd64.tar.gz"
+        local sha256
+        sha256=$(nix-prefetch-url "$url")
+        echo "      {"
+        echo "        url = \"${url}\";"
+        echo "        sha256 = \"$sha256\";"
+        echo "      }"
+    done
+}
+
+cat <<EOF
+# DO NOT EDIT! This file is generated automatically by update.sh
+{ }:
+{
+  version = "${VERSION}";
+  pulumiPkgs = {
+    x86_64-linux = [
+EOF
+genMainSrc "linux"
+genSrcs "linux"
+echo "    ];"
+
+echo "    x86_64-darwin = ["
+genMainSrc "darwin"
+genSrcs "darwin"
+echo "    ];"
+echo "  };"
+echo "}"


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Without providers (also called plugins) pulumi doesn't do much. The way
they work, if you want to use a provider, pulimi will look for it in
your PATH, and if not found it will download it. Providers are just
executables, but third party binaries usually don't work on nixos unless
they are patched with the patchelf utility. Because of that, I'm
installing some patched providers with the main pulumi binary.

I'm also adding a small script helper to generate the hashes for all the
binaries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peterromfeldhk
