### PR TITLE
trac: init at 1.4

### DIFF
--- a/pkgs/tools/misc/trac/default.nix
+++ b/pkgs/tools/misc/trac/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, Babel
+, docutils
+, pygments
+, pytz
+, jinja2
+, pysqlite
+, psycopg2
+, pymysql
+, git
+, setuptools
+}:
+
+
+buildPythonApplication rec {
+  pname = "trac";
+  version = "1.4";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "Trac";
+    sha256 = "1cg51rg0vb9vf23wgn28z3szlxhwnxprj5m0mvibqyypi123bvx1";
+  };
+
+  prePatch = ''
+    # Removing the date format tests as they are outdated
+    substituteInPlace trac/util/tests/__init__.py \
+      --replace "suite.addTest(datefmt.test_suite())" ""
+  '';
+
+  propagatedBuildInputs = [
+    Babel
+    docutils
+    pygments
+    pytz
+    jinja2
+    pysqlite
+    psycopg2
+    pymysql
+    git
+    setuptools
+  ];
+
+  meta = with lib; {
+    description = "Integrated SCM, wiki, issue tracker and project environment";
+    homepage = "https://trac.edgewall.org/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mmahut ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2881,6 +2881,8 @@ in
   tsm-client = callPackage ../tools/backup/tsm-client { jdk8 = null; };
   tsm-client-withGui = callPackage ../tools/backup/tsm-client { };
 
+  trac = pythonPackages.callPackage ../tools/misc/trac { };
+
   tracker = callPackage ../development/libraries/tracker { };
 
   tracker-miners = callPackage ../development/libraries/tracker-miners { };


### PR DESCRIPTION
###### Motivation for this change

trac: init at 1.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).