### PR TITLE
jhead: add patches for CVE-2019-1010301, CVE-2019-1010302

### DIFF
--- a/pkgs/tools/graphics/jhead/default.nix
+++ b/pkgs/tools/graphics/jhead/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libjpeg }:
+{ stdenv, fetchurl, fetchpatch, libjpeg }:
 
 stdenv.mkDerivation rec {
   pname = "jhead";
@@ -8,6 +8,19 @@ stdenv.mkDerivation rec {
     url = "http://www.sentex.net/~mwandel/jhead/${pname}-${version}.tar.gz";
     sha256 = "1hn0yqcicq3qa20h1g313l1a671r8mccpb9gz0w1056r500lw6c2";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-1010301.patch";
+      url = "https://sources.debian.org/data/main/j/jhead/1:3.03-3/debian/patches/36_CVE-2019-1010301";
+      sha256 = "1vvrg50z5y7sjhfi973wh1q1v79sqp7hk5d4z0dlnx3fqgkjrx7q";
+    })
+    (fetchpatch {
+      name = "CVE-2019-1010302.patch";
+      url = "https://sources.debian.org/data/main/j/jhead/1:3.03-3/debian/patches/37_CVE-2019-1010302";
+      sha256 = "1h11mpsi7hpwbi8kpnkjwn6zpqf88f132h0rsg8sggcs3vva2x8y";
+    })
+  ];
 
   buildInputs = [ libjpeg ];
 


### PR DESCRIPTION
##### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-1010301
https://nvd.nist.gov/vuln/detail/CVE-2019-1010302

Most of the discussion/fixing of this issue has happened here https://bugzilla.redhat.com/show_bug.cgi?id=1679952 with little help from upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
