### PR TITLE
[19.09] imagemagick bumps

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -13,8 +13,8 @@ let
     else throw "ImageMagick is not supported on this platform.";
 
   cfg = {
-    version = "7.0.8-66";
-    sha256 = "0wih8ag5i6qg2zhbjrlcripb5ic5l6i1z04chnlgykb84n5pcirv";
+    version = "7.0.8-68";
+    sha256 = "07p3gdqdfmip7066n8v7ark8kgffg7miiin814lj4zg6p3h0aja7";
     patches = [];
   };
 in

--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -13,8 +13,8 @@ let
     else throw "ImageMagick is not supported on this platform.";
 
   cfg = {
-    version = "7.0.8-68";
-    sha256 = "07p3gdqdfmip7066n8v7ark8kgffg7miiin814lj4zg6p3h0aja7";
+    version = "7.0.9-0";
+    sha256 = "1w7ci7v5qlayd7a5z69px94fz3fshvn1diqw7k1ymsyvz5888d39";
     patches = [];
   };
 in

--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -13,8 +13,8 @@ let
     else throw "ImageMagick is not supported on this platform.";
 
   cfg = {
-    version = "7.0.8-58";
-    sha256 = "0yfw32nydwy7ag7ina1zc6yssa146x4v35hjv6v59bci9mmj9fb1";
+    version = "7.0.8-66";
+    sha256 = "0wih8ag5i6qg2zhbjrlcripb5ic5l6i1z04chnlgykb84n5pcirv";
     patches = [];
   };
 in

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -13,8 +13,8 @@ let
     else throw "ImageMagick is not supported on this platform.";
 
   cfg = {
-    version = "6.9.10-68";
-    sha256 = "0ldkw6j4x0k7l6ykgpx9hz9cs7dmlapz2lv3lbrgz2nn9znqswxk";
+    version = "6.9.10-69";
+    sha256 = "0l4lllis16gbwjpvvsyfz91i9nq11zb3lg2zlmyay7v5697jshh6";
     patches = [];
   }
     # Freeze version on mingw so we don't need to port the patch too often.


### PR DESCRIPTION
###### Motivation for this change
Backport imagemagick version bumps to 19.09. Contains CVE fixes.

See https://github.com/NixOS/nixpkgs/pull/71099 and https://github.com/NixOS/nixpkgs/pull/72098 for details. Might break gscan2pdf.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @veprbl 
