### PR TITLE
waylandpp: 0.2.5 -> 0.2.7, make it split-output package

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -183,7 +183,7 @@ in stdenv.mkDerivation {
     ++ lib.optional  usbSupport      libusb
     ++ lib.optional  vdpauSupport    libvdpau
     ++ lib.optionals useWayland [
-      wayland waylandpp
+      wayland waylandpp.dev
       # Not sure why ".dev" is needed here, but CMake doesn't find libxkbcommon otherwise
       libxkbcommon.dev
     ]
@@ -200,7 +200,7 @@ in stdenv.mkDerivation {
       which
       pkgconfig gnumake
       autoconf automake libtool # still needed for some components. Check if that is the case with 19.0
-    ] ++ lib.optionals useWayland [ wayland-protocols ];
+    ] ++ lib.optionals useWayland [ wayland-protocols waylandpp.bin ];
 
     cmakeFlags = [
       "-Dlibdvdcss_URL=${libdvdcss.src}"

--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -1,18 +1,26 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, pugixml, wayland, libGL }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, pugixml, wayland, libGL
+, docSupport ? true, doxygen ? null }:
 
+assert docSupport -> doxygen != null;
+
+with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "waylandpp";
-  version = "0.2.5";
+  version = "0.2.7";
 
   src = fetchFromGitHub {
     owner = "NilsBrause";
     repo = pname;
     rev = version;
-    sha256 = "16h57hzd688664qcyznzhjp3hxipdkzgv46x82yhkww24av8b55n";
+    sha256 = "1r4m0xhvwpcqxrqvp3hz1bzlkxqj2jiymd5r6hj8xjzz536hyprz";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig ] ++ optional docSupport doxygen;
   buildInputs = [ pugixml wayland libGL ];
+
+  outputs = [ "bin" "dev" "lib" "out" ] ++ optionals docSupport [ "doc" "devman" ];
+
+  cmakeFlags = [ "-DCMAKE_INSTALL_DATADIR=${placeholder "dev"}" ];
 
   meta = with stdenv.lib; {
     description = "Wayland C++ binding";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bigger numbers is better. Multiple output packages are nicer, and better for cross-compilation (although I didn't test cross compilation).

It wasn't possible to upgrade to Waylandpp 0.2.6 because kodi-wayland failed to compile, but this was fixed with [this waylandpp commit](https://github.com/NilsBrause/waylandpp/commit/fef85e50eb39e6c709fb473c17dcd2aa009f0dbe). 

Closes #70811

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Result of `nix-review` [1](https://github.com/Mic92/nix-review)
<details>
  <summary>3 package were build:</summary>

  - kodi-wayland
  - kodiPlainWayland
  - waylandpp
</details>

###### Notify maintainers

That's me.

For the Kodi modifications:

@domenkozar @titanous @edwtjo @peterhoeg @sephalon 