### PR TITLE
transifex-client: Fix build

### DIFF
--- a/pkgs/tools/text/transifex-client/default.nix
+++ b/pkgs/tools/text/transifex-client/default.nix
@@ -15,9 +15,9 @@ buildPythonApplication rec {
   };
 
   prePatch = ''
-    substituteInPlace requirements.txt --replace "urllib3<1.24" "urllib3<2.0" \
-      --replace "six==1.11.0" "six<2.0.0" \
-      --replace "python-slugify==1.2.6" "python-slugify<4.0.0"
+    substituteInPlace requirements.txt --replace "urllib3<1.24" "urllib3>=1.24" \
+      --replace "six==1.11.0" "six>=1.11.0" \
+      --replace "python-slugify==1.2.6" "python-slugify>=1.2.6"
   '';
 
   # Requires external resources


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
We have updated python-slugify to 4.0.0 (or newer) which broke the
build. This has happened several times before without actually
breaking the software.

So yeah, lets just accept newer versions and fix it if it breaks for
some other reason in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
