### PR TITLE
python3Packages.solo-python: 0.0.15 -> 0.0.18

### DIFF
--- a/pkgs/development/python-modules/solo-python/default.nix
+++ b/pkgs/development/python-modules/solo-python/default.nix
@@ -1,21 +1,22 @@
-{ lib, buildPythonPackage, fetchFromGitHub
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
 , click, ecdsa, fido2, intelhex, pyserial, pyusb, requests}:
 
  buildPythonPackage rec {
   pname = "solo-python";
-  version = "0.0.15";
+  version = "0.0.18";
   format = "flit";
+  disabled = pythonOlder "3.6"; # only python>=3.6 is supported
 
   src = fetchFromGitHub {
     owner = "solokeys";
     repo = pname;
     rev = version;
-    sha256 = "14na9s65hxzx141bdv0j7rx1wi3cv85jzpdivsq1rwp6hdhiazr1";
+    sha256 = "01mgppjvxlr93vrgz7bzisghpg1vqyaj4cg5wngk0h499iyx4d9q";
   };
 
-  # TODO: remove ASAP
+  # replaced pinned fido, with unrestricted fido version
   patchPhase = ''
-    substituteInPlace pyproject.toml --replace "fido2 == 0.7.0" "fido2 >= 0.7.0"
+    sed -i '/fido2/c\"fido2",' pyproject.toml
   '';
 
   propagatedBuildInputs = [
@@ -26,6 +27,20 @@
     pyserial
     pyusb
     requests
+  ];
+
+  # allow for writable directory for darwin
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+
+  # repo doesn't contain tests, ensure imports aren't broken
+  pythonImportsCheck = [
+    "solo"
+    "solo.cli"
+    "solo.commands"
+    "solo.fido2"
+    "solo.operations"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
##### Motivation for this change
while doing #72445, noticed this was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

python3.8 version is broken by pyfakefs being broken
```
builder for '/nix/store/vkcl9ymxif4j8zrijc7vwanhxjhw4xl2-python3.8-pyfakefs-3.6.1.drv' failed with exit code 1; last 10 log lines:
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/build/pyfakefs-3.6.1/pyfakefs/tests/fake_filesystem_shutil_test.py", line 263, in test_copytree_src_is_file
      self.assertRaises(OSError,
  AssertionError: OSError not raised by copytree

  ----------------------------------------------------------------------
  Ran 1853 tests in 4.219s

  FAILED (failures=1, errors=8, skipped=717, expected failures=2)
cannot build derivation '/nix/store/wpgdr6xvvkv9kp7n7c1hk3k8kzxcr8cm-python3.8-fido2-0.7.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/nmwhwbra1pf8plv54h4kqymrwyfikg05-python3.8-solo-python-0.0.18.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/w396yxh764mix1kpk7sd1dl4dp2brpa8-env.drv': 1 dependencies couldn't be built
[0 built (1 failed), 6 copied (0.9 MiB), 0.2 MiB DL]
error: build of '/nix/store/w396yxh764mix1kpk7sd1dl4dp2brpa8-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/72449
1 package failed to build:
python38Packages.solo-python

1 package were build:
python37Packages.solo-python
```