### PR TITLE
nixos/gnupg: add dbus dependencies for gnome3 pinentry

### DIFF
--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -121,6 +121,8 @@ in
       wantedBy = [ "sockets.target" ];
     };
 
+    services.dbus.packages = mkIf (cfg.agent.pinentryFlavor == "gnome3") [ pkgs.gcr ];
+
     environment.systemPackages = with pkgs; [ cfg.package ];
     systemd.packages = [ cfg.package ];
 


### PR DESCRIPTION
###### Motivation for this change

`pinentry.gnome3` doesn't work without `gcr` in `dbus.packages`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
- Built on platform(s)
   - [X] NixOS
- [X] Tested that `pinentry` works after this change.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @globin
