### PR TITLE
vapoursynth-editor: use qt's mkDerivation

### DIFF
--- a/pkgs/development/libraries/vapoursynth/editor.nix
+++ b/pkgs/development/libraries/vapoursynth/editor.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchFromBitbucket, makeWrapper
+{ stdenv, mkDerivation, fetchFromBitbucket
 , python3, vapoursynth
 , qmake, qtbase, qtwebsockets
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "vapoursynth-editor";
   version = "R19";
 
@@ -14,18 +14,20 @@ stdenv.mkDerivation rec {
     sha256 = "1zlaynkkvizf128ln50yvzz3b764f5a0yryp6993s9fkwa7djb6n";
   };
 
-  nativeBuildInputs = [ qmake makeWrapper ];
+  nativeBuildInputs = [ qmake ];
   buildInputs = [ qtbase vapoursynth qtwebsockets ];
+
+  dontWrapQtApps = true;
 
   preConfigure = "cd pro";
 
-  installPhase = ''
+  preFixup = ''
     cd ../build/release*
     mkdir -p $out/bin
     for bin in vsedit{,-job-server{,-watcher}}; do
         mv $bin $out/bin
 
-        wrapProgram $out/bin/$bin \
+        wrapQtApp $out/bin/$bin \
             --prefix PYTHONPATH : ${vapoursynth}/${python3.sitePackages} \
             --prefix LD_LIBRARY_PATH : ${vapoursynth}/lib
     done


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
