### PR TITLE
[19.09] backport #71851 handbrake: fix missing audio

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -3,7 +3,7 @@
 # Derivation patches HandBrake to use Nix closure dependencies.
 #
 
-{ stdenv, lib, fetchurl,
+{ stdenv, lib, fetchurl, fetchpatch,
   # Main build tools
   python2, pkgconfig, autoconf, automake, cmake, nasm, libtool, m4,
   # Processing, video codecs, containers
@@ -60,6 +60,13 @@ stdenv.mkDerivation rec {
   # don't trigger cmake build
   dontUseCmakeConfigure = true;
   enableParallelBuilding = true;
+
+  # The samplerate patch should be removed when HandBrake 1.3.0 is released
+  patches = [(fetchpatch {
+    name = "set-ffmpeg-samplerate.patch";
+    url = "https://patch-diff.githubusercontent.com/raw/HandBrake/HandBrake/pull/2126.patch";
+    sha256 = "00lds9h27cvyr53qpvv8gbv01hfxdxd8gphxcwbwg8akqrvk9gbf";
+  })];
 
   preConfigure = ''
     patchShebangs scripts


### PR DESCRIPTION
We build HandBrake with a newer ffmpeg than upstream expects,
triggering a problem where the audio samplerate defaults to zero
because HandBrake was not explicitly setting it.

This has been fixed in HandBrake upstream, but we must cherry pick
this change in order to produce videos with audio until HandBrake
1.3.0 is released.

(cherry picked from commit d51e366ffee3bef79f39a541bdc3acf6d84cf149)

###### Motivation for this change
backport handbrake audio fix to 19.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

