### PR TITLE
flexibee: 2019.3.0.3 -> 2019.3.0.7 and adding the server binary

### DIFF
--- a/pkgs/applications/office/flexibee/default.nix
+++ b/pkgs/applications/office/flexibee/default.nix
@@ -16,11 +16,20 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  prePatch = ''
+    substituteInPlace usr/sbin/flexibee-server \
+      --replace "/usr/share/flexibee" $out \
+      --replace "/var/run" "/run"
+  '';
+
+
   installPhase = ''
     runHook preInstall
     cp -R usr/share/flexibee/ $out/
     install -Dm755 usr/bin/flexibee $out/bin/flexibee
+    install -Dm755 usr/sbin/flexibee-server $out/bin/flexibee-server
     wrapProgram  $out/bin/flexibee --set JAVA_HOME "${jre}"
+    wrapProgram $out/bin/flexibee-server --set JAVA_HOME "${jre}"
     runHook postInstall
   '';
 

--- a/pkgs/applications/office/flexibee/default.nix
+++ b/pkgs/applications/office/flexibee/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper, jre }:
 
 let
-  version = "2019.3.0.3";
+  version = "2019.3.0.7";
   majorVersion = builtins.substring 0 6 version;
 in
 
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://download.flexibee.eu/download/${majorVersion}/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1ivhqh1rl4ll0af9nfgfm7f647vc9zk61aplinvz73xb3grb4j6f";
+    sha256 = "01n2pkh17s2iab7n9xgq9vqcf1fnzmb382zmmd1lwyw3x57f5rq2";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     cp -R usr/share/flexibee/ $out/
     install -Dm755 usr/bin/flexibee $out/bin/flexibee
     install -Dm755 usr/sbin/flexibee-server $out/bin/flexibee-server
-    wrapProgram  $out/bin/flexibee --set JAVA_HOME "${jre}"
+    wrapProgram $out/bin/flexibee --set JAVA_HOME "${jre}"
     wrapProgram $out/bin/flexibee-server --set JAVA_HOME "${jre}"
     runHook postInstall
   '';


### PR DESCRIPTION
###### Motivation for this change

ChangeLog https://www.flexibee.eu/k/prehled-verzi-flexibee/prehled-verzi-flexibee-2019/

And packaging the flexibee-server binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
