### PR TITLE
stdenv/check-meta: getEnv if the attribute is unset

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -13,8 +13,7 @@ let
   # for why this defaults to false, but I (@copumpkin) want to default it to true soon.
   shouldCheckMeta = config.checkMeta or false;
 
-  allowUnfree = config.allowUnfree or false
-    || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
+  allowUnfree = config.allowUnfree or false;
 
   whitelist = config.whitelistedLicenses or [];
   blacklist = config.blacklistedLicenses or [];
@@ -41,11 +40,9 @@ let
   hasBlacklistedLicense = assert areLicenseListsValid; attrs:
     hasLicense attrs && builtins.elem attrs.meta.license blacklist;
 
-  allowBroken = config.allowBroken or false
-    || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
+  allowBroken = config.allowBroken or false;
 
-  allowUnsupportedSystem = config.allowUnsupportedSystem or false
-    || builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
+  allowUnsupportedSystem = config.allowUnsupportedSystem or false;
 
   isUnfree = licenses: lib.lists.any (l: !l.free or true) licenses;
 
@@ -73,7 +70,7 @@ let
   hasAllowedInsecure = attrs:
     (attrs.meta.knownVulnerabilities or []) == [] ||
     allowInsecurePredicate attrs ||
-    builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
+    config.allowInsecure or false;
 
   showLicense = license: license.shortName or "unknown";
 

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -10,6 +10,14 @@ let
   # Return ‘x’ if it evaluates, or ‘def’ if it throws an exception.
   try = x: def: let res = tryEval x; in if res.success then res.value else def;
 
+  defaultConfig = {
+    # These attributes are used in pkgs/stdenv/generic/check-meta.nix
+    allowBroken = builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
+    allowInsecure = builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
+    allowUnfree = builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
+    allowUnsupportedSystem = builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
+  };
+
 in
 
 { # We combine legacy `system` and `platform` into `localSystem`, if
@@ -82,7 +90,10 @@ in
 assert args ? localSystem -> !(args ? system || args ? platform);
 
 import ./. (builtins.removeAttrs args [ "system" "platform" ] // {
-  inherit config overlays crossSystem crossOverlays;
+  inherit overlays crossSystem crossOverlays;
+
+  config = defaultConfig // config;
+
   # Fallback: Assume we are building packages on the current (build, in GNU
   # Autotools parlance) system.
   localSystem = if builtins.isString localSystem then localSystem


### PR DESCRIPTION
There were two issues:

* builtins.getEnv was called deep into the nixpkgs tree making it hard
  to discover. This is solved by moving the call into
  pkgs/top-level/impure.nix
* when the config was explicitly set by the user to false, it would
  still try and load the environment variable. This meant that it was
  not possible to guarantee the same outcome on two different systems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
