### PR TITLE
qmapshack: 1.13.2 -> 1.14.0

### DIFF
--- a/pkgs/applications/misc/qmapshack/default.nix
+++ b/pkgs/applications/misc/qmapshack/default.nix
@@ -3,16 +3,13 @@
 
 mkDerivation rec {
   pname = "qmapshack";
-  version = "1.13.2";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "Maproom";
     repo = pname;
-    # TODO: remove it on next release.
-    # 1.13.2 release tarball is essentially broken, use fixed commit instead.
-    # See https://github.com/maproom/qmapshack/pull/4 for more details.
-    rev = "763cfc149566325cce9e4690cb7b5f986048f86a"; #"V_${version}";
-    sha256 = "1lfivhm9rv9ly1srlmb7d80s77306xplg23lx35vav879bri29rx";
+    rev = "V_${version}";
+    sha256 = "07c2hrq9sn456w7l3gdr599rmjfv2k6mh159zza7p1py8r7ywksa";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

[Changelog](https://github.com/Maproom/qmapshack/blob/dev/changelog.txt)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dotlambda, @markuskowa 
