### PR TITLE
opensmtpd: 6.4.2p1 -> 6.6.1p1

### DIFF
--- a/nixos/modules/services/mail/opensmtpd.nix
+++ b/nixos/modules/services/mail/opensmtpd.nix
@@ -101,6 +101,12 @@ in {
       };
     };
 
+    systemd.tmpfiles.rules = [
+      "d /var/spool/smtpd 711 root - - -"
+      "d /var/spool/smtpd/offline 770 root smtpq - -"
+      "d /var/spool/smtpd/purge 700 smtpq root - -"
+    ];
+
     systemd.services.opensmtpd = let
       procEnv = pkgs.buildEnv {
         name = "opensmtpd-procs";
@@ -110,18 +116,6 @@ in {
     in {
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      preStart = ''
-        mkdir -p /var/spool/smtpd
-        chmod 711 /var/spool/smtpd
-
-        mkdir -p /var/spool/smtpd/offline
-        chown root.smtpq /var/spool/smtpd/offline
-        chmod 770 /var/spool/smtpd/offline
-
-        mkdir -p /var/spool/smtpd/purge
-        chown smtpq.root /var/spool/smtpd/purge
-        chmod 700 /var/spool/smtpd/purge
-      '';
       serviceConfig.ExecStart = "${cfg.package}/sbin/smtpd -d -f ${conf} ${args}";
       environment.OPENSMTPD_PROC_PATH = "${procEnv}/libexec/opensmtpd";
     };

--- a/nixos/tests/opensmtpd.nix
+++ b/nixos/tests/opensmtpd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix {
+import ./make-test-python.nix {
   name = "opensmtpd";
 
   nodes = {
@@ -102,23 +102,23 @@ import ./make-test.nix {
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $client->waitForUnit("network-online.target");
-    $smtp1->waitForUnit('opensmtpd');
-    $smtp2->waitForUnit('opensmtpd');
-    $smtp2->waitForUnit('dovecot2');
+    client.wait_for_unit("network-online.target")
+    smtp1.wait_for_unit("opensmtpd")
+    smtp2.wait_for_unit("opensmtpd")
+    smtp2.wait_for_unit("dovecot2")
 
     # To prevent sporadic failures during daemon startup, make sure
     # services are listening on their ports before sending requests
-    $smtp1->waitForOpenPort(25);
-    $smtp2->waitForOpenPort(25);
-    $smtp2->waitForOpenPort(143);
+    smtp1.wait_for_open_port(25)
+    smtp2.wait_for_open_port(25)
+    smtp2.wait_for_open_port(143)
 
-    $client->succeed('send-a-test-mail');
-    $smtp1->waitUntilFails('smtpctl show queue | egrep .');
-    $smtp2->waitUntilFails('smtpctl show queue | egrep .');
-    $client->succeed('check-mail-landed >&2');
+    client.succeed("send-a-test-mail")
+    smtp1.wait_until_fails("smtpctl show queue | egrep .")
+    smtp2.wait_until_fails("smtpctl show queue | egrep .")
+    client.succeed("check-mail-landed >&2")
   '';
 
   meta.timeout = 30;

--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -4,14 +4,14 @@
 
 stdenv.mkDerivation rec {
   pname = "opensmtpd";
-  version = "6.4.2p1";
+  version = "6.6.1p1";
 
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ libasr libevent zlib libressl db pam ];
 
   src = fetchurl {
     url = "https://www.opensmtpd.org/archives/${pname}-${version}.tar.gz";
-    sha256 = "0pgv080ai7d98l9340jadp9wjiaqj2qvgpqhilcz0kps2mdiawbd";
+    sha256 = "1ngil8j13m2rq07g94j4yjr6zmaimzy8wbfr17shi7rxnazys6zb";
   };
 
   patches = [
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
   # See https://github.com/OpenSMTPD/OpenSMTPD/issues/885 for the `sh bootstrap`
   # requirement
   postPatch = ''
-    substituteInPlace smtpd/parse.y \
-      --replace "/usr/libexec/" "$out/libexec/opensmtpd/"
     substituteInPlace mk/smtpctl/Makefile.am --replace "chgrp" "true"
     substituteInPlace mk/smtpctl/Makefile.am --replace "chmod 2555" "chmod 0555"
     sh bootstrap


### PR DESCRIPTION
The substitition in smtpd/parse.y isn't necessary anymore (it's gone).

opensmtpd 6.6.0p1 fails to build with libressl like this:
```
    make[1]: Entering directory '/build/opensmtpd-6.6.0p1'
    Making all in openbsd-compat
    make[2]: Entering directory '/build/opensmtpd-6.6.0p1/openbsd-compat'
    gcc -DHAVE_CONFIG_H -I. -I..  -I../smtpd -I../openbsd-compat -I../openbsd-compat/err_h -I/nix/store/7hgyarrzkhvp47ynwljabdfy28vzwjwb-libevent-2.1.11-dev/include   -ffunction-sections -c -o arc4random.o arc4random.c
    arc4random.c:167:21: error: macro "arc4random_stir" passed 1 arguments, but takes just 0
     arc4random_stir(void)
                         ^
    arc4random.c:168:1: error: expected '=', ',', ';', 'asm' or '__attribute__' before '{' token
     {
     ^
    make[2]: *** [Makefile:445: arc4random.o] Error 1
    make[2]: Leaving directory '/build/opensmtpd-6.6.0p1/openbsd-compat'
    make[1]: *** [Makefile:419: all-recursive] Error 1
    make[1]: Leaving directory '/build/opensmtpd-6.6.0p1'
    make: *** [Makefile:351: all] Error 2
```
Internet suggests it's a libressl-specific issue, so build with openssl for now.

Also update the module to use tmpfiles to set up the spool directories.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ekleog @rickynils @obadz 
