### PR TITLE
spirv-tools: 2019.3 -> 2019.4

### DIFF
--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -1,18 +1,15 @@
 { stdenv, fetchFromGitHub, cmake, python3, spirv-headers }:
-let
-  # Update spirv-headers rev in lockstep according to DEPs file
-  version = "2019.3";
-in
 
 stdenv.mkDerivation rec {
   pname = "spirv-tools";
-  inherit version;
+  # Update spirv-headers rev in lockstep according to DEPs file
+  version = "2019.4";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
     rev = "v${version}";
-    sha256 = "1wvipjcjsi815ls08s3dz9hwlbb59dbl4syxkskg1k9d5jjph1a8";
+    sha256 = "17bbvhk4p42x4jlvcr5p9903xiiryw57c8yyfxmqik10s8601an9";
   };
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken in hydra logs

broken by #71882, found through bisect

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/72457
1 package were build:
spirv-tools
```