### PR TITLE
tpm2-pkcs11: init at 1.0.1

### DIFF
--- a/pkgs/misc/tpm2-pkcs11/0001-configure-ac-version.patch
+++ b/pkgs/misc/tpm2-pkcs11/0001-configure-ac-version.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index e861e42..018c19c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -26,7 +26,7 @@
+ #;**********************************************************************;
+ 
+ AC_INIT([tpm2-pkcs11],
+-  [m4_esyscmd_s([git describe --tags --always --dirty])],
++  [git-@VERSION@],
+   [https://github.com/tpm2-software/tpm2-pkcs11/issues],
+   [],
+   [https://github.com/tpm2-software/tpm2-pkcs11])

--- a/pkgs/misc/tpm2-pkcs11/default.nix
+++ b/pkgs/misc/tpm2-pkcs11/default.nix
@@ -1,0 +1,79 @@
+{ stdenv, lib, fetchFromGitHub, substituteAll
+, pkgconfig, autoreconfHook, autoconf-archive, makeWrapper, patchelf
+, tpm2-tss, tpm2-tools, opensc, openssl, sqlite, python37, glibc, libyaml
+, abrmdSupport ? true, tpm2-abrmd ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tpm2-pkcs11";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "tpm2-software";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256:06kpf730al50xv1q53ahycky3im23ysrqp40libls4k24zxs9ha2";
+  };
+
+  patches = lib.singleton (
+    substituteAll {
+      src = ./0001-configure-ac-version.patch;
+      VERSION = version;
+    });
+
+  # The preConfigure phase doesn't seem to be working here
+  # ./bootstrap MUST be executed as the first step, before all
+  # of the autoreconfHook stuff
+  postPatch = ''
+    ./bootstrap
+  '';
+
+  nativeBuildInputs = [
+    pkgconfig autoreconfHook autoconf-archive makeWrapper patchelf
+  ];
+  buildInputs = [
+    tpm2-tss tpm2-tools opensc openssl sqlite libyaml
+    (python37.withPackages (ps: [ ps.pyyaml ps.cryptography ps.pyasn1-modules ]))
+  ];
+
+  outputs = [ "out" "bin" "dev" ];
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  # To be able to use the userspace resource manager, the RUNPATH must
+  # explicitly include the tpm2-abrmd shared libraries.
+  preFixup = let
+    rpath = lib.makeLibraryPath (
+      (lib.optional abrmdSupport tpm2-abrmd)
+      ++ [
+        tpm2-tss
+        sqlite
+        openssl
+        glibc
+        libyaml
+      ]
+    );
+  in ''
+    patchelf \
+      --set-rpath ${rpath} \
+      ${lib.optionalString abrmdSupport "--add-needed ${lib.makeLibraryPath [tpm2-abrmd]}/libtss2-tcti-tabrmd.so"} \
+      --add-needed ${lib.makeLibraryPath [tpm2-tss]}/libtss2-tcti-device.so \
+      $out/lib/libtpm2_pkcs11.so.0.0.0
+  '';
+
+  postInstall = ''
+    mkdir -p $bin/bin/ $bin/share/tpm2_pkcs11/
+    mv ./tools/* $bin/share/tpm2_pkcs11/
+    makeWrapper $bin/share/tpm2_pkcs11/tpm2_ptool.py $bin/bin/tpm2_ptool \
+      --prefix PATH : ${lib.makeBinPath [ tpm2-tools ]}
+  '';
+
+  meta = with lib; {
+    description = "A PKCS#11 interface for TPM2 hardware";
+    homepage = https://github.com/tpm2-software/tpm2-pkcs11;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lschuermann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6847,6 +6847,8 @@ in
 
   tpm2-abrmd = callPackage ../tools/security/tpm2-abrmd { };
 
+  tpm2-pkcs11 = callPackage ../misc/tpm2-pkcs11 { };
+
   tpm2-tools = callPackage ../tools/security/tpm2-tools { };
 
   trezor-udev-rules = callPackage ../os-specific/linux/trezor-udev-rules {};


### PR DESCRIPTION
This PR adds the TPM2 PKCS11 module as a Nix package.

It has a default target, which is the PKCS11 shared library (with the `rpath` correctly set to include all other required shared libraries). In addition to that, the `bin` target (selected by default for instance with `nix-shell -p`) makes the `tpm2_ptool` Python application for management available. Together with #72029 and this [setup guide](https://github.com/tpm2-software/tpm2-pkcs11/blob/master/docs/INITIALIZING.md), usage is pretty straightforward.


###### Motivation for this change
I'd like to use my TPM2 chip as a generic Smartcard. This, for instance, enables storing SSH keys on a hardware device, which can improve security drastically.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@lassulus 
