### PR TITLE
darling: 11b51fw -> 0.2019.8

### DIFF
--- a/pkgs/os-specific/darwin/darling/default.nix
+++ b/pkgs/os-specific/darwin/darling/default.nix
@@ -1,19 +1,15 @@
-{stdenv, lib, fetchzip}:
+{stdenv, lib, fetchFromGitHub}:
 
 stdenv.mkDerivation rec {
   pname = "darling";
   name = pname;
+  version = "0.2019.8";
 
-  src = fetchzip {
-    url = "https://github.com/darlinghq/darling/archive/d2cc5fa748003aaa70ad4180fff0a9a85dc65e9b.tar.gz";
-    sha256 = "11b51fw47nl505h63bgx5kqiyhf3glhp1q6jkpb6nqfislnzzkrf";
-    postFetch = ''
-      # Get rid of case conflict
-      mkdir $out
-      cd $out
-      tar -xzf $downloadedFile --strip-components=1
-      rm -r $out/src/libm
-    '';
+  src = fetchFromGitHub {
+    owner = "darlinghq";
+    repo = "darling";
+    rev = "v${version}";
+    sha256 = "1v3isad22fxn7vcs7yzy0j1wvsfgzk9mrszpigl17di4bgq2xri3";
   };
 
   # only packaging sandbox for now


### PR DESCRIPTION
Darling now has a release tag available on GitHub. This release includes
darlinghq/darling@c45e7204c7848729b89957f14ef1b3b742edb8af, a fix that
makes it possible to install on macOS. I'm not entirely sure why Darling
needs to be installed on macOS, but as long as it is, being able to
install it is important.

This will also switch from `fetchzip` to `fetchFromGitHub` which removes
a little of the overhead needed to install and clean up Darling.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
