### PR TITLE
pythonPackages.flask-cors: fix build

### DIFF
--- a/pkgs/development/python-modules/flask-cors/default.nix
+++ b/pkgs/development/python-modules/flask-cors/default.nix
@@ -10,8 +10,14 @@ buildPythonPackage rec {
     sha256 = "05id72xwvhni23yasdvpdd8vsf3v4j6gzbqqff2g04j6xcih85vj";
   };
 
-  buildInputs = [ nose ];
+  checkInputs = [ nose ];
   propagatedBuildInputs = [ flask six ];
+
+  # Exclude test_acl_uncaught_exception_500 test case because is not compatible
+  # with Flask>=1.1.0. See: https://github.com/corydolphin/flask-cors/issues/253
+  checkPhase = ''
+    nosetests --exclude test_acl_uncaught_exception_500
+  '';
 
   meta = with stdenv.lib; {
     description = "A Flask extension adding a decorator for CORS support";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/72446
cc: @sjau

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
