### PR TITLE
rustc: add support for armv7l targets

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, echo_build_heading, noisily, makeDeps }:
+{ lib, stdenv, echo_build_heading, noisily, makeDeps, rustPlatform }:
 { crateName,
   dependencies,
   crateFeatures, crateRenames, libName, release, libPath,
@@ -14,16 +14,6 @@
         (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOpts);
     rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";
 
-    # Some platforms have different names for rustc.
-    rustPlatform =
-      with stdenv.hostPlatform.parsed;
-      let cpu_ = if cpu.name == "armv7a" then "armv7"
-                 else cpu.name;
-          vendor_ = vendor.name;
-          kernel_ = kernel.name;
-          abi_ = abi.name;
-      in
-      "${cpu_}-${vendor_}-${kernel_}-${abi_}";
   in ''
     runHook preBuild
     norm=""
@@ -67,7 +57,7 @@
         ${crateFeatures} --out-dir target/bin --emit=dep-info,link -L dependency=target/deps \
         $LINK ${deps}$EXTRA_LIB --cap-lints allow \
         $BUILD_OUT_DIR $EXTRA_BUILD $EXTRA_FEATURES --color ${colors} \
-        ${if stdenv.hostPlatform != stdenv.buildPlatform then "--target ${rustPlatform} -C linker=${stdenv.hostPlatform.config}-gcc" else ""}
+        ${if stdenv.hostPlatform != stdenv.buildPlatform then "--target ${rustPlatform.toRustTarget stdenv.hostPlatform} -C linker=${stdenv.hostPlatform.config}-gcc" else ""}
       if [ "$crate_name_" != "$crate_name" ]; then
         mv target/bin/$crate_name_ target/bin/$crate_name
       fi

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -4,7 +4,7 @@
 # This can be useful for deploying packages with NixOps, and to share
 # binary dependencies between projects.
 
-{ lib, stdenv, defaultCrateOverrides, fetchCrate, rustc }:
+{ lib, stdenv, defaultCrateOverrides, fetchCrate, rustc, rustPlatform }:
 
 let
     # This doesn't appear to be officially documented anywhere yet.
@@ -59,7 +59,7 @@ let
     '';
 
     configureCrate = import ./configure-crate.nix { inherit lib stdenv echo_build_heading noisily makeDeps; };
-    buildCrate = import ./build-crate.nix { inherit lib stdenv echo_build_heading noisily makeDeps; };
+    buildCrate = import ./build-crate.nix { inherit lib stdenv echo_build_heading noisily makeDeps rustPlatform; };
     installCrate = import ./install-crate.nix;
 
     in

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cacert, git, cargo, rustc, fetchcargo, buildPackages, windows }:
+{ stdenv, cacert, git, cargo, rust, rustc, fetchcargo, buildPackages, windows }:
 
 { name ? "${args.pname}-${args.version}"
 , cargoSha256 ? "unset"
@@ -46,12 +46,7 @@ let
       cargoDepsCopy="$sourceRoot/${cargoVendorDir}"
     '';
 
-  hostConfig = stdenv.hostPlatform.config;
-
-  rustHostConfig = {
-    x86_64-pc-mingw32 = "x86_64-pc-windows-gnu";
-  }.${hostConfig} or hostConfig;
-  rustTarget = if target == null then rustHostConfig else target;
+  rustTarget = if target == null then (rust.toRustTarget stdenv.hostPlatform) else target;
 
   ccForBuild="${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc";
   cxxForBuild="${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}c++";
@@ -129,10 +124,10 @@ stdenv.mkDerivation (args // {
     (
     set -x
     env \
-      "CC_${stdenv.buildPlatform.config}"="${ccForBuild}" \
-      "CXX_${stdenv.buildPlatform.config}"="${cxxForBuild}" \
-      "CC_${stdenv.hostPlatform.config}"="${ccForHost}" \
-      "CXX_${stdenv.hostPlatform.config}"="${cxxForHost}" \
+      "CC_${rust.toRustTarget stdenv.buildPlatform}"="${ccForBuild}" \
+      "CXX_${rust.toRustTarget stdenv.buildPlatform}"="${cxxForBuild}" \
+      "CC_${rust.toRustTarget stdenv.hostPlatform}"="${ccForHost}" \
+      "CXX_${rust.toRustTarget stdenv.hostPlatform}"="${cxxForHost}" \
       cargo build \
         ${stdenv.lib.optionalString (buildType == "release") "--release"} \
         --target ${rustTarget} \

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -11,13 +11,23 @@
 , llvmPackages_5
 , pkgsBuildTarget, pkgsBuildBuild
 }: rec {
-  makeRustPlatform = { rustc, cargo, ... }: {
+  toRustTarget = platform: {
+        "x86_64-pc-mingw32" = "x86_64-pc-windows-gnu";
+      }.${platform.config} or (with platform.parsed; let
+        cpu_ = {
+          "armv7a" = "armv7";
+          "armv7l" = "armv7";
+          "armv6l" = "arm";
+        }.${cpu.name} or cpu.name;
+      in "${cpu_}-${vendor.name}-${kernel.name}-${abi.name}");
+
+  makeRustPlatform = { rustc, cargo, ... }: rec {
     rust = {
-      inherit rustc cargo;
+      inherit rustc cargo toRustTarget;
     };
 
     buildRustPackage = callPackage ../../../build-support/rust {
-      inherit rustc cargo;
+      inherit rustc cargo rust;
 
       fetchcargo = buildPackages.callPackage ../../../build-support/rust/fetchcargo.nix {
         inherit cargo;

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -68,9 +68,9 @@ in stdenv.mkDerivation rec {
     "--set=build.cargo=${rustPlatform.rust.cargo}/bin/cargo"
     "--enable-rpath"
     "--enable-vendor"
-    "--build=${stdenv.buildPlatform.config}"
-    "--host=${stdenv.hostPlatform.config}"
-    "--target=${stdenv.targetPlatform.config}"
+    "--build=${rustPlatform.rust.toRustTarget stdenv.buildPlatform}"
+    "--host=${rustPlatform.rust.toRustTarget stdenv.hostPlatform}"
+    "--target=${rustPlatform.rust.toRustTarget stdenv.targetPlatform}"
 
     "${setBuild}.cc=${ccForBuild}"
     "${setHost}.cc=${ccForHost}"


### PR DESCRIPTION
###### Motivation for this change
rustc and Rust packages would not compile on Raspbian on a Raspberry Pi. It turns out that Rust's ARMv7 targets are slightly different from Nix's.

Addresses issue #72473


###### Things done
This change adds a function that maps `armv7a` and `armv7l` architectures to `armv7`. The former are used in Raspbian on Raspberry Pi but are unknown to rustc. Rust knows only `armv7`.
    
In addition, this change also disables the `m_hugefile` test in `e2fsprogs` as it was failing on ARMv7 Raspbian on the Raspberry Pi.


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edolstra @madjar @cstrahan @globin @Havvy