### PR TITLE
veracrypt: 1.23-Hotfix-2 -> 1.24-Hotfix1

### DIFF
--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -1,21 +1,36 @@
-{ stdenv, fetchurl, pkgconfig, makeself, yasm, fuse, unzip, wxGTK, lvm2 }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, makeself, yasm, fuse, wxGTK, lvm2 }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "veracrypt";
-  version = "1.23";
-  minorVersion = "-Hotfix-2";
+  version = "1.24-Hotfix1";
 
   src = fetchurl {
-    url = "https://launchpad.net/${pname}/trunk/${version}/+download/VeraCrypt_${version}${minorVersion}_Source.zip";
-    sha256 = "229de81b2478cfa5fa73e74e60798a298cd616e9852b9f47b484c80bc2a2c259";
+    url = "https://launchpad.net/${pname}/trunk/${toLower version}/+download/VeraCrypt_${version}_Source.tar.bz2";
+    sha256 = "8b40ece805b216843d7a71b1a30069c4057931341b030bf65caace59263c5c8c";
   };
+
+
+  patches = [
+    # https://github.com/veracrypt/VeraCrypt/issues/529 - fix build on non-x86
+    (fetchpatch {
+      url = "https://github.com/veracrypt/VeraCrypt/commit/afe6b2f45b15393026a1159e5f3d165ac7d0b94a.patch";
+      sha256 = "1xm9cl6zinlr0vah5xr9bvh0y9gw4331zl7d2n5xvqrcdxw3ww1y";
+      stripLen = 1;
+    })
+    # https://github.com/veracrypt/VeraCrypt/issues/529 - fix build on non-x86
+    (fetchpatch {
+      url = "https://github.com/veracrypt/VeraCrypt/commit/3fa636d477119fff6e372074568edb42d038f508.patch";
+      sha256 = "0qsccilip0ksnlzxina38a052gb533r4s422lxhrj3wv9zgpp7l3";
+      stripLen = 1;
+    })
+  ];
 
   sourceRoot = "src";
 
   nativeBuildInputs = [ makeself pkgconfig yasm ];
-  buildInputs = [ fuse lvm2 unzip wxGTK ];
+  buildInputs = [ fuse lvm2 wxGTK ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to latest

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
