### PR TITLE
duplicacy: 2.1.2 -> 2.2.3

### DIFF
--- a/pkgs/tools/backup/duplicacy/default.nix
+++ b/pkgs/tools/backup/duplicacy/default.nix
@@ -2,15 +2,15 @@
 
 buildGoPackage rec {
   pname = "duplicacy";
-  version = "2.1.2";
+  version = "2.3.0";
 
-  goPackagePath = "github.com/gilbertchen/duplicacy/";
+  goPackagePath = "github.com/gilbertchen/duplicacy";
 
   src = fetchFromGitHub {
     owner = "gilbertchen";
     repo = "duplicacy";
     rev = "v${version}";
-    sha256 = "0v3rk4da4b6dhqq8zsr4z27wd8p7crxapkn265kwpsaa99xszzbv";
+    sha256 = "12swp3kbwkmwn3g2mp964m60kabmz0ip7kkhvhiqq7k74nxzj312";
   };
   goDeps = ./deps.nix;
   buildPhase = ''
@@ -24,7 +24,7 @@ buildGoPackage rec {
 
   meta = with lib; {
     homepage = https://duplicacy.com;
-    description = "A new generation cloud backup tool ";
+    description = "A new generation cloud backup tool";
     platforms = platforms.linux ++ platforms.darwin;
     license = lib.licenses.unfree;
     maintainers = with maintainers; [ ffinkdevs ];

--- a/pkgs/tools/backup/duplicacy/deps.nix
+++ b/pkgs/tools/backup/duplicacy/deps.nix
@@ -104,8 +104,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/gilbertchen/go.dbus";
-      rev =  "9e442e6378618c083fd3b85b703ffd202721fb17";
-      sha256 = "0q8ld38gnr4adzw5287lw5f5l14yp8slxsz1za5ryrkprh04bhkv";
+      rev =  "8591994fa32f1dbe3fa9486bc6f4d4361ac16649";
+      sha256 = "0wg82hwgk4s65ns76x7cby6dfdxsdkc4jyqn9zd7g037fhzh8rk5";
     };
   }
   {
@@ -230,8 +230,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/pkg/sftp";
-      rev =  "98203f5a8333288eb3163b7c667d4260fe1333e9";
-      sha256 = "09wxyrhwwh20rzpzb06vsj8k2bmw52cjlx7j4115zhky27528sx9";
+      rev =  "3edd153f213d8d4191a0ee4577c61cca19436632";
+      sha256 = "0iw6lijdljwh5xw5hsy0b578cr52h6vvm7hbnzlrvciwhh4sfhhp";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

