### PR TITLE
nodePackages.coc-prettier: init at 1.1.10

### DIFF
--- a/pkgs/development/node-packages/node-packages-v10.json
+++ b/pkgs/development/node-packages/node-packages-v10.json
@@ -18,6 +18,7 @@
 , "browserify"
 , "castnow"
 , "clean-css"
+, "coc-prettier"
 , "coffee-script"
 , "coinmon"
 , "configurable-http-proxy"

--- a/pkgs/development/node-packages/node-packages-v10.nix
+++ b/pkgs/development/node-packages/node-packages-v10.nix
@@ -13,67 +13,67 @@ let
         sha512 = "t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==";
       };
     };
-    "@angular-devkit/architect-0.803.5" = {
+    "@angular-devkit/architect-0.803.17" = {
       name = "_at_angular-devkit_slash_architect";
       packageName = "@angular-devkit/architect";
-      version = "0.803.5";
+      version = "0.803.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.803.5.tgz";
-        sha512 = "hOcYF5fG3oieTc/C1QZqXsON8m8cpdtfdWhY7F7tmqqZ4JBR7igH4SSFQOoQwTj77rsqtkOLI9isVLpoSGX0DQ==";
+        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.803.17.tgz";
+        sha512 = "QbuWJhjh78Pb/9574OIjR38hhJCRBd0BtdrRRdTjP7By6liXURnA/OH6iZ9o1jA8It1NvoJQtM2flr8dQf83Mw==";
       };
     };
-    "@angular-devkit/core-8.3.5" = {
+    "@angular-devkit/core-8.3.17" = {
       name = "_at_angular-devkit_slash_core";
       packageName = "@angular-devkit/core";
-      version = "8.3.5";
+      version = "8.3.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.5.tgz";
-        sha512 = "ag7Nr94wQUqCFtZjw+rMET+djGBmLk989Id5lLWViW99g4XFeS+e45mJv3JYRzF218+6EdicZz0DGQRYHekVeg==";
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.17.tgz";
+        sha512 = "cR2H/7OxxqagwGfzxwNWDOYN4QpOZ56Fei9JED/2p/K/5UDAowl20o3qP9mTfia/lEhFeyjMBcM8gsHxhJNYJQ==";
       };
     };
-    "@angular-devkit/schematics-8.3.5" = {
+    "@angular-devkit/schematics-8.3.17" = {
       name = "_at_angular-devkit_slash_schematics";
       packageName = "@angular-devkit/schematics";
-      version = "8.3.5";
+      version = "8.3.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.3.5.tgz";
-        sha512 = "RMtM10kS+Docg90jzFMa4HQ+UzX95Gi5rCT/kSydEkBhp+Jeu/B0K2y67Fm2/qTdVNRCujrCpEmtiRcp1qsOQg==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.3.17.tgz";
+        sha512 = "1ttzYGnw5Ux7Nfr/TGyWx3C/rarq5l+dn+5SpKof/8ctvQU1gJaswF492ngPs/jDjaPq5MucKYoX+wTUJHnUhg==";
       };
     };
-    "@antora/asciidoc-loader-2.1.1" = {
+    "@antora/asciidoc-loader-2.1.2" = {
       name = "_at_antora_slash_asciidoc-loader";
       packageName = "@antora/asciidoc-loader";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-2.1.1.tgz";
-        sha512 = "5j4wKrLgoiIoghqMYv9FkEstISozG753L5YMuQ5sbiQToKhZp4frKx8hZfrwlUCyGQ9BKqIVlkhkPValkpp26g==";
+        url = "https://registry.npmjs.org/@antora/asciidoc-loader/-/asciidoc-loader-2.1.2.tgz";
+        sha512 = "Hm/E+ff5HgafFi4iAkMHTHP0/iHRrTg96wnX4fFtogHW3tuAOCN+e0d1e4HmHeUwRwy+PSJgXECKyswWA5h8cw==";
       };
     };
-    "@antora/content-aggregator-2.1.1" = {
+    "@antora/content-aggregator-2.1.2" = {
       name = "_at_antora_slash_content-aggregator";
       packageName = "@antora/content-aggregator";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-2.1.1.tgz";
-        sha512 = "uORcwPt2js5i6m492zOyszU0+GA748+Zvcrwf6jeOWsBePyYIVxI2L6TmJ8Ulw65scEQOKTrvsITb8lFCVLkWQ==";
+        url = "https://registry.npmjs.org/@antora/content-aggregator/-/content-aggregator-2.1.2.tgz";
+        sha512 = "yNhtS2JcHlwcgz06HS2jtkWmbruxqRENT2raN9xk1PkKeubDEOKmbBXNQHvUjQviDXwpB2jehgIpGFlo/UcqoA==";
       };
     };
-    "@antora/content-classifier-2.1.1" = {
+    "@antora/content-classifier-2.1.2" = {
       name = "_at_antora_slash_content-classifier";
       packageName = "@antora/content-classifier";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-2.1.1.tgz";
-        sha512 = "HQlDCoycTxk8IDMx4IaaNkqlHcik5Q22L2/nHQTevYfiErS4wfCmern1O42DvPj72VT72JnnDg87WBvTgZTRTA==";
+        url = "https://registry.npmjs.org/@antora/content-classifier/-/content-classifier-2.1.2.tgz";
+        sha512 = "JiuBrvJFmjtvka5zcpYOxXbf8n7wWTHDcCMsCxFeadoyXBvUrdGHmT/oKq9/IiyCrda9onwV/IY/mdrD4Gr9uQ==";
       };
     };
-    "@antora/document-converter-2.1.1" = {
+    "@antora/document-converter-2.1.2" = {
       name = "_at_antora_slash_document-converter";
       packageName = "@antora/document-converter";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/document-converter/-/document-converter-2.1.1.tgz";
-        sha512 = "WnMHE5JCkdOYFQ7ytqq2d6Wj0zmy2ifXzU1M2Eo7ZwbSxjkrLVGRFlPbTIybdgnqhIss6ef01qZ+F/+8ZBTFvw==";
+        url = "https://registry.npmjs.org/@antora/document-converter/-/document-converter-2.1.2.tgz";
+        sha512 = "gmjXV5gSkDi6dhagojQAMHeMH0jvqmkce8AZCPAePeQfc5gpdiSCtRMP/vld5InfYQJ40ckxdQilPqFUpxJk3Q==";
       };
     };
     "@antora/expand-path-helper-1.0.0" = {
@@ -85,67 +85,76 @@ let
         sha512 = "hg3y6M3OvRTb7jtLAnwwloYDxafbyKYttcf16kGCXvP7Wqosh7c+Ag+ltaZ7VSebpzpphO/umb/BXdpU7rxapw==";
       };
     };
-    "@antora/navigation-builder-2.1.1" = {
+    "@antora/navigation-builder-2.1.2" = {
       name = "_at_antora_slash_navigation-builder";
       packageName = "@antora/navigation-builder";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-2.1.1.tgz";
-        sha512 = "H3VmqIfvuCTAae7Xd1rWYXhQKXhvCLhr0lxWeuSvVp6xzTo3Zf/VnhCGlllLoB+69PSCfcSEm2J5oCy6ySa6WA==";
+        url = "https://registry.npmjs.org/@antora/navigation-builder/-/navigation-builder-2.1.2.tgz";
+        sha512 = "LDc5j9VJWjeBtvGHiQWd3GHSJAUXuLze5oRpO3WaHjlR6oxt0q9vlfWWNTQg+5yj0BBXdINkHv+LzuxcWys0mw==";
       };
     };
-    "@antora/page-composer-2.1.1" = {
+    "@antora/page-composer-2.1.2" = {
       name = "_at_antora_slash_page-composer";
       packageName = "@antora/page-composer";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/page-composer/-/page-composer-2.1.1.tgz";
-        sha512 = "PqxMt+s4aTCW2woC/MjjfTG1Hy20A3olsW7ZqpanAao+CGdcqeGbu9LFh65lKGL3MOM0NBIDJG0qqX1RNBX1Nw==";
+        url = "https://registry.npmjs.org/@antora/page-composer/-/page-composer-2.1.2.tgz";
+        sha512 = "COMB+t/9l/QM4G6o3VwP+IBkI24CvhTp2yEmlt/dQ0JE1yFuO/jEKGXmBoL02rll3g/WRlUxSIGNJLt7R1QWZQ==";
       };
     };
-    "@antora/playbook-builder-2.1.1" = {
+    "@antora/playbook-builder-2.1.2" = {
       name = "_at_antora_slash_playbook-builder";
       packageName = "@antora/playbook-builder";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-2.1.1.tgz";
-        sha512 = "mdsV8OJq9gbw8IUOhNI5+gCfPJl5UyS7H/TbE4oVimebHpmHSld3/GKc7DjuR0Ge4jxNxwlRyDEtfQiNvnBmug==";
+        url = "https://registry.npmjs.org/@antora/playbook-builder/-/playbook-builder-2.1.2.tgz";
+        sha512 = "JggjwTxiguVyAJaOuAVqpg06aYtahYiTXmSsczOILEEP6viehxuXS1dbNCqg+xwvdvPxJhsBI5x3bfWhcTWs0w==";
       };
     };
-    "@antora/redirect-producer-2.1.1" = {
+    "@antora/redirect-producer-2.1.2" = {
       name = "_at_antora_slash_redirect-producer";
       packageName = "@antora/redirect-producer";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-2.1.1.tgz";
-        sha512 = "jdnx19b5qlbjUZCwSGrUTUozRPj39OxTr8PeF3jp+qD+TMZuA6XV/6Qp6d1TN2d6a5PQ+d5852g+B2wZmPMIoQ==";
+        url = "https://registry.npmjs.org/@antora/redirect-producer/-/redirect-producer-2.1.2.tgz";
+        sha512 = "Y5H5/7Mm9c6rMnLMTRI+c3f2AqHisMDAvBy8OyBW75rlg2+fwG1I1VdZxOoTkCXmAS93QyPX/wDymbRUpiBOHQ==";
       };
     };
-    "@antora/site-mapper-2.1.1" = {
+    "@antora/site-mapper-2.1.2" = {
       name = "_at_antora_slash_site-mapper";
       packageName = "@antora/site-mapper";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-2.1.1.tgz";
-        sha512 = "nJvzzu/S4B+qm5SLfNToaC576spPx/FGZqvS99QbRQ11KK10y7rqERlq/wR/nu1IL+zISgw5zJW3qNlTq9YSIg==";
+        url = "https://registry.npmjs.org/@antora/site-mapper/-/site-mapper-2.1.2.tgz";
+        sha512 = "KgXn7W47HW7WIYuoptawvkXq2Fg1Es6zn0IlTCyQF/zjQmfoxgHrMk6dW93YjD75RdhKTEeI7hhMzKfwoTYRHA==";
       };
     };
-    "@antora/site-publisher-2.1.1" = {
+    "@antora/site-publisher-2.1.2" = {
       name = "_at_antora_slash_site-publisher";
       packageName = "@antora/site-publisher";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-2.1.1.tgz";
-        sha512 = "sGuUeIV5bo4VgbnVN6lJNLnVrJWJyyM1rfu5eInOvPru0dQ5zzH8ij93q+5Lxc30zwj+TDI371AFluzz+TWK3A==";
+        url = "https://registry.npmjs.org/@antora/site-publisher/-/site-publisher-2.1.2.tgz";
+        sha512 = "5ekXPBRk3YMVeqhPCnPdjKNRqcI8OKqxisVhWplS/YgY9n2TGICyz01ZtAmueWD0l3mHH5cJRfPHPnTPNXc7Aw==";
       };
     };
-    "@antora/ui-loader-2.1.1" = {
+    "@antora/ui-loader-2.1.2" = {
       name = "_at_antora_slash_ui-loader";
       packageName = "@antora/ui-loader";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-2.1.1.tgz";
-        sha512 = "/fPYFRtJsUp4LwOu1MrstAcd+BQFdr5afb5l0iaAi3GuXLLLMasdCIH0jByi4GSiNsYlJ6P+/Jbv+BiUiMY/cg==";
+        url = "https://registry.npmjs.org/@antora/ui-loader/-/ui-loader-2.1.2.tgz";
+        sha512 = "fHjJ0wBr0NIaWn6+xDMFOtCc7kf7sdt8I9g/r090X4lImodD2rNm5Jf3wnvAL91M66hDrFaJmE2Fkpbv8fmkBA==";
+      };
+    };
+    "@apollo/federation-0.10.2" = {
+      name = "_at_apollo_slash_federation";
+      packageName = "@apollo/federation";
+      version = "0.10.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@apollo/federation/-/federation-0.10.2.tgz";
+        sha512 = "N+JoD7YraGAgDJq1GTkAzRRPUA+FgclFgAUcUDng9ICA4N147nuGUrbrpQdgLnE59nCLJAhcFvOgQRs177XMWw==";
       };
     };
     "@apollographql/apollo-tools-0.4.0" = {
@@ -155,6 +164,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.0.tgz";
         sha512 = "7wEO+S+zgz/wVe3ilFQqICufRBYYDSNUkd1V03JWvXuSydbYq2SM5EgvWmFF+04iadt+aQ0XCCsRzCzRPQODfQ==";
+      };
+    };
+    "@apollographql/graphql-language-service-interface-2.0.2" = {
+      name = "_at_apollographql_slash_graphql-language-service-interface";
+      packageName = "@apollographql/graphql-language-service-interface";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@apollographql/graphql-language-service-interface/-/graphql-language-service-interface-2.0.2.tgz";
+        sha512 = "28wePK0hlIVjgmvMXMAUq8qRSjz9O+6lqFp4PzOTHtfJfSsjVe9EfjF98zTpHsTgT3HcOxmbqDZZy8jlXtOqEA==";
+      };
+    };
+    "@apollographql/graphql-language-service-parser-2.0.2" = {
+      name = "_at_apollographql_slash_graphql-language-service-parser";
+      packageName = "@apollographql/graphql-language-service-parser";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@apollographql/graphql-language-service-parser/-/graphql-language-service-parser-2.0.2.tgz";
+        sha512 = "rpTPrEJu1PMaRQxz5P8BZWsixNNhYloS0H0dwTxNBuE3qctbARvR7o8UCKLsmKgTbo+cz3T3a6IAsWlkHgMWGg==";
+      };
+    };
+    "@apollographql/graphql-language-service-types-2.0.2" = {
+      name = "_at_apollographql_slash_graphql-language-service-types";
+      packageName = "@apollographql/graphql-language-service-types";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@apollographql/graphql-language-service-types/-/graphql-language-service-types-2.0.2.tgz";
+        sha512 = "vE+Dz8pG+Xa1Z2nMl82LoO66lQ6JqBUjaXqLDvS3eMjvA3N4hf+YUDOWfPdNZ0zjhHhHXzUIIZCkax6bXfFbzQ==";
+      };
+    };
+    "@apollographql/graphql-language-service-utils-2.0.2" = {
+      name = "_at_apollographql_slash_graphql-language-service-utils";
+      packageName = "@apollographql/graphql-language-service-utils";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@apollographql/graphql-language-service-utils/-/graphql-language-service-utils-2.0.2.tgz";
+        sha512 = "fDj5rWlTi/czvUS5t7V7I45Ai6bOO3Z7JARYj21Y2xxfbRGtJi6h8FvLX0N/EbzQgo/fiZc/HAhtfwn+OCjD7A==";
       };
     };
     "@apollographql/graphql-playground-html-1.6.24" = {
@@ -184,15 +229,6 @@ let
         sha1 = "e70187f8a862e191b1bce6c0268f13acd3a56b20";
       };
     };
-    "@babel/code-frame-7.0.0" = {
-      name = "_at_babel_slash_code-frame";
-      packageName = "@babel/code-frame";
-      version = "7.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz";
-        sha512 = "OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==";
-      };
-    };
     "@babel/code-frame-7.5.5" = {
       name = "_at_babel_slash_code-frame";
       packageName = "@babel/code-frame";
@@ -202,22 +238,13 @@ let
         sha512 = "27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==";
       };
     };
-    "@babel/core-7.3.4" = {
+    "@babel/core-7.6.4" = {
       name = "_at_babel_slash_core";
       packageName = "@babel/core";
-      version = "7.3.4";
+      version = "7.6.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz";
-        sha512 = "jRsuseXBo9pN197KnDwhhaaBzyZr2oIcLHHTt2oDdQrej5Qp57dCCJafWx5ivU8/alEYDpssYqv1MUqcxwQlrA==";
-      };
-    };
-    "@babel/core-7.6.0" = {
-      name = "_at_babel_slash_core";
-      packageName = "@babel/core";
-      version = "7.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz";
-        sha512 = "FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==";
+        url = "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz";
+        sha512 = "Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==";
       };
     };
     "@babel/generator-7.0.0-beta.38" = {
@@ -229,22 +256,13 @@ let
         sha512 = "aOHQPhsEyaB6p2n+AK981+onHoc+Ork9rcAQVSUJR33wUkGiWRpu6/C685knRyIZVsKeSdG5Q4xMiYeFUhuLzA==";
       };
     };
-    "@babel/generator-7.3.4" = {
+    "@babel/generator-7.6.4" = {
       name = "_at_babel_slash_generator";
       packageName = "@babel/generator";
-      version = "7.3.4";
+      version = "7.6.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz";
-        sha512 = "8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==";
-      };
-    };
-    "@babel/generator-7.6.0" = {
-      name = "_at_babel_slash_generator";
-      packageName = "@babel/generator";
-      version = "7.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz";
-        sha512 = "Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==";
+        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz";
+        sha512 = "jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==";
       };
     };
     "@babel/helper-annotate-as-pure-7.0.0" = {
@@ -436,13 +454,13 @@ let
         sha512 = "o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==";
       };
     };
-    "@babel/helpers-7.6.0" = {
+    "@babel/helpers-7.6.2" = {
       name = "_at_babel_slash_helpers";
       packageName = "@babel/helpers";
-      version = "7.6.0";
+      version = "7.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz";
-        sha512 = "W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==";
+        url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz";
+        sha512 = "3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==";
       };
     };
     "@babel/highlight-7.5.0" = {
@@ -454,22 +472,13 @@ let
         sha512 = "7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==";
       };
     };
-    "@babel/parser-7.3.4" = {
+    "@babel/parser-7.6.4" = {
       name = "_at_babel_slash_parser";
       packageName = "@babel/parser";
-      version = "7.3.4";
+      version = "7.6.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz";
-        sha512 = "tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==";
-      };
-    };
-    "@babel/parser-7.6.0" = {
-      name = "_at_babel_slash_parser";
-      packageName = "@babel/parser";
-      version = "7.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz";
-        sha512 = "+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==";
+        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz";
+        sha512 = "D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==";
       };
     };
     "@babel/plugin-external-helpers-7.0.0" = {
@@ -517,13 +526,13 @@ let
         sha512 = "MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==";
       };
     };
-    "@babel/plugin-proposal-object-rest-spread-7.5.5" = {
+    "@babel/plugin-proposal-object-rest-spread-7.6.2" = {
       name = "_at_babel_slash_plugin-proposal-object-rest-spread";
       packageName = "@babel/plugin-proposal-object-rest-spread";
-      version = "7.5.5";
+      version = "7.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz";
-        sha512 = "F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==";
+        url = "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz";
+        sha512 = "LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==";
       };
     };
     "@babel/plugin-proposal-optional-catch-binding-7.2.0" = {
@@ -535,13 +544,13 @@ let
         sha512 = "mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==";
       };
     };
-    "@babel/plugin-proposal-unicode-property-regex-7.4.4" = {
+    "@babel/plugin-proposal-unicode-property-regex-7.6.2" = {
       name = "_at_babel_slash_plugin-proposal-unicode-property-regex";
       packageName = "@babel/plugin-proposal-unicode-property-regex";
-      version = "7.4.4";
+      version = "7.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz";
-        sha512 = "j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==";
+        url = "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz";
+        sha512 = "NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==";
       };
     };
     "@babel/plugin-syntax-async-generators-7.2.0" = {
@@ -643,13 +652,13 @@ let
         sha512 = "ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==";
       };
     };
-    "@babel/plugin-transform-block-scoping-7.6.0" = {
+    "@babel/plugin-transform-block-scoping-7.6.3" = {
       name = "_at_babel_slash_plugin-transform-block-scoping";
       packageName = "@babel/plugin-transform-block-scoping";
-      version = "7.6.0";
+      version = "7.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.0.tgz";
-        sha512 = "tIt4E23+kw6TgL/edACZwP1OUKrjOTyMrFMLoT5IOFrfMRabCgekjqFd5o6PaAMildBu46oFkekIdMuGkkPEpA==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz";
+        sha512 = "7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==";
       };
     };
     "@babel/plugin-transform-classes-7.5.5" = {
@@ -679,13 +688,13 @@ let
         sha512 = "2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==";
       };
     };
-    "@babel/plugin-transform-dotall-regex-7.4.4" = {
+    "@babel/plugin-transform-dotall-regex-7.6.2" = {
       name = "_at_babel_slash_plugin-transform-dotall-regex";
       packageName = "@babel/plugin-transform-dotall-regex";
-      version = "7.4.4";
+      version = "7.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz";
-        sha512 = "P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz";
+        sha512 = "KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==";
       };
     };
     "@babel/plugin-transform-duplicate-keys-7.5.0" = {
@@ -706,22 +715,13 @@ let
         sha512 = "umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==";
       };
     };
-    "@babel/plugin-transform-flow-strip-types-7.3.4" = {
+    "@babel/plugin-transform-flow-strip-types-7.6.3" = {
       name = "_at_babel_slash_plugin-transform-flow-strip-types";
       packageName = "@babel/plugin-transform-flow-strip-types";
-      version = "7.3.4";
+      version = "7.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.3.4.tgz";
-        sha512 = "PmQC9R7DwpBFA+7ATKMyzViz3zCaMNouzZMPZN2K5PnbBbtL3AXFYTkDk+Hey5crQq2A90UG5Uthz0mel+XZrA==";
-      };
-    };
-    "@babel/plugin-transform-flow-strip-types-7.4.4" = {
-      name = "_at_babel_slash_plugin-transform-flow-strip-types";
-      packageName = "@babel/plugin-transform-flow-strip-types";
-      version = "7.4.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz";
-        sha512 = "WyVedfeEIILYEaWGAUWzVNyqG4sfsNooMhXWsu/YzOvVGcsnPb5PguysjJqI3t3qiaYj0BR8T2f5njdjTGe44Q==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.6.3.tgz";
+        sha512 = "l0ETkyEofkqFJ9LS6HChNIKtVJw2ylKbhYMlJ5C6df+ldxxaLIyXY4yOdDQQspfFpV8/vDiaWoJlvflstlYNxg==";
       };
     };
     "@babel/plugin-transform-for-of-7.4.4" = {
@@ -769,15 +769,6 @@ let
         sha512 = "n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==";
       };
     };
-    "@babel/plugin-transform-modules-commonjs-7.2.0" = {
-      name = "_at_babel_slash_plugin-transform-modules-commonjs";
-      packageName = "@babel/plugin-transform-modules-commonjs";
-      version = "7.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz";
-        sha512 = "V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==";
-      };
-    };
     "@babel/plugin-transform-modules-commonjs-7.6.0" = {
       name = "_at_babel_slash_plugin-transform-modules-commonjs";
       packageName = "@babel/plugin-transform-modules-commonjs";
@@ -805,13 +796,13 @@ let
         sha512 = "BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==";
       };
     };
-    "@babel/plugin-transform-named-capturing-groups-regex-7.6.0" = {
+    "@babel/plugin-transform-named-capturing-groups-regex-7.6.3" = {
       name = "_at_babel_slash_plugin-transform-named-capturing-groups-regex";
       packageName = "@babel/plugin-transform-named-capturing-groups-regex";
-      version = "7.6.0";
+      version = "7.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.0.tgz";
-        sha512 = "jem7uytlmrRl3iCAuQyw8BpB4c4LWvSpvIeXKpMb+7j84lkx4m4mYr5ErAcmN5KM7B6BqrAvRGjBIbbzqCczew==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz";
+        sha512 = "jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==";
       };
     };
     "@babel/plugin-transform-new-target-7.4.4" = {
@@ -877,13 +868,13 @@ let
         sha512 = "fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==";
       };
     };
-    "@babel/plugin-transform-runtime-7.6.0" = {
+    "@babel/plugin-transform-runtime-7.6.2" = {
       name = "_at_babel_slash_plugin-transform-runtime";
       packageName = "@babel/plugin-transform-runtime";
-      version = "7.6.0";
+      version = "7.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz";
-        sha512 = "Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz";
+        sha512 = "cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==";
       };
     };
     "@babel/plugin-transform-shorthand-properties-7.2.0" = {
@@ -895,13 +886,13 @@ let
         sha512 = "QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==";
       };
     };
-    "@babel/plugin-transform-spread-7.2.2" = {
+    "@babel/plugin-transform-spread-7.6.2" = {
       name = "_at_babel_slash_plugin-transform-spread";
       packageName = "@babel/plugin-transform-spread";
-      version = "7.2.2";
+      version = "7.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz";
-        sha512 = "KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz";
+        sha512 = "DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==";
       };
     };
     "@babel/plugin-transform-sticky-regex-7.2.0" = {
@@ -931,49 +922,40 @@ let
         sha512 = "2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==";
       };
     };
-    "@babel/plugin-transform-typescript-7.6.0" = {
+    "@babel/plugin-transform-typescript-7.6.3" = {
       name = "_at_babel_slash_plugin-transform-typescript";
       packageName = "@babel/plugin-transform-typescript";
-      version = "7.6.0";
+      version = "7.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.0.tgz";
-        sha512 = "yzw7EopOOr6saONZ3KA3lpizKnWRTe+rfBqg4AmQbSow7ik7fqmzrfIqt053osLwLE2AaTqGinLM2tl6+M/uog==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.3.tgz";
+        sha512 = "aiWINBrPMSC3xTXRNM/dfmyYuPNKY/aexYqBgh0HBI5Y+WO5oRAqW/oROYeYHrF4Zw12r9rK4fMk/ZlAmqx/FQ==";
       };
     };
-    "@babel/plugin-transform-unicode-regex-7.4.4" = {
+    "@babel/plugin-transform-unicode-regex-7.6.2" = {
       name = "_at_babel_slash_plugin-transform-unicode-regex";
       packageName = "@babel/plugin-transform-unicode-regex";
-      version = "7.4.4";
+      version = "7.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz";
-        sha512 = "il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz";
+        sha512 = "orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==";
       };
     };
-    "@babel/polyfill-7.4.4" = {
+    "@babel/polyfill-7.6.0" = {
       name = "_at_babel_slash_polyfill";
       packageName = "@babel/polyfill";
-      version = "7.4.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz";
-        sha512 = "WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==";
-      };
-    };
-    "@babel/preset-env-7.3.4" = {
-      name = "_at_babel_slash_preset-env";
-      packageName = "@babel/preset-env";
-      version = "7.3.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz";
-        sha512 = "2mwqfYMK8weA0g0uBKOt4FE3iEodiHy9/CW0b+nWXcbL+pGzLx8ESYc+j9IIxr6LTDHWKgPm71i9smo02bw+gA==";
-      };
-    };
-    "@babel/preset-env-7.6.0" = {
-      name = "_at_babel_slash_preset-env";
-      packageName = "@babel/preset-env";
       version = "7.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.0.tgz";
-        sha512 = "1efzxFv/TcPsNXlRhMzRnkBFMeIqBBgzwmZwlFDw5Ubj0AGLeufxugirwZmkkX/ayi3owsSqoQ4fw8LkfK9SYg==";
+        url = "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz";
+        sha512 = "q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==";
+      };
+    };
+    "@babel/preset-env-7.6.3" = {
+      name = "_at_babel_slash_preset-env";
+      packageName = "@babel/preset-env";
+      version = "7.6.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz";
+        sha512 = "CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==";
       };
     };
     "@babel/preset-flow-7.0.0" = {
@@ -1003,58 +985,40 @@ let
         sha512 = "4xKw3tTcCm0qApyT6PqM9qniseCE79xGHiUnNdKGdxNsGUc2X7WwZybqIpnTmoukg3nhPceI5KPNzNqLNeIJww==";
       };
     };
-    "@babel/register-7.6.0" = {
+    "@babel/register-7.6.2" = {
       name = "_at_babel_slash_register";
       packageName = "@babel/register";
-      version = "7.6.0";
+      version = "7.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/register/-/register-7.6.0.tgz";
-        sha512 = "78BomdN8el+x/nkup9KwtjJXuptW5oXMFmP11WoM2VJBjxrKv4grC3qjpLL8RGGUYUGsm57xnjYFM2uom+jWUQ==";
+        url = "https://registry.npmjs.org/@babel/register/-/register-7.6.2.tgz";
+        sha512 = "xgZk2LRZvt6i2SAUWxc7ellk4+OYRgS3Zpsnr13nMS1Qo25w21Uu8o6vTOAqNaxiqrnv30KTYzh9YWY2k21CeQ==";
       };
     };
-    "@babel/runtime-7.3.4" = {
+    "@babel/runtime-7.6.2" = {
       name = "_at_babel_slash_runtime";
       packageName = "@babel/runtime";
-      version = "7.3.4";
+      version = "7.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz";
-        sha512 = "IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==";
+        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz";
+        sha512 = "EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==";
       };
     };
-    "@babel/runtime-7.4.5" = {
+    "@babel/runtime-7.6.3" = {
       name = "_at_babel_slash_runtime";
       packageName = "@babel/runtime";
-      version = "7.4.5";
+      version = "7.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz";
-        sha512 = "TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==";
+        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz";
+        sha512 = "kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==";
       };
     };
-    "@babel/runtime-7.6.0" = {
-      name = "_at_babel_slash_runtime";
-      packageName = "@babel/runtime";
-      version = "7.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz";
-        sha512 = "89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==";
-      };
-    };
-    "@babel/runtime-corejs2-7.6.0" = {
+    "@babel/runtime-corejs2-7.6.3" = {
       name = "_at_babel_slash_runtime-corejs2";
       packageName = "@babel/runtime-corejs2";
-      version = "7.6.0";
+      version = "7.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.6.0.tgz";
-        sha512 = "zbPQzlbyJab2xCYb6VaESn8Tk/XiVpQJU7WvIKiQCwlFyc2NSCzKjqtBXCvpZBbiTOHCx10s2656REVnySwb+A==";
-      };
-    };
-    "@babel/template-7.2.2" = {
-      name = "_at_babel_slash_template";
-      packageName = "@babel/template";
-      version = "7.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz";
-        sha512 = "zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==";
+        url = "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.6.3.tgz";
+        sha512 = "nuA2o+rgX2+PrNTZ063ehncVcg7sn+tU71BB81SaWRVUbGwCOlb0+yQA1e0QqmzOfRSYOxfvf8cosYqFbJEiwQ==";
       };
     };
     "@babel/template-7.6.0" = {
@@ -1066,22 +1030,13 @@ let
         sha512 = "5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==";
       };
     };
-    "@babel/traverse-7.3.4" = {
+    "@babel/traverse-7.6.3" = {
       name = "_at_babel_slash_traverse";
       packageName = "@babel/traverse";
-      version = "7.3.4";
+      version = "7.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz";
-        sha512 = "TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==";
-      };
-    };
-    "@babel/traverse-7.6.0" = {
-      name = "_at_babel_slash_traverse";
-      packageName = "@babel/traverse";
-      version = "7.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz";
-        sha512 = "93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==";
+        url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz";
+        sha512 = "unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==";
       };
     };
     "@babel/types-7.0.0-beta.38" = {
@@ -1093,22 +1048,13 @@ let
         sha512 = "SAtyEjmA7KiEoL2eAOAUM6M9arQJGWxJKK0S9x0WyPOosHS420RXoxPhn57u/8orRnK8Kxm0nHQQNTX203cP1Q==";
       };
     };
-    "@babel/types-7.3.4" = {
+    "@babel/types-7.6.3" = {
       name = "_at_babel_slash_types";
       packageName = "@babel/types";
-      version = "7.3.4";
+      version = "7.6.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz";
-        sha512 = "WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==";
-      };
-    };
-    "@babel/types-7.6.1" = {
-      name = "_at_babel_slash_types";
-      packageName = "@babel/types";
-      version = "7.6.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz";
-        sha512 = "X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==";
+        url = "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz";
+        sha512 = "CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==";
       };
     };
     "@calebboyd/semaphore-1.3.1" = {
@@ -1219,6 +1165,15 @@ let
         sha512 = "Ce3xE2JvTSEbASFbRbA1gAIcMcZWdS2yUYRaQbeM0nbOzaZrUYfa3ePtcriYRZOZmr+CkKA+zbjhvTpIOAYVcw==";
       };
     };
+    "@endemolshinegroup/cosmiconfig-typescript-loader-1.0.1" = {
+      name = "_at_endemolshinegroup_slash_cosmiconfig-typescript-loader";
+      packageName = "@endemolshinegroup/cosmiconfig-typescript-loader";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.1.tgz";
+        sha512 = "bhUR9035PbgL6A/nfLayjoqKo4W7hCtzxqVxq2cgDB+Ndpsa3dGIr71/ymgY3vCTCQaufkFxAcEeoECyJ498CA==";
+      };
+    };
     "@evocateur/libnpmaccess-3.1.2" = {
       name = "_at_evocateur_slash_libnpmaccess";
       packageName = "@evocateur/libnpmaccess";
@@ -1291,13 +1246,13 @@ let
         sha512 = "1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==";
       };
     };
-    "@hapi/hoek-8.2.4" = {
+    "@hapi/hoek-8.5.0" = {
       name = "_at_hapi_slash_hoek";
       packageName = "@hapi/hoek";
-      version = "8.2.4";
+      version = "8.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz";
-        sha512 = "Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow==";
+        url = "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz";
+        sha512 = "7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==";
       };
     };
     "@hapi/joi-15.1.1" = {
@@ -1309,13 +1264,13 @@ let
         sha512 = "entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==";
       };
     };
-    "@hapi/topo-3.1.4" = {
+    "@hapi/topo-3.1.6" = {
       name = "_at_hapi_slash_topo";
       packageName = "@hapi/topo";
-      version = "3.1.4";
+      version = "3.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.4.tgz";
-        sha512 = "aVWQTOI9wBD6zawmOr6f+tdEIxQC8JXfQVLTjgGe8YEStAWGn/GNNVTobKJhbWKveQj2RyYF3oYbO9SC8/eOCA==";
+        url = "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz";
+        sha512 = "tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==";
       };
     };
     "@iarna/toml-2.2.3" = {
@@ -1327,13 +1282,22 @@ let
         sha512 = "FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==";
       };
     };
-    "@ionic/cli-framework-2.1.7" = {
+    "@ionic/cli-framework-3.0.0" = {
       name = "_at_ionic_slash_cli-framework";
       packageName = "@ionic/cli-framework";
-      version = "2.1.7";
+      version = "3.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/cli-framework/-/cli-framework-2.1.7.tgz";
-        sha512 = "osuKbmCIzT0H+g39lDy+EmsP5RHc+aYOv+BN+IngsaxKb7ya0V/JlLO1vLkd7RYT+lmiQWiCi7RpHPeEgQJFtw==";
+        url = "https://registry.npmjs.org/@ionic/cli-framework/-/cli-framework-3.0.0.tgz";
+        sha512 = "Pm7Kq2xg/Zas1eU98UC9Ghb4l2kUQh2/IH06SUof5dpB+YpK9mh78IRAcppPnYC5d7SNDYy8fWeo6m+NR9il/w==";
+      };
+    };
+    "@ionic/cli-framework-prompts-1.0.1" = {
+      name = "_at_ionic_slash_cli-framework-prompts";
+      packageName = "@ionic/cli-framework-prompts";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@ionic/cli-framework-prompts/-/cli-framework-prompts-1.0.1.tgz";
+        sha512 = "jYFc8pA9Vk64CX5S0wJ6Mq/WtowsZcebfvQe0X2JRwMkwpiOa2ZqK00CYrw1ytS9jeUzJChNX6n1hBUdarwlsw==";
       };
     };
     "@ionic/discover-2.0.6" = {
@@ -1354,13 +1318,13 @@ let
         sha512 = "t0/gXFf70oDPpviGUHpaDD9++zIx8nFXpPm8c3We8iH5dRwEJLSun+AJTqxO/XPzEhM24KBuj3rLY9bSYBadEg==";
       };
     };
-    "@ionic/utils-fs-2.0.7" = {
+    "@ionic/utils-fs-2.0.8" = {
       name = "_at_ionic_slash_utils-fs";
       packageName = "@ionic/utils-fs";
-      version = "2.0.7";
+      version = "2.0.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-2.0.7.tgz";
-        sha512 = "rXTKJD66qocDs8w72+z7yw6P8H095yexIMsUbNiJFjMm3Cx542i+Tw9gbGwYN356WrA/0EATXD/zVZDzvDsSKQ==";
+        url = "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-2.0.8.tgz";
+        sha512 = "7yuU+L+tlt9NIwA6nb/3A+zPr7NIKuvIAo5ijVdHX3VTAdw/x5JXJgGl0BApKcqT1cTJImNt5tc2O4CB1cnhKA==";
       };
     };
     "@ionic/utils-network-1.0.5" = {
@@ -1399,13 +1363,13 @@ let
         sha512 = "qha4Msonb44++xvf8YppBR27dNBRuMLSty4/THH9uD6UEdjU2+23LWACKuqnQUSsZjQdvALVDMcRRWEIYEL2VQ==";
       };
     };
-    "@ionic/utils-subprocess-1.0.8" = {
+    "@ionic/utils-subprocess-1.0.9" = {
       name = "_at_ionic_slash_utils-subprocess";
       packageName = "@ionic/utils-subprocess";
-      version = "1.0.8";
+      version = "1.0.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-1.0.8.tgz";
-        sha512 = "gfVCzccOQ3PVfY6d1hDZq1Qv7hOXAn3ZlepAEbUBOeFauIhXmwmwVdIRa9cfi3cESpDidNQ3dpmXyC+nKxv0Og==";
+        url = "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-1.0.9.tgz";
+        sha512 = "rNT5/aVsstNebIGM+sq/iibKe1q07NMShKODeRSq1DUVSs8SVQdJGKPZ4/3rGFT5CYsqCZVPQDk/VzDhjQoHMA==";
       };
     };
     "@ionic/utils-terminal-1.0.5" = {
@@ -1426,103 +1390,94 @@ let
         sha512 = "CNVsCrMge/jq6DCT5buNZ8PACY9RTvPJbCNoIcndfkJOCsNxOx9dnc5qw4pHZdHi8GS6l3qlgkuFKp33iD8J2Q==";
       };
     };
-    "@lerna/add-3.16.2" = {
+    "@lerna/add-3.18.0" = {
       name = "_at_lerna_slash_add";
       packageName = "@lerna/add";
-      version = "3.16.2";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/add/-/add-3.16.2.tgz";
-        sha512 = "RAAaF8aODPogj2Ge9Wj3uxPFIBGpog9M+HwSuq03ZnkkO831AmasCTJDqV+GEpl1U2DvnhZQEwHpWmTT0uUeEw==";
+        url = "https://registry.npmjs.org/@lerna/add/-/add-3.18.0.tgz";
+        sha512 = "Z5EaQbBnJn1LEPb0zb0Q2o9T8F8zOnlCsj6JYpY6aSke17UUT7xx0QMN98iBK+ueUHKjN/vdFdYlNCYRSIdujA==";
       };
     };
-    "@lerna/batch-packages-3.16.0" = {
-      name = "_at_lerna_slash_batch-packages";
-      packageName = "@lerna/batch-packages";
-      version = "3.16.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.16.0.tgz";
-        sha512 = "7AdMkANpubY/FKFI01im01tlx6ygOBJ/0JcixMUWoWP/7Ds3SWQF22ID6fbBr38jUWptYLDs2fagtTDL7YUPuA==";
-      };
-    };
-    "@lerna/bootstrap-3.16.2" = {
+    "@lerna/bootstrap-3.18.0" = {
       name = "_at_lerna_slash_bootstrap";
       packageName = "@lerna/bootstrap";
-      version = "3.16.2";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.16.2.tgz";
-        sha512 = "I+gs7eh6rv9Vyd+CwqL7sftRfOOsSzCle8cv/CGlMN7/p7EAVhxEdAw8SYoHIKHzipXszuqqy1Y3opyleD0qdA==";
+        url = "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.18.0.tgz";
+        sha512 = "3DZKWIaKvr7sUImoKqSz6eqn84SsOVMnA5QHwgzXiQjoeZ/5cg9x2r+Xj3+3w/lvLoh0j8U2GNtrIaPNis4bKQ==";
       };
     };
-    "@lerna/changed-3.16.4" = {
+    "@lerna/changed-3.18.3" = {
       name = "_at_lerna_slash_changed";
       packageName = "@lerna/changed";
-      version = "3.16.4";
+      version = "3.18.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/changed/-/changed-3.16.4.tgz";
-        sha512 = "NCD7XkK744T23iW0wqKEgF4R9MYmReUbyHCZKopFnsNpQdqumc3SOIvQUAkKCP6hQJmYvxvOieoVgy/CVDpZ5g==";
+        url = "https://registry.npmjs.org/@lerna/changed/-/changed-3.18.3.tgz";
+        sha512 = "xZW7Rm+DlDIGc0EvKGyJZgT9f8FFa4d52mr/Y752dZuXR2qRmf9tXhVloRG39881s2A6yi3jqLtXZggKhsQW4Q==";
       };
     };
-    "@lerna/check-working-tree-3.14.2" = {
+    "@lerna/check-working-tree-3.16.5" = {
       name = "_at_lerna_slash_check-working-tree";
       packageName = "@lerna/check-working-tree";
-      version = "3.14.2";
+      version = "3.16.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.14.2.tgz";
-        sha512 = "7safqxM/MYoAoxZxulUDtIJIbnBIgo0PB/FHytueG+9VaX7GMnDte2Bt1EKa0dz2sAyQdmQ3Q8ZXpf/6JDjaeg==";
+        url = "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.16.5.tgz";
+        sha512 = "xWjVBcuhvB8+UmCSb5tKVLB5OuzSpw96WEhS2uz6hkWVa/Euh1A0/HJwn2cemyK47wUrCQXtczBUiqnq9yX5VQ==";
       };
     };
-    "@lerna/child-process-3.14.2" = {
+    "@lerna/child-process-3.16.5" = {
       name = "_at_lerna_slash_child-process";
       packageName = "@lerna/child-process";
-      version = "3.14.2";
+      version = "3.16.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.14.2.tgz";
-        sha512 = "xnq+W5yQb6RkwI0p16ZQnrn6HkloH/MWTw4lGE1nKsBLAUbmSU5oTE93W1nrG0X3IMF/xWc9UYvNdUGMWvZZ4w==";
+        url = "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.16.5.tgz";
+        sha512 = "vdcI7mzei9ERRV4oO8Y1LHBZ3A5+ampRKg1wq5nutLsUA4mEBN6H7JqjWOMY9xZemv6+kATm2ofjJ3lW5TszQg==";
       };
     };
-    "@lerna/clean-3.16.0" = {
+    "@lerna/clean-3.18.0" = {
       name = "_at_lerna_slash_clean";
       packageName = "@lerna/clean";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/clean/-/clean-3.16.0.tgz";
-        sha512 = "5P9U5Y19WmYZr7UAMGXBpY7xCRdlR7zhHy8MAPDKVx70rFIBS6nWXn5n7Kntv74g7Lm1gJ2rsiH5tj1OPcRJgg==";
+        url = "https://registry.npmjs.org/@lerna/clean/-/clean-3.18.0.tgz";
+        sha512 = "BiwBELZNkarRQqj+v5NPB1aIzsOX+Y5jkZ9a5UbwHzEdBUQ5lQa0qaMLSOve/fSkaiZQxe6qnTyatN75lOcDMg==";
       };
     };
-    "@lerna/cli-3.13.0" = {
+    "@lerna/cli-3.18.0" = {
       name = "_at_lerna_slash_cli";
       packageName = "@lerna/cli";
-      version = "3.13.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz";
-        sha512 = "HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==";
+        url = "https://registry.npmjs.org/@lerna/cli/-/cli-3.18.0.tgz";
+        sha512 = "AwDyfGx7fxJgeaZllEuyJ9LZ6Tdv9yqRD9RX762yCJu+PCAFvB9bp6OYuRSGli7QQgM0CuOYnSg4xVNOmuGKDA==";
       };
     };
-    "@lerna/collect-uncommitted-3.14.2" = {
+    "@lerna/collect-uncommitted-3.16.5" = {
       name = "_at_lerna_slash_collect-uncommitted";
       packageName = "@lerna/collect-uncommitted";
-      version = "3.14.2";
+      version = "3.16.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.14.2.tgz";
-        sha512 = "4EkQu4jIOdNL2BMzy/N0ydHB8+Z6syu6xiiKXOoFl0WoWU9H1jEJCX4TH7CmVxXL1+jcs8FIS2pfQz4oew99Eg==";
+        url = "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.16.5.tgz";
+        sha512 = "ZgqnGwpDZiWyzIQVZtQaj9tRizsL4dUOhuOStWgTAw1EMe47cvAY2kL709DzxFhjr6JpJSjXV5rZEAeU3VE0Hg==";
       };
     };
-    "@lerna/collect-updates-3.16.0" = {
+    "@lerna/collect-updates-3.18.0" = {
       name = "_at_lerna_slash_collect-updates";
       packageName = "@lerna/collect-updates";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.16.0.tgz";
-        sha512 = "HwAIl815X2TNlmcp28zCrSdXfoZWNP7GJPEqNWYk7xDJTYLqQ+SrmKUePjb3AMGBwYAraZSEJLbHdBpJ5+cHmQ==";
+        url = "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.18.0.tgz";
+        sha512 = "LJMKgWsE/var1RSvpKDIxS8eJ7POADEc0HM3FQiTpEczhP6aZfv9x3wlDjaHpZm9MxJyQilqxZcasRANmRcNgw==";
       };
     };
-    "@lerna/command-3.16.0" = {
+    "@lerna/command-3.18.0" = {
       name = "_at_lerna_slash_command";
       packageName = "@lerna/command";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/command/-/command-3.16.0.tgz";
-        sha512 = "u7tE4GC4/gfbPA9eQg+0ulnoJ+PMoMqomx033r/IxqZrHtmJR9+pF/37S0fsxJ2hX/RMFPC7c9Q/i8NEufSpdQ==";
+        url = "https://registry.npmjs.org/@lerna/command/-/command-3.18.0.tgz";
+        sha512 = "JQ0TGzuZc9Ky8xtwtSLywuvmkU8X62NTUT3rMNrUykIkOxBaO+tE0O98u2yo/9BYOeTRji9IsjKZEl5i9Qt0xQ==";
       };
     };
     "@lerna/conventional-commits-3.16.4" = {
@@ -1534,13 +1489,13 @@ let
         sha512 = "QSZJ0bC9n6FVaf+7KDIq5zMv8WnHXnwhyL5jG1Nyh3SgOg9q2uflqh7YsYB+G6FwaRfnPaKosh6obijpYg0llA==";
       };
     };
-    "@lerna/create-3.16.0" = {
+    "@lerna/create-3.18.0" = {
       name = "_at_lerna_slash_create";
       packageName = "@lerna/create";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/create/-/create-3.16.0.tgz";
-        sha512 = "OZApR1Iz7awutbmj4sAArwhqCyKgcrnw9rH0aWAUrkYWrD1w4TwkvAcYAsfx5GpQGbLQwoXhoyyPwPfZRRWz3Q==";
+        url = "https://registry.npmjs.org/@lerna/create/-/create-3.18.0.tgz";
+        sha512 = "y9oS7ND5T13c+cCTJHa2Y9in02ppzyjsNynVWFuS40eIzZ3z058d9+3qSBt1nkbbQlVyfLoP6+bZPsjyzap5ig==";
       };
     };
     "@lerna/create-symlink-3.16.2" = {
@@ -1552,49 +1507,49 @@ let
         sha512 = "pzXIJp6av15P325sgiIRpsPXLFmkisLhMBCy4764d+7yjf2bzrJ4gkWVMhsv4AdF0NN3OyZ5jjzzTtLNqfR+Jw==";
       };
     };
-    "@lerna/describe-ref-3.14.2" = {
+    "@lerna/describe-ref-3.16.5" = {
       name = "_at_lerna_slash_describe-ref";
       packageName = "@lerna/describe-ref";
-      version = "3.14.2";
+      version = "3.16.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.14.2.tgz";
-        sha512 = "qa5pzDRK2oBQXNjyRmRnN7E8a78NMYfQjjlRFB0KNHMsT6mCiL9+8kIS39sSE2NqT8p7xVNo2r2KAS8R/m3CoQ==";
+        url = "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.16.5.tgz";
+        sha512 = "c01+4gUF0saOOtDBzbLMFOTJDHTKbDFNErEY6q6i9QaXuzy9LNN62z+Hw4acAAZuJQhrVWncVathcmkkjvSVGw==";
       };
     };
-    "@lerna/diff-3.16.0" = {
+    "@lerna/diff-3.18.0" = {
       name = "_at_lerna_slash_diff";
       packageName = "@lerna/diff";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/diff/-/diff-3.16.0.tgz";
-        sha512 = "QUpVs5TPl8vBIne10/vyjUxanQBQQp7Lk3iaB8MnCysKr0O+oy7trWeFVDPEkBTCD177By7yPGyW5Yey1nCBbA==";
+        url = "https://registry.npmjs.org/@lerna/diff/-/diff-3.18.0.tgz";
+        sha512 = "3iLNlpurc2nV9k22w8ini2Zjm2UPo3xtQgWyqdA6eJjvge0+5AlNAWfPoV6cV+Hc1xDbJD2YDSFpZPJ1ZGilRw==";
       };
     };
-    "@lerna/exec-3.16.0" = {
+    "@lerna/exec-3.18.0" = {
       name = "_at_lerna_slash_exec";
       packageName = "@lerna/exec";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/exec/-/exec-3.16.0.tgz";
-        sha512 = "mH3O5NXf/O88jBaBBTUf+d56CUkxpg782s3Jxy7HWbVuSUULt3iMRPTh+zEXO5/555etsIVVDDyUR76meklrJA==";
+        url = "https://registry.npmjs.org/@lerna/exec/-/exec-3.18.0.tgz";
+        sha512 = "hwkuzg1+38+pbzdZPhGtLIYJ59z498/BCNzR8d4/nfMYm8lFbw9RgJJajLcdbuJ9LJ08cZ93hf8OlzetL84TYg==";
       };
     };
-    "@lerna/filter-options-3.16.0" = {
+    "@lerna/filter-options-3.18.0" = {
       name = "_at_lerna_slash_filter-options";
       packageName = "@lerna/filter-options";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.16.0.tgz";
-        sha512 = "InIi1fF8+PxpCwir9bIy+pGxrdE6hvN0enIs1eNGCVS1TTE8osNgiZXa838bMQ1yaEccdcnVX6Z03BNKd56kNg==";
+        url = "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.18.0.tgz";
+        sha512 = "UGVcixs3TGzD8XSmFSbwUVVQnAjaZ6Rmt8Vuq2RcR98ULkGB1LiGNMY89XaNBhaaA8vx7yQWiLmJi2AfmD63Qg==";
       };
     };
-    "@lerna/filter-packages-3.16.0" = {
+    "@lerna/filter-packages-3.18.0" = {
       name = "_at_lerna_slash_filter-packages";
       packageName = "@lerna/filter-packages";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.16.0.tgz";
-        sha512 = "eGFzQTx0ogkGDCnbTuXqssryR6ilp8+dcXt6B+aq1MaqL/vOJRZyqMm4TY3CUOUnzZCi9S2WWyMw3PnAJOF+kg==";
+        url = "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.18.0.tgz";
+        sha512 = "6/0pMM04bCHNATIOkouuYmPg6KH3VkPCIgTfQmdkPJTullERyEQfNUKikrefjxo1vHOoCACDpy65JYyKiAbdwQ==";
       };
     };
     "@lerna/get-npm-exec-opts-3.13.0" = {
@@ -1615,13 +1570,13 @@ let
         sha512 = "AjsFiaJzo1GCPnJUJZiTW6J1EihrPkc2y3nMu6m3uWFxoleklsSCyImumzVZJssxMi3CPpztj8LmADLedl9kXw==";
       };
     };
-    "@lerna/github-client-3.16.0" = {
+    "@lerna/github-client-3.16.5" = {
       name = "_at_lerna_slash_github-client";
       packageName = "@lerna/github-client";
-      version = "3.16.0";
+      version = "3.16.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.16.0.tgz";
-        sha512 = "IVJjcKjkYaUEPJsDyAblHGEFFNKCRyMagbIDm14L7Ab94ccN6i4TKOqAFEJn2SJHYvKKBdp3Zj2zNlASOMe3DA==";
+        url = "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.16.5.tgz";
+        sha512 = "rHQdn8Dv/CJrO3VouOP66zAcJzrHsm+wFuZ4uGAai2At2NkgKH+tpNhQy2H1PSC0Ezj9LxvdaHYrUzULqVK5Hw==";
       };
     };
     "@lerna/gitlab-client-3.15.0" = {
@@ -1642,58 +1597,58 @@ let
         sha512 = "SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==";
       };
     };
-    "@lerna/has-npm-version-3.16.0" = {
+    "@lerna/has-npm-version-3.16.5" = {
       name = "_at_lerna_slash_has-npm-version";
       packageName = "@lerna/has-npm-version";
-      version = "3.16.0";
+      version = "3.16.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.16.0.tgz";
-        sha512 = "TIY036dA9J8OyTrZq9J+it2DVKifL65k7hK8HhkUPpitJkw6jwbMObA/8D40LOGgWNPweJWqmlrTbRSwsR7DrQ==";
+        url = "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.16.5.tgz";
+        sha512 = "WL7LycR9bkftyqbYop5rEGJ9sRFIV55tSGmbN1HLrF9idwOCD7CLrT64t235t3t4O5gehDnwKI5h2U3oxTrF8Q==";
       };
     };
-    "@lerna/import-3.16.0" = {
+    "@lerna/import-3.18.0" = {
       name = "_at_lerna_slash_import";
       packageName = "@lerna/import";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/import/-/import-3.16.0.tgz";
-        sha512 = "trsOmGHzw0rL/f8BLNvd+9PjoTkXq2Dt4/V2UCha254hMQaYutbxcYu8iKPxz9x86jSPlH7FpbTkkHXDsoY7Yg==";
+        url = "https://registry.npmjs.org/@lerna/import/-/import-3.18.0.tgz";
+        sha512 = "2pYIkkBTZsEdccfc+dPsKZeSw3tBzKSyl0b2lGrfmNX2Y41qqOzsJCyI1WO1uvEIP8aOaLy4hPpqRIBe4ee7hw==";
       };
     };
-    "@lerna/init-3.16.0" = {
+    "@lerna/init-3.18.0" = {
       name = "_at_lerna_slash_init";
       packageName = "@lerna/init";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/init/-/init-3.16.0.tgz";
-        sha512 = "Ybol/x5xMtBgokx4j7/Y3u0ZmNh0NiSWzBFVaOs2NOJKvuqrWimF67DKVz7yYtTYEjtaMdug64ohFF4jcT/iag==";
+        url = "https://registry.npmjs.org/@lerna/init/-/init-3.18.0.tgz";
+        sha512 = "/vHpmXkMlSaJaq25v5K13mcs/2L7E32O6dSsEkHaZCDRiV2BOqsZng9jjbE/4ynfsWfLLlU9ZcydwG72C3I+mQ==";
       };
     };
-    "@lerna/link-3.16.2" = {
+    "@lerna/link-3.18.0" = {
       name = "_at_lerna_slash_link";
       packageName = "@lerna/link";
-      version = "3.16.2";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/link/-/link-3.16.2.tgz";
-        sha512 = "eCPg5Lo8HT525fIivNoYF3vWghO3UgEVFdbsiPmhzwI7IQyZro5HWYzLtywSAdEog5XZpd2Bbn0CsoHWBB3gww==";
+        url = "https://registry.npmjs.org/@lerna/link/-/link-3.18.0.tgz";
+        sha512 = "FbbIpH0EpsC+dpAbvxCoF3cn7F1MAyJjEa5Lh3XkDGATOlinMFuKCbmX0NLpOPQZ5zghvrui97cx+jz5F2IlHw==";
       };
     };
-    "@lerna/list-3.16.0" = {
+    "@lerna/list-3.18.0" = {
       name = "_at_lerna_slash_list";
       packageName = "@lerna/list";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/list/-/list-3.16.0.tgz";
-        sha512 = "TkvstoPsgKqqQ0KfRumpsdMXfRSEhdXqOLq519XyI5IRWYxhoqXqfi8gG37UoBPhBNoe64japn5OjphF3rOmQA==";
+        url = "https://registry.npmjs.org/@lerna/list/-/list-3.18.0.tgz";
+        sha512 = "mpB7Q6T+n2CaiPFz0LuOE+rXphDfHm0mKIwShnyS/XDcii8jXv+z9Iytj8p3rfCH2I1L80j2qL6jWzyGy/uzKA==";
       };
     };
-    "@lerna/listable-3.16.0" = {
+    "@lerna/listable-3.18.0" = {
       name = "_at_lerna_slash_listable";
       packageName = "@lerna/listable";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/listable/-/listable-3.16.0.tgz";
-        sha512 = "mtdAT2EEECqrJSDm/aXlOUFr1MRE4p6hppzY//Klp05CogQy6uGaKk+iKG5yyCLaOXFFZvG4HfO11CmoGSDWzw==";
+        url = "https://registry.npmjs.org/@lerna/listable/-/listable-3.18.0.tgz";
+        sha512 = "9gLGKYNLSKeurD+sJ2RA+nz4Ftulr91U127gefz0RlmAPpYSjwcJkxwa0UfJvpQTXv9C7yzHLnn0BjyAQRjuew==";
       };
     };
     "@lerna/log-packed-3.16.0" = {
@@ -1714,22 +1669,22 @@ let
         sha512 = "HbO3DUrTkCAn2iQ9+FF/eisDpWY5POQAOF1m7q//CZjdC2HSW3UYbKEGsSisFxSfaF9Z4jtrV+F/wX6qWs3CuA==";
       };
     };
-    "@lerna/npm-dist-tag-3.16.0" = {
+    "@lerna/npm-dist-tag-3.18.1" = {
       name = "_at_lerna_slash_npm-dist-tag";
       packageName = "@lerna/npm-dist-tag";
-      version = "3.16.0";
+      version = "3.18.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.16.0.tgz";
-        sha512 = "MQrBkqJJB9+eNphuj9w90QPMOs4NQXMuSRk9NqzeFunOmdDopPCV0Q7IThSxEuWnhJ2n3B7G0vWUP7tNMPdqIQ==";
+        url = "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.18.1.tgz";
+        sha512 = "vWkZh2T/O9OjPLDrba0BTWO7ug/C3sCwjw7Qyk1aEbxMBXB/eEJPqirwJTWT+EtRJQYB01ky3K8ZFOhElVyjLw==";
       };
     };
-    "@lerna/npm-install-3.16.0" = {
+    "@lerna/npm-install-3.16.5" = {
       name = "_at_lerna_slash_npm-install";
       packageName = "@lerna/npm-install";
-      version = "3.16.0";
+      version = "3.16.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.16.0.tgz";
-        sha512 = "APUOIilZCzDzce92uLEwzt1r7AEMKT/hWA1ThGJL+PO9Rn8A95Km3o2XZAYG4W0hR+P4O2nSVuKbsjQtz8CjFQ==";
+        url = "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.16.5.tgz";
+        sha512 = "hfiKk8Eku6rB9uApqsalHHTHY+mOrrHeWEs+gtg7+meQZMTS3kzv4oVp5cBZigndQr3knTLjwthT/FX4KvseFg==";
       };
     };
     "@lerna/npm-publish-3.16.2" = {
@@ -1741,13 +1696,13 @@ let
         sha512 = "tGMb9vfTxP57vUV5svkBQxd5Tzc+imZbu9ZYf8Mtwe0+HYfDjNiiHLIQw7G95w4YRdc5KsCE8sQ0uSj+f2soIg==";
       };
     };
-    "@lerna/npm-run-script-3.14.2" = {
+    "@lerna/npm-run-script-3.16.5" = {
       name = "_at_lerna_slash_npm-run-script";
       packageName = "@lerna/npm-run-script";
-      version = "3.14.2";
+      version = "3.16.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.14.2.tgz";
-        sha512 = "LbVFv+nvAoRTYLMrJlJ8RiakHXrLslL7Jp/m1R18vYrB8LYWA3ey+nz5Tel2OELzmjUiemAKZsD9h6i+Re5egg==";
+        url = "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.16.5.tgz";
+        sha512 = "1asRi+LjmVn3pMjEdpqKJZFT/3ZNpb+VVeJMwrJaV/3DivdNg7XlPK9LTrORuKU4PSvhdEZvJmSlxCKyDpiXsQ==";
       };
     };
     "@lerna/otplease-3.16.0" = {
@@ -1786,13 +1741,13 @@ let
         sha512 = "2lHBWpaxcBoiNVbtyLtPUuTYEaB/Z+eEqRS9duxpZs6D+mTTZMNy6/5vpEVSCBmzvdYpyqhqaYjjSLvjjr5Riw==";
       };
     };
-    "@lerna/package-graph-3.16.0" = {
+    "@lerna/package-graph-3.18.0" = {
       name = "_at_lerna_slash_package-graph";
       packageName = "@lerna/package-graph";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.16.0.tgz";
-        sha512 = "A2mum/gNbv7zCtAwJqoxzqv89As73OQNK2MgSX1SHWya46qoxO9a9Z2c5lOFQ8UFN5ZxqWMfFYXRCz7qzwmFXw==";
+        url = "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.18.0.tgz";
+        sha512 = "BLYDHO5ihPh20i3zoXfLZ5ZWDCrPuGANgVhl7k5pCmRj90LCvT+C7V3zrw70fErGAfvkcYepMqxD+oBrAYwquQ==";
       };
     };
     "@lerna/prerelease-id-from-version-3.16.0" = {
@@ -1804,13 +1759,13 @@ let
         sha512 = "qZyeUyrE59uOK8rKdGn7jQz+9uOpAaF/3hbslJVFL1NqF9ELDTqjCPXivuejMX/lN4OgD6BugTO4cR7UTq/sZA==";
       };
     };
-    "@lerna/project-3.16.0" = {
+    "@lerna/project-3.18.0" = {
       name = "_at_lerna_slash_project";
       packageName = "@lerna/project";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/project/-/project-3.16.0.tgz";
-        sha512 = "NrKcKK1EqXqhrGvslz6Q36+ZHuK3zlDhGdghRqnxDcHxMPT01NgLcmsnymmQ+gjMljuLRmvKYYCuHrknzX8VrA==";
+        url = "https://registry.npmjs.org/@lerna/project/-/project-3.18.0.tgz";
+        sha512 = "+LDwvdAp0BurOAWmeHE3uuticsq9hNxBI0+FMHiIai8jrygpJGahaQrBYWpwbshbQyVLeQgx3+YJdW2TbEdFWA==";
       };
     };
     "@lerna/prompt-3.13.0" = {
@@ -1822,13 +1777,13 @@ let
         sha512 = "P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==";
       };
     };
-    "@lerna/publish-3.16.4" = {
+    "@lerna/publish-3.18.3" = {
       name = "_at_lerna_slash_publish";
       packageName = "@lerna/publish";
-      version = "3.16.4";
+      version = "3.18.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/publish/-/publish-3.16.4.tgz";
-        sha512 = "XZY+gRuF7/v6PDQwl7lvZaGWs8CnX6WIPIu+OCcyFPSL/rdWegdN7HieKBHskgX798qRQc2GrveaY7bNoTKXAw==";
+        url = "https://registry.npmjs.org/@lerna/publish/-/publish-3.18.3.tgz";
+        sha512 = "XlfWOWIhaSK0Y2sX5ppNWI5Y3CDtlxMcQa1hTbZlC5rrDA6vD32iutbmH6Ix3c6wtvVbSkgA39GWsQEXxPS+7w==";
       };
     };
     "@lerna/pulse-till-done-3.13.0" = {
@@ -1840,13 +1795,13 @@ let
         sha512 = "1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==";
       };
     };
-    "@lerna/query-graph-3.16.0" = {
+    "@lerna/query-graph-3.18.0" = {
       name = "_at_lerna_slash_query-graph";
       packageName = "@lerna/query-graph";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.16.0.tgz";
-        sha512 = "p0RO+xmHDO95ChJdWkcy9TNLysLkoDARXeRHzY5U54VCwl3Ot/2q8fMCVlA5UeGXDutEyyByl3URqEpcQCWI7Q==";
+        url = "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.18.0.tgz";
+        sha512 = "fgUhLx6V0jDuKZaKj562jkuuhrfVcjl5sscdfttJ8dXNVADfDz76nzzwLY0ZU7/0m69jDedohn5Fx5p7hDEVEg==";
       };
     };
     "@lerna/resolve-symlink-3.16.0" = {
@@ -1858,22 +1813,22 @@ let
         sha512 = "Ibj5e7njVHNJ/NOqT4HlEgPFPtPLWsO7iu59AM5bJDcAJcR96mLZ7KGVIsS2tvaO7akMEJvt2P+ErwCdloG3jQ==";
       };
     };
-    "@lerna/rimraf-dir-3.14.2" = {
+    "@lerna/rimraf-dir-3.16.5" = {
       name = "_at_lerna_slash_rimraf-dir";
       packageName = "@lerna/rimraf-dir";
-      version = "3.14.2";
+      version = "3.16.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.14.2.tgz";
-        sha512 = "eFNkZsy44Bu9v1Hrj5Zk6omzg8O9h/7W6QYK1TTUHeyrjTEwytaNQlqF0lrTLmEvq55sviV42NC/8P3M2cvq8Q==";
+        url = "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.16.5.tgz";
+        sha512 = "bQlKmO0pXUsXoF8lOLknhyQjOZsCc0bosQDoX4lujBXSWxHVTg1VxURtWf2lUjz/ACsJVDfvHZbDm8kyBk5okA==";
       };
     };
-    "@lerna/run-3.16.0" = {
+    "@lerna/run-3.18.0" = {
       name = "_at_lerna_slash_run";
       packageName = "@lerna/run";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/run/-/run-3.16.0.tgz";
-        sha512 = "woTeLlB1OAAz4zzjdI6RyIxSGuxiUPHJZm89E1pDEPoWwtQV6HMdMgrsQd9ATsJ5Ez280HH4bF/LStAlqW8Ufg==";
+        url = "https://registry.npmjs.org/@lerna/run/-/run-3.18.0.tgz";
+        sha512 = "sblxHBZ9djaaG7wefPcfEicDqzrB7CP1m/jIB0JvPEQwG4C2qp++ewBpkjRw/mBtjtzg0t7v0nNMXzaWYrQckQ==";
       };
     };
     "@lerna/run-lifecycle-3.16.2" = {
@@ -1885,40 +1840,31 @@ let
         sha512 = "RqFoznE8rDpyyF0rOJy3+KjZCeTkO8y/OB9orPauR7G2xQ7PTdCpgo7EO6ZNdz3Al+k1BydClZz/j78gNCmL2A==";
       };
     };
-    "@lerna/run-parallel-batches-3.16.0" = {
-      name = "_at_lerna_slash_run-parallel-batches";
-      packageName = "@lerna/run-parallel-batches";
-      version = "3.16.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.16.0.tgz";
-        sha512 = "2J/Nyv+MvogmQEfC7VcS21ifk7w0HVvzo2yOZRPvkCzGRu/rducxtB4RTcr58XCZ8h/Bt1aqQYKExu3c/3GXwg==";
-      };
-    };
-    "@lerna/run-topologically-3.16.0" = {
+    "@lerna/run-topologically-3.18.0" = {
       name = "_at_lerna_slash_run-topologically";
       packageName = "@lerna/run-topologically";
-      version = "3.16.0";
+      version = "3.18.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.16.0.tgz";
-        sha512 = "4Hlpv4zDtKWa5Z0tPkeu0sK+bxZEKgkNESMGmWrUCNfj7xwvAJurcraK8+a2Y0TFYwf0qjSLY/MzX+ZbJA3Cgw==";
+        url = "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.18.0.tgz";
+        sha512 = "lrfEewwuUMC3ioxf9Z9NdHUakN6ihekcPfdYbzR2slmdbjYKmIA5srkWdrK8NwOpQCAuekpOovH2s8X3FGEopg==";
       };
     };
-    "@lerna/symlink-binary-3.16.2" = {
+    "@lerna/symlink-binary-3.17.0" = {
       name = "_at_lerna_slash_symlink-binary";
       packageName = "@lerna/symlink-binary";
-      version = "3.16.2";
+      version = "3.17.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.16.2.tgz";
-        sha512 = "kz9XVoFOGSF83gg4gBqH+mG6uxfJfTp8Uy+Cam40CvMiuzfODrGkjuBEFoM/uO2QOAwZvbQDYOBpKUa9ZxHS1Q==";
+        url = "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.17.0.tgz";
+        sha512 = "RLpy9UY6+3nT5J+5jkM5MZyMmjNHxZIZvXLV+Q3MXrf7Eaa1hNqyynyj4RO95fxbS+EZc4XVSk25DGFQbcRNSQ==";
       };
     };
-    "@lerna/symlink-dependencies-3.16.2" = {
+    "@lerna/symlink-dependencies-3.17.0" = {
       name = "_at_lerna_slash_symlink-dependencies";
       packageName = "@lerna/symlink-dependencies";
-      version = "3.16.2";
+      version = "3.17.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.16.2.tgz";
-        sha512 = "wnZqGJQ+Jvr1I3inxrkffrFZfmQI7Ta8gySw/UWCy95QtZWF/f5yk8zVIocCAsjzD0wgb3jJE3CFJ9W5iwWk1A==";
+        url = "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.17.0.tgz";
+        sha512 = "KmjU5YT1bpt6coOmdFueTJ7DFJL4H1w5eF8yAQ2zsGNTtZ+i5SGFBWpb9AQaw168dydc3s4eu0W0Sirda+F59Q==";
       };
     };
     "@lerna/timer-3.13.0" = {
@@ -1939,13 +1885,13 @@ let
         sha512 = "SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==";
       };
     };
-    "@lerna/version-3.16.4" = {
+    "@lerna/version-3.18.3" = {
       name = "_at_lerna_slash_version";
       packageName = "@lerna/version";
-      version = "3.16.4";
+      version = "3.18.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/version/-/version-3.16.4.tgz";
-        sha512 = "ikhbMeIn5ljCtWTlHDzO4YvTmpGTX1lWFFIZ79Vd1TNyOr+OUuKLo/+p06mCl2WEdZu0W2s5E9oxfAAQbyDxEg==";
+        url = "https://registry.npmjs.org/@lerna/version/-/version-3.18.3.tgz";
+        sha512 = "IXXRlyM3Q/jrc+QZio+bgjG4ZaK+4LYmY4Yql1xyY0wZhAKsWP/Q6ho7e1EJNjNC5dUJO99Fq7qB05MkDf2OcQ==";
       };
     };
     "@lerna/write-log-file-3.13.0" = {
@@ -1966,58 +1912,58 @@ let
         sha512 = "bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==";
       };
     };
-    "@node-red/editor-api-0.20.8" = {
+    "@node-red/editor-api-1.0.2" = {
       name = "_at_node-red_slash_editor-api";
       packageName = "@node-red/editor-api";
-      version = "0.20.8";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-0.20.8.tgz";
-        sha512 = "VaetYYU/gu4CgUs80ymiBg9BVw4Ge4kYF4NPgs4S8t/c1BRz2ZZd5idCDw7MaN602eDiYnspx3QMH8X3sqYsTQ==";
+        url = "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-1.0.2.tgz";
+        sha512 = "yUvTU5b7gDL35NIC2qC54NY0uuIAewVzcPWsc+Rbjy9YpY1DUD2Gt5Ub9gR2QPWYtVPG4zSPOBtPhZEcZvBSxQ==";
       };
     };
-    "@node-red/editor-client-0.20.8" = {
+    "@node-red/editor-client-1.0.2" = {
       name = "_at_node-red_slash_editor-client";
       packageName = "@node-red/editor-client";
-      version = "0.20.8";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-0.20.8.tgz";
-        sha512 = "TyZ+ma0jRU/T0BChpl17hHa0cMOnPX9DYFbpyT8p5ghRHIHYYL/3rFFflwB+5bAwbK1Y8Z2LKB7dngzL7jzpTQ==";
+        url = "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-1.0.2.tgz";
+        sha512 = "BhgzwWjxjrQJnZC/BMIZvco4H5ksZl+qh+3hy40ReDrNpp8xSc3mDIFoB785CZrYBtFMhasE2q0kqdYuNKE/Zw==";
       };
     };
-    "@node-red/nodes-0.20.8" = {
+    "@node-red/nodes-1.0.2" = {
       name = "_at_node-red_slash_nodes";
       packageName = "@node-red/nodes";
-      version = "0.20.8";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/nodes/-/nodes-0.20.8.tgz";
-        sha512 = "yR+kNSkUQowQLHpk7buY36Pz5utA3q3n/49LvgvyxxRwgOPUBv4KNaFLDipUjqgD2spaznh+VTAMT8UUO0xeig==";
+        url = "https://registry.npmjs.org/@node-red/nodes/-/nodes-1.0.2.tgz";
+        sha512 = "o5N0FZnLAEd1lF2ArLGoETosukFVI+nPTHWKUOoSd069eLuaS262BOTbbnk/oY4H2DEWQzjGZ2KKBItWlhbpXQ==";
       };
     };
-    "@node-red/registry-0.20.8" = {
+    "@node-red/registry-1.0.2" = {
       name = "_at_node-red_slash_registry";
       packageName = "@node-red/registry";
-      version = "0.20.8";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/registry/-/registry-0.20.8.tgz";
-        sha512 = "3B5wYJOAWNLa3qhzdFZYqHa8X2+U4mdno6f0GQ2vzaNMdcxM9VvkpXLvmnThcQJsYqbxAiwuaUZUL1mX0KePsA==";
+        url = "https://registry.npmjs.org/@node-red/registry/-/registry-1.0.2.tgz";
+        sha512 = "i6TZvVriini0732IN2DVMofkG8RmiaLKpkHaP1aRceHvweDQB4yorcQsPDxqU+uiJo3lQlc1oB5j13X3mdq8DQ==";
       };
     };
-    "@node-red/runtime-0.20.8" = {
+    "@node-red/runtime-1.0.2" = {
       name = "_at_node-red_slash_runtime";
       packageName = "@node-red/runtime";
-      version = "0.20.8";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/runtime/-/runtime-0.20.8.tgz";
-        sha512 = "R7X3E8VXGlzXbYd0hTqhgU8rzyc2uNXDb3u37C3rduCViotcKWrQho4n/UdQS4H+T1Bu0H6Zoo+1EGAsQ92nGA==";
+        url = "https://registry.npmjs.org/@node-red/runtime/-/runtime-1.0.2.tgz";
+        sha512 = "YMKu5HA4WWYdf2PinysONiEFkmoz+PHD4u9ormREBXPr4iCWmZ2+XqL4QRGAc/RA8FJQ8liCr2rLDUvAuSSVOQ==";
       };
     };
-    "@node-red/util-0.20.8" = {
+    "@node-red/util-1.0.2" = {
       name = "_at_node-red_slash_util";
       packageName = "@node-red/util";
-      version = "0.20.8";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@node-red/util/-/util-0.20.8.tgz";
-        sha512 = "tid1o8fy94b6XU6/8cVDm5Kn9tNWm1AoaLPrhfDxJaObtrcHC6KtEhJJxPq61nhzZxJOuT/DHqBUGwTXTKg7Zg==";
+        url = "https://registry.npmjs.org/@node-red/util/-/util-1.0.2.tgz";
+        sha512 = "DwaS8ZDcIFcMUQCWpMEVt38Pr6H2JBCeghZEs5v6nH+pnemUi1x6Mi+CSvwywVc4WN4uzGhVr8dWxFh1Q6/iEQ==";
       };
     };
     "@nodelib/fs.stat-1.1.3" = {
@@ -2029,13 +1975,121 @@ let
         sha512 = "shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==";
       };
     };
-    "@octokit/endpoint-5.3.5" = {
+    "@oclif/color-0.0.0" = {
+      name = "_at_oclif_slash_color";
+      packageName = "@oclif/color";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/color/-/color-0.0.0.tgz";
+        sha512 = "KKd3W7eNwfNF061tr663oUNdt8EMnfuyf5Xv55SGWA1a0rjhWqS/32P7OeB7CbXcJUBdfVrPyR//1afaW12AWw==";
+      };
+    };
+    "@oclif/command-1.5.19" = {
+      name = "_at_oclif_slash_command";
+      packageName = "@oclif/command";
+      version = "1.5.19";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/command/-/command-1.5.19.tgz";
+        sha512 = "6+iaCMh/JXJaB2QWikqvGE9//wLEVYYwZd5sud8aLoLKog1Q75naZh2vlGVtg5Mq/NqpqGQvdIjJb3Bm+64AUQ==";
+      };
+    };
+    "@oclif/config-1.13.3" = {
+      name = "_at_oclif_slash_config";
+      packageName = "@oclif/config";
+      version = "1.13.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/config/-/config-1.13.3.tgz";
+        sha512 = "qs5XvGRw+1M41abOKCjd0uoeHCgsMxa2MurD2g2K8CtQlzlMXl0rW5idVeimIg5208LLuxkfzQo8TKAhhRCWLg==";
+      };
+    };
+    "@oclif/errors-1.2.2" = {
+      name = "_at_oclif_slash_errors";
+      packageName = "@oclif/errors";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/errors/-/errors-1.2.2.tgz";
+        sha512 = "Eq8BFuJUQcbAPVofDxwdE0bL14inIiwt5EaKRVY9ZDIG11jwdXZqiQEECJx0VfnLyUZdYfRd/znDI/MytdJoKg==";
+      };
+    };
+    "@oclif/linewrap-1.0.0" = {
+      name = "_at_oclif_slash_linewrap";
+      packageName = "@oclif/linewrap";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz";
+        sha512 = "Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==";
+      };
+    };
+    "@oclif/parser-3.8.4" = {
+      name = "_at_oclif_slash_parser";
+      packageName = "@oclif/parser";
+      version = "3.8.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.4.tgz";
+        sha512 = "cyP1at3l42kQHZtqDS3KfTeyMvxITGwXwH1qk9ktBYvqgMp5h4vHT+cOD74ld3RqJUOZY/+Zi9lb4Tbza3BtuA==";
+      };
+    };
+    "@oclif/plugin-autocomplete-0.1.4" = {
+      name = "_at_oclif_slash_plugin-autocomplete";
+      packageName = "@oclif/plugin-autocomplete";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-0.1.4.tgz";
+        sha512 = "ZyxJyL6jSt9Df68Smeu14xhZZwELE9IB5twhie1/56rt62nG6TJB4CZhaMqRk+33MDfU3JyWxNbIDMNMESlGqg==";
+      };
+    };
+    "@oclif/plugin-help-2.2.1" = {
+      name = "_at_oclif_slash_plugin-help";
+      packageName = "@oclif/plugin-help";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.1.tgz";
+        sha512 = "psEA3t41MSGBErLk6xCaAq2jKrRtx3Br+kHpd43vZeGEeZ7Gos4wgK0JAaHBbvhvUQskCHg8dzoqv4XEeTWeVQ==";
+      };
+    };
+    "@oclif/plugin-not-found-1.2.3" = {
+      name = "_at_oclif_slash_plugin-not-found";
+      packageName = "@oclif/plugin-not-found";
+      version = "1.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-1.2.3.tgz";
+        sha512 = "Igbw2T4gLrb/f28Llr730FeMXBSI2PXdky2YvQfsZeQGDsyBZmC4gprJJtmrMWQcjz0B51IInRBnZYERvwfIpw==";
+      };
+    };
+    "@oclif/plugin-plugins-1.7.8" = {
+      name = "_at_oclif_slash_plugin-plugins";
+      packageName = "@oclif/plugin-plugins";
+      version = "1.7.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-1.7.8.tgz";
+        sha512 = "GxLxaf8Lk1RqHVAIBZyA7hmhU7u5oV97i/OsWgFPdjPaT+BmWlWXR8IpmtA8giNo6atR+JpfgDmYndMU75zYUQ==";
+      };
+    };
+    "@oclif/plugin-warn-if-update-available-1.7.0" = {
+      name = "_at_oclif_slash_plugin-warn-if-update-available";
+      packageName = "@oclif/plugin-warn-if-update-available";
+      version = "1.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-1.7.0.tgz";
+        sha512 = "Nwyz3BJ8RhsfQ+OmFSsJSPIfn5YJqMrCzPh72Zgo2jqIjKIBWD8N9vTTe4kZlpeUUn77SyXFfwlBQbNCL5OEuQ==";
+      };
+    };
+    "@oclif/screen-1.0.4" = {
+      name = "_at_oclif_slash_screen";
+      packageName = "@oclif/screen";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz";
+        sha512 = "60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==";
+      };
+    };
+    "@octokit/endpoint-5.5.0" = {
       name = "_at_octokit_slash_endpoint";
       packageName = "@octokit/endpoint";
-      version = "5.3.5";
+      version = "5.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.3.5.tgz";
-        sha512 = "f8KqzIrnzPLiezDsZZPB+K8v8YSv6aKFl7eOu59O46lmlW4HagWl1U6NWl6LmT8d1w7NsKBI3paVtzcnRGO1gw==";
+        url = "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.0.tgz";
+        sha512 = "TXYS6zXeBImNB9BVj+LneMDqXX+H0exkOpyXobvp92O3B1348QsKnNioISFKgOMsb3ibZvQGwCdpiwQd3KAjIA==";
       };
     };
     "@octokit/plugin-enterprise-rest-3.6.2" = {
@@ -2047,13 +2101,13 @@ let
         sha512 = "3wF5eueS5OHQYuAEudkpN+xVeUsg8vYEMMenEzLphUZ7PRZ8OJtDcsreL3ad9zxXmBbaFWzLmFcdob5CLyZftA==";
       };
     };
-    "@octokit/request-5.1.0" = {
+    "@octokit/request-5.3.0" = {
       name = "_at_octokit_slash_request";
       packageName = "@octokit/request";
-      version = "5.1.0";
+      version = "5.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/request/-/request-5.1.0.tgz";
-        sha512 = "I15T9PwjFs4tbWyhtFU2Kq7WDPidYMvRB7spmxoQRZfxSmiqullG+Nz+KbSmpkfnlvHwTr1e31R5WReFRKMXjg==";
+        url = "https://registry.npmjs.org/@octokit/request/-/request-5.3.0.tgz";
+        sha512 = "mMIeNrtYyNEIYNsKivDyUAukBkw0M5ckyJX56xoFRXSasDPCloIXaQOnaKNopzQ8dIOvpdq1ma8gmrS+h6O2OQ==";
       };
     };
     "@octokit/request-error-1.0.4" = {
@@ -2065,13 +2119,22 @@ let
         sha512 = "L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==";
       };
     };
-    "@octokit/rest-16.30.0" = {
+    "@octokit/rest-16.34.1" = {
       name = "_at_octokit_slash_rest";
       packageName = "@octokit/rest";
-      version = "16.30.0";
+      version = "16.34.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/rest/-/rest-16.30.0.tgz";
-        sha512 = "TN5MbqVuqxT/s87D6tGe3zsMvyHUQSkGFMBHuwBToPQGV3eG2a67rJW2rag2vJr7JusWyERDhQ4g/4HvFo9B1g==";
+        url = "https://registry.npmjs.org/@octokit/rest/-/rest-16.34.1.tgz";
+        sha512 = "JUoS12cdktf1fv86rgrjC/RvYLuL+o7p57W7zX1x7ANFJ7OvdV8emvUNkFlcidEaOkYrxK3SoWgQFt3FhNmabA==";
+      };
+    };
+    "@octokit/types-1.1.0" = {
+      name = "_at_octokit_slash_types";
+      packageName = "@octokit/types";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@octokit/types/-/types-1.1.0.tgz";
+        sha512 = "t4ZD74UnNVMq6kZBDZceflRKK3q4o5PoCKMAGht0RK84W57tqonqKL3vCxJHtbGExdan9RwV8r7VJBZxIM1O7Q==";
       };
     };
     "@parcel/fs-1.11.0" = {
@@ -2083,13 +2146,13 @@ let
         sha512 = "86RyEqULbbVoeo8OLcv+LQ1Vq2PKBAvWTU9fCgALxuCTbbs5Ppcvll4Vr+Ko1AnmMzja/k++SzNAwJfeQXVlpA==";
       };
     };
-    "@parcel/logger-1.11.0" = {
+    "@parcel/logger-1.11.1" = {
       name = "_at_parcel_slash_logger";
       packageName = "@parcel/logger";
-      version = "1.11.0";
+      version = "1.11.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@parcel/logger/-/logger-1.11.0.tgz";
-        sha512 = "lIRfDg+junbFUUeU0QtHX00gKCgEsYHZydFKwrJ8dc0D+WE2SYT1FcVCgpPAfKYgtg0QQMns8E9vzT9UjH92PQ==";
+        url = "https://registry.npmjs.org/@parcel/logger/-/logger-1.11.1.tgz";
+        sha512 = "9NF3M6UVeP2udOBDILuoEHd8VrF4vQqoWHEafymO1pfSoOMfxrSJZw1MfyAAIUN/IFp9qjcpDCUbDZB+ioVevA==";
       };
     };
     "@parcel/utils-1.11.0" = {
@@ -2101,13 +2164,13 @@ let
         sha512 = "cA3p4jTlaMeOtAKR/6AadanOPvKeg8VwgnHhOyfi0yClD0TZS/hi9xu12w4EzA/8NtHu0g6o4RDfcNjqN8l1AQ==";
       };
     };
-    "@parcel/watcher-1.12.0" = {
+    "@parcel/watcher-1.12.1" = {
       name = "_at_parcel_slash_watcher";
       packageName = "@parcel/watcher";
-      version = "1.12.0";
+      version = "1.12.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@parcel/watcher/-/watcher-1.12.0.tgz";
-        sha512 = "yijGiAqG7Tjf5WnFwOkiNWwerfZQDNABldiiqRDtr7vDWLO+F/DIncyB7tTcaD5Loevrr5mzzGo8Ntf3d2GIPg==";
+        url = "https://registry.npmjs.org/@parcel/watcher/-/watcher-1.12.1.tgz";
+        sha512 = "od+uCtCxC/KoNQAIE1vWx1YTyKYY+7CTrxBJPRh3cDWw/C0tCtlBMVlrbplscGoEpt6B27KhJDCv82PBxOERNA==";
       };
     };
     "@parcel/workers-1.11.0" = {
@@ -2218,31 +2281,40 @@ let
         sha512 = "YXJqp9gdHcZKAmBY/WnwFpPtNQp2huD/ME2YMurH2YHJvxrVzYsmpKw/pb7yINArRpp8E++fwbQd3ajYXGA45Q==";
       };
     };
-    "@schematics/angular-8.3.5" = {
+    "@samverschueren/stream-to-observable-0.3.0" = {
+      name = "_at_samverschueren_slash_stream-to-observable";
+      packageName = "@samverschueren/stream-to-observable";
+      version = "0.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz";
+        sha512 = "MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==";
+      };
+    };
+    "@schematics/angular-8.3.17" = {
       name = "_at_schematics_slash_angular";
       packageName = "@schematics/angular";
-      version = "8.3.5";
+      version = "8.3.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.5.tgz";
-        sha512 = "3YKurSNqUfjVrbENVlnTBNGYBWjdyjrWzJRlwWbCq+owQLhkZ/N5qVirt/SDw5T9hK2AEMOKjLkQYtpE+aOCgg==";
+        url = "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.17.tgz";
+        sha512 = "Ot++j7vpEBKUD+D6eQxIJto+PYR2HPR9hmBoshZ2nt1/mU3OPEpIMIO/OBnbVtGmuzKXdq2n2NvbPtnhlxWplA==";
       };
     };
-    "@schematics/update-0.803.5" = {
+    "@schematics/update-0.803.17" = {
       name = "_at_schematics_slash_update";
       packageName = "@schematics/update";
-      version = "0.803.5";
+      version = "0.803.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/update/-/update-0.803.5.tgz";
-        sha512 = "v2qU0ATb1jND8GIGQFnI1QLWoquUjJ2fJ37HoDSO3rmttZ/NvoV4sNDGhk/pPUcmeXa+prURfJCCCSeHZ/yKkw==";
+        url = "https://registry.npmjs.org/@schematics/update/-/update-0.803.17.tgz";
+        sha512 = "42CqIcm0i1BfBXYm6YuE8Q6kEEb0ATYiPYJQTgmb+bZSF2Sl9eAzPBaackW2EwVK1JP3Rdyl2S31OwGvgAk6xA==";
       };
     };
-    "@serverless/cli-1.2.3" = {
+    "@serverless/cli-1.4.0" = {
       name = "_at_serverless_slash_cli";
       packageName = "@serverless/cli";
-      version = "1.2.3";
+      version = "1.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/cli/-/cli-1.2.3.tgz";
-        sha512 = "N/hsPZrE/zK8Iv98bdEG7J6ZhotWXwywjc/bKWcbhZeXENqbS7UD2qtyL/pfGuNodFVG587l8Cf+UvK8OcA6Qg==";
+        url = "https://registry.npmjs.org/@serverless/cli/-/cli-1.4.0.tgz";
+        sha512 = "YqlCiYmRFeGksw6XJaXbigIDlktc7OfRuVpyPB7IZgkCJ9mUlBmvyWdwqJEQdkUz0xPTGsd4Jd/XSrwyiw1Brg==";
       };
     };
     "@serverless/component-metrics-1.0.8" = {
@@ -2254,22 +2326,22 @@ let
         sha512 = "lOUyRopNTKJYVEU9T6stp2irwlTDsYMmUKBOUjnMcwGveuUfIJqrCOtFLtIPPj3XJlbZy5F68l4KP9rZ8Ipang==";
       };
     };
-    "@serverless/core-1.0.0" = {
+    "@serverless/core-1.1.2" = {
       name = "_at_serverless_slash_core";
       packageName = "@serverless/core";
-      version = "1.0.0";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/core/-/core-1.0.0.tgz";
-        sha512 = "XP5KXvEGlrNIOV/KJ0KKwzeov9MqZQ+Ck3z7JW/gtd8ryoKK+5+ah2WL77DXETeHeEwxZhJdrNatqc0FXauEiw==";
+        url = "https://registry.npmjs.org/@serverless/core/-/core-1.1.2.tgz";
+        sha512 = "PY7gH+7aQ+MltcUD7SRDuQODJ9Sav9HhFJsgOiyf8IVo7XVD6FxZIsSnpMI6paSkptOB7n+0Jz03gNlEkKetQQ==";
       };
     };
-    "@serverless/enterprise-plugin-3.0.0" = {
+    "@serverless/enterprise-plugin-3.2.1" = {
       name = "_at_serverless_slash_enterprise-plugin";
       packageName = "@serverless/enterprise-plugin";
-      version = "3.0.0";
+      version = "3.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.0.0.tgz";
-        sha512 = "+L+SeQV0MKQN9TBXC6Xmgcw7BVfW8Q3F/lMjB1MPsBd0RZPzYnVlWcVg4cA6tgvkpfdw8NVlh/QXFs+603zHrg==";
+        url = "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.2.1.tgz";
+        sha512 = "CLTuvtEYhmvV7qiYuHkDJxoIIdcRU8OQBUhoBhUscK6UVdsKB2Y4ykz8su0rGg5rdgcaaluJF0+H87oBNw77ag==";
       };
     };
     "@serverless/event-mocks-1.1.1" = {
@@ -2281,22 +2353,22 @@ let
         sha512 = "YAV5V/y+XIOfd+HEVeXfPWZb8C6QLruFk9tBivoX2roQLWVq145s4uxf8D0QioCueuRzkukHUS4JIj+KVoS34A==";
       };
     };
-    "@serverless/platform-sdk-2.1.1" = {
+    "@serverless/platform-sdk-2.2.0" = {
       name = "_at_serverless_slash_platform-sdk";
       packageName = "@serverless/platform-sdk";
-      version = "2.1.1";
+      version = "2.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-2.1.1.tgz";
-        sha512 = "bWmXwhUmnDxY4A5zFKinbBQaPcMbxd5i07i8nyJUDjvr8F8gB9fo2n5A20c1ahOIEiFntBRC9y4/6fxNjIsXqQ==";
+        url = "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-2.2.0.tgz";
+        sha512 = "w5A/szD0ZMUIuqUt5HyHllQ9LKO9/mpgv3rtJjLRI5ZJq1GvY4pv2pyQQPxGLT1gv0ER+b5vF+4tfrkx6MEuEw==";
       };
     };
-    "@serverless/template-1.1.0" = {
+    "@serverless/template-1.1.3" = {
       name = "_at_serverless_slash_template";
       packageName = "@serverless/template";
-      version = "1.1.0";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/template/-/template-1.1.0.tgz";
-        sha512 = "ezrtGAf1pKXKfsd+o381L2HAtVxhmXlm59rq7iBPosqChrrE8NI081IIMNTi93JLpTULZaSCRLMDMwVrCJ0ZMw==";
+        url = "https://registry.npmjs.org/@serverless/template/-/template-1.1.3.tgz";
+        sha512 = "hcMiX523rkp6kHeKnM1x6/dXEY+d1UFSr901yVKeeCgpFy4u33UI9vlKaPweAZCF6Ahzqywf01IsFTuBVadCrQ==";
       };
     };
     "@sindresorhus/is-0.14.0" = {
@@ -2326,13 +2398,31 @@ let
         sha512 = "CWr7a3rTVrN5Vs8GYReRAvTourbXHOqB1zglcskj05ICH4GZL5BOAza2ARai+qc3Nz0nY08Bozi1x0014KOqlg==";
       };
     };
-    "@snyk/cli-interface-2.1.0" = {
+    "@snyk/cli-interface-1.5.0" = {
       name = "_at_snyk_slash_cli-interface";
       packageName = "@snyk/cli-interface";
-      version = "2.1.0";
+      version = "1.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.1.0.tgz";
-        sha512 = "b/magC8iNQP9QhSDeV9RQDSaY3sNy57k0UH1Y/sMOSvVLHLsA7dOi/HrPWTiLouyGqcuYzwjkz7bNbu8cwmVDQ==";
+        url = "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-1.5.0.tgz";
+        sha512 = "+Qo+IO3YOXWgazlo+CKxOuWFLQQdaNCJ9cSfhFQd687/FuesaIxWdInaAdfpsLScq0c6M1ieZslXgiZELSzxbg==";
+      };
+    };
+    "@snyk/cli-interface-2.2.0" = {
+      name = "_at_snyk_slash_cli-interface";
+      packageName = "@snyk/cli-interface";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.2.0.tgz";
+        sha512 = "sA7V2JhgqJB9z5uYotgQc5iNDv//y+Mdm39rANxmFjtZMSYJZHkP80arzPjw1mB5ni/sWec7ieYUUFeySZBfVg==";
+      };
+    };
+    "@snyk/cocoapods-lockfile-parser-2.0.4" = {
+      name = "_at_snyk_slash_cocoapods-lockfile-parser";
+      packageName = "@snyk/cocoapods-lockfile-parser";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@snyk/cocoapods-lockfile-parser/-/cocoapods-lockfile-parser-2.0.4.tgz";
+        sha512 = "d57bajPjqCiNXMuyMmt9Zt98zbjABZUFw+91B705flzV6oB7OThgtA40Eoin6iatYoStIx28bC3T6b0mScy/iA==";
       };
     };
     "@snyk/composer-lockfile-parser-1.0.3" = {
@@ -2344,13 +2434,22 @@ let
         sha512 = "hb+6E7kMzWlcwfe//ILDoktBPKL2a3+RnJT/CXnzRXaiLQpsdkf5li4q2v0fmvd+4v7L3tTN8KM+//lJyviEkg==";
       };
     };
-    "@snyk/dep-graph-1.12.0" = {
+    "@snyk/dep-graph-1.13.0" = {
       name = "_at_snyk_slash_dep-graph";
       packageName = "@snyk/dep-graph";
-      version = "1.12.0";
+      version = "1.13.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.12.0.tgz";
-        sha512 = "n7+PlHn3SqznHgsCpeBRfEvU1oiQydoGkXQlnSB2+tfImiKXvY7YZbrg4wlbvYgylYiTbpCi5CpPNkJG14S+UQ==";
+        url = "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.13.0.tgz";
+        sha512 = "e0XcLH6Kgs/lunf6iDjbxEnm9+JYFEJn6eo/PlEUW+SMWBZ2uEXHBTDNp9oxjJou48PngzWMveEkniBAN+ulOQ==";
+      };
+    };
+    "@snyk/dep-graph-1.13.1" = {
+      name = "_at_snyk_slash_dep-graph";
+      packageName = "@snyk/dep-graph";
+      version = "1.13.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.13.1.tgz";
+        sha512 = "Ww2xvm5UQgrq9eV0SdTBCh+w/4oI2rCx5vn1IOSeypaR0CO4p+do1vm3IDZ2ugg4jLSfHP8+LiD6ORESZMkQ2w==";
       };
     };
     "@snyk/gemfile-1.2.0" = {
@@ -2360,6 +2459,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@snyk/gemfile/-/gemfile-1.2.0.tgz";
         sha512 = "nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA==";
+      };
+    };
+    "@snyk/ruby-semver-2.0.4" = {
+      name = "_at_snyk_slash_ruby-semver";
+      packageName = "@snyk/ruby-semver";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@snyk/ruby-semver/-/ruby-semver-2.0.4.tgz";
+        sha512 = "ceMD4CBS3qtAg+O0BUvkKdsheUNCqi+/+Rju243Ul8PsUgZnXmGiqfk/2z7DCprRQnxUTra4+IyeDQT7wAheCQ==";
+      };
+    };
+    "@snyk/snyk-cocoapods-plugin-1.0.3" = {
+      name = "_at_snyk_slash_snyk-cocoapods-plugin";
+      packageName = "@snyk/snyk-cocoapods-plugin";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@snyk/snyk-cocoapods-plugin/-/snyk-cocoapods-plugin-1.0.3.tgz";
+        sha512 = "AHAA7z23nPi1eHODsDxeSkl73Ze3yphuqJjMl39ie323EzBDcb9g6uAACrk0Qn2K/K2D8uyxMAf2zDtc+JGQfw==";
       };
     };
     "@starptech/expression-parser-0.9.0" = {
@@ -2461,121 +2578,121 @@ let
         sha512 = "XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==";
       };
     };
-    "@textlint/ast-node-types-4.2.4" = {
+    "@textlint/ast-node-types-4.2.5" = {
       name = "_at_textlint_slash_ast-node-types";
       packageName = "@textlint/ast-node-types";
-      version = "4.2.4";
+      version = "4.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.4.tgz";
-        sha512 = "ggiixpScxgdMY42b6UafD1iUboSvl9k3vGA9kynP+kd6mEhTDzxtb1aHPDAnV+DpAEw4qpHMz72GBFkX/iOSFw==";
+        url = "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.2.5.tgz";
+        sha512 = "+rEx4jLOeZpUcdvll7jEg/7hNbwYvHWFy4IGW/tk2JdbyB3SJVyIP6arAwzTH/sp/pO9jftfyZnRj4//sLbLvQ==";
       };
     };
-    "@textlint/ast-traverse-2.1.5" = {
+    "@textlint/ast-traverse-2.1.6" = {
       name = "_at_textlint_slash_ast-traverse";
       packageName = "@textlint/ast-traverse";
-      version = "2.1.5";
+      version = "2.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-2.1.5.tgz";
-        sha512 = "Xt1x8eBmXS+4nOQ+0VjIoyXgcz9VFxK3ug8EiG7tGkhezIU90HRW2O8jPOPXhOcrrRzBGQNG9tsL7+IUDzF5FQ==";
+        url = "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-2.1.6.tgz";
+        sha512 = "qSPTUptR/C4YwoeVXRLUij6TpxbXT7U0P9S0No+p9Q+EYJeNvl1NUTrcpQmzrRydo6vCR0RzVkHmj+gEckH2Ug==";
       };
     };
-    "@textlint/feature-flag-3.1.3" = {
+    "@textlint/feature-flag-3.1.4" = {
       name = "_at_textlint_slash_feature-flag";
       packageName = "@textlint/feature-flag";
-      version = "3.1.3";
+      version = "3.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-3.1.3.tgz";
-        sha512 = "59RaAmdsMB3e32PD04N0YOJI2L3ljWR8fEk9FDLbOJAZeu7c+TqgETHDiVnkrh8gM+m8RL0h4wWq1jbB1kj0Xw==";
+        url = "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-3.1.4.tgz";
+        sha512 = "sQle1237X/ckMnHkSAuQYDRuCnKgBHdJuWFPHMpgT4CBb2UjWSZkjCgmzf3Ov6UZQL/1BwuA53wT4T+i1rB1zw==";
       };
     };
-    "@textlint/fixer-formatter-3.1.8" = {
+    "@textlint/fixer-formatter-3.1.9" = {
       name = "_at_textlint_slash_fixer-formatter";
       packageName = "@textlint/fixer-formatter";
-      version = "3.1.8";
+      version = "3.1.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-3.1.8.tgz";
-        sha512 = "PKpUA2EOinFSE9kEhr6C2kpdEJj4U7nHuB4dCRHV9so3hIJyqXJBx4YwTpyggIUgNv6OkY2qo8D0g3YOu99zSw==";
+        url = "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-3.1.9.tgz";
+        sha512 = "4eU2kJC0A5EljfhbVhwVaNUEiBSCaRq0k4h19/OeVk9blkAwmILtBbAgbuxGuQAOquBLJGLx+3+tspBOlydS2g==";
       };
     };
-    "@textlint/kernel-3.1.8" = {
+    "@textlint/kernel-3.1.9" = {
       name = "_at_textlint_slash_kernel";
       packageName = "@textlint/kernel";
-      version = "3.1.8";
+      version = "3.1.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/kernel/-/kernel-3.1.8.tgz";
-        sha512 = "ViCHoy2QMpCD8Vu+2vXHXc+Jt9D5lIKUH7+j1TzP5JPiPmV1IbEMrztk4ubjacYQTSRHXE9BCLGOffOKSxt+ag==";
+        url = "https://registry.npmjs.org/@textlint/kernel/-/kernel-3.1.9.tgz";
+        sha512 = "WGD5Xb0wyYMdiqF+Ozo1TqnAo1LA5n+jmpFT/Q/Pnx2zifT4/OszwBd9g43g3xGdsUJKk00eKwvSQaCXxj07wg==";
       };
     };
-    "@textlint/linter-formatter-3.1.7" = {
+    "@textlint/linter-formatter-3.1.8" = {
       name = "_at_textlint_slash_linter-formatter";
       packageName = "@textlint/linter-formatter";
-      version = "3.1.7";
+      version = "3.1.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-3.1.7.tgz";
-        sha512 = "myFj1Vj22LdzDecAvfIWojobi0AIGCEuEhLlrGcn478Wv6vQgP+51o0zTu1e2Duth1Z7YYjdTIcn2yZWxWSalg==";
+        url = "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-3.1.8.tgz";
+        sha512 = "gq8g5GbRDxYlffjP+CuggSk5Hb35jg1fXLbffkLGbiWiJn/s6InbcBqCkxGLCzPqdRhN6uHE40ID3idKJWp2Rg==";
       };
     };
-    "@textlint/markdown-to-ast-6.1.5" = {
+    "@textlint/markdown-to-ast-6.1.6" = {
       name = "_at_textlint_slash_markdown-to-ast";
       packageName = "@textlint/markdown-to-ast";
-      version = "6.1.5";
+      version = "6.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.1.5.tgz";
-        sha512 = "WM2z0/wXpEREXAkSoKyPLG4qp5e5XGI5ctuQ5sUG1BE4aaAxJ3ogomaocQc82MPobiQjYp5791A+cXXYx5ML5w==";
+        url = "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.1.6.tgz";
+        sha512 = "xIaMn6gW1Ig+M+2Xcdbxt4cgOqWJSuB0pIO98KppQyqPzQ5k5deea7SBABqLZiKeNIxLl+2C1vfIfnBFFjxlmg==";
       };
     };
-    "@textlint/module-interop-1.0.1" = {
+    "@textlint/module-interop-1.0.2" = {
       name = "_at_textlint_slash_module-interop";
       packageName = "@textlint/module-interop";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-1.0.1.tgz";
-        sha512 = "gqx1Te+lMnXX6xyGTUdzGhm8RT7IfiSRMtWoH1FeTMg2InArRT+lTksCFc/x5dtaPN4vwOFZUvU8oTzYQzXbyg==";
-      };
-    };
-    "@textlint/text-to-ast-3.1.5" = {
-      name = "_at_textlint_slash_text-to-ast";
-      packageName = "@textlint/text-to-ast";
-      version = "3.1.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-3.1.5.tgz";
-        sha512 = "LGDlK+Jk5hpVPYcBxFU1Go9bG3AYAkHwNkAy573gLBKuGjb69FY6Wpmt4XBcKCKaa1j7S9cq7OxiSu69dVyQlQ==";
-      };
-    };
-    "@textlint/textlint-plugin-markdown-5.1.8" = {
-      name = "_at_textlint_slash_textlint-plugin-markdown";
-      packageName = "@textlint/textlint-plugin-markdown";
-      version = "5.1.8";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-5.1.8.tgz";
-        sha512 = "x38FOJzbgz1DLc5inRz0qyjd879CMvWkeUJc0tcuYvZWEoQ7RS5YwjQK3Q9C3LGGM2JGy4Wnkr6jBIBFCBBbdA==";
-      };
-    };
-    "@textlint/textlint-plugin-text-4.1.8" = {
-      name = "_at_textlint_slash_textlint-plugin-text";
-      packageName = "@textlint/textlint-plugin-text";
-      version = "4.1.8";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-4.1.8.tgz";
-        sha512 = "QMc1xQKyQL+oLMNaij6v4Gt02m51lwM4lN5FCjUrhVA+0LfX/2whBLBcXbnw5+GVkkQmVcF98aQovEJ8YPLTtA==";
-      };
-    };
-    "@textlint/types-1.2.1" = {
-      name = "_at_textlint_slash_types";
-      packageName = "@textlint/types";
-      version = "1.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/types/-/types-1.2.1.tgz";
-        sha512 = "HNbVS+F9hNy4E/Hnv2mV/6rjlPB7Mdc5KCiT+uFjMK7vqiVuW/DeKjkYScRirQ0jf8gWUXBVTxZgwBBlJZmV1Q==";
-      };
-    };
-    "@textlint/utils-1.0.2" = {
-      name = "_at_textlint_slash_utils";
-      packageName = "@textlint/utils";
       version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@textlint/utils/-/utils-1.0.2.tgz";
-        sha512 = "T8med69p37s1TE/G56kxWSYz8PqWYCnqyVZp2K0WoQbkNDrckmqkJ6xTmw4uZg4kypn3+EXVuktWLOpaSUcktA==";
+        url = "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-1.0.2.tgz";
+        sha512 = "qQ6dqlg4SYywCywimIbkveQZu1MG6ugf6fcJuWDi3D51FbdkSRsMrPusJ1YoW6Y3XBp0ww9fJjXWtlUStGeQsw==";
+      };
+    };
+    "@textlint/text-to-ast-3.1.6" = {
+      name = "_at_textlint_slash_text-to-ast";
+      packageName = "@textlint/text-to-ast";
+      version = "3.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-3.1.6.tgz";
+        sha512 = "w0oBF3OeTT8syF+Y3BT1/pFYhBT2ZbzBDGqFELZVeBQNtGUKCpvJtu4Q1fCftElTbOIY01aSecj3GJTS6tmlBg==";
+      };
+    };
+    "@textlint/textlint-plugin-markdown-5.1.9" = {
+      name = "_at_textlint_slash_textlint-plugin-markdown";
+      packageName = "@textlint/textlint-plugin-markdown";
+      version = "5.1.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-5.1.9.tgz";
+        sha512 = "5bYPGid5dIWBjY3oKhmWmeWvBfl04ZGp0c4OD24MZHRkxrARKJg7i+hR7qhedAGdkeZ33fxQt/NILvbuLSvQVw==";
+      };
+    };
+    "@textlint/textlint-plugin-text-4.1.9" = {
+      name = "_at_textlint_slash_textlint-plugin-text";
+      packageName = "@textlint/textlint-plugin-text";
+      version = "4.1.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-4.1.9.tgz";
+        sha512 = "7iWNs2gsc+GXcDQfaow/S/BVjlu/bSw1dbiMJLfVaRb+D9gAojVm+sGHt9ePAhr9MWjt1uDUsWsvSNDL0UpZWA==";
+      };
+    };
+    "@textlint/types-1.2.2" = {
+      name = "_at_textlint_slash_types";
+      packageName = "@textlint/types";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@textlint/types/-/types-1.2.2.tgz";
+        sha512 = "eo+/NSmJxAk47Dvnjp4p3jbA/z/adVoAXjFURRhVQ4W/1KTVLyvB+WdiJBp8fiT5t5Kf3XSxyiS7mZcrY2bf/Q==";
+      };
+    };
+    "@textlint/utils-1.0.3" = {
+      name = "_at_textlint_slash_utils";
+      packageName = "@textlint/utils";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@textlint/utils/-/utils-1.0.3.tgz";
+        sha512 = "6oGaBKXYpg5Ooph5p32OFdp1dXDUC1z5mpHg2gmQbx6QZjmP4QX+ygBQdNoCq15d1w88+We6koJl0n0WXjItYw==";
       };
     };
     "@types/accepts-1.3.5" = {
@@ -2614,13 +2731,13 @@ let
         sha512 = "xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==";
       };
     };
-    "@types/bluebird-3.5.27" = {
+    "@types/bluebird-3.5.28" = {
       name = "_at_types_slash_bluebird";
       packageName = "@types/bluebird";
-      version = "3.5.27";
+      version = "3.5.28";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.27.tgz";
-        sha512 = "6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ==";
+        url = "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.28.tgz";
+        sha512 = "0Vk/kqkukxPKSzP9c8WJgisgGDx5oZDbsLLWIP5t70yThO/YleE+GEm2S1GlRALTaack3O7U5OS5qEm7q2kciA==";
       };
     };
     "@types/body-parser-1.17.1" = {
@@ -2659,13 +2776,13 @@ let
         sha512 = "aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==";
       };
     };
-    "@types/cookies-0.7.3" = {
+    "@types/cookies-0.7.4" = {
       name = "_at_types_slash_cookies";
       packageName = "@types/cookies";
-      version = "0.7.3";
+      version = "0.7.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.3.tgz";
-        sha512 = "NEkYn8pNsYZIxf3ZrjdPoeyueiPc0RbQClUpTwmdHkpmQQ8iDAlQYKpabuegHy7BJcqTteSTkhURMEs9ZxyEWg==";
+        url = "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.4.tgz";
+        sha512 = "oTGtMzZZAVuEjTwCjIh8T8FrC8n/uwy+PG0yTvQcdZ7etoel7C7/3MSd7qrukENTgQtotG7gvBlBojuVs7X5rw==";
       };
     };
     "@types/cors-2.8.6" = {
@@ -2684,6 +2801,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz";
         sha512 = "Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==";
+      };
+    };
+    "@types/eslint-visitor-keys-1.0.0" = {
+      name = "_at_types_slash_eslint-visitor-keys";
+      packageName = "@types/eslint-visitor-keys";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz";
+        sha512 = "OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==";
       };
     };
     "@types/estree-0.0.39" = {
@@ -2713,13 +2839,13 @@ let
         sha512 = "VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==";
       };
     };
-    "@types/express-serve-static-core-4.16.9" = {
+    "@types/express-serve-static-core-4.16.10" = {
       name = "_at_types_slash_express-serve-static-core";
       packageName = "@types/express-serve-static-core";
-      version = "4.16.9";
+      version = "4.16.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz";
-        sha512 = "GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==";
+        url = "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.10.tgz";
+        sha512 = "gM6evDj0OvTILTRKilh9T5dTaGpv1oYiFcJAfgSejuMJgGJUsD9hKEU2lB4aiTNy4WwChxRnjfYFuBQsULzsJw==";
       };
     };
     "@types/fs-capacitor-2.0.0" = {
@@ -2729,6 +2855,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz";
         sha512 = "FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==";
+      };
+    };
+    "@types/fs-extra-5.1.0" = {
+      name = "_at_types_slash_fs-extra";
+      packageName = "@types/fs-extra";
+      version = "5.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz";
+        sha512 = "AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==";
       };
     };
     "@types/glob-7.1.1" = {
@@ -2758,6 +2893,24 @@ let
         sha512 = "PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ==";
       };
     };
+    "@types/js-yaml-3.12.1" = {
+      name = "_at_types_slash_js-yaml";
+      packageName = "@types/js-yaml";
+      version = "3.12.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz";
+        sha512 = "SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==";
+      };
+    };
+    "@types/json-schema-7.0.3" = {
+      name = "_at_types_slash_json-schema";
+      packageName = "@types/json-schema";
+      version = "7.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz";
+        sha512 = "Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==";
+      };
+    };
     "@types/keygrip-1.0.1" = {
       name = "_at_types_slash_keygrip";
       packageName = "@types/keygrip";
@@ -2767,13 +2920,13 @@ let
         sha1 = "ff540462d2fb4d0a88441ceaf27d287b01c3d878";
       };
     };
-    "@types/koa-2.0.49" = {
+    "@types/koa-2.0.51" = {
       name = "_at_types_slash_koa";
       packageName = "@types/koa";
-      version = "2.0.49";
+      version = "2.0.51";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/koa/-/koa-2.0.49.tgz";
-        sha512 = "WQWpCH8O4Dslk8IcXfazff40aM1jXX7BQRbADIj/fKozVPu76P/wQE4sRe2SCWMn8yNkOcare2MkDrnZqLMkPQ==";
+        url = "https://registry.npmjs.org/@types/koa/-/koa-2.0.51.tgz";
+        sha512 = "L5e/l6Z+SR9Jk6HM0wNYdkvWhSUBOvi+7Q5Uwn7kE/VmBXX7NIxARMigARWAyXAtXiv5Ry1P2HmebolFdvuIVg==";
       };
     };
     "@types/koa-compose-3.2.4" = {
@@ -2785,13 +2938,13 @@ let
         sha512 = "ioou0rxkuWL+yBQYsHUQAzRTfVxAg8Y2VfMftU+Y3RA03/MzuFL0x/M2sXXj3PkfnENbHsjeHR1aMdezLYpTeA==";
       };
     };
-    "@types/lodash-4.14.138" = {
+    "@types/lodash-4.14.144" = {
       name = "_at_types_slash_lodash";
       packageName = "@types/lodash";
-      version = "4.14.138";
+      version = "4.14.144";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz";
-        sha512 = "A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==";
+        url = "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz";
+        sha512 = "ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==";
       };
     };
     "@types/long-4.0.0" = {
@@ -2821,40 +2974,40 @@ let
         sha512 = "tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==";
       };
     };
-    "@types/node-10.14.18" = {
+    "@types/node-10.17.2" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "10.14.18";
+      version = "10.17.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz";
-        sha512 = "ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ==";
+        url = "https://registry.npmjs.org/@types/node/-/node-10.17.2.tgz";
+        sha512 = "sAh60KDol+MpwOr1RTK0+HgBEYejKsxdpmrOS1Wts5bI03dLzq8F7T0sRXDKeaEK8iWDlGfdzxrzg6vx/c5pNA==";
       };
     };
-    "@types/node-12.7.5" = {
+    "@types/node-12.12.3" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "12.7.5";
+      version = "12.12.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz";
-        sha512 = "9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==";
+        url = "https://registry.npmjs.org/@types/node/-/node-12.12.3.tgz";
+        sha512 = "opgSsy+cEF9N8MgaVPnWVtdJ3o4mV2aMHvDq7thkQUFt0EuOHJon4rQpJfhjmNHB+ikl0Cd6WhWIErOyQ+f7tw==";
       };
     };
-    "@types/node-6.14.7" = {
+    "@types/node-6.14.9" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "6.14.7";
+      version = "6.14.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-6.14.7.tgz";
-        sha512 = "YbPXbaynBTe0pVExPhL76TsWnxSPeFAvImIsmylpBWn/yfw+lHy+Q68aawvZHsgskT44ZAoeE67GM5f+Brekew==";
+        url = "https://registry.npmjs.org/@types/node/-/node-6.14.9.tgz";
+        sha512 = "leP/gxHunuazPdZaCvsCefPQxinqUDsCxCR5xaDUrY2MkYxQRFZZwU5e7GojyYsGB7QVtCi7iVEl/hoFXQYc+w==";
       };
     };
-    "@types/node-8.10.54" = {
+    "@types/node-8.10.58" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "8.10.54";
+      version = "8.10.58";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz";
-        sha512 = "kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==";
+        url = "https://registry.npmjs.org/@types/node/-/node-8.10.58.tgz";
+        sha512 = "NNcUk/rAdR7Pie7WiA5NHp345dTkD62qaxqscQXVIjCjog/ZXsrG8Wo7dZMZAzE7PSpA+qR2S3TYTeFCKuBFxQ==";
       };
     };
     "@types/q-1.5.2" = {
@@ -2965,40 +3118,67 @@ let
         sha512 = "te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==";
       };
     };
-    "@vue/cli-shared-utils-3.11.0" = {
+    "@typescript-eslint/experimental-utils-1.13.0" = {
+      name = "_at_typescript-eslint_slash_experimental-utils";
+      packageName = "@typescript-eslint/experimental-utils";
+      version = "1.13.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz";
+        sha512 = "zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==";
+      };
+    };
+    "@typescript-eslint/parser-1.13.0" = {
+      name = "_at_typescript-eslint_slash_parser";
+      packageName = "@typescript-eslint/parser";
+      version = "1.13.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz";
+        sha512 = "ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==";
+      };
+    };
+    "@typescript-eslint/typescript-estree-1.13.0" = {
+      name = "_at_typescript-eslint_slash_typescript-estree";
+      packageName = "@typescript-eslint/typescript-estree";
+      version = "1.13.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz";
+        sha512 = "b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==";
+      };
+    };
+    "@vue/cli-shared-utils-4.0.5" = {
       name = "_at_vue_slash_cli-shared-utils";
       packageName = "@vue/cli-shared-utils";
-      version = "3.11.0";
+      version = "4.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.11.0.tgz";
-        sha512 = "D7pst/4v9H1DD66fLxlZOwRR09R03MV0ROdKxBHmh3FmnApCA/RiaolFA/8w+B3CnevYMlV3SJ5fOAgedbswbA==";
+        url = "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-4.0.5.tgz";
+        sha512 = "NlNZ4Dx5QcP5uO5fCOLgkN2tbhNan5EcptPvXawW/md18cIpMlKbph6L6lEfJj8vrSvTUf2i/FyoFSh1rV53hw==";
       };
     };
-    "@vue/cli-ui-3.11.0" = {
+    "@vue/cli-ui-4.0.5" = {
       name = "_at_vue_slash_cli-ui";
       packageName = "@vue/cli-ui";
-      version = "3.11.0";
+      version = "4.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-3.11.0.tgz";
-        sha512 = "mbCUUOJSPGLQ+wxPTX+NE6HsiCpt3wpv56AuUlCv14mUEkm98p+4xzkgPQ1neYxG7fg5Vn8fExiFvge73Lvzdg==";
+        url = "https://registry.npmjs.org/@vue/cli-ui/-/cli-ui-4.0.5.tgz";
+        sha512 = "pnK0qRMEocjhL965o2Zxw9iYYwwCDOIxAl7jg6pmQybgmz68ipi/gXDTe3IyDzyEJraVIsGDScvJL9/IbRLDZw==";
       };
     };
-    "@vue/cli-ui-addon-webpack-3.11.0" = {
+    "@vue/cli-ui-addon-webpack-4.0.5" = {
       name = "_at_vue_slash_cli-ui-addon-webpack";
       packageName = "@vue/cli-ui-addon-webpack";
-      version = "3.11.0";
+      version = "4.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-3.11.0.tgz";
-        sha512 = "q0kELq8c6nPAM74J2NELxn9NdaQ0bqYS9l8EsvLbqfTd/GM7leWytkdO6GYClu1VJ3Ohm3xQsKjpDHCcKSW7tw==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-4.0.5.tgz";
+        sha512 = "BMRW+g374RnqQNFLyUGHg099lADoZbYEjycCKZzBI4v+QCqUXEnn70l02/7H3sEee6PqR/dfquSJiZqxhSIJmQ==";
       };
     };
-    "@vue/cli-ui-addon-widgets-3.11.0" = {
+    "@vue/cli-ui-addon-widgets-4.0.5" = {
       name = "_at_vue_slash_cli-ui-addon-widgets";
       packageName = "@vue/cli-ui-addon-widgets";
-      version = "3.11.0";
+      version = "4.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-3.11.0.tgz";
-        sha512 = "iEKaaWyGafYmHJKDd2rISSqMw61L3XX9E9Vo/sVWK0uVITTsSyBmNwZeTcaaEB6YVbZeCHRJtq2Q/JRjvD9SPA==";
+        url = "https://registry.npmjs.org/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-4.0.5.tgz";
+        sha512 = "55KgyH0yDiStE0j04+5z+UTLATReQjIc1s7n9aVGsRte+nnt9bN74pBg9//CW8EWpD1OmEpTtsidn2NafuaxLQ==";
       };
     };
     "@webassemblyjs/ast-1.8.1" = {
@@ -3478,13 +3658,13 @@ let
         sha1 = "5faad9c2c07f60dd76770f71cf025b62a63cfd4e";
       };
     };
-    "abab-2.0.1" = {
+    "abab-2.0.2" = {
       name = "abab";
       packageName = "abab";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz";
-        sha512 = "1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==";
+        url = "https://registry.npmjs.org/abab/-/abab-2.0.2.tgz";
+        sha512 = "2scffjvioEmNz0OyDSLGWDfKCVwaKc6l9Pm9kOIREU13ClXZvHpg/nRL5xyjSSSLhOnXqft2HpsAzNEEA8cFFg==";
       };
     };
     "abbrev-1.1.1" = {
@@ -3523,13 +3703,13 @@ let
         sha512 = "jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==";
       };
     };
-    "abstract-leveldown-6.1.1" = {
+    "abstract-leveldown-6.2.2" = {
       name = "abstract-leveldown";
       packageName = "abstract-leveldown";
-      version = "6.1.1";
+      version = "6.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.1.1.tgz";
-        sha512 = "7fK/KySVqzKIomdhkSWzX4YBQhzkzEMbWSiaB6mSN9e+ZdV3KEeKxia/8xQzCkATA5xnnukdP88cFR0D2FsFXw==";
+        url = "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz";
+        sha512 = "/a+Iwj0rn//CX0EJOasNyZJd2o8xur8Ce9C57Sznti/Ilt/cb6Qd8/k98A4ZOklXgTG+iAYYUs1OTG0s1eH+zQ==";
       };
     };
     "abstract-logging-1.0.0" = {
@@ -3631,13 +3811,13 @@ let
         sha512 = "/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==";
       };
     };
-    "acorn-7.0.0" = {
+    "acorn-7.1.0" = {
       name = "acorn";
       packageName = "acorn";
-      version = "7.0.0";
+      version = "7.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz";
-        sha512 = "PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==";
+        url = "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz";
+        sha512 = "kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==";
       };
     };
     "acorn-globals-1.0.9" = {
@@ -3676,13 +3856,13 @@ let
         sha1 = "afdf9488fb1ecefc8348f6fb22f464e32a58b36b";
       };
     };
-    "acorn-jsx-5.0.2" = {
+    "acorn-jsx-5.1.0" = {
       name = "acorn-jsx";
       packageName = "acorn-jsx";
-      version = "5.0.2";
+      version = "5.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz";
-        sha512 = "tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==";
+        url = "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz";
+        sha512 = "tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==";
       };
     };
     "acorn-loose-6.1.0" = {
@@ -3766,13 +3946,13 @@ let
         sha1 = "f291be701a2efc567a63fc7aa6afcded31430be1";
       };
     };
-    "addons-linter-1.10.0" = {
+    "addons-linter-1.14.0" = {
       name = "addons-linter";
       packageName = "addons-linter";
-      version = "1.10.0";
+      version = "1.14.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/addons-linter/-/addons-linter-1.10.0.tgz";
-        sha512 = "2i2qSayVPx4h1Aa2ZTdQlpgmjcCNIHZ4AJQS8V/QsBXIdmXl+Djmeyr096bjaC3Usq0rZfYhGgFdwR1dgHVItw==";
+        url = "https://registry.npmjs.org/addons-linter/-/addons-linter-1.14.0.tgz";
+        sha512 = "Of7A53J2ltaIZzD8RPH1hVxOR+DmLDuHBtwfhXJw8JTXwzpDIvOKn/i6XDtPgfFlj5wIWxpUGV+tFb/kE/K9gg==";
       };
     };
     "addr-to-ip-port-1.5.1" = {
@@ -3782,15 +3962,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/addr-to-ip-port/-/addr-to-ip-port-1.5.1.tgz";
         sha512 = "bA+dyydTNuQtrEDJ0g9eR7XabNhvrM5yZY0hvTbNK3yvoeC73ZqMES6E1cEqH9WPxs4uMtMsOjfwS4FmluhsAA==";
-      };
-    };
-    "addressparser-1.0.1" = {
-      name = "addressparser";
-      packageName = "addressparser";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz";
-        sha1 = "47afbe1a2a9262191db6838e4fd1d39b40821746";
       };
     };
     "adm-zip-0.4.13" = {
@@ -3883,13 +4054,13 @@ let
         sha1 = "888344dad0220a72e3af50906117f48771925fac";
       };
     };
-    "aggregate-error-3.0.0" = {
+    "aggregate-error-3.0.1" = {
       name = "aggregate-error";
       packageName = "aggregate-error";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.0.tgz";
-        sha512 = "yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==";
+        url = "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz";
+        sha512 = "quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==";
       };
     };
     "airplay-js-0.2.16" = {
@@ -3944,15 +4115,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz";
         sha1 = "73b5eeca3fab653e3d3f9422b341ad42205dc965";
-      };
-    };
-    "ajv-6.10.0" = {
-      name = "ajv";
-      packageName = "ajv";
-      version = "6.10.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz";
-        sha512 = "nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==";
       };
     };
     "ajv-6.10.2" = {
@@ -4315,13 +4477,13 @@ let
         sha1 = "fd753efa4beada0eac99981bc52a3f6ff019deb7";
       };
     };
-    "ansi-to-html-0.6.11" = {
+    "ansi-to-html-0.6.12" = {
       name = "ansi-to-html";
       packageName = "ansi-to-html";
-      version = "0.6.11";
+      version = "0.6.12";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.11.tgz";
-        sha512 = "88XZtrcwrfkyn6fGstHnkaF1kl7hGtNCYh4vSmItgEV+6JnQHryDBf7udF4f2RhTRQmYvJvPcTtqgaqrxzc9oA==";
+        url = "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.12.tgz";
+        sha512 = "qBkIqLW979675mP76yB7yVkzeAWtATegdnDQ0RA3CZzknx0yUlNxMSML4xFdBfTs2GWYFQ1FELfbGbVSPzJ+LA==";
       };
     };
     "ansi-wrap-0.1.0" = {
@@ -4351,6 +4513,15 @@ let
         sha1 = "665597de86a9ffe3aa9bfbe6cae5c6ea426b4979";
       };
     };
+    "any-observable-0.3.0" = {
+      name = "any-observable";
+      packageName = "any-observable";
+      version = "0.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz";
+        sha512 = "/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==";
+      };
+    };
     "any-promise-1.3.0" = {
       name = "any-promise";
       packageName = "any-promise";
@@ -4378,13 +4549,13 @@ let
         sha512 = "5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==";
       };
     };
-    "anymatch-3.1.0" = {
+    "anymatch-3.1.1" = {
       name = "anymatch";
       packageName = "anymatch";
-      version = "3.1.0";
+      version = "3.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz";
-        sha512 = "Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==";
+        url = "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz";
+        sha512 = "mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==";
       };
     };
     "ap-0.1.0" = {
@@ -4414,6 +4585,15 @@ let
         sha1 = "ee49736b639b4f108b6e9e626c6da99306b41692";
       };
     };
+    "apollo-2.21.0" = {
+      name = "apollo";
+      packageName = "apollo";
+      version = "2.21.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo/-/apollo-2.21.0.tgz";
+        sha512 = "S0PzWA6Ja3E68/LjG3D4wbOW5BiWo+PdST/TZD7n4TjRKV4eeMONEd95OSv5OzMMYaLtHSRq8xZmQEDe4l0NsA==";
+      };
+    };
     "apollo-cache-1.3.2" = {
       name = "apollo-cache";
       packageName = "apollo-cache";
@@ -4423,13 +4603,13 @@ let
         sha512 = "+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==";
       };
     };
-    "apollo-cache-control-0.8.4" = {
+    "apollo-cache-control-0.8.5" = {
       name = "apollo-cache-control";
       packageName = "apollo-cache-control";
-      version = "0.8.4";
+      version = "0.8.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.4.tgz";
-        sha512 = "IZ1d3AXZtkZhLYo0kWqTbZ6nqLFaeUvLdMESs+9orMadBZ7mvzcAfBwrhKyCWPGeAAZ/jKv8FtYHybpchHgFAg==";
+        url = "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.5.tgz";
+        sha512 = "2yQ1vKgJQ54SGkoQS/ZLZrDX3La6cluAYYdruFYJMJtL4zQrSdeOCy11CQliCMYEd6eKNyE70Rpln51QswW2Og==";
       };
     };
     "apollo-cache-inmemory-1.6.3" = {
@@ -4468,6 +4648,15 @@ let
         sha512 = "sanUIqXWyyDpxY3fYOVU+Hsxwxdj5fmn3Zcy6CcMGnWmh9o7tautQAuod2a63wrDs1jcNQcFq3EKIpeB+2xECw==";
       };
     };
+    "apollo-codegen-core-0.35.7" = {
+      name = "apollo-codegen-core";
+      packageName = "apollo-codegen-core";
+      version = "0.35.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.35.7.tgz";
+        sha512 = "Aj8bzwUnnsILaOxjPLJKpkzb4yNNQCpY21Atj0NZYGi6Zzfl9EK/PZn7BE2/4pyNpomErjd2C7X3m9bdvndTAg==";
+      };
+    };
     "apollo-codegen-flow-0.20.0" = {
       name = "apollo-codegen-flow";
       packageName = "apollo-codegen-flow";
@@ -4475,6 +4664,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.20.0.tgz";
         sha512 = "XgKE19B0Q74PBLVqHP/77NcCFrcvrN9wi3CcotH+FV8BeHTjvpHlilTsQMmd2STPt19cCvY2Qtz0EOeLXTUQ2Q==";
+      };
+    };
+    "apollo-codegen-flow-0.33.32" = {
+      name = "apollo-codegen-flow";
+      packageName = "apollo-codegen-flow";
+      version = "0.33.32";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.32.tgz";
+        sha512 = "/DWh6/8/BKYlwPg5/kQQQU78skC3TCRxhg4rUaR0s23px/N3YiLCcqmcV6HzcMKpjNE+dIxpha+WLNMAtb4ypg==";
       };
     };
     "apollo-codegen-flow-legacy-0.20.0" = {
@@ -4495,6 +4693,15 @@ let
         sha512 = "NbnMOfUXXovlTGRj4mIZGXB9HvidQhwKfAmdYHox5peHPkjjsqEzxGCIuWCSnubWiCF2uHZnQoIkg4sXWf0KLw==";
       };
     };
+    "apollo-codegen-scala-0.34.32" = {
+      name = "apollo-codegen-scala";
+      packageName = "apollo-codegen-scala";
+      version = "0.34.32";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.32.tgz";
+        sha512 = "c41a6NdEsPo/uRSY1FBbEJ2MUfM+NKlLVe3hBulc3huqaStz3PuQuOtQ5ZA0XjCwL8GhLFgC1D8TAiuDCA5+tQ==";
+      };
+    };
     "apollo-codegen-swift-0.20.0" = {
       name = "apollo-codegen-swift";
       packageName = "apollo-codegen-swift";
@@ -4504,6 +4711,15 @@ let
         sha512 = "L9Y4StbXw0t/nuF+miz0ybSt/io6tsLc063Yeh1A8GCvhFFQyXE/yK0Rf3nO1Bl5Z9UZ5o8Aae9kK4GSWYIGNQ==";
       };
     };
+    "apollo-codegen-swift-0.35.12" = {
+      name = "apollo-codegen-swift";
+      packageName = "apollo-codegen-swift";
+      version = "0.35.12";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.35.12.tgz";
+        sha512 = "pbeUwkLEpfr/hkCLnwmxfxroib5QFP0xz7cvORN3Hh9xxtpqfd0SdnrbXS8RpRxBN2jTbV78ubA6hDFm4B0BCA==";
+      };
+    };
     "apollo-codegen-typescript-0.20.0" = {
       name = "apollo-codegen-typescript";
       packageName = "apollo-codegen-typescript";
@@ -4511,6 +4727,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.20.0.tgz";
         sha512 = "mzlIJXz+5WPwzeALqRHHR9aPPEf6IlhSrjCawpUHmFU1NK9hgwbguYCEYZv9mKkYBUUgDY+9cGFK1cafJX70AQ==";
+      };
+    };
+    "apollo-codegen-typescript-0.35.7" = {
+      name = "apollo-codegen-typescript";
+      packageName = "apollo-codegen-typescript";
+      version = "0.35.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.35.7.tgz";
+        sha512 = "r5MzXwWVPvkuyWfUV5kWzIsezoiDw2o459L3i07iM2JwOl7AW88/wkPsp/GrKh5q/Y2HRABg4oSqEiaQtrVazQ==";
       };
     };
     "apollo-codegen-typescript-legacy-0.20.0" = {
@@ -4531,22 +4756,22 @@ let
         sha512 = "gRYyFVpJgHE2hhS+VxMeOerxXQ/QYxWG7T6QddfugJWYAG9DRCl65e2b7txcGq2NP3r+O1iCm4GNwhRBDJbd8A==";
       };
     };
-    "apollo-engine-reporting-1.4.6" = {
+    "apollo-engine-reporting-1.4.7" = {
       name = "apollo-engine-reporting";
       packageName = "apollo-engine-reporting";
-      version = "1.4.6";
+      version = "1.4.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.6.tgz";
-        sha512 = "acfb7oFnru/8YQdY4x6+7WJbZfzdVETI8Cl+9ImgUrvUnE8P+f2SsGTKXTC1RuUvve4c56PAvaPgE+z8X1a1Mw==";
+        url = "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.7.tgz";
+        sha512 = "qsKDz9VkoctFhojM3Nj3nvRBO98t8TS2uTgtiIjUGs3Hln2poKMP6fIQ37Nm2Q2B3JJst76HQtpPwXmRJd1ZUg==";
       };
     };
-    "apollo-engine-reporting-protobuf-0.4.0" = {
+    "apollo-engine-reporting-protobuf-0.4.1" = {
       name = "apollo-engine-reporting-protobuf";
       packageName = "apollo-engine-reporting-protobuf";
-      version = "0.4.0";
+      version = "0.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.0.tgz";
-        sha512 = "cXHZSienkis8v4RhqB3YG3DkaksqLpcxApRLTpRMs7IXNozgV7CUPYGFyFBEra1ZFgUyHXx4G9MpelV+n2cCfA==";
+        url = "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.1.tgz";
+        sha512 = "d7vFFZ2oUrvGaN0Hpet8joe2ZG0X0lIGilN+SwgVP38dJnOuadjsaYMyrD9JudGQJg0bJA5wVQfYzcCVy0slrw==";
       };
     };
     "apollo-env-0.5.1" = {
@@ -4558,13 +4783,22 @@ let
         sha512 = "fndST2xojgSdH02k5hxk1cbqA9Ti8RX4YzzBoAB4oIe1Puhq7+YlhXGXfXB5Y4XN0al8dLg+5nAkyjNAR2qZTw==";
       };
     };
-    "apollo-graphql-0.3.3" = {
+    "apollo-graphql-0.3.4" = {
       name = "apollo-graphql";
       packageName = "apollo-graphql";
-      version = "0.3.3";
+      version = "0.3.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.3.tgz";
-        sha512 = "t3CO/xIDVsCG2qOvx2MEbuu4b/6LzQjcBBwiVnxclmmFyAxYCIe7rpPlnLHSq7HyOMlCWDMozjoeWfdqYSaLqQ==";
+        url = "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.4.tgz";
+        sha512 = "w+Az1qxePH4oQ8jvbhQBl5iEVvqcqynmU++x/M7MM5xqN1C7m1kyIzpN17gybXlTJXY4Oxej2WNURC2/hwpfYw==";
+      };
+    };
+    "apollo-language-server-1.17.0" = {
+      name = "apollo-language-server";
+      packageName = "apollo-language-server";
+      version = "1.17.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.17.0.tgz";
+        sha512 = "x/CfKYl+GSFGLxLDx6d3aWLzpQssnHUdwczZxTHyU/RkQlfnNyLdZXodCmWBRpSj2Ifkuzii+uxwj4kjWG6jOA==";
       };
     };
     "apollo-link-1.2.13" = {
@@ -4583,6 +4817,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.19.tgz";
         sha512 = "TUi5TyufU84hEiGkpt+5gdH5HkB3Gx46npNfoxR4of3DKBCMuItGERt36RCaryGcU/C3u2zsICU3tJ+Z9LjFoQ==";
+      };
+    };
+    "apollo-link-error-1.1.12" = {
+      name = "apollo-link-error";
+      packageName = "apollo-link-error";
+      version = "1.1.12";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.12.tgz";
+        sha512 = "psNmHyuy3valGikt/XHJfe0pKJnRX19tLLs6P6EHRxg+6q6JMXNVLYPaQBkL0FkwdTCB0cbFJAGRYCBviG8TDA==";
+      };
+    };
+    "apollo-link-http-1.5.16" = {
+      name = "apollo-link-http";
+      packageName = "apollo-link-http";
+      version = "1.5.16";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.16.tgz";
+        sha512 = "IA3xA/OcrOzINRZEECI6IdhRp/Twom5X5L9jMehfzEo2AXdeRwAMlH5LuvTZHgKD8V1MBnXdM6YXawXkTDSmJw==";
       };
     };
     "apollo-link-http-common-0.2.15" = {
@@ -4630,13 +4882,13 @@ let
         sha512 = "l7ieNCGxUaUAVAAp600HjbUJxVaxjJygtPV0tPTe1Q3HkPy6LEWoY6mNHV7T268g1hxtPTxcdRu7WLsJrg7ufw==";
       };
     };
-    "apollo-server-core-2.9.3" = {
+    "apollo-server-core-2.9.7" = {
       name = "apollo-server-core";
       packageName = "apollo-server-core";
-      version = "2.9.3";
+      version = "2.9.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.3.tgz";
-        sha512 = "KQpOM3nAXdMqKVE0HHcOkH/EVhyDqFEKLNFlsyGHGOn9ujpI6RsltX+YpXRyAdbfQHpTk11v/IAo6XksWN+g1Q==";
+        url = "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.7.tgz";
+        sha512 = "EqKyROy+21sM93YHjGpy6wlnzK/vH0fnZh7RCf3uB69aQ3OjgdP4AQ5oWRQ62NDN+aoic7OLhChSDJeDonq/NQ==";
       };
     };
     "apollo-server-env-2.4.3" = {
@@ -4648,58 +4900,58 @@ let
         sha512 = "23R5Xo9OMYX0iyTu2/qT0EUb+AULCBriA9w8HDfMoChB8M+lFClqUkYtaTTHDfp6eoARLW8kDBhPOBavsvKAjA==";
       };
     };
-    "apollo-server-errors-2.3.3" = {
+    "apollo-server-errors-2.3.4" = {
       name = "apollo-server-errors";
       packageName = "apollo-server-errors";
-      version = "2.3.3";
+      version = "2.3.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.3.tgz";
-        sha512 = "MO4oJ129vuCcbqwr5ZwgxqGGiLz3hCyowz0bstUF7MR+vNGe4oe3DWajC9lv4CxrhcqUHQOeOPViOdIo1IxE3g==";
+        url = "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.4.tgz";
+        sha512 = "Y0PKQvkrb2Kd18d1NPlHdSqmlr8TgqJ7JQcNIfhNDgdb45CnqZlxL1abuIRhr8tiw8OhVOcFxz2KyglBi8TKdA==";
       };
     };
-    "apollo-server-express-2.9.3" = {
+    "apollo-server-express-2.9.7" = {
       name = "apollo-server-express";
       packageName = "apollo-server-express";
-      version = "2.9.3";
+      version = "2.9.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.9.3.tgz";
-        sha512 = "Hkfs+ce6GqaoSzDOJs8Pj7W3YUjH0BzGglo5HMsOXOnjPZ0pJE9v8fmK76rlkITLw7GjvIq5GKlafymC31FMBw==";
+        url = "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.9.7.tgz";
+        sha512 = "+DuJk1oq34Zx0bLYzgBgJH/eXS0JNxw2JycHQvV0+PAQ0Qi01oomJRA2r1S5isnfnSAnHb2E9jyBTptoHdw3MQ==";
       };
     };
-    "apollo-server-plugin-base-0.6.4" = {
+    "apollo-server-plugin-base-0.6.5" = {
       name = "apollo-server-plugin-base";
       packageName = "apollo-server-plugin-base";
-      version = "0.6.4";
+      version = "0.6.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.4.tgz";
-        sha512 = "4rY+cBAIpQomGWYBtk8hHkLQWHrh5hgIBPQqmhXh00YFdcY+Ob1/cU2/2iqTcIzhtcaezsc8OZ63au6ahSBQqg==";
+        url = "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.5.tgz";
+        sha512 = "z2ve7HEPWmZI3EzL0iiY9qyt1i0hitT+afN5PzssCw594LB6DfUQWsI14UW+W+gcw8hvl8VQUpXByfUntAx5vw==";
       };
     };
-    "apollo-server-types-0.2.4" = {
+    "apollo-server-types-0.2.5" = {
       name = "apollo-server-types";
       packageName = "apollo-server-types";
-      version = "0.2.4";
+      version = "0.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.4.tgz";
-        sha512 = "G4FvBVgGQcTW6ZBS2+hvcDQkSfdOIKV+cHADduXA275v+5zl42g+bCaGd/hCCKTDRjmQvObLiMxH/BJ6pDMQgA==";
+        url = "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.5.tgz";
+        sha512 = "6iJQsPh59FWu4K7ABrVmpnQVgeK8Ockx8BcawBh+saFYWTlVczwcLyGSZPeV1tPSKwFwKZutyEslrYSafcarXQ==";
       };
     };
-    "apollo-tracing-0.8.4" = {
+    "apollo-tracing-0.8.5" = {
       name = "apollo-tracing";
       packageName = "apollo-tracing";
-      version = "0.8.4";
+      version = "0.8.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.4.tgz";
-        sha512 = "DjbFW0IvHicSlTVG+vK+1WINfBMRCdPPHJSW/j65JMir9Oe56WGeqL8qz8hptdUUmLYEb+azvcyyGsJsiR3zpQ==";
+        url = "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.5.tgz";
+        sha512 = "lZn10/GRBZUlMxVYLghLMFsGcLN0jTYDd98qZfBtxw+wEWUx+PKkZdljDT+XNoOm/kDvEutFGmi5tSLhArIzWQ==";
       };
     };
-    "apollo-upload-client-10.0.1" = {
+    "apollo-upload-client-11.0.0" = {
       name = "apollo-upload-client";
       packageName = "apollo-upload-client";
-      version = "10.0.1";
+      version = "11.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-10.0.1.tgz";
-        sha512 = "K6WnuYQi0RRTNO+aSPVjoUWXp4QSr+eoKU4fE0OKQp25XRF2oXl2cTLs+Q4Nk0wOIHM76YGdo/IHtzuNR7jO+A==";
+        url = "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-11.0.0.tgz";
+        sha512 = "JChTrBi1VSF8u6OPrkWUApJlyUvzwhw98kqRB3fSi7/CU6z0OUD42Mee9s5h8mfjKEfOanK6GNZhF4t2tIPXSw==";
       };
     };
     "apollo-utilities-1.3.2" = {
@@ -5116,15 +5368,6 @@ let
         sha512 = "hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==";
       };
     };
-    "array-from-2.1.1" = {
-      name = "array-from";
-      packageName = "array-from";
-      version = "2.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz";
-        sha1 = "cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195";
-      };
-    };
     "array-ify-1.0.0" = {
       name = "array-ify";
       packageName = "array-ify";
@@ -5141,15 +5384,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz";
         sha1 = "184b48f62d92d7452bb31b323165c7f8bd02266d";
-      };
-    };
-    "array-indexofobject-0.0.1" = {
-      name = "array-indexofobject";
-      packageName = "array-indexofobject";
-      version = "0.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/array-indexofobject/-/array-indexofobject-0.0.1.tgz";
-        sha1 = "aaa128e62c9b3c358094568c219ff64fe489d42a";
       };
     };
     "array-initial-1.1.0" = {
@@ -5503,15 +5737,6 @@ let
         sha512 = "2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw==";
       };
     };
-    "ast-types-0.12.4" = {
-      name = "ast-types";
-      packageName = "ast-types";
-      version = "0.12.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ast-types/-/ast-types-0.12.4.tgz";
-        sha512 = "ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw==";
-      };
-    };
     "ast-types-0.13.2" = {
       name = "ast-types";
       packageName = "ast-types";
@@ -5656,13 +5881,13 @@ let
         sha512 = "zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==";
       };
     };
-    "async-3.0.1" = {
+    "async-3.1.0" = {
       name = "async";
       packageName = "async";
-      version = "3.0.1";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/async/-/async-3.0.1.tgz";
-        sha512 = "ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw==";
+        url = "https://registry.npmjs.org/async/-/async-3.1.0.tgz";
+        sha512 = "4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ==";
       };
     };
     "async-done-1.3.2" = {
@@ -5701,13 +5926,13 @@ let
         sha512 = "uczz62z2fMWOFbyo6rG4NlV2SdxugJT6sZA2QcfB1XaSjEiOh8CuOb/TttyMnYQCda6nkWecJe465tGQDPJiKw==";
       };
     };
-    "async-mutex-0.1.3" = {
+    "async-mutex-0.1.4" = {
       name = "async-mutex";
       packageName = "async-mutex";
-      version = "0.1.3";
+      version = "0.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/async-mutex/-/async-mutex-0.1.3.tgz";
-        sha1 = "0aad2112369795ab3f17e33744556d2ecf547566";
+        url = "https://registry.npmjs.org/async-mutex/-/async-mutex-0.1.4.tgz";
+        sha512 = "zVWTmAnxxHaeB2B1te84oecI8zTDJ/8G49aVBblRX6be0oq6pAybNcUSxwfgVOmOjSCvN4aYZAqwtyNI8e1YGw==";
       };
     };
     "async-retry-1.2.3" = {
@@ -5836,6 +6061,24 @@ let
         sha1 = "ece7d92527ca37ea502f99e8f41fe44daf00dbce";
       };
     };
+    "autoprefixer-7.2.6" = {
+      name = "autoprefixer";
+      packageName = "autoprefixer";
+      version = "7.2.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz";
+        sha512 = "Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==";
+      };
+    };
+    "await-to-js-2.1.1" = {
+      name = "await-to-js";
+      packageName = "await-to-js";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/await-to-js/-/await-to-js-2.1.1.tgz";
+        sha512 = "CHBC6gQGCIzjZ09tJ+XmpQoZOn4GdWePB4qUweCaKNJ0D3f115YdhmYVTZ4rMVpiJ3cFzZcTYK1VMYEICV4YXw==";
+      };
+    };
     "aws-sdk-1.18.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
@@ -5845,13 +6088,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.533.0" = {
+    "aws-sdk-2.561.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.533.0";
+      version = "2.561.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.533.0.tgz";
-        sha512 = "OSe7C0jnBdgfzedOtK+TgBEwtJaaZovm+Q2fbqIlfhUWg3rhhkt3oLyQ9bRD30/CFaunLhLr/8HAAN+/x+DWAA==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.561.0.tgz";
+        sha512 = "UXsjWDZFIIcfXULAEBeE42Eae1xHq4mkDfhPIw1VBlfsIzOVB2Bp+Y3+EvxH31OzO5SN0x03VracLlZFo4HElQ==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -6700,6 +6943,15 @@ let
         sha1 = "2d45021df87e26a374b6d4d1a9c65964d17f2422";
       };
     };
+    "babel-polyfill-6.26.0" = {
+      name = "babel-polyfill";
+      packageName = "babel-polyfill";
+      version = "6.26.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz";
+        sha1 = "379937abc67d7895970adc621f284cd966cf2153";
+      };
+    };
     "babel-preset-jest-23.2.0" = {
       name = "babel-preset-jest";
       packageName = "babel-preset-jest";
@@ -7114,13 +7366,13 @@ let
         sha1 = "38f716b24c8cee07a262abc41c22c314e20e3869";
       };
     };
-    "bezier-js-2.4.3" = {
+    "bezier-js-2.4.4" = {
       name = "bezier-js";
       packageName = "bezier-js";
-      version = "2.4.3";
+      version = "2.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/bezier-js/-/bezier-js-2.4.3.tgz";
-        sha512 = "qAz1iAGoSE+kk5guAMyvoUgfHq+e5JwK5jRHh2/tuk4XDRUuECrrHLouN27jAzjhlJD2vAsBHofCi5sOn1jcbQ==";
+        url = "https://registry.npmjs.org/bezier-js/-/bezier-js-2.4.4.tgz";
+        sha512 = "qYC9FBubdTK4VZe0m+lS7lEpf87w1fnm6g2m1FKsnlz+wfNnJy3gjQt4Y5nnI1NrjJrnQqnZt3S6Z5qjhloDNA==";
       };
     };
     "biased-opener-0.2.8" = {
@@ -7132,13 +7384,13 @@ let
         sha1 = "159a49b9a9714c1fb102f2e0ed1906fab6a450f4";
       };
     };
-    "big-integer-1.6.45" = {
+    "big-integer-1.6.47" = {
       name = "big-integer";
       packageName = "big-integer";
-      version = "1.6.45";
+      version = "1.6.47";
       src = fetchurl {
-        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.45.tgz";
-        sha512 = "nmb9E7oEtVJ7SmSCH/DeJobXyuRmaofkpoQSimMFu3HKJ5MADtM825SPLhDuWhZ6TElLAQtgJbQmBZuHIRlZoA==";
+        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.47.tgz";
+        sha512 = "9t9f7X3as2XGX8b52GqG6ox0GvIdM86LyIXASJnDCFhYNgt+A+MByQZ3W2PyMRZjEvG5f8TEbSPfEotVuMJnQg==";
       };
     };
     "big.js-5.2.2" = {
@@ -7366,6 +7618,15 @@ let
         sha512 = "EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==";
       };
     };
+    "bl-4.0.0" = {
+      name = "bl";
+      packageName = "bl";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bl/-/bl-4.0.0.tgz";
+        sha512 = "QwQvAZZA1Bw1FWnhNj2X5lu+sPxxB2ITH3mqEqYyahN6JZR13ONjk+XiTnBaGEzMPUrAgOkaD68pBH1rvPRPsw==";
+      };
+    };
     "blake2b-2.1.3" = {
       name = "blake2b";
       packageName = "blake2b";
@@ -7402,13 +7663,13 @@ let
         sha1 = "f962d687ec2c369570ae71af843256e6d0ca1129";
       };
     };
-    "blessed-contrib-4.8.17" = {
+    "blessed-contrib-4.8.18" = {
       name = "blessed-contrib";
       packageName = "blessed-contrib";
-      version = "4.8.17";
+      version = "4.8.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/blessed-contrib/-/blessed-contrib-4.8.17.tgz";
-        sha512 = "uhywRrzJQxtpkowgDHdejIE911Pgt0raYOQUoFC/qREyQvXsz5DMj2J2JVjwcx2bpzbDdHRoP/lcWLE1Ol3vCQ==";
+        url = "https://registry.npmjs.org/blessed-contrib/-/blessed-contrib-4.8.18.tgz";
+        sha512 = "l0XXpwbxp1NIYMkhTplbi6siZZvVH3JRHy+NPNznPvlD6uBUWVd/wQx4pmo1NCZQMN4MYRjICjedDGp34p/MUQ==";
       };
     };
     "blob-0.0.2" = {
@@ -7510,6 +7771,15 @@ let
         sha512 = "5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==";
       };
     };
+    "bluebird-3.7.1" = {
+      name = "bluebird";
+      packageName = "bluebird";
+      version = "3.7.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz";
+        sha512 = "DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==";
+      };
+    };
     "blueimp-md5-2.10.0" = {
       name = "blueimp-md5";
       packageName = "blueimp-md5";
@@ -7609,13 +7879,13 @@ let
         sha1 = "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e";
       };
     };
-    "boolean-1.0.0" = {
+    "boolean-2.0.3" = {
       name = "boolean";
       packageName = "boolean";
-      version = "1.0.0";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/boolean/-/boolean-1.0.0.tgz";
-        sha512 = "IB1lgIywn37N9Aff8CciCblVpMUflgL42vyxPUH0IvaDdIi/QwBHKv1lq/HOkATHCfa7c4MbMYJ7Bo7hGuoI+w==";
+        url = "https://registry.npmjs.org/boolean/-/boolean-2.0.3.tgz";
+        sha512 = "iHzXeFCXWrpjYE7DToXGCBPGZf0eVISqzL+4sgrOSYEKXnb59WHPFvGTTyCj6zJ/MuuLAxEn8zPkrTHHzlt3IA==";
       };
     };
     "boom-2.10.1" = {
@@ -7715,6 +7985,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz";
         sha512 = "cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==";
+      };
+    };
+    "boxen-4.1.0" = {
+      name = "boxen";
+      packageName = "boxen";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/boxen/-/boxen-4.1.0.tgz";
+        sha512 = "Iwq1qOkmEsl0EVABa864Bbj3HCL4186DRZgFW/NrFs5y5GMM3ljsxzMLgOHdWISDRvcM8beh8q4tTNzXz+mSKg==";
       };
     };
     "bplist-creator-0.0.6" = {
@@ -7960,13 +8239,22 @@ let
         sha512 = "Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==";
       };
     };
-    "browserslist-4.7.0" = {
+    "browserslist-2.11.3" = {
       name = "browserslist";
       packageName = "browserslist";
-      version = "4.7.0";
+      version = "2.11.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz";
-        sha512 = "9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==";
+        url = "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz";
+        sha512 = "yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==";
+      };
+    };
+    "browserslist-4.7.2" = {
+      name = "browserslist";
+      packageName = "browserslist";
+      version = "4.7.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz";
+        sha512 = "uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==";
       };
     };
     "btoa-lite-1.0.0" = {
@@ -8662,13 +8950,13 @@ let
         sha512 = "bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==";
       };
     };
-    "caniuse-lite-1.0.30000989" = {
+    "caniuse-lite-1.0.30001006" = {
       name = "caniuse-lite";
       packageName = "caniuse-lite";
-      version = "1.0.30000989";
+      version = "1.0.30001006";
       src = fetchurl {
-        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz";
-        sha512 = "vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==";
+        url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001006.tgz";
+        sha512 = "MXnUVX27aGs/QINz+QG1sWSLDr3P1A3Hq5EUWoIt0T7K24DuvMxZEnh3Y5aHlJW6Bz2aApJdSewdYLd8zQnUuw==";
       };
     };
     "capture-stack-trace-1.0.1" = {
@@ -8687,6 +8975,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz";
         sha1 = "50e21c1b0aa37729f9377def196b5a9cec932ee9";
+      };
+    };
+    "cardinal-2.1.1" = {
+      name = "cardinal";
+      packageName = "cardinal";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz";
+        sha1 = "7cc1055d822d212954d07b085dea251cc7bc5505";
       };
     };
     "caryll-shapeops-0.3.1" = {
@@ -9112,13 +9409,13 @@ let
         sha512 = "c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==";
       };
     };
-    "chokidar-3.1.1" = {
+    "chokidar-3.2.3" = {
       name = "chokidar";
       packageName = "chokidar";
-      version = "3.1.1";
+      version = "3.2.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chokidar/-/chokidar-3.1.1.tgz";
-        sha512 = "df4o16uZmMHzVQwECZRHwfguOt5ixpuQVaZHjYMvYisgKhE+JXwcj/Tcr3+3bu/XeOJQ9ycYmzu7Mv8XrGxJDQ==";
+        url = "https://registry.npmjs.org/chokidar/-/chokidar-3.2.3.tgz";
+        sha512 = "GtrxGuRf6bzHQmXWRepvsGnXpkQkVU+D2/9a7dAe4a7v1NhrfZOZ2oKf76M3nOs46fFYL8D+Q8JYA4GYeJ8Cjw==";
       };
     };
     "chownr-0.0.2" = {
@@ -9130,31 +9427,31 @@ let
         sha1 = "2f9aebf746f90808ce00607b72ba73b41604c485";
       };
     };
-    "chownr-1.1.2" = {
+    "chownr-1.1.3" = {
       name = "chownr";
       packageName = "chownr";
-      version = "1.1.2";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz";
-        sha512 = "GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==";
+        url = "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz";
+        sha512 = "i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==";
       };
     };
-    "chroma-js-2.0.6" = {
+    "chroma-js-2.1.0" = {
       name = "chroma-js";
       packageName = "chroma-js";
-      version = "2.0.6";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chroma-js/-/chroma-js-2.0.6.tgz";
-        sha512 = "IiiClbBRkRwuXNl6impq5ssEhUGpmWvc5zzImZbDUWLWcFbj6ZbtsdZEx6sIXMKes7azgYaUpnmsY1T8BL6PqQ==";
+        url = "https://registry.npmjs.org/chroma-js/-/chroma-js-2.1.0.tgz";
+        sha512 = "uiRdh4ZZy+UTPSrAdp8hqEdVb1EllLtTHOt5TMaOjJUvi+O54/83Fc5K2ld1P+TJX+dw5B+8/sCgzI6eaur/lg==";
       };
     };
-    "chrome-dgram-3.0.3" = {
+    "chrome-dgram-3.0.4" = {
       name = "chrome-dgram";
       packageName = "chrome-dgram";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.3.tgz";
-        sha512 = "rktbTuXuzriInBm9qESjTqRhnscp26gAdsQnUSWIY4a3miF9gnFOBGib+DO0zcJ0ZF2wj6wwQrPgyWfT4+as3g==";
+        url = "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.4.tgz";
+        sha512 = "G8rOANSvSRC4hGny/K/ec1gXtNuZGzryFeoev49u0J4g/qws7H25vMKQlbD9izuedFVHwXFTdKQG62Tf/7Cmwg==";
       };
     };
     "chrome-dns-1.0.1" = {
@@ -9166,6 +9463,15 @@ let
         sha512 = "HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==";
       };
     };
+    "chrome-launcher-0.11.2" = {
+      name = "chrome-launcher";
+      packageName = "chrome-launcher";
+      version = "0.11.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.11.2.tgz";
+        sha512 = "jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==";
+      };
+    };
     "chrome-net-3.3.3" = {
       name = "chrome-net";
       packageName = "chrome-net";
@@ -9175,13 +9481,13 @@ let
         sha512 = "11jL8+Ogna8M5TEdyalE8IG6cpaFEU3YcaxAj3YjZKjRM/PeT70pZbrUY+xoGwqiEJZwJE4Td2CvGxUvS9ytKQ==";
       };
     };
-    "chrome-remote-interface-0.26.1" = {
+    "chrome-remote-interface-0.27.2" = {
       name = "chrome-remote-interface";
       packageName = "chrome-remote-interface";
-      version = "0.26.1";
+      version = "0.27.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.26.1.tgz";
-        sha512 = "ela482aJK0riFu05sl+zdbnb3ezMiqzwsqf/f/27HngWds+Fat3vcZWpIoDoeQuWMid/+LfKAteAYWaWPqsweg==";
+        url = "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.27.2.tgz";
+        sha512 = "pVLljQ29SAx8KIv5tSa9sIf8GrEsAZdPJoeWOmY3/nrIzFmE+EryNNHvDkddGod0cmAFTv+GmPG0uvzxi2NWsA==";
       };
     };
     "chrome-trace-event-1.0.2" = {
@@ -9328,6 +9634,15 @@ let
         sha1 = "5325dc839eab01c974ae0e97f5734782750f88ec";
       };
     };
+    "clean-html-1.5.0" = {
+      name = "clean-html";
+      packageName = "clean-html";
+      version = "1.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/clean-html/-/clean-html-1.5.0.tgz";
+        sha512 = "eDu0vN44ZBvoEU0oRIKwWPIccGWXtdnUNmKJuTukZ1de00Uoqavb5pfIMKiC7/r+knQ5RbvAjGuVZiN3JwJL4Q==";
+      };
+    };
     "clean-stack-1.3.0" = {
       name = "clean-stack";
       packageName = "clean-stack";
@@ -9418,6 +9733,15 @@ let
         sha1 = "7e673ee0dd39a611a486476e53f3c6b3941cb582";
       };
     };
+    "cli-spinner-0.2.10" = {
+      name = "cli-spinner";
+      packageName = "cli-spinner";
+      version = "0.2.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.10.tgz";
+        sha512 = "U0sSQ+JJvSLi1pAYuJykwiA8Dsr15uHEy85iCJ6A+0DjVxivr3d+N2Wjvodeg89uP5K6TswFkKBfAD7B3YSn/Q==";
+      };
+    };
     "cli-spinners-1.3.1" = {
       name = "cli-spinners";
       packageName = "cli-spinners";
@@ -9454,6 +9778,15 @@ let
         sha1 = "2d1ef7f218a0e786e214540562d4bd177fe32d97";
       };
     };
+    "cli-truncate-0.2.1" = {
+      name = "cli-truncate";
+      packageName = "cli-truncate";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz";
+        sha1 = "9f15cfbb0705005369216c626ac7d05ab90dd574";
+      };
+    };
     "cli-truncate-1.1.0" = {
       name = "cli-truncate";
       packageName = "cli-truncate";
@@ -9461,6 +9794,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz";
         sha512 = "bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==";
+      };
+    };
+    "cli-ux-4.9.3" = {
+      name = "cli-ux";
+      packageName = "cli-ux";
+      version = "4.9.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli-ux/-/cli-ux-4.9.3.tgz";
+        sha512 = "/1owvF0SZ5Gn54cgrikJ0QskgTzeg30HGjkmjFoaHDJzAqFpuX1DBpFR8aLvsE1J5s9MgeYRENQK4BFwOag5VA==";
+      };
+    };
+    "cli-ux-5.3.3" = {
+      name = "cli-ux";
+      packageName = "cli-ux";
+      version = "5.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli-ux/-/cli-ux-5.3.3.tgz";
+        sha512 = "a16g+BTjASUH41s1pevai4P3JKwhx85wkOSm6sXWsk6KkdSmDeJ16pSCn2x3nqK7W8n35igOu2YiW+qFkqLRJg==";
       };
     };
     "cli-width-1.1.1" = {
@@ -9634,15 +9985,6 @@ let
         sha1 = "da309cc263df15994c688ca902179ca3c7cd7c7e";
       };
     };
-    "clone-2.0.0" = {
-      name = "clone";
-      packageName = "clone";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/clone/-/clone-2.0.0.tgz";
-        sha1 = "df65d3ca142e4a4a47db33da3468d088a16fc76e";
-      };
-    };
     "clone-2.1.2" = {
       name = "clone";
       packageName = "clone";
@@ -9713,15 +10055,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz";
         sha512 = "2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==";
-      };
-    };
-    "clones-1.2.0" = {
-      name = "clones";
-      packageName = "clones";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/clones/-/clones-1.2.0.tgz";
-        sha512 = "FXDYw4TjR8wgPZYui2LeTqWh1BLpfQ8lB6upMtlpDF6WlOOxghmTTxWyngdKTgozqBgKnHbTVwTE+hOHqAykuQ==";
       };
     };
     "cmd-shim-2.1.0" = {
@@ -10228,6 +10561,15 @@ let
         sha512 = "7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==";
       };
     };
+    "commander-2.20.3" = {
+      name = "commander";
+      packageName = "commander";
+      version = "2.20.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz";
+        sha512 = "GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==";
+      };
+    };
     "commander-2.3.0" = {
       name = "commander";
       packageName = "commander";
@@ -10255,22 +10597,22 @@ let
         sha1 = "9c99094176e12240cb22d6c5146098400fe0f7d4";
       };
     };
-    "commander-3.0.0" = {
+    "commander-3.0.2" = {
       name = "commander";
       packageName = "commander";
-      version = "3.0.0";
+      version = "3.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/commander/-/commander-3.0.0.tgz";
-        sha512 = "pl3QrGOBa9RZaslQiqnnKX2J068wcQw7j9AIaBQ9/JEp5RY6je4jKTImg0Bd+rpoONSe7GUFSgkxLeo17m3Pow==";
+        url = "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz";
+        sha512 = "Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==";
       };
     };
-    "commander-3.0.1" = {
+    "commander-4.0.0" = {
       name = "commander";
       packageName = "commander";
-      version = "3.0.1";
+      version = "4.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/commander/-/commander-3.0.1.tgz";
-        sha512 = "UNgvDd+csKdc9GD4zjtkHKQbT8Aspt2jCBqNSPp53vAS0L1tS9sXB2TCEOPHJ7kt9bN/niWkYj8T3RQSoMXdSQ==";
+        url = "https://registry.npmjs.org/commander/-/commander-4.0.0.tgz";
+        sha512 = "SEa2abMBTZuEjLVYpNrAFoRgxPwG4rXP3+SGY6CM/HZGeDzIA7Pzp+7H3AHDukKEpyy2SoSGGPShKqqfH9T9AQ==";
       };
     };
     "commist-1.1.0" = {
@@ -10588,6 +10930,15 @@ let
         sha1 = "f0241c45730a9fc6323b206dbf38edc741d0bb10";
       };
     };
+    "console-browserify-1.2.0" = {
+      name = "console-browserify";
+      packageName = "console-browserify";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz";
+        sha512 = "ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==";
+      };
+    };
     "console-control-strings-1.1.0" = {
       name = "console-control-strings";
       packageName = "console-control-strings";
@@ -10759,13 +11110,13 @@ let
         sha1 = "3243397ae93a71d655b3026834a51590b958b9e8";
       };
     };
-    "conventional-changelog-angular-5.0.3" = {
+    "conventional-changelog-angular-5.0.5" = {
       name = "conventional-changelog-angular";
       packageName = "conventional-changelog-angular";
-      version = "5.0.3";
+      version = "5.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz";
-        sha512 = "YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==";
+        url = "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.5.tgz";
+        sha512 = "RrkdWnL/TVyWV1ayWmSsrWorsTDqjL/VwG5ZSEneBQrd65ONcfeA1cW7FLtNweQyMiKOyriCMTKRSlk18DjTrw==";
       };
     };
     "conventional-changelog-core-3.2.3" = {
@@ -10777,22 +11128,22 @@ let
         sha512 = "LMMX1JlxPIq/Ez5aYAYS5CpuwbOk6QFp8O4HLAcZxe3vxoCtABkhfjetk8IYdRB9CDQGwJFLR3Dr55Za6XKgUQ==";
       };
     };
-    "conventional-changelog-preset-loader-2.2.0" = {
+    "conventional-changelog-preset-loader-2.3.0" = {
       name = "conventional-changelog-preset-loader";
       packageName = "conventional-changelog-preset-loader";
-      version = "2.2.0";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.2.0.tgz";
-        sha512 = "zXB+5vF7D5Y3Cb/rJfSyCCvFphCVmF8mFqOdncX3BmjZwAtGAPfYrBcT225udilCKvBbHgyzgxqz2GWDB5xShQ==";
+        url = "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.0.tgz";
+        sha512 = "/rHb32J2EJnEXeK4NpDgMaAVTFZS3o1ExmjKMtYVgIC4MQn0vkNSbYpdGRotkfGGRWiqk3Ri3FBkiZGbAfIfOQ==";
       };
     };
-    "conventional-changelog-writer-4.0.7" = {
+    "conventional-changelog-writer-4.0.10" = {
       name = "conventional-changelog-writer";
       packageName = "conventional-changelog-writer";
-      version = "4.0.7";
+      version = "4.0.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.7.tgz";
-        sha512 = "p/wzs9eYaxhFbrmX/mCJNwJuvvHR+j4Fd0SQa2xyAhYed6KBiZ780LvoqUUvsayP4R1DtC27czalGUhKV2oabw==";
+        url = "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.10.tgz";
+        sha512 = "vtO9vBAVh7XnSpGLTB1BOGgsGTz1MdvFjzbSXLrtapWCHWwuVOZFgwdLhlS0MaXwlF1dksWdEb6tnr42Ie2INw==";
       };
     };
     "conventional-commits-filter-2.0.2" = {
@@ -10804,13 +11155,13 @@ let
         sha512 = "WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==";
       };
     };
-    "conventional-commits-parser-3.0.3" = {
+    "conventional-commits-parser-3.0.6" = {
       name = "conventional-commits-parser";
       packageName = "conventional-commits-parser";
-      version = "3.0.3";
+      version = "3.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz";
-        sha512 = "KaA/2EeUkO4bKjinNfGUyqPTX/6w9JGshuQRik4r/wJz7rUw3+D3fDG6sZSEqJvKILzKXFQuFkpPLclcsAuZcg==";
+        url = "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.6.tgz";
+        sha512 = "9FDoCTnNQRhiDRhlRx6UEaxpcKPy6hiHYWZqJO80BAmFlbovAnMcCkdcxGyJGTe8sDidVHEiqPkLoJuG/aUs0A==";
       };
     };
     "conventional-recommended-bump-5.0.1" = {
@@ -11065,31 +11416,31 @@ let
         sha512 = "h479g/5a0PXn//yiFuMrD5MDEbB+mtihNkWcE6uD/aCh/6z0FRZ9sWH3NfZbHDB+Bp1yGLYsjbH8LZBL8KOQ0w==";
       };
     };
-    "core-js-2.6.9" = {
+    "core-js-2.6.10" = {
       name = "core-js";
       packageName = "core-js";
-      version = "2.6.9";
+      version = "2.6.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz";
-        sha512 = "HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==";
+        url = "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz";
+        sha512 = "I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==";
       };
     };
-    "core-js-3.2.1" = {
+    "core-js-3.3.6" = {
       name = "core-js";
       packageName = "core-js";
-      version = "3.2.1";
+      version = "3.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz";
-        sha512 = "Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==";
+        url = "https://registry.npmjs.org/core-js/-/core-js-3.3.6.tgz";
+        sha512 = "u4oM8SHwmDuh5mWZdDg9UwNVq5s1uqq6ZDLLIs07VY+VJU91i3h4f3K/pgFvtUQPGdeStrZ+odKyfyt4EnKHfA==";
       };
     };
-    "core-js-compat-3.2.1" = {
+    "core-js-compat-3.3.6" = {
       name = "core-js-compat";
       packageName = "core-js-compat";
-      version = "3.2.1";
+      version = "3.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz";
-        sha512 = "MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==";
+        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.6.tgz";
+        sha512 = "YnwZG/+0/f7Pf6Lr3jxtVAFjtGBW9lsLYcqrxhYJai1GfvrP8DEyEpnNzj/FRQfIkOOfk1j5tTBvPBLWVVJm4A==";
       };
     };
     "core-util-is-1.0.2" = {
@@ -11135,6 +11486,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/corsify/-/corsify-2.1.0.tgz";
         sha1 = "11a45bc47ab30c54d00bb869ea1802fbcd9a09d0";
+      };
+    };
+    "cosmiconfig-3.1.0" = {
+      name = "cosmiconfig";
+      packageName = "cosmiconfig";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz";
+        sha512 = "zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==";
       };
     };
     "cosmiconfig-5.2.1" = {
@@ -11281,13 +11641,13 @@ let
         sha512 = "LuoXnCRMKEo3KR3jEbCRpP3Nu2TUhLTlb/axP9+rl+ouhBpxTaHaTTN1bdUS2x2VK3wWyCBl1OZHyHhlRBntWg==";
       };
     };
-    "creato-1.0.5" = {
+    "creato-1.0.7" = {
       name = "creato";
       packageName = "creato";
-      version = "1.0.5";
+      version = "1.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/creato/-/creato-1.0.5.tgz";
-        sha512 = "bneB5jF+I0XNe4d3E6PYszPRb+5S8B3UQ3hDlY6ZSkfEU34RKqCfbUodxwwJn8DhmPYiuefEqEGxvstXEwXuUA==";
+        url = "https://registry.npmjs.org/creato/-/creato-1.0.7.tgz";
+        sha512 = "FuIJS+j87XAZGeblY2GINN+C4QHoFGP1gMAbsdr2uU+m8HvSHokzE/Ok6SLVFnSMQMLjDX0jS0EW6jlVmo5MsQ==";
       };
     };
     "crocks-0.12.1" = {
@@ -11315,6 +11675,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz";
         sha512 = "jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==";
+      };
+    };
+    "cross-env-6.0.3" = {
+      name = "cross-env";
+      packageName = "cross-env";
+      version = "6.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz";
+        sha512 = "+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==";
       };
     };
     "cross-fetch-2.2.2" = {
@@ -11362,13 +11731,13 @@ let
         sha512 = "eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==";
       };
     };
-    "cross-spawn-7.0.0" = {
+    "cross-spawn-7.0.1" = {
       name = "cross-spawn";
       packageName = "cross-spawn";
-      version = "7.0.0";
+      version = "7.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.0.tgz";
-        sha512 = "6U/8SMK2FBNnB21oQ4+6Nsodxanw1gTkntYA2zBdkFYFu3ZDx65P2ONEXGSvob/QS6REjVHQ9zxzdOafwFdstw==";
+        url = "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz";
+        sha512 = "u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==";
       };
     };
     "cross-spawn-async-2.2.5" = {
@@ -11387,15 +11756,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/crossroads/-/crossroads-0.12.2.tgz";
         sha1 = "b1d5f9c1d98af3bdd61f1bda6a86dd1aee4ff8f2";
-      };
-    };
-    "crx-parser-0.1.2" = {
-      name = "crx-parser";
-      packageName = "crx-parser";
-      version = "0.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/crx-parser/-/crx-parser-0.1.2.tgz";
-        sha1 = "7eeeed9eddc95e22c189382e34624044a89a5a6d";
       };
     };
     "crypt-0.0.2" = {
@@ -11542,22 +11902,13 @@ let
         sha512 = "xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==";
       };
     };
-    "css-tree-1.0.0-alpha.29" = {
+    "css-tree-1.0.0-alpha.37" = {
       name = "css-tree";
       packageName = "css-tree";
-      version = "1.0.0-alpha.29";
+      version = "1.0.0-alpha.37";
       src = fetchurl {
-        url = "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz";
-        sha512 = "sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==";
-      };
-    };
-    "css-tree-1.0.0-alpha.33" = {
-      name = "css-tree";
-      packageName = "css-tree";
-      version = "1.0.0-alpha.33";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz";
-        sha512 = "SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==";
+        url = "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz";
+        sha512 = "DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==";
       };
     };
     "css-unit-converter-1.1.1" = {
@@ -11677,13 +12028,13 @@ let
         sha512 = "WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==";
       };
     };
-    "csso-3.5.1" = {
+    "csso-4.0.2" = {
       name = "csso";
       packageName = "csso";
-      version = "3.5.1";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz";
-        sha512 = "vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==";
+        url = "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz";
+        sha512 = "kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==";
       };
     };
     "cssom-0.3.8" = {
@@ -11821,13 +12172,13 @@ let
         sha1 = "988df33feab191ef799a61369dd76c17adf957ea";
       };
     };
-    "cuss-1.16.0" = {
+    "cuss-1.17.0" = {
       name = "cuss";
       packageName = "cuss";
-      version = "1.16.0";
+      version = "1.17.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cuss/-/cuss-1.16.0.tgz";
-        sha512 = "VtYrZxNqRWLd/z3a57ezUv9WLR0l0n0qmYA5O9QBepliUWlEvRgBUnfZO6bZK29KocssaZ6ks7EistDLYPFWhA==";
+        url = "https://registry.npmjs.org/cuss/-/cuss-1.17.0.tgz";
+        sha512 = "3ZCx/QsMbJczIwh7A0mFzg4fmugBVf+LS3G310RD5fX6Td2imd9WV+zO1shsN9OkMOjeS3Mk5V28mUrsR6Y6Qg==";
       };
     };
     "custom-error-instance-2.1.1" = {
@@ -12064,13 +12415,13 @@ let
         sha512 = "gz9RuhUxq3coYBrelzuFXCNyC579aO3Bm1Wlwa12/9tJr1NP0AAGxpHJYA1HZvt8X7ZdrtMzpFyNvs2Y9PFG6w==";
       };
     };
-    "data-uri-to-buffer-2.0.1" = {
+    "data-uri-to-buffer-1.2.0" = {
       name = "data-uri-to-buffer";
       packageName = "data-uri-to-buffer";
-      version = "2.0.1";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.1.tgz";
-        sha512 = "OkVVLrerfAKZlW2ZZ3Ve2y65jgiWqBKsTfUIAFbn8nVbPcCZg6l6gikKlEYv0kXcmzqGm6mFq/Jf2vriuEkv8A==";
+        url = "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz";
+        sha512 = "vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==";
       };
     };
     "data-urls-1.1.0" = {
@@ -12080,6 +12431,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz";
         sha512 = "YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==";
+      };
+    };
+    "date-fns-1.30.1" = {
+      name = "date-fns";
+      packageName = "date-fns";
+      version = "1.30.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz";
+        sha512 = "hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==";
       };
     };
     "date-format-2.1.0" = {
@@ -12541,15 +12901,6 @@ let
         sha512 = "R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==";
       };
     };
-    "deepmerge-3.2.0" = {
-      name = "deepmerge";
-      packageName = "deepmerge";
-      version = "3.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz";
-        sha512 = "6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==";
-      };
-    };
     "deepmerge-3.3.0" = {
       name = "deepmerge";
       packageName = "deepmerge";
@@ -12557,6 +12908,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz";
         sha512 = "GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==";
+      };
+    };
+    "deepmerge-4.0.0" = {
+      name = "deepmerge";
+      packageName = "deepmerge";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz";
+        sha512 = "YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==";
+      };
+    };
+    "deepmerge-4.2.2" = {
+      name = "deepmerge";
+      packageName = "deepmerge";
+      version = "4.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz";
+        sha512 = "FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==";
       };
     };
     "default-browser-id-1.0.4" = {
@@ -12640,13 +13009,13 @@ let
         sha1 = "2cef1f111e1c57870d8bbb8af2650e587cd2f5b4";
       };
     };
-    "deferred-leveldown-5.2.1" = {
+    "deferred-leveldown-5.3.0" = {
       name = "deferred-leveldown";
       packageName = "deferred-leveldown";
-      version = "5.2.1";
+      version = "5.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.2.1.tgz";
-        sha512 = "PwXZRn5EmW+IKYVAYVc7G9FsRkShr0myPubPuq+mtLhDq9xSUqfvTlNZKoeQGeXACHXkeCFurKrz5oo6TZ3qwg==";
+        url = "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz";
+        sha512 = "a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==";
       };
     };
     "define-properties-1.1.3" = {
@@ -12829,13 +13198,13 @@ let
         sha512 = "xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==";
       };
     };
-    "deps-sort-2.0.0" = {
+    "deps-sort-2.0.1" = {
       name = "deps-sort";
       packageName = "deps-sort";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz";
-        sha1 = "091724902e84658260eb910748cccd1af6e21fb5";
+        url = "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz";
+        sha512 = "1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==";
       };
     };
     "deref-0.6.4" = {
@@ -13198,13 +13567,13 @@ let
         sha1 = "57ddacb47324ae5f58d2cc0da886db4ce9eeb718";
       };
     };
-    "dispensary-0.37.0" = {
+    "dispensary-0.40.0" = {
       name = "dispensary";
       packageName = "dispensary";
-      version = "0.37.0";
+      version = "0.40.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dispensary/-/dispensary-0.37.0.tgz";
-        sha512 = "Baqbt8MDkRYQZHB7XEd8iBUP8wRkRLjNWbm16nSDTOIoGvgF4Z8Q9wV1yD72TYjFC0kj1/o3nfPXPiAvWqjC8g==";
+        url = "https://registry.npmjs.org/dispensary/-/dispensary-0.40.0.tgz";
+        sha512 = "ttKDQvGBf+ygQ4rXuLBLErp3kMJIS+Gfmy+nJ6N/EfV8/RQdjd9SORpc729YK5SYAI+IuBo88S2xGUjKjU2jYw==";
       };
     };
     "diveSync-0.3.0" = {
@@ -13576,31 +13945,31 @@ let
         sha512 = "HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==";
       };
     };
-    "dotenv-8.1.0" = {
+    "dotenv-8.2.0" = {
       name = "dotenv";
       packageName = "dotenv";
-      version = "8.1.0";
+      version = "8.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz";
-        sha512 = "GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==";
+        url = "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz";
+        sha512 = "8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==";
       };
     };
-    "dotenv-expand-4.2.0" = {
+    "dotenv-expand-5.1.0" = {
       name = "dotenv-expand";
       packageName = "dotenv-expand";
-      version = "4.2.0";
+      version = "5.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz";
-        sha1 = "def1f1ca5d6059d24a766e587942c21106ce1275";
+        url = "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz";
+        sha512 = "YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==";
       };
     };
-    "dotnet-deps-parser-4.5.0" = {
+    "dotnet-deps-parser-4.5.2" = {
       name = "dotnet-deps-parser";
       packageName = "dotnet-deps-parser";
-      version = "4.5.0";
+      version = "4.5.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-4.5.0.tgz";
-        sha512 = "t6rBxcWVZSDNhhWdsbq9ozaCzfPXV79FiyES1JLNEoA7nYF+zDC2VZvFZSnH8ilU3bghJXxZPH+EcKYvfw8g/g==";
+        url = "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-4.5.2.tgz";
+        sha512 = "bk5Q1luEwQ10rrBwZbtTxUNadaLz2dM6xzOLoTK+oUBcaq6saCeELmkIgdG+Fwkn58XRgLQvOySVS0gp4OG6RA==";
       };
     };
     "downgrade-root-1.2.2" = {
@@ -13936,13 +14305,13 @@ let
         sha512 = "kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ==";
       };
     };
-    "electron-to-chromium-1.3.264" = {
+    "electron-to-chromium-1.3.298" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.264";
+      version = "1.3.298";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.264.tgz";
-        sha512 = "z8E7WkrrquCuGYv+kKyybuZIbdms+4PeHp7Zm2uIgEhAigP0bOwqXILItwj0YO73o+QyHY/7XtEfP5DsHOWQgQ==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.298.tgz";
+        sha512 = "IcgwlR5x4qtsVr1X+GDnbDEp0bAAqRA9EHP+bvIn3g5KF59Eiqjm59p27tg8b4YmgmpjfKWgec3trDRTWiVJgg==";
       };
     };
     "elegant-spinner-1.0.1" = {
@@ -14117,13 +14486,13 @@ let
         sha1 = "538b66f3ee62cd1ab51ec323829d1f9480c74beb";
       };
     };
-    "encoding-down-6.2.0" = {
+    "encoding-down-6.3.0" = {
       name = "encoding-down";
       packageName = "encoding-down";
-      version = "6.2.0";
+      version = "6.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/encoding-down/-/encoding-down-6.2.0.tgz";
-        sha512 = "XlIoQMBMbU4aE01uSKpAix0sXBJWK8YPhuOdvKa1CroThZyUpj0zWzt+bbe7g1KWsdhNFFzHkQHSdDymVtpJ1w==";
+        url = "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz";
+        sha512 = "QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==";
       };
     };
     "end-of-stream-0.1.5" = {
@@ -14153,13 +14522,13 @@ let
         sha1 = "e9353258baa9108965efc41cb0ef8ade2f3cfb07";
       };
     };
-    "end-of-stream-1.4.1" = {
+    "end-of-stream-1.4.4" = {
       name = "end-of-stream";
       packageName = "end-of-stream";
-      version = "1.4.1";
+      version = "1.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz";
-        sha512 = "1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==";
+        url = "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz";
+        sha512 = "+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==";
       };
     };
     "end-with-1.0.2" = {
@@ -14306,6 +14675,15 @@ let
         sha512 = "F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==";
       };
     };
+    "enhanced-resolve-4.1.1" = {
+      name = "enhanced-resolve";
+      packageName = "enhanced-resolve";
+      version = "4.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz";
+        sha512 = "98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==";
+      };
+    };
     "ensure-posix-path-1.1.1" = {
       name = "ensure-posix-path";
       packageName = "ensure-posix-path";
@@ -14351,6 +14729,15 @@ let
         sha512 = "D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==";
       };
     };
+    "env-ci-3.2.2" = {
+      name = "env-ci";
+      packageName = "env-ci";
+      version = "3.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/env-ci/-/env-ci-3.2.2.tgz";
+        sha512 = "AOiNZ3lmxrtva3r/roqaYDF+1PX2V+ouUzuGqJf7KNxyyYkuU+CsfFbbUeibQPdixxjI/lP6eDtvtkX1/wymJw==";
+      };
+    };
     "env-paths-1.0.0" = {
       name = "env-paths";
       packageName = "env-paths";
@@ -14358,6 +14745,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz";
         sha1 = "4168133b42bb05c38a35b1ae4397c8298ab369e0";
+      };
+    };
+    "env-paths-2.2.0" = {
+      name = "env-paths";
+      packageName = "env-paths";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz";
+        sha512 = "6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==";
       };
     };
     "env-variable-0.0.5" = {
@@ -14385,6 +14781,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/envinfo/-/envinfo-7.3.1.tgz";
         sha512 = "GvXiDTqLYrORVSCuJCsWHPXF5BFvoWMQA9xX4YVjPT1jyS3aZEHUBwjzxU/6LTPF9ReHgVEbX7IEN5UvSXHw/A==";
+      };
+    };
+    "envinfo-7.4.0" = {
+      name = "envinfo";
+      packageName = "envinfo";
+      version = "7.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/envinfo/-/envinfo-7.4.0.tgz";
+        sha512 = "FdDfnWnCVjxTTpWE3d6Jgh5JDIA3Cw7LCgpM/pI7kK1ORkjaqI2r6NqQ+ln2j0dfpgxY00AWieSvtkiZQKIItA==";
       };
     };
     "epidemic-broadcast-trees-7.0.0" = {
@@ -14450,13 +14855,13 @@ let
         sha512 = "rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==";
       };
     };
-    "es-abstract-1.14.2" = {
+    "es-abstract-1.16.0" = {
       name = "es-abstract";
       packageName = "es-abstract";
-      version = "1.14.2";
+      version = "1.16.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz";
-        sha512 = "DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==";
+        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz";
+        sha512 = "xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==";
       };
     };
     "es-to-primitive-1.2.0" = {
@@ -14468,13 +14873,13 @@ let
         sha512 = "qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==";
       };
     };
-    "es5-ext-0.10.51" = {
+    "es5-ext-0.10.52" = {
       name = "es5-ext";
       packageName = "es5-ext";
-      version = "0.10.51";
+      version = "0.10.52";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz";
-        sha512 = "oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==";
+        url = "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz";
+        sha512 = "bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==";
       };
     };
     "es5-ext-0.8.2" = {
@@ -14576,15 +14981,6 @@ let
         sha1 = "5109d62f3e56ea967c4b63505aef08291c8a5203";
       };
     };
-    "es6-promisify-6.0.1" = {
-      name = "es6-promisify";
-      packageName = "es6-promisify";
-      version = "6.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.1.tgz";
-        sha512 = "J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==";
-      };
-    };
     "es6-promisify-6.0.2" = {
       name = "es6-promisify";
       packageName = "es6-promisify";
@@ -14612,13 +15008,13 @@ let
         sha1 = "bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77";
       };
     };
-    "es6-symbol-3.1.2" = {
+    "es6-symbol-3.1.3" = {
       name = "es6-symbol";
       packageName = "es6-symbol";
-      version = "3.1.2";
+      version = "3.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz";
-        sha512 = "/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==";
+        url = "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz";
+        sha512 = "NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==";
       };
     };
     "es6-weak-map-2.0.3" = {
@@ -14774,13 +15170,13 @@ let
         sha512 = "S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==";
       };
     };
-    "eslint-6.4.0" = {
+    "eslint-6.6.0" = {
       name = "eslint";
       packageName = "eslint";
-      version = "6.4.0";
+      version = "6.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz";
-        sha512 = "WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==";
+        url = "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz";
+        sha512 = "PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==";
       };
     };
     "eslint-plugin-no-unsafe-innerhtml-1.0.16" = {
@@ -14837,22 +15233,13 @@ let
         sha512 = "oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==";
       };
     };
-    "eslint-utils-1.4.2" = {
+    "eslint-utils-1.4.3" = {
       name = "eslint-utils";
       packageName = "eslint-utils";
-      version = "1.4.2";
+      version = "1.4.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz";
-        sha512 = "eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==";
-      };
-    };
-    "eslint-visitor-keys-1.0.0" = {
-      name = "eslint-visitor-keys";
-      packageName = "eslint-visitor-keys";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz";
-        sha512 = "qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==";
+        url = "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz";
+        sha512 = "fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==";
       };
     };
     "eslint-visitor-keys-1.1.0" = {
@@ -14925,6 +15312,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz";
         sha512 = "EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==";
+      };
+    };
+    "espree-6.1.2" = {
+      name = "espree";
+      packageName = "espree";
+      version = "6.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz";
+        sha512 = "2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==";
       };
     };
     "esprima-1.1.1" = {
@@ -15395,6 +15791,15 @@ let
         sha512 = "adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==";
       };
     };
+    "execa-3.2.0" = {
+      name = "execa";
+      packageName = "execa";
+      version = "3.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/execa/-/execa-3.2.0.tgz";
+        sha512 = "kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==";
+      };
+    };
     "execall-1.0.0" = {
       name = "execall";
       packageName = "execall";
@@ -15584,6 +15989,15 @@ let
         sha1 = "f5fc2f9fa9e9a8578634f10e86ba5a4346b96f4f";
       };
     };
+    "ext-1.1.2" = {
+      name = "ext";
+      packageName = "ext";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ext/-/ext-1.1.2.tgz";
+        sha512 = "/KLjJdTNyDepCihrk4HQt57nAE1IRCEo5jUt+WgWGCr1oARhibDvmI2DMcSNWood1T9AUWwq+jaV1wvRqaXfnA==";
+      };
+    };
     "ext-list-2.2.2" = {
       name = "ext-list";
       packageName = "ext-list";
@@ -15735,6 +16149,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz";
         sha1 = "5abbedc98c0d5202e3278727f9192d7e086c6be1";
+      };
+    };
+    "extract-stack-1.0.0" = {
+      name = "extract-stack";
+      packageName = "extract-stack";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extract-stack/-/extract-stack-1.0.0.tgz";
+        sha1 = "b97acaf9441eea2332529624b732fc5a1c8165fa";
       };
     };
     "extract-zip-1.6.7" = {
@@ -16043,15 +16466,6 @@ let
         sha512 = "lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==";
       };
     };
-    "feedparser-2.2.9" = {
-      name = "feedparser";
-      packageName = "feedparser";
-      version = "2.2.9";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/feedparser/-/feedparser-2.2.9.tgz";
-        sha1 = "9138197dafdae05fcadde0036beeaf6066c2c5e9";
-      };
-    };
     "fibers-1.0.15" = {
       name = "fibers";
       packageName = "fibers";
@@ -16106,13 +16520,13 @@ let
         sha1 = "3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962";
       };
     };
-    "figures-3.0.0" = {
+    "figures-3.1.0" = {
       name = "figures";
       packageName = "figures";
-      version = "3.0.0";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz";
-        sha512 = "HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==";
+        url = "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz";
+        sha512 = "ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==";
       };
     };
     "file-entry-cache-2.0.0" = {
@@ -16142,13 +16556,13 @@ let
         sha512 = "uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==";
       };
     };
-    "file-type-12.1.0" = {
+    "file-type-12.3.1" = {
       name = "file-type";
       packageName = "file-type";
-      version = "12.1.0";
+      version = "12.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/file-type/-/file-type-12.1.0.tgz";
-        sha512 = "aZkf42yWGiH+vSOpbVgvbnoRuX4JiitMX9pHYqTHemNQ3lrx64iHi33YGAP7TSJSno56kxQY1lHmw8S6ujlFUg==";
+        url = "https://registry.npmjs.org/file-type/-/file-type-12.3.1.tgz";
+        sha512 = "FXxY5h6vSYMjrRal4YqbtfuoKD/oE0AMjJ7E5Hm+BdaQECcFVD03B41RAWYJ7wyuLr/wRnCtFo7y37l+nh+TAA==";
       };
     };
     "file-type-3.9.0" = {
@@ -16610,13 +17024,13 @@ let
         sha512 = "ougBA2q6Rn9sZrjZQ9r5pTFxCotlGouySpD2yRIuq5AYwwfIT8HHhVMeSwrN5qJayjHINLJyrnsSkkPCZyfMrQ==";
       };
     };
-    "flow-parser-0.108.0" = {
+    "flow-parser-0.111.0" = {
       name = "flow-parser";
       packageName = "flow-parser";
-      version = "0.108.0";
+      version = "0.111.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.108.0.tgz";
-        sha512 = "Ug8VuwlyDIZq5Xgrf+T7XLpKydhqYyNd8lmFtf7PZbu90T5LL+FeHjWzxyrBn35RCCZMw7pXrjCrHOSs+2zXyg==";
+        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.111.0.tgz";
+        sha512 = "wE1xnptr3qcA6hk7zeP170gBtcnaNp1zZ3jK7YqhPEmBzgb0uEDaYzAT5g4jOQyxxegYz9eDwcz+RcNMP5/JwQ==";
       };
     };
     "fluent-ffmpeg-2.1.2" = {
@@ -17249,13 +17663,13 @@ let
         sha1 = "1504ad2523158caa40db4a2787cb01411994ea4f";
       };
     };
-    "fs2-0.3.5" = {
+    "fs2-0.3.6" = {
       name = "fs2";
       packageName = "fs2";
-      version = "0.3.5";
+      version = "0.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fs2/-/fs2-0.3.5.tgz";
-        sha512 = "EL6G81ucjbmmycRwgekYMjjbKGFSop+eHgYLvBiQydp0H0Qugwbs5qOhifSzbCLZPy25rgXxsxsSrFqpTkitwA==";
+        url = "https://registry.npmjs.org/fs2/-/fs2-0.3.6.tgz";
+        sha512 = "Zs7c3SBPiiNEEg+w3PTIgxTbWA6ZWVJP+1DlwUCxNDtwQD2qM5pfdho7IaiR0ceu4UVvXRj9l6Ml+X6rs21ERw==";
       };
     };
     "fsevents-1.2.9" = {
@@ -17274,6 +17688,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz";
         sha512 = "a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==";
+      };
+    };
+    "fsevents-2.1.1" = {
+      name = "fsevents";
+      packageName = "fsevents";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fsevents/-/fsevents-2.1.1.tgz";
+        sha512 = "4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==";
       };
     };
     "fstream-0.1.31" = {
@@ -17609,13 +18032,13 @@ let
         sha512 = "EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==";
       };
     };
-    "get-uri-2.0.3" = {
+    "get-uri-2.0.4" = {
       name = "get-uri";
       packageName = "get-uri";
-      version = "2.0.3";
+      version = "2.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/get-uri/-/get-uri-2.0.3.tgz";
-        sha512 = "x5j6Ks7FOgLD/GlvjKwgu7wdmMR55iuRHhn8hj/+gA+eSbxQvZ+AEomq+3MgVEZj1vpi738QahGbCCSIDtXtkw==";
+        url = "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz";
+        sha512 = "v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==";
       };
     };
     "get-value-2.0.6" = {
@@ -17706,6 +18129,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/git-packidx-parser/-/git-packidx-parser-1.0.0.tgz";
         sha1 = "c57d1145eec16465ab9bfbdf575262b1691624d6";
+      };
+    };
+    "git-parse-1.0.3" = {
+      name = "git-parse";
+      packageName = "git-parse";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/git-parse/-/git-parse-1.0.3.tgz";
+        sha512 = "LlGDePBQ9Lr/jsL3ULrnV8SQL8sk3cdScyc+vAk6jVLkHBOxdIj3JosNWemH2o9pNnGtcqukl+ym1Nl6k5jw0Q==";
       };
     };
     "git-raw-commits-2.0.0" = {
@@ -17915,6 +18347,15 @@ let
         sha512 = "hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==";
       };
     };
+    "glob-7.1.5" = {
+      name = "glob";
+      packageName = "glob";
+      version = "7.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz";
+        sha512 = "J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==";
+      };
+    };
     "glob-base-0.3.0" = {
       name = "glob-base";
       packageName = "glob-base";
@@ -18014,13 +18455,13 @@ let
         sha1 = "e76989268a6c74c38908b1305b10fc0e394e9d0f";
       };
     };
-    "global-agent-2.1.1" = {
+    "global-agent-2.1.5" = {
       name = "global-agent";
       packageName = "global-agent";
-      version = "2.1.1";
+      version = "2.1.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/global-agent/-/global-agent-2.1.1.tgz";
-        sha512 = "MjLP2o331SpSxBMBFSWxs5PaWDhjXxysHepQ/hmBCjhjw74cbO9R/IBCbaSJ4GLPKm01dRcgXBtRr7p7XZEnfg==";
+        url = "https://registry.npmjs.org/global-agent/-/global-agent-2.1.5.tgz";
+        sha512 = "pYJjCxxNBzYxo6iNO62JZn8iCFVbvpiM0zE4w/G5hBNIvLjnvzIeCVQPMKc3aK8ju5L7Q8NNI/oBSosU0eeSYw==";
       };
     };
     "global-dirs-0.1.1" = {
@@ -18168,6 +18609,15 @@ let
         sha1 = "f5a6d70e8395e21c858fb0489d64df02424d506c";
       };
     };
+    "globby-7.1.1" = {
+      name = "globby";
+      packageName = "globby";
+      version = "7.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz";
+        sha1 = "fb2ccff9401f8600945dfada97440cca972b8680";
+      };
+    };
     "globby-8.0.2" = {
       name = "globby";
       packageName = "globby";
@@ -18184,6 +18634,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz";
         sha512 = "ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==";
+      };
+    };
+    "globjoin-0.1.4" = {
+      name = "globjoin";
+      packageName = "globjoin";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz";
+        sha1 = "2f4494ac8919e3767c5cbb691e9f463324285d43";
       };
     };
     "globrex-0.1.2" = {
@@ -18229,6 +18688,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz";
         sha1 = "2edeeb958084d0f8ea7988e5d995b1c7dfc14777";
+      };
+    };
+    "gonzales-pe-4.2.4" = {
+      name = "gonzales-pe";
+      packageName = "gonzales-pe";
+      version = "4.2.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz";
+        sha512 = "v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==";
       };
     };
     "good-listener-1.2.2" = {
@@ -18348,13 +18816,13 @@ let
         sha512 = "b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==";
       };
     };
-    "graceful-fs-4.2.2" = {
+    "graceful-fs-4.2.3" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.2.2";
+      version = "4.2.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz";
-        sha512 = "IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz";
+        sha512 = "a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==";
       };
     };
     "graceful-readlink-1.0.1" = {
@@ -18420,13 +18888,13 @@ let
         sha512 = "QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==";
       };
     };
-    "graphql-14.5.7" = {
+    "graphql-14.5.8" = {
       name = "graphql";
       packageName = "graphql";
-      version = "14.5.7";
+      version = "14.5.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql/-/graphql-14.5.7.tgz";
-        sha512 = "as410RMJSUFqF8RcH2QWxZ5ioqHzsH9VWnWbaU+UnDXJ/6azMDIYPrtXCBPXd8rlunEVb7W8z6fuUnNHMbFu9A==";
+        url = "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz";
+        sha512 = "MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==";
       };
     };
     "graphql-anywhere-4.2.4" = {
@@ -18474,13 +18942,13 @@ let
         sha512 = "bOufkkog0cSfHJ9gVD3Wy+KHmkSTHWcFfPaV/NVpIvfJx15gU0/CzuC6lcTjioWmn+UGzYdoqmP7OrJAWT57sw==";
       };
     };
-    "graphql-extensions-0.10.3" = {
+    "graphql-extensions-0.10.4" = {
       name = "graphql-extensions";
       packageName = "graphql-extensions";
-      version = "0.10.3";
+      version = "0.10.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.10.3.tgz";
-        sha512 = "kwU0gUe+Qdfr8iZYT91qrPSwQNgPhB/ClF1m1LEPdxlptk5FhFmjpxAcbMZ8q7j0kjfnbp2IeV1OhRDCEPqz2w==";
+        url = "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.10.4.tgz";
+        sha512 = "lE6MroluEYocbR/ICwccv39w+Pz4cBPadJ11z1rJkbZv5wstISEganbDOwl9qN21rcZGiWzh7QUNxUiFUXXEDw==";
       };
     };
     "graphql-import-0.4.5" = {
@@ -18564,31 +19032,31 @@ let
         sha512 = "jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==";
       };
     };
-    "graphql-tools-4.0.5" = {
+    "graphql-tools-4.0.6" = {
       name = "graphql-tools";
       packageName = "graphql-tools";
-      version = "4.0.5";
+      version = "4.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.5.tgz";
-        sha512 = "kQCh3IZsMqquDx7zfIGWBau42xe46gmqabwYkpPlCLIjcEY1XK+auP7iGRD9/205BPyoQdY8hT96MPpgERdC9Q==";
+        url = "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.6.tgz";
+        sha512 = "jHLQw8x3xmSNRBCsaZqelXXsFfUSUSktSCUP8KYHiX1Z9qEuwcMpAf+FkdBzk8aTAFqOlPdNZ3OI4DKKqGKUqg==";
       };
     };
-    "graphql-type-json-0.2.4" = {
+    "graphql-type-json-0.3.0" = {
       name = "graphql-type-json";
       packageName = "graphql-type-json";
-      version = "0.2.4";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.4.tgz";
-        sha512 = "/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==";
+        url = "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.0.tgz";
+        sha512 = "lnxg5HiB95yxy+/5cDKtP6pZo0zgntsOmqsjeCBXFGJ4YoMF3+1YaSEKWJntNTu+VsAm3zf6lPxFpp1kxzofLA==";
       };
     };
-    "graphql-upload-8.0.7" = {
+    "graphql-upload-8.1.0" = {
       name = "graphql-upload";
       packageName = "graphql-upload";
-      version = "8.0.7";
+      version = "8.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.7.tgz";
-        sha512 = "gi2yygbDPXbHPC7H0PNPqP++VKSoNoJO4UrXWq4T0Bi4IhyUd3Ycop/FSxhx2svWIK3jdXR/i0vi91yR1aAF0g==";
+        url = "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz";
+        sha512 = "U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==";
       };
     };
     "gray-matter-2.1.1" = {
@@ -18690,13 +19158,13 @@ let
         sha512 = "FQLY7unaHdTOXG0jlwxeBQcWoPPrTMQZRA7HfYwSNi9IPVx5l7GJEN72mG4ri2yigp/f/VNGUAJnFMJHBmH3iw==";
       };
     };
-    "gulp-sourcemaps-2.6.4" = {
+    "gulp-sourcemaps-2.6.5" = {
       name = "gulp-sourcemaps";
       packageName = "gulp-sourcemaps";
-      version = "2.6.4";
+      version = "2.6.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.4.tgz";
-        sha1 = "cbb2008450b1bcce6cd23bf98337be751bf6e30a";
+        url = "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-2.6.5.tgz";
+        sha512 = "SYLBRzPTew8T5Suh2U8jCSDKY+4NARua4aqjj8HOysBh2tSgT9u4jc1FYirAdPx1akUxxDeK++fqw6Jg0LkQRg==";
       };
     };
     "gulp-typescript-4.0.2" = {
@@ -18708,13 +19176,13 @@ let
         sha512 = "Hhbn5Aa2l3T+tnn0KqsG6RRJmcYEsr3byTL2nBpNBeAK8pqug9Od4AwddU4JEI+hRw7mzZyjRbB8DDWR6paGVA==";
       };
     };
-    "gulp-uglify-3.0.1" = {
+    "gulp-uglify-3.0.2" = {
       name = "gulp-uglify";
       packageName = "gulp-uglify";
-      version = "3.0.1";
+      version = "3.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.1.tgz";
-        sha512 = "KVffbGY9d4Wv90bW/B1KZJyunLMyfHTBbilpDvmcrj5Go0/a1G3uVpt+1gRBWSw/11dqR3coJ1oWNTt1AiXuWQ==";
+        url = "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.2.tgz";
+        sha512 = "gk1dhB74AkV2kzqPMQBLA3jPoIAPd/nlNzP2XMDSG8XZrqnlCiDGAqC+rZOumzFvB5zOphlFh6yr3lgcAb/OOg==";
       };
     };
     "gulp-util-3.0.8" = {
@@ -18744,13 +19212,22 @@ let
         sha1 = "e28c4d45d05ecbbed818363ce8f9c5926229ffe5";
       };
     };
-    "handlebars-4.2.1" = {
+    "handlebars-4.4.5" = {
       name = "handlebars";
       packageName = "handlebars";
-      version = "4.2.1";
+      version = "4.4.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.2.1.tgz";
-        sha512 = "bqPIlDk06UWbVEIFoYj+LVo42WhK96J+b25l7hbFDpxrOXMphFM3fNIm+cluwg4Pk2jiLjWU5nHQY7igGE75NQ==";
+        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz";
+        sha512 = "0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==";
+      };
+    };
+    "handlebars-4.5.1" = {
+      name = "handlebars";
+      packageName = "handlebars";
+      version = "4.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz";
+        sha512 = "C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==";
       };
     };
     "har-schema-1.0.5" = {
@@ -19266,13 +19743,13 @@ let
         sha1 = "e6d9dbe57cbefe60751f02af336195870c90c01e";
       };
     };
-    "highlight.js-9.15.10" = {
+    "highlight.js-9.16.2" = {
       name = "highlight.js";
       packageName = "highlight.js";
-      version = "9.15.10";
+      version = "9.16.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz";
-        sha512 = "RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==";
+        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-9.16.2.tgz";
+        sha512 = "feMUrVLZvjy0oC7FVJQcSQRqbBq9kwqnYE4+Kj9ZjbHh3g+BisiPgF49NyQbVLNdrL/qqZr3Ca9yOKwgn2i/tw==";
       };
     };
     "hipchatter-0.3.2" = {
@@ -19347,13 +19824,13 @@ let
         sha1 = "08a74d9272a9cc83ae8e6bbe0303f0ee76432094";
       };
     };
-    "hosted-git-info-2.8.4" = {
+    "hosted-git-info-2.8.5" = {
       name = "hosted-git-info";
       packageName = "hosted-git-info";
-      version = "2.8.4";
+      version = "2.8.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz";
-        sha512 = "pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==";
+        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz";
+        sha512 = "kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==";
       };
     };
     "hsl-regex-1.0.0" = {
@@ -19419,13 +19896,13 @@ let
         sha1 = "c78de65b5663aa597989dd2b7ab49200d7e4db98";
       };
     };
-    "html-to-text-5.1.1" = {
-      name = "html-to-text";
-      packageName = "html-to-text";
-      version = "5.1.1";
+    "html-tags-2.0.0" = {
+      name = "html-tags";
+      packageName = "html-tags";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/html-to-text/-/html-to-text-5.1.1.tgz";
-        sha512 = "Bci6bD/JIfZSvG4s0gW/9mMKwBRoe/1RWLxUME/d6WUSZCdY7T60bssf/jFf7EYXRyqU4P5xdClVqiYU0/ypdA==";
+        url = "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz";
+        sha1 = "10b30a386085f43cede353cc8fa7cb0deeea668b";
       };
     };
     "html-void-elements-1.0.4" = {
@@ -19534,6 +20011,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz";
         sha512 = "TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==";
+      };
+    };
+    "http-call-5.2.5" = {
+      name = "http-call";
+      packageName = "http-call";
+      version = "5.2.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-call/-/http-call-5.2.5.tgz";
+        sha512 = "SfJ9j2xfi8zhQuJxcBCN1AhPCUAvPhipNaoeHWHfHiV0gz4uf9RUt2kl+xu9mxJLKxhNP7We87aRGbaSGPjr8A==";
       };
     };
     "http-errors-1.6.3" = {
@@ -19717,6 +20203,24 @@ let
         sha512 = "c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==";
       };
     };
+    "https-proxy-agent-2.2.4" = {
+      name = "https-proxy-agent";
+      packageName = "https-proxy-agent";
+      version = "2.2.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz";
+        sha512 = "OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==";
+      };
+    };
+    "https-proxy-agent-3.0.1" = {
+      name = "https-proxy-agent";
+      packageName = "https-proxy-agent";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz";
+        sha512 = "+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==";
+      };
+    };
     "hue-sdk-0.1.0" = {
       name = "hue-sdk";
       packageName = "hue-sdk";
@@ -19724,6 +20228,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/hue-sdk/-/hue-sdk-0.1.0.tgz";
         sha512 = "Rz+tFQZs4n+7atl2mukSgXzi0EPGYwlN0Z4clFMQM9ktOyX+sIZ3fC8y9+8LMXMYQpUvdsweFQM6MGGoolOtLw==";
+      };
+    };
+    "human-signals-1.1.1" = {
+      name = "human-signals";
+      packageName = "human-signals";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz";
+        sha512 = "SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==";
       };
     };
     "humanize-0.0.9" = {
@@ -19816,6 +20329,15 @@ let
         sha512 = "JolPS374h6oS1rmz1iebFfeDDvA2nAtiHbx9VJJGMgSDSx4Q77eeY09hDgZwY7KatSKUGWnnSyydSgVUb3+8Lw==";
       };
     };
+    "hyperlinker-1.0.0" = {
+      name = "hyperlinker";
+      packageName = "hyperlinker";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz";
+        sha512 = "Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==";
+      };
+    };
     "hyperquest-2.1.3" = {
       name = "hyperquest";
       packageName = "hyperquest";
@@ -19834,13 +20356,13 @@ let
         sha1 = "d96c92732076f072711b6b10fd7d4f65ad8ee23d";
       };
     };
-    "i18next-15.1.0" = {
+    "i18next-15.1.2" = {
       name = "i18next";
       packageName = "i18next";
-      version = "15.1.0";
+      version = "15.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/i18next/-/i18next-15.1.0.tgz";
-        sha512 = "7cCrVn/BcoSOGJwTilAjGgWWzUDg4scTLX1sIBMWq6QjYYBrT+ChSAvmgVyQxkHinaIcswC04XK6l15RxM4Dkg==";
+        url = "https://registry.npmjs.org/i18next/-/i18next-15.1.2.tgz";
+        sha512 = "98ELn/dqep00DQ/v1E1gpM21HNN6nqU3mS85mYKd9P7lXrhfUcuysPaa3HviKSFb3WPdjf7avuAST3P0dhNp/A==";
       };
     };
     "iconv-lite-0.4.23" = {
@@ -19951,13 +20473,13 @@ let
         sha1 = "48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09";
       };
     };
-    "ignore-walk-3.0.2" = {
+    "ignore-walk-3.0.3" = {
       name = "ignore-walk";
       packageName = "ignore-walk";
-      version = "3.0.2";
+      version = "3.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.2.tgz";
-        sha512 = "EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==";
+        url = "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz";
+        sha512 = "m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==";
       };
     };
     "image-data-uri-2.0.1" = {
@@ -20075,6 +20597,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz";
         sha1 = "05698e3d45c88e8d7e9d92cb0584e77f096f3e43";
+      };
+    };
+    "import-local-0.1.1" = {
+      name = "import-local";
+      packageName = "import-local";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz";
+        sha1 = "b1179572aacdc11c6a91009fb430dbcab5f668a8";
       };
     };
     "import-local-2.0.0" = {
@@ -20590,6 +21121,15 @@ let
         sha512 = "wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==";
       };
     };
+    "invert-kv-3.0.0" = {
+      name = "invert-kv";
+      packageName = "invert-kv";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/invert-kv/-/invert-kv-3.0.0.tgz";
+        sha512 = "JzF8q2BeZA1ZkE3XROwRpoMQ9ObMgTtp0JH8EXewlbkikuOj2GPLIpUipdO+VL8QsTr2teAJD02EFGGL5cO7uw==";
+      };
+    };
     "iota-array-1.0.0" = {
       name = "iota-array";
       packageName = "iota-array";
@@ -20761,13 +21301,13 @@ let
         sha1 = "50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6";
       };
     };
-    "is-absolute-url-3.0.2" = {
+    "is-absolute-url-3.0.3" = {
       name = "is-absolute-url";
       packageName = "is-absolute-url";
-      version = "3.0.2";
+      version = "3.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.2.tgz";
-        sha512 = "+5g/wLlcm1AcxSP7014m6GvbPHswDx980vD/3bZaap8aGV9Yfs7Q6y6tfaupgZ5O74Byzc8dGrSCJ+bFXx0KdA==";
+        url = "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz";
+        sha512 = "opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==";
       };
     };
     "is-accessor-descriptor-0.1.6" = {
@@ -20795,6 +21335,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz";
         sha512 = "eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==";
+      };
+    };
+    "is-alphanumeric-1.0.0" = {
+      name = "is-alphanumeric";
+      packageName = "is-alphanumeric";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz";
+        sha1 = "4a9cef71daf4c001c1d81d63d140cf53fd6889f4";
       };
     };
     "is-alphanumerical-1.0.3" = {
@@ -20869,13 +21418,13 @@ let
         sha512 = "NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==";
       };
     };
-    "is-buffer-2.0.3" = {
+    "is-buffer-2.0.4" = {
       name = "is-buffer";
       packageName = "is-buffer";
-      version = "2.0.3";
+      version = "2.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz";
-        sha512 = "U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==";
+        url = "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz";
+        sha512 = "Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==";
       };
     };
     "is-callable-1.1.4" = {
@@ -21202,6 +21751,15 @@ let
         sha1 = "0dfd98f5a9111716dd535dda6492f67bf3d25a80";
       };
     };
+    "is-interactive-1.0.0" = {
+      name = "is-interactive";
+      packageName = "is-interactive";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz";
+        sha512 = "2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==";
+      };
+    };
     "is-invalid-path-0.1.0" = {
       name = "is-invalid-path";
       packageName = "is-invalid-path";
@@ -21220,13 +21778,13 @@ let
         sha1 = "7e147be4768dc466db3bfb21cc60b31e6ad69393";
       };
     };
-    "is-mergeable-object-1.1.0" = {
+    "is-mergeable-object-1.1.1" = {
       name = "is-mergeable-object";
       packageName = "is-mergeable-object";
-      version = "1.1.0";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.0.tgz";
-        sha512 = "JfyDDwUdtS4yHCgUpxOyKB9dnfZ0gecufxB0eytX6BmSXSE+8dbxDGt+V7CNRIRJ9sYFV/WQt2KJG6hNob2sBw==";
+        url = "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.1.tgz";
+        sha512 = "CPduJfuGg8h8vW74WOxHtHmtQutyQBzR+3MjQ6iDHIYdbOnm1YC7jv43SqCoU8OPGTJD4nibmiryA4kmogbGrA==";
       };
     };
     "is-module-1.0.0" = {
@@ -21344,6 +21902,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz";
         sha1 = "8952688c5ec2ffd6b03ecc85e769e02903083470";
+      };
+    };
+    "is-observable-1.1.0" = {
+      name = "is-observable";
+      packageName = "is-observable";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz";
+        sha512 = "NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==";
       };
     };
     "is-options-1.0.1" = {
@@ -21481,13 +22048,13 @@ let
         sha512 = "Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==";
       };
     };
-    "is-relative-url-2.0.0" = {
+    "is-relative-url-3.0.0" = {
       name = "is-relative-url";
       packageName = "is-relative-url";
-      version = "2.0.0";
+      version = "3.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-relative-url/-/is-relative-url-2.0.0.tgz";
-        sha1 = "72902d7fe04b3d4792e7db15f9db84b7204c9cef";
+        url = "https://registry.npmjs.org/is-relative-url/-/is-relative-url-3.0.0.tgz";
+        sha512 = "U1iSYRlY2GIMGuZx7gezlB5dp1Kheaym7zKzO1PV06mOihiWTXejLwm4poEJysPyXF+HtK/BEd0DVlcCh30pEA==";
       };
     };
     "is-resolvable-1.1.0" = {
@@ -21544,6 +22111,15 @@ let
         sha1 = "12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44";
       };
     };
+    "is-stream-2.0.0" = {
+      name = "is-stream";
+      packageName = "is-stream";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz";
+        sha512 = "XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==";
+      };
+    };
     "is-string-1.0.4" = {
       name = "is-string";
       packageName = "is-string";
@@ -21580,13 +22156,13 @@ let
         sha512 = "HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==";
       };
     };
-    "is-text-path-2.0.0" = {
+    "is-text-path-1.0.1" = {
       name = "is-text-path";
       packageName = "is-text-path";
-      version = "2.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz";
-        sha512 = "+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==";
+        url = "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz";
+        sha1 = "4e1aa0fb51bfbcb3e92688001397202c1775b66e";
       };
     };
     "is-typedarray-1.0.0" = {
@@ -21967,13 +22543,22 @@ let
         sha1 = "dc5ebed10d04a5e0eaf49ef0009bec473d1a6b31";
       };
     };
-    "jaeger-client-3.16.0" = {
+    "jaeger-client-3.17.1" = {
       name = "jaeger-client";
       packageName = "jaeger-client";
-      version = "3.16.0";
+      version = "3.17.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jaeger-client/-/jaeger-client-3.16.0.tgz";
-        sha512 = "F4y4rQ7RTYFDu6QGsFXOnrZb2Pk6BvhnecOZQZvM+BmNahgE+5y9mfToMe4SsELuJ7NQM5JF+Oau1u/xwefr9A==";
+        url = "https://registry.npmjs.org/jaeger-client/-/jaeger-client-3.17.1.tgz";
+        sha512 = "S3fS3vk7dcWTWUWGqMWD9fGa/diLhPIP9h0S8L+OQdz24+7hR7cdALk+AOZD1VzbvqUIQbj6uUELp31J4Frgcw==";
+      };
+    };
+    "java-properties-1.0.2" = {
+      name = "java-properties";
+      packageName = "java-properties";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz";
+        sha512 = "qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==";
       };
     };
     "javascript-natural-sort-0.7.1" = {
@@ -22039,22 +22624,22 @@ let
         sha1 = "06d4912255093419477d425633606e0e90782967";
       };
     };
-    "joplin-turndown-4.0.17" = {
+    "joplin-turndown-4.0.18" = {
       name = "joplin-turndown";
       packageName = "joplin-turndown";
-      version = "4.0.17";
+      version = "4.0.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/joplin-turndown/-/joplin-turndown-4.0.17.tgz";
-        sha512 = "57mw92ZOKoR77YBLUkauN1xNq1xlxOm2KaPty/jlYrkEyGotUBBvq46a6wXh6d3aM4CccGuwymSge18/9IoB3A==";
+        url = "https://registry.npmjs.org/joplin-turndown/-/joplin-turndown-4.0.18.tgz";
+        sha512 = "YD0pkj2a7+XjjNNI1X9ZIwYthFwNsswvO4gl5aAoWdwJj5m8tunnoSyVenvqleXzAcaURIi/q9EOAQ1jw7xDiQ==";
       };
     };
-    "joplin-turndown-plugin-gfm-1.0.9" = {
+    "joplin-turndown-plugin-gfm-1.0.11" = {
       name = "joplin-turndown-plugin-gfm";
       packageName = "joplin-turndown-plugin-gfm";
-      version = "1.0.9";
+      version = "1.0.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/joplin-turndown-plugin-gfm/-/joplin-turndown-plugin-gfm-1.0.9.tgz";
-        sha512 = "SOa/Uiy3nyoBGtHqFe+TBg10UTIOzzcUUzNhx2MyR4Z0vbKL3enGggGypig1t7G5uHwv5j+NhooRuM619Zk0bw==";
+        url = "https://registry.npmjs.org/joplin-turndown-plugin-gfm/-/joplin-turndown-plugin-gfm-1.0.11.tgz";
+        sha512 = "S2I+VCTqIhpWKKkPHsyJ5rdll9H/JjMXoBVClRX1TnphcmrSxufevdoXWWVgLncdXpSSiuoifCXgFZy3ueVElg==";
       };
     };
     "jpeg-js-0.1.2" = {
@@ -22417,13 +23002,13 @@ let
         sha1 = "b480c892e59a2f05954ce727bd3f2a4e882f9e13";
       };
     };
-    "json-schema-deref-sync-0.3.4" = {
+    "json-schema-deref-sync-0.6.0" = {
       name = "json-schema-deref-sync";
       packageName = "json-schema-deref-sync";
-      version = "0.3.4";
+      version = "0.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.3.4.tgz";
-        sha512 = "4Ssj+1UGDJAzPIdTL1QW/rvHwWeuwC28gjbA0EjStLxVsalc+UPciKXxs3rhtr4gaGdIBojW/VmvC8B8bCQwcA==";
+        url = "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.6.0.tgz";
+        sha512 = "0efemmp3LWItb3Nux9gsoDA0xpzWaCDwoUuECEBOZQaTjAGqTrGkrJQwaIHAOD+X0SJnY+1dpsd2yE4EO+ZzRg==";
       };
     };
     "json-schema-faker-0.2.16" = {
@@ -22534,6 +23119,15 @@ let
         sha512 = "8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==";
       };
     };
+    "json5-2.1.1" = {
+      name = "json5";
+      packageName = "json5";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz";
+        sha512 = "l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==";
+      };
+    };
     "jsonata-1.6.5" = {
       name = "jsonata";
       packageName = "jsonata";
@@ -22541,6 +23135,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/jsonata/-/jsonata-1.6.5.tgz";
         sha512 = "iRx9U6AkvsjrRdFf9MMbQmGVAL3bXVANR12vbVxjgXouMPU9VJQEcFnLWUCaW8IDmOzdxsaxK4Xe7SGlBYr5Bg==";
+      };
+    };
+    "jsonata-1.7.0" = {
+      name = "jsonata";
+      packageName = "jsonata";
+      version = "1.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/jsonata/-/jsonata-1.7.0.tgz";
+        sha512 = "W1qxnGXtbaboFFA8DMLL2GZgiWoeFuMo0Yf3J23o03omzIuW9a9hgowgfUChQq8bfMfh/zmQJpwn/gQirn46ew==";
       };
     };
     "jsonc-parser-1.0.3" = {
@@ -23066,6 +23669,15 @@ let
         sha512 = "vBUF/IsBDzaejHkNpiquKdc5uPrImXuQ4Mb9lEfNNJ5cyHGI8ThDupR+h3eMFZhfmPE/brfwcIAn/fm0yOvJUg==";
       };
     };
+    "known-css-properties-0.5.0" = {
+      name = "known-css-properties";
+      packageName = "known-css-properties";
+      version = "0.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.5.0.tgz";
+        sha512 = "LOS0CoS8zcZnB1EjLw4LLqDXw8nvt3AGH5dXLQP3D9O1nLLA+9GC5GnPl5mmF+JiQAtSX4VyZC7KvEtcA4kUtA==";
+      };
+    };
     "kuduscript-1.0.16" = {
       name = "kuduscript";
       packageName = "kuduscript";
@@ -23237,6 +23849,15 @@ let
         sha512 = "avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==";
       };
     };
+    "lcid-3.1.1" = {
+      name = "lcid";
+      packageName = "lcid";
+      version = "3.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lcid/-/lcid-3.1.1.tgz";
+        sha512 = "M6T051+5QCGLBQb8id3hdvIW8+zeFV2FyBGFS9IEK5H9Wt4MueD4bW1eWikpHgZp+5xR3l5c8pZUkQsIA0BFZg==";
+      };
+    };
     "ldap-filter-0.2.2" = {
       name = "ldap-filter";
       packageName = "ldap-filter";
@@ -23246,6 +23867,15 @@ let
         sha1 = "f2b842be0b86da3352798505b31ebcae590d77d0";
       };
     };
+    "ldap-filter-0.3.3" = {
+      name = "ldap-filter";
+      packageName = "ldap-filter";
+      version = "0.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.3.3.tgz";
+        sha1 = "2b14c68a2a9d4104dbdbc910a1ca85fd189e9797";
+      };
+    };
     "ldapjs-1.0.2" = {
       name = "ldapjs";
       packageName = "ldapjs";
@@ -23253,6 +23883,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ldapjs/-/ldapjs-1.0.2.tgz";
         sha1 = "544ff7032b7b83c68f0701328d9297aa694340f9";
+      };
+    };
+    "ldapjs-2.0.0-pre.2" = {
+      name = "ldapjs";
+      packageName = "ldapjs";
+      version = "2.0.0-pre.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ldapjs/-/ldapjs-2.0.0-pre.2.tgz";
+        sha512 = "KZnKiFXu5eEU4jKWoz29yUWh6fS8pIBuxFq9njji8LfHu3T4i05j6lsnGyDLayhJDw+rtKpEgmS3/As7CXg7WQ==";
       };
     };
     "lead-1.0.0" = {
@@ -23345,13 +23984,13 @@ let
         sha512 = "UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==";
       };
     };
-    "level-iterator-stream-4.0.1" = {
+    "level-iterator-stream-4.0.2" = {
       name = "level-iterator-stream";
       packageName = "level-iterator-stream";
-      version = "4.0.1";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.1.tgz";
-        sha512 = "pSZWqXK6/yHQkZKCHrR59nKpU5iqorKM22C/BOHTb/cwNQ2EOZG+bovmFFGcOgaBoF3KxqJEI27YwewhJQTzsw==";
+        url = "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz";
+        sha512 = "ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==";
       };
     };
     "level-js-4.0.1" = {
@@ -23363,13 +24002,13 @@ let
         sha512 = "m5JRIyHZn5VnCCFeRegJkn5bQd3MJK5qZX12zg3Oivc8+BUIS2yFS6ANMMeHX2ieGxucNvEn6/ZnyjmZQLLUWw==";
       };
     };
-    "level-packager-5.0.3" = {
+    "level-packager-5.1.0" = {
       name = "level-packager";
       packageName = "level-packager";
-      version = "5.0.3";
+      version = "5.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/level-packager/-/level-packager-5.0.3.tgz";
-        sha512 = "Ut62o3nvUNCxYldM5+13+0sYow6ifKj2C26/0ToB7zKgdypF5wRKcVkcztQVwsQi+ZnrmDzhimp7FKP5Ynv6Rg==";
+        url = "https://registry.npmjs.org/level-packager/-/level-packager-5.1.0.tgz";
+        sha512 = "3pbJmDgGvp/lUQNULPoYQZtUbhMI8KoViYDw7Sa0kWl1mPeHWWJF7T/9upWI/NTMuEikkEE/cd6wBvmrW1+ZnQ==";
       };
     };
     "level-post-1.0.7" = {
@@ -23390,13 +24029,22 @@ let
         sha512 = "SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==";
       };
     };
-    "leveldown-5.2.1" = {
+    "level-supports-1.0.1" = {
+      name = "level-supports";
+      packageName = "level-supports";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz";
+        sha512 = "rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==";
+      };
+    };
+    "leveldown-5.4.1" = {
       name = "leveldown";
       packageName = "leveldown";
-      version = "5.2.1";
+      version = "5.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/leveldown/-/leveldown-5.2.1.tgz";
-        sha512 = "369I1rGibXV7CIoLhsSpp/ExwQucI3xUe0RXQrMu4ji6OG9PFMVAQuzsEXKwAi3BWsjFzcFtodAP8MW5fmfung==";
+        url = "https://registry.npmjs.org/leveldown/-/leveldown-5.4.1.tgz";
+        sha512 = "3lMPc7eU3yj5g+qF1qlALInzIYnkySIosR1AsUKFjL9D8fYbTLuENBAeDRZXIG4qeWOAyqRItOoLu2v2avWiMA==";
       };
     };
     "levelup-0.19.1" = {
@@ -23408,13 +24056,13 @@ let
         sha1 = "f3a6a7205272c4b5f35e412ff004a03a0aedf50b";
       };
     };
-    "levelup-4.2.0" = {
+    "levelup-4.3.2" = {
       name = "levelup";
       packageName = "levelup";
-      version = "4.2.0";
+      version = "4.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/levelup/-/levelup-4.2.0.tgz";
-        sha512 = "TiHUSYrSUQhG7a5MZIKq6ClDcARSvMvSy5GTM8I62tHV5XiWqf+aInF+CAenQKzVRG2s6fufg62Lv8614Extyg==";
+        url = "https://registry.npmjs.org/levelup/-/levelup-4.3.2.tgz";
+        sha512 = "cRTjU4ktWo59wf13PHEiOayHC3n0dOh4i5+FHr4tv4MX9+l7mqETicNq3Aj07HKlLdk0z5muVoDL2RD+ovgiyA==";
       };
     };
     "leven-2.1.0" = {
@@ -23453,24 +24101,6 @@ let
         sha1 = "3b09924edf9f083c0490fdd4c0bc4421e04764ee";
       };
     };
-    "libbase64-1.0.3" = {
-      name = "libbase64";
-      packageName = "libbase64";
-      version = "1.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/libbase64/-/libbase64-1.0.3.tgz";
-        sha512 = "ULQZAATVGTAgVNwP61R+MbbSGNBy1tVzWupB9kbE6p+VccWd+J+ICXgOwQic5Yqagzpu+oPZ8sI7yXdWJnPPkA==";
-      };
-    };
-    "libmime-4.1.1" = {
-      name = "libmime";
-      packageName = "libmime";
-      version = "4.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/libmime/-/libmime-4.1.1.tgz";
-        sha512 = "HkOfBSj+l7pBOOucEgiI6PdbgHa8ljv+1rARzW743HQ51UP8gabMlcA2wAF3Dg1aeuMjHZ+LzAPYxM52IZsyGA==";
-      };
-    };
     "libnested-1.4.1" = {
       name = "libnested";
       packageName = "libnested";
@@ -23489,31 +24119,22 @@ let
         sha512 = "9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==";
       };
     };
-    "libqp-1.1.0" = {
-      name = "libqp";
-      packageName = "libqp";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz";
-        sha1 = "f5e6e06ad74b794fb5b5b66988bf728ef1dedbe8";
-      };
-    };
-    "libsodium-0.7.5" = {
+    "libsodium-0.7.6" = {
       name = "libsodium";
       packageName = "libsodium";
-      version = "0.7.5";
+      version = "0.7.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/libsodium/-/libsodium-0.7.5.tgz";
-        sha512 = "0YVU2QJc5sDR5HHkGCaliYImS7pGeXi11fiOfm4DirBd96PJVZIn3LJa06ZOFjLNsWkL3UbNjYhLRUOABPL9vw==";
+        url = "https://registry.npmjs.org/libsodium/-/libsodium-0.7.6.tgz";
+        sha512 = "hPb/04sEuLcTRdWDtd+xH3RXBihpmbPCsKW/Jtf4PsvdyKh+D6z2D2gvp/5BfoxseP+0FCOg66kE+0oGUE/loQ==";
       };
     };
-    "libsodium-wrappers-0.7.5" = {
+    "libsodium-wrappers-0.7.6" = {
       name = "libsodium-wrappers";
       packageName = "libsodium-wrappers";
-      version = "0.7.5";
+      version = "0.7.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.5.tgz";
-        sha512 = "QE9Q+FxLLGdJRiJTuC2GB3LEHZeHX/VcbMQeNPdAixEKo86JPy6bOWND1XmMLu0tjWUu0xIY0YpJYQApxIZwbQ==";
+        url = "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.6.tgz";
+        sha512 = "OUO2CWW5bHdLr6hkKLHIKI4raEkZrf3QHkhXsJ1yCh6MZ3JDA7jFD3kCATNquuGSG6MjjPHQIQms0y0gBDzjQg==";
       };
     };
     "libspiro-js-0.3.1" = {
@@ -23552,6 +24173,15 @@ let
         sha512 = "DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==";
       };
     };
+    "lighthouse-logger-1.2.0" = {
+      name = "lighthouse-logger";
+      packageName = "lighthouse-logger";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz";
+        sha512 = "wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==";
+      };
+    };
     "limit-spawn-0.0.3" = {
       name = "limit-spawn";
       packageName = "limit-spawn";
@@ -23559,6 +24189,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/limit-spawn/-/limit-spawn-0.0.3.tgz";
         sha1 = "cc09c24467a0f0a1ed10a5196dba597cad3f65dc";
+      };
+    };
+    "lines-and-columns-1.1.6" = {
+      name = "lines-and-columns";
+      packageName = "lines-and-columns";
+      version = "1.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz";
+        sha1 = "1c00c743b433cd0a4e80758f7b64a57440d9ff00";
       };
     };
     "linewise-0.0.3" = {
@@ -23570,22 +24209,13 @@ let
         sha1 = "bf967ba0dd31faaf09ab5bdb3676ad7f2aa18493";
       };
     };
-    "link-check-4.4.5" = {
+    "link-check-4.4.6" = {
       name = "link-check";
       packageName = "link-check";
-      version = "4.4.5";
+      version = "4.4.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/link-check/-/link-check-4.4.5.tgz";
-        sha512 = "csF0k7MAQjyDLkrZfsAJNkTav/vvATMYkm9dAstzmu60vzNGlgvWd3SgBTFH9KLWOO1hUuVxgSEPuWv+fdyuaQ==";
-      };
-    };
-    "linkify-it-2.1.0" = {
-      name = "linkify-it";
-      packageName = "linkify-it";
-      version = "2.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz";
-        sha512 = "4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==";
+        url = "https://registry.npmjs.org/link-check/-/link-check-4.4.6.tgz";
+        sha512 = "83RPcCsgZ1BsSuUtcdEOYv7zndQ3fbZCuoKIrKCuUfDhBWqBzWnU+Un1WdGuveMGAOHahL0LHLFUr6KqZ2Mrzg==";
       };
     };
     "linkify-it-2.2.0" = {
@@ -23604,6 +24234,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz";
         sha1 = "84c8a72ab59c4725321480c975e6508342e70937";
+      };
+    };
+    "listr-0.14.3" = {
+      name = "listr";
+      packageName = "listr";
+      version = "0.14.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz";
+        sha512 = "RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==";
+      };
+    };
+    "listr-silent-renderer-1.1.1" = {
+      name = "listr-silent-renderer";
+      packageName = "listr-silent-renderer";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz";
+        sha1 = "924b5a3757153770bf1a8e3fbf74b8bbf3f9242e";
+      };
+    };
+    "listr-update-renderer-0.5.0" = {
+      name = "listr-update-renderer";
+      packageName = "listr-update-renderer";
+      version = "0.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz";
+        sha512 = "tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==";
+      };
+    };
+    "listr-verbose-renderer-0.5.0" = {
+      name = "listr-verbose-renderer";
+      packageName = "listr-verbose-renderer";
+      version = "0.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz";
+        sha512 = "04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==";
       };
     };
     "load-ip-set-2.1.0" = {
@@ -24326,15 +24992,6 @@ let
         sha1 = "0b08a1dcf68397c397855c3239783832df7403d1";
       };
     };
-    "lodash.has-4.5.2" = {
-      name = "lodash.has";
-      packageName = "lodash.has";
-      version = "4.5.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz";
-        sha1 = "d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862";
-      };
-    };
     "lodash.identity-2.4.1" = {
       name = "lodash.identity";
       packageName = "lodash.identity";
@@ -24342,6 +24999,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz";
         sha1 = "6694cffa65fef931f7c31ce86c74597cf560f4f1";
+      };
+    };
+    "lodash.identity-3.0.0" = {
+      name = "lodash.identity";
+      packageName = "lodash.identity";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz";
+        sha1 = "ad7bc6a4e647d79c972e1b80feef7af156267876";
       };
     };
     "lodash.includes-4.3.0" = {
@@ -24596,6 +25262,15 @@ let
         sha1 = "52f05610fff9ded422611441ed1fc123a03001b3";
       };
     };
+    "lodash.pickby-4.6.0" = {
+      name = "lodash.pickby";
+      packageName = "lodash.pickby";
+      version = "4.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz";
+        sha1 = "7dea21d8c18d7703a27c704c15d3b84a67e33aff";
+      };
+    };
     "lodash.reduce-4.6.0" = {
       name = "lodash.reduce";
       packageName = "lodash.reduce";
@@ -24758,6 +25433,15 @@ let
         sha1 = "a3a17bbf62eeb6240f491846e97c1c4e2a5e1e21";
       };
     };
+    "lodash.xorby-4.7.0" = {
+      name = "lodash.xorby";
+      packageName = "lodash.xorby";
+      version = "4.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.xorby/-/lodash.xorby-4.7.0.tgz";
+        sha1 = "9c19a6f9f063a6eb53dd03c1b6871799801463d7";
+      };
+    };
     "log-symbols-1.0.2" = {
       name = "log-symbols";
       packageName = "log-symbols";
@@ -24774,6 +25458,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz";
         sha512 = "VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==";
+      };
+    };
+    "log-symbols-3.0.0" = {
+      name = "log-symbols";
+      packageName = "log-symbols";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz";
+        sha512 = "dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==";
       };
     };
     "log-update-1.0.2" = {
@@ -24893,13 +25586,13 @@ let
         sha1 = "d06597c4d4c31b52ccb1f5d8f8fe7148eafd6965";
       };
     };
-    "longjohn-0.2.12" = {
-      name = "longjohn";
-      packageName = "longjohn";
-      version = "0.2.12";
+    "longest-streak-2.0.3" = {
+      name = "longest-streak";
+      packageName = "longest-streak";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/longjohn/-/longjohn-0.2.12.tgz";
-        sha1 = "7ca7446b083655c377e7512213dc754d52a64a7e";
+        url = "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz";
+        sha512 = "9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==";
       };
     };
     "looper-2.0.0" = {
@@ -24965,13 +25658,13 @@ let
         sha1 = "5b46f80147edee578870f086d04821cf998e551f";
       };
     };
-    "loud-rejection-2.1.0" = {
+    "loud-rejection-2.2.0" = {
       name = "loud-rejection";
       packageName = "loud-rejection";
-      version = "2.1.0";
+      version = "2.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.1.0.tgz";
-        sha512 = "g/6MQxUXYHeVqZ4PGpPL1fS1fOvlXoi7bay0pizmjAd/3JhyXwxzwrnr74yzdmhuerlslbRJ3x7IOXzFz0cE5w==";
+        url = "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.2.0.tgz";
+        sha512 = "S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==";
       };
     };
     "lowdb-1.0.0" = {
@@ -25217,6 +25910,15 @@ let
         sha512 = "6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==";
       };
     };
+    "magic-string-0.25.4" = {
+      name = "magic-string";
+      packageName = "magic-string";
+      version = "0.25.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/magic-string/-/magic-string-0.25.4.tgz";
+        sha512 = "oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==";
+      };
+    };
     "magicli-0.0.5" = {
       name = "magicli";
       packageName = "magicli";
@@ -25262,24 +25964,6 @@ let
         sha512 = "VYaJMxhr8B9BrCiNINUsuhaEe40YnG+AQBwcqUKO66lSVaI9I3A1iH/6EmEwRI8OYUg5Gt+4lLE7achg676lrg==";
       };
     };
-    "mailparser-2.7.1" = {
-      name = "mailparser";
-      packageName = "mailparser";
-      version = "2.7.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mailparser/-/mailparser-2.7.1.tgz";
-        sha512 = "qAyDPuyd0ygTM3V9yzxVilYyRt0mpjLmp6OSzBPjwMZYX1PVDOoGEyUgDtyCDoEgC5fqslpXpWCI6t7RN3i3fw==";
-      };
-    };
-    "mailsplit-4.4.1" = {
-      name = "mailsplit";
-      packageName = "mailsplit";
-      version = "4.4.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mailsplit/-/mailsplit-4.4.1.tgz";
-        sha512 = "AmWLEHQAg/zbNb1MdrPQS9VOzysHaU9IuoQV9kGU5fgjM5RCbgqVkZzp0+DhPep8sj8iHfbWkl16Nb1PbNlTYg==";
-      };
-    };
     "make-dir-1.3.0" = {
       name = "make-dir";
       packageName = "make-dir";
@@ -25316,13 +26000,13 @@ let
         sha1 = "df0388fcd0b37816dff0a5fb8108939777dcbc9d";
       };
     };
-    "make-fetch-happen-5.0.0" = {
+    "make-fetch-happen-5.0.1" = {
       name = "make-fetch-happen";
       packageName = "make-fetch-happen";
-      version = "5.0.0";
+      version = "5.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.0.tgz";
-        sha512 = "nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==";
+        url = "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.1.tgz";
+        sha512 = "b4dfaMvUDR67zxUq1+GN7Ke9rH5WvGRmoHuMH7l+gmUCR2tCXFP6mpeJ9Dp+jB6z8mShRopSf1vLRBhRs8Cu5w==";
       };
     };
     "make-iterator-1.0.1" = {
@@ -25478,13 +26162,13 @@ let
         sha512 = "GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==";
       };
     };
-    "markdown-it-anchor-5.2.4" = {
+    "markdown-it-anchor-5.2.5" = {
       name = "markdown-it-anchor";
       packageName = "markdown-it-anchor";
-      version = "5.2.4";
+      version = "5.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz";
-        sha512 = "n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A==";
+        url = "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.5.tgz";
+        sha512 = "xLIjLQmtym3QpoY9llBgApknl7pxAcN3WDRc2d3rwpl+/YvDZHPmKscGs+L6E05xf2KrCXPBvosWt7MZukwSpQ==";
       };
     };
     "markdown-it-emoji-1.4.0" = {
@@ -25496,13 +26180,13 @@ let
         sha1 = "9bee0e9a990a963ba96df6980c4fddb05dfb4dcc";
       };
     };
-    "markdown-it-github-headings-1.1.1" = {
+    "markdown-it-github-headings-1.1.2" = {
       name = "markdown-it-github-headings";
       packageName = "markdown-it-github-headings";
-      version = "1.1.1";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/markdown-it-github-headings/-/markdown-it-github-headings-1.1.1.tgz";
-        sha512 = "jEthmVitZXhYJ0Fkvh6RfBcxdIKKec/p3LidX9a+Hs5/AnUjtxi1nxDVhu1muyacXoTiA+ChVilASQyTdfWk2Q==";
+        url = "https://registry.npmjs.org/markdown-it-github-headings/-/markdown-it-github-headings-1.1.2.tgz";
+        sha512 = "8haIwpAx87DQHcEtzkfsWv2hxg4jOvow6/nJKAMQ2wYRMZQTIfJm9VzrDkqw72Bb4YXBmI0u3GA/3MdXVL/x5g==";
       };
     };
     "markdown-it-task-checkbox-1.0.6" = {
@@ -25514,13 +26198,13 @@ let
         sha512 = "7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw==";
       };
     };
-    "markdown-link-extractor-1.2.1" = {
+    "markdown-link-extractor-1.2.2" = {
       name = "markdown-link-extractor";
       packageName = "markdown-link-extractor";
-      version = "1.2.1";
+      version = "1.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/markdown-link-extractor/-/markdown-link-extractor-1.2.1.tgz";
-        sha512 = "eo4hXLZC6/NrVimHqEu0X029ymIreg0VQjlWudGtOg1FiiZYPwU+Sh1CP3CQqP16woyCsDplVfqPD2Oi8JRpdw==";
+        url = "https://registry.npmjs.org/markdown-link-extractor/-/markdown-link-extractor-1.2.2.tgz";
+        sha512 = "VYDUhlC70hKl0coCY6dXyJ4OCRAX5dTh0/oSTdidhYS7dYIJ9kYAez6KR0vc3HWySMuo564J1rN0NOAPBDI0iA==";
       };
     };
     "markdown-serve-0.3.3" = {
@@ -25541,6 +26225,15 @@ let
         sha1 = "890c2c1b3bfe83fb00e4129b8e4cfe645270f9d1";
       };
     };
+    "markdown-table-1.1.3" = {
+      name = "markdown-table";
+      packageName = "markdown-table";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz";
+        sha512 = "1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==";
+      };
+    };
     "marked-0.3.19" = {
       name = "marked";
       packageName = "marked";
@@ -25548,15 +26241,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz";
         sha512 = "ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==";
-      };
-    };
-    "marked-0.6.3" = {
-      name = "marked";
-      packageName = "marked";
-      version = "0.6.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz";
-        sha512 = "Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==";
       };
     };
     "marked-0.7.0" = {
@@ -25646,8 +26330,8 @@ let
       version = "3.0.0";
       src = fetchgit {
         url = "git://github.com/mathjax/MathJax-src.git";
-        rev = "0d74266e1820220d33cb6b29d4ca3575b352ac0d";
-        sha256 = "a4d1a272ec79367f3e4515d1cbd9bbe3f77687aa17443398288e91a6f23b1241";
+        rev = "1e1a30f0a89e52fa7764dbb510763145a4da49f1";
+        sha256 = "e44c97d2d7ade5ac91d13456a631778a9f2f3d73ef7e4cffc2b5e7bffa02164b";
       };
     };
     "mathjs-5.10.3" = {
@@ -25657,6 +26341,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mathjs/-/mathjs-5.10.3.tgz";
         sha512 = "ySjg30BC3dYjQm73ILZtwcWzFJde0VU6otkXW/57IjjuYRa3Qaf0Kb8pydEuBZYtqW2OxreAtsricrAmOj3jIw==";
+      };
+    };
+    "mathml-tag-names-2.1.1" = {
+      name = "mathml-tag-names";
+      packageName = "mathml-tag-names";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz";
+        sha512 = "pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==";
       };
     };
     "md5-2.2.1" = {
@@ -25704,6 +26397,15 @@ let
         sha512 = "TWZDaUtPLwKX1pzDIY48MkSUQRDwX/HqbTB4m3iYdL/zosi/Z6Xqfdv0C0hNVKvzrPjZENrpWDt4p4odeVO0Iw==";
       };
     };
+    "mdast-util-compact-1.0.3" = {
+      name = "mdast-util-compact";
+      packageName = "mdast-util-compact";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz";
+        sha512 = "nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==";
+      };
+    };
     "mdast-util-to-nlcst-3.2.3" = {
       name = "mdast-util-to-nlcst";
       packageName = "mdast-util-to-nlcst";
@@ -25722,22 +26424,13 @@ let
         sha1 = "c04891883c28c83602e1d06b05a11037e359b4c8";
       };
     };
-    "mdn-browser-compat-data-0.0.82" = {
+    "mdn-browser-compat-data-0.0.94" = {
       name = "mdn-browser-compat-data";
       packageName = "mdn-browser-compat-data";
-      version = "0.0.82";
+      version = "0.0.94";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.82.tgz";
-        sha512 = "RmC87C45AgXLuNlkrGLCK2wh0zRwpFnnro5jsNxmS90xLCxfKmTLPtqM9cocKFD7Ro9pWmtvkIkRiesGakd1Ig==";
-      };
-    };
-    "mdn-data-1.1.4" = {
-      name = "mdn-data";
-      packageName = "mdn-data";
-      version = "1.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz";
-        sha512 = "FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==";
+        url = "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.94.tgz";
+        sha512 = "O3zJqbmehz0Hn3wpk62taA0+jNF7yn6BDWqQ9Wh2bEoO9Rx1BYiTmNX565eNVbW0ixfQkY6Sp9FvY/rr79Qmyg==";
       };
     };
     "mdn-data-2.0.4" = {
@@ -25848,6 +26541,15 @@ let
         sha512 = "qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==";
       };
     };
+    "mem-5.1.1" = {
+      name = "mem";
+      packageName = "mem";
+      version = "5.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mem/-/mem-5.1.1.tgz";
+        sha512 = "qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==";
+      };
+    };
     "mem-fs-1.1.3" = {
       name = "mem-fs";
       packageName = "mem-fs";
@@ -25866,13 +26568,13 @@ let
         sha512 = "/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==";
       };
     };
-    "memory-cache-0.1.6" = {
+    "memory-cache-0.2.0" = {
       name = "memory-cache";
       packageName = "memory-cache";
-      version = "0.1.6";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/memory-cache/-/memory-cache-0.1.6.tgz";
-        sha1 = "2ed9933ed7a8c718249be7366f7ca8749acf8a24";
+        url = "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz";
+        sha1 = "7890b01d52c00c8ebc9d533e1f8eb17e3034871a";
       };
     };
     "memory-chunk-store-1.3.0" = {
@@ -25900,6 +26602,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz";
         sha1 = "3a9a20b8462523e447cfbc7e8bb80ed667bfc552";
+      };
+    };
+    "memory-fs-0.5.0" = {
+      name = "memory-fs";
+      packageName = "memory-fs";
+      version = "0.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz";
+        sha512 = "jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==";
       };
     };
     "memory-pager-1.5.0" = {
@@ -26008,6 +26719,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz";
         sha1 = "a5de46538dae84d4114cc5ea02b4772a6346701f";
+      };
+    };
+    "merge-stream-2.0.0" = {
+      name = "merge-stream";
+      packageName = "merge-stream";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz";
+        sha512 = "abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==";
       };
     };
     "merge2-1.3.0" = {
@@ -26244,13 +26964,13 @@ let
         sha512 = "jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==";
       };
     };
-    "mime-db-1.41.0" = {
+    "mime-db-1.42.0" = {
       name = "mime-db";
       packageName = "mime-db";
-      version = "1.41.0";
+      version = "1.42.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.41.0.tgz";
-        sha512 = "B5gxBI+2K431XW8C2rcc/lhppbuji67nf9v39eH8pkWoZDxnAL0PxdpH32KYRScniF8qDHBDlI+ipgg5WrCUYw==";
+        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz";
+        sha512 = "UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==";
       };
     };
     "mime-types-2.0.14" = {
@@ -26424,6 +27144,15 @@ let
         sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
       };
     };
+    "minimist-1.1.3" = {
+      name = "minimist";
+      packageName = "minimist";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz";
+        sha1 = "3bedfd91a92d39016fcfaa1c681e8faa1a1efda8";
+      };
+    };
     "minimist-1.2.0" = {
       name = "minimist";
       packageName = "minimist";
@@ -26451,13 +27180,13 @@ let
         sha512 = "oP88Dw3LK/pdrKyMdlbmg3W50969UNr4ctISzJfPl+YPYHTAOrS+dihXnsgRNKSRIzDsrnV3eE2CCVlZbpOKdQ==";
       };
     };
-    "minipass-2.8.1" = {
+    "minipass-2.9.0" = {
       name = "minipass";
       packageName = "minipass";
-      version = "2.8.1";
+      version = "2.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minipass/-/minipass-2.8.1.tgz";
-        sha512 = "QCG523ParRcE2+9A6wYh9UI3uy2FFLw4DQaVYQrY5HPfszc5M6VDD+j0QCwHm19LI2imes4RB+NBD8cOJccyCg==";
+        url = "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz";
+        sha512 = "wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==";
       };
     };
     "minitouch-prebuilt-1.2.0" = {
@@ -26469,13 +27198,13 @@ let
         sha512 = "YBTCTK0kPQIry0dJUqnj+OKw7qk1BDk4JnOH55ujaL4vtf9f3fRsHtD+zz899SKwT2t319HrrfBNwMLx6h2Vtg==";
       };
     };
-    "minizlib-1.2.2" = {
+    "minizlib-1.3.3" = {
       name = "minizlib";
       packageName = "minizlib";
-      version = "1.2.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minizlib/-/minizlib-1.2.2.tgz";
-        sha512 = "hR3At21uSrsjjDTWrbu0IMLTpnkpv8IIMFDFaoz43Tmu4LkmAXfH44vNNzpTnf+OAQQCHrb91y/wc2J4x5XgSQ==";
+        url = "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz";
+        sha512 = "6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==";
       };
     };
     "mired-0.0.0" = {
@@ -26631,15 +27360,6 @@ let
         sha512 = "Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==";
       };
     };
-    "moment-2.22.2" = {
-      name = "moment";
-      packageName = "moment";
-      version = "2.22.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz";
-        sha1 = "3c257f9839fc0e93ff53149632239eb90783ff66";
-      };
-    };
     "moment-2.24.0" = {
       name = "moment";
       packageName = "moment";
@@ -26658,13 +27378,13 @@ let
         sha1 = "359a19ec634cda3c706c8709adda54c0329aaec4";
       };
     };
-    "moment-timezone-0.5.26" = {
+    "moment-timezone-0.5.27" = {
       name = "moment-timezone";
       packageName = "moment-timezone";
-      version = "0.5.26";
+      version = "0.5.27";
       src = fetchurl {
-        url = "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz";
-        sha512 = "sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==";
+        url = "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz";
+        sha512 = "EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==";
       };
     };
     "monotonic-timestamp-0.0.9" = {
@@ -26739,13 +27459,13 @@ let
         sha512 = "ZQQjf0VEiqPucwRvmT3e0pfZfMSE3nc5ngGUiN1+2VMxCtrInrlAjZ2K6jpNmxSZ/roiQne/ovYJYTeOvZDXPw==";
       };
     };
-    "mpath-0.2.1" = {
+    "mpath-0.5.2" = {
       name = "mpath";
       packageName = "mpath";
-      version = "0.2.1";
+      version = "0.5.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz";
-        sha1 = "3a4e829359801de96309c27a6b2e102e89f9e96e";
+        url = "https://registry.npmjs.org/mpath/-/mpath-0.5.2.tgz";
+        sha512 = "NOeCoW6AYc3hLi30npe7uzbD9b4FQZKH40YKABUCCvaKKL5agj6YzvHoNx8jQpDMNPgIa5bvSZQbQpWBAVD0Kw==";
       };
     };
     "mqtt-2.18.8" = {
@@ -26764,15 +27484,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-5.6.1.tgz";
         sha512 = "eaF9rO2uFrIYEHomJxziuKTDkbWW5psLBaIGCazQSKqYsTaB3n4SpvJ1PexKaDBiPnMLPIFWBIiTYT3IfEJfww==";
-      };
-    };
-    "mri-1.1.4" = {
-      name = "mri";
-      packageName = "mri";
-      version = "1.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz";
-        sha512 = "6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==";
       };
     };
     "ms-0.7.0" = {
@@ -26863,15 +27574,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz";
         sha1 = "dd3c50b26f059f25e7edee3644418358e2a9ad89";
-      };
-    };
-    "multer-1.4.1" = {
-      name = "multer";
-      packageName = "multer";
-      version = "1.4.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/multer/-/multer-1.4.1.tgz";
-        sha512 = "zzOLNRxzszwd+61JFuAo0fxdQfvku12aNJgnla0AQ+hHxFmfc/B7jBVuPr5Rmvu46Jze/iJrFpSOsD7afO8SDw==";
       };
     };
     "multer-1.4.2" = {
@@ -27018,13 +27720,13 @@ let
         sha1 = "2a8f2ddf70eed564dff2d57f1e1a137d9f05078b";
       };
     };
-    "multiserver-3.4.0" = {
+    "multiserver-3.6.0" = {
       name = "multiserver";
       packageName = "multiserver";
-      version = "3.4.0";
+      version = "3.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/multiserver/-/multiserver-3.4.0.tgz";
-        sha512 = "HSGnZBXDM9e8gi3YyhObwiDYP3BFeL+TV22H1dAReigHHMc52IDBsz9N1OR72OKxCd7SMD+gKBpVJbJohhb3og==";
+        url = "https://registry.npmjs.org/multiserver/-/multiserver-3.6.0.tgz";
+        sha512 = "MeANpx7//lJTwYKLYfsucdRvDafbyxaijUm9BhmF+QfLBMGRebNoKRYLhZItbHYAcsI0HBTtpBVHNw+bmRRnFQ==";
       };
     };
     "multiserver-address-1.0.1" = {
@@ -27072,13 +27774,13 @@ let
         sha512 = "KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==";
       };
     };
-    "mustache-3.0.1" = {
+    "mustache-3.0.2" = {
       name = "mustache";
       packageName = "mustache";
-      version = "3.0.1";
+      version = "3.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz";
-        sha512 = "jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA==";
+        url = "https://registry.npmjs.org/mustache/-/mustache-3.0.2.tgz";
+        sha512 = "64neoEgmozb8e/ecGBOSE+RfnevLSFzCI0UKPcrWmjv953/8fXhYO9+EQFtfbi6hwoFxcTA+Fp5mRiOiI9eTuA==";
       };
     };
     "mutate.js-0.2.0" = {
@@ -27297,13 +27999,13 @@ let
         sha512 = "XowCxURA68arCQEypYKAxyIvBUP2EkqA8mZCXqJ2yzLpFblxSjiP06PUUpVK2no3cgGhsbRlBrsEuYIflxu79w==";
       };
     };
-    "nanoid-2.1.1" = {
+    "nanoid-2.1.6" = {
       name = "nanoid";
       packageName = "nanoid";
-      version = "2.1.1";
+      version = "2.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nanoid/-/nanoid-2.1.1.tgz";
-        sha512 = "0YbJdaL4JFoejIOoawgLcYValFGJ2iyUuVDIWL3g8Es87SSOWFbWdRUMV3VMSiyPs3SQ3QxCIxFX00q5DLkMCw==";
+        url = "https://registry.npmjs.org/nanoid/-/nanoid-2.1.6.tgz";
+        sha512 = "2NDzpiuEy3+H0AVtdt8LoFi7PnqkOnIzYmJQp7xsEU6VexLluHQwKREuiz57XaQC5006seIadPrIZJhyS2n7aw==";
       };
     };
     "nanolru-1.0.0" = {
@@ -27454,13 +28156,22 @@ let
         sha1 = "17b09581988979fddafe0201e931ba933c96cbb4";
       };
     };
-    "ncjsm-3.0.0" = {
+    "natural-orderby-2.0.3" = {
+      name = "natural-orderby";
+      packageName = "natural-orderby";
+      version = "2.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz";
+        sha512 = "p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==";
+      };
+    };
+    "ncjsm-4.0.1" = {
       name = "ncjsm";
       packageName = "ncjsm";
-      version = "3.0.0";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ncjsm/-/ncjsm-3.0.0.tgz";
-        sha512 = "UEEzv/yccTNNyS7ZLmOUquT/k9ttrJCgGrswRrfuj4riplQquZoxAhCaoxSATj59gdpLaGWqXDXRxrRS2zOarw==";
+        url = "https://registry.npmjs.org/ncjsm/-/ncjsm-4.0.1.tgz";
+        sha512 = "gxh5Sgait8HyclaulfhgetHQGyhFm00ZQqISIfqtwFVnyWJ20rk+55SUamo9n3KhM6Vk63gemKPxIDYiSV/xZw==";
       };
     };
     "nconf-0.10.0" = {
@@ -27850,13 +28561,13 @@ let
         sha512 = "iEOqDAOFl6uN5jZGRj39Jdo8qALzf2HPXtpFso8+BMaDylDrUMYMwhFbfYGgxdnMlsRnxYTwv68kaXEpsHIapg==";
       };
     };
-    "node-abi-2.11.0" = {
+    "node-abi-2.12.0" = {
       name = "node-abi";
       packageName = "node-abi";
-      version = "2.11.0";
+      version = "2.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-abi/-/node-abi-2.11.0.tgz";
-        sha512 = "kuy/aEg75u40v378WRllQ4ZexaXJiCvB68D2scDXclp/I4cRq6togpbOoKhmN07tns9Zldu51NNERo0wehfX9g==";
+        url = "https://registry.npmjs.org/node-abi/-/node-abi-2.12.0.tgz";
+        sha512 = "VhPBXCIcvmo/5K8HPmnWJyyhvgKxnHTUMXR/XwGHV68+wrgkzST4UmQrY/XszSWA5dtnXpNp528zkcyJ/pzVcw==";
       };
     };
     "node-addon-api-1.7.1" = {
@@ -28022,13 +28733,13 @@ let
         sha512 = "3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==";
       };
     };
-    "node-gyp-5.0.3" = {
+    "node-gyp-5.0.5" = {
       name = "node-gyp";
       packageName = "node-gyp";
-      version = "5.0.3";
+      version = "5.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.3.tgz";
-        sha512 = "z/JdtkFGUm0QaQUusvloyYuGDub3nUbOo5de1Fz57cM++osBTvQatBUSTlF1k/w8vFHPxxXW6zxGvkxXSpaBkQ==";
+        url = "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.5.tgz";
+        sha512 = "WABl9s4/mqQdZneZHVWVG4TVr6QQJZUC6PAx47ITSk9lreZ1n+7Z9mMAIbA3vnO4J9W20P7LhCxtzfWsAD/KDw==";
       };
     };
     "node-gyp-build-3.7.0" = {
@@ -28094,15 +28805,6 @@ let
         sha1 = "8d9dbe28964a4ac5712e9131642107c71e90ec40";
       };
     };
-    "node-notifier-5.4.0" = {
-      name = "node-notifier";
-      packageName = "node-notifier";
-      version = "5.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz";
-        sha512 = "SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==";
-      };
-    };
     "node-notifier-5.4.3" = {
       name = "node-notifier";
       packageName = "node-notifier";
@@ -28110,6 +28812,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz";
         sha512 = "M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==";
+      };
+    };
+    "node-notifier-6.0.0" = {
+      name = "node-notifier";
+      packageName = "node-notifier";
+      version = "6.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz";
+        sha512 = "SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==";
       };
     };
     "node-persist-2.1.0" = {
@@ -28166,24 +28877,6 @@ let
         sha512 = "OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==";
       };
     };
-    "node-red-node-email-1.6.3" = {
-      name = "node-red-node-email";
-      packageName = "node-red-node-email";
-      version = "1.6.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-email/-/node-red-node-email-1.6.3.tgz";
-        sha512 = "78O7CASdGAP2wmMJvqsMYdNrCHI54lSE97hWpbNQPG2QC2d15TEUQU+E8KgNzquPtJn0Pjh/cvzt+kQwKjkaUg==";
-      };
-    };
-    "node-red-node-feedparser-0.1.14" = {
-      name = "node-red-node-feedparser";
-      packageName = "node-red-node-feedparser";
-      version = "0.1.14";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-feedparser/-/node-red-node-feedparser-0.1.14.tgz";
-        sha512 = "Bb9M5bFrOqoFxBVxfstBM/g+VPaV4EPQptXQBMrlsCd3P40CXcGL0mDylXU+3cekWNd5hLHfqTHvXJdkowHGDw==";
-      };
-    };
     "node-red-node-rbe-0.2.5" = {
       name = "node-red-node-rbe";
       packageName = "node-red-node-rbe";
@@ -28193,40 +28886,22 @@ let
         sha512 = "WPwIOZIdDprgfqOe8bEun47wkFFc+5Uw/1w3O/kZn/kS2IpI1q+wijUDK+Hw8q4d8KgA58B30wh+10UvXzsPDA==";
       };
     };
-    "node-red-node-sentiment-0.1.4" = {
-      name = "node-red-node-sentiment";
-      packageName = "node-red-node-sentiment";
-      version = "0.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-sentiment/-/node-red-node-sentiment-0.1.4.tgz";
-        sha512 = "lZxov4OdGKoqvXcUK7oyVeW5a2qJsBr5+T8cq9kP5N0bnI9AQoywiIiVQ2HcFCHXy70U4ZIAhetGroNfAb68Zg==";
-      };
-    };
-    "node-red-node-tail-0.0.2" = {
+    "node-red-node-tail-0.0.3" = {
       name = "node-red-node-tail";
       packageName = "node-red-node-tail";
-      version = "0.0.2";
+      version = "0.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-tail/-/node-red-node-tail-0.0.2.tgz";
-        sha512 = "+92kgY+SOW6Oq7GfH3x9HC/9YBAg5UmdZBl426nFg0K4x9oegLqCqW2S0/fBAgyDBQQF8eHmn/GjHeO32R0aRg==";
+        url = "https://registry.npmjs.org/node-red-node-tail/-/node-red-node-tail-0.0.3.tgz";
+        sha512 = "wEiT7bSeU9oVHPK7S+mHb3cR6cIf9l205wTiHzhnUAuoDJS+IdwQkkpFgKTYmkL4Py2LvqCU90h85YpQul7QFQ==";
       };
     };
-    "node-red-node-twitter-1.1.5" = {
-      name = "node-red-node-twitter";
-      packageName = "node-red-node-twitter";
-      version = "1.1.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-twitter/-/node-red-node-twitter-1.1.5.tgz";
-        sha512 = "8V4tLL0nM1DOUgEtTOBSTZcLbtZ4Gg4CPFVHiPmLCo2QYTMQ0JdBIYj4pg95LbJbYkV721fqsw1RDsitBfYuCQ==";
-      };
-    };
-    "node-releases-1.1.32" = {
+    "node-releases-1.1.39" = {
       name = "node-releases";
       packageName = "node-releases";
-      version = "1.1.32";
+      version = "1.1.39";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-releases/-/node-releases-1.1.32.tgz";
-        sha512 = "VhVknkitq8dqtWoluagsGPn3dxTvN9fwgR59fV3D7sLBHe0JfDramsMI8n8mY//ccq/Kkrf8ZRHRpsyVZ3qw1A==";
+        url = "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz";
+        sha512 = "8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==";
       };
     };
     "node-request-by-swagger-1.1.4" = {
@@ -28328,31 +29003,13 @@ let
         sha1 = "fae179165265509302cefbebeabd29bd4035184d";
       };
     };
-    "nodemailer-6.1.1" = {
-      name = "nodemailer";
-      packageName = "nodemailer";
-      version = "6.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/nodemailer/-/nodemailer-6.1.1.tgz";
-        sha512 = "/x5MRIh56VyuuhLfcz+DL2SlBARpZpgQIf2A4Ao4hMb69MHSgDIMPwYmFwesGT1lkRDZ0eBSoym5+JoIZ3N+cQ==";
-      };
-    };
-    "nodemailer-6.3.0" = {
-      name = "nodemailer";
-      packageName = "nodemailer";
-      version = "6.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/nodemailer/-/nodemailer-6.3.0.tgz";
-        sha512 = "TEHBNBPHv7Ie/0o3HXnb7xrPSSQmH1dXwQKRaMKDBGt/ZN54lvDVujP6hKkO/vjkIYL9rK8kHSG11+G42Nhxuw==";
-      };
-    };
-    "nodemon-1.19.2" = {
+    "nodemon-1.19.4" = {
       name = "nodemon";
       packageName = "nodemon";
-      version = "1.19.2";
+      version = "1.19.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nodemon/-/nodemon-1.19.2.tgz";
-        sha512 = "hRLYaw5Ihyw9zK7NF+9EUzVyS6Cvgc14yh8CAYr38tPxJa6UrOxwAQ351GwrgoanHCF0FalQFn6w5eoX/LGdJw==";
+        url = "https://registry.npmjs.org/nodemon/-/nodemon-1.19.4.tgz";
+        sha512 = "VGPaqQBNk193lrJFotBU8nvWZPqEZY2eIzymy2jjY0fJ9qIsxA0sxQ8ATPl0gZC645gijYEc1jtZvpS8QWzJGQ==";
       };
     };
     "nomnom-1.8.1" = {
@@ -28472,6 +29129,24 @@ let
         sha512 = "6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==";
       };
     };
+    "normalize-range-0.1.2" = {
+      name = "normalize-range";
+      packageName = "normalize-range";
+      version = "0.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz";
+        sha1 = "2d10c06bdfd312ea9777695a4d28439456b75942";
+      };
+    };
+    "normalize-selector-0.2.0" = {
+      name = "normalize-selector";
+      packageName = "normalize-selector";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz";
+        sha1 = "d0b145eb691189c63a78d201dc4fdb1293ef0c03";
+      };
+    };
     "normalize-uri-1.1.2" = {
       name = "normalize-uri";
       packageName = "normalize-uri";
@@ -28499,13 +29174,13 @@ let
         sha512 = "U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==";
       };
     };
-    "normalize-url-4.4.1" = {
+    "normalize-url-4.5.0" = {
       name = "normalize-url";
       packageName = "normalize-url";
-      version = "4.4.1";
+      version = "4.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/normalize-url/-/normalize-url-4.4.1.tgz";
-        sha512 = "rjH3yRt0Ssx19mUwS0hrDUOdG9VI+oRLpLHJ7tXRdjcuQ7v7wo6qPvOZppHRrqfslTKr0L2yBhjj4UXd7c3cQg==";
+        url = "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz";
+        sha512 = "2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==";
       };
     };
     "now-and-later-2.0.1" = {
@@ -28589,13 +29264,13 @@ let
         sha512 = "qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==";
       };
     };
-    "npm-packlist-1.4.4" = {
+    "npm-packlist-1.4.6" = {
       name = "npm-packlist";
       packageName = "npm-packlist";
-      version = "1.4.4";
+      version = "1.4.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz";
-        sha512 = "zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==";
+        url = "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.6.tgz";
+        sha512 = "u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==";
       };
     };
     "npm-path-2.0.4" = {
@@ -28661,13 +29336,13 @@ let
         sha512 = "Qs6P6nnopig+Y8gbzpeN/dkt+n7IyVd8f45NTMotGk6Qo7GfBmzwYx6jRLoOOgKiMnaQfYxsuyQlD8Mc3guBhg==";
       };
     };
-    "npm-registry-fetch-4.0.1" = {
+    "npm-registry-fetch-4.0.2" = {
       name = "npm-registry-fetch";
       packageName = "npm-registry-fetch";
-      version = "4.0.1";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.1.tgz";
-        sha512 = "1ZQ+yjnxc698R5h9Yje9CASapzAZr7aYDkJDdERg9xg2hOEY0vRJwskOaJAXq8N/eLavzvW4g564YAfq6zMn/A==";
+        url = "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.2.tgz";
+        sha512 = "Z0IFtPEozNdeZRPh3aHHxdG+ZRpzcbQaJLthsm3VhNf6DScicTFRHZzK82u8RsJUsUHkX+QH/zcB/5pmd20H4A==";
       };
     };
     "npm-run-4.1.2" = {
@@ -28695,6 +29370,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz";
         sha1 = "35a9232dfa35d7067b4cb2ddf2357b1871536c5f";
+      };
+    };
+    "npm-run-path-3.1.0" = {
+      name = "npm-run-path";
+      packageName = "npm-run-path";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz";
+        sha512 = "Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==";
+      };
+    };
+    "npm-run-path-4.0.0" = {
+      name = "npm-run-path";
+      packageName = "npm-run-path";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.0.tgz";
+        sha512 = "8eyAOAH+bYXFPSnNnKr3J+yoybe8O87Is5rtAQ8qRczJz1ajcsjg8l2oZqP+Ppx15Ii3S1vUTjQN2h4YO2tWWQ==";
       };
     };
     "npm-which-3.0.1" = {
@@ -28776,6 +29469,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/num-sort/-/num-sort-1.0.0.tgz";
         sha1 = "cabec1fd5f4da4aca995af90b7a0f379944e1dbd";
+      };
+    };
+    "num2fraction-1.2.2" = {
+      name = "num2fraction";
+      packageName = "num2fraction";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz";
+        sha1 = "6f682b6a027a4e9ddfa4564cd2589d1d4e669ede";
       };
     };
     "number-is-nan-1.0.1" = {
@@ -29346,6 +30048,15 @@ let
         sha512 = "IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==";
       };
     };
+    "open-7.0.0" = {
+      name = "open";
+      packageName = "open";
+      version = "7.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/open/-/open-7.0.0.tgz";
+        sha512 = "K6EKzYqnwQzk+/dzJAQSBORub3xlBTxMz+ntpZpH/LyCa1o6KjXhuN+2npAaI9jaSmU3R1Q8NWf4KUWcyytGsQ==";
+      };
+    };
     "opencollective-postinstall-2.0.2" = {
       name = "opencollective-postinstall";
       packageName = "opencollective-postinstall";
@@ -29544,6 +30255,15 @@ let
         sha512 = "eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==";
       };
     };
+    "ora-4.0.2" = {
+      name = "ora";
+      packageName = "ora";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ora/-/ora-4.0.2.tgz";
+        sha512 = "YUOZbamht5mfLxPmk4M35CD/5DuOkAacxlEUbStVXpBAt4fyhBf+vZHI/HRkI++QUp3sNoeA2Gw4C+hi4eGSig==";
+      };
+    };
     "orchestrator-0.3.8" = {
       name = "orchestrator";
       packageName = "orchestrator";
@@ -29614,6 +30334,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz";
         sha512 = "Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==";
+      };
+    };
+    "os-locale-4.0.0" = {
+      name = "os-locale";
+      packageName = "os-locale";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/os-locale/-/os-locale-4.0.0.tgz";
+        sha512 = "HsSR1+2l6as4Wp2SGZxqLnuFHxVvh1Ir9pvZxyujsC13egZVe7P0YeBLN0ijQzM/twrO5To3ia3jzBXAvpMTEA==";
       };
     };
     "os-name-3.1.0" = {
@@ -29742,6 +30471,15 @@ let
         sha1 = "3fbcfb15b899a44123b34b6dcc18b724336a2cae";
       };
     };
+    "p-finally-2.0.1" = {
+      name = "p-finally";
+      packageName = "p-finally";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz";
+        sha512 = "vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==";
+      };
+    };
     "p-is-promise-1.1.0" = {
       name = "p-is-promise";
       packageName = "p-is-promise";
@@ -29841,13 +30579,13 @@ let
         sha512 = "3cRXXn3/O0o3+eVmUroJPSj/esxoEFIm0ZOno/T+NzG/VZgPOqQ8WKmlNqubSEpZmCIngEy34unkHGg83ZIBmg==";
       };
     };
-    "p-queue-6.1.1" = {
+    "p-queue-6.2.0" = {
       name = "p-queue";
       packageName = "p-queue";
-      version = "6.1.1";
+      version = "6.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/p-queue/-/p-queue-6.1.1.tgz";
-        sha512 = "R9gq36Th88xZ+rWAptN5IXLwqkwA1gagCQhT6ZXQ6RxEfmjb9ZW+UBzRVqv9sm5TQmbbI/TsKgGLbOaA61xR5w==";
+        url = "https://registry.npmjs.org/p-queue/-/p-queue-6.2.0.tgz";
+        sha512 = "B2LXNONcyn/G6uz2UBFsGjmSa0e/br3jznlzhEyCXg56c7VhEpiT2pZxGOfv32Q3FSyugAdys9KGpsv3kV+Sbg==";
       };
     };
     "p-reduce-1.0.0" = {
@@ -29922,13 +30660,13 @@ let
         sha1 = "7ed94b3ceb3332782353af6aae11aa9fc235bb00";
       };
     };
-    "pac-proxy-agent-3.0.0" = {
+    "pac-proxy-agent-3.0.1" = {
       name = "pac-proxy-agent";
       packageName = "pac-proxy-agent";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.0.tgz";
-        sha512 = "AOUX9jES/EkQX2zRz0AW7lSx9jD//hQS8wFXBvcnd/J2Py9KaMJMqV/LPqJssj1tgGufotb2mmopGPR15ODv1Q==";
+        url = "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz";
+        sha512 = "44DUg21G/liUZ48dJpUSjZnFfZro/0K5JTyFYLBcmh9+T6Ooi4/i4efwUiEy0+4oQusCBqWdhv16XohIj1GqnQ==";
       };
     };
     "pac-resolver-3.0.0" = {
@@ -30003,13 +30741,13 @@ let
         sha512 = "jAEP+Nqj4kyMWyNpfTU/Whx1jA7jEc5cCOlurm0/0oL+v8TAp1QSsK83N7bYe+2bEdFzMAtPG5TBebjzzGV0cA==";
       };
     };
-    "pacote-9.5.8" = {
+    "pacote-9.5.9" = {
       name = "pacote";
       packageName = "pacote";
-      version = "9.5.8";
+      version = "9.5.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pacote/-/pacote-9.5.8.tgz";
-        sha512 = "0Tl8Oi/K0Lo4MZmH0/6IsT3gpGf9eEAznLXEQPKgPq7FscnbUOyopnVpwXlnQdIbCUaojWy1Wd7VMyqfVsRrIw==";
+        url = "https://registry.npmjs.org/pacote/-/pacote-9.5.9.tgz";
+        sha512 = "S1nYW9ly+3btn3VmwRAk2LG3TEh8mkrFdY+psbnHSk8oPODbZ28uG0Z0d3yI0EpqcpLR6BukoVRf3H4IbGCkPQ==";
       };
     };
     "pad-0.0.5" = {
@@ -30201,6 +30939,15 @@ let
         sha1 = "f480f40434ef80741f8469099f8dea18f55a4dc9";
       };
     };
+    "parse-json-3.0.0" = {
+      name = "parse-json";
+      packageName = "parse-json";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz";
+        sha1 = "fa6f47b18e23826ead32f263e744d0e1e847fb13";
+      };
+    };
     "parse-json-4.0.0" = {
       name = "parse-json";
       packageName = "parse-json";
@@ -30208,6 +30955,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz";
         sha1 = "be35f5425be1f7f6c747184f98a788cb99477ee0";
+      };
+    };
+    "parse-json-5.0.0" = {
+      name = "parse-json";
+      packageName = "parse-json";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz";
+        sha512 = "OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==";
       };
     };
     "parse-latin-4.2.0" = {
@@ -30505,6 +31261,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/passwd-user/-/passwd-user-2.1.0.tgz";
         sha1 = "fad9db6ae252f8b088e0c5decd20a7da0c5d9f1e";
+      };
+    };
+    "password-prompt-1.1.2" = {
+      name = "password-prompt";
+      packageName = "password-prompt";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.2.tgz";
+        sha512 = "bpuBhROdrhuN3E7G/koAju0WjVw9/uQOG5Co5mokNj0MiOSBVZS1JTwM4zl55hu0WFmIEFvO9cU9sJQiBIYeIA==";
       };
     };
     "patel-0.33.1" = {
@@ -30885,13 +31650,13 @@ let
         sha1 = "18de2f97e4bf7a9551ad7511942b5496f7aba660";
       };
     };
-    "picomatch-2.0.7" = {
+    "picomatch-2.1.0" = {
       name = "picomatch";
       packageName = "picomatch";
-      version = "2.0.7";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz";
-        sha512 = "oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==";
+        url = "https://registry.npmjs.org/picomatch/-/picomatch-2.1.0.tgz";
+        sha512 = "uhnEDzAbrcJ8R3g2fANnSuXZMBtkpSjxTTgn2LeSiQlfmq72enQJWdQllXW24MBLYnA1SBD2vfvx2o0Zw3Ielw==";
       };
     };
     "picture-tuber-1.0.2" = {
@@ -30984,13 +31749,13 @@ let
         sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
       };
     };
-    "pino-5.12.6" = {
+    "pino-5.13.3" = {
       name = "pino";
       packageName = "pino";
-      version = "5.12.6";
+      version = "5.13.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pino/-/pino-5.12.6.tgz";
-        sha512 = "LM5ug2b27uymIIkaBw54ncF+9DSf8S4z1uzw+Y5I94dRu3Z+lFuB13j0kg1InAeyxy+CsLGnWHKy9+zgTreFOg==";
+        url = "https://registry.npmjs.org/pino/-/pino-5.13.3.tgz";
+        sha512 = "FL12DKlPwBlbhztlUz6kseR03PRR8nD+wvLdN/Sji9UiBYYfSjX+k8ocU7/NwW55JdFRONTn3iACoelXnMFVVQ==";
       };
     };
     "pino-std-serializers-2.4.2" = {
@@ -31036,6 +31801,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz";
         sha1 = "378e56d6fd13e88bfb6f4a25df7a83faabddba5b";
+      };
+    };
+    "pkg-dir-2.0.0" = {
+      name = "pkg-dir";
+      packageName = "pkg-dir";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz";
+        sha1 = "f6d5d1109e19d63edf428e0bd57e12777615334b";
       };
     };
     "pkg-dir-3.0.0" = {
@@ -31236,22 +32010,13 @@ let
         sha1 = "47bb2952da32d58a1be2f256a598eebc0b745118";
       };
     };
-    "poplib-0.1.7" = {
-      name = "poplib";
-      packageName = "poplib";
-      version = "0.1.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/poplib/-/poplib-0.1.7.tgz";
-        sha1 = "2f4b58b5592972350cd97f482aba68f8e05574bc";
-      };
-    };
-    "portfinder-1.0.24" = {
+    "portfinder-1.0.25" = {
       name = "portfinder";
       packageName = "portfinder";
-      version = "1.0.24";
+      version = "1.0.25";
       src = fetchurl {
-        url = "https://registry.npmjs.org/portfinder/-/portfinder-1.0.24.tgz";
-        sha512 = "ekRl7zD2qxYndYflwiryJwMioBI7LI7rVXg3EnLK3sjkouT5eOuhS3gS255XxBksa30VG8UPZYZCdgfGOfkSUg==";
+        url = "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz";
+        sha512 = "6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==";
       };
     };
     "posix-character-classes-0.1.1" = {
@@ -31273,6 +32038,15 @@ let
         sha256 = "0092766ac49279342f7d17677359880b44b245ad9d32237a11a5ea45cb0d03fa";
       };
     };
+    "postcss-5.2.18" = {
+      name = "postcss";
+      packageName = "postcss";
+      version = "5.2.18";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz";
+        sha512 = "zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==";
+      };
+    };
     "postcss-6.0.1" = {
       name = "postcss";
       packageName = "postcss";
@@ -31291,15 +32065,6 @@ let
         sha512 = "soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==";
       };
     };
-    "postcss-7.0.16" = {
-      name = "postcss";
-      packageName = "postcss";
-      version = "7.0.16";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz";
-        sha512 = "MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==";
-      };
-    };
     "postcss-7.0.18" = {
       name = "postcss";
       packageName = "postcss";
@@ -31307,6 +32072,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz";
         sha512 = "/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==";
+      };
+    };
+    "postcss-7.0.21" = {
+      name = "postcss";
+      packageName = "postcss";
+      version = "7.0.21";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz";
+        sha512 = "uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==";
       };
     };
     "postcss-calc-7.0.1" = {
@@ -31370,6 +32144,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz";
         sha512 = "IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==";
+      };
+    };
+    "postcss-html-0.12.0" = {
+      name = "postcss-html";
+      packageName = "postcss-html";
+      version = "0.12.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss-html/-/postcss-html-0.12.0.tgz";
+        sha512 = "KxKUpj7AY7nlCbLcTOYxdfJnGE7QFAfU2n95ADj1Q90RM/pOLdz8k3n4avOyRFs7MDQHcRzJQWM1dehCwJxisQ==";
+      };
+    };
+    "postcss-less-1.1.5" = {
+      name = "postcss-less";
+      packageName = "postcss-less";
+      version = "1.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.5.tgz";
+        sha512 = "QQIiIqgEjNnquc0d4b6HDOSFZxbFQoy4MPpli2lSLpKhMyBkKwwca2HFqu4xzxlKID/F2fxSOowwtKpgczhF7A==";
+      };
+    };
+    "postcss-media-query-parser-0.2.3" = {
+      name = "postcss-media-query-parser";
+      packageName = "postcss-media-query-parser";
+      version = "0.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz";
+        sha1 = "27b39c6f4d94f81b1a73b8f76351c609e5cef244";
       };
     };
     "postcss-merge-longhand-4.0.11" = {
@@ -31570,6 +32371,51 @@ let
         sha512 = "EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==";
       };
     };
+    "postcss-reporter-5.0.0" = {
+      name = "postcss-reporter";
+      packageName = "postcss-reporter";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz";
+        sha512 = "rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==";
+      };
+    };
+    "postcss-resolve-nested-selector-0.1.1" = {
+      name = "postcss-resolve-nested-selector";
+      packageName = "postcss-resolve-nested-selector";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz";
+        sha1 = "29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e";
+      };
+    };
+    "postcss-safe-parser-3.0.1" = {
+      name = "postcss-safe-parser";
+      packageName = "postcss-safe-parser";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz";
+        sha1 = "b753eff6c7c0aea5e8375fbe4cde8bf9063ff142";
+      };
+    };
+    "postcss-sass-0.2.0" = {
+      name = "postcss-sass";
+      packageName = "postcss-sass";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.2.0.tgz";
+        sha512 = "cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==";
+      };
+    };
+    "postcss-scss-1.0.6" = {
+      name = "postcss-scss";
+      packageName = "postcss-scss";
+      version = "1.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.6.tgz";
+        sha512 = "4EFYGHcEw+H3E06PT/pQQri06u/1VIIPjeJQaM8skB80vZuXMhp4cSNV5azmdNkontnOID/XYWEvEEELLFB1ww==";
+      };
+    };
     "postcss-selector-parser-3.1.1" = {
       name = "postcss-selector-parser";
       packageName = "postcss-selector-parser";
@@ -31741,6 +32587,24 @@ let
         sha512 = "2UzApPuxi2yRoyMlXMazgR6UcH9DKJhNgCviIwY3ixZ9THWSSrUww5vkiZ3C48WvpFl1M1y/oU63deSy1puWEA==";
       };
     };
+    "prettier-eslint-9.0.0" = {
+      name = "prettier-eslint";
+      packageName = "prettier-eslint";
+      version = "9.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-9.0.0.tgz";
+        sha512 = "0dael2aMpMAxAwClnLi2Coc30v3BubsTX6clqseZ8NFCJZnbZlwxZGHHESYBlqTyN9lvZDHHv+XdeHW0fKhxJQ==";
+      };
+    };
+    "prettier-stylelint-0.4.2" = {
+      name = "prettier-stylelint";
+      packageName = "prettier-stylelint";
+      version = "0.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prettier-stylelint/-/prettier-stylelint-0.4.2.tgz";
+        sha512 = "CmatjDsW8xKMtWg/Tc6/W02wC59p50kkItrXmkgbhR4b2EKMU5Pm55x1WuCahkkZeZoNVReWRxA8VL/s69mkBg==";
+      };
+    };
     "prettier-tslint-0.4.2" = {
       name = "prettier-tslint";
       packageName = "prettier-tslint";
@@ -31876,13 +32740,13 @@ let
         sha512 = "zsK6DDEC+cnNiunYamcVbx4ZCLbKnzTOZa09K4Pj3/tH3nQFPUO9K2QoYy4kfxLqmoyw6RPDtACN9OYviMQZ2Q==";
       };
     };
-    "probe-image-size-4.0.0" = {
+    "probe-image-size-5.0.0" = {
       name = "probe-image-size";
       packageName = "probe-image-size";
-      version = "4.0.0";
+      version = "5.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.0.0.tgz";
-        sha512 = "nm7RvWUxps+2+jZKNLkd04mNapXNariS6G5WIEVzvAqjx7EUuKcY1Dp3e6oUK7GLwzJ+3gbSbPLFAASHFQrPcQ==";
+        url = "https://registry.npmjs.org/probe-image-size/-/probe-image-size-5.0.0.tgz";
+        sha512 = "V6uBYw5eBc5UVIE7MUZD6Nxg0RYuGDWLDenEn0B1WC6PcTvn1xdQ6HLDDuznefsiExC6rNrCz7mFRBo0f3Xekg==";
       };
     };
     "process-0.10.1" = {
@@ -32119,13 +32983,13 @@ let
         sha1 = "0ee97a7fc020b1a2a55b8659eda4aa8d869094bd";
       };
     };
-    "property-information-5.2.2" = {
+    "property-information-5.3.0" = {
       name = "property-information";
       packageName = "property-information";
-      version = "5.2.2";
+      version = "5.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/property-information/-/property-information-5.2.2.tgz";
-        sha512 = "N2moasZmjn2mjVGIWpaqz5qnz6QyeQSGgGvMtl81gA9cPTWa6wpesRSe/quNnOjUHpvSH1oZx0pdz0EEckLFnA==";
+        url = "https://registry.npmjs.org/property-information/-/property-information-5.3.0.tgz";
+        sha512 = "IslotQn1hBCZDY7SaJ3zmCjVea219VTwmOk6Pu3z9haU9m4+T8GwaDubur+6NMHEU+Fjs/6/p66z6QULPkcL1w==";
       };
     };
     "proto-list-1.2.4" = {
@@ -32218,13 +33082,13 @@ let
         sha512 = "t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==";
       };
     };
-    "proxy-agent-3.1.0" = {
+    "proxy-agent-3.1.1" = {
       name = "proxy-agent";
       packageName = "proxy-agent";
-      version = "3.1.0";
+      version = "3.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.0.tgz";
-        sha512 = "IkbZL4ClW3wwBL/ABFD2zJ8iP84CY0uKMvBPk/OceQe/cEjrxzN1pMHsLwhbzUoRhG9QbSxYC+Z7LBkTiBNvrA==";
+        url = "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.1.tgz";
+        sha512 = "WudaR0eTsDx33O3EJE16PjBRZWcX8GqCEeERw1W3hZJgH/F2a46g7jty6UGty6NeJ4CKQy8ds2CJPMiyeqaTvw==";
       };
     };
     "proxy-from-env-1.0.0" = {
@@ -33262,13 +34126,13 @@ let
         sha512 = "F9wwNePtXrzZenAB3ax0Y8TSKGvuB7Qw16J30hspEUTbfUM+H827XyN3rlpwhVmtm5wuZtbKIHjOnwDn7MUxWQ==";
       };
     };
-    "quick-format-unescaped-3.0.2" = {
+    "quick-format-unescaped-3.0.3" = {
       name = "quick-format-unescaped";
       packageName = "quick-format-unescaped";
-      version = "3.0.2";
+      version = "3.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz";
-        sha512 = "FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA==";
+        url = "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz";
+        sha512 = "dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==";
       };
     };
     "quick-lru-1.1.0" = {
@@ -33586,13 +34450,13 @@ let
         sha512 = "C0SIXdXDSus2yqqvV7qifnb4NoWP7mEBXJq3axci301mXHCZb8Djwm4hrEZo4UeXRaEnfjH98uQ8EBppk2oNWA==";
       };
     };
-    "react-is-16.9.0" = {
+    "react-is-16.11.0" = {
       name = "react-is";
       packageName = "react-is";
-      version = "16.9.0";
+      version = "16.11.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz";
-        sha512 = "tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==";
+        url = "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz";
+        sha512 = "gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==";
       };
     };
     "read-1.0.7" = {
@@ -33820,13 +34684,13 @@ let
         sha512 = "1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==";
       };
     };
-    "readdirp-3.1.2" = {
+    "readdirp-3.2.0" = {
       name = "readdirp";
       packageName = "readdirp";
-      version = "3.1.2";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz";
-        sha512 = "8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==";
+        url = "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz";
+        sha512 = "crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==";
       };
     };
     "readline2-0.1.1" = {
@@ -33865,13 +34729,13 @@ let
         sha512 = "O/7qXi51DPjRVdbrpNzoBQH5dnAPQNbfoOFyRiUwreTMJfIHYOEBzwuH+c0+/BTSJ3CQyKs6ILSWXhESH6Op3A==";
       };
     };
-    "recast-0.17.6" = {
+    "recast-0.18.5" = {
       name = "recast";
       packageName = "recast";
-      version = "0.17.6";
+      version = "0.18.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/recast/-/recast-0.17.6.tgz";
-        sha512 = "yoQRMRrK1lszNtbkGyM4kN45AwylV5hMiuEveUBlxytUViWevjvX6w+tzJt1LH4cfUhWt4NZvy3ThIhu6+m5wQ==";
+        url = "https://registry.npmjs.org/recast/-/recast-0.18.5.tgz";
+        sha512 = "sD1WJrpLQAkXGyQZyGzTM75WJvyAd98II5CHdK3IYbt/cZlU0UzCRVU11nUFNXX9fBVEt4E9ajkMjBlUlG+Oog==";
       };
     };
     "rechoir-0.6.2" = {
@@ -33937,6 +34801,15 @@ let
         sha1 = "e96c193b40c0816b00aec842698e61185e55498a";
       };
     };
+    "redeyed-2.1.1" = {
+      name = "redeyed";
+      packageName = "redeyed";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz";
+        sha1 = "8984b5815d99cb220469c99eeeffe38913e6cc0b";
+      };
+    };
     "redis-0.12.1" = {
       name = "redis";
       packageName = "redis";
@@ -33991,6 +34864,15 @@ let
         sha512 = "LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==";
       };
     };
+    "regenerator-runtime-0.10.5" = {
+      name = "regenerator-runtime";
+      packageName = "regenerator-runtime";
+      version = "0.10.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz";
+        sha1 = "336c3efc1220adcedda2c9fab67b5a7955a33658";
+      };
+    };
     "regenerator-runtime-0.11.1" = {
       name = "regenerator-runtime";
       packageName = "regenerator-runtime";
@@ -33998,24 +34880,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz";
         sha512 = "MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==";
-      };
-    };
-    "regenerator-runtime-0.12.1" = {
-      name = "regenerator-runtime";
-      packageName = "regenerator-runtime";
-      version = "0.12.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz";
-        sha512 = "odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==";
-      };
-    };
-    "regenerator-runtime-0.13.2" = {
-      name = "regenerator-runtime";
-      packageName = "regenerator-runtime";
-      version = "0.13.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz";
-        sha512 = "S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==";
       };
     };
     "regenerator-runtime-0.13.3" = {
@@ -34061,15 +34925,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz";
         sha512 = "J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==";
-      };
-    };
-    "regexp-tree-0.1.13" = {
-      name = "regexp-tree";
-      packageName = "regexp-tree";
-      version = "0.1.13";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.13.tgz";
-        sha512 = "hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==";
       };
     };
     "regexp.prototype.flags-1.2.0" = {
@@ -34171,13 +35026,13 @@ let
         sha1 = "6c016adeac554f75823fe37ac05b92d5a4edb1f7";
       };
     };
-    "regjsgen-0.5.0" = {
+    "regjsgen-0.5.1" = {
       name = "regjsgen";
       packageName = "regjsgen";
-      version = "0.5.0";
+      version = "0.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz";
-        sha512 = "RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==";
+        url = "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz";
+        sha512 = "5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==";
       };
     };
     "regjsparser-0.1.5" = {
@@ -34261,6 +35116,15 @@ let
         sha1 = "cb463bd3dbcb4b99794935eee1cf71d7a8e3068c";
       };
     };
+    "remark-8.0.0" = {
+      name = "remark";
+      packageName = "remark";
+      version = "8.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/remark/-/remark-8.0.0.tgz";
+        sha512 = "K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==";
+      };
+    };
     "remark-frontmatter-1.3.2" = {
       name = "remark-frontmatter";
       packageName = "remark-frontmatter";
@@ -34331,6 +35195,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/remark-stringify/-/remark-stringify-1.1.0.tgz";
         sha1 = "a7105e25b9ee2bf9a49b75d2c423f11b06ae2092";
+      };
+    };
+    "remark-stringify-4.0.0" = {
+      name = "remark-stringify";
+      packageName = "remark-stringify";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz";
+        sha512 = "xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==";
       };
     };
     "remove-array-items-1.1.1" = {
@@ -34540,13 +35413,13 @@ let
         sha512 = "rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==";
       };
     };
-    "requestretry-4.0.0" = {
+    "requestretry-4.0.2" = {
       name = "requestretry";
       packageName = "requestretry";
-      version = "4.0.0";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/requestretry/-/requestretry-4.0.0.tgz";
-        sha512 = "ST8m0+5FQH2FA+gbzUQyOQjUwHf22kbPQnd6TexveR0p+2UV1YYBg+Roe7BnKQ1Bb/+LtJwwm0QzxK2NA20Cug==";
+        url = "https://registry.npmjs.org/requestretry/-/requestretry-4.0.2.tgz";
+        sha512 = "ZGdO1ZXUQAeCB9xOS2keSN501y7T1t0zPOD58jTAOwamt6qkcBMaGdRBHEOMQRnDtT5fn7S99F0dwADUqCmYqg==";
       };
     };
     "require-directory-2.1.1" = {
@@ -34610,15 +35483,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz";
         sha1 = "4e0d56d6c9662fd31e43011c4b95aa49955421d3";
-      };
-    };
-    "require-uncached-2.0.0" = {
-      name = "require-uncached";
-      packageName = "require-uncached";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/require-uncached/-/require-uncached-2.0.0.tgz";
-        sha512 = "rPv1//BQwg4gzIbpJcKXWIfjDJEtgS8jzbsNoLcdVSE5FpBzKEKKuoG6MfCbLC28ZTv+qlQWC9/K7J5GBGPSMg==";
       };
     };
     "requireg-0.2.2" = {
@@ -35116,13 +35980,13 @@ let
         sha1 = "df43e80d9bc82ad4430bcfef03f49c717e8b2e8c";
       };
     };
-    "roarr-2.14.1" = {
+    "roarr-2.14.3" = {
       name = "roarr";
       packageName = "roarr";
-      version = "2.14.1";
+      version = "2.14.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/roarr/-/roarr-2.14.1.tgz";
-        sha512 = "Fhm9shQ8JhpjFnOT7bgxKR7Xcg1Tq+0/Tdy+bloB4sUxxAib4MZDMJ6AjUBRE+798l2MnhhF2JTqbqx1+/kRyQ==";
+        url = "https://registry.npmjs.org/roarr/-/roarr-2.14.3.tgz";
+        sha512 = "D4BpKVruUDCJ9DJWcC7T+fx4o10IUYJ7MdmjM4Skx1aqc42CE7LGzPDUAfczibhavNGcnY1IHqJdq16NmiG4rQ==";
       };
     };
     "rollup-0.67.0" = {
@@ -35215,13 +36079,13 @@ let
         sha1 = "6f04063a2d04eba3303a1bbc6765eef63037cf3d";
       };
     };
-    "rss-parser-3.7.2" = {
+    "rss-parser-3.7.3" = {
       name = "rss-parser";
       packageName = "rss-parser";
-      version = "3.7.2";
+      version = "3.7.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/rss-parser/-/rss-parser-3.7.2.tgz";
-        sha512 = "kx0VIFelgwBk5qA4n32U6cx40anAU7TwlRXjyxLDFgMlg8/UcJ64x+Hj5oRX1Kjos+OeFGOmnd5YXH5ES+bmzg==";
+        url = "https://registry.npmjs.org/rss-parser/-/rss-parser-3.7.3.tgz";
+        sha512 = "Ys+fC5wHqWkfR+jNEL7QvC0crUCAcygxHel3ab9QQzHjmH7fNz379lrp984CuCPUf3WzxHEa73lL86W7yc9qjQ==";
       };
     };
     "rsvp-3.6.2" = {
@@ -35485,15 +36349,6 @@ let
         sha512 = "YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==";
       };
     };
-    "safer-eval-1.3.5" = {
-      name = "safer-eval";
-      packageName = "safer-eval";
-      version = "1.3.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.5.tgz";
-        sha512 = "BJ//K2Y+EgCbOHEsDGS5YahYBcYy7JcFpKDo2ba5t4MnOGHYtk7HvQkcxTDFvjQvJ0CRcdas/PyF+gTTCay+3w==";
-      };
-    };
     "sander-0.5.1" = {
       name = "sander";
       packageName = "sander";
@@ -35755,15 +36610,6 @@ let
         sha512 = "PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==";
       };
     };
-    "semver-5.6.0" = {
-      name = "semver";
-      packageName = "semver";
-      version = "5.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz";
-        sha512 = "RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==";
-      };
-    };
     "semver-5.7.1" = {
       name = "semver";
       packageName = "semver";
@@ -35782,15 +36628,6 @@ let
         sha512 = "0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==";
       };
     };
-    "semver-6.1.1" = {
-      name = "semver";
-      packageName = "semver";
-      version = "6.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz";
-        sha512 = "rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==";
-      };
-    };
     "semver-6.1.3" = {
       name = "semver";
       packageName = "semver";
@@ -35798,15 +36635,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/semver/-/semver-6.1.3.tgz";
         sha512 = "aymF+56WJJMyXQHcd4hlK4N75rwj5RQpfW8ePlQnJsTYOBLlLbcIErR/G1s9SkIvKBqOudR3KAx4wEqP+F1hNQ==";
-      };
-    };
-    "semver-6.2.0" = {
-      name = "semver";
-      packageName = "semver";
-      version = "6.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz";
-        sha512 = "jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==";
       };
     };
     "semver-6.3.0" = {
@@ -35944,22 +36772,13 @@ let
         sha512 = "QnpHNykm4nI4T6mT+NoVayh9Ixl5DohYCSVqMgPJsO2WejOcqaYTh4HQOkmzaDzXH3NO5pif4z/hpo2NGtgNlg==";
       };
     };
-    "sentence-splitter-3.0.11" = {
+    "sentence-splitter-3.1.0" = {
       name = "sentence-splitter";
       packageName = "sentence-splitter";
-      version = "3.0.11";
+      version = "3.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-3.0.11.tgz";
-        sha512 = "8k/74ErjpdvgBVLQ7kI7jbbaqNdgMXVqMF8gWlJan25xfm1mg8cYmHQgMb+zx8xyocm1Dq46af4TpmnKWHr/yA==";
-      };
-    };
-    "sentiment-2.1.0" = {
-      name = "sentiment";
-      packageName = "sentiment";
-      version = "2.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sentiment/-/sentiment-2.1.0.tgz";
-        sha1 = "33279100c35c38519ca5e435245186c512fe0fdc";
+        url = "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-3.1.0.tgz";
+        sha512 = "S8ye/Ic5ryKynwgjcS0ggncqhVJW3mgmo/gFNIcKKU1cdLjYzqtQ/PCkD7l0rZtSSfcjLqqVjfdMVN6FKkwUuQ==";
       };
     };
     "separator-escape-0.0.0" = {
@@ -35980,13 +36799,13 @@ let
         sha1 = "90cff19d02e07027fd767f5ead3e7b95d1e7380c";
       };
     };
-    "serialize-error-4.1.0" = {
+    "serialize-error-5.0.0" = {
       name = "serialize-error";
       packageName = "serialize-error";
-      version = "4.1.0";
+      version = "5.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/serialize-error/-/serialize-error-4.1.0.tgz";
-        sha512 = "5j9GgyGsP9vV9Uj1S0lDCvlsd+gc2LEPVK7HHHte7IyPwOD4lVQFeaX143gx3U5AnoCi+wbcb3mvaxVysjpxEw==";
+        url = "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz";
+        sha512 = "/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==";
       };
     };
     "serialize-javascript-1.9.1" = {
@@ -35998,13 +36817,13 @@ let
         sha512 = "0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==";
       };
     };
-    "serialize-to-js-1.2.2" = {
+    "serialize-to-js-3.0.0" = {
       name = "serialize-to-js";
       packageName = "serialize-to-js";
-      version = "1.2.2";
+      version = "3.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz";
-        sha512 = "mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==";
+        url = "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.0.0.tgz";
+        sha512 = "WdGgi0jGnWCQXph2p3vkxceDnTfvfyXfYxherQMRcZjSaJzMQdMBAW6i0nojsBKIZ3fFOztZKKVbbm05VbIdRA==";
       };
     };
     "serializerr-1.0.3" = {
@@ -36025,13 +36844,13 @@ let
         sha1 = "935d240cdfe0f5805307fdfe967d88942a2cbcf0";
       };
     };
-    "serve-handler-6.1.0" = {
+    "serve-handler-6.1.2" = {
       name = "serve-handler";
       packageName = "serve-handler";
-      version = "6.1.0";
+      version = "6.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.0.tgz";
-        sha512 = "63N075Tn3PsFYcu0NVV7tb367UbiW3gnC+/50ohL4oqOhAG6bmbaWqiRcXQgbzqc0ALBjSAzg7VTfa0Qw4E3hA==";
+        url = "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.2.tgz";
+        sha512 = "RFh49wX7zJmmOVDcIjiDSJnMH+ItQEvyuYLYuDBVoA/xmQSCuj+uRmk1cmBB5QQlI3qOiWKp6p4DUGY+Z5AB2A==";
       };
     };
     "serve-index-1.9.1" = {
@@ -36142,13 +36961,13 @@ let
         sha512 = "JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==";
       };
     };
-    "seventh-0.7.28" = {
+    "seventh-0.7.30" = {
       name = "seventh";
       packageName = "seventh";
-      version = "0.7.28";
+      version = "0.7.30";
       src = fetchurl {
-        url = "https://registry.npmjs.org/seventh/-/seventh-0.7.28.tgz";
-        sha512 = "WitJqSwsjLWbCP9cciaozByx4csddLQyNoaPBqOpYFMNE6iD6FK/pM8J2yqtpauSxJUUo7Wfv5KF5w1jbVov7A==";
+        url = "https://registry.npmjs.org/seventh/-/seventh-0.7.30.tgz";
+        sha512 = "GDX4eZEZXQFqURkUA802R3GkawzGA8zm2QS9AfFqPcJKakoytxhI0soTRfhEqNhqh0RrRFO/EraffrAULaxiQQ==";
       };
     };
     "sha.js-2.4.11" = {
@@ -36205,6 +37024,15 @@ let
         sha1 = "e7012310d8f417f4deb5712150e5678b87ae565f";
       };
     };
+    "shasum-object-1.0.0" = {
+      name = "shasum-object";
+      packageName = "shasum-object";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.0.tgz";
+        sha512 = "Iqo5rp/3xVi6M4YheapzZhhGPVs0yZwHj7wvwQ1B9z8H6zk+FEnI7y3Teq7qwnekfEhu8WmG2z0z4iWZaxLWVg==";
+      };
+    };
     "shebang-command-1.2.0" = {
       name = "shebang-command";
       packageName = "shebang-command";
@@ -36214,6 +37042,15 @@ let
         sha1 = "44aac65b695b03398968c39f363fee5deafdf1ea";
       };
     };
+    "shebang-command-2.0.0" = {
+      name = "shebang-command";
+      packageName = "shebang-command";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz";
+        sha512 = "kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==";
+      };
+    };
     "shebang-regex-1.0.0" = {
       name = "shebang-regex";
       packageName = "shebang-regex";
@@ -36221,6 +37058,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz";
         sha1 = "da42f49740c0b42db2ca9728571cb190c98efea3";
+      };
+    };
+    "shebang-regex-3.0.0" = {
+      name = "shebang-regex";
+      packageName = "shebang-regex";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz";
+        sha512 = "7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==";
       };
     };
     "shell-quote-1.6.1" = {
@@ -36529,6 +37375,15 @@ let
         sha512 = "ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==";
       };
     };
+    "slash-3.0.0" = {
+      name = "slash";
+      packageName = "slash";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz";
+        sha512 = "g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==";
+      };
+    };
     "slasp-0.0.4" = {
       name = "slasp";
       packageName = "slasp";
@@ -36709,15 +37564,6 @@ let
         sha1 = "6541184cc90aeea6c6e7b35e2659082443c66198";
       };
     };
-    "snyk-1.228.3" = {
-      name = "snyk";
-      packageName = "snyk";
-      version = "1.228.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/snyk/-/snyk-1.228.3.tgz";
-        sha512 = "TwyJcMXBvic1xJ+rVLdIYS1xDYuzcogIXdmyvGvXBZgwIQdjOVMnZBVxUo5igkOIntBL2sCynZiydQtGbe08JA==";
-      };
-    };
     "snyk-config-2.2.3" = {
       name = "snyk-config";
       packageName = "snyk-config";
@@ -36727,13 +37573,13 @@ let
         sha512 = "9NjxHVMd1U1LFw66Lya4LXgrsFUiuRiL4opxfTFo0LmMNzUoU5Bk/p0zDdg3FE5Wg61r4fP2D8w+QTl6M8CGiw==";
       };
     };
-    "snyk-docker-plugin-1.29.1" = {
+    "snyk-docker-plugin-1.33.1" = {
       name = "snyk-docker-plugin";
       packageName = "snyk-docker-plugin";
-      version = "1.29.1";
+      version = "1.33.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.29.1.tgz";
-        sha512 = "Mucc1rZ7l0U8Dykr5m6HPjau8b2H8JVtVaXGbKSZD6e/47JDJhudkgrWjsS5Yt/Zdp1weE3+4SguftFiVR971A==";
+        url = "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.33.1.tgz";
+        sha512 = "xfs3DN1tPMTh6J8x2341wGK4HRr+pI5+i/YRuRmsslnBnwk/DkKYcbt8zOIWk6kzMoW8vo+9LqqXBQO/24szKg==";
       };
     };
     "snyk-go-parser-1.3.1" = {
@@ -36745,13 +37591,13 @@ let
         sha512 = "jrFRfIk6yGHFeipGD66WV9ei/A/w/lIiGqI80w1ndMbg6D6M5pVNbK7ngDTmo4GdHrZDYqx/VBGBsUm2bol3Rg==";
       };
     };
-    "snyk-go-plugin-1.11.0" = {
+    "snyk-go-plugin-1.11.1" = {
       name = "snyk-go-plugin";
       packageName = "snyk-go-plugin";
-      version = "1.11.0";
+      version = "1.11.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.11.0.tgz";
-        sha512 = "9hsGgloioGuey5hbZfv+MkFEslxXHyzUlaAazcR0NsY7VLyG/b2g3f88f/ZwCwlWaKL9LMv/ERIiey3oWAB/qg==";
+        url = "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.11.1.tgz";
+        sha512 = "IsNi7TmpHoRHzONOWJTT8+VYozQJnaJpKgnYNQjzNm2JlV8bDGbdGQ1a8LcEoChxnJ8v8aMZy7GTiQyGGABtEQ==";
       };
     };
     "snyk-gradle-plugin-3.1.0" = {
@@ -36790,13 +37636,13 @@ let
         sha512 = "cf3uozRXEG88nsjOQlo+SfOJPpcLs45qpnuk2vhBBZ577IMnV+fTOJQsP2YRiikLUbdgkVlduviwUO6OVn1PhA==";
       };
     };
-    "snyk-nuget-plugin-1.12.1" = {
+    "snyk-nuget-plugin-1.13.1" = {
       name = "snyk-nuget-plugin";
       packageName = "snyk-nuget-plugin";
-      version = "1.12.1";
+      version = "1.13.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.12.1.tgz";
-        sha512 = "QuANQxBjTGj3hEf2YpEQ0WuI4Yq/93boqWUs4eoSTfDyBRFgIkUP6fLkzNldrkL8fQbcagqQ2Xz8M9IEKRQtMg==";
+        url = "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.13.1.tgz";
+        sha512 = "2AQVeahBK7Rt38p0Acl1fMsFQu3dsqoRODPoRaS0IM/bOBzVdAkDF9pCb5yKMREGpMZcyRFkt8Q+hGiUk0Nlfg==";
       };
     };
     "snyk-paket-parser-1.5.0" = {
@@ -36826,13 +37672,13 @@ let
         sha512 = "KI6GHt+Oj4fYKiCp7duhseUj5YhyL/zJOrrJg0u6r59Ux9w8gmkUYT92FHW27ihwuT6IPzdGNEuy06Yv2C9WaQ==";
       };
     };
-    "snyk-python-plugin-1.13.2" = {
+    "snyk-python-plugin-1.13.3" = {
       name = "snyk-python-plugin";
       packageName = "snyk-python-plugin";
-      version = "1.13.2";
+      version = "1.13.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.13.2.tgz";
-        sha512 = "G9R1cYHw0E/VSx9tFa5nZp+653FIMXheteidrF3hjUe71jRdJELEUV/z5jxqYEWEFemcwGhMfW87De91GChVIQ==";
+        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.13.3.tgz";
+        sha512 = "Ud7mHmpMG4uCChvYLx5jA8HwOV/FNpT65xTxSt+6wsOjIUTuLiqM86mbvgzgk3pir8vMP9yQEsCi1i0zYLBArw==";
       };
     };
     "snyk-resolve-1.0.1" = {
@@ -37303,15 +38149,6 @@ let
         sha1 = "32552aa64b458392a85eab3b0b5ee61527167aeb";
       };
     };
-    "source-map-support-0.5.12" = {
-      name = "source-map-support";
-      packageName = "source-map-support";
-      version = "0.5.12";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz";
-        sha512 = "4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==";
-      };
-    };
     "source-map-support-0.5.13" = {
       name = "source-map-support";
       packageName = "source-map-support";
@@ -37319,6 +38156,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz";
         sha512 = "SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==";
+      };
+    };
+    "source-map-support-0.5.16" = {
+      name = "source-map-support";
+      packageName = "source-map-support";
+      version = "0.5.16";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz";
+        sha512 = "efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==";
       };
     };
     "source-map-url-0.4.0" = {
@@ -37456,6 +38302,15 @@ let
         sha1 = "70eff23cde4e97d52a445f65afddcc5695eb5edb";
       };
     };
+    "specificity-0.3.2" = {
+      name = "specificity";
+      packageName = "specificity";
+      version = "0.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/specificity/-/specificity-0.3.2.tgz";
+        sha512 = "Nc/QN/A425Qog7j9aHmwOrlwX2e7pNI47ciwxwy4jOlvbbMHkNNJchit+FX+UjF3IAdiaaV5BKeWuDUnws6G1A==";
+      };
+    };
     "speech-rule-engine-3.0.0-beta.6" = {
       name = "speech-rule-engine";
       packageName = "speech-rule-engine";
@@ -37483,13 +38338,13 @@ let
         sha512 = "z/wAiTESw2XVPssY2XRcme4niTc4S5FkkJ4gknudtVoc33Zil8TdTxHy5torRcgqMqksJV2Yz8HQcvtbsnw0mQ==";
       };
     };
-    "speedtest-net-1.5.1" = {
+    "speedtest-net-1.6.0" = {
       name = "speedtest-net";
       packageName = "speedtest-net";
-      version = "1.5.1";
+      version = "1.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/speedtest-net/-/speedtest-net-1.5.1.tgz";
-        sha512 = "az10ue3vkUUt49p5ommRO5eKXB5GfzyLehWCNRUnO686GjtdXJcSJFPnluc93UdoWTtWbr4fCVeH9Kka1OpHIA==";
+        url = "https://registry.npmjs.org/speedtest-net/-/speedtest-net-1.6.0.tgz";
+        sha512 = "uxeA4BGApj3Ghb6VQtcsem0ZoeyQGwLDzL6WP3hJiegS9GBIvpPKDeTzY5/K2/CMoZcihrVYIW3yIABQb2LMOg==";
       };
     };
     "split-0.2.10" = {
@@ -37618,15 +38473,6 @@ let
         sha512 = "VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==";
       };
     };
-    "sqlite3-4.0.9" = {
-      name = "sqlite3";
-      packageName = "sqlite3";
-      version = "4.0.9";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.9.tgz";
-        sha512 = "IkvzjmsWQl9BuBiM4xKpl5X8WCR4w0AeJHRdobCdXZ8dT/lNc1XS6WqvY35N6+YzIIgzSBeY5prdFObID9F9tA==";
-      };
-    };
     "sqlite3-4.1.0" = {
       name = "sqlite3";
       packageName = "sqlite3";
@@ -37654,13 +38500,13 @@ let
         sha1 = "06cd70795ee58d1462d100a45c660df3179d3b39";
       };
     };
-    "ssb-blobs-1.2.1" = {
+    "ssb-blobs-1.2.2" = {
       name = "ssb-blobs";
       packageName = "ssb-blobs";
-      version = "1.2.1";
+      version = "1.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.2.1.tgz";
-        sha512 = "3x21LBIo/TDdUVw3IPnMYyh3T31+i6Xw2v0WftiuY0djPkq3dfwQV11+t3AY6LBtKsN1jS1bpxaDZcM/npF9dA==";
+        url = "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.2.2.tgz";
+        sha512 = "N+X46lE/KaIH9y1w3LQ9pPnt2tQr5VCSj1dAo/pJGYnSwnHz8GhIiboq7UGzrCZwCWgVUs22/2YiytCXSC9ASg==";
       };
     };
     "ssb-caps-1.1.0" = {
@@ -37690,13 +38536,13 @@ let
         sha512 = "UF+4+khFXILLBqtu9HfrpUwYnDXIdAyJe3u9X4GrApuoakxuSKwaUGakUxLPyo6COyV2brMqufUgf+fDOI8Ftw==";
       };
     };
-    "ssb-config-3.3.2" = {
+    "ssb-config-3.4.2" = {
       name = "ssb-config";
       packageName = "ssb-config";
-      version = "3.3.2";
+      version = "3.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-config/-/ssb-config-3.3.2.tgz";
-        sha512 = "EUOp8QbFgCqy6RzNgLqoTqI+jtpBi3AHUwAymR3jHGbgc3DqCMnvGCHt7My8m15LA88oyeDjrzNNJsLfbVyTZQ==";
+        url = "https://registry.npmjs.org/ssb-config/-/ssb-config-3.4.2.tgz";
+        sha512 = "y8SQeTsTzkbB7rrugSytdTqnJbQuNe9AayOAuFGlbR5Z81tRskWjDgOvqm/4rPkS6BO8YWRwSaRnHF2LVAT8DA==";
       };
     };
     "ssb-db-19.2.0" = {
@@ -37744,22 +38590,22 @@ let
         sha512 = "7GVq5Ael/get+3Ot5exLdRWU8psSQNv/SkyO0KUhjoc4VfTdz8XuN1K195LKiyL/7u31A50KmkG9U9twb+1rGQ==";
       };
     };
-    "ssb-gossip-1.1.0" = {
+    "ssb-gossip-1.1.1" = {
       name = "ssb-gossip";
       packageName = "ssb-gossip";
-      version = "1.1.0";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-gossip/-/ssb-gossip-1.1.0.tgz";
-        sha512 = "z4DBUtGJ+/k6z67EjavmPYAKz9BLF7zWcSDwUwLKZZT3AJp/5J6iPxHkilz2UfJ9LdGT4gF5CUe2xyIt1QFguA==";
+        url = "https://registry.npmjs.org/ssb-gossip/-/ssb-gossip-1.1.1.tgz";
+        sha512 = "lbizlDBCtOOnbnz7zS81NOtnAyHnXu9E3gxrAJHZe7oyxINRI7IpQ8J79to9aXzkb8+2M32R8K4whmsAHGvJAg==";
       };
     };
-    "ssb-invite-2.1.3" = {
+    "ssb-invite-2.1.4" = {
       name = "ssb-invite";
       packageName = "ssb-invite";
-      version = "2.1.3";
+      version = "2.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-invite/-/ssb-invite-2.1.3.tgz";
-        sha512 = "hHLsmlTqk6ecxpWlHiwpFNwXDfMY8gO6OdXrU2lkoqLStPrriPgzlCJnfZA06Gdi2ZL5Az4+M2fyWvnza9x/kg==";
+        url = "https://registry.npmjs.org/ssb-invite/-/ssb-invite-2.1.4.tgz";
+        sha512 = "bq4Iow4DOfsfWKE6otgD2+sWd59PcLW/WUbwZdJlukaT2m0nazPu2s8k9xX/95p+pJS7xkLyywHxMzytiKRqTg==";
       };
     };
     "ssb-issues-1.0.0" = {
@@ -38536,13 +39382,13 @@ let
         sha1 = "5ea211cd92d228e184294990a6cc97b366a77cb0";
       };
     };
-    "string-kit-0.9.12" = {
+    "string-kit-0.10.1" = {
       name = "string-kit";
       packageName = "string-kit";
-      version = "0.9.12";
+      version = "0.10.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/string-kit/-/string-kit-0.9.12.tgz";
-        sha512 = "l6BRL9uO4uV1o6/r/mJthahp8qatqGv4l6Z2o2mX+y2VYc7gFb2YD0k3zThvw3BATj/nDvLTB1s167vc2JdeDg==";
+        url = "https://registry.npmjs.org/string-kit/-/string-kit-0.10.1.tgz";
+        sha512 = "qxIqv5bJqYoWzJa0WJFdw9CCoPJ3/9EixXQXVerIYMghd45w0XiESgUchYCEeGg8bQQWHS+TYZW1DcJmHwAxZA==";
       };
     };
     "string-length-2.0.0" = {
@@ -38824,6 +39670,15 @@ let
         sha1 = "2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3";
       };
     };
+    "strip-bom-4.0.0" = {
+      name = "strip-bom";
+      packageName = "strip-bom";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz";
+        sha512 = "3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==";
+      };
+    };
     "strip-bom-buf-1.0.0" = {
       name = "strip-bom-buf";
       packageName = "strip-bom-buf";
@@ -38894,6 +39749,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz";
         sha1 = "bb43ff5598a6eb05d89b59fcd129c983313606bf";
+      };
+    };
+    "strip-final-newline-2.0.0" = {
+      name = "strip-final-newline";
+      packageName = "strip-final-newline";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz";
+        sha512 = "BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==";
       };
     };
     "strip-indent-1.0.1" = {
@@ -38995,6 +39859,15 @@ let
         sha1 = "dd802425e0f53dc4a6e7aca3752901a1ccda7af5";
       };
     };
+    "style-search-0.1.0" = {
+      name = "style-search";
+      packageName = "style-search";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz";
+        sha1 = "7958c793e47e32e07d2b5cafe5c0bf8e12e77902";
+      };
+    };
     "stylehacks-4.0.3" = {
       name = "stylehacks";
       packageName = "stylehacks";
@@ -39002,6 +39875,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz";
         sha512 = "7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==";
+      };
+    };
+    "stylelint-8.4.0" = {
+      name = "stylelint";
+      packageName = "stylelint";
+      version = "8.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stylelint/-/stylelint-8.4.0.tgz";
+        sha512 = "56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==";
       };
     };
     "stylint-1.5.9" = {
@@ -39022,13 +39904,13 @@ let
         sha512 = "Yw3WMTzVwevT6ZTrLCYNHAFmanMxdylelL3hkWNgPMeTCpMwpV3nXjpOHuBXtFv7aiO2xRuQS6OoAdgkNcSNug==";
       };
     };
-    "stylus-supremacy-2.12.7" = {
+    "stylus-supremacy-2.14.0" = {
       name = "stylus-supremacy";
       packageName = "stylus-supremacy";
-      version = "2.12.7";
+      version = "2.14.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/stylus-supremacy/-/stylus-supremacy-2.12.7.tgz";
-        sha512 = "Z5P0XttU45C+s1F360Bn9pd/5rZrct28NTfhKnrXC33Y7KDWwJCYHvT8Ypwie6Huxnt9W1ffCjBbkZYlk9yXYw==";
+        url = "https://registry.npmjs.org/stylus-supremacy/-/stylus-supremacy-2.14.0.tgz";
+        sha512 = "XeoMvDSTxgJnRPvnyVnIyTDLawLoKcZw1zoWc88p9oFZXxZbEDx8PGLjR4pSkLXVn/VqU5p5YILa7FqYaFakUA==";
       };
     };
     "subarg-1.0.0" = {
@@ -39065,6 +39947,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sudo-block/-/sudo-block-1.2.0.tgz";
         sha1 = "cc539bf8191624d4f507d83eeb45b4cea27f3463";
+      };
+    };
+    "sugarss-1.0.1" = {
+      name = "sugarss";
+      packageName = "sugarss";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz";
+        sha512 = "3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==";
       };
     };
     "superagent-0.21.0" = {
@@ -39202,6 +40093,15 @@ let
         sha512 = "qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==";
       };
     };
+    "supports-hyperlinks-1.0.1" = {
+      name = "supports-hyperlinks";
+      packageName = "supports-hyperlinks";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz";
+        sha512 = "HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==";
+      };
+    };
     "sver-compat-1.5.0" = {
       name = "sver-compat";
       packageName = "sver-compat";
@@ -39211,13 +40111,22 @@ let
         sha1 = "3cf87dfeb4d07b4a3f14827bc186b3fd0c645cd8";
       };
     };
-    "svgo-1.3.0" = {
+    "svg-tags-1.0.0" = {
+      name = "svg-tags";
+      packageName = "svg-tags";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz";
+        sha1 = "58f71cee3bd519b59d4b2a843b6c7de64ac04764";
+      };
+    };
+    "svgo-1.3.2" = {
       name = "svgo";
       packageName = "svgo";
-      version = "1.3.0";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz";
-        sha512 = "MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==";
+        url = "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz";
+        sha512 = "yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==";
       };
     };
     "swagger-converter-0.1.7" = {
@@ -39283,13 +40192,13 @@ let
         sha1 = "70070468d6d2977ca5237b2e519ca7d06a2ea3fd";
       };
     };
-    "swagger-test-templates-1.5.1" = {
+    "swagger-test-templates-1.6.0" = {
       name = "swagger-test-templates";
       packageName = "swagger-test-templates";
-      version = "1.5.1";
+      version = "1.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/swagger-test-templates/-/swagger-test-templates-1.5.1.tgz";
-        sha512 = "p5EotTsyVunfNGvIr07r33Tij5p4r1aUv7QFvYYW3iO6pEUo2OXxINufkx8jBjD4/4hvP2ZlCjgLDexT2ClnGw==";
+        url = "https://registry.npmjs.org/swagger-test-templates/-/swagger-test-templates-1.6.0.tgz";
+        sha512 = "yWlUYlxT6FjVSvWJbHCMnAAAShSYdGvk1V1hd78Huey08Ra1Vzl8kIhhdExQ5+oLVzMrQE/FIm8fOtNjRXQqjA==";
       };
     };
     "swagger-tools-0.9.16" = {
@@ -39400,13 +40309,13 @@ let
         sha512 = "YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==";
       };
     };
-    "systeminformation-4.14.8" = {
+    "systeminformation-4.14.17" = {
       name = "systeminformation";
       packageName = "systeminformation";
-      version = "4.14.8";
+      version = "4.14.17";
       src = fetchurl {
-        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.14.8.tgz";
-        sha512 = "05wW1YaMBI6LlVtvw2wXQGr0thpX8E0IImYcpbqUiNanfmq8e+V89pDW2L5V/mN8kU37W0VtVySftQ0PwMIXKw==";
+        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.14.17.tgz";
+        sha512 = "CQbT5vnkqNb3JNl41xr8sYA8AX7GoaWP55/jnmFNQY0XQmUuoFshSNUkCkxiDdEC1qu2Vg9s0jR6LLmVSmNJUw==";
       };
     };
     "syswide-cas-5.3.0" = {
@@ -39436,6 +40345,15 @@ let
         sha512 = "UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==";
       };
     };
+    "table-4.0.3" = {
+      name = "table";
+      packageName = "table";
+      version = "4.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/table/-/table-4.0.3.tgz";
+        sha512 = "S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==";
+      };
+    };
     "table-5.4.6" = {
       name = "table";
       packageName = "table";
@@ -39463,13 +40381,13 @@ let
         sha1 = "bb9c2ca6324f659fde7634c2caf3c096e1187ca7";
       };
     };
-    "tabtab-2.2.2" = {
+    "tabtab-3.0.2" = {
       name = "tabtab";
       packageName = "tabtab";
-      version = "2.2.2";
+      version = "3.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tabtab/-/tabtab-2.2.2.tgz";
-        sha1 = "7a047f143b010b4cbd31f857e82961512cbf4e14";
+        url = "https://registry.npmjs.org/tabtab/-/tabtab-3.0.2.tgz";
+        sha512 = "jANKmUe0sIQc/zTALTBy186PoM/k6aPrh3A7p6AaAfF6WPSbTx1JYeGIGH162btpH+mmVEXln+UxwViZHO2Jhg==";
       };
     };
     "tabtab-git+https://github.com/mixu/node-tabtab.git" = {
@@ -39572,13 +40490,13 @@ let
         sha512 = "FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==";
       };
     };
-    "tar-4.4.11" = {
+    "tar-4.4.13" = {
       name = "tar";
       packageName = "tar";
-      version = "4.4.11";
+      version = "4.4.13";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar/-/tar-4.4.11.tgz";
-        sha512 = "iI4zh3ktLJKaDNZKZc+fUONiQrSn9HkCFzamtb7k8FFmVilHVob7QsLX/VySAW8lAviMzMbFw4QtFb4errwgYA==";
+        url = "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz";
+        sha512 = "w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==";
       };
     };
     "tar-fs-2.0.0" = {
@@ -39653,13 +40571,13 @@ let
         sha1 = "9450e8768c83b416fd4d1a6a9449eeccbf496c29";
       };
     };
-    "telegraf-3.32.0" = {
+    "telegraf-3.33.3" = {
       name = "telegraf";
       packageName = "telegraf";
-      version = "3.32.0";
+      version = "3.33.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/telegraf/-/telegraf-3.32.0.tgz";
-        sha512 = "5ZHiovyuG1rVLygJjaqf57wDt8e1nijAinKXCxN1tyUZ4BcrkZW/z5rVTEXA+KegpFbWxKKv3KnJwUJrKDqD0Q==";
+        url = "https://registry.npmjs.org/telegraf/-/telegraf-3.33.3.tgz";
+        sha512 = "ItSAeE9OjFH+X0rS8DeErccoUZRy2hBl+mDjFWDqyZWyRElxA5L178UpJV7tM6hCVN/leFY+9orfra2JtX4AyQ==";
       };
     };
     "telegram-typings-3.6.1" = {
@@ -39689,6 +40607,15 @@ let
         sha1 = "e0c6bc4d26b903124410e4fed81103014dfc1f59";
       };
     };
+    "temp-0.8.4" = {
+      name = "temp";
+      packageName = "temp";
+      version = "0.8.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz";
+        sha512 = "s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==";
+      };
+    };
     "temp-0.9.0" = {
       name = "temp";
       packageName = "temp";
@@ -39696,6 +40623,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz";
         sha512 = "YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==";
+      };
+    };
+    "temp-0.9.1" = {
+      name = "temp";
+      packageName = "temp";
+      version = "0.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz";
+        sha512 = "WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==";
       };
     };
     "temp-dir-1.0.0" = {
@@ -39752,13 +40688,22 @@ let
         sha1 = "458b83887f288fc56d6fffbfad262e26638efa69";
       };
     };
-    "terminal-kit-1.31.3" = {
+    "term-size-2.1.0" = {
+      name = "term-size";
+      packageName = "term-size";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/term-size/-/term-size-2.1.0.tgz";
+        sha512 = "I42EWhJ+2aeNQawGx1VtpO0DFI9YcfuvAMNIdKyf/6sRbHJ4P+ZQ/zIT87tE+ln1ymAGcCJds4dolfSAS0AcNg==";
+      };
+    };
+    "terminal-kit-1.31.4" = {
       name = "terminal-kit";
       packageName = "terminal-kit";
-      version = "1.31.3";
+      version = "1.31.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.31.3.tgz";
-        sha512 = "nFNMB70bnvvlCazD2GLhJNmL8uaYxtCd5NarsNFI98oDtn7VJr2TCkfKGX2NxIK42wFWE9ieCUEA93kDvPcBWw==";
+        url = "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.31.4.tgz";
+        sha512 = "alrT1vDcKamNxdU8HrN25hTsHBuSWb++HVPVy98xbbUJBTw5l+NiF+ILAO56fl0XQLPOMqVUs0lhqf0B20Lucg==";
       };
     };
     "terser-3.17.0" = {
@@ -39770,13 +40715,13 @@ let
         sha512 = "/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==";
       };
     };
-    "terser-4.3.1" = {
+    "terser-4.3.9" = {
       name = "terser";
       packageName = "terser";
-      version = "4.3.1";
+      version = "4.3.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terser/-/terser-4.3.1.tgz";
-        sha512 = "pnzH6dnFEsR2aa2SJaKb1uSCl3QmIsJ8dEkj0Fky+2AwMMcC9doMqLOQIH6wVTEKaVfKVvLSk5qxPBEZT9mywg==";
+        url = "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz";
+        sha512 = "NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==";
       };
     };
     "terser-webpack-plugin-1.4.1" = {
@@ -39797,13 +40742,13 @@ let
         sha512 = "SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==";
       };
     };
-    "text-extensions-2.0.0" = {
+    "text-extensions-1.9.0" = {
       name = "text-extensions";
       packageName = "text-extensions";
-      version = "2.0.0";
+      version = "1.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz";
-        sha512 = "F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==";
+        url = "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz";
+        sha512 = "wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==";
       };
     };
     "text-hex-1.0.0" = {
@@ -39849,15 +40794,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-2.1.1.tgz";
         sha512 = "PW6rXqLNGL3xZ6d5/INrX+pt8qbffmeDPLcvkBOlfNpDRFhVvNNjFmZXH86ZQjrOz9t/nNZDBXqnzqJuioJbSQ==";
-      };
-    };
-    "thelounge-ldapjs-non-maintained-fork-1.0.4" = {
-      name = "thelounge-ldapjs-non-maintained-fork";
-      packageName = "thelounge-ldapjs-non-maintained-fork";
-      version = "1.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/thelounge-ldapjs-non-maintained-fork/-/thelounge-ldapjs-non-maintained-fork-1.0.4.tgz";
-        sha512 = "uf6H6UMv6EKmU81V1Q5lECwiGz4noSua+C+nGiC/Vgtayu3VRjtSSIJzUJDUjJT3YS8HJgkvBe2SsgGrPlT/7g==";
       };
     };
     "then-fs-2.0.0" = {
@@ -40049,13 +40985,13 @@ let
         sha1 = "bf30146824e2b6e67b0f2d7a4ac8beb26908684e";
       };
     };
-    "thunky-1.0.3" = {
+    "thunky-1.1.0" = {
       name = "thunky";
       packageName = "thunky";
-      version = "1.0.3";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz";
-        sha512 = "YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==";
+        url = "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz";
+        sha512 = "eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==";
       };
     };
     "tildify-1.2.0" = {
@@ -40562,13 +41498,13 @@ let
         sha512 = "H/Z/yCuvZJj1vl1IQHI8dvF2QrUuXRJoptT5DW5967/dsLpXlCg+uyhFR5lfNj5mNaYePUbKtnL+qKWZGXv4Nw==";
       };
     };
-    "torrent-stream-1.1.0" = {
+    "torrent-stream-1.2.0" = {
       name = "torrent-stream";
       packageName = "torrent-stream";
-      version = "1.1.0";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/torrent-stream/-/torrent-stream-1.1.0.tgz";
-        sha512 = "yjKU8l985+/D2CdnAR2+pEpyMX13rlQ1kNYik34EHxcul7BjifW5sMizT+u47suOeBTji3lHBA7eZGhBjpnM6g==";
+        url = "https://registry.npmjs.org/torrent-stream/-/torrent-stream-1.2.0.tgz";
+        sha512 = "piQP9/wrXRYvEUAsmdu+fy2D2WPwU7BcsflTnKLsZsrUDBT/Y1INhuYU7Fw9PqEm+RF7QAa2gD8nMmvfb7QomA==";
       };
     };
     "tosource-1.0.0" = {
@@ -40715,22 +41651,13 @@ let
         sha512 = "7mV4KbsLMuA6ths3J1wpVUj2PLmLdoNEGnP9fm3kxef4UXYC/A0rL5gKsqtkUaCMuRYUMORyioy8IpBWUBQ1Ig==";
       };
     };
-    "tree-sitter-0.13.23" = {
-      name = "tree-sitter";
-      packageName = "tree-sitter";
-      version = "0.13.23";
+    "treeify-1.1.0" = {
+      name = "treeify";
+      packageName = "treeify";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.13.23.tgz";
-        sha512 = "75AiPbMEstv+YK8h4FkAHnmAJ6nNIUj/NFzRvKCHovmwSEKMi8Wc/E/crB4lJnHBOfV/f/DMQjN+e1Y36kagug==";
-      };
-    };
-    "tree-sitter-bash-0.13.9" = {
-      name = "tree-sitter-bash";
-      packageName = "tree-sitter-bash";
-      version = "0.13.9";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tree-sitter-bash/-/tree-sitter-bash-0.13.9.tgz";
-        sha512 = "b0L+QLS2eeIVrHnnbkFlvO1nElhPwqTxLIwyTeJytPYT0TS50Pe7bP+uPi3gkHT1YajxcauCxX1aDWDiZK1h5Q==";
+        url = "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz";
+        sha512 = "1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==";
       };
     };
     "trim-0.0.1" = {
@@ -40958,6 +41885,15 @@ let
         sha512 = "+bGy9iDAqg3WSfc2ZrprToSPJhZjqy7vUv9wupQzsiv+BVPVx1T2a6G4T0290SpQj+56Toaw9BiLO5j5Bd7QzA==";
       };
     };
+    "tty-1.0.1" = {
+      name = "tty";
+      packageName = "tty";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tty/-/tty-1.0.1.tgz";
+        sha1 = "e4409ac98b0dd1c50b59ff38e86eac3f0764ee45";
+      };
+    };
     "tty-browserify-0.0.0" = {
       name = "tty-browserify";
       packageName = "tty-browserify";
@@ -41066,15 +42002,6 @@ let
         sha512 = "Kjart2102Kf0IdsEmLonSJKcByU7o9uiJhBde3GhrNHrX4XenT5WSKu4Hpkx+rF6Kyppeyd48BKsCREIOPXd/g==";
       };
     };
-    "twitter-ng-0.6.2" = {
-      name = "twitter-ng";
-      packageName = "twitter-ng";
-      version = "0.6.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/twitter-ng/-/twitter-ng-0.6.2.tgz";
-        sha1 = "13707115dd04c9bd1f2c646da976589be4d64bc4";
-      };
-    };
     "txt-to-ast-3.0.3" = {
       name = "txt-to-ast";
       packageName = "txt-to-ast";
@@ -41091,6 +42018,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/type/-/type-1.2.0.tgz";
         sha512 = "+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==";
+      };
+    };
+    "type-2.0.0" = {
+      name = "type";
+      packageName = "type";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/type/-/type-2.0.0.tgz";
+        sha512 = "KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==";
       };
     };
     "type-check-0.3.2" = {
@@ -41127,6 +42063,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz";
         sha512 = "DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==";
+      };
+    };
+    "type-fest-0.8.1" = {
+      name = "type-fest";
+      packageName = "type-fest";
+      version = "0.8.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz";
+        sha512 = "4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==";
       };
     };
     "type-is-1.5.7" = {
@@ -41201,22 +42146,13 @@ let
         sha512 = "kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==";
       };
     };
-    "typescript-3.5.3" = {
+    "typescript-3.6.4" = {
       name = "typescript";
       packageName = "typescript";
-      version = "3.5.3";
+      version = "3.6.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz";
-        sha512 = "ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==";
-      };
-    };
-    "typescript-3.6.3" = {
-      name = "typescript";
-      packageName = "typescript";
-      version = "3.6.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz";
-        sha512 = "N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==";
+        url = "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz";
+        sha512 = "unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==";
       };
     };
     "typescript-eslint-parser-16.0.1" = {
@@ -41309,15 +42245,6 @@ let
         sha512 = "Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==";
       };
     };
-    "uglify-js-3.4.9" = {
-      name = "uglify-js";
-      packageName = "uglify-js";
-      version = "3.4.9";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz";
-        sha512 = "8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==";
-      };
-    };
     "uglify-js-3.6.0" = {
       name = "uglify-js";
       packageName = "uglify-js";
@@ -41325,6 +42252,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz";
         sha512 = "W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==";
+      };
+    };
+    "uglify-js-3.6.6" = {
+      name = "uglify-js";
+      packageName = "uglify-js";
+      version = "3.6.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.6.tgz";
+        sha512 = "q3Zusqd028P8MdbarqL0I1snTZ7+IbIWiKUXVZyXMVdOSxOG2FFqLXyGlgYSqYu46SR7tR3Sk0xqN1VtvxGWnQ==";
       };
     };
     "uglify-to-browserify-1.0.2" = {
@@ -41795,6 +42731,15 @@ let
         sha1 = "1062bbb6928c7a97c6adc89b53745d4c46c222a2";
       };
     };
+    "unist-util-find-all-after-1.0.4" = {
+      name = "unist-util-find-all-after";
+      packageName = "unist-util-find-all-after";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz";
+        sha512 = "CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==";
+      };
+    };
     "unist-util-inspect-4.1.4" = {
       name = "unist-util-inspect";
       packageName = "unist-util-inspect";
@@ -41939,13 +42884,13 @@ let
         sha512 = "rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==";
       };
     };
-    "unix-crypt-td-js-1.0.0" = {
+    "unix-crypt-td-js-1.1.4" = {
       name = "unix-crypt-td-js";
       packageName = "unix-crypt-td-js";
-      version = "1.0.0";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.0.0.tgz";
-        sha1 = "1c0824150481bc7a01d49e98f1ec668d82412f3b";
+        url = "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz";
+        sha512 = "8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==";
       };
     };
     "unixify-1.0.0" = {
@@ -42083,15 +43028,6 @@ let
         sha512 = "icFtME1RD648v+cjfcUWoky4bHbMTi8nk06nGxH77EPYyEeKaTgT3nRHM/dQ3znGXLi3+OlhYo86zQzNBRdNhw==";
       };
     };
-    "upath-1.1.2" = {
-      name = "upath";
-      packageName = "upath";
-      version = "1.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz";
-        sha512 = "kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==";
-      };
-    };
     "upath-1.2.0" = {
       name = "upath";
       packageName = "upath";
@@ -42182,13 +43118,13 @@ let
         sha512 = "KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==";
       };
     };
-    "urijs-1.19.1" = {
+    "urijs-1.19.2" = {
       name = "urijs";
       packageName = "urijs";
-      version = "1.19.1";
+      version = "1.19.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz";
-        sha512 = "xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==";
+        url = "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz";
+        sha512 = "s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==";
       };
     };
     "urix-0.1.0" = {
@@ -42839,6 +43775,15 @@ let
         sha1 = "dfe93616ad0e7ae801b332a9d88bfc5cdc8e1d1f";
       };
     };
+    "vasync-2.2.0" = {
+      name = "vasync";
+      packageName = "vasync";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vasync/-/vasync-2.2.0.tgz";
+        sha1 = "cfde751860a15822db3b132bc59b116a4adaf01b";
+      };
+    };
     "vendors-1.0.3" = {
       name = "vendors";
       packageName = "vendors";
@@ -42848,13 +43793,13 @@ let
         sha512 = "fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==";
       };
     };
-    "verda-1.0.0-4" = {
+    "verda-1.0.0-10" = {
       name = "verda";
       packageName = "verda";
-      version = "1.0.0-4";
+      version = "1.0.0-10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/verda/-/verda-1.0.0-4.tgz";
-        sha512 = "DKr2WdWlPwJvmqCcjs6LPaBOacFQUdk6+u7tqwkxYKbHa0Touff7Y6x+YAWbnT1dace5Qlv/CRr6YBEaB08r3A==";
+        url = "https://registry.npmjs.org/verda/-/verda-1.0.0-10.tgz";
+        sha512 = "5VWCbPzZnYjjrlvCE4XW4wT8ko9ppCSo6EyHDfH7XBsv0EEglzq/Pdg8k77aV/9xQwFvnFcd1y/XnmDbya77Ow==";
       };
     };
     "verror-1.1.0" = {
@@ -43199,13 +44144,13 @@ let
         sha512 = "pTnfXbsME3pl+yDfhUp/mtvPyIJk0Le4zqJxDn56s9GY9LqY0RmkSEh0oHH6D0HXR3Ni6wKosIaqu8a2G0+jdw==";
       };
     };
-    "vscode-emmet-helper-1.2.15" = {
+    "vscode-emmet-helper-1.2.16" = {
       name = "vscode-emmet-helper";
       packageName = "vscode-emmet-helper";
-      version = "1.2.15";
+      version = "1.2.16";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-emmet-helper/-/vscode-emmet-helper-1.2.15.tgz";
-        sha512 = "JplvmMMWSvm/6/dZezix2ADPM49u6YahPYjs/QToohUpomW/2Eb27ecCrkCyOGBPfKLKGiOPHCssss8TSDA9ag==";
+        url = "https://registry.npmjs.org/vscode-emmet-helper/-/vscode-emmet-helper-1.2.16.tgz";
+        sha512 = "BuQK6fTV2w65Yd0/CJGj1EOvcJ9NHWfrMJ9nA8pjnu9jzAAnXLhnbviuGT9medMiPU0mp0tJqc/8Z0qlXcqdGw==";
       };
     };
     "vscode-html-languageservice-2.1.12" = {
@@ -43235,13 +44180,13 @@ let
         sha512 = "perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==";
       };
     };
-    "vscode-jsonrpc-4.1.0-next.3" = {
+    "vscode-jsonrpc-5.0.0-next.2" = {
       name = "vscode-jsonrpc";
       packageName = "vscode-jsonrpc";
-      version = "4.1.0-next.3";
+      version = "5.0.0-next.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.3.tgz";
-        sha512 = "Z6oxBiMks2+UADV1QHXVooSakjyhI+eHTnXzDyVvVMmegvSfkXk2w6mPEdSkaNHFBdtWW7n20H1yw2nA3A17mg==";
+        url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.0-next.2.tgz";
+        sha512 = "Q3/jabZUNviCG9hhF6hHWjhrABevPF9mv0aiE2j8BYCAP2k+aHTpjMyk+04MzaAqWYwXdQuZkLSbcYCCqbzJLg==";
       };
     };
     "vscode-languageclient-4.0.1" = {
@@ -43298,13 +44243,13 @@ let
         sha512 = "IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==";
       };
     };
-    "vscode-languageserver-protocol-3.15.0-next.8" = {
+    "vscode-languageserver-protocol-3.15.0-next.9" = {
       name = "vscode-languageserver-protocol";
       packageName = "vscode-languageserver-protocol";
-      version = "3.15.0-next.8";
+      version = "3.15.0-next.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.8.tgz";
-        sha512 = "9FigDhuYTUqX73IGKgJeyLmfXQJv9p3t22RF3peT+HM33uFiTZE3MUgHj4I9m/dKCDvuJt0yvbI27ut4hDoGRQ==";
+        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.9.tgz";
+        sha512 = "b9PAxouMmtsLEe8ZjbIMPb7wRWPhckGfgjwZLmp/dWnaAuRPYtY3lGO0/rNbLc3jKIqCVlnEyYVFKalzDAzj0g==";
       };
     };
     "vscode-languageserver-protocol-3.6.0" = {
@@ -43334,13 +44279,13 @@ let
         sha512 = "lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==";
       };
     };
-    "vscode-languageserver-types-3.15.0-next.4" = {
+    "vscode-languageserver-types-3.15.0-next.5" = {
       name = "vscode-languageserver-types";
       packageName = "vscode-languageserver-types";
-      version = "3.15.0-next.4";
+      version = "3.15.0-next.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.4.tgz";
-        sha512 = "IKIWTdUPBnOtwznIrhxKnjVZ7hYxEzwZ3M2xmDi7OjjexuOM6LnGtoo1Dv4wYSik4epK4STEib6e8da2GxUsJA==";
+        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.5.tgz";
+        sha512 = "7hrELhTeWieUgex3+6692KjCkcmO/+V/bFItM5MHGcBotzwmjEuXjapLLYTYhIspuJ1ibRSik5MhX5YwLpsPiw==";
       };
     };
     "vscode-languageserver-types-3.6.0" = {
@@ -43388,6 +44333,15 @@ let
         sha1 = "631bdbf716dccab0e65291a8dc25c23232085a52";
       };
     };
+    "vscode-uri-1.0.6" = {
+      name = "vscode-uri";
+      packageName = "vscode-uri";
+      version = "1.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz";
+        sha512 = "sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==";
+      };
+    };
     "vscode-uri-1.0.8" = {
       name = "vscode-uri";
       packageName = "vscode-uri";
@@ -43406,13 +44360,13 @@ let
         sha1 = "13587190f34e72ba7a07ebbaa7e70ac147b1fb7d";
       };
     };
-    "vue-cli-plugin-apollo-0.20.0" = {
+    "vue-cli-plugin-apollo-0.21.3" = {
       name = "vue-cli-plugin-apollo";
       packageName = "vue-cli-plugin-apollo";
-      version = "0.20.0";
+      version = "0.21.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vue-cli-plugin-apollo/-/vue-cli-plugin-apollo-0.20.0.tgz";
-        sha512 = "Ey/luK5HtP4ZQhua5RKETR672pE7BPymaso//Ccl/wxQI1BqVTxg9o/wYeXuURBIw2Et9JaVLXmh0e9uKgk8Jw==";
+        url = "https://registry.npmjs.org/vue-cli-plugin-apollo/-/vue-cli-plugin-apollo-0.21.3.tgz";
+        sha512 = "8CzRVrAsFkB9lpl600cRCNR9OUnrSYYAIVF9/qW4pP0TMXbhrd1F1wEAAN6E0CPimjTLB+qSt6zWS4vb2wC8Wg==";
       };
     };
     "vue-eslint-parser-2.0.3" = {
@@ -43568,13 +44522,22 @@ let
         sha1 = "7137946585c73fe44882013853bd000c5d687a4e";
       };
     };
-    "web-push-3.3.5" = {
+    "web-push-3.4.1" = {
       name = "web-push";
       packageName = "web-push";
-      version = "3.3.5";
+      version = "3.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/web-push/-/web-push-3.3.5.tgz";
-        sha512 = "sukVBk0chRCL4n+Xwurl2TlD4/JmezNv4L2nwlTZx4KwMeUPfmD9TdGl6A6taayNgjObYzp0k0gubAcQCp7TMg==";
+        url = "https://registry.npmjs.org/web-push/-/web-push-3.4.1.tgz";
+        sha512 = "wtx18llPtWWW+x8hv+Gxvz+2VjO+vZuyihInsjySNpNGNVswH1Bb2KkbbCtE96yi52VUmbFMdidxM8kJAPaSWQ==";
+      };
+    };
+    "web-tree-sitter-0.15.10" = {
+      name = "web-tree-sitter";
+      packageName = "web-tree-sitter";
+      version = "0.15.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.15.10.tgz";
+        sha512 = "8utowZB5h5djbotf1umt4na9Vt6Q18ZICUeC9jW4qWWjUrtQ2xvxDuAJ+EibmqUJBAKATrDMXnY2xYaskGg8wg==";
       };
     };
     "webassemblyjs-1.8.5" = {
@@ -43604,22 +44567,22 @@ let
         sha512 = "YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==";
       };
     };
-    "webpack-4.40.2" = {
+    "webpack-4.41.2" = {
       name = "webpack";
       packageName = "webpack";
-      version = "4.40.2";
+      version = "4.41.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webpack/-/webpack-4.40.2.tgz";
-        sha512 = "5nIvteTDCUws2DVvP9Qe+JPla7kWPPIDFZv55To7IycHWZ+Z5qBdaBYPyuXWdhggTufZkQwfIK+5rKQTVovm2A==";
+        url = "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz";
+        sha512 = "Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==";
       };
     };
-    "webpack-cli-3.3.9" = {
+    "webpack-cli-3.3.10" = {
       name = "webpack-cli";
       packageName = "webpack-cli";
-      version = "3.3.9";
+      version = "3.3.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.9.tgz";
-        sha512 = "xwnSxWl8nZtBl/AFJCOn9pG7s5CYUYdZxmmukv+fAHLcBIHM36dImfpQg3WfShZXeArkWlf6QRw24Klcsv8a5A==";
+        url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz";
+        sha512 = "u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==";
       };
     };
     "webpack-core-0.6.9" = {
@@ -43730,6 +44693,15 @@ let
         sha512 = "37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==";
       };
     };
+    "whatwg-url-7.1.0" = {
+      name = "whatwg-url";
+      packageName = "whatwg-url";
+      version = "7.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz";
+        sha512 = "WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==";
+      };
+    };
     "whatwg-url-compat-0.6.5" = {
       name = "whatwg-url-compat";
       packageName = "whatwg-url-compat";
@@ -43773,6 +44745,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/which/-/which-1.3.1.tgz";
         sha512 = "HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==";
+      };
+    };
+    "which-2.0.1" = {
+      name = "which";
+      packageName = "which";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/which/-/which-2.0.1.tgz";
+        sha512 = "N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==";
       };
     };
     "which-module-1.0.0" = {
@@ -43836,6 +44817,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz";
         sha512 = "Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==";
+      };
+    };
+    "widest-line-3.1.0" = {
+      name = "widest-line";
+      packageName = "widest-line";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz";
+        sha512 = "NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==";
       };
     };
     "win-detect-browsers-1.0.2" = {
@@ -44090,6 +45080,15 @@ let
         sha1 = "288a04d87eda5c286e060dfe8f135ce8d007f8ba";
       };
     };
+    "wrap-ansi-4.0.0" = {
+      name = "wrap-ansi";
+      packageName = "wrap-ansi";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz";
+        sha512 = "uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==";
+      };
+    };
     "wrap-ansi-5.1.0" = {
       name = "wrap-ansi";
       packageName = "wrap-ansi";
@@ -44099,13 +45098,13 @@ let
         sha512 = "QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==";
       };
     };
-    "wrap-ansi-6.0.0" = {
+    "wrap-ansi-6.1.0" = {
       name = "wrap-ansi";
       packageName = "wrap-ansi";
-      version = "6.0.0";
+      version = "6.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.0.0.tgz";
-        sha512 = "8YwLklVkHe4QNpGFrK6Mxm+BaMY7da6C9GlDED3xs3XwThyJHSbVwg9qC4s1N8tBFcnM1S0s8I390RC6SgGe+g==";
+        url = "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.1.0.tgz";
+        sha512 = "y8j9eJaotnWgJkysmwld5GkLH2KE9srRvqQE2bu1tZb0O9Qgk1mLyz4Q4KIWyjZAi2+6NRqkM/A580IsUseDdw==";
       };
     };
     "wrap-fn-0.1.5" = {
@@ -44153,13 +45152,13 @@ let
         sha512 = "GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==";
       };
     };
-    "write-file-atomic-3.0.0" = {
+    "write-file-atomic-3.0.1" = {
       name = "write-file-atomic";
       packageName = "write-file-atomic";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz";
-        sha512 = "EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==";
+        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz";
+        sha512 = "JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==";
       };
     };
     "write-good-0.11.3" = {
@@ -44277,6 +45276,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz";
         sha512 = "gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==";
+      };
+    };
+    "ws-7.2.0" = {
+      name = "ws";
+      packageName = "ws";
+      version = "7.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz";
+        sha512 = "+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==";
       };
     };
     "x-default-browser-0.3.1" = {
@@ -44712,13 +45720,13 @@ let
         sha1 = "1c11f9218f076089a47dd512f93c6699a6a81d52";
       };
     };
-    "yallist-3.0.3" = {
+    "yallist-3.1.1" = {
       name = "yallist";
       packageName = "yallist";
-      version = "3.0.3";
+      version = "3.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz";
-        sha512 = "S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==";
+        url = "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz";
+        sha512 = "a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==";
       };
     };
     "yaml-ast-parser-0.0.40" = {
@@ -44784,13 +45792,13 @@ let
         sha512 = "ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==";
       };
     };
-    "yargs-11.1.0" = {
+    "yargs-11.1.1" = {
       name = "yargs";
       packageName = "yargs";
-      version = "11.1.0";
+      version = "11.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz";
-        sha512 = "NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==";
+        url = "https://registry.npmjs.org/yargs/-/yargs-11.1.1.tgz";
+        sha512 = "PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==";
       };
     };
     "yargs-12.0.4" = {
@@ -44811,15 +45819,6 @@ let
         sha512 = "Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==";
       };
     };
-    "yargs-13.2.2" = {
-      name = "yargs";
-      packageName = "yargs";
-      version = "13.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz";
-        sha512 = "WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==";
-      };
-    };
     "yargs-13.2.4" = {
       name = "yargs";
       packageName = "yargs";
@@ -44838,13 +45837,22 @@ let
         sha512 = "2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==";
       };
     };
-    "yargs-14.1.0" = {
+    "yargs-14.0.0" = {
       name = "yargs";
       packageName = "yargs";
-      version = "14.1.0";
+      version = "14.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs/-/yargs-14.1.0.tgz";
-        sha512 = "IdkQq1NiiV1fPwN5I2o4B0PKVjKh1EP71egpWO8dlovT8LG8JrXRmbH23v6I3CtjeEMnNC/IF3lq6XepPoELdg==";
+        url = "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz";
+        sha512 = "ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==";
+      };
+    };
+    "yargs-14.2.1" = {
+      name = "yargs";
+      packageName = "yargs";
+      version = "14.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yargs/-/yargs-14.2.1.tgz";
+        sha512 = "rZ00XIuGAoI58F0weHyCP3PAN17wJqdN/pF8eMp+imuP+jSdMCD5t4bSf5d5FKPvEDrK9zYlnhO7bFYKQ5UYow==";
       };
     };
     "yargs-3.10.0" = {
@@ -44937,13 +45945,13 @@ let
         sha512 = "oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==";
       };
     };
-    "yargs-parser-14.0.0" = {
+    "yargs-parser-15.0.0" = {
       name = "yargs-parser";
       packageName = "yargs-parser";
-      version = "14.0.0";
+      version = "15.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-14.0.0.tgz";
-        sha512 = "zn/Mnx+tbFjkCFUodEpjXckNS65NfpB5oyqOkDDEG/8uxlfLZJu2IoBLQFjukUkn9rBbGkVYNzrDh6qy4NUd3g==";
+        url = "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz";
+        sha512 = "xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==";
       };
     };
     "yargs-parser-2.4.1" = {
@@ -45000,22 +46008,22 @@ let
         sha1 = "9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077";
       };
     };
-    "yargs-unparser-1.5.0" = {
+    "yargs-unparser-1.6.0" = {
       name = "yargs-unparser";
       packageName = "yargs-unparser";
-      version = "1.5.0";
+      version = "1.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz";
-        sha512 = "HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==";
+        url = "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz";
+        sha512 = "W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==";
       };
     };
-    "yarn-1.17.3" = {
+    "yarn-1.19.1" = {
       name = "yarn";
       packageName = "yarn";
-      version = "1.17.3";
+      version = "1.19.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yarn/-/yarn-1.17.3.tgz";
-        sha512 = "CgA8o7nRZaQvmeF/WBx2FC7f9W/0X59T2IaLYqgMo6637wfp5mMEsM3YXoJtKUspnpmDJKl/gGFhnqS+sON7hA==";
+        url = "https://registry.npmjs.org/yarn/-/yarn-1.19.1.tgz";
+        sha512 = "gBnfbL9rYY05Gt0cjJhs/siqQXHYlZalTjK3nXn2QO20xbkIFPob+LlH44ML47GcR4VU9/2dYck1BWFM0Javxw==";
       };
     };
     "yauzl-2.10.0" = {
@@ -45072,13 +46080,13 @@ let
         sha512 = "CP0fwGk5Y+jel+A0AQbyqnIFZRRpkKOeYUibiTSmlgV9PcgNFFVwn86VcUIpDLOqVjF+9v+O9FWQMo+IUcV2mA==";
       };
     };
-    "yeoman-environment-2.4.0" = {
+    "yeoman-environment-2.6.0" = {
       name = "yeoman-environment";
       packageName = "yeoman-environment";
-      version = "2.4.0";
+      version = "2.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.4.0.tgz";
-        sha512 = "SsvoL0RNAFIX69eFxkUhwKUN2hG1UwUjxrcP+T2ytwdhqC/kHdnFOH2SXdtSN1Ju4aO4xuimmzfRoheYY88RuA==";
+        url = "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.6.0.tgz";
+        sha512 = "Hl0LBs9/mKun8XyJ6gFiUNhZwjN/eezn+E9IFWz6KtXg/3wsnztF2lgtE8eIjfhWYtvY4yMq9iizi1Ei5JJ+7A==";
       };
     };
     "yn-3.1.1" = {
@@ -45186,17 +46194,17 @@ in
   "@angular/cli" = nodeEnv.buildNodePackage {
     name = "_at_angular_slash_cli";
     packageName = "@angular/cli";
-    version = "8.3.5";
+    version = "8.3.17";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@angular/cli/-/cli-8.3.5.tgz";
-      sha512 = "gKzYV5YhypXKpt4vH/YJ/T7a72EqxTJynJ8dtoVsZw5YTdCzqa6APvObNs4lZaZ3pYxUOQr36W4Rz8Lv8CSBWA==";
+      url = "https://registry.npmjs.org/@angular/cli/-/cli-8.3.17.tgz";
+      sha512 = "1R4IlPnrm6B9drhrCHTu9fBFIqCvOXK1zqYLsdobz6KfdkBcLSFqRqRfgEqADLChkxMo4tedtsftkuqY5Xinrg==";
     };
     dependencies = [
-      sources."@angular-devkit/architect-0.803.5"
-      sources."@angular-devkit/core-8.3.5"
-      sources."@angular-devkit/schematics-8.3.5"
-      sources."@schematics/angular-8.3.5"
-      sources."@schematics/update-0.803.5"
+      sources."@angular-devkit/architect-0.803.17"
+      sources."@angular-devkit/core-8.3.17"
+      sources."@angular-devkit/schematics-8.3.17"
+      sources."@schematics/angular-8.3.17"
+      sources."@schematics/update-0.803.17"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONStream-1.3.5"
       sources."agent-base-4.3.0"
@@ -45215,15 +46223,19 @@ in
       sources."aws4-1.8.0"
       sources."balanced-match-1.0.0"
       sources."bcrypt-pbkdf-1.0.2"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."brace-expansion-1.1.11"
       sources."buffer-from-1.1.1"
       sources."builtins-1.0.3"
-      sources."cacache-12.0.3"
+      (sources."cacache-12.0.3" // {
+        dependencies = [
+          sources."rimraf-2.7.1"
+        ];
+      })
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."cli-cursor-3.1.0"
       sources."cli-width-2.2.0"
       sources."color-convert-1.9.3"
@@ -45231,7 +46243,11 @@ in
       sources."combined-stream-1.0.8"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
-      sources."copy-concurrently-1.0.5"
+      (sources."copy-concurrently-1.0.5" // {
+        dependencies = [
+          sources."rimraf-2.7.1"
+        ];
+      })
       sources."core-util-is-1.0.2"
       sources."cyclist-1.0.1"
       sources."dashdash-1.14.1"
@@ -45244,9 +46260,9 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."emoji-regex-8.0.0"
       sources."encoding-0.1.12"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."err-code-1.1.2"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
@@ -45257,7 +46273,7 @@ in
       sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."figgy-pudding-3.5.1"
-      sources."figures-3.0.0"
+      sources."figures-3.1.0"
       sources."flush-write-stream-1.1.1"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -45269,14 +46285,14 @@ in
       sources."genfun-5.0.0"
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
       sources."has-symbols-1.0.0"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-cache-semantics-3.8.1"
       (sources."http-proxy-agent-2.1.0" // {
         dependencies = [
@@ -45285,7 +46301,7 @@ in
         ];
       })
       sources."http-signature-1.2.0"
-      (sources."https-proxy-agent-2.2.2" // {
+      (sources."https-proxy-agent-2.2.4" // {
         dependencies = [
           sources."debug-3.2.6"
         ];
@@ -45293,7 +46309,7 @@ in
       sources."humanize-ms-1.2.1"
       sources."iconv-lite-0.4.24"
       sources."iferr-0.1.5"
-      sources."ignore-walk-3.0.2"
+      sources."ignore-walk-3.0.3"
       sources."imurmurhash-0.1.4"
       sources."infer-owner-1.0.4"
       sources."inflight-1.0.6"
@@ -45322,17 +46338,21 @@ in
       sources."lodash-4.17.15"
       sources."lru-cache-5.1.1"
       sources."magic-string-0.25.3"
-      sources."make-fetch-happen-5.0.0"
+      sources."make-fetch-happen-5.0.1"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."mimic-fn-2.1.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.8.1"
-      sources."minizlib-1.2.2"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
       sources."mississippi-3.0.0"
       sources."mkdirp-0.5.1"
-      sources."move-concurrently-1.0.1"
+      (sources."move-concurrently-1.0.1" // {
+        dependencies = [
+          sources."rimraf-2.7.1"
+        ];
+      })
       sources."ms-2.1.2"
       sources."mute-stream-0.0.8"
       sources."node-fetch-npm-2.0.2"
@@ -45347,13 +46367,13 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."npm-packlist-1.4.4"
-      (sources."npm-pick-manifest-2.2.3" // {
+      sources."npm-packlist-1.4.6"
+      (sources."npm-pick-manifest-3.0.2" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
       })
-      sources."npm-registry-fetch-4.0.1"
+      sources."npm-registry-fetch-4.0.2"
       sources."oauth-sign-0.9.0"
       sources."object-inspect-1.6.0"
       sources."object-keys-1.1.1"
@@ -45366,6 +46386,8 @@ in
       sources."osenv-0.1.5"
       (sources."pacote-9.5.5" // {
         dependencies = [
+          sources."npm-pick-manifest-2.2.3"
+          sources."rimraf-2.7.1"
           sources."semver-5.7.1"
         ];
       })
@@ -45398,7 +46420,7 @@ in
       sources."resolve-1.12.0"
       sources."restore-cursor-3.1.0"
       sources."retry-0.10.1"
-      sources."rimraf-2.7.1"
+      sources."rimraf-3.0.0"
       sources."run-async-2.3.0"
       sources."run-queue-1.0.3"
       sources."rxjs-6.4.0"
@@ -45440,7 +46462,7 @@ in
       sources."strip-ansi-5.2.0"
       sources."supports-color-5.5.0"
       sources."symbol-observable-1.2.0"
-      sources."tar-4.4.11"
+      sources."tar-4.4.13"
       sources."through-2.3.8"
       sources."through2-2.0.5"
       sources."tmp-0.0.33"
@@ -45472,7 +46494,7 @@ in
       sources."wrappy-1.0.2"
       sources."xtend-4.0.2"
       sources."y18n-4.0.0"
-      sources."yallist-3.0.3"
+      sources."yallist-3.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -45487,24 +46509,28 @@ in
   "@antora/cli" = nodeEnv.buildNodePackage {
     name = "_at_antora_slash_cli";
     packageName = "@antora/cli";
-    version = "2.1.1";
+    version = "2.1.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@antora/cli/-/cli-2.1.1.tgz";
-      sha512 = "U0xrC4/k2ci04u9Y1Qme6DcZNo1vcJfX8GC8JueMbe+58V6mxewE6yoIuYYCsuy+SI1D0Kbod+M8DrDnxubMSA==";
+      url = "https://registry.npmjs.org/@antora/cli/-/cli-2.1.2.tgz";
+      sha512 = "U0N8yjQl7kFUsJuCSMiXTWFnXFKMwmDwPy0cH98Kx251PrsvNRv1i2SdHrlp6Ve2+VcaJ3qpv2UcuyG1GKUzKg==";
     };
     dependencies = [
-      sources."@antora/playbook-builder-2.1.1"
+      sources."@antora/playbook-builder-2.1.2"
       sources."@iarna/toml-2.2.3"
       sources."argparse-1.0.10"
       sources."camelcase-5.3.1"
       sources."camelcase-keys-6.0.1"
-      sources."commander-3.0.1"
-      sources."convict-5.1.0"
+      sources."commander-3.0.2"
+      (sources."convict-5.1.0" // {
+        dependencies = [
+          sources."json5-2.1.0"
+        ];
+      })
       sources."decamelize-1.2.0"
       sources."deep-freeze-node-1.1.3"
       sources."esprima-4.0.1"
       sources."js-yaml-3.13.1"
-      sources."json5-2.1.0"
+      sources."json5-2.1.1"
       sources."lodash.clonedeep-4.5.0"
       sources."map-obj-4.1.0"
       sources."minimist-1.2.0"
@@ -45527,25 +46553,25 @@ in
   "@antora/site-generator-default" = nodeEnv.buildNodePackage {
     name = "_at_antora_slash_site-generator-default";
     packageName = "@antora/site-generator-default";
-    version = "2.1.1";
+    version = "2.1.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@antora/site-generator-default/-/site-generator-default-2.1.1.tgz";
-      sha512 = "lXE4+gW29OM20t8z1aYyr51KQuEow7kxu4sN8TDCr+2yU0Oqx/6Nxm9zUN33hT6XkNH0oMccdcWr0Aay22Lg2w==";
+      url = "https://registry.npmjs.org/@antora/site-generator-default/-/site-generator-default-2.1.2.tgz";
+      sha512 = "iHy4YFdIsOO5wTuB1CAvuPcojTSSIhKgiY1E4e1FZVUe3J7SGfbrj49pSbwYugrMgPtCf2KwcCZKwXnKW+k71A==";
     };
     dependencies = [
-      sources."@antora/asciidoc-loader-2.1.1"
-      sources."@antora/content-aggregator-2.1.1"
-      sources."@antora/content-classifier-2.1.1"
-      sources."@antora/document-converter-2.1.1"
+      sources."@antora/asciidoc-loader-2.1.2"
+      sources."@antora/content-aggregator-2.1.2"
+      sources."@antora/content-classifier-2.1.2"
+      sources."@antora/document-converter-2.1.2"
       sources."@antora/expand-path-helper-1.0.0"
-      sources."@antora/navigation-builder-2.1.1"
-      sources."@antora/page-composer-2.1.1"
-      sources."@antora/playbook-builder-2.1.1"
-      sources."@antora/redirect-producer-2.1.1"
-      sources."@antora/site-mapper-2.1.1"
-      sources."@antora/site-publisher-2.1.1"
-      sources."@antora/ui-loader-2.1.1"
-      sources."@babel/runtime-7.6.0"
+      sources."@antora/navigation-builder-2.1.2"
+      sources."@antora/page-composer-2.1.2"
+      sources."@antora/playbook-builder-2.1.2"
+      sources."@antora/redirect-producer-2.1.2"
+      sources."@antora/site-mapper-2.1.2"
+      sources."@antora/site-publisher-2.1.2"
+      sources."@antora/ui-loader-2.1.2"
+      sources."@babel/runtime-7.6.3"
       sources."@iarna/toml-2.2.3"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
@@ -45556,7 +46582,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base64-js-0.0.2"
       sources."benchmark-1.0.0"
-      sources."bl-3.0.0"
+      sources."bl-4.0.0"
       sources."bops-0.0.7"
       sources."brace-expansion-1.1.11"
       sources."buffer-crc32-0.2.13"
@@ -45587,14 +46613,18 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."concat-map-0.0.1"
       (sources."convert-source-map-1.6.0" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
         ];
       })
-      sources."convict-5.1.0"
+      (sources."convict-5.1.0" // {
+        dependencies = [
+          sources."json5-2.1.0"
+        ];
+      })
       sources."core-util-is-1.0.2"
       sources."crc-32-1.2.0"
       sources."decamelize-1.2.0"
@@ -45613,7 +46643,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."escape-string-regexp-2.0.0"
       sources."esprima-4.0.1"
       sources."event-stream-3.3.4"
@@ -45649,7 +46679,7 @@ in
       sources."glob-parent-3.1.0"
       (sources."glob-stream-6.1.0" // {
         dependencies = [
-          sources."glob-7.1.4"
+          sources."glob-7.1.5"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
@@ -45663,7 +46693,7 @@ in
           sources."mimic-response-1.0.1"
         ];
       })
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       (sources."gulp-vinyl-zip-2.1.2" // {
         dependencies = [
           sources."readable-stream-2.3.6"
@@ -45672,7 +46702,7 @@ in
           sources."through2-2.0.5"
         ];
       })
-      sources."handlebars-4.2.1"
+      sources."handlebars-4.4.5"
       sources."has-symbols-1.0.0"
       sources."http-cache-semantics-4.0.3"
       sources."ignore-5.1.4"
@@ -45693,7 +46723,7 @@ in
       sources."js-yaml-3.13.1"
       sources."json-buffer-3.0.0"
       sources."json-stable-stringify-without-jsonify-1.0.1"
-      sources."json5-2.1.0"
+      sources."json5-2.1.1"
       sources."jsonfile-4.0.0"
       sources."keyv-3.1.0"
       (sources."lazystream-1.0.0" // {
@@ -45723,7 +46753,7 @@ in
       sources."neo-async-2.6.1"
       sources."nick-0.1.3"
       sources."normalize-path-2.1.1"
-      sources."normalize-url-4.4.1"
+      sources."normalize-url-4.5.0"
       sources."now-and-later-2.0.1"
       sources."object-keys-1.1.1"
       sources."object.assign-4.1.0"
@@ -45812,7 +46842,7 @@ in
         ];
       })
       sources."to-utf8-0.0.1"
-      sources."uglify-js-3.6.0"
+      sources."uglify-js-3.6.6"
       sources."unc-path-regex-0.1.2"
       sources."unique-stream-2.3.1"
       sources."universalify-0.1.2"
@@ -45853,22 +46883,27 @@ in
   "@vue/cli" = nodeEnv.buildNodePackage {
     name = "_at_vue_slash_cli";
     packageName = "@vue/cli";
-    version = "3.11.0";
+    version = "4.0.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@vue/cli/-/cli-3.11.0.tgz";
-      sha512 = "dhnkqsg1TRyaauKl7j8b0n5N8vB1Vm6cBqU4n2Re0LeYzO4UUE6KlOAt1zTVn+5Nx45V1NAoPWff1iefPDTT8g==";
+      url = "https://registry.npmjs.org/@vue/cli/-/cli-4.0.5.tgz";
+      sha512 = "G13V2wlye7IClgO/S8j/QOjp1fBv7MEawTXqGBX/FqSajY4DPmzZRK0eoc6+IZQLmHSYAwmVZ242HE8YL1McAw==";
     };
     dependencies = [
       sources."@akryum/winattr-3.0.0"
+      sources."@apollo/federation-0.10.2"
       sources."@apollographql/apollo-tools-0.4.0"
+      sources."@apollographql/graphql-language-service-interface-2.0.2"
+      sources."@apollographql/graphql-language-service-parser-2.0.2"
+      sources."@apollographql/graphql-language-service-types-2.0.2"
+      sources."@apollographql/graphql-language-service-utils-2.0.2"
       sources."@apollographql/graphql-playground-html-1.6.24"
       sources."@babel/code-frame-7.5.5"
-      (sources."@babel/core-7.6.0" // {
+      (sources."@babel/core-7.6.4" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
       })
-      sources."@babel/generator-7.6.0"
+      sources."@babel/generator-7.6.4"
       sources."@babel/helper-annotate-as-pure-7.0.0"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.1.0"
       sources."@babel/helper-call-delegate-7.4.4"
@@ -45889,16 +46924,16 @@ in
       sources."@babel/helper-simple-access-7.1.0"
       sources."@babel/helper-split-export-declaration-7.4.4"
       sources."@babel/helper-wrap-function-7.2.0"
-      sources."@babel/helpers-7.6.0"
+      sources."@babel/helpers-7.6.2"
       sources."@babel/highlight-7.5.0"
-      sources."@babel/parser-7.6.0"
+      sources."@babel/parser-7.6.4"
       sources."@babel/plugin-proposal-async-generator-functions-7.2.0"
       sources."@babel/plugin-proposal-class-properties-7.5.5"
       sources."@babel/plugin-proposal-dynamic-import-7.5.0"
       sources."@babel/plugin-proposal-json-strings-7.2.0"
-      sources."@babel/plugin-proposal-object-rest-spread-7.5.5"
+      sources."@babel/plugin-proposal-object-rest-spread-7.6.2"
       sources."@babel/plugin-proposal-optional-catch-binding-7.2.0"
-      sources."@babel/plugin-proposal-unicode-property-regex-7.4.4"
+      sources."@babel/plugin-proposal-unicode-property-regex-7.6.2"
       sources."@babel/plugin-syntax-async-generators-7.2.0"
       sources."@babel/plugin-syntax-dynamic-import-7.2.0"
       sources."@babel/plugin-syntax-flow-7.2.0"
@@ -45909,14 +46944,14 @@ in
       sources."@babel/plugin-transform-arrow-functions-7.2.0"
       sources."@babel/plugin-transform-async-to-generator-7.5.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.2.0"
-      sources."@babel/plugin-transform-block-scoping-7.6.0"
+      sources."@babel/plugin-transform-block-scoping-7.6.3"
       sources."@babel/plugin-transform-classes-7.5.5"
       sources."@babel/plugin-transform-computed-properties-7.2.0"
       sources."@babel/plugin-transform-destructuring-7.6.0"
-      sources."@babel/plugin-transform-dotall-regex-7.4.4"
+      sources."@babel/plugin-transform-dotall-regex-7.6.2"
       sources."@babel/plugin-transform-duplicate-keys-7.5.0"
       sources."@babel/plugin-transform-exponentiation-operator-7.2.0"
-      sources."@babel/plugin-transform-flow-strip-types-7.4.4"
+      sources."@babel/plugin-transform-flow-strip-types-7.6.3"
       sources."@babel/plugin-transform-for-of-7.4.4"
       sources."@babel/plugin-transform-function-name-7.4.4"
       sources."@babel/plugin-transform-literals-7.2.0"
@@ -45925,7 +46960,7 @@ in
       sources."@babel/plugin-transform-modules-commonjs-7.6.0"
       sources."@babel/plugin-transform-modules-systemjs-7.5.0"
       sources."@babel/plugin-transform-modules-umd-7.2.0"
-      sources."@babel/plugin-transform-named-capturing-groups-regex-7.6.0"
+      sources."@babel/plugin-transform-named-capturing-groups-regex-7.6.3"
       sources."@babel/plugin-transform-new-target-7.4.4"
       sources."@babel/plugin-transform-object-super-7.5.5"
       sources."@babel/plugin-transform-parameters-7.4.4"
@@ -45933,30 +46968,80 @@ in
       sources."@babel/plugin-transform-regenerator-7.4.5"
       sources."@babel/plugin-transform-reserved-words-7.2.0"
       sources."@babel/plugin-transform-shorthand-properties-7.2.0"
-      sources."@babel/plugin-transform-spread-7.2.2"
+      sources."@babel/plugin-transform-spread-7.6.2"
       sources."@babel/plugin-transform-sticky-regex-7.2.0"
       sources."@babel/plugin-transform-template-literals-7.4.4"
       sources."@babel/plugin-transform-typeof-symbol-7.2.0"
-      sources."@babel/plugin-transform-typescript-7.6.0"
-      sources."@babel/plugin-transform-unicode-regex-7.4.4"
-      (sources."@babel/preset-env-7.6.0" // {
+      sources."@babel/plugin-transform-typescript-7.6.3"
+      sources."@babel/plugin-transform-unicode-regex-7.6.2"
+      (sources."@babel/preset-env-7.6.3" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
       })
       sources."@babel/preset-flow-7.0.0"
       sources."@babel/preset-typescript-7.6.0"
-      sources."@babel/register-7.6.0"
+      sources."@babel/register-7.6.2"
+      (sources."@babel/runtime-7.6.3" // {
+        dependencies = [
+          sources."regenerator-runtime-0.13.3"
+        ];
+      })
       sources."@babel/template-7.6.0"
-      sources."@babel/traverse-7.6.0"
-      sources."@babel/types-7.6.1"
+      sources."@babel/traverse-7.6.3"
+      sources."@babel/types-7.6.3"
+      sources."@endemolshinegroup/cosmiconfig-typescript-loader-1.0.1"
       sources."@hapi/address-2.1.2"
       sources."@hapi/bourne-1.3.2"
-      sources."@hapi/hoek-8.2.4"
+      sources."@hapi/hoek-8.5.0"
       sources."@hapi/joi-15.1.1"
-      sources."@hapi/topo-3.1.4"
+      sources."@hapi/topo-3.1.6"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
+      sources."@oclif/color-0.0.0"
+      (sources."@oclif/command-1.5.19" // {
+        dependencies = [
+          sources."semver-5.7.1"
+        ];
+      })
+      sources."@oclif/config-1.13.3"
+      (sources."@oclif/errors-1.2.2" // {
+        dependencies = [
+          sources."clean-stack-1.3.0"
+          sources."indent-string-3.2.0"
+        ];
+      })
+      sources."@oclif/linewrap-1.0.0"
+      sources."@oclif/parser-3.8.4"
+      (sources."@oclif/plugin-autocomplete-0.1.4" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."fs-extra-6.0.1"
+        ];
+      })
+      (sources."@oclif/plugin-help-2.2.1" // {
+        dependencies = [
+          sources."indent-string-3.2.0"
+          sources."string-width-3.1.0"
+        ];
+      })
+      sources."@oclif/plugin-not-found-1.2.3"
+      (sources."@oclif/plugin-plugins-1.7.8" // {
+        dependencies = [
+          sources."cli-ux-5.3.3"
+          sources."indent-string-3.2.0"
+          sources."npm-run-path-3.1.0"
+          sources."path-key-3.1.0"
+          sources."semver-5.7.1"
+          sources."string-width-3.1.0"
+        ];
+      })
+      (sources."@oclif/plugin-warn-if-update-available-1.7.0" // {
+        dependencies = [
+          sources."semver-5.7.1"
+        ];
+      })
+      sources."@oclif/screen-1.0.4"
       sources."@protobufjs/aspromise-1.1.2"
       sources."@protobufjs/base64-1.1.2"
       sources."@protobufjs/codegen-2.0.4"
@@ -45967,76 +47052,89 @@ in
       sources."@protobufjs/path-1.1.2"
       sources."@protobufjs/pool-1.1.0"
       sources."@protobufjs/utf8-1.1.0"
+      sources."@samverschueren/stream-to-observable-0.3.0"
       sources."@types/accepts-1.3.5"
       sources."@types/body-parser-1.17.1"
       sources."@types/connect-3.4.32"
-      sources."@types/cookies-0.7.3"
+      sources."@types/cookies-0.7.4"
       sources."@types/cors-2.8.6"
       sources."@types/events-3.0.0"
       sources."@types/express-4.17.1"
-      sources."@types/express-serve-static-core-4.16.9"
+      sources."@types/express-serve-static-core-4.16.10"
       sources."@types/fs-capacitor-2.0.0"
+      sources."@types/fs-extra-5.1.0"
       sources."@types/glob-7.1.1"
       sources."@types/graphql-upload-8.0.3"
       sources."@types/http-assert-1.5.1"
       sources."@types/keygrip-1.0.1"
-      sources."@types/koa-2.0.49"
+      sources."@types/koa-2.0.51"
       sources."@types/koa-compose-3.2.4"
       sources."@types/long-4.0.0"
       sources."@types/mime-2.0.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.7.5"
+      sources."@types/node-12.12.3"
       sources."@types/range-parser-1.2.3"
       sources."@types/serve-static-1.13.3"
       sources."@types/ws-6.0.3"
       sources."@types/zen-observable-0.8.0"
-      sources."@vue/cli-shared-utils-3.11.0"
-      (sources."@vue/cli-ui-3.11.0" // {
+      sources."@vue/cli-shared-utils-4.0.5"
+      (sources."@vue/cli-ui-4.0.5" // {
         dependencies = [
           sources."clone-2.1.2"
         ];
       })
-      sources."@vue/cli-ui-addon-webpack-3.11.0"
-      sources."@vue/cli-ui-addon-widgets-3.11.0"
+      sources."@vue/cli-ui-addon-webpack-4.0.5"
+      sources."@vue/cli-ui-addon-widgets-4.0.5"
       sources."@wry/context-0.4.4"
       sources."@wry/equality-0.1.9"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
-      sources."aggregate-error-3.0.0"
+      sources."aggregate-error-3.0.1"
       sources."ajv-6.10.2"
       sources."ansi-align-2.0.0"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
+      sources."ansicolors-0.3.2"
+      sources."any-observable-0.3.0"
       (sources."anymatch-2.0.0" // {
         dependencies = [
           sources."normalize-path-2.1.1"
         ];
       })
+      sources."apollo-2.21.0"
       sources."apollo-cache-1.3.2"
-      sources."apollo-cache-control-0.8.4"
+      sources."apollo-cache-control-0.8.5"
       sources."apollo-cache-inmemory-1.6.3"
       sources."apollo-client-2.6.4"
+      sources."apollo-codegen-core-0.35.7"
+      sources."apollo-codegen-flow-0.33.32"
+      sources."apollo-codegen-scala-0.34.32"
+      sources."apollo-codegen-swift-0.35.12"
+      sources."apollo-codegen-typescript-0.35.7"
       sources."apollo-datasource-0.6.3"
-      sources."apollo-engine-reporting-1.4.6"
-      sources."apollo-engine-reporting-protobuf-0.4.0"
+      sources."apollo-engine-reporting-1.4.7"
+      sources."apollo-engine-reporting-protobuf-0.4.1"
       sources."apollo-env-0.5.1"
-      sources."apollo-graphql-0.3.3"
+      sources."apollo-graphql-0.3.4"
+      sources."apollo-language-server-1.17.0"
       sources."apollo-link-1.2.13"
       sources."apollo-link-context-1.0.19"
+      sources."apollo-link-error-1.1.12"
+      sources."apollo-link-http-1.5.16"
       sources."apollo-link-http-common-0.2.15"
       sources."apollo-link-persisted-queries-0.2.2"
       sources."apollo-link-state-0.4.2"
       sources."apollo-link-ws-1.0.19"
       sources."apollo-server-caching-0.5.0"
-      sources."apollo-server-core-2.9.3"
+      sources."apollo-server-core-2.9.7"
       sources."apollo-server-env-2.4.3"
-      sources."apollo-server-errors-2.3.3"
-      sources."apollo-server-express-2.9.3"
-      sources."apollo-server-plugin-base-0.6.4"
-      sources."apollo-server-types-0.2.4"
-      sources."apollo-tracing-0.8.4"
-      sources."apollo-upload-client-10.0.1"
+      sources."apollo-server-errors-2.3.4"
+      sources."apollo-server-express-2.9.7"
+      sources."apollo-server-plugin-base-0.6.5"
+      sources."apollo-server-types-0.2.5"
+      sources."apollo-tracing-0.8.5"
+      sources."apollo-upload-client-11.0.0"
       sources."apollo-utilities-1.3.2"
       sources."arg-4.1.1"
       sources."argparse-1.0.10"
@@ -46051,17 +47149,30 @@ in
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."assign-symbols-1.0.0"
-      sources."ast-types-0.11.7"
-      sources."async-1.5.2"
+      sources."ast-types-0.13.2"
+      sources."astral-regex-1.0.0"
+      sources."async-2.6.3"
       sources."async-each-1.0.3"
       sources."async-limiter-1.0.1"
       sources."async-retry-1.2.3"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
+      sources."await-to-js-2.1.1"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."babel-core-7.0.0-bridge.0"
       sources."babel-plugin-dynamic-import-node-2.3.0"
+      (sources."babel-polyfill-6.26.0" // {
+        dependencies = [
+          sources."core-js-2.6.10"
+        ];
+      })
+      (sources."babel-runtime-6.26.0" // {
+        dependencies = [
+          sources."core-js-2.6.10"
+          sources."regenerator-runtime-0.11.1"
+        ];
+      })
       sources."backo2-1.0.2"
       sources."balanced-match-1.0.0"
       (sources."base-0.11.2" // {
@@ -46078,13 +47189,30 @@ in
           sources."debug-2.6.9"
           sources."http-errors-1.7.2"
           sources."inherits-2.0.3"
+          sources."ms-2.0.0"
         ];
       })
       sources."boolbase-1.0.0"
-      sources."boxen-1.3.0"
+      (sources."boxen-4.1.0" // {
+        dependencies = [
+          (sources."ansi-align-3.0.0" // {
+            dependencies = [
+              sources."string-width-3.1.0"
+            ];
+          })
+          sources."camelcase-5.3.1"
+          sources."cli-boxes-2.2.0"
+          sources."emoji-regex-8.0.0"
+          sources."is-fullwidth-code-point-3.0.0"
+          sources."string-width-4.1.0"
+          sources."term-size-2.1.0"
+          sources."type-fest-0.5.2"
+          sources."widest-line-3.1.0"
+        ];
+      })
       sources."brace-expansion-1.1.11"
       sources."braces-2.3.2"
-      sources."browserslist-4.7.0"
+      sources."browserslist-4.7.2"
       sources."buffer-5.4.3"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
@@ -46093,15 +47221,22 @@ in
       sources."buffer-from-1.1.1"
       sources."builtins-1.0.3"
       sources."busboy-0.3.1"
+      sources."byline-5.0.0"
       sources."bytes-3.1.0"
       sources."cache-base-1.0.1"
       sources."call-me-maybe-1.0.1"
+      sources."caller-callsite-2.0.0"
+      sources."caller-path-2.0.0"
+      sources."callsites-2.0.0"
+      sources."camel-case-3.0.0"
       sources."camelcase-4.1.0"
-      sources."caniuse-lite-1.0.30000989"
+      sources."caniuse-lite-1.0.30001006"
       sources."capture-stack-trace-1.0.1"
+      sources."cardinal-2.1.1"
       sources."caseless-0.12.0"
       sources."caw-2.0.1"
       sources."chalk-2.4.2"
+      sources."change-case-3.1.0"
       sources."chardet-0.7.0"
       sources."cheerio-1.0.0-rc.3"
       sources."chokidar-2.1.8"
@@ -46127,36 +47262,53 @@ in
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
       sources."cli-spinners-2.2.0"
+      (sources."cli-truncate-0.2.1" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          sources."is-fullwidth-code-point-1.0.0"
+          sources."string-width-1.0.2"
+          sources."strip-ansi-3.0.1"
+        ];
+      })
+      (sources."cli-ux-4.9.3" // {
+        dependencies = [
+          sources."indent-string-3.2.0"
+          sources."semver-5.7.1"
+        ];
+      })
       sources."cli-width-2.2.0"
       sources."clipboard-2.0.4"
       sources."clone-1.0.4"
       sources."cmd-shim-2.1.0"
+      sources."code-point-at-1.1.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."colors-1.4.0"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
+      sources."common-tags-1.8.0"
       sources."commondir-1.0.1"
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
       sources."config-chain-1.1.12"
       sources."configstore-3.1.2"
+      sources."constant-case-2.0.0"
       sources."content-disposition-0.5.3"
       sources."content-type-1.0.4"
       sources."convert-source-map-1.6.0"
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-3.2.1"
-      sources."core-js-compat-3.2.1"
+      sources."core-js-3.3.6"
+      sources."core-js-compat-3.3.6"
       sources."core-util-is-1.0.2"
       sources."cors-2.8.5"
+      sources."cosmiconfig-5.2.1"
       sources."create-error-class-3.0.2"
       (sources."cross-spawn-5.1.0" // {
         dependencies = [
           sources."lru-cache-4.1.5"
-          sources."yallist-2.1.2"
         ];
       })
       sources."crypto-random-string-1.0.0"
@@ -46164,12 +47316,9 @@ in
       sources."css-what-2.1.3"
       sources."csv-parser-1.12.1"
       sources."dashdash-1.14.1"
+      sources."date-fns-1.30.1"
       sources."de-indent-1.0.2"
-      (sources."debug-4.1.1" // {
-        dependencies = [
-          sources."ms-2.1.2"
-        ];
-      })
+      sources."debug-4.1.1"
       sources."decode-uri-component-0.2.0"
       (sources."decompress-4.2.0" // {
         dependencies = [
@@ -46209,7 +47358,9 @@ in
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
       sources."domutils-1.5.1"
+      sources."dot-case-2.1.1"
       sources."dot-prop-4.2.0"
+      sources."dotenv-8.2.0"
       (sources."download-5.0.3" // {
         dependencies = [
           sources."pify-2.3.0"
@@ -46221,12 +47372,16 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."ejs-2.7.1"
-      sources."electron-to-chromium-1.3.264"
+      sources."electron-to-chromium-1.3.298"
+      sources."elegant-spinner-1.0.1"
+      sources."emoji-regex-7.0.3"
       sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
-      sources."envinfo-7.3.1"
-      sources."es-abstract-1.14.2"
+      sources."env-ci-3.2.2"
+      sources."envinfo-7.4.0"
+      sources."error-ex-1.3.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
@@ -46260,12 +47415,14 @@ in
           })
           sources."is-descriptor-0.1.6"
           sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
         ];
       })
       sources."expand-tilde-2.0.2"
       (sources."express-4.17.1" // {
         dependencies = [
           sources."debug-2.6.9"
+          sources."ms-2.0.0"
         ];
       })
       sources."express-history-api-fallback-2.2.1"
@@ -46278,12 +47435,14 @@ in
         ];
       })
       sources."extract-files-5.0.1"
+      sources."extract-stack-1.0.0"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-2.0.1"
       sources."fast-glob-2.2.7"
       sources."fast-json-stable-stringify-2.0.0"
+      sources."fast-levenshtein-2.0.6"
       sources."fd-slicer-1.1.0"
-      sources."figures-2.0.0"
+      sources."figures-1.7.0"
       sources."file-type-5.2.0"
       sources."filename-reserved-regex-2.0.0"
       sources."filenamify-2.1.0"
@@ -46291,6 +47450,7 @@ in
       (sources."finalhandler-1.1.2" // {
         dependencies = [
           sources."debug-2.6.9"
+          sources."ms-2.0.0"
         ];
       })
       (sources."find-cache-dir-2.1.0" // {
@@ -46302,7 +47462,7 @@ in
       })
       sources."find-up-3.0.0"
       sources."fkill-6.2.0"
-      sources."flow-parser-0.108.0"
+      sources."flow-parser-0.111.0"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -46318,6 +47478,7 @@ in
       sources."fsevents-1.2.9"
       sources."fswin-2.17.1227"
       sources."function-bind-1.1.1"
+      sources."gaze-1.1.3"
       sources."generate-function-1.1.0"
       sources."generate-object-property-1.2.0"
       sources."get-proxy-2.1.0"
@@ -46326,6 +47487,12 @@ in
       sources."getpass-0.1.7"
       sources."git-clone-0.1.0"
       sources."git-config-path-1.0.1"
+      sources."git-parse-1.0.3"
+      (sources."git-rev-sync-1.12.0" // {
+        dependencies = [
+          sources."graceful-fs-4.1.11"
+        ];
+      })
       sources."glob-7.1.4"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
@@ -46338,28 +47505,35 @@ in
       (sources."globby-9.2.0" // {
         dependencies = [
           sources."pify-4.0.1"
+          sources."slash-2.0.0"
         ];
       })
+      sources."globule-1.2.1"
       sources."good-listener-1.2.2"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."graceful-readlink-1.0.1"
-      sources."graphql-14.5.7"
+      sources."graphql-14.5.8"
       (sources."graphql-anywhere-4.2.4" // {
         dependencies = [
           sources."ts-invariant-0.3.3"
         ];
       })
-      sources."graphql-extensions-0.10.3"
+      sources."graphql-extensions-0.10.4"
       sources."graphql-subscriptions-1.1.0"
       sources."graphql-tag-2.10.1"
-      sources."graphql-tools-4.0.5"
-      sources."graphql-type-json-0.2.4"
-      sources."graphql-upload-8.0.7"
+      sources."graphql-tools-4.0.6"
+      sources."graphql-type-json-0.3.0"
+      sources."graphql-upload-8.1.0"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
+      (sources."has-ansi-2.0.0" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+        ];
+      })
       sources."has-flag-3.0.0"
       sources."has-symbol-support-x-1.4.2"
       sources."has-symbols-1.0.0"
@@ -46372,30 +47546,46 @@ in
       })
       sources."hash.js-1.1.7"
       sources."he-1.2.0"
+      sources."header-case-1.0.1"
       sources."homedir-polyfill-1.0.3"
       (sources."htmlparser2-3.10.1" // {
         dependencies = [
           sources."readable-stream-3.4.0"
         ];
       })
+      (sources."http-call-5.2.5" // {
+        dependencies = [
+          sources."is-stream-2.0.0"
+        ];
+      })
       sources."http-errors-1.7.3"
       sources."http-signature-1.2.0"
+      sources."human-signals-1.1.1"
+      sources."hyperlinker-1.0.0"
       sources."iconv-lite-0.4.24"
       sources."ieee754-1.1.13"
       sources."ignore-4.0.6"
       sources."ignore-by-default-1.0.1"
+      sources."import-fresh-2.0.0"
       sources."import-global-0.1.0"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
-      sources."indent-string-3.2.0"
+      sources."indent-string-4.0.0"
+      sources."inflected-2.0.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      sources."inquirer-6.5.2"
+      (sources."inquirer-6.5.2" // {
+        dependencies = [
+          sources."figures-2.0.0"
+        ];
+      })
+      sources."interpret-1.2.0"
       sources."into-stream-2.0.1"
       sources."invariant-2.2.4"
       sources."ipaddr.js-1.9.0"
       sources."is-accessor-descriptor-1.0.0"
+      sources."is-arrayish-0.2.1"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
       sources."is-callable-1.1.4"
@@ -46403,11 +47593,13 @@ in
       sources."is-data-descriptor-1.0.0"
       sources."is-date-object-1.0.1"
       sources."is-descriptor-1.0.2"
+      sources."is-directory-0.3.1"
       sources."is-extendable-0.1.1"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
       sources."is-installed-globally-0.1.0"
+      sources."is-lower-case-1.1.3"
       sources."is-natural-number-4.0.1"
       sources."is-npm-1.0.0"
       (sources."is-number-3.0.0" // {
@@ -46417,6 +47609,7 @@ in
       })
       sources."is-obj-1.0.1"
       sources."is-object-1.0.1"
+      sources."is-observable-1.1.0"
       sources."is-path-inside-1.0.1"
       sources."is-plain-object-2.0.4"
       sources."is-promise-2.1.0"
@@ -46427,6 +47620,7 @@ in
       sources."is-stream-1.1.0"
       sources."is-symbol-1.0.2"
       sources."is-typedarray-1.0.0"
+      sources."is-upper-case-1.1.2"
       sources."is-windows-1.0.2"
       sources."is-wsl-1.1.0"
       sources."isarray-1.0.0"
@@ -46436,6 +47630,7 @@ in
       sources."isstream-0.1.2"
       sources."isurl-1.0.0"
       sources."iterall-1.2.2"
+      sources."java-properties-1.0.2"
       sources."javascript-stringify-1.6.0"
       sources."js-levenshtein-1.1.6"
       sources."js-message-1.0.5"
@@ -46445,31 +47640,77 @@ in
       sources."jsbn-0.1.1"
       (sources."jscodeshift-0.6.4" // {
         dependencies = [
+          sources."ast-types-0.11.7"
           sources."recast-0.16.2"
           sources."source-map-0.6.1"
         ];
       })
       sources."jsesc-2.5.2"
+      sources."json-parse-better-errors-1.0.2"
       sources."json-schema-0.2.3"
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
-      sources."json5-2.1.0"
+      sources."json5-2.1.1"
       sources."jsonfile-4.0.0"
       sources."jsprim-1.4.1"
       sources."kind-of-6.0.2"
       sources."latest-version-3.1.0"
       sources."launch-editor-2.2.1"
+      sources."listr-0.14.3"
+      sources."listr-silent-renderer-1.1.1"
+      (sources."listr-update-renderer-0.5.0" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          sources."ansi-styles-2.2.1"
+          sources."chalk-1.1.3"
+          sources."indent-string-3.2.0"
+          sources."log-symbols-1.0.2"
+          sources."strip-ansi-3.0.1"
+          sources."supports-color-2.0.0"
+        ];
+      })
+      (sources."listr-verbose-renderer-0.5.0" // {
+        dependencies = [
+          sources."figures-2.0.0"
+        ];
+      })
+      (sources."load-json-file-5.3.0" // {
+        dependencies = [
+          sources."pify-4.0.1"
+        ];
+      })
       sources."locate-path-3.0.0"
       sources."lodash-4.17.15"
+      sources."lodash._reinterpolate-3.0.0"
       sources."lodash.clonedeep-4.5.0"
+      sources."lodash.debounce-4.0.8"
+      sources."lodash.get-4.4.2"
+      sources."lodash.identity-3.0.0"
       sources."lodash.merge-4.6.2"
+      sources."lodash.pickby-4.6.0"
       sources."lodash.sortby-4.7.0"
+      sources."lodash.template-4.5.0"
+      sources."lodash.templatesettings-4.2.0"
+      sources."lodash.xorby-4.7.0"
       sources."log-symbols-2.2.0"
+      (sources."log-update-2.3.0" // {
+        dependencies = [
+          sources."ansi-regex-3.0.0"
+          sources."strip-ansi-4.0.0"
+          sources."wrap-ansi-3.0.1"
+        ];
+      })
       sources."long-4.0.0"
       sources."loose-envify-1.4.0"
       sources."lowdb-1.0.0"
+      sources."lower-case-1.1.4"
+      sources."lower-case-first-1.0.2"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-5.1.1"
+      (sources."lru-cache-5.1.1" // {
+        dependencies = [
+          sources."yallist-3.1.1"
+        ];
+      })
       sources."make-dir-1.3.0"
       sources."make-error-1.3.5"
       sources."map-cache-0.2.2"
@@ -46477,6 +47718,7 @@ in
       sources."media-typer-0.3.0"
       sources."merge-1.2.1"
       sources."merge-descriptors-1.0.1"
+      sources."merge-stream-2.0.0"
       sources."merge2-1.3.0"
       sources."methods-1.1.2"
       (sources."micromatch-3.1.10" // {
@@ -46502,16 +47744,18 @@ in
           sources."minimist-0.0.8"
         ];
       })
-      sources."ms-2.0.0"
+      sources."moment-2.24.0"
+      sources."ms-2.1.2"
       sources."mute-stream-0.0.7"
       sources."nan-2.14.0"
-      sources."nanoid-2.1.1"
+      sources."nanoid-2.1.6"
       (sources."nanomatch-1.2.13" // {
         dependencies = [
           sources."extend-shallow-3.0.2"
           sources."is-extendable-1.0.1"
         ];
       })
+      sources."natural-orderby-2.0.3"
       sources."ndjson-1.5.0"
       (sources."neat-csv-2.1.0" // {
         dependencies = [
@@ -46521,6 +47765,7 @@ in
       sources."negotiator-0.6.2"
       sources."neo-async-2.6.1"
       sources."nice-try-1.0.5"
+      sources."no-case-2.3.2"
       sources."node-dir-0.1.17"
       sources."node-fetch-2.6.0"
       sources."node-ipc-9.1.1"
@@ -46530,15 +47775,10 @@ in
           sources."semver-5.7.1"
         ];
       })
-      (sources."node-releases-1.1.32" // {
-        dependencies = [
-          sources."semver-5.7.1"
-        ];
-      })
-      (sources."nodemon-1.19.2" // {
+      sources."node-releases-1.1.39"
+      (sources."nodemon-1.19.4" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.2"
           sources."semver-5.7.1"
         ];
       })
@@ -46547,6 +47787,7 @@ in
       sources."npm-conf-1.1.3"
       sources."npm-run-path-2.0.2"
       sources."nth-check-1.0.2"
+      sources."number-is-nan-1.0.1"
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
       (sources."object-copy-0.1.0" // {
@@ -46579,17 +47820,28 @@ in
       sources."p-finally-1.0.0"
       sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
+      sources."p-map-2.1.0"
       sources."p-try-2.2.0"
       (sources."package-json-4.0.1" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
       })
+      sources."param-case-2.1.1"
       sources."parse-git-config-2.0.3"
+      sources."parse-json-4.0.0"
       sources."parse-passwd-1.0.0"
       sources."parse5-3.0.3"
       sources."parseurl-1.3.3"
+      sources."pascal-case-2.0.1"
       sources."pascalcase-0.1.1"
+      (sources."password-prompt-1.1.2" // {
+        dependencies = [
+          sources."cross-spawn-6.0.5"
+          sources."semver-5.7.1"
+        ];
+      })
+      sources."path-case-2.1.1"
       sources."path-dirname-1.0.2"
       sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
@@ -46610,9 +47862,9 @@ in
       sources."pinkie-promise-2.0.1"
       sources."pirates-4.0.1"
       sources."pkg-dir-3.0.0"
-      (sources."portfinder-1.0.24" // {
+      (sources."portfinder-1.0.25" // {
         dependencies = [
-          sources."debug-2.6.9"
+          sources."debug-3.2.6"
         ];
       })
       sources."posix-character-classes-0.1.1"
@@ -46624,7 +47876,7 @@ in
       sources."proto-list-1.2.4"
       (sources."protobufjs-6.8.8" // {
         dependencies = [
-          sources."@types/node-10.14.18"
+          sources."@types/node-10.17.2"
         ];
       })
       sources."proxy-addr-2.0.5"
@@ -46645,14 +47897,16 @@ in
       sources."rc-1.2.8"
       sources."readable-stream-2.3.6"
       sources."readdirp-2.2.1"
-      (sources."recast-0.17.6" // {
+      (sources."recast-0.18.5" // {
         dependencies = [
-          sources."ast-types-0.12.4"
           sources."source-map-0.6.1"
         ];
       })
+      sources."rechoir-0.6.2"
+      sources."redeyed-2.1.1"
       sources."regenerate-1.4.0"
       sources."regenerate-unicode-properties-8.1.0"
+      sources."regenerator-runtime-0.10.5"
       sources."regenerator-transform-0.14.1"
       (sources."regex-not-1.0.2" // {
         dependencies = [
@@ -46660,11 +47914,10 @@ in
           sources."is-extendable-1.0.1"
         ];
       })
-      sources."regexp-tree-0.1.13"
       sources."regexpu-core-4.6.0"
       sources."registry-auth-token-3.4.0"
       sources."registry-url-3.1.0"
-      sources."regjsgen-0.5.0"
+      sources."regjsgen-0.5.1"
       (sources."regjsparser-0.6.0" // {
         dependencies = [
           sources."jsesc-0.5.0"
@@ -46681,12 +47934,13 @@ in
       sources."request-promise-core-1.1.2"
       sources."request-promise-native-1.0.7"
       sources."resolve-1.12.0"
+      sources."resolve-from-3.0.0"
       sources."resolve-url-0.2.1"
       sources."restore-cursor-2.0.0"
       sources."ret-0.1.15"
       sources."retry-0.12.0"
       sources."rimraf-2.7.1"
-      sources."rss-parser-3.7.2"
+      sources."rss-parser-3.7.3"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.3"
       sources."safe-buffer-5.1.2"
@@ -46716,6 +47970,7 @@ in
           sources."ms-2.1.1"
         ];
       })
+      sources."sentence-case-2.1.1"
       sources."serve-static-1.14.1"
       sources."set-value-2.0.1"
       sources."setprototypeof-1.1.1"
@@ -46723,10 +47978,13 @@ in
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."shell-quote-1.7.2"
+      sources."shelljs-0.7.7"
       sources."shellwords-0.1.1"
       sources."shortid-2.2.15"
       sources."signal-exit-3.0.2"
-      sources."slash-2.0.0"
+      sources."slash-3.0.0"
+      sources."slice-ansi-0.0.4"
+      sources."snake-case-2.1.0"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
           sources."debug-2.6.9"
@@ -46743,6 +48001,7 @@ in
           })
           sources."is-descriptor-0.1.6"
           sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
         ];
       })
       (sources."snapdragon-node-2.1.1" // {
@@ -46757,7 +48016,7 @@ in
       })
       sources."source-map-0.5.7"
       sources."source-map-resolve-0.5.2"
-      (sources."source-map-support-0.5.13" // {
+      (sources."source-map-support-0.5.16" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -46804,8 +48063,10 @@ in
       sources."string.prototype.trimright-2.1.0"
       sources."string_decoder-1.1.1"
       sources."strip-ansi-5.2.0"
+      sources."strip-bom-3.0.0"
       sources."strip-dirs-2.1.0"
       sources."strip-eof-1.0.0"
+      sources."strip-final-newline-2.0.0"
       sources."strip-json-comments-2.0.1"
       sources."strip-outer-1.0.1"
       (sources."subscriptions-transport-ws-0.9.16" // {
@@ -46814,7 +48075,19 @@ in
         ];
       })
       sources."supports-color-5.5.0"
+      (sources."supports-hyperlinks-1.0.1" // {
+        dependencies = [
+          sources."has-flag-2.0.0"
+        ];
+      })
+      sources."swap-case-1.1.2"
       sources."symbol-observable-1.2.0"
+      (sources."table-5.4.6" // {
+        dependencies = [
+          sources."slice-ansi-2.1.0"
+          sources."string-width-3.1.0"
+        ];
+      })
       sources."tar-stream-1.6.2"
       sources."taskkill-3.0.0"
       (sources."tasklist-3.1.1" // {
@@ -46822,9 +48095,9 @@ in
           sources."pify-2.3.0"
         ];
       })
-      (sources."temp-0.8.3" // {
+      (sources."temp-0.8.4" // {
         dependencies = [
-          sources."rimraf-2.2.8"
+          sources."rimraf-2.6.3"
         ];
       })
       (sources."term-size-1.2.0" // {
@@ -46836,6 +48109,7 @@ in
       sources."through2-2.0.5"
       sources."timed-out-4.0.1"
       sources."tiny-emitter-2.1.0"
+      sources."title-case-2.1.1"
       sources."tmp-0.0.33"
       sources."to-buffer-1.1.1"
       sources."to-fast-properties-2.0.0"
@@ -46858,19 +48132,22 @@ in
           sources."punycode-1.4.1"
         ];
       })
+      sources."treeify-1.1.0"
       sources."trim-repeated-1.0.0"
-      sources."trim-right-1.0.1"
       sources."ts-invariant-0.4.4"
       sources."ts-node-8.4.1"
       sources."tslib-1.10.0"
+      sources."tty-1.0.1"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
+      sources."type-fest-0.3.1"
       sources."type-is-1.6.18"
-      sources."typescript-3.6.3"
+      sources."typescript-3.6.4"
       sources."unbzip2-stream-1.3.3"
       (sources."undefsafe-2.0.2" // {
         dependencies = [
           sources."debug-2.6.9"
+          sources."ms-2.0.0"
         ];
       })
       sources."unicode-canonical-property-names-ecmascript-1.0.4"
@@ -46893,7 +48170,13 @@ in
       })
       sources."unzip-response-2.0.1"
       sources."upath-1.2.0"
-      sources."update-notifier-2.5.0"
+      (sources."update-notifier-2.5.0" // {
+        dependencies = [
+          sources."boxen-1.3.0"
+        ];
+      })
+      sources."upper-case-1.1.3"
+      sources."upper-case-first-1.1.2"
       sources."uri-js-4.2.2"
       sources."urix-0.1.0"
       sources."url-parse-lax-1.0.0"
@@ -46906,18 +48189,46 @@ in
       sources."validate-npm-package-name-3.0.0"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
-      sources."vue-cli-plugin-apollo-0.20.0"
-      (sources."vue-jscodeshift-adapter-2.0.2" // {
+      sources."vscode-jsonrpc-4.0.0"
+      sources."vscode-languageserver-5.2.1"
+      sources."vscode-languageserver-protocol-3.14.1"
+      sources."vscode-languageserver-types-3.14.0"
+      sources."vscode-uri-1.0.6"
+      (sources."vue-cli-plugin-apollo-0.21.3" // {
         dependencies = [
-          sources."indent-string-4.0.0"
+          sources."cross-spawn-7.0.1"
+          sources."deepmerge-4.2.2"
+          sources."execa-3.2.0"
+          sources."fs-extra-8.1.0"
+          sources."get-stream-5.1.0"
+          sources."is-stream-2.0.0"
+          sources."mimic-fn-2.1.0"
+          sources."npm-run-path-4.0.0"
+          sources."onetime-5.1.0"
+          sources."p-finally-2.0.1"
+          sources."path-key-3.1.0"
+          sources."shebang-command-2.0.0"
+          sources."shebang-regex-3.0.0"
+          sources."which-2.0.1"
         ];
       })
-      sources."vue-sfc-descriptor-to-string-1.0.0"
+      sources."vue-jscodeshift-adapter-2.0.2"
+      (sources."vue-sfc-descriptor-to-string-1.0.0" // {
+        dependencies = [
+          sources."indent-string-3.2.0"
+        ];
+      })
       sources."vue-template-compiler-2.6.10"
       sources."watch-1.0.2"
       sources."wcwidth-1.0.1"
       sources."which-1.3.1"
       sources."widest-line-2.0.1"
+      (sources."wrap-ansi-4.0.0" // {
+        dependencies = [
+          sources."ansi-regex-3.0.0"
+          sources."strip-ansi-4.0.0"
+        ];
+      })
       sources."wrappy-1.0.2"
       sources."write-file-atomic-2.4.3"
       sources."ws-6.2.1"
@@ -46925,12 +48236,13 @@ in
       sources."xml2js-0.4.22"
       sources."xmlbuilder-11.0.1"
       sources."xtend-4.0.2"
-      sources."yallist-3.0.3"
+      sources."yallist-2.1.2"
       (sources."yaml-front-matter-3.4.1" // {
         dependencies = [
           sources."commander-1.0.0"
         ];
       })
+      sources."yarn-1.19.1"
       sources."yauzl-2.10.0"
       sources."yn-3.1.1"
       sources."zen-observable-0.8.14"
@@ -47071,11 +48383,11 @@ in
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
-      sources."@babel/generator-7.6.0"
+      sources."@babel/generator-7.6.4"
       sources."@babel/highlight-7.5.0"
-      sources."@babel/parser-7.6.0"
+      sources."@babel/parser-7.6.4"
       sources."@babel/template-7.6.0"
-      sources."@babel/types-7.6.1"
+      sources."@babel/types-7.6.3"
       sources."@webassemblyjs/ast-1.8.5"
       sources."@webassemblyjs/floating-point-hex-parser-1.8.5"
       sources."@webassemblyjs/helper-api-error-1.8.5"
@@ -47095,7 +48407,7 @@ in
       sources."chalk-2.4.2"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."escape-string-regexp-1.0.5"
       sources."esutils-2.0.3"
       sources."has-flag-3.0.0"
@@ -47106,7 +48418,6 @@ in
       sources."source-map-0.5.7"
       sources."supports-color-5.5.0"
       sources."to-fast-properties-2.0.0"
-      sources."trim-right-1.0.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -47157,12 +48468,12 @@ in
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
-      (sources."@babel/core-7.6.0" // {
+      (sources."@babel/core-7.6.4" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
       })
-      (sources."@babel/generator-7.6.0" // {
+      (sources."@babel/generator-7.6.4" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
@@ -47170,12 +48481,12 @@ in
       sources."@babel/helper-function-name-7.1.0"
       sources."@babel/helper-get-function-arity-7.0.0"
       sources."@babel/helper-split-export-declaration-7.4.4"
-      sources."@babel/helpers-7.6.0"
+      sources."@babel/helpers-7.6.2"
       sources."@babel/highlight-7.5.0"
-      sources."@babel/parser-7.6.0"
+      sources."@babel/parser-7.6.4"
       sources."@babel/template-7.6.0"
-      sources."@babel/traverse-7.6.0"
-      sources."@babel/types-7.6.1"
+      sources."@babel/traverse-7.6.3"
+      sources."@babel/types-7.6.3"
       sources."JSV-4.0.2"
       sources."ansi-styles-3.2.1"
       sources."array-unique-0.3.2"
@@ -47187,7 +48498,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."colors-1.4.0"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."concat-map-0.0.1"
       sources."convert-source-map-1.6.0"
       sources."debug-4.1.1"
@@ -47208,7 +48519,7 @@ in
         ];
       })
       sources."globals-11.12.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-color-0.1.7"
       sources."has-flag-3.0.0"
       sources."homedir-polyfill-1.0.3"
@@ -47218,7 +48529,7 @@ in
       sources."isexe-2.0.0"
       sources."js-tokens-4.0.0"
       sources."jsesc-2.5.2"
-      sources."json5-2.1.0"
+      sources."json5-2.1.1"
       sources."jsonfile-4.0.0"
       sources."jsonlint-1.6.2"
       sources."lodash-4.17.15"
@@ -47245,7 +48556,6 @@ in
       sources."strip-ansi-0.1.1"
       sources."supports-color-5.5.0"
       sources."to-fast-properties-2.0.0"
-      sources."trim-right-1.0.1"
       sources."underscore-1.6.0"
       sources."universalify-0.1.2"
       sources."walk-sync-0.3.4"
@@ -47274,14 +48584,14 @@ in
     };
     dependencies = [
       sources."balanced-match-1.0.0"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."brace-expansion-1.1.11"
       sources."chromium-pickle-js-0.2.0"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."concat-map-0.0.1"
       sources."cuint-0.2.2"
       sources."fs.realpath-1.0.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."minimatch-3.0.4"
@@ -47313,7 +48623,7 @@ in
       sha512 = "MMiK5sFfIocNMWCc5PshUCAe6aY4P13/GCmSwudOziA/pFdQMHU8jhu+jU2SSWFug4K1ugeuCwtMXe43oL0PhQ==";
     };
     dependencies = [
-      sources."@types/node-8.10.54"
+      sources."@types/node-8.10.58"
       sources."JSV-4.0.2"
       sources."adal-node-0.1.28"
       sources."ajv-6.10.2"
@@ -47477,7 +48787,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ecdsa-sig-formatter-1.0.11"
       sources."envconf-0.0.4"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-string-regexp-1.0.5"
       sources."event-stream-3.1.5"
@@ -47506,11 +48816,11 @@ in
         ];
       })
       sources."github-0.1.6"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."har-schema-2.0.0"
       (sources."har-validator-2.0.6" // {
         dependencies = [
-          sources."commander-2.20.0"
+          sources."commander-2.20.3"
         ];
       })
       sources."has-1.0.3"
@@ -47736,16 +49046,16 @@ in
   azure-functions-core-tools = nodeEnv.buildNodePackage {
     name = "azure-functions-core-tools";
     packageName = "azure-functions-core-tools";
-    version = "2.7.1585";
+    version = "2.7.1724";
     src = fetchurl {
-      url = "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-2.7.1585.tgz";
-      sha512 = "jxtiDsa1M5eMmXyjrkX8b2jl+7QKsjWifF8ralXI9DJYh1jJATUKGAPw56n5SJFbsxZlxxdxDoboOkgFP4aeog==";
+      url = "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-2.7.1724.tgz";
+      sha512 = "7RVxAkZbwpfkQbxVrq41kuLZHJ0hhoCgITYvcZoyl14aF2acRlm4jv8WP8vCkYZ+J1JmjTskxc9bs9foZFFHrg==";
     };
     dependencies = [
       sources."agent-base-4.3.0"
       sources."ansi-styles-3.2.1"
       sources."balanced-match-1.0.0"
-      sources."big-integer-1.6.45"
+      sources."big-integer-1.6.47"
       sources."binary-0.3.0"
       sources."bluebird-3.4.7"
       sources."brace-expansion-1.1.11"
@@ -47766,7 +49076,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."fstream-1.0.12"
       sources."glob-7.1.3"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
       sources."https-proxy-agent-2.2.1"
       sources."inflight-1.0.6"
@@ -47807,13 +49117,13 @@ in
   bash-language-server = nodeEnv.buildNodePackage {
     name = "bash-language-server";
     packageName = "bash-language-server";
-    version = "1.5.6";
+    version = "1.6.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/bash-language-server/-/bash-language-server-1.5.6.tgz";
-      sha512 = "GqW24myNihrUroXdL40AemizC3lBvr2wOiF0GzxYWqsBsJvi6CQor0Y9t10jOGn11evMhncmR2f2LoQdjsNpqw==";
+      url = "https://registry.npmjs.org/bash-language-server/-/bash-language-server-1.6.1.tgz";
+      sha512 = "i40MhENbRrfGEjhfwacQ0iBMX0WyhYou3AjPXa6C6RMvsuFu5J0LFwY4BjKOF2IFGZPaS6VgcffmfRvmD1TgRA==";
     };
     dependencies = [
-      sources."abab-2.0.1"
+      sources."abab-2.0.2"
       sources."acorn-5.7.3"
       (sources."acorn-globals-4.3.4" // {
         dependencies = [
@@ -47822,9 +49132,6 @@ in
       })
       sources."acorn-walk-6.2.0"
       sources."ajv-6.10.2"
-      sources."ansi-regex-2.1.1"
-      sources."aproba-1.2.0"
-      sources."are-we-there-yet-1.1.5"
       sources."array-equal-1.0.0"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
@@ -47834,42 +49141,28 @@ in
       sources."aws4-1.8.0"
       sources."balanced-match-1.0.0"
       sources."bcrypt-pbkdf-1.0.2"
-      (sources."bl-3.0.0" // {
-        dependencies = [
-          sources."readable-stream-3.4.0"
-        ];
-      })
       sources."brace-expansion-1.1.11"
       sources."browser-process-hrtime-0.1.3"
       sources."caseless-0.12.0"
-      sources."chownr-1.1.2"
-      sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.8"
       sources."concat-map-0.0.1"
-      sources."console-control-strings-1.1.0"
       sources."core-util-is-1.0.2"
       sources."cssom-0.3.8"
       sources."cssstyle-1.4.0"
       sources."dashdash-1.14.1"
       (sources."data-urls-1.1.0" // {
         dependencies = [
-          sources."whatwg-url-7.0.0"
+          sources."whatwg-url-7.1.0"
         ];
       })
-      sources."decompress-response-4.2.1"
-      sources."deep-extend-0.6.0"
       sources."deep-is-0.1.3"
       sources."delayed-stream-1.0.0"
-      sources."delegates-1.0.0"
-      sources."detect-libc-1.0.3"
       sources."domexception-1.0.1"
       sources."ecc-jsbn-0.1.2"
-      sources."end-of-stream-1.4.1"
       sources."escodegen-1.12.0"
       sources."esprima-3.1.3"
       sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
-      sources."expand-template-2.0.3"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-2.0.1"
@@ -47877,24 +49170,17 @@ in
       sources."fast-levenshtein-2.0.6"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
-      sources."fs-constants-1.0.0"
       sources."fs.realpath-1.0.0"
-      sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."github-from-package-0.0.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
-      sources."has-unicode-2.0.1"
       sources."html-encoding-sniffer-1.0.2"
       sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.24"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."ini-1.3.5"
-      sources."is-fullwidth-code-point-1.0.0"
       sources."is-typedarray-1.0.0"
-      sources."isarray-1.0.0"
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
       sources."jsdom-11.12.0"
@@ -47908,100 +49194,54 @@ in
       sources."lodash.sortby-4.7.0"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
-      sources."mimic-response-2.0.0"
       sources."minimatch-3.0.4"
-      sources."minimist-1.2.0"
-      (sources."mkdirp-0.5.1" // {
-        dependencies = [
-          sources."minimist-0.0.8"
-        ];
-      })
-      sources."nan-2.14.0"
-      sources."napi-build-utils-1.0.1"
-      sources."node-abi-2.11.0"
-      sources."noop-logger-0.1.1"
-      sources."npmlog-4.1.2"
-      sources."number-is-nan-1.0.1"
       sources."nwsapi-2.1.4"
       sources."oauth-sign-0.9.0"
-      sources."object-assign-4.1.1"
       sources."once-1.4.0"
       sources."optionator-0.8.2"
       sources."parse5-4.0.0"
       sources."path-is-absolute-1.0.1"
       sources."performance-now-2.1.0"
       sources."pn-1.1.0"
-      sources."prebuild-install-5.3.2"
       sources."prelude-ls-1.1.2"
-      sources."process-nextick-args-2.0.1"
       sources."psl-1.4.0"
-      sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
-      sources."rc-1.2.8"
-      (sources."readable-stream-2.3.6" // {
-        dependencies = [
-          sources."safe-buffer-5.1.2"
-        ];
-      })
       sources."request-2.88.0"
       sources."request-promise-core-1.1.2"
       sources."request-promise-native-1.0.7"
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-5.7.1"
-      sources."set-blocking-2.0.0"
-      sources."signal-exit-3.0.2"
-      sources."simple-concat-1.0.0"
-      sources."simple-get-3.1.0"
       sources."source-map-0.6.1"
       sources."sshpk-1.16.1"
       sources."stealthy-require-1.1.1"
-      sources."string-width-1.0.2"
-      (sources."string_decoder-1.1.1" // {
-        dependencies = [
-          sources."safe-buffer-5.1.2"
-        ];
-      })
-      sources."strip-ansi-3.0.1"
-      sources."strip-json-comments-2.0.1"
       sources."symbol-tree-3.2.4"
-      sources."tar-fs-2.0.0"
-      (sources."tar-stream-2.1.0" // {
-        dependencies = [
-          sources."readable-stream-3.4.0"
-        ];
-      })
       (sources."tough-cookie-2.4.3" // {
         dependencies = [
           sources."punycode-1.4.1"
         ];
       })
       sources."tr46-1.0.1"
-      sources."tree-sitter-0.13.23"
-      sources."tree-sitter-bash-0.13.9"
       sources."tunnel-agent-0.6.0"
       sources."turndown-4.0.2"
       sources."tweetnacl-0.14.5"
       sources."type-check-0.3.2"
       sources."uri-js-4.2.2"
-      sources."urijs-1.19.1"
-      sources."util-deprecate-1.0.2"
+      sources."urijs-1.19.2"
       sources."uuid-3.3.3"
       sources."verror-1.10.0"
       sources."vscode-jsonrpc-4.0.0"
-      sources."vscode-languageserver-4.4.2"
+      sources."vscode-languageserver-5.2.1"
       sources."vscode-languageserver-protocol-3.14.1"
       sources."vscode-languageserver-types-3.14.0"
       sources."vscode-uri-1.0.8"
       sources."w3c-hr-time-1.0.1"
+      sources."web-tree-sitter-0.15.10"
       sources."webidl-conversions-4.0.2"
       sources."whatwg-encoding-1.0.5"
       sources."whatwg-mimetype-2.3.0"
       sources."whatwg-url-6.5.0"
-      sources."which-pm-runs-1.0.0"
-      sources."wide-align-1.1.3"
       sources."wordwrap-1.0.0"
       sources."wrappy-1.0.2"
       sources."ws-5.2.2"
@@ -48066,14 +49306,14 @@ in
       sources."find-up-1.1.2"
       (sources."fs-extra-0.26.7" // {
         dependencies = [
-          sources."graceful-fs-4.2.2"
+          sources."graceful-fs-4.2.3"
         ];
       })
       sources."fs.realpath-1.0.0"
       sources."get-stdin-4.0.1"
       sources."glob-6.0.4"
       sources."graceful-fs-3.0.12"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."indent-string-2.1.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -48084,24 +49324,24 @@ in
       sources."is-utf8-0.2.1"
       (sources."jsonfile-2.4.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.2"
+          sources."graceful-fs-4.2.3"
         ];
       })
       (sources."klaw-1.3.1" // {
         dependencies = [
-          sources."graceful-fs-4.2.2"
+          sources."graceful-fs-4.2.3"
         ];
       })
       (sources."load-json-file-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.2"
+          sources."graceful-fs-4.2.3"
         ];
       })
       sources."lodash-4.2.1"
       sources."loud-rejection-1.6.0"
       sources."map-obj-1.0.1"
       sources."meow-3.7.0"
-      sources."mime-db-1.41.0"
+      sources."mime-db-1.42.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       (sources."mkdirp-0.5.1" // {
@@ -48122,7 +49362,7 @@ in
       sources."path-parse-1.0.6"
       (sources."path-type-1.1.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.2"
+          sources."graceful-fs-4.2.3"
         ];
       })
       sources."pify-2.3.0"
@@ -48137,7 +49377,7 @@ in
       sources."resolve-1.12.0"
       (sources."rimraf-2.7.1" // {
         dependencies = [
-          sources."glob-7.1.4"
+          sources."glob-7.1.5"
         ];
       })
       sources."semver-5.7.1"
@@ -48180,7 +49420,7 @@ in
     };
     dependencies = [
       sources."JSONStream-1.3.5"
-      sources."acorn-7.0.0"
+      sources."acorn-7.1.0"
       sources."acorn-node-1.8.2"
       sources."acorn-walk-7.0.0"
       sources."asn1.js-4.10.1"
@@ -48216,7 +49456,7 @@ in
       sources."combine-source-map-0.8.0"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
-      sources."console-browserify-1.1.0"
+      sources."console-browserify-1.2.0"
       sources."constants-browserify-1.0.0"
       sources."convert-source-map-1.1.3"
       sources."core-util-is-1.0.2"
@@ -48225,9 +49465,8 @@ in
       sources."create-hmac-1.1.7"
       sources."crypto-browserify-3.12.0"
       sources."dash-ast-1.0.0"
-      sources."date-now-0.1.4"
       sources."defined-1.0.0"
-      sources."deps-sort-2.0.0"
+      sources."deps-sort-2.0.1"
       sources."des.js-1.0.0"
       (sources."detective-5.2.0" // {
         dependencies = [
@@ -48240,10 +49479,11 @@ in
       sources."elliptic-6.5.1"
       sources."events-2.1.0"
       sources."evp_bytestokey-1.0.3"
+      sources."fast-safe-stringify-2.0.7"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."get-assigned-identifiers-1.2.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."has-1.0.3"
       sources."hash-base-3.0.4"
       sources."hash.js-1.1.7"
@@ -48301,6 +49541,7 @@ in
       sources."safe-buffer-5.2.0"
       sources."sha.js-2.4.11"
       sources."shasum-1.0.2"
+      sources."shasum-object-1.0.0"
       sources."shell-quote-1.7.2"
       sources."simple-concat-1.0.0"
       sources."source-map-0.5.7"
@@ -48371,7 +49612,7 @@ in
       sources."@protobufjs/pool-1.1.0"
       sources."@protobufjs/utf8-1.1.0"
       sources."@types/long-4.0.0"
-      sources."@types/node-10.14.18"
+      sources."@types/node-10.17.2"
       sources."addr-to-ip-port-1.5.1"
       sources."airplay-js-0.2.16"
       sources."ajv-6.10.2"
@@ -48422,7 +49663,7 @@ in
       })
       sources."castv2-client-1.2.0"
       sources."chalk-1.0.0"
-      sources."chrome-dgram-3.0.3"
+      sources."chrome-dgram-3.0.4"
       sources."chrome-dns-1.0.1"
       sources."chrome-net-3.3.3"
       sources."chromecast-player-0.2.3"
@@ -48432,7 +49673,7 @@ in
       sources."co-3.1.0"
       sources."codepage-1.4.0"
       sources."combined-stream-1.0.8"
-      sources."commander-3.0.1"
+      sources."commander-4.0.0"
       sources."compact2string-1.4.1"
       sources."concat-map-0.0.1"
       (sources."concat-stream-2.0.0" // {
@@ -48465,7 +49706,7 @@ in
         ];
       })
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-string-regexp-1.0.5"
       sources."exit-on-epipe-1.0.1"
@@ -48487,7 +49728,7 @@ in
         dependencies = [
           sources."minimist-0.0.8"
           sources."mkdirp-0.5.1"
-          sources."thunky-1.0.3"
+          sources."thunky-1.1.0"
         ];
       })
       sources."fs.realpath-1.0.0"
@@ -48495,16 +49736,16 @@ in
       sources."get-browser-rtc-1.0.2"
       sources."get-stdin-4.0.1"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."got-1.2.2"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
       sources."has-ansi-1.0.3"
       sources."has-symbols-1.0.0"
       sources."hat-0.0.3"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-signature-1.2.0"
       sources."immediate-chunk-store-1.0.8"
       sources."indent-string-2.1.0"
@@ -48731,7 +49972,7 @@ in
       sources."time-line-1.0.1"
       sources."torrent-discovery-5.4.0"
       sources."torrent-piece-1.1.2"
-      (sources."torrent-stream-1.1.0" // {
+      (sources."torrent-stream-1.2.0" // {
         dependencies = [
           sources."end-of-stream-0.1.5"
           sources."magnet-uri-4.2.3"
@@ -48812,6 +50053,873 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
+  coc-prettier = nodeEnv.buildNodePackage {
+    name = "coc-prettier";
+    packageName = "coc-prettier";
+    version = "1.1.10";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/coc-prettier/-/coc-prettier-1.1.10.tgz";
+      sha512 = "xvT1pwDctcqSh6N0O1o/Xd+KRQXI0CPllXctk7EdB/HR/8jVUOCgN4LhMeNVYxTqlu/pkvAA+YpKgrOLLg/7lw==";
+    };
+    dependencies = [
+      sources."@babel/code-frame-7.5.5"
+      sources."@babel/highlight-7.5.0"
+      sources."@mrmlnc/readdir-enhanced-2.2.1"
+      sources."@nodelib/fs.stat-1.1.3"
+      sources."@types/eslint-visitor-keys-1.0.0"
+      sources."@types/json-schema-7.0.3"
+      sources."@typescript-eslint/experimental-utils-1.13.0"
+      sources."@typescript-eslint/parser-1.13.0"
+      sources."@typescript-eslint/typescript-estree-1.13.0"
+      sources."acorn-6.3.0"
+      sources."acorn-jsx-5.1.0"
+      sources."ajv-6.10.2"
+      sources."ajv-keywords-3.4.1"
+      sources."ansi-align-2.0.0"
+      sources."ansi-escapes-3.2.0"
+      sources."ansi-regex-4.1.0"
+      sources."ansi-styles-3.2.1"
+      sources."argparse-1.0.10"
+      sources."arr-diff-2.0.0"
+      sources."arr-flatten-1.1.0"
+      sources."arr-union-3.1.0"
+      sources."array-find-index-1.0.2"
+      sources."array-union-1.0.2"
+      sources."array-uniq-1.0.3"
+      sources."array-unique-0.2.1"
+      sources."arrify-1.0.1"
+      sources."assign-symbols-1.0.0"
+      sources."astral-regex-1.0.0"
+      sources."atob-2.1.2"
+      sources."autoprefixer-7.2.6"
+      sources."bail-1.0.4"
+      sources."balanced-match-1.0.0"
+      (sources."base-0.11.2" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."isobject-3.0.1"
+        ];
+      })
+      (sources."boxen-1.3.0" // {
+        dependencies = [
+          sources."camelcase-4.1.0"
+        ];
+      })
+      sources."brace-expansion-1.1.11"
+      sources."braces-1.8.5"
+      sources."browserslist-2.11.3"
+      sources."builtin-modules-1.1.1"
+      (sources."cache-base-1.0.1" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."call-me-maybe-1.0.1"
+      sources."callsites-3.1.0"
+      sources."camelcase-2.1.1"
+      sources."camelcase-keys-2.1.0"
+      sources."caniuse-lite-1.0.30001006"
+      sources."capture-stack-trace-1.0.1"
+      sources."ccount-1.0.4"
+      sources."chalk-2.4.2"
+      sources."character-entities-1.2.3"
+      sources."character-entities-html4-1.1.3"
+      sources."character-entities-legacy-1.1.3"
+      sources."character-reference-invalid-1.1.3"
+      sources."chardet-0.7.0"
+      sources."ci-info-1.6.0"
+      sources."circular-json-0.3.3"
+      (sources."class-utils-0.3.6" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."isobject-3.0.1"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."cli-boxes-1.0.0"
+      sources."cli-cursor-2.1.0"
+      sources."cli-width-2.2.0"
+      sources."cliui-4.1.0"
+      sources."clone-regexp-1.0.1"
+      sources."code-point-at-1.1.0"
+      sources."collapse-white-space-1.0.5"
+      sources."collection-visit-1.0.0"
+      sources."color-convert-1.9.3"
+      sources."color-name-1.1.3"
+      sources."commander-2.20.3"
+      sources."common-tags-1.8.0"
+      sources."component-emitter-1.3.0"
+      sources."concat-map-0.0.1"
+      sources."configstore-3.1.2"
+      sources."copy-descriptor-0.1.1"
+      sources."core-js-3.3.6"
+      sources."cosmiconfig-3.1.0"
+      sources."create-error-class-3.0.2"
+      sources."cross-spawn-6.0.5"
+      sources."crypto-random-string-1.0.0"
+      sources."currently-unhandled-0.4.1"
+      sources."debug-4.1.1"
+      sources."decamelize-1.2.0"
+      sources."decamelize-keys-1.1.0"
+      sources."decode-uri-component-0.2.0"
+      sources."deep-extend-0.6.0"
+      sources."deep-is-0.1.3"
+      (sources."define-property-2.0.2" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."diff-4.0.1"
+      (sources."dir-glob-2.2.2" // {
+        dependencies = [
+          sources."path-type-3.0.0"
+        ];
+      })
+      sources."dlv-1.1.3"
+      sources."doctrine-3.0.0"
+      (sources."dom-serializer-0.2.1" // {
+        dependencies = [
+          sources."domelementtype-2.0.1"
+          sources."entities-2.0.0"
+        ];
+      })
+      sources."domelementtype-1.3.1"
+      sources."domhandler-2.4.2"
+      sources."domutils-1.7.0"
+      sources."dot-prop-4.2.0"
+      sources."duplexer3-0.1.4"
+      sources."electron-to-chromium-1.3.298"
+      sources."emoji-regex-7.0.3"
+      sources."end-of-stream-1.4.4"
+      sources."entities-1.1.2"
+      sources."error-ex-1.3.2"
+      sources."escape-string-regexp-1.0.5"
+      (sources."eslint-5.16.0" // {
+        dependencies = [
+          sources."semver-5.7.1"
+        ];
+      })
+      sources."eslint-scope-4.0.3"
+      sources."eslint-utils-1.4.3"
+      sources."eslint-visitor-keys-1.1.0"
+      sources."espree-5.0.1"
+      sources."esprima-4.0.1"
+      sources."esquery-1.0.1"
+      sources."esrecurse-4.2.1"
+      sources."estraverse-4.3.0"
+      sources."esutils-2.0.3"
+      (sources."execa-0.7.0" // {
+        dependencies = [
+          sources."cross-spawn-5.1.0"
+        ];
+      })
+      sources."execall-1.0.0"
+      sources."expand-brackets-0.1.5"
+      sources."expand-range-1.8.2"
+      sources."extend-3.0.2"
+      (sources."extend-shallow-3.0.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      sources."external-editor-3.1.0"
+      sources."extglob-0.3.2"
+      sources."fast-deep-equal-2.0.1"
+      (sources."fast-glob-2.2.7" // {
+        dependencies = [
+          sources."arr-diff-4.0.0"
+          sources."array-unique-0.3.2"
+          (sources."braces-2.3.2" // {
+            dependencies = [
+              sources."extend-shallow-2.0.1"
+            ];
+          })
+          sources."debug-2.6.9"
+          (sources."expand-brackets-2.1.4" // {
+            dependencies = [
+              sources."define-property-0.2.5"
+              sources."extend-shallow-2.0.1"
+            ];
+          })
+          (sources."extglob-2.0.4" // {
+            dependencies = [
+              sources."define-property-1.0.0"
+              sources."extend-shallow-2.0.1"
+            ];
+          })
+          (sources."fill-range-4.0.0" // {
+            dependencies = [
+              sources."extend-shallow-2.0.1"
+            ];
+          })
+          (sources."glob-parent-3.1.0" // {
+            dependencies = [
+              sources."is-glob-3.1.0"
+            ];
+          })
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-5.1.0"
+            ];
+          })
+          sources."is-extglob-2.1.1"
+          sources."is-glob-4.0.1"
+          (sources."is-number-3.0.0" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."isobject-3.0.1"
+          sources."kind-of-6.0.2"
+          sources."micromatch-3.1.10"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."fast-json-stable-stringify-2.0.0"
+      sources."fast-levenshtein-2.0.6"
+      sources."figures-2.0.0"
+      sources."file-entry-cache-5.0.1"
+      sources."filename-regex-2.0.1"
+      sources."fill-range-2.2.4"
+      sources."find-up-2.1.0"
+      sources."flat-cache-2.0.1"
+      sources."flatted-2.0.1"
+      sources."for-in-1.0.2"
+      sources."for-own-0.1.5"
+      sources."fragment-cache-0.2.1"
+      sources."fs.realpath-1.0.0"
+      sources."functional-red-black-tree-1.0.1"
+      sources."get-caller-file-1.0.3"
+      sources."get-stdin-5.0.1"
+      sources."get-stream-3.0.0"
+      sources."get-value-2.0.6"
+      sources."glob-7.1.5"
+      sources."glob-base-0.3.0"
+      sources."glob-parent-2.0.0"
+      sources."glob-to-regexp-0.3.0"
+      sources."global-dirs-0.1.1"
+      sources."globals-11.12.0"
+      (sources."globby-6.1.0" // {
+        dependencies = [
+          sources."pify-2.3.0"
+        ];
+      })
+      sources."globjoin-0.1.4"
+      (sources."gonzales-pe-4.2.4" // {
+        dependencies = [
+          sources."minimist-1.1.3"
+        ];
+      })
+      sources."got-6.7.1"
+      sources."graceful-fs-4.2.3"
+      (sources."has-ansi-2.0.0" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+        ];
+      })
+      sources."has-flag-3.0.0"
+      (sources."has-value-1.0.0" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      (sources."has-values-1.0.0" // {
+        dependencies = [
+          (sources."is-number-3.0.0" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."kind-of-4.0.0"
+        ];
+      })
+      sources."hosted-git-info-2.8.5"
+      sources."html-tags-2.0.0"
+      sources."htmlparser2-3.10.1"
+      sources."iconv-lite-0.4.24"
+      sources."ignore-4.0.6"
+      sources."import-fresh-3.1.0"
+      sources."import-lazy-2.1.0"
+      sources."import-local-0.1.1"
+      sources."imurmurhash-0.1.4"
+      sources."indent-string-4.0.0"
+      sources."indexes-of-1.0.1"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.4"
+      sources."ini-1.3.5"
+      (sources."inquirer-6.5.2" // {
+        dependencies = [
+          sources."strip-ansi-5.2.0"
+        ];
+      })
+      sources."invert-kv-2.0.0"
+      (sources."is-accessor-descriptor-1.0.0" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
+      sources."is-alphabetical-1.0.3"
+      sources."is-alphanumeric-1.0.0"
+      sources."is-alphanumerical-1.0.3"
+      sources."is-arrayish-0.2.1"
+      sources."is-buffer-1.1.6"
+      sources."is-ci-1.2.1"
+      (sources."is-data-descriptor-1.0.0" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
+      sources."is-decimal-1.0.3"
+      (sources."is-descriptor-1.0.2" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
+      sources."is-directory-0.3.1"
+      sources."is-dotfile-1.0.3"
+      sources."is-equal-shallow-0.1.3"
+      sources."is-extendable-0.1.1"
+      sources."is-extglob-1.0.0"
+      sources."is-finite-1.0.2"
+      sources."is-fullwidth-code-point-2.0.0"
+      sources."is-glob-2.0.1"
+      sources."is-hexadecimal-1.0.3"
+      sources."is-installed-globally-0.1.0"
+      sources."is-npm-1.0.0"
+      sources."is-number-2.1.0"
+      sources."is-obj-1.0.1"
+      sources."is-path-inside-1.0.1"
+      sources."is-plain-obj-1.1.0"
+      (sources."is-plain-object-2.0.4" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."is-posix-bracket-0.1.1"
+      sources."is-primitive-2.0.0"
+      sources."is-promise-2.1.0"
+      sources."is-redirect-1.0.0"
+      sources."is-regexp-1.0.0"
+      sources."is-retry-allowed-1.2.0"
+      sources."is-stream-1.1.0"
+      sources."is-supported-regexp-flag-1.0.1"
+      sources."is-utf8-0.2.1"
+      sources."is-whitespace-character-1.0.3"
+      sources."is-windows-1.0.2"
+      sources."is-word-character-1.0.3"
+      sources."isarray-1.0.0"
+      sources."isexe-2.0.0"
+      sources."isobject-2.1.0"
+      sources."js-base64-2.5.1"
+      sources."js-tokens-4.0.0"
+      sources."js-yaml-3.13.1"
+      sources."json-parse-better-errors-1.0.2"
+      sources."json-schema-traverse-0.4.1"
+      sources."json-stable-stringify-without-jsonify-1.0.1"
+      sources."kind-of-3.2.2"
+      sources."known-css-properties-0.5.0"
+      sources."latest-version-3.1.0"
+      sources."lcid-2.0.0"
+      sources."levn-0.3.0"
+      (sources."load-json-file-1.1.0" // {
+        dependencies = [
+          sources."parse-json-2.2.0"
+          sources."pify-2.3.0"
+        ];
+      })
+      sources."locate-path-2.0.0"
+      sources."lodash-4.17.15"
+      sources."lodash.merge-4.6.2"
+      sources."lodash.unescape-4.0.1"
+      sources."log-symbols-2.2.0"
+      sources."loglevel-1.6.4"
+      (sources."loglevel-colored-level-prefix-1.0.0" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          sources."ansi-styles-2.2.1"
+          sources."chalk-1.1.3"
+          sources."strip-ansi-3.0.1"
+          sources."supports-color-2.0.0"
+        ];
+      })
+      sources."longest-streak-2.0.3"
+      sources."loud-rejection-1.6.0"
+      sources."lowercase-keys-1.0.1"
+      sources."lru-cache-4.1.5"
+      sources."make-dir-1.3.0"
+      sources."map-age-cleaner-0.1.3"
+      sources."map-cache-0.2.2"
+      sources."map-obj-1.0.1"
+      sources."map-visit-1.0.0"
+      sources."markdown-escapes-1.0.3"
+      sources."markdown-table-1.1.3"
+      sources."math-random-1.0.4"
+      sources."mathml-tag-names-2.1.1"
+      sources."mdast-util-compact-1.0.3"
+      (sources."mem-4.3.0" // {
+        dependencies = [
+          sources."mimic-fn-2.1.0"
+        ];
+      })
+      (sources."meow-3.7.0" // {
+        dependencies = [
+          sources."minimist-1.2.0"
+        ];
+      })
+      sources."merge2-1.3.0"
+      sources."micromatch-2.3.11"
+      sources."mimic-fn-1.2.0"
+      sources."minimatch-3.0.4"
+      sources."minimist-0.0.8"
+      sources."minimist-options-3.0.2"
+      (sources."mixin-deep-1.3.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      sources."mkdirp-0.5.1"
+      sources."ms-2.1.2"
+      sources."mute-stream-0.0.7"
+      (sources."nanomatch-1.2.13" // {
+        dependencies = [
+          sources."arr-diff-4.0.0"
+          sources."array-unique-0.3.2"
+          sources."kind-of-6.0.2"
+        ];
+      })
+      sources."natural-compare-1.4.0"
+      sources."nice-try-1.0.5"
+      sources."normalize-package-data-2.5.0"
+      sources."normalize-path-2.1.1"
+      sources."normalize-range-0.1.2"
+      sources."normalize-selector-0.2.0"
+      sources."npm-run-path-2.0.2"
+      sources."num2fraction-1.2.2"
+      sources."number-is-nan-1.0.1"
+      sources."object-assign-4.1.1"
+      (sources."object-copy-0.1.0" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          sources."is-accessor-descriptor-0.1.6"
+          sources."is-data-descriptor-0.1.4"
+          (sources."is-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-5.1.0"
+            ];
+          })
+        ];
+      })
+      (sources."object-visit-1.0.1" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."object.omit-2.0.1"
+      (sources."object.pick-1.3.0" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."once-1.4.0"
+      sources."onetime-2.0.1"
+      sources."optionator-0.8.2"
+      (sources."os-locale-3.1.0" // {
+        dependencies = [
+          sources."execa-1.0.0"
+          sources."get-stream-4.1.0"
+        ];
+      })
+      sources."os-tmpdir-1.0.2"
+      sources."p-defer-1.0.0"
+      sources."p-finally-1.0.0"
+      sources."p-is-promise-2.1.0"
+      sources."p-limit-1.3.0"
+      sources."p-locate-2.0.0"
+      sources."p-try-1.0.0"
+      sources."package-json-4.0.1"
+      sources."parent-module-1.0.1"
+      sources."parse-entities-1.2.2"
+      sources."parse-glob-3.0.4"
+      sources."parse-json-3.0.0"
+      sources."pascalcase-0.1.1"
+      sources."path-dirname-1.0.2"
+      sources."path-exists-3.0.0"
+      sources."path-is-absolute-1.0.1"
+      sources."path-is-inside-1.0.2"
+      sources."path-key-2.0.1"
+      sources."path-parse-1.0.6"
+      (sources."path-type-1.1.0" // {
+        dependencies = [
+          sources."pify-2.3.0"
+        ];
+      })
+      sources."pify-3.0.0"
+      sources."pinkie-2.0.4"
+      sources."pinkie-promise-2.0.1"
+      sources."pkg-dir-2.0.0"
+      sources."posix-character-classes-0.1.1"
+      sources."postcss-6.0.23"
+      sources."postcss-html-0.12.0"
+      (sources."postcss-less-1.1.5" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          sources."ansi-styles-2.2.1"
+          (sources."chalk-1.1.3" // {
+            dependencies = [
+              sources."supports-color-2.0.0"
+            ];
+          })
+          sources."has-flag-1.0.0"
+          sources."postcss-5.2.18"
+          sources."source-map-0.5.7"
+          sources."strip-ansi-3.0.1"
+          sources."supports-color-3.2.3"
+        ];
+      })
+      sources."postcss-media-query-parser-0.2.3"
+      sources."postcss-reporter-5.0.0"
+      sources."postcss-resolve-nested-selector-0.1.1"
+      sources."postcss-safe-parser-3.0.1"
+      sources."postcss-sass-0.2.0"
+      sources."postcss-scss-1.0.6"
+      sources."postcss-selector-parser-3.1.1"
+      sources."postcss-value-parser-3.3.1"
+      sources."prelude-ls-1.1.2"
+      sources."prepend-http-1.0.4"
+      sources."preserve-0.2.0"
+      sources."prettier-1.18.2"
+      sources."prettier-eslint-9.0.0"
+      (sources."prettier-stylelint-0.4.2" // {
+        dependencies = [
+          sources."debug-3.2.6"
+          sources."ignore-3.3.10"
+        ];
+      })
+      (sources."prettier-tslint-0.4.2" // {
+        dependencies = [
+          sources."dir-glob-2.0.0"
+          sources."globby-8.0.2"
+          sources."ignore-3.3.10"
+          sources."path-type-3.0.0"
+        ];
+      })
+      (sources."pretty-format-23.6.0" // {
+        dependencies = [
+          sources."ansi-regex-3.0.0"
+        ];
+      })
+      sources."progress-2.0.3"
+      sources."pseudomap-1.0.2"
+      sources."pump-3.0.0"
+      sources."punycode-2.1.1"
+      sources."quick-lru-1.1.0"
+      (sources."randomatic-3.1.1" // {
+        dependencies = [
+          sources."is-number-4.0.0"
+          sources."kind-of-6.0.2"
+        ];
+      })
+      (sources."rc-1.2.8" // {
+        dependencies = [
+          sources."minimist-1.2.0"
+        ];
+      })
+      sources."read-pkg-1.1.0"
+      (sources."read-pkg-up-1.0.1" // {
+        dependencies = [
+          sources."find-up-1.1.2"
+          sources."path-exists-2.1.0"
+        ];
+      })
+      sources."readable-stream-3.4.0"
+      (sources."redent-1.0.0" // {
+        dependencies = [
+          sources."indent-string-2.1.0"
+        ];
+      })
+      sources."regex-cache-0.4.4"
+      sources."regex-not-1.0.2"
+      sources."regexpp-2.0.1"
+      sources."registry-auth-token-3.4.0"
+      sources."registry-url-3.1.0"
+      sources."remark-8.0.0"
+      sources."remark-parse-4.0.0"
+      sources."remark-stringify-4.0.0"
+      sources."remove-trailing-separator-1.1.0"
+      sources."repeat-element-1.1.3"
+      sources."repeat-string-1.6.1"
+      sources."repeating-2.0.1"
+      sources."replace-ext-1.0.0"
+      sources."require-directory-2.1.1"
+      sources."require-from-string-2.0.2"
+      sources."require-main-filename-1.0.1"
+      sources."require-relative-0.8.7"
+      sources."resolve-1.12.0"
+      (sources."resolve-cwd-2.0.0" // {
+        dependencies = [
+          sources."resolve-from-3.0.0"
+        ];
+      })
+      sources."resolve-from-4.0.0"
+      sources."resolve-url-0.2.1"
+      sources."restore-cursor-2.0.0"
+      sources."ret-0.1.15"
+      sources."rimraf-2.6.3"
+      sources."run-async-2.3.0"
+      sources."rxjs-6.5.3"
+      sources."safe-buffer-5.2.0"
+      sources."safe-regex-1.1.0"
+      sources."safer-buffer-2.1.2"
+      sources."semver-5.5.0"
+      sources."semver-diff-2.1.0"
+      sources."set-blocking-2.0.0"
+      (sources."set-value-2.0.1" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."shebang-command-1.2.0"
+      sources."shebang-regex-1.0.0"
+      sources."signal-exit-3.0.2"
+      sources."slash-1.0.0"
+      sources."slice-ansi-2.1.0"
+      (sources."snapdragon-0.8.2" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
+          sources."source-map-0.5.7"
+        ];
+      })
+      (sources."snapdragon-node-2.1.1" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."snapdragon-util-3.0.1"
+      sources."source-map-0.6.1"
+      sources."source-map-resolve-0.5.2"
+      sources."source-map-url-0.4.0"
+      sources."spdx-correct-3.1.0"
+      sources."spdx-exceptions-2.2.0"
+      sources."spdx-expression-parse-3.0.0"
+      sources."spdx-license-ids-3.0.5"
+      sources."specificity-0.3.2"
+      sources."split-string-3.1.0"
+      sources."sprintf-js-1.0.3"
+      sources."state-toggle-1.0.2"
+      (sources."static-extend-0.1.2" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."string-width-2.1.1"
+      sources."string_decoder-1.3.0"
+      sources."stringify-entities-1.3.2"
+      (sources."strip-ansi-4.0.0" // {
+        dependencies = [
+          sources."ansi-regex-3.0.0"
+        ];
+      })
+      sources."strip-bom-2.0.0"
+      sources."strip-eof-1.0.0"
+      (sources."strip-indent-1.0.1" // {
+        dependencies = [
+          sources."get-stdin-4.0.1"
+        ];
+      })
+      sources."strip-json-comments-2.0.1"
+      sources."style-search-0.1.0"
+      (sources."stylelint-8.4.0" // {
+        dependencies = [
+          sources."camelcase-4.1.0"
+          sources."camelcase-keys-4.2.0"
+          sources."debug-3.2.6"
+          sources."file-entry-cache-2.0.0"
+          sources."flat-cache-1.3.4"
+          sources."globby-7.1.1"
+          sources."ignore-3.3.10"
+          sources."indent-string-3.2.0"
+          sources."load-json-file-4.0.0"
+          sources."map-obj-2.0.0"
+          sources."meow-4.0.1"
+          sources."minimist-1.2.0"
+          sources."parse-json-4.0.0"
+          sources."path-type-3.0.0"
+          sources."read-pkg-3.0.0"
+          sources."read-pkg-up-3.0.0"
+          sources."redent-2.0.0"
+          sources."slice-ansi-1.0.0"
+          sources."strip-bom-3.0.0"
+          sources."strip-indent-2.0.0"
+          sources."table-4.0.3"
+          sources."trim-newlines-2.0.0"
+          sources."write-0.2.1"
+        ];
+      })
+      sources."sugarss-1.0.1"
+      sources."supports-color-5.5.0"
+      sources."svg-tags-1.0.0"
+      (sources."table-5.4.6" // {
+        dependencies = [
+          sources."string-width-3.1.0"
+          sources."strip-ansi-5.2.0"
+        ];
+      })
+      sources."temp-dir-1.0.0"
+      sources."temp-write-3.4.0"
+      sources."tempy-0.2.1"
+      sources."term-size-1.2.0"
+      sources."text-table-0.2.0"
+      sources."through-2.3.8"
+      sources."timed-out-4.0.1"
+      sources."tmp-0.0.33"
+      sources."to-object-path-0.3.0"
+      sources."to-regex-3.0.2"
+      (sources."to-regex-range-2.1.1" // {
+        dependencies = [
+          sources."is-number-3.0.0"
+        ];
+      })
+      sources."trim-0.0.1"
+      sources."trim-newlines-1.0.0"
+      sources."trim-trailing-lines-1.1.2"
+      sources."trough-1.0.4"
+      sources."tslib-1.10.0"
+      sources."tslint-5.20.0"
+      sources."tsutils-2.29.0"
+      sources."type-check-0.3.2"
+      sources."typescript-3.6.4"
+      sources."unherit-1.1.2"
+      sources."unified-6.2.0"
+      sources."union-value-1.0.1"
+      sources."uniq-1.0.1"
+      sources."unique-string-1.0.0"
+      sources."unist-util-find-all-after-1.0.4"
+      sources."unist-util-is-3.0.0"
+      sources."unist-util-remove-position-1.1.3"
+      sources."unist-util-stringify-position-1.1.2"
+      sources."unist-util-visit-1.4.1"
+      sources."unist-util-visit-parents-2.1.2"
+      (sources."unset-value-1.0.0" // {
+        dependencies = [
+          (sources."has-value-0.3.1" // {
+            dependencies = [
+              sources."isobject-2.1.0"
+            ];
+          })
+          sources."has-values-0.1.4"
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."unzip-response-2.0.1"
+      sources."update-notifier-2.5.0"
+      sources."uri-js-4.2.2"
+      sources."urix-0.1.0"
+      sources."url-parse-lax-1.0.0"
+      sources."use-3.1.1"
+      sources."util-deprecate-1.0.2"
+      sources."uuid-3.3.3"
+      sources."validate-npm-package-license-3.0.4"
+      sources."vfile-2.3.0"
+      sources."vfile-location-2.0.5"
+      sources."vfile-message-1.1.1"
+      (sources."vue-eslint-parser-2.0.3" // {
+        dependencies = [
+          sources."acorn-5.7.3"
+          (sources."acorn-jsx-3.0.1" // {
+            dependencies = [
+              sources."acorn-3.3.0"
+            ];
+          })
+          sources."debug-3.2.6"
+          sources."eslint-scope-3.7.3"
+          sources."espree-3.5.4"
+        ];
+      })
+      sources."which-1.3.1"
+      sources."which-module-2.0.0"
+      sources."widest-line-2.0.1"
+      sources."wordwrap-1.0.0"
+      (sources."wrap-ansi-2.1.0" // {
+        dependencies = [
+          sources."ansi-regex-2.1.1"
+          sources."is-fullwidth-code-point-1.0.0"
+          sources."string-width-1.0.2"
+          sources."strip-ansi-3.0.1"
+        ];
+      })
+      sources."wrappy-1.0.2"
+      sources."write-1.0.3"
+      sources."write-file-atomic-2.4.3"
+      sources."x-is-string-0.1.0"
+      sources."xdg-basedir-3.0.0"
+      sources."xtend-4.0.2"
+      sources."y18n-3.2.1"
+      sources."yallist-2.1.2"
+      sources."yargs-11.1.1"
+      (sources."yargs-parser-9.0.2" // {
+        dependencies = [
+          sources."camelcase-4.1.0"
+        ];
+      })
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "prettier extension for coc.nvim";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
   coffee-script = nodeEnv.buildNodePackage {
     name = "coffee-script";
     packageName = "coffee-script";
@@ -48850,7 +50958,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."colors-1.4.0"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."debug-3.2.6"
       sources."escape-string-regexp-1.0.5"
       sources."follow-redirects-1.9.0"
@@ -48965,7 +51073,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.7.5"
+      sources."@types/node-12.12.3"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       sources."ajv-6.10.2"
@@ -48998,7 +51106,7 @@ in
       })
       sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
-      sources."big-integer-1.6.45"
+      sources."big-integer-1.6.47"
       (sources."body-parser-1.19.0" // {
         dependencies = [
           sources."bytes-3.1.0"
@@ -49108,10 +51216,10 @@ in
       sources."ee-first-1.1.1"
       sources."elementtree-0.1.7"
       sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."endent-1.3.0"
       sources."env-paths-1.0.0"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
@@ -49175,7 +51283,7 @@ in
       sources."get-stream-4.1.0"
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -49193,7 +51301,7 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
@@ -49205,7 +51313,7 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       (sources."http-errors-1.7.2" // {
         dependencies = [
           sources."inherits-2.0.3"
@@ -49277,7 +51385,7 @@ in
       sources."locate-path-2.0.0"
       sources."lodash-4.17.15"
       sources."lodash.debounce-4.0.8"
-      sources."loud-rejection-2.1.0"
+      sources."loud-rejection-2.2.0"
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.5"
       sources."macos-release-2.3.0"
@@ -49599,7 +51707,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.7.5"
+      sources."@types/node-12.12.3"
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
       sources."arr-union-3.1.0"
@@ -49701,7 +51809,7 @@ in
       sources."fragment-cache-0.2.1"
       sources."fs.realpath-1.0.0"
       sources."get-value-2.0.6"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -49709,14 +51817,14 @@ in
       })
       sources."glob-to-regexp-0.3.0"
       sources."globby-9.2.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."ignore-4.0.6"
       sources."indent-string-3.2.0"
       sources."inflight-1.0.6"
@@ -49927,7 +52035,7 @@ in
       sources."@cycle/run-3.4.0"
       sources."@cycle/time-0.10.1"
       sources."@types/cookiejar-2.1.1"
-      sources."@types/node-12.7.5"
+      sources."@types/node-12.12.3"
       sources."@types/superagent-3.8.2"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-2.1.1"
@@ -49956,7 +52064,7 @@ in
       sources."d-1.0.1"
       sources."debug-3.2.6"
       sources."delayed-stream-1.0.0"
-      sources."es5-ext-0.10.51"
+      sources."es5-ext-0.10.52"
       sources."es6-iterator-2.0.3"
       sources."es6-map-0.1.5"
       (sources."es6-set-0.1.5" // {
@@ -49964,9 +52072,14 @@ in
           sources."es6-symbol-3.1.1"
         ];
       })
-      sources."es6-symbol-3.1.2"
+      sources."es6-symbol-3.1.3"
       sources."escape-string-regexp-1.0.5"
       sources."event-emitter-0.3.5"
+      (sources."ext-1.1.2" // {
+        dependencies = [
+          sources."type-2.0.0"
+        ];
+      })
       sources."extend-3.0.2"
       sources."external-editor-2.2.0"
       sources."figures-2.0.0"
@@ -50064,10 +52177,10 @@ in
   create-react-app = nodeEnv.buildNodePackage {
     name = "create-react-app";
     packageName = "create-react-app";
-    version = "3.1.2";
+    version = "3.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/create-react-app/-/create-react-app-3.1.2.tgz";
-      sha512 = "y5wgEQwt6IpUP1N64uorVavhp8NPUAamVqA/paZmpvPSrW3l2c5UhXRi5m61plBBzDde2WyDr+3vCwDsfaS03w==";
+      url = "https://registry.npmjs.org/create-react-app/-/create-react-app-3.2.0.tgz";
+      sha512 = "BWbSreHNhZbSStkvLrEepjVuNp7ooKOiO7amoezEZPAac2H0MxBhzUIazto9OT7fZkcaRNubDuHKxGcxqlIwRA==";
     };
     dependencies = [
       sources."ansi-escapes-3.2.0"
@@ -50102,8 +52215,8 @@ in
       sources."fs.realpath-1.0.0"
       sources."fstream-1.0.12"
       sources."fstream-ignore-1.0.5"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
       sources."hyperquest-2.1.3"
       sources."iconv-lite-0.4.24"
@@ -50200,11 +52313,11 @@ in
       sources."chalk-2.4.2"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
-      sources."core-js-2.6.9"
+      sources."core-js-2.6.10"
       sources."cross-spawn-5.1.0"
       sources."escape-string-regexp-1.0.5"
       sources."fs-extra-4.0.3"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
       sources."isexe-2.0.0"
       sources."jsonfile-4.0.0"
@@ -50334,7 +52447,7 @@ in
       sources."capture-stack-trace-1.0.1"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
-      sources."chrome-dgram-3.0.3"
+      sources."chrome-dgram-3.0.4"
       sources."chrome-dns-1.0.1"
       sources."chrome-net-3.3.3"
       sources."ci-info-1.6.0"
@@ -50433,8 +52546,8 @@ in
       sources."duplexer3-0.1.4"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
-      sources."end-of-stream-1.4.1"
-      sources."es-abstract-1.14.2"
+      sources."end-of-stream-1.4.4"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-string-regexp-1.0.5"
       sources."execa-0.7.0"
@@ -50495,11 +52608,11 @@ in
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."global-4.3.2"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
@@ -50835,7 +52948,7 @@ in
       sources."supports-color-5.5.0"
       sources."term-size-1.2.0"
       sources."throttle-1.0.3"
-      sources."thunky-1.0.3"
+      sources."thunky-1.1.0"
       sources."timed-out-4.0.1"
       sources."timeout-refresh-1.0.1"
       sources."to-buffer-1.1.1"
@@ -51138,10 +53251,10 @@ in
   elasticdump = nodeEnv.buildNodePackage {
     name = "elasticdump";
     packageName = "elasticdump";
-    version = "6.10.6";
+    version = "6.15.7";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.10.6.tgz";
-      sha512 = "Zjrmui3KS2Fem8OyVNoN1pWOCvULJP88rl1RdnBA/lkBx7u15G0B7FIlzOwX7sjBuJcqb9G5K9FuJXPU3MEqZg==";
+      url = "https://registry.npmjs.org/elasticdump/-/elasticdump-6.15.7.tgz";
+      sha512 = "Z6AsKLwPxSz7auY4+p9mFOR+Ep0+iAIJ9OxADLeadprQO33A4XuerCpkePOzewQeVFbnspdB0+jCRsj9shPpCw==";
     };
     dependencies = [
       sources."JSONStream-1.3.5"
@@ -51150,7 +53263,7 @@ in
       sources."assert-plus-1.0.0"
       sources."async-2.6.3"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.533.0"
+      sources."aws-sdk-2.561.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."base64-js-1.3.1"
@@ -51166,6 +53279,7 @@ in
       sources."delay-4.3.0"
       sources."delayed-stream-1.0.0"
       sources."ecc-jsbn-0.1.2"
+      sources."end-of-stream-1.4.4"
       sources."eventemitter3-4.0.0"
       sources."events-1.1.1"
       sources."extend-3.0.2"
@@ -51202,13 +53316,15 @@ in
       sources."mime-types-2.1.24"
       sources."minimist-0.0.10"
       sources."oauth-sign-0.9.0"
+      sources."once-1.4.0"
       sources."optimist-0.6.1"
       sources."p-finally-1.0.0"
-      sources."p-queue-6.1.1"
+      sources."p-queue-6.2.0"
       sources."p-timeout-3.2.0"
       sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.1"
       sources."psl-1.4.0"
+      sources."pump-3.0.0"
       sources."punycode-1.3.2"
       sources."qs-6.5.2"
       sources."querystring-0.2.0"
@@ -51218,7 +53334,7 @@ in
         ];
       })
       sources."request-2.88.0"
-      sources."requestretry-4.0.0"
+      sources."requestretry-4.0.2"
       sources."s3-stream-upload-2.0.2"
       sources."s3signed-0.1.0"
       (sources."s3urls-1.5.2" // {
@@ -51258,6 +53374,7 @@ in
       sources."verror-1.10.0"
       sources."when-3.7.8"
       sources."wordwrap-0.0.3"
+      sources."wrappy-1.0.2"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
     ];
@@ -51274,15 +53391,15 @@ in
   elm-live = nodeEnv.buildNodePackage {
     name = "elm-live";
     packageName = "elm-live";
-    version = "4.0.0";
+    version = "4.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/elm-live/-/elm-live-4.0.0.tgz";
-      sha512 = "Yf6afXvBnghRZkefxgXCf/KjCm3DlwT6lfTrjLSc5v0I0VXE2Rc5T9iqXihjg3alh9t8NwDVLL+/py8PkkdC9Q==";
+      url = "https://registry.npmjs.org/elm-live/-/elm-live-4.0.1.tgz";
+      sha512 = "IlonaC1pO/QoXlOrwwrJaxyvpJAT8QDSfzenkChbhU1PC1fJetkj2TwZfki+y1ZxpSMTnMSomMraOdWA6DO3VQ==";
     };
     dependencies = [
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-2.2.1"
-      sources."anymatch-3.1.0"
+      sources."anymatch-3.1.1"
       sources."async-limiter-1.0.1"
       sources."binary-extensions-2.0.0"
       sources."braces-3.0.2"
@@ -51300,7 +53417,7 @@ in
       sources."ee-first-1.1.1"
       sources."elm-hot-1.1.1"
       sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."es6-promisify-6.0.2"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
@@ -51320,7 +53437,7 @@ in
         ];
       })
       sources."fresh-0.5.2"
-      sources."fsevents-2.0.7"
+      sources."fsevents-2.1.1"
       sources."get-stream-4.1.0"
       sources."glob-parent-5.1.0"
       sources."has-ansi-2.0.0"
@@ -51353,11 +53470,11 @@ in
       sources."parseurl-1.3.3"
       sources."path-key-2.0.1"
       sources."pem-1.14.2"
-      sources."picomatch-2.0.7"
+      sources."picomatch-2.1.0"
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
       sources."range-parser-1.2.1"
-      sources."readdirp-3.1.2"
+      sources."readdirp-3.2.0"
       sources."requires-port-1.0.0"
       sources."semver-5.7.1"
       (sources."send-0.17.1" // {
@@ -51468,7 +53585,7 @@ in
           sources."safe-buffer-5.1.2"
         ];
       })
-      sources."core-js-2.6.9"
+      sources."core-js-2.6.10"
       sources."cross-spawn-5.1.0"
       sources."currently-unhandled-0.4.1"
       sources."debug-2.6.9"
@@ -51487,13 +53604,13 @@ in
       sources."get-stream-3.0.0"
       sources."globals-9.18.0"
       sources."got-7.1.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-ansi-3.0.0"
       sources."has-flag-3.0.0"
       sources."has-symbol-support-x-1.4.2"
       sources."has-to-string-tag-x-1.4.1"
       sources."home-or-tmp-2.0.0"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."import-jsx-1.3.2"
       sources."imurmurhash-0.1.4"
       sources."indent-string-3.2.0"
@@ -51580,7 +53697,7 @@ in
       sources."private-0.1.8"
       sources."prop-types-15.7.2"
       sources."pseudomap-1.0.2"
-      sources."react-is-16.9.0"
+      sources."react-is-16.11.0"
       sources."read-pkg-1.1.0"
       (sources."read-pkg-up-1.0.1" // {
         dependencies = [
@@ -51673,19 +53790,19 @@ in
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";
-    version = "6.4.0";
+    version = "6.6.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz";
-      sha512 = "WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==";
+      url = "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz";
+      sha512 = "PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==";
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
       sources."@babel/highlight-7.5.0"
-      sources."acorn-7.0.0"
-      sources."acorn-jsx-5.0.2"
+      sources."acorn-7.1.0"
+      sources."acorn-jsx-5.1.0"
       sources."ajv-6.10.2"
-      sources."ansi-escapes-3.2.0"
-      sources."ansi-regex-3.0.0"
+      sources."ansi-escapes-4.2.1"
+      sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
       sources."argparse-1.0.10"
       sources."astral-regex-1.0.0"
@@ -51694,7 +53811,7 @@ in
       sources."callsites-3.1.0"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
-      sources."cli-cursor-2.1.0"
+      sources."cli-cursor-3.1.0"
       sources."cli-width-2.2.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -51707,12 +53824,12 @@ in
       sources."debug-4.1.1"
       sources."deep-is-0.1.3"
       sources."doctrine-3.0.0"
-      sources."emoji-regex-7.0.3"
+      sources."emoji-regex-8.0.0"
       sources."escape-string-regexp-1.0.5"
       sources."eslint-scope-5.0.0"
-      sources."eslint-utils-1.4.2"
+      sources."eslint-utils-1.4.3"
       sources."eslint-visitor-keys-1.1.0"
-      sources."espree-6.1.1"
+      sources."espree-6.1.2"
       sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
@@ -51722,13 +53839,13 @@ in
       sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fast-levenshtein-2.0.6"
-      sources."figures-2.0.0"
+      sources."figures-3.1.0"
       sources."file-entry-cache-5.0.1"
       sources."flat-cache-2.0.1"
       sources."flatted-2.0.1"
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."glob-parent-5.1.0"
       sources."globals-11.12.0"
       sources."has-flag-3.0.0"
@@ -51738,9 +53855,9 @@ in
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."inquirer-6.5.2"
+      sources."inquirer-7.0.0"
       sources."is-extglob-2.1.1"
-      sources."is-fullwidth-code-point-2.0.0"
+      sources."is-fullwidth-code-point-3.0.0"
       sources."is-glob-4.0.1"
       sources."is-promise-2.1.0"
       sources."isexe-2.0.0"
@@ -51750,16 +53867,16 @@ in
       sources."json-stable-stringify-without-jsonify-1.0.1"
       sources."levn-0.3.0"
       sources."lodash-4.17.15"
-      sources."mimic-fn-1.2.0"
+      sources."mimic-fn-2.1.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       sources."ms-2.1.2"
-      sources."mute-stream-0.0.7"
+      sources."mute-stream-0.0.8"
       sources."natural-compare-1.4.0"
       sources."nice-try-1.0.5"
       sources."once-1.4.0"
-      sources."onetime-2.0.1"
+      sources."onetime-5.1.0"
       sources."optionator-0.8.2"
       sources."os-tmpdir-1.0.2"
       sources."parent-module-1.0.1"
@@ -51770,7 +53887,7 @@ in
       sources."punycode-2.1.1"
       sources."regexpp-2.0.1"
       sources."resolve-from-4.0.0"
-      sources."restore-cursor-2.0.0"
+      sources."restore-cursor-3.1.0"
       sources."rimraf-2.6.3"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.3"
@@ -51779,22 +53896,20 @@ in
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
-      sources."slice-ansi-2.1.0"
+      (sources."slice-ansi-2.1.0" // {
+        dependencies = [
+          sources."is-fullwidth-code-point-2.0.0"
+        ];
+      })
       sources."sprintf-js-1.0.3"
-      (sources."string-width-2.1.1" // {
-        dependencies = [
-          sources."strip-ansi-4.0.0"
-        ];
-      })
-      (sources."strip-ansi-5.2.0" // {
-        dependencies = [
-          sources."ansi-regex-4.1.0"
-        ];
-      })
+      sources."string-width-4.1.0"
+      sources."strip-ansi-5.2.0"
       sources."strip-json-comments-3.0.1"
       sources."supports-color-5.5.0"
       (sources."table-5.4.6" // {
         dependencies = [
+          sources."emoji-regex-7.0.3"
+          sources."is-fullwidth-code-point-2.0.0"
           sources."string-width-3.1.0"
         ];
       })
@@ -51803,6 +53918,7 @@ in
       sources."tmp-0.0.33"
       sources."tslib-1.10.0"
       sources."type-check-0.3.2"
+      sources."type-fest-0.5.2"
       sources."uri-js-4.2.2"
       sources."v8-compile-cache-2.1.0"
       sources."which-1.3.1"
@@ -51831,11 +53947,11 @@ in
     dependencies = [
       sources."@babel/code-frame-7.5.5"
       sources."@babel/highlight-7.5.0"
-      sources."acorn-7.0.0"
-      sources."acorn-jsx-5.0.2"
+      sources."acorn-7.1.0"
+      sources."acorn-jsx-5.1.0"
       sources."ajv-6.10.2"
-      sources."ansi-escapes-3.2.0"
-      sources."ansi-regex-3.0.0"
+      sources."ansi-escapes-4.2.1"
+      sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
       sources."argparse-1.0.10"
       sources."astral-regex-1.0.0"
@@ -51844,7 +53960,7 @@ in
       sources."callsites-3.1.0"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
-      sources."cli-cursor-2.1.0"
+      sources."cli-cursor-3.1.0"
       sources."cli-width-2.2.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -51858,13 +53974,13 @@ in
       sources."debug-4.1.1"
       sources."deep-is-0.1.3"
       sources."doctrine-3.0.0"
-      sources."emoji-regex-7.0.3"
+      sources."emoji-regex-8.0.0"
       sources."escape-string-regexp-1.0.5"
-      sources."eslint-6.4.0"
+      sources."eslint-6.6.0"
       sources."eslint-scope-5.0.0"
-      sources."eslint-utils-1.4.2"
+      sources."eslint-utils-1.4.3"
       sources."eslint-visitor-keys-1.1.0"
-      sources."espree-6.1.1"
+      sources."espree-6.1.2"
       sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
@@ -51874,13 +53990,13 @@ in
       sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fast-levenshtein-2.0.6"
-      sources."figures-2.0.0"
+      sources."figures-3.1.0"
       sources."file-entry-cache-5.0.1"
       sources."flat-cache-2.0.1"
       sources."flatted-2.0.1"
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."glob-parent-5.1.0"
       sources."globals-11.12.0"
       sources."has-flag-3.0.0"
@@ -51890,9 +54006,9 @@ in
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."inquirer-6.5.2"
+      sources."inquirer-7.0.0"
       sources."is-extglob-2.1.1"
-      sources."is-fullwidth-code-point-2.0.0"
+      sources."is-fullwidth-code-point-3.0.0"
       sources."is-glob-4.0.1"
       sources."is-promise-2.1.0"
       sources."isexe-2.0.0"
@@ -51902,17 +54018,17 @@ in
       sources."json-stable-stringify-without-jsonify-1.0.1"
       sources."levn-0.3.0"
       sources."lodash-4.17.15"
-      sources."mimic-fn-1.2.0"
+      sources."mimic-fn-2.1.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       sources."ms-2.1.2"
-      sources."mute-stream-0.0.7"
+      sources."mute-stream-0.0.8"
       sources."nanolru-1.0.0"
       sources."natural-compare-1.4.0"
       sources."nice-try-1.0.5"
       sources."once-1.4.0"
-      sources."onetime-2.0.1"
+      sources."onetime-5.1.0"
       sources."optionator-0.8.2"
       sources."os-tmpdir-1.0.2"
       sources."parent-module-1.0.1"
@@ -51925,7 +54041,7 @@ in
       sources."regexpp-2.0.1"
       sources."resolve-1.12.0"
       sources."resolve-from-4.0.0"
-      sources."restore-cursor-2.0.0"
+      sources."restore-cursor-3.1.0"
       sources."rimraf-2.6.3"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.3"
@@ -51934,22 +54050,20 @@ in
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
-      sources."slice-ansi-2.1.0"
+      (sources."slice-ansi-2.1.0" // {
+        dependencies = [
+          sources."is-fullwidth-code-point-2.0.0"
+        ];
+      })
       sources."sprintf-js-1.0.3"
-      (sources."string-width-2.1.1" // {
-        dependencies = [
-          sources."strip-ansi-4.0.0"
-        ];
-      })
-      (sources."strip-ansi-5.2.0" // {
-        dependencies = [
-          sources."ansi-regex-4.1.0"
-        ];
-      })
+      sources."string-width-4.1.0"
+      sources."strip-ansi-5.2.0"
       sources."strip-json-comments-3.0.1"
       sources."supports-color-5.5.0"
       (sources."table-5.4.6" // {
         dependencies = [
+          sources."emoji-regex-7.0.3"
+          sources."is-fullwidth-code-point-2.0.0"
           sources."string-width-3.1.0"
         ];
       })
@@ -51958,6 +54072,7 @@ in
       sources."tmp-0.0.33"
       sources."tslib-1.10.0"
       sources."type-check-0.3.2"
+      sources."type-fest-0.5.2"
       sources."uri-js-4.2.2"
       sources."v8-compile-cache-2.1.0"
       sources."which-1.3.1"
@@ -52030,13 +54145,13 @@ in
       sources."fs-extra-1.0.0"
       sources."get-stdin-4.0.1"
       sources."getpass-0.1.7"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."hasha-2.2.0"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-signature-1.2.0"
       sources."indent-string-2.1.0"
       sources."inherits-2.0.4"
@@ -52217,9 +54332,9 @@ in
       sources."generate-function-1.1.0"
       sources."generate-object-property-1.2.0"
       sources."get-stream-3.0.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."iconv-lite-0.4.24"
       sources."indent-string-3.2.0"
       sources."inherits-2.0.4"
@@ -52471,10 +54586,10 @@ in
       sources."fsevents-1.2.9"
       sources."function-bind-1.1.1"
       sources."get-value-2.0.6"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-1.0.3"
       (sources."has-value-1.0.0" // {
         dependencies = [
@@ -52834,7 +54949,7 @@ in
       sources."asyncmemo-1.0.0"
       sources."chloride-2.2.14"
       sources."chloride-test-1.2.4"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."debug-4.1.1"
       sources."deep-extend-0.6.0"
       sources."diff-3.5.0"
@@ -52848,7 +54963,7 @@ in
       sources."git-remote-ssb-2.0.4"
       sources."git-ssb-web-2.8.0"
       sources."hashlru-2.3.0"
-      sources."highlight.js-9.15.10"
+      sources."highlight.js-9.16.2"
       sources."increment-buffer-1.0.1"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -52863,8 +54978,8 @@ in
       sources."jsonpointer-4.0.1"
       sources."kvgraph-0.1.0"
       sources."kvset-1.0.0"
-      sources."libsodium-0.7.5"
-      sources."libsodium-wrappers-0.7.5"
+      sources."libsodium-0.7.6"
+      sources."libsodium-wrappers-0.7.6"
       sources."lodash.get-4.4.2"
       sources."looper-4.0.0"
       sources."lrucache-1.0.3"
@@ -52880,7 +54995,7 @@ in
       sources."moo-0.4.3"
       sources."ms-2.1.2"
       sources."multicb-1.2.2"
-      sources."multiserver-3.4.0"
+      sources."multiserver-3.6.0"
       sources."multiserver-address-1.0.1"
       sources."multiserver-scopes-1.0.0"
       sources."muxrpc-6.4.2"
@@ -52967,7 +55082,7 @@ in
       sources."ssb-caps-1.1.0"
       (sources."ssb-client-4.7.8" // {
         dependencies = [
-          sources."ssb-config-3.3.2"
+          sources."ssb-config-3.4.2"
         ];
       })
       sources."ssb-config-2.3.9"
@@ -53055,7 +55170,7 @@ in
       sources."agent-base-4.3.0"
       sources."ajv-6.10.2"
       sources."ansi-align-2.0.0"
-      sources."ansi-escapes-3.2.0"
+      sources."ansi-escapes-4.2.1"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
       (sources."apollo-codegen-0.20.2" // {
@@ -53083,7 +55198,7 @@ in
       sources."babel-runtime-6.26.0"
       sources."balanced-match-1.0.0"
       sources."bcrypt-pbkdf-1.0.2"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       (sources."body-parser-1.19.0" // {
         dependencies = [
           sources."qs-6.7.0"
@@ -53105,10 +55220,10 @@ in
       sources."chalk-2.4.2"
       sources."change-case-3.1.0"
       sources."chardet-0.7.0"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."ci-info-1.6.0"
       sources."cli-boxes-1.0.0"
-      sources."cli-cursor-2.1.0"
+      sources."cli-cursor-3.1.0"
       sources."cli-spinners-2.2.0"
       sources."cli-width-2.2.0"
       sources."cliui-4.1.0"
@@ -53125,7 +55240,7 @@ in
       })
       sources."combined-stream-1.0.8"
       sources."command-exists-1.2.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."common-tags-1.8.0"
       sources."concat-map-0.0.1"
       sources."configstore-3.1.2"
@@ -53138,11 +55253,20 @@ in
       sources."content-type-1.0.4"
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
-      sources."core-js-2.6.9"
+      sources."core-js-2.6.10"
       sources."core-util-is-1.0.2"
       sources."cosmiconfig-5.2.1"
       sources."create-error-class-3.0.2"
-      sources."creato-1.0.5"
+      (sources."creato-1.0.7" // {
+        dependencies = [
+          sources."ansi-regex-4.1.0"
+          sources."inquirer-7.0.0"
+          sources."is-fullwidth-code-point-3.0.0"
+          sources."ora-4.0.2"
+          sources."string-width-4.1.0"
+          sources."strip-ansi-5.2.0"
+        ];
+      })
       (sources."cross-fetch-2.2.2" // {
         dependencies = [
           sources."node-fetch-2.1.2"
@@ -53177,9 +55301,10 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ecdsa-sig-formatter-1.0.11"
       sources."ee-first-1.1.1"
+      sources."emoji-regex-8.0.0"
       sources."encodeurl-1.0.2"
       sources."encoding-0.1.12"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."errno-0.1.7"
       sources."error-ex-1.3.2"
       sources."es6-promise-4.2.8"
@@ -53217,7 +55342,7 @@ in
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
-      sources."figures-2.0.0"
+      sources."figures-3.1.0"
       sources."finalhandler-1.1.2"
       sources."find-0.2.9"
       sources."find-up-2.1.0"
@@ -53232,12 +55357,12 @@ in
       sources."get-caller-file-1.0.3"
       sources."get-stream-3.0.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."global-dirs-0.1.1"
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."graphcool-json-schema-1.2.1"
       (sources."graphcool-yml-0.4.15" // {
         dependencies = [
@@ -53250,7 +55375,7 @@ in
           sources."ms-2.1.2"
         ];
       })
-      sources."graphql-14.5.7"
+      sources."graphql-14.5.8"
       (sources."graphql-cli-prepare-1.4.19" // {
         dependencies = [
           sources."chalk-2.3.1"
@@ -53275,7 +55400,7 @@ in
       sources."has-flag-3.0.0"
       sources."header-case-1.0.1"
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       (sources."http-errors-1.7.2" // {
         dependencies = [
           sources."inherits-2.0.3"
@@ -53287,7 +55412,7 @@ in
         ];
       })
       sources."http-signature-1.2.0"
-      (sources."https-proxy-agent-2.2.2" // {
+      (sources."https-proxy-agent-2.2.4" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
@@ -53305,7 +55430,16 @@ in
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
-      sources."inquirer-6.2.0"
+      (sources."inquirer-6.2.0" // {
+        dependencies = [
+          sources."ansi-escapes-3.2.0"
+          sources."cli-cursor-2.1.0"
+          sources."figures-2.0.0"
+          sources."mute-stream-0.0.7"
+          sources."onetime-2.0.1"
+          sources."restore-cursor-2.0.0"
+        ];
+      })
       sources."invert-kv-1.0.0"
       sources."ip-regex-1.0.3"
       sources."ipaddr.js-1.9.0"
@@ -53314,6 +55448,7 @@ in
       sources."is-directory-0.3.1"
       sources."is-fullwidth-code-point-1.0.0"
       sources."is-installed-globally-0.1.0"
+      sources."is-interactive-1.0.0"
       sources."is-lower-case-1.1.3"
       sources."is-npm-1.0.0"
       sources."is-obj-1.0.1"
@@ -53379,7 +55514,7 @@ in
       sources."lodash.isplainobject-4.0.6"
       sources."lodash.isstring-4.0.1"
       sources."lodash.once-4.1.1"
-      sources."log-symbols-2.2.0"
+      sources."log-symbols-3.0.0"
       sources."lower-case-1.1.4"
       sources."lower-case-first-1.0.2"
       sources."lowercase-keys-1.0.1"
@@ -53400,15 +55535,15 @@ in
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      (sources."minipass-2.8.1" // {
+      (sources."minipass-2.9.0" // {
         dependencies = [
-          sources."yallist-3.0.3"
+          sources."yallist-3.1.1"
         ];
       })
-      sources."minizlib-1.2.2"
+      sources."minizlib-1.3.3"
       sources."mkdirp-0.5.1"
       sources."ms-2.0.0"
-      sources."mute-stream-0.0.7"
+      sources."mute-stream-0.0.8"
       sources."negotiator-0.6.2"
       sources."nice-try-1.0.5"
       sources."no-case-2.3.2"
@@ -53429,13 +55564,21 @@ in
       sources."oauth-sign-0.9.0"
       sources."on-finished-2.3.0"
       sources."once-1.4.0"
-      sources."onetime-2.0.1"
+      (sources."onetime-5.1.0" // {
+        dependencies = [
+          sources."mimic-fn-2.1.0"
+        ];
+      })
       sources."ono-4.0.11"
       sources."open-0.0.5"
       sources."opn-5.5.0"
       (sources."ora-3.4.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
+          sources."cli-cursor-2.1.0"
+          sources."log-symbols-2.2.0"
+          sources."onetime-2.0.1"
+          sources."restore-cursor-2.0.0"
           sources."strip-ansi-5.2.0"
         ];
       })
@@ -53513,7 +55656,7 @@ in
       sources."resolve-1.12.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-from-4.0.0"
-      sources."restore-cursor-2.0.0"
+      sources."restore-cursor-3.1.0"
       sources."rimraf-2.7.1"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.3"
@@ -53538,7 +55681,7 @@ in
       sources."simple-errors-1.0.1"
       sources."snake-case-2.1.0"
       sources."source-map-0.5.7"
-      (sources."source-map-support-0.5.13" // {
+      (sources."source-map-support-0.5.16" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -53568,9 +55711,9 @@ in
       sources."supports-color-5.5.0"
       sources."swap-case-1.1.2"
       sources."sync-exec-0.6.2"
-      (sources."tar-4.4.11" // {
+      (sources."tar-4.4.13" // {
         dependencies = [
-          sources."yallist-3.0.3"
+          sources."yallist-3.1.1"
         ];
       })
       sources."term-size-1.2.0"
@@ -53592,6 +55735,7 @@ in
       sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
+      sources."type-fest-0.5.2"
       sources."type-is-1.6.18"
       sources."unique-string-1.0.0"
       sources."universalify-0.1.2"
@@ -53942,7 +56086,7 @@ in
       sources."ansi-term-0.0.2"
       sources."ansicolors-0.2.1"
       sources."blessed-0.1.81"
-      sources."blessed-contrib-4.8.17"
+      sources."blessed-contrib-4.8.18"
       sources."bresenham-0.0.3"
       sources."buffers-0.1.1"
       sources."cardinal-1.0.0"
@@ -53954,7 +56098,7 @@ in
       sources."define-properties-1.1.3"
       sources."drawille-blessed-contrib-1.0.0"
       sources."drawille-canvas-blessed-contrib-0.1.3"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-3.0.0"
@@ -54000,7 +56144,7 @@ in
       sources."string_decoder-0.10.31"
       sources."strip-ansi-3.0.1"
       sources."supports-color-2.0.0"
-      sources."systeminformation-4.14.8"
+      sources."systeminformation-4.14.17"
       sources."term-canvas-0.0.5"
       sources."util.promisify-1.0.0"
       sources."wordwrap-0.0.3"
@@ -54133,11 +56277,11 @@ in
       sources."detect-file-1.0.0"
       sources."duplexify-3.7.1"
       sources."each-props-1.3.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."error-ex-1.3.2"
-      sources."es5-ext-0.10.51"
+      sources."es5-ext-0.10.52"
       sources."es6-iterator-2.0.3"
-      sources."es6-symbol-3.1.2"
+      sources."es6-symbol-3.1.3"
       sources."es6-weak-map-2.0.3"
       (sources."expand-brackets-2.1.4" // {
         dependencies = [
@@ -54158,6 +56302,11 @@ in
         ];
       })
       sources."expand-tilde-2.0.2"
+      (sources."ext-1.1.2" // {
+        dependencies = [
+          sources."type-2.0.0"
+        ];
+      })
       sources."extend-3.0.2"
       (sources."extend-shallow-3.0.2" // {
         dependencies = [
@@ -54190,7 +56339,7 @@ in
       sources."function-bind-1.1.1"
       sources."get-caller-file-1.0.3"
       sources."get-value-2.0.6"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -54201,7 +56350,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."gulp-cli-2.2.0"
       sources."gulplog-1.0.0"
       sources."has-symbols-1.0.0"
@@ -54212,7 +56361,7 @@ in
         ];
       })
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -54534,9 +56683,9 @@ in
       sources."detect-file-1.0.0"
       sources."each-props-1.3.2"
       sources."error-ex-1.3.2"
-      sources."es5-ext-0.10.51"
+      sources."es5-ext-0.10.52"
       sources."es6-iterator-2.0.3"
-      sources."es6-symbol-3.1.2"
+      sources."es6-symbol-3.1.3"
       (sources."expand-brackets-2.1.4" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -54548,6 +56697,11 @@ in
         ];
       })
       sources."expand-tilde-2.0.2"
+      (sources."ext-1.1.2" // {
+        dependencies = [
+          sources."type-2.0.0"
+        ];
+      })
       sources."extend-3.0.2"
       (sources."extend-shallow-3.0.2" // {
         dependencies = [
@@ -54578,7 +56732,7 @@ in
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."glogg-1.0.2"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."gulplog-1.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -54587,7 +56741,7 @@ in
         ];
       })
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
       sources."interpret-1.2.0"
@@ -54822,14 +56976,14 @@ in
     dependencies = [
       sources."camel-case-3.0.0"
       sources."clean-css-4.2.1"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."he-1.2.0"
       sources."lower-case-1.1.4"
       sources."no-case-2.3.2"
       sources."param-case-2.1.1"
       sources."relateurl-0.2.7"
       sources."source-map-0.6.1"
-      sources."uglify-js-3.6.0"
+      sources."uglify-js-3.6.6"
       sources."upper-case-1.1.3"
     ];
     buildInputs = globalBuildInputs;
@@ -54973,7 +57127,7 @@ in
       sha512 = "6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==";
     };
     dependencies = [
-      sources."async-1.5.2"
+      sources."async-2.6.3"
       sources."colors-1.0.3"
       sources."corser-2.0.1"
       sources."debug-3.2.6"
@@ -54982,6 +57136,7 @@ in
       sources."follow-redirects-1.9.0"
       sources."he-1.2.0"
       sources."http-proxy-1.18.0"
+      sources."lodash-4.17.15"
       sources."mime-1.6.0"
       sources."minimist-1.2.0"
       (sources."mkdirp-0.5.1" // {
@@ -54996,12 +57151,7 @@ in
           sources."minimist-0.0.10"
         ];
       })
-      (sources."portfinder-1.0.24" // {
-        dependencies = [
-          sources."debug-2.6.9"
-          sources."ms-2.0.0"
-        ];
-      })
+      sources."portfinder-1.0.25"
       sources."qs-2.3.3"
       sources."requires-port-1.0.0"
       sources."union-0.4.6"
@@ -55043,7 +57193,7 @@ in
       sources."extsprintf-1.4.0"
       sources."fs.realpath-1.0.0"
       sources."fuzzyset.js-0.0.1"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."hue-sdk-0.1.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -55140,21 +57290,19 @@ in
   indium = nodeEnv.buildNodePackage {
     name = "indium";
     packageName = "indium";
-    version = "3.4.1";
+    version = "5.0.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/indium/-/indium-3.4.1.tgz";
-      sha512 = "RJ8nHsE4diosqkSpKot3unMn05ExCisUDy/URw/3M9t8MetvthBBQpcfaRPGftXRGebaMF1HnH6dLG994TpNVQ==";
+      url = "https://registry.npmjs.org/indium/-/indium-5.0.0.tgz";
+      sha512 = "NGgQYdtKoh6zXoo1Sp3cvBur7SMud1JU6ghMQTBUxmPGlRmoB0esc3qVlLbK8f0d8j7OZgUUYkfGd0+xTYGvOw==";
     };
     dependencies = [
       sources."async-limiter-1.0.1"
-      sources."chrome-remote-interface-0.26.1"
+      sources."chrome-remote-interface-0.27.2"
       sources."commander-2.11.0"
       sources."node-fetch-2.6.0"
-      sources."safe-buffer-5.1.2"
       sources."semver-5.7.1"
       sources."source-map-0.7.3"
-      sources."ultron-1.1.1"
-      sources."ws-3.3.3"
+      sources."ws-6.2.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -55169,25 +57317,25 @@ in
   ionic = nodeEnv.buildNodePackage {
     name = "ionic";
     packageName = "ionic";
-    version = "5.4.1";
+    version = "5.4.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ionic/-/ionic-5.4.1.tgz";
-      sha512 = "z4Zdb1lEZoqx6HsURVgdqGw0INtDeNrbahTZacrqm3cNmjq6X4SOP+dILIeZoURq/V0KcyVcVQnssWRFbVd8TQ==";
+      url = "https://registry.npmjs.org/ionic/-/ionic-5.4.5.tgz";
+      sha512 = "hc45gTZeqNGQl8Pr3R9F2Ud8qrMybOK9YiG1vGwZVm4ZwnhQw3urB4UHIQVjuruHWQBXS+KM9gFAopJlan9E4Q==";
     };
     dependencies = [
-      sources."@ionic/cli-framework-2.1.7"
+      sources."@ionic/cli-framework-3.0.0"
+      sources."@ionic/cli-framework-prompts-1.0.1"
       sources."@ionic/discover-2.0.6"
       sources."@ionic/utils-array-1.2.1"
-      sources."@ionic/utils-fs-2.0.7"
+      sources."@ionic/utils-fs-2.0.8"
       sources."@ionic/utils-network-1.0.5"
       sources."@ionic/utils-object-1.0.5"
       sources."@ionic/utils-process-1.0.5"
       sources."@ionic/utils-stream-2.0.4"
-      sources."@ionic/utils-subprocess-1.0.8"
+      sources."@ionic/utils-subprocess-1.0.9"
       sources."@ionic/utils-terminal-1.0.5"
-      sources."@types/node-8.10.54"
       sources."agent-base-4.3.0"
-      sources."ansi-escapes-4.2.1"
+      sources."ansi-escapes-3.2.0"
       sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
       sources."ast-types-0.13.2"
@@ -55199,8 +57347,8 @@ in
       sources."bytes-3.1.0"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
-      sources."chownr-1.1.2"
-      sources."cli-cursor-3.1.0"
+      sources."chownr-1.1.3"
+      sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.0"
       sources."co-4.6.0"
       sources."color-convert-1.9.3"
@@ -55210,8 +57358,8 @@ in
       sources."concat-map-0.0.1"
       sources."cookiejar-2.1.2"
       sources."core-util-is-1.0.2"
-      sources."cross-spawn-7.0.0"
-      sources."data-uri-to-buffer-2.0.1"
+      sources."cross-spawn-7.0.1"
+      sources."data-uri-to-buffer-1.2.0"
       sources."debug-4.1.1"
       sources."deep-is-0.1.3"
       sources."degenerator-1.0.4"
@@ -55227,7 +57375,7 @@ in
       })
       sources."elementtree-0.1.7"
       sources."emoji-regex-7.0.3"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
@@ -55240,12 +57388,15 @@ in
           sources."cross-spawn-6.0.5"
           sources."path-key-2.0.1"
           sources."semver-5.7.1"
+          sources."shebang-command-1.2.0"
+          sources."shebang-regex-1.0.0"
+          sources."which-1.3.1"
         ];
       })
       sources."extend-3.0.2"
       sources."external-editor-3.1.0"
       sources."fast-levenshtein-2.0.6"
-      sources."figures-3.0.0"
+      sources."figures-3.1.0"
       sources."file-uri-to-path-1.0.0"
       sources."form-data-2.5.1"
       sources."formidable-1.2.1"
@@ -55260,9 +57411,17 @@ in
         ];
       })
       sources."get-stream-4.1.0"
-      sources."get-uri-2.0.3"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      (sources."get-uri-2.0.4" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+          sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
+          sources."string_decoder-1.1.1"
+        ];
+      })
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
       sources."http-errors-1.7.3"
       (sources."http-proxy-agent-2.1.0" // {
@@ -55271,7 +57430,7 @@ in
           sources."ms-2.0.0"
         ];
       })
-      (sources."https-proxy-agent-2.2.2" // {
+      (sources."https-proxy-agent-3.0.1" // {
         dependencies = [
           sources."debug-3.2.6"
         ];
@@ -55280,13 +57439,21 @@ in
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."inquirer-7.0.0"
+      (sources."inquirer-7.0.0" // {
+        dependencies = [
+          sources."ansi-escapes-4.2.1"
+          sources."cli-cursor-3.1.0"
+          sources."mimic-fn-2.1.0"
+          sources."onetime-5.1.0"
+          sources."restore-cursor-3.1.0"
+        ];
+      })
       sources."ip-1.1.5"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-promise-2.1.0"
       sources."is-stream-1.1.0"
       sources."is-typedarray-1.0.0"
-      sources."is-wsl-1.1.0"
+      sources."is-wsl-2.1.1"
       sources."isarray-1.0.0"
       sources."isexe-2.0.0"
       sources."jsonfile-4.0.0"
@@ -55311,30 +57478,21 @@ in
       sources."lodash.restparam-3.6.1"
       (sources."log-update-3.3.0" // {
         dependencies = [
-          sources."ansi-escapes-3.2.0"
-          sources."cli-cursor-2.1.0"
-          sources."mimic-fn-1.2.0"
-          sources."onetime-2.0.1"
-          sources."restore-cursor-2.0.0"
           sources."string-width-3.1.0"
           sources."wrap-ansi-5.1.0"
         ];
       })
-      sources."lru-cache-4.1.5"
+      sources."lru-cache-5.1.1"
       sources."macos-release-2.3.0"
       sources."methods-1.1.2"
       sources."mime-2.4.4"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
-      sources."mimic-fn-2.1.0"
+      sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."minipass-2.8.1" // {
-        dependencies = [
-          sources."yallist-3.0.3"
-        ];
-      })
-      sources."minizlib-1.2.2"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
@@ -55350,34 +57508,25 @@ in
         ];
       })
       sources."once-1.4.0"
-      sources."onetime-5.1.0"
-      sources."open-6.4.0"
+      sources."onetime-2.0.1"
+      sources."open-7.0.0"
       sources."optionator-0.8.2"
       sources."os-name-3.1.0"
       sources."os-tmpdir-1.0.2"
       sources."p-finally-1.0.0"
-      (sources."pac-proxy-agent-3.0.0" // {
-        dependencies = [
-          sources."debug-3.2.6"
-        ];
-      })
+      sources."pac-proxy-agent-3.0.1"
       sources."pac-resolver-3.0.0"
       sources."path-is-absolute-1.0.1"
       sources."path-key-3.1.0"
       sources."prelude-ls-1.1.2"
       sources."process-nextick-args-2.0.1"
-      (sources."proxy-agent-3.1.0" // {
-        dependencies = [
-          sources."debug-3.2.6"
-        ];
-      })
+      sources."proxy-agent-3.1.1"
       sources."proxy-from-env-1.0.0"
-      sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
       sources."qs-6.9.0"
       sources."raw-body-2.4.1"
       sources."readable-stream-3.4.0"
-      sources."restore-cursor-3.1.0"
+      sources."restore-cursor-2.0.0"
       sources."rimraf-3.0.0"
       sources."rsvp-3.6.2"
       sources."run-async-2.3.0"
@@ -55387,8 +57536,8 @@ in
       sources."sax-1.1.4"
       sources."semver-6.3.0"
       sources."setprototypeof-1.1.1"
-      sources."shebang-command-1.2.0"
-      sources."shebang-regex-1.0.0"
+      sources."shebang-command-2.0.0"
+      sources."shebang-regex-3.0.0"
       sources."signal-exit-3.0.2"
       sources."slice-ansi-2.1.0"
       sources."smart-buffer-4.0.2"
@@ -55425,11 +57574,7 @@ in
         ];
       })
       sources."supports-color-5.5.0"
-      (sources."tar-4.4.11" // {
-        dependencies = [
-          sources."yallist-3.0.3"
-        ];
-      })
+      sources."tar-4.4.13"
       sources."through-2.3.8"
       sources."through2-3.0.1"
       sources."thunkify-2.1.2"
@@ -55445,10 +57590,10 @@ in
       sources."untildify-4.0.0"
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.3"
-      sources."which-1.3.1"
+      sources."which-2.0.1"
       sources."windows-release-3.2.0"
       sources."wordwrap-1.0.0"
-      (sources."wrap-ansi-6.0.0" // {
+      (sources."wrap-ansi-6.1.0" // {
         dependencies = [
           sources."ansi-styles-4.1.0"
           sources."color-convert-2.0.1"
@@ -55456,10 +57601,10 @@ in
         ];
       })
       sources."wrappy-1.0.2"
-      sources."write-file-atomic-3.0.0"
-      sources."ws-7.1.2"
+      sources."write-file-atomic-3.0.1"
+      sources."ws-7.2.0"
       sources."xregexp-2.0.0"
-      sources."yallist-2.1.2"
+      sources."yallist-3.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -55512,10 +57657,10 @@ in
       sources."aws4-1.8.0"
       sources."balanced-match-1.0.0"
       sources."bcrypt-pbkdf-1.0.2"
-      sources."bezier-js-2.4.3"
+      sources."bezier-js-2.4.4"
       sources."bindings-1.5.0"
       sources."block-stream-0.0.9"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."brace-expansion-1.1.11"
       sources."bufferstreams-1.1.3"
       sources."camelcase-4.1.0"
@@ -55553,7 +57698,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
       sources."ecc-jsbn-0.1.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."error-ex-1.3.2"
       sources."escape-latex-1.2.0"
       sources."escape-string-regexp-1.0.5"
@@ -55611,13 +57756,13 @@ in
       sources."get-caller-file-1.0.3"
       sources."get-stream-3.0.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
       sources."has-unicode-2.0.1"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -55748,7 +57893,7 @@ in
       sources."restore-cursor-2.0.0"
       sources."resumer-0.0.0"
       sources."retry-0.12.0"
-      sources."rimraf-2.2.8"
+      sources."rimraf-2.6.3"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
@@ -55791,7 +57936,7 @@ in
       })
       sources."supports-color-5.5.0"
       sources."tar-2.2.2"
-      sources."temp-0.8.3"
+      sources."temp-0.8.4"
       sources."through-2.3.8"
       sources."tiny-emitter-2.1.0"
       sources."toml-2.3.6"
@@ -55817,7 +57962,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
-      (sources."verda-1.0.0-4" // {
+      (sources."verda-1.0.0-10" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."fs-extra-6.0.1"
@@ -55872,26 +58017,29 @@ in
   jake = nodeEnv.buildNodePackage {
     name = "jake";
     packageName = "jake";
-    version = "8.1.1";
+    version = "10.1.6";
     src = fetchurl {
-      url = "https://registry.npmjs.org/jake/-/jake-8.1.1.tgz";
-      sha512 = "RJUWDas5xu4rP6CbCPqkVP9+vglMPThhZIj08EtjSiUBpwRtVjhShPKIpETyEhy/Z1hEk97qITxbZK+WXtSyzw==";
+      url = "https://registry.npmjs.org/jake/-/jake-10.1.6.tgz";
+      sha512 = "gGnRHch3G461ryAnrBEeepuoyBHtqOfskwTWJntwF9hfzhe5kfcYbIpZKqFDniBWkyoUqktigvoTn+tysnjJdg==";
     };
     dependencies = [
-      sources."ansi-styles-1.0.0"
+      sources."ansi-styles-3.2.1"
       sources."async-0.9.2"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
-      sources."chalk-0.4.0"
+      sources."chalk-2.4.2"
+      sources."color-convert-1.9.3"
+      sources."color-name-1.1.3"
       sources."concat-map-0.0.1"
+      sources."escape-string-regexp-1.0.5"
       (sources."filelist-0.0.6" // {
         dependencies = [
           sources."utilities-0.0.37"
         ];
       })
-      sources."has-color-0.1.7"
+      sources."has-flag-3.0.0"
       sources."minimatch-3.0.4"
-      sources."strip-ansi-0.1.1"
+      sources."supports-color-5.5.0"
       sources."utilities-1.0.5"
     ];
     buildInputs = globalBuildInputs;
@@ -55926,7 +58074,7 @@ in
       sources."check-error-1.0.2"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."concat-map-0.0.1"
       sources."deep-eql-3.0.1"
       sources."error-7.0.2"
@@ -55935,13 +58083,13 @@ in
       sources."fast-json-patch-2.2.1"
       sources."fs.realpath-1.0.0"
       sources."get-func-name-2.0.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."has-flag-3.0.0"
       sources."hexer-1.5.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."iterare-1.2.0"
-      (sources."jaeger-client-3.16.0" // {
+      (sources."jaeger-client-3.17.1" // {
         dependencies = [
           sources."opentracing-0.13.0"
         ];
@@ -55993,14 +58141,14 @@ in
   joplin = nodeEnv.buildNodePackage {
     name = "joplin";
     packageName = "joplin";
-    version = "1.0.146";
+    version = "1.0.149";
     src = fetchurl {
-      url = "https://registry.npmjs.org/joplin/-/joplin-1.0.146.tgz";
-      sha512 = "Qy7lEfrvRfCL2c+NQWXjSVrwVTsflwxSozvntF8yMtPDhGvy912PjQQFjRplqusdmUEOOacupcRovcvC+T5Bbw==";
+      url = "https://registry.npmjs.org/joplin/-/joplin-1.0.149.tgz";
+      sha512 = "DDMvPmNgsp3yQtwsIvxeCrE5MByDaUojKGfFH4vYTAbboO7jB34rwknwW3efVoOjQVtLmMH6OpBajArci9q8tQ==";
     };
     dependencies = [
       sources."@cronvel/get-pixels-3.3.1"
-      sources."abab-2.0.1"
+      sources."abab-2.0.2"
       sources."abbrev-1.1.1"
       sources."acorn-5.7.3"
       (sources."acorn-globals-4.3.4" // {
@@ -56019,7 +58167,13 @@ in
       sources."ansi-styles-3.2.1"
       sources."app-module-path-2.2.0"
       sources."aproba-1.2.0"
-      sources."are-we-there-yet-1.1.5"
+      (sources."are-we-there-yet-1.1.5" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
+          sources."string_decoder-1.1.1"
+        ];
+      })
       (sources."argparse-1.0.10" // {
         dependencies = [
           sources."sprintf-js-1.0.3"
@@ -56031,7 +58185,7 @@ in
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."async-limiter-1.0.1"
-      sources."async-mutex-0.1.3"
+      sources."async-mutex-0.1.4"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
       sources."aws-sign2-0.7.0"
@@ -56039,11 +58193,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base-64-0.1.0"
       sources."bcrypt-pbkdf-1.0.2"
-      (sources."bl-3.0.0" // {
-        dependencies = [
-          sources."readable-stream-3.4.0"
-        ];
-      })
+      sources."bl-3.0.0"
       sources."brace-expansion-1.1.11"
       sources."browser-process-hrtime-0.1.3"
       sources."camel-case-3.0.0"
@@ -56051,9 +58201,10 @@ in
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."charenc-0.0.2"
-      sources."chownr-1.1.2"
-      sources."chroma-js-2.0.6"
+      sources."chownr-1.1.3"
+      sources."chroma-js-2.1.0"
       sources."clean-css-4.2.1"
+      sources."clean-html-1.5.0"
       sources."cliss-0.0.2"
       sources."code-point-at-1.1.0"
       sources."color-3.1.2"
@@ -56067,6 +58218,8 @@ in
       sources."concat-map-0.0.1"
       sources."console-control-strings-1.1.0"
       sources."core-util-is-1.0.2"
+      sources."cross-env-6.0.3"
+      sources."cross-spawn-7.0.1"
       sources."crypt-0.0.2"
       sources."css-2.2.4"
       sources."cssom-0.3.8"
@@ -56075,7 +58228,7 @@ in
       sources."dashdash-1.14.1"
       (sources."data-urls-1.1.0" // {
         dependencies = [
-          sources."whatwg-url-7.0.0"
+          sources."whatwg-url-7.1.0"
         ];
       })
       sources."debug-3.2.6"
@@ -56091,7 +58244,16 @@ in
       sources."detect-libc-1.0.3"
       sources."diacritics-1.3.0"
       sources."diff-match-patch-1.0.4"
+      (sources."dom-serializer-0.2.1" // {
+        dependencies = [
+          sources."domelementtype-2.0.1"
+          sources."entities-2.0.0"
+        ];
+      })
+      sources."domelementtype-1.3.1"
       sources."domexception-1.0.1"
+      sources."domhandler-2.4.2"
+      sources."domutils-1.7.0"
       sources."ecc-jsbn-0.1.2"
       (sources."emphasize-1.5.0" // {
         dependencies = [
@@ -56102,9 +58264,9 @@ in
         ];
       })
       sources."encoding-0.1.12"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."es6-promise-pool-2.5.0"
       sources."escape-string-regexp-1.0.5"
@@ -56144,8 +58306,8 @@ in
       sources."get-stdin-5.0.1"
       sources."getpass-0.1.7"
       sources."github-from-package-0.0.0"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-1.0.3"
@@ -56158,10 +58320,11 @@ in
       sources."html-encoding-sniffer-1.0.2"
       sources."html-entities-1.2.1"
       sources."html-minifier-3.5.21"
+      sources."htmlparser2-3.10.1"
       sources."http-errors-1.7.3"
       sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.24"
-      sources."ignore-walk-3.0.2"
+      sources."ignore-walk-3.0.3"
       (sources."image-data-uri-2.0.1" // {
         dependencies = [
           sources."fs-extra-0.26.7"
@@ -56218,9 +58381,10 @@ in
         ];
       })
       sources."isarray-1.0.0"
+      sources."isexe-2.0.0"
       sources."isstream-0.1.2"
-      sources."joplin-turndown-4.0.17"
-      sources."joplin-turndown-plugin-gfm-1.0.9"
+      sources."joplin-turndown-4.0.18"
+      sources."joplin-turndown-plugin-gfm-1.0.11"
       sources."jpeg-js-0.1.2"
       sources."js-tokens-4.0.0"
       sources."jsbn-0.1.1"
@@ -56255,13 +58419,21 @@ in
       sources."mime-types-2.1.24"
       sources."mimic-response-2.0.0"
       sources."minimatch-3.0.4"
-      sources."minimist-0.0.8"
-      sources."minipass-2.8.1"
-      sources."minizlib-1.2.2"
-      sources."mkdirp-0.5.1"
+      sources."minimist-1.2.0"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
+      (sources."mkdirp-0.5.1" // {
+        dependencies = [
+          sources."minimist-0.0.8"
+        ];
+      })
       sources."moment-2.24.0"
       sources."ms-2.1.2"
-      sources."multiparty-4.2.1"
+      (sources."multiparty-4.2.1" // {
+        dependencies = [
+          sources."safe-buffer-5.1.2"
+        ];
+      })
       sources."nan-2.14.0"
       sources."napi-build-utils-1.0.1"
       sources."ndarray-1.0.18"
@@ -56269,7 +58441,7 @@ in
       sources."needle-2.4.0"
       sources."nextgen-events-1.3.0"
       sources."no-case-2.3.2"
-      (sources."node-abi-2.11.0" // {
+      (sources."node-abi-2.12.0" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
@@ -56286,7 +58458,7 @@ in
       sources."noop-logger-0.1.1"
       sources."nopt-4.0.1"
       sources."npm-bundled-1.0.6"
-      sources."npm-packlist-1.4.4"
+      sources."npm-packlist-1.4.6"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
       sources."nwsapi-2.1.4"
@@ -56314,17 +58486,14 @@ in
       sources."parse5-4.0.0"
       sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
+      sources."path-key-3.1.0"
       sources."pend-1.2.0"
       sources."performance-now-2.1.0"
       sources."pify-3.0.0"
       sources."pipe-functions-1.3.0"
       sources."pn-1.1.0"
       sources."pngjs-2.3.1"
-      (sources."prebuild-install-5.3.2" // {
-        dependencies = [
-          sources."minimist-1.2.0"
-        ];
-      })
+      sources."prebuild-install-5.3.2"
       sources."prelude-ls-1.1.2"
       sources."process-nextick-args-2.0.1"
       sources."promise-7.3.1"
@@ -56337,13 +58506,9 @@ in
       sources."query-string-4.3.4"
       sources."querystringify-2.1.1"
       sources."random-bytes-1.0.0"
-      (sources."rc-1.2.8" // {
-        dependencies = [
-          sources."minimist-1.2.0"
-        ];
-      })
+      sources."rc-1.2.8"
       sources."read-chunk-2.1.0"
-      sources."readable-stream-2.3.6"
+      sources."readable-stream-3.4.0"
       sources."reduce-flatten-1.0.1"
       sources."redux-3.7.2"
       sources."relateurl-0.2.7"
@@ -56360,7 +58525,7 @@ in
       sources."resolve-url-0.2.1"
       sources."retry-0.10.1"
       sources."rimraf-2.7.1"
-      sources."safe-buffer-5.1.2"
+      sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
       sources."semver-6.3.0"
@@ -56368,8 +58533,10 @@ in
       sources."set-blocking-2.0.0"
       sources."setimmediate-1.0.5"
       sources."setprototypeof-1.1.1"
-      sources."seventh-0.7.28"
+      sources."seventh-0.7.30"
       sources."sharp-0.22.1"
+      sources."shebang-command-2.0.0"
+      sources."shebang-regex-3.0.0"
       sources."signal-exit-3.0.2"
       sources."simple-concat-1.0.0"
       sources."simple-get-3.1.0"
@@ -56389,9 +58556,15 @@ in
       sources."statuses-1.5.0"
       sources."stealthy-require-1.1.1"
       sources."strict-uri-encode-1.1.0"
-      sources."string-kit-0.9.12"
+      sources."string-kit-0.10.1"
       sources."string-padding-1.0.2"
-      sources."string-to-stream-1.1.1"
+      (sources."string-to-stream-1.1.1" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+          sources."safe-buffer-5.1.2"
+          sources."string_decoder-1.1.1"
+        ];
+      })
       (sources."string-width-1.0.2" // {
         dependencies = [
           sources."strip-ansi-3.0.1"
@@ -56399,7 +58572,7 @@ in
       })
       sources."string.prototype.trimleft-2.1.0"
       sources."string.prototype.trimright-2.1.0"
-      sources."string_decoder-1.1.1"
+      sources."string_decoder-1.3.0"
       (sources."stringify-parameters-0.0.4" // {
         dependencies = [
           sources."magicli-0.0.5"
@@ -56416,20 +58589,16 @@ in
       sources."symbol-tree-3.2.4"
       sources."syswide-cas-5.3.0"
       sources."table-layout-0.4.5"
-      sources."tar-4.4.11"
+      sources."tar-4.4.13"
       sources."tar-fs-2.0.0"
-      (sources."tar-stream-2.1.0" // {
-        dependencies = [
-          sources."readable-stream-3.4.0"
-        ];
-      })
+      sources."tar-stream-2.1.0"
       (sources."tcp-port-used-0.1.2" // {
         dependencies = [
           sources."debug-0.7.4"
           sources."q-0.9.7"
         ];
       })
-      sources."terminal-kit-1.31.3"
+      sources."terminal-kit-1.31.4"
       (sources."tkwidgets-0.5.26" // {
         dependencies = [
           sources."is-fullwidth-code-point-2.0.0"
@@ -56470,6 +58639,7 @@ in
       sources."whatwg-encoding-1.0.5"
       sources."whatwg-mimetype-2.3.0"
       sources."whatwg-url-6.5.0"
+      sources."which-2.0.1"
       sources."which-pm-runs-1.0.0"
       sources."wide-align-1.1.3"
       sources."word-wrap-1.2.3"
@@ -56486,7 +58656,7 @@ in
       sources."xml-name-validator-3.0.0"
       sources."xml2js-0.4.22"
       sources."xmlbuilder-11.0.1"
-      sources."yallist-3.0.3"
+      sources."yallist-3.1.1"
       sources."yargs-parser-7.0.0"
     ];
     buildInputs = globalBuildInputs;
@@ -56511,12 +58681,12 @@ in
       sources."abbrev-1.1.1"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."concat-map-0.0.1"
       sources."config-chain-1.1.12"
       sources."editorconfig-0.15.3"
       sources."fs.realpath-1.0.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -56579,19 +58749,19 @@ in
       sha512 = "Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==";
     };
     dependencies = [
-      sources."@babel/parser-7.6.0"
+      sources."@babel/parser-7.6.4"
       sources."argparse-1.0.10"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."catharsis-0.8.11"
       sources."entities-1.1.2"
       sources."escape-string-regexp-2.0.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."js2xmlparser-4.0.0"
       sources."klaw-3.0.0"
       sources."linkify-it-2.2.0"
       sources."lodash-4.17.15"
       sources."markdown-it-8.4.2"
-      sources."markdown-it-anchor-5.2.4"
+      sources."markdown-it-anchor-5.2.5"
       sources."marked-0.7.0"
       sources."mdurl-1.0.1"
       sources."minimist-0.0.8"
@@ -56642,7 +58812,7 @@ in
       sources."entities-1.0.0"
       sources."exit-0.1.2"
       sources."fs.realpath-1.0.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."htmlparser2-3.8.3"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -56839,7 +59009,7 @@ in
       sources."ee-first-1.1.1"
       sources."emoji-regex-7.0.3"
       sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."errorhandler-1.5.1"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
@@ -56870,7 +59040,7 @@ in
           sources."get-stream-4.1.0"
         ];
       })
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
@@ -56929,9 +59099,9 @@ in
       sources."minimist-1.2.0"
       sources."morgan-1.9.1"
       sources."ms-2.0.0"
-      sources."nanoid-2.1.1"
+      sources."nanoid-2.1.6"
       sources."negotiator-0.6.2"
-      sources."normalize-url-4.4.1"
+      sources."normalize-url-4.5.0"
       sources."npm-run-path-2.0.2"
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
@@ -57038,8 +59208,8 @@ in
       sources."xdg-basedir-3.0.0"
       sources."y18n-4.0.0"
       sources."yallist-2.1.2"
-      sources."yargs-14.1.0"
-      sources."yargs-parser-14.0.0"
+      sources."yargs-14.2.1"
+      sources."yargs-parser-15.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -57080,15 +59250,15 @@ in
   karma = nodeEnv.buildNodePackage {
     name = "karma";
     packageName = "karma";
-    version = "4.3.0";
+    version = "4.4.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/karma/-/karma-4.3.0.tgz";
-      sha512 = "NSPViHOt+RW38oJklvYxQC4BSQsv737oQlr/r06pCM+slDOr4myuI1ivkRmp+3dVpJDfZt2DmaPJ2wkx+ZZuMQ==";
+      url = "https://registry.npmjs.org/karma/-/karma-4.4.1.tgz";
+      sha512 = "L5SIaXEYqzrh6b1wqYC42tNsFMx2PWuxky84pK9coK09MvmL7mxii3G3bZBh/0rvD27lqDd0le9jyhzvwif73A==";
     };
     dependencies = [
       sources."accepts-1.3.7"
       sources."after-0.8.2"
-      sources."anymatch-3.1.0"
+      sources."anymatch-3.1.1"
       sources."arraybuffer.slice-0.0.7"
       sources."async-2.6.3"
       sources."async-limiter-1.0.1"
@@ -57099,7 +59269,7 @@ in
       sources."better-assert-1.0.2"
       sources."binary-extensions-2.0.0"
       sources."blob-0.0.5"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."body-parser-1.19.0"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
@@ -57108,7 +59278,7 @@ in
       sources."buffer-fill-1.0.0"
       sources."bytes-3.1.0"
       sources."callsite-1.0.0"
-      sources."chokidar-3.1.1"
+      sources."chokidar-3.2.3"
       sources."colors-1.4.0"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.2.1"
@@ -57117,7 +59287,6 @@ in
       sources."connect-3.7.0"
       sources."content-type-1.0.4"
       sources."cookie-0.3.1"
-      sources."core-js-3.2.1"
       sources."custom-event-1.0.1"
       sources."date-format-2.1.0"
       sources."debug-2.6.9"
@@ -57152,10 +59321,10 @@ in
       })
       sources."fs-extra-7.0.1"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.0.7"
-      sources."glob-7.1.4"
+      sources."fsevents-2.1.1"
+      sources."glob-7.1.5"
       sources."glob-parent-5.1.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-binary2-1.0.3"
       sources."has-cors-1.1.0"
       sources."http-errors-1.7.2"
@@ -57197,13 +59366,13 @@ in
       sources."parseuri-0.0.5"
       sources."parseurl-1.3.3"
       sources."path-is-absolute-1.0.1"
-      sources."picomatch-2.0.7"
+      sources."picomatch-2.1.0"
       sources."pseudomap-1.0.2"
       sources."qjobs-1.2.0"
       sources."qs-6.7.0"
       sources."range-parser-1.2.1"
       sources."raw-body-2.4.0"
-      sources."readdirp-3.1.2"
+      sources."readdirp-3.2.0"
       sources."requires-port-1.0.0"
       sources."rfdc-1.1.4"
       sources."rimraf-2.7.1"
@@ -57288,16 +59457,16 @@ in
       sources."core-util-is-1.0.2"
       sources."define-properties-1.1.3"
       sources."duplexify-3.7.1"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."extend-3.0.2"
       sources."flush-write-stream-1.1.1"
       sources."fs-mkdirp-stream-1.0.0"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."glob-parent-3.1.0"
       sources."glob-stream-6.1.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-symbols-1.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -57363,10 +59532,10 @@ in
   leetcode-cli = nodeEnv.buildNodePackage {
     name = "leetcode-cli";
     packageName = "leetcode-cli";
-    version = "2.6.1";
+    version = "2.6.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/leetcode-cli/-/leetcode-cli-2.6.1.tgz";
-      sha512 = "B3OXkxcsHUBnXoO2X5JOt2tDAEjMO+Mf3PxVJwgLhjdbK5XeR2GKDa6YcMuBv5fhJRzGUfQ+l6KEMQE6lRl8eg==";
+      url = "https://registry.npmjs.org/leetcode-cli/-/leetcode-cli-2.6.2.tgz";
+      sha512 = "wP2yB6yGq+dlXgi8PMNgXS24Sb7rtYRs/WYQ4+zrJ9Oa/7Qp47PbVxuS4Dl62yeEo3OSlT1hovp1SWY6jE7ToQ==";
     };
     dependencies = [
       sources."abab-1.0.4"
@@ -57417,7 +59586,7 @@ in
       sources."domhandler-2.3.0"
       sources."domutils-1.5.1"
       sources."ecc-jsbn-0.1.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
       sources."escape-string-regexp-1.0.5"
       sources."escodegen-1.12.0"
@@ -57438,7 +59607,7 @@ in
       sources."get-caller-file-1.0.3"
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
@@ -57619,10 +59788,10 @@ in
   lerna = nodeEnv.buildNodePackage {
     name = "lerna";
     packageName = "lerna";
-    version = "3.16.4";
+    version = "3.18.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/lerna/-/lerna-3.16.4.tgz";
-      sha512 = "0HfwXIkqe72lBLZcNO9NMRfylh5Ng1l8tETgYQ260ZdHRbPuaLKE3Wqnd2YYRRkWfwPyEyZO8mZweBR+slVe1A==";
+      url = "https://registry.npmjs.org/lerna/-/lerna-3.18.3.tgz";
+      sha512 = "Bnr/RjyDSVA2Vu+NArK7do4UIpyy+EShOON7tignfAekPbi7cNDnMMGgSmbCQdKITkqPACMfCMdyq0hJlg6n3g==";
     };
     dependencies = [
       (sources."@evocateur/libnpmaccess-3.1.2" // {
@@ -57642,102 +59811,101 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."@lerna/add-3.16.2"
-      sources."@lerna/batch-packages-3.16.0"
-      sources."@lerna/bootstrap-3.16.2"
-      sources."@lerna/changed-3.16.4"
-      sources."@lerna/check-working-tree-3.14.2"
-      sources."@lerna/child-process-3.14.2"
-      sources."@lerna/clean-3.16.0"
-      sources."@lerna/cli-3.13.0"
-      sources."@lerna/collect-uncommitted-3.14.2"
-      sources."@lerna/collect-updates-3.16.0"
-      sources."@lerna/command-3.16.0"
+      sources."@lerna/add-3.18.0"
+      sources."@lerna/bootstrap-3.18.0"
+      sources."@lerna/changed-3.18.3"
+      sources."@lerna/check-working-tree-3.16.5"
+      sources."@lerna/child-process-3.16.5"
+      sources."@lerna/clean-3.18.0"
+      sources."@lerna/cli-3.18.0"
+      sources."@lerna/collect-uncommitted-3.16.5"
+      sources."@lerna/collect-updates-3.18.0"
+      sources."@lerna/command-3.18.0"
       (sources."@lerna/conventional-commits-3.16.4" // {
         dependencies = [
           sources."pify-4.0.1"
         ];
       })
-      (sources."@lerna/create-3.16.0" // {
+      (sources."@lerna/create-3.18.0" // {
         dependencies = [
           sources."pify-4.0.1"
         ];
       })
       sources."@lerna/create-symlink-3.16.2"
-      sources."@lerna/describe-ref-3.14.2"
-      sources."@lerna/diff-3.16.0"
-      sources."@lerna/exec-3.16.0"
-      sources."@lerna/filter-options-3.16.0"
-      sources."@lerna/filter-packages-3.16.0"
+      sources."@lerna/describe-ref-3.16.5"
+      sources."@lerna/diff-3.18.0"
+      sources."@lerna/exec-3.18.0"
+      sources."@lerna/filter-options-3.18.0"
+      sources."@lerna/filter-packages-3.18.0"
       sources."@lerna/get-npm-exec-opts-3.13.0"
       sources."@lerna/get-packed-3.16.0"
-      sources."@lerna/github-client-3.16.0"
+      sources."@lerna/github-client-3.16.5"
       sources."@lerna/gitlab-client-3.15.0"
       sources."@lerna/global-options-3.13.0"
-      sources."@lerna/has-npm-version-3.16.0"
-      sources."@lerna/import-3.16.0"
-      sources."@lerna/init-3.16.0"
-      sources."@lerna/link-3.16.2"
-      sources."@lerna/list-3.16.0"
-      sources."@lerna/listable-3.16.0"
+      sources."@lerna/has-npm-version-3.16.5"
+      sources."@lerna/import-3.18.0"
+      sources."@lerna/init-3.18.0"
+      sources."@lerna/link-3.18.0"
+      sources."@lerna/list-3.18.0"
+      sources."@lerna/listable-3.18.0"
       sources."@lerna/log-packed-3.16.0"
       (sources."@lerna/npm-conf-3.16.0" // {
         dependencies = [
           sources."pify-4.0.1"
         ];
       })
-      sources."@lerna/npm-dist-tag-3.16.0"
-      sources."@lerna/npm-install-3.16.0"
+      sources."@lerna/npm-dist-tag-3.18.1"
+      sources."@lerna/npm-install-3.16.5"
       (sources."@lerna/npm-publish-3.16.2" // {
         dependencies = [
           sources."pify-4.0.1"
         ];
       })
-      sources."@lerna/npm-run-script-3.14.2"
+      sources."@lerna/npm-run-script-3.16.5"
       sources."@lerna/otplease-3.16.0"
       sources."@lerna/output-3.13.0"
       sources."@lerna/pack-directory-3.16.4"
       sources."@lerna/package-3.16.0"
-      sources."@lerna/package-graph-3.16.0"
+      sources."@lerna/package-graph-3.18.0"
       sources."@lerna/prerelease-id-from-version-3.16.0"
-      sources."@lerna/project-3.16.0"
+      sources."@lerna/project-3.18.0"
       sources."@lerna/prompt-3.13.0"
-      sources."@lerna/publish-3.16.4"
+      sources."@lerna/publish-3.18.3"
       sources."@lerna/pulse-till-done-3.13.0"
-      sources."@lerna/query-graph-3.16.0"
+      sources."@lerna/query-graph-3.18.0"
       sources."@lerna/resolve-symlink-3.16.0"
-      sources."@lerna/rimraf-dir-3.14.2"
-      sources."@lerna/run-3.16.0"
+      sources."@lerna/rimraf-dir-3.16.5"
+      sources."@lerna/run-3.18.0"
       sources."@lerna/run-lifecycle-3.16.2"
-      sources."@lerna/run-parallel-batches-3.16.0"
-      sources."@lerna/run-topologically-3.16.0"
-      sources."@lerna/symlink-binary-3.16.2"
-      sources."@lerna/symlink-dependencies-3.16.2"
+      sources."@lerna/run-topologically-3.18.0"
+      sources."@lerna/symlink-binary-3.17.0"
+      sources."@lerna/symlink-dependencies-3.17.0"
       sources."@lerna/timer-3.13.0"
       sources."@lerna/validation-error-3.13.0"
-      sources."@lerna/version-3.16.4"
+      sources."@lerna/version-3.18.3"
       sources."@lerna/write-log-file-3.13.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
-      (sources."@octokit/endpoint-5.3.5" // {
+      (sources."@octokit/endpoint-5.5.0" // {
         dependencies = [
           sources."is-plain-object-3.0.0"
           sources."isobject-4.0.0"
         ];
       })
       sources."@octokit/plugin-enterprise-rest-3.6.2"
-      (sources."@octokit/request-5.1.0" // {
+      (sources."@octokit/request-5.3.0" // {
         dependencies = [
           sources."is-plain-object-3.0.0"
           sources."isobject-4.0.0"
         ];
       })
       sources."@octokit/request-error-1.0.4"
-      sources."@octokit/rest-16.30.0"
+      sources."@octokit/rest-16.34.1"
+      sources."@octokit/types-1.1.0"
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.7.5"
+      sources."@types/node-12.12.3"
       sources."@zkochan/cmd-shim-3.1.0"
       sources."JSONStream-1.3.5"
       sources."abbrev-1.1.1"
@@ -57778,7 +59946,7 @@ in
       })
       sources."bcrypt-pbkdf-1.0.2"
       sources."before-after-hook-2.1.0"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."brace-expansion-1.1.11"
       (sources."braces-2.3.2" // {
         dependencies = [
@@ -57805,7 +59973,7 @@ in
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."ci-info-2.0.0"
       (sources."class-utils-0.3.6" // {
         dependencies = [
@@ -57826,10 +59994,11 @@ in
       })
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.0"
-      (sources."cliui-4.1.0" // {
+      (sources."cliui-5.0.0" // {
         dependencies = [
-          sources."ansi-regex-3.0.0"
-          sources."strip-ansi-4.0.0"
+          sources."ansi-regex-4.1.0"
+          sources."string-width-3.1.0"
+          sources."strip-ansi-5.2.0"
         ];
       })
       sources."clone-1.0.4"
@@ -57839,7 +60008,7 @@ in
       sources."color-name-1.1.3"
       sources."columnify-1.5.4"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       (sources."compare-func-1.3.2" // {
         dependencies = [
           sources."dot-prop-3.0.0"
@@ -57850,20 +60019,20 @@ in
       sources."concat-stream-1.6.2"
       sources."config-chain-1.1.12"
       sources."console-control-strings-1.1.0"
-      sources."conventional-changelog-angular-5.0.3"
+      sources."conventional-changelog-angular-5.0.5"
       (sources."conventional-changelog-core-3.2.3" // {
         dependencies = [
           sources."through2-3.0.1"
         ];
       })
-      sources."conventional-changelog-preset-loader-2.2.0"
-      (sources."conventional-changelog-writer-4.0.7" // {
+      sources."conventional-changelog-preset-loader-2.3.0"
+      (sources."conventional-changelog-writer-4.0.10" // {
         dependencies = [
           sources."through2-3.0.1"
         ];
       })
       sources."conventional-commits-filter-2.0.2"
-      (sources."conventional-commits-parser-3.0.3" // {
+      (sources."conventional-commits-parser-3.0.6" // {
         dependencies = [
           sources."through2-3.0.1"
         ];
@@ -57915,12 +60084,13 @@ in
       sources."duplexer-0.1.1"
       sources."duplexify-3.7.1"
       sources."ecc-jsbn-0.1.2"
+      sources."emoji-regex-7.0.3"
       sources."encoding-0.1.12"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."env-paths-1.0.0"
       sources."err-code-1.1.2"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
@@ -57999,7 +60169,7 @@ in
         ];
       })
       sources."genfun-5.0.0"
-      sources."get-caller-file-1.0.3"
+      sources."get-caller-file-2.0.5"
       (sources."get-pkg-repo-1.4.0" // {
         dependencies = [
           sources."camelcase-2.1.1"
@@ -58037,7 +60207,7 @@ in
       sources."git-up-4.0.1"
       sources."git-url-parse-11.1.2"
       sources."gitconfiglocal-1.0.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."glob-parent-5.1.0"
       sources."glob-to-regexp-0.3.0"
       (sources."globby-9.2.0" // {
@@ -58045,8 +60215,8 @@ in
           sources."pify-4.0.1"
         ];
       })
-      sources."graceful-fs-4.2.2"
-      (sources."handlebars-4.2.1" // {
+      sources."graceful-fs-4.2.3"
+      (sources."handlebars-4.5.1" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -58063,16 +60233,16 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-cache-semantics-3.8.1"
       sources."http-proxy-agent-2.1.0"
       sources."http-signature-1.2.0"
-      sources."https-proxy-agent-2.2.2"
+      sources."https-proxy-agent-2.2.4"
       sources."humanize-ms-1.2.1"
       sources."iconv-lite-0.4.24"
       sources."iferr-0.1.5"
       sources."ignore-4.0.6"
-      sources."ignore-walk-3.0.2"
+      sources."ignore-walk-3.0.3"
       (sources."import-fresh-2.0.0" // {
         dependencies = [
           sources."resolve-from-3.0.0"
@@ -58096,7 +60266,6 @@ in
           sources."strip-ansi-5.2.0"
         ];
       })
-      sources."invert-kv-2.0.0"
       sources."ip-1.1.5"
       sources."is-accessor-descriptor-1.0.0"
       sources."is-arrayish-0.2.1"
@@ -58125,7 +60294,7 @@ in
       sources."is-ssh-1.3.1"
       sources."is-stream-1.1.0"
       sources."is-symbol-1.0.2"
-      sources."is-text-path-2.0.0"
+      sources."is-text-path-1.0.1"
       sources."is-typedarray-1.0.0"
       sources."is-utf8-0.2.1"
       sources."is-windows-1.0.2"
@@ -58143,7 +60312,6 @@ in
       sources."jsonparse-1.3.1"
       sources."jsprim-1.4.1"
       sources."kind-of-6.0.2"
-      sources."lcid-2.0.0"
       (sources."load-json-file-5.3.0" // {
         dependencies = [
           sources."pify-4.0.1"
@@ -58164,16 +60332,10 @@ in
       sources."lru-cache-5.1.1"
       sources."macos-release-2.3.0"
       sources."make-dir-1.3.0"
-      sources."make-fetch-happen-5.0.0"
-      sources."map-age-cleaner-0.1.3"
+      sources."make-fetch-happen-5.0.1"
       sources."map-cache-0.2.2"
       sources."map-obj-2.0.0"
       sources."map-visit-1.0.0"
-      (sources."mem-4.3.0" // {
-        dependencies = [
-          sources."mimic-fn-2.1.0"
-        ];
-      })
       (sources."meow-4.0.1" // {
         dependencies = [
           sources."minimist-1.2.0"
@@ -58187,8 +60349,8 @@ in
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."minimist-options-3.0.2"
-      sources."minipass-2.8.1"
-      sources."minizlib-1.2.2"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
       sources."mississippi-3.0.0"
       (sources."mixin-deep-1.3.2" // {
         dependencies = [
@@ -58208,7 +60370,7 @@ in
       sources."nice-try-1.0.5"
       sources."node-fetch-2.6.0"
       sources."node-fetch-npm-2.0.2"
-      (sources."node-gyp-5.0.3" // {
+      (sources."node-gyp-5.0.5" // {
         dependencies = [
           sources."semver-5.3.0"
         ];
@@ -58227,7 +60389,7 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."npm-packlist-1.4.4"
+      sources."npm-packlist-1.4.6"
       (sources."npm-pick-manifest-3.0.2" // {
         dependencies = [
           sources."semver-5.7.1"
@@ -58261,13 +60423,10 @@ in
       sources."onetime-2.0.1"
       sources."optimist-0.6.1"
       sources."os-homedir-1.0.2"
-      sources."os-locale-3.1.0"
       sources."os-name-3.1.0"
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
-      sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
-      sources."p-is-promise-2.1.0"
       sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-map-2.1.0"
@@ -58348,7 +60507,7 @@ in
       sources."repeating-2.0.1"
       sources."request-2.88.0"
       sources."require-directory-2.1.1"
-      sources."require-main-filename-1.0.1"
+      sources."require-main-filename-2.0.0"
       sources."resolve-1.12.0"
       (sources."resolve-cwd-2.0.0" // {
         dependencies = [
@@ -58472,10 +60631,10 @@ in
         ];
       })
       sources."supports-color-5.5.0"
-      sources."tar-4.4.11"
+      sources."tar-4.4.13"
       sources."temp-dir-1.0.0"
       sources."temp-write-3.4.0"
-      sources."text-extensions-2.0.0"
+      sources."text-extensions-1.9.0"
       sources."thenify-3.3.0"
       sources."thenify-all-1.6.0"
       sources."through-2.3.8"
@@ -58501,7 +60660,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."type-fest-0.3.1"
       sources."typedarray-0.0.6"
-      (sources."uglify-js-3.6.0" // {
+      (sources."uglify-js-3.6.6" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -58534,16 +60693,17 @@ in
       sources."verror-1.10.0"
       sources."wcwidth-1.0.1"
       sources."webidl-conversions-4.0.2"
-      sources."whatwg-url-7.0.0"
+      sources."whatwg-url-7.1.0"
       sources."which-1.3.1"
       sources."which-module-2.0.0"
       sources."wide-align-1.1.3"
       sources."windows-release-3.2.0"
       sources."wordwrap-0.0.3"
-      (sources."wrap-ansi-2.1.0" // {
+      (sources."wrap-ansi-5.1.0" // {
         dependencies = [
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."string-width-1.0.2"
+          sources."ansi-regex-4.1.0"
+          sources."string-width-3.1.0"
+          sources."strip-ansi-5.2.0"
         ];
       })
       sources."wrappy-1.0.2"
@@ -58562,9 +60722,15 @@ in
       })
       sources."xtend-4.0.2"
       sources."y18n-4.0.0"
-      sources."yallist-3.0.3"
-      sources."yargs-12.0.5"
-      sources."yargs-parser-11.1.1"
+      sources."yallist-3.1.1"
+      (sources."yargs-14.2.1" // {
+        dependencies = [
+          sources."ansi-regex-4.1.0"
+          sources."string-width-3.1.0"
+          sources."strip-ansi-5.2.0"
+        ];
+      })
+      sources."yargs-parser-15.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -58608,7 +60774,7 @@ in
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."getpass-0.1.7"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
@@ -58804,7 +60970,7 @@ in
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -58973,7 +61139,7 @@ in
           sources."is-extendable-0.1.1"
         ];
       })
-      sources."unix-crypt-td-js-1.0.0"
+      sources."unix-crypt-td-js-1.1.4"
       sources."unpipe-1.0.0"
       (sources."unset-value-1.0.0" // {
         dependencies = [
@@ -59150,7 +61316,7 @@ in
       sources."github-slugger-1.2.1"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
@@ -59229,7 +61395,7 @@ in
       sources."map-visit-1.0.0"
       sources."markdown-it-8.4.2"
       sources."markdown-it-emoji-1.4.0"
-      sources."markdown-it-github-headings-1.1.1"
+      sources."markdown-it-github-headings-1.1.2"
       sources."markdown-it-task-checkbox-1.0.6"
       sources."math-random-1.0.4"
       sources."mdurl-1.0.1"
@@ -59504,7 +61670,7 @@ in
       sources."uuid-3.3.3"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
-      sources."ws-7.1.2"
+      sources."ws-7.2.0"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."yeast-0.1.2"
     ];
@@ -59525,8 +61691,8 @@ in
     src = ../interpreters/clojurescript/lumo;
     dependencies = [
       sources."@babel/code-frame-7.5.5"
-      sources."@babel/core-7.6.0"
-      sources."@babel/generator-7.6.0"
+      sources."@babel/core-7.6.4"
+      sources."@babel/generator-7.6.4"
       sources."@babel/helper-annotate-as-pure-7.0.0"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.1.0"
       sources."@babel/helper-call-delegate-7.4.4"
@@ -59547,17 +61713,17 @@ in
       sources."@babel/helper-simple-access-7.1.0"
       sources."@babel/helper-split-export-declaration-7.4.4"
       sources."@babel/helper-wrap-function-7.2.0"
-      sources."@babel/helpers-7.6.0"
+      sources."@babel/helpers-7.6.2"
       sources."@babel/highlight-7.5.0"
-      sources."@babel/parser-7.6.0"
+      sources."@babel/parser-7.6.4"
       sources."@babel/plugin-external-helpers-7.0.0"
       sources."@babel/plugin-proposal-async-generator-functions-7.2.0"
       sources."@babel/plugin-proposal-class-properties-7.5.5"
       sources."@babel/plugin-proposal-dynamic-import-7.5.0"
       sources."@babel/plugin-proposal-json-strings-7.2.0"
-      sources."@babel/plugin-proposal-object-rest-spread-7.5.5"
+      sources."@babel/plugin-proposal-object-rest-spread-7.6.2"
       sources."@babel/plugin-proposal-optional-catch-binding-7.2.0"
-      sources."@babel/plugin-proposal-unicode-property-regex-7.4.4"
+      sources."@babel/plugin-proposal-unicode-property-regex-7.6.2"
       sources."@babel/plugin-syntax-async-generators-7.2.0"
       sources."@babel/plugin-syntax-dynamic-import-7.2.0"
       sources."@babel/plugin-syntax-json-strings-7.2.0"
@@ -59566,11 +61732,11 @@ in
       sources."@babel/plugin-transform-arrow-functions-7.2.0"
       sources."@babel/plugin-transform-async-to-generator-7.5.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.2.0"
-      sources."@babel/plugin-transform-block-scoping-7.6.0"
+      sources."@babel/plugin-transform-block-scoping-7.6.3"
       sources."@babel/plugin-transform-classes-7.5.5"
       sources."@babel/plugin-transform-computed-properties-7.2.0"
       sources."@babel/plugin-transform-destructuring-7.6.0"
-      sources."@babel/plugin-transform-dotall-regex-7.4.4"
+      sources."@babel/plugin-transform-dotall-regex-7.6.2"
       sources."@babel/plugin-transform-duplicate-keys-7.5.0"
       sources."@babel/plugin-transform-exponentiation-operator-7.2.0"
       sources."@babel/plugin-transform-for-of-7.4.4"
@@ -59581,26 +61747,26 @@ in
       sources."@babel/plugin-transform-modules-commonjs-7.6.0"
       sources."@babel/plugin-transform-modules-systemjs-7.5.0"
       sources."@babel/plugin-transform-modules-umd-7.2.0"
-      sources."@babel/plugin-transform-named-capturing-groups-regex-7.6.0"
+      sources."@babel/plugin-transform-named-capturing-groups-regex-7.6.3"
       sources."@babel/plugin-transform-new-target-7.4.4"
       sources."@babel/plugin-transform-object-super-7.5.5"
       sources."@babel/plugin-transform-parameters-7.4.4"
       sources."@babel/plugin-transform-property-literals-7.2.0"
       sources."@babel/plugin-transform-regenerator-7.4.5"
       sources."@babel/plugin-transform-reserved-words-7.2.0"
-      sources."@babel/plugin-transform-runtime-7.6.0"
+      sources."@babel/plugin-transform-runtime-7.6.2"
       sources."@babel/plugin-transform-shorthand-properties-7.2.0"
-      sources."@babel/plugin-transform-spread-7.2.2"
+      sources."@babel/plugin-transform-spread-7.6.2"
       sources."@babel/plugin-transform-sticky-regex-7.2.0"
       sources."@babel/plugin-transform-template-literals-7.4.4"
       sources."@babel/plugin-transform-typeof-symbol-7.2.0"
-      sources."@babel/plugin-transform-unicode-regex-7.4.4"
-      sources."@babel/preset-env-7.6.0"
+      sources."@babel/plugin-transform-unicode-regex-7.6.2"
+      sources."@babel/preset-env-7.6.3"
       sources."@babel/preset-stage-2-7.0.0"
-      sources."@babel/runtime-7.6.0"
+      sources."@babel/runtime-7.6.3"
       sources."@babel/template-7.6.0"
-      sources."@babel/traverse-7.6.0"
-      sources."@babel/types-7.6.1"
+      sources."@babel/traverse-7.6.3"
+      sources."@babel/types-7.6.3"
       sources."@calebboyd/semaphore-1.3.1"
       sources."@comandeer/babel-plugin-banner-4.1.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
@@ -59611,7 +61777,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.7.5"
+      sources."@types/node-12.12.3"
       sources."@webassemblyjs/ast-1.8.5"
       sources."@webassemblyjs/floating-point-hex-parser-1.8.5"
       sources."@webassemblyjs/helper-api-error-1.8.5"
@@ -59793,7 +61959,7 @@ in
       sources."big.js-5.2.2"
       sources."binary-extensions-1.13.1"
       sources."bl-1.2.2"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."bn.js-4.11.8"
       sources."brace-expansion-1.1.11"
       sources."braces-1.8.5"
@@ -59804,7 +61970,7 @@ in
       sources."browserify-rsa-4.0.1"
       sources."browserify-sign-4.0.4"
       sources."browserify-zlib-0.2.0"
-      sources."browserslist-4.7.0"
+      sources."browserslist-4.7.2"
       sources."buffer-5.4.3"
       sources."buffer-alloc-1.2.0"
       sources."buffer-alloc-unsafe-1.1.0"
@@ -59827,7 +61993,7 @@ in
       })
       sources."call-me-maybe-1.0.1"
       sources."camelcase-5.3.1"
-      sources."caniuse-lite-1.0.30000989"
+      sources."caniuse-lite-1.0.30001006"
       sources."caw-2.0.1"
       (sources."chalk-2.4.2" // {
         dependencies = [
@@ -59854,7 +62020,7 @@ in
           sources."normalize-path-3.0.0"
         ];
       })
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."chrome-trace-event-1.0.2"
       sources."cipher-base-1.0.4"
       (sources."class-utils-0.3.6" // {
@@ -59897,14 +62063,14 @@ in
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
       sources."config-chain-1.1.12"
-      sources."console-browserify-1.1.0"
+      sources."console-browserify-1.2.0"
       sources."constants-browserify-1.0.0"
       sources."content-disposition-0.5.3"
       sources."convert-source-map-1.6.0"
       sources."copy-concurrently-1.0.5"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-2.6.9"
-      (sources."core-js-compat-3.2.1" // {
+      sources."core-js-2.6.10"
+      (sources."core-js-compat-3.3.6" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -59917,7 +62083,6 @@ in
       sources."cross-spawn-6.0.5"
       sources."crypto-browserify-3.12.0"
       sources."cyclist-1.0.1"
-      sources."date-now-0.1.4"
       sources."death-1.1.0"
       sources."debug-4.1.1"
       sources."decamelize-1.2.0"
@@ -59985,12 +62150,12 @@ in
       })
       sources."duplexer3-0.1.4"
       sources."duplexify-3.7.1"
-      sources."electron-to-chromium-1.3.264"
+      sources."electron-to-chromium-1.3.298"
       sources."elliptic-6.5.1"
       sources."emoji-regex-7.0.3"
       sources."emojis-list-2.1.0"
-      sources."end-of-stream-1.4.1"
-      sources."enhanced-resolve-4.1.0"
+      sources."end-of-stream-1.4.4"
+      sources."enhanced-resolve-4.1.1"
       sources."errno-0.1.7"
       sources."error-ex-1.3.2"
       sources."escape-string-regexp-1.0.5"
@@ -60147,7 +62312,7 @@ in
       sources."get-proxy-2.1.0"
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
       sources."glob-to-regexp-0.3.0"
@@ -60176,11 +62341,11 @@ in
           })
           sources."get-stream-4.1.0"
           sources."http-cache-semantics-4.0.3"
-          sources."normalize-url-4.4.1"
+          sources."normalize-url-4.5.0"
           sources."p-cancelable-1.1.0"
         ];
       })
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."graceful-readlink-1.0.1"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
@@ -60206,7 +62371,7 @@ in
       sources."hash.js-1.1.7"
       sources."hmac-drbg-1.0.1"
       sources."homedir-polyfill-1.0.3"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-cache-semantics-3.8.1"
       sources."https-browserify-1.0.0"
       sources."ieee754-1.1.13"
@@ -60276,7 +62441,7 @@ in
       sources."json-buffer-3.0.0"
       sources."json-parse-better-errors-1.0.2"
       sources."json-schema-traverse-0.4.1"
-      sources."json5-2.1.0"
+      sources."json5-2.1.1"
       sources."jszip-git://github.com/anmonteiro/jszip#patch-1"
       sources."keyv-3.0.0"
       sources."kind-of-3.2.2"
@@ -60294,7 +62459,7 @@ in
       sources."loose-envify-1.4.0"
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-5.1.1"
-      sources."magic-string-0.25.3"
+      sources."magic-string-0.25.4"
       (sources."make-dir-2.1.0" // {
         dependencies = [
           sources."pify-4.0.1"
@@ -60312,11 +62477,11 @@ in
           sources."p-is-promise-2.1.0"
         ];
       })
-      sources."memory-fs-0.4.1"
+      sources."memory-fs-0.5.0"
       sources."merge2-1.3.0"
       sources."micromatch-2.3.11"
       sources."miller-rabin-4.0.1"
-      sources."mime-db-1.41.0"
+      sources."mime-db-1.42.0"
       sources."mimic-fn-1.2.0"
       sources."mimic-response-1.0.1"
       sources."minimalistic-assert-1.0.1"
@@ -60359,7 +62524,11 @@ in
           sources."punycode-1.4.1"
         ];
       })
-      sources."node-releases-1.1.32"
+      (sources."node-releases-1.1.39" // {
+        dependencies = [
+          sources."semver-6.3.0"
+        ];
+      })
       sources."normalize-package-data-2.5.0"
       sources."normalize-path-2.1.1"
       (sources."normalize-url-2.0.1" // {
@@ -60540,9 +62709,8 @@ in
       sources."regenerator-transform-0.14.1"
       sources."regex-cache-0.4.4"
       sources."regex-not-1.0.2"
-      sources."regexp-tree-0.1.13"
       sources."regexpu-core-4.6.0"
-      sources."regjsgen-0.5.0"
+      sources."regjsgen-0.5.1"
       (sources."regjsparser-0.6.0" // {
         dependencies = [
           sources."jsesc-0.5.0"
@@ -60646,7 +62814,7 @@ in
       sources."source-list-map-0.1.8"
       sources."source-map-0.5.7"
       sources."source-map-resolve-0.5.2"
-      (sources."source-map-support-0.5.13" // {
+      (sources."source-map-support-0.5.16" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -60696,9 +62864,9 @@ in
       sources."supports-color-2.0.0"
       sources."tapable-1.1.3"
       sources."tar-stream-1.6.2"
-      (sources."terser-4.3.1" // {
+      (sources."terser-4.3.9" // {
         dependencies = [
-          sources."commander-2.20.0"
+          sources."commander-2.20.3"
           sources."source-map-0.6.1"
         ];
       })
@@ -60771,7 +62939,7 @@ in
       sources."vm-browserify-1.1.0"
       sources."watchpack-1.6.0"
       sources."wcwidth-1.0.1"
-      (sources."webpack-4.40.2" // {
+      (sources."webpack-4.41.2" // {
         dependencies = [
           sources."arr-diff-4.0.0"
           sources."array-unique-0.3.2"
@@ -60809,12 +62977,15 @@ in
           })
           sources."isobject-3.0.1"
           sources."kind-of-6.0.2"
+          sources."memory-fs-0.4.1"
           sources."micromatch-3.1.10"
           sources."ms-2.0.0"
         ];
       })
-      (sources."webpack-cli-3.3.9" // {
+      (sources."webpack-cli-3.3.10" // {
         dependencies = [
+          sources."enhanced-resolve-4.1.0"
+          sources."memory-fs-0.4.1"
           sources."supports-color-6.1.0"
         ];
       })
@@ -60848,7 +63019,7 @@ in
       sources."wrappy-1.0.2"
       sources."xtend-4.0.2"
       sources."y18n-4.0.0"
-      sources."yallist-3.0.3"
+      sources."yallist-3.1.1"
       (sources."yargs-13.2.4" // {
         dependencies = [
           sources."find-up-3.0.0"
@@ -60895,17 +63066,17 @@ in
   markdown-link-check = nodeEnv.buildNodePackage {
     name = "markdown-link-check";
     packageName = "markdown-link-check";
-    version = "3.7.3";
+    version = "3.8.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.7.3.tgz";
-      sha512 = "X/HWomzeox5HtkKLupin4affBXHq22r7RNqiSKsxlgZQMSU9n+zpGY0sbzJr1IycB6FXpKUZet1VH3Rs1/8WQg==";
+      url = "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.8.0.tgz";
+      sha512 = "tpBlUsnJfJ5xMHAjBC/10s8Un/WT/FmF+xXaZjeaegESmjcPlEcxZ+UuCtxArETovLS5gZ8lZXzdhgslHziLsg==";
     };
     dependencies = [
       sources."ajv-6.10.2"
       sources."ansi-styles-3.2.1"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
-      sources."async-2.6.3"
+      sources."async-3.1.0"
       sources."asynckit-0.4.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
@@ -60915,7 +63086,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-3.0.2"
       sources."core-util-is-1.0.2"
       sources."dashdash-1.14.1"
       sources."delayed-stream-1.0.0"
@@ -60932,8 +63103,8 @@ in
       sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
       sources."http-signature-1.2.0"
-      sources."is-absolute-url-2.1.0"
-      sources."is-relative-url-2.0.0"
+      sources."is-absolute-url-3.0.3"
+      sources."is-relative-url-3.0.0"
       sources."is-typedarray-1.0.0"
       sources."isemail-3.2.0"
       sources."isstream-0.1.2"
@@ -60942,10 +63113,10 @@ in
       sources."json-schema-traverse-0.4.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
-      sources."link-check-4.4.5"
+      sources."link-check-4.4.6"
       sources."lodash-4.17.15"
-      sources."markdown-link-extractor-1.2.1"
-      sources."marked-0.6.3"
+      sources."markdown-link-extractor-1.2.2"
+      sources."marked-0.7.0"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."ms-2.1.2"
@@ -60990,7 +63161,7 @@ in
       sha512 = "z4uLbDHNbs/aRuR6zCcnzwFQuMixkHCcWqgVaommfK/3cA1Ahq7OXemn+m8JwTYcBApSHgcrSbPr9sm3sZFL+A==";
     };
     dependencies = [
-      sources."commander-3.0.1"
+      sources."commander-4.0.0"
       sources."esm-3.2.25"
       sources."mathjax-full-git://github.com/mathjax/MathJax-src.git"
       sources."mj-context-menu-0.2.0"
@@ -61048,10 +63219,10 @@ in
   meguca = nodeEnv.buildNodePackage {
     name = "meguca";
     packageName = "meguca";
-    version = "1.1.6";
+    version = "1.1.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/meguca/-/meguca-1.1.6.tgz";
-      sha512 = "kqg6t8mUUpb4WwD+4WqgS41AejdSkIEmPCB7v2D7ioxtLFiCaQUlu+K8rT6qOe3PmMacZ2sZsmdIs5jtYtxPig==";
+      url = "https://registry.npmjs.org/meguca/-/meguca-1.1.8.tgz";
+      sha512 = "BrbjYMq6FeZYMKx9mw7aHGUtLCyGPX4kSoCqZiRBFw5ESTgJcmmr+DbLCC29k8hRpBVRqdq3OapSEbAGXZ6z/g==";
     };
     dependencies = [
       (sources."@gulp-sourcemaps/identity-map-1.0.2" // {
@@ -61071,7 +63242,7 @@ in
       })
       (sources."accord-0.28.0" // {
         dependencies = [
-          sources."glob-7.1.4"
+          sources."glob-7.1.5"
           sources."minimatch-3.0.4"
           sources."semver-5.7.1"
           sources."uglify-js-2.8.29"
@@ -61167,7 +63338,7 @@ in
       sources."collection-visit-1.0.0"
       sources."color-support-1.1.3"
       sources."combined-stream-1.0.8"
-      sources."commander-2.17.1"
+      sources."commander-2.20.3"
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
       sources."convert-source-map-1.6.0"
@@ -61210,7 +63381,7 @@ in
       })
       (sources."duplexify-3.7.1" // {
         dependencies = [
-          sources."end-of-stream-1.4.1"
+          sources."end-of-stream-1.4.4"
           sources."once-1.4.0"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
@@ -61219,9 +63390,9 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."end-of-stream-0.1.5"
       sources."errno-0.1.7"
-      sources."es5-ext-0.10.51"
+      sources."es5-ext-0.10.52"
       sources."es6-iterator-2.0.3"
-      sources."es6-symbol-3.1.2"
+      sources."es6-symbol-3.1.3"
       sources."es6-weak-map-2.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."event-emitter-0.3.5"
@@ -61244,6 +63415,11 @@ in
         ];
       })
       sources."expand-tilde-2.0.2"
+      (sources."ext-1.1.2" // {
+        dependencies = [
+          sources."type-2.0.0"
+        ];
+      })
       sources."extend-3.0.2"
       (sources."extend-shallow-3.0.2" // {
         dependencies = [
@@ -61281,7 +63457,7 @@ in
       sources."fragment-cache-0.2.1"
       (sources."fs-mkdirp-stream-1.0.0" // {
         dependencies = [
-          sources."graceful-fs-4.2.2"
+          sources."graceful-fs-4.2.3"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
           sources."through2-2.0.5"
@@ -61334,9 +63510,9 @@ in
           sources."through2-2.0.5"
         ];
       })
-      (sources."gulp-sourcemaps-2.6.4" // {
+      (sources."gulp-sourcemaps-2.6.5" // {
         dependencies = [
-          sources."graceful-fs-4.2.2"
+          sources."graceful-fs-4.2.3"
           sources."readable-stream-2.3.6"
           sources."source-map-0.6.1"
           sources."string_decoder-1.1.1"
@@ -61351,9 +63527,9 @@ in
           sources."clone-2.1.2"
           sources."clone-stats-1.0.0"
           sources."extend-shallow-1.1.4"
-          sources."glob-7.1.4"
+          sources."glob-7.1.5"
           sources."glob-stream-6.1.0"
-          sources."graceful-fs-4.2.2"
+          sources."graceful-fs-4.2.3"
           sources."kind-of-1.1.0"
           sources."minimatch-3.0.4"
           sources."ordered-read-streams-1.0.1"
@@ -61367,9 +63543,8 @@ in
           sources."vinyl-fs-3.0.3"
         ];
       })
-      (sources."gulp-uglify-3.0.1" // {
+      (sources."gulp-uglify-3.0.2" // {
         dependencies = [
-          sources."lodash-4.17.15"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
           sources."through2-2.0.5"
@@ -61455,7 +63630,7 @@ in
       sources."lead-1.0.0"
       (sources."less-2.7.3" // {
         dependencies = [
-          sources."graceful-fs-4.2.2"
+          sources."graceful-fs-4.2.3"
         ];
       })
       sources."liftoff-2.5.0"
@@ -61558,7 +63733,7 @@ in
       sources."prr-1.0.1"
       (sources."pump-2.0.1" // {
         dependencies = [
-          (sources."end-of-stream-1.4.1" // {
+          (sources."end-of-stream-1.4.4" // {
             dependencies = [
               sources."once-1.4.0"
             ];
@@ -61699,8 +63874,8 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-1.2.0"
-      sources."typescript-3.5.3"
-      (sources."uglify-js-3.4.9" // {
+      sources."typescript-3.6.4"
+      (sources."uglify-js-3.6.6" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -61741,7 +63916,7 @@ in
         dependencies = [
           sources."clone-2.1.2"
           sources."clone-stats-1.0.0"
-          sources."graceful-fs-4.2.2"
+          sources."graceful-fs-4.2.3"
           sources."vinyl-2.2.0"
         ];
       })
@@ -61767,10 +63942,10 @@ in
   mocha = nodeEnv.buildNodePackage {
     name = "mocha";
     packageName = "mocha";
-    version = "6.2.0";
+    version = "6.2.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz";
-      sha512 = "qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==";
+      url = "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz";
+      sha512 = "FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==";
     };
     dependencies = [
       sources."ansi-colors-3.2.3"
@@ -61786,29 +63961,30 @@ in
           sources."supports-color-5.5.0"
         ];
       })
-      sources."cliui-4.1.0"
-      sources."code-point-at-1.1.0"
+      (sources."cliui-5.0.0" // {
+        dependencies = [
+          sources."ansi-regex-4.1.0"
+          sources."string-width-3.1.0"
+          sources."strip-ansi-5.2.0"
+        ];
+      })
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."concat-map-0.0.1"
-      sources."cross-spawn-6.0.5"
       sources."debug-3.2.6"
       sources."decamelize-1.2.0"
       sources."define-properties-1.1.3"
       sources."diff-3.5.0"
       sources."emoji-regex-7.0.3"
-      sources."end-of-stream-1.4.1"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
-      sources."execa-1.0.0"
       sources."find-up-3.0.0"
       sources."flat-4.1.0"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."get-caller-file-2.0.5"
-      sources."get-stream-4.1.0"
       sources."glob-7.1.3"
       sources."growl-1.10.5"
       sources."has-1.0.3"
@@ -61817,91 +63993,64 @@ in
       sources."he-1.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."invert-kv-2.0.0"
-      sources."is-buffer-2.0.3"
+      sources."is-buffer-2.0.4"
       sources."is-callable-1.1.4"
       sources."is-date-object-1.0.1"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-regex-1.0.4"
-      sources."is-stream-1.1.0"
       sources."is-symbol-1.0.2"
       sources."isexe-2.0.0"
       sources."js-yaml-3.13.1"
-      sources."lcid-2.0.0"
       sources."locate-path-3.0.0"
       sources."lodash-4.17.15"
       sources."log-symbols-2.2.0"
-      sources."map-age-cleaner-0.1.3"
-      sources."mem-4.3.0"
-      sources."mimic-fn-2.1.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       sources."ms-2.1.1"
-      sources."nice-try-1.0.5"
       sources."node-environment-flags-1.0.5"
-      sources."npm-run-path-2.0.2"
-      sources."number-is-nan-1.0.1"
       sources."object-inspect-1.6.0"
       sources."object-keys-1.1.1"
       sources."object.assign-4.1.0"
       sources."object.getownpropertydescriptors-2.0.3"
       sources."once-1.4.0"
-      sources."os-locale-3.1.0"
-      sources."p-defer-1.0.0"
-      sources."p-finally-1.0.0"
-      sources."p-is-promise-2.1.0"
       sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
       sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
-      sources."path-key-2.0.1"
-      sources."pump-3.0.0"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
       sources."semver-5.7.1"
       sources."set-blocking-2.0.0"
-      sources."shebang-command-1.2.0"
-      sources."shebang-regex-1.0.0"
-      sources."signal-exit-3.0.2"
       sources."sprintf-js-1.0.3"
       sources."string-width-2.1.1"
       sources."string.prototype.trimleft-2.1.0"
       sources."string.prototype.trimright-2.1.0"
       sources."strip-ansi-4.0.0"
-      sources."strip-eof-1.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-6.0.0"
       sources."which-1.3.1"
       sources."which-module-2.0.0"
       sources."wide-align-1.1.3"
-      (sources."wrap-ansi-2.1.0" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."string-width-1.0.2"
-          sources."strip-ansi-3.0.1"
-        ];
-      })
-      sources."wrappy-1.0.2"
-      sources."y18n-4.0.0"
-      (sources."yargs-13.2.2" // {
+      (sources."wrap-ansi-5.1.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
           sources."string-width-3.1.0"
           sources."strip-ansi-5.2.0"
         ];
       })
-      sources."yargs-parser-13.0.0"
-      (sources."yargs-unparser-1.5.0" // {
+      sources."wrappy-1.0.2"
+      sources."y18n-4.0.0"
+      (sources."yargs-13.3.0" // {
         dependencies = [
-          sources."get-caller-file-1.0.3"
-          sources."require-main-filename-1.0.1"
-          sources."yargs-12.0.5"
-          sources."yargs-parser-11.1.1"
+          sources."ansi-regex-4.1.0"
+          sources."string-width-3.1.0"
+          sources."strip-ansi-5.2.0"
         ];
       })
+      sources."yargs-parser-13.1.1"
+      sources."yargs-unparser-1.6.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -61925,7 +64074,7 @@ in
       sources."argparse-1.0.10"
       sources."asynckit-0.4.0"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."component-emitter-1.3.0"
       sources."cookiejar-2.1.2"
       sources."core-util-is-1.0.2"
@@ -62035,10 +64184,10 @@ in
   node-gyp = nodeEnv.buildNodePackage {
     name = "node-gyp";
     packageName = "node-gyp";
-    version = "5.0.3";
+    version = "6.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.3.tgz";
-      sha512 = "z/JdtkFGUm0QaQUusvloyYuGDub3nUbOo5de1Fz57cM++osBTvQatBUSTlF1k/w8vFHPxxXW6zxGvkxXSpaBkQ==";
+      url = "https://registry.npmjs.org/node-gyp/-/node-gyp-6.0.1.tgz";
+      sha512 = "udHG4hGe3Ji97AYJbJhaRwuSOuQO7KHnE4ZPH3Sox3tjRZ+bkBsDvfZ7eYA1qwD8eLWr//193x806ss3HFTPRw==";
     };
     dependencies = [
       sources."abbrev-1.1.1"
@@ -62055,7 +64204,7 @@ in
       sources."bcrypt-pbkdf-1.0.2"
       sources."brace-expansion-1.1.11"
       sources."caseless-0.12.0"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.8"
       sources."concat-map-0.0.1"
@@ -62065,7 +64214,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."delegates-1.0.0"
       sources."ecc-jsbn-0.1.2"
-      sources."env-paths-1.0.0"
+      sources."env-paths-2.2.0"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-2.0.1"
@@ -62076,8 +64225,8 @@ in
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
@@ -62098,15 +64247,18 @@ in
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.8.1"
-      sources."minizlib-1.2.2"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
       sources."mkdirp-0.5.1"
-      sources."nopt-3.0.6"
+      sources."nopt-4.0.1"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
       sources."once-1.4.0"
+      sources."os-homedir-1.0.2"
+      sources."os-tmpdir-1.0.2"
+      sources."osenv-0.1.5"
       sources."path-is-absolute-1.0.1"
       sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.1"
@@ -62118,14 +64270,14 @@ in
       sources."rimraf-2.7.1"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
-      sources."semver-5.3.0"
+      sources."semver-5.7.1"
       sources."set-blocking-2.0.0"
       sources."signal-exit-3.0.2"
       sources."sshpk-1.16.1"
       sources."string-width-1.0.2"
       sources."string_decoder-1.1.1"
       sources."strip-ansi-3.0.1"
-      sources."tar-4.4.11"
+      sources."tar-4.4.13"
       (sources."tough-cookie-2.4.3" // {
         dependencies = [
           sources."punycode-1.4.1"
@@ -62140,7 +64292,7 @@ in
       sources."which-1.3.1"
       sources."wide-align-1.1.3"
       sources."wrappy-1.0.2"
-      sources."yallist-3.0.3"
+      sources."yallist-3.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -62198,7 +64350,7 @@ in
       sources."base64-js-0.0.8"
       sources."bcrypt-pbkdf-1.0.2"
       sources."biased-opener-0.2.8"
-      sources."big-integer-1.6.45"
+      sources."big-integer-1.6.47"
       sources."block-stream-0.0.9"
       sources."body-parser-1.19.0"
       sources."boom-2.10.1"
@@ -62262,14 +64414,14 @@ in
         ];
       })
       sources."glob-5.0.15"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-1.0.5"
       sources."har-validator-4.2.1"
       sources."has-unicode-2.0.1"
       sources."hawk-3.1.3"
       sources."headless-0.1.7"
       sources."hoek-2.16.3"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-errors-1.7.2"
       sources."http-signature-1.1.1"
       sources."iconv-lite-0.4.24"
@@ -62321,7 +64473,7 @@ in
       sources."negotiator-0.6.2"
       (sources."node-pre-gyp-0.6.39" // {
         dependencies = [
-          sources."glob-7.1.4"
+          sources."glob-7.1.5"
           sources."rimraf-2.7.1"
           sources."semver-5.7.1"
         ];
@@ -62410,7 +64562,7 @@ in
       sources."tar-2.2.2"
       (sources."tar-pack-3.4.1" // {
         dependencies = [
-          sources."glob-7.1.4"
+          sources."glob-7.1.5"
           sources."rimraf-2.7.1"
         ];
       })
@@ -62472,10 +64624,10 @@ in
   node-pre-gyp = nodeEnv.buildNodePackage {
     name = "node-pre-gyp";
     packageName = "node-pre-gyp";
-    version = "0.13.0";
+    version = "0.14.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz";
-      sha512 = "Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==";
+      url = "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz";
+      sha512 = "+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==";
     };
     dependencies = [
       sources."abbrev-1.1.1"
@@ -62484,7 +64636,7 @@ in
       sources."are-we-there-yet-1.1.5"
       sources."balanced-match-1.0.0"
       sources."brace-expansion-1.1.11"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."code-point-at-1.1.0"
       sources."concat-map-0.0.1"
       sources."console-control-strings-1.1.0"
@@ -62496,10 +64648,10 @@ in
       sources."fs-minipass-1.2.7"
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."has-unicode-2.0.1"
       sources."iconv-lite-0.4.24"
-      sources."ignore-walk-3.0.2"
+      sources."ignore-walk-3.0.3"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -62507,14 +64659,14 @@ in
       sources."isarray-1.0.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.8.1"
-      sources."minizlib-1.2.2"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
       sources."mkdirp-0.5.1"
       sources."ms-2.1.2"
       sources."needle-2.4.0"
       sources."nopt-4.0.1"
       sources."npm-bundled-1.0.6"
-      sources."npm-packlist-1.4.4"
+      sources."npm-packlist-1.4.6"
       sources."npmlog-4.1.2"
       sources."number-is-nan-1.0.1"
       sources."object-assign-4.1.1"
@@ -62541,11 +64693,11 @@ in
       sources."string_decoder-1.1.1"
       sources."strip-ansi-3.0.1"
       sources."strip-json-comments-2.0.1"
-      sources."tar-4.4.11"
+      sources."tar-4.4.13"
       sources."util-deprecate-1.0.2"
       sources."wide-align-1.1.3"
       sources."wrappy-1.0.2"
-      sources."yallist-3.0.3"
+      sources."yallist-3.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -62560,16 +64712,16 @@ in
   node-red = nodeEnv.buildNodePackage {
     name = "node-red";
     packageName = "node-red";
-    version = "0.20.8";
+    version = "1.0.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/node-red/-/node-red-0.20.8.tgz";
-      sha512 = "+i2SHPo8AQED0lyf7xoGcWAs142Nc5zvCTzmuncslgxVt/fl6XADEEY4yT/eDVNOwRrf9TZMjhSxBM9ScJJu7Q==";
+      url = "https://registry.npmjs.org/node-red/-/node-red-1.0.2.tgz";
+      sha512 = "QSyPpAGGVFgVlKyumWFd8j2hd420+sh8DSxlvAtatDVaIG3+MaAD3eDLg49HIwRyAhiROVS1XNWkqyq/H1/cBA==";
     };
     dependencies = [
-      sources."@babel/runtime-7.6.0"
-      sources."@node-red/editor-api-0.20.8"
-      sources."@node-red/editor-client-0.20.8"
-      (sources."@node-red/nodes-0.20.8" // {
+      sources."@babel/runtime-7.6.3"
+      sources."@node-red/editor-api-1.0.2"
+      sources."@node-red/editor-client-1.0.2"
+      (sources."@node-red/nodes-1.0.2" // {
         dependencies = [
           sources."cookie-0.4.0"
           sources."http-errors-1.7.3"
@@ -62583,14 +64735,13 @@ in
           })
         ];
       })
-      sources."@node-red/registry-0.20.8"
-      sources."@node-red/runtime-0.20.8"
-      sources."@node-red/util-0.20.8"
+      sources."@node-red/registry-1.0.2"
+      sources."@node-red/runtime-1.0.2"
+      sources."@node-red/util-1.0.2"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
-      sources."addressparser-1.0.1"
       sources."agent-base-4.3.0"
-      sources."ajv-6.10.0"
+      sources."ajv-6.10.2"
       sources."ansi-regex-2.1.1"
       sources."append-field-1.0.0"
       sources."aproba-1.2.0"
@@ -62602,7 +64753,6 @@ in
       })
       sources."argparse-1.0.10"
       sources."array-flatten-1.1.1"
-      sources."array-indexofobject-0.0.1"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."async-0.1.22"
@@ -62641,11 +64791,11 @@ in
       })
       sources."caseless-0.12.0"
       sources."cheerio-0.22.0"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."clone-2.1.2"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."commist-1.1.0"
       sources."concat-map-0.0.1"
       (sources."concat-stream-1.6.2" // {
@@ -62695,9 +64845,9 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
-      sources."es5-ext-0.10.51"
+      sources."es5-ext-0.10.52"
       sources."es6-iterator-2.0.3"
       sources."es6-map-0.1.5"
       sources."es6-promise-4.2.8"
@@ -62707,7 +64857,7 @@ in
           sources."es6-symbol-3.1.1"
         ];
       })
-      sources."es6-symbol-3.1.2"
+      sources."es6-symbol-3.1.3"
       sources."escape-html-1.0.3"
       sources."esprima-4.0.1"
       sources."etag-1.8.1"
@@ -62722,16 +64872,15 @@ in
           sources."depd-2.0.0"
         ];
       })
+      (sources."ext-1.1.2" // {
+        dependencies = [
+          sources."type-2.0.0"
+        ];
+      })
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
-      (sources."feedparser-2.2.9" // {
-        dependencies = [
-          sources."readable-stream-2.3.6"
-          sources."string_decoder-1.1.1"
-        ];
-      })
       sources."finalhandler-1.1.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -62743,7 +64892,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."glob-parent-3.1.0"
       (sources."glob-stream-6.1.0" // {
         dependencies = [
@@ -62751,33 +64900,24 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
       sources."hash-sum-2.0.0"
-      sources."he-1.2.0"
       sources."help-me-1.1.0"
-      sources."html-to-text-5.1.1"
       sources."htmlparser2-3.10.1"
       sources."http-errors-1.7.2"
       sources."http-signature-1.2.0"
-      (sources."https-proxy-agent-2.2.1" // {
+      (sources."https-proxy-agent-2.2.2" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
         ];
       })
-      sources."i18next-15.1.0"
+      sources."i18next-15.1.2"
       sources."iconv-lite-0.4.24"
-      sources."ignore-walk-3.0.2"
-      (sources."imap-0.8.19" // {
-        dependencies = [
-          sources."isarray-0.0.1"
-          sources."readable-stream-1.1.14"
-          sources."string_decoder-0.10.31"
-        ];
-      })
+      sources."ignore-walk-3.0.3"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
       sources."ini-1.3.5"
@@ -62804,34 +64944,19 @@ in
       sources."jsonfile-4.0.0"
       sources."jsprim-1.4.1"
       sources."leven-2.1.0"
-      sources."libbase64-1.0.3"
-      sources."libmime-4.1.1"
-      sources."libqp-1.1.0"
-      sources."linkify-it-2.1.0"
-      sources."lodash-4.17.15"
-      sources."lodash.assign-4.2.0"
       sources."lodash.assignin-4.2.0"
       sources."lodash.bind-4.2.1"
       sources."lodash.defaults-4.2.0"
       sources."lodash.filter-4.6.0"
       sources."lodash.flatten-4.4.0"
       sources."lodash.foreach-4.5.0"
-      sources."lodash.get-4.4.2"
-      sources."lodash.has-4.5.2"
       sources."lodash.map-4.6.0"
       sources."lodash.merge-4.6.2"
       sources."lodash.pick-4.4.0"
       sources."lodash.reduce-4.6.0"
       sources."lodash.reject-4.6.0"
       sources."lodash.some-4.6.0"
-      sources."lodash.uniq-4.5.0"
       sources."lru-cache-4.1.5"
-      (sources."mailparser-2.7.1" // {
-        dependencies = [
-          sources."nodemailer-6.1.1"
-        ];
-      })
-      sources."mailsplit-4.4.1"
       sources."media-typer-0.3.0"
       (sources."memorystore-1.6.1" // {
         dependencies = [
@@ -62845,19 +64970,19 @@ in
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."minipass-2.8.1" // {
+      (sources."minipass-2.9.0" // {
         dependencies = [
-          sources."yallist-3.0.3"
+          sources."yallist-3.1.1"
         ];
       })
-      sources."minizlib-1.2.2"
+      sources."minizlib-1.3.3"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
         ];
       })
       sources."moment-2.24.0"
-      sources."moment-timezone-0.5.26"
+      sources."moment-timezone-0.5.27"
       (sources."mqtt-2.18.8" // {
         dependencies = [
           sources."readable-stream-2.3.6"
@@ -62865,10 +64990,9 @@ in
         ];
       })
       sources."mqtt-packet-5.6.1"
-      sources."mri-1.1.4"
       sources."ms-2.0.0"
-      sources."multer-1.4.1"
-      sources."mustache-3.0.1"
+      sources."multer-1.4.2"
+      sources."mustache-3.0.2"
       sources."nan-2.13.2"
       (sources."needle-2.4.0" // {
         dependencies = [
@@ -62883,31 +65007,20 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."node-red-node-email-1.6.3"
-      sources."node-red-node-feedparser-0.1.14"
       sources."node-red-node-rbe-0.2.5"
-      sources."node-red-node-sentiment-0.1.4"
-      sources."node-red-node-tail-0.0.2"
-      sources."node-red-node-twitter-1.1.5"
-      sources."nodemailer-6.3.0"
+      sources."node-red-node-tail-0.0.3"
       sources."nopt-4.0.1"
       sources."npm-bundled-1.0.6"
-      sources."npm-packlist-1.4.4"
+      sources."npm-packlist-1.4.6"
       sources."npmlog-4.1.2"
       sources."nth-check-1.0.2"
       sources."number-is-nan-1.0.1"
-      sources."oauth-0.9.15"
       sources."oauth-sign-0.9.0"
       sources."oauth2orize-1.11.0"
       sources."object-assign-4.1.1"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
-      (sources."optimist-0.6.1" // {
-        dependencies = [
-          sources."minimist-0.0.10"
-        ];
-      })
       (sources."ordered-read-streams-1.0.1" // {
         dependencies = [
           sources."readable-stream-2.3.6"
@@ -62927,7 +65040,6 @@ in
       sources."path-to-regexp-0.1.7"
       sources."pause-0.0.1"
       sources."performance-now-2.1.0"
-      sources."poplib-0.1.7"
       sources."process-nextick-args-2.0.1"
       sources."proxy-addr-2.0.5"
       sources."pseudomap-1.0.2"
@@ -62958,14 +65070,13 @@ in
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."semver-6.2.0"
+      sources."semver-6.3.0"
       (sources."send-0.17.1" // {
         dependencies = [
           sources."mime-1.6.0"
           sources."ms-2.1.1"
         ];
       })
-      sources."sentiment-2.1.0"
       sources."serve-static-1.14.1"
       sources."set-blocking-2.0.0"
       sources."setprototypeof-1.1.1"
@@ -62986,9 +65097,9 @@ in
       sources."strip-ansi-3.0.1"
       sources."strip-json-comments-2.0.1"
       sources."tail-2.0.3"
-      (sources."tar-4.4.11" // {
+      (sources."tar-4.4.13" // {
         dependencies = [
-          sources."yallist-3.0.3"
+          sources."yallist-3.1.1"
         ];
       })
       (sources."through2-2.0.5" // {
@@ -62998,7 +65109,6 @@ in
         ];
       })
       sources."through2-filter-3.0.0"
-      sources."tlds-1.203.1"
       sources."to-absolute-glob-2.0.2"
       sources."toidentifier-1.0.0"
       (sources."tough-cookie-2.4.3" // {
@@ -63008,11 +65118,9 @@ in
       })
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."twitter-ng-0.6.2"
       sources."type-1.2.0"
       sources."type-is-1.6.18"
       sources."typedarray-0.0.6"
-      sources."uc.micro-1.0.6"
       sources."uglify-js-3.6.0"
       sources."uid-safe-2.1.5"
       sources."uid2-0.0.3"
@@ -63022,11 +65130,6 @@ in
       sources."universalify-0.1.2"
       sources."unpipe-1.0.0"
       sources."uri-js-4.2.2"
-      (sources."utf7-1.0.2" // {
-        dependencies = [
-          sources."semver-5.3.0"
-        ];
-      })
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
       sources."uuid-3.3.3"
@@ -63041,7 +65144,6 @@ in
       })
       sources."when-3.7.8"
       sources."wide-align-1.1.3"
-      sources."wordwrap-0.0.3"
       sources."wrappy-1.0.2"
       sources."ws-6.2.1"
       sources."xml2js-0.4.19"
@@ -63051,7 +65153,7 @@ in
     ];
     buildInputs = globalBuildInputs;
     meta = {
-      description = "A visual tool for wiring the Internet of Things";
+      description = "Low-code programming for event-driven applications";
       homepage = http://nodered.org/;
       license = "Apache-2.0";
     };
@@ -63085,7 +65187,7 @@ in
       sources."buffer-from-1.1.1"
       sources."builtins-1.0.3"
       sources."caseless-0.12.0"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.8"
       sources."concat-map-0.0.1"
@@ -63120,12 +65222,12 @@ in
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -63144,8 +65246,8 @@ in
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.8.1"
-      sources."minizlib-1.2.2"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
       sources."mkdirp-0.5.1"
       sources."ncp-0.4.2"
       sources."nijs-0.0.25"
@@ -63217,8 +65319,8 @@ in
         ];
       })
       sources."strip-ansi-3.0.1"
-      sources."tar-4.4.11"
-      sources."temp-0.9.0"
+      sources."tar-4.4.13"
+      sources."temp-0.9.1"
       (sources."tough-cookie-2.4.3" // {
         dependencies = [
           sources."punycode-1.4.1"
@@ -63237,7 +65339,7 @@ in
       sources."walk-2.3.14"
       sources."wide-align-1.1.3"
       sources."wrappy-1.0.2"
-      sources."yallist-3.0.3"
+      sources."yallist-3.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -63252,10 +65354,10 @@ in
   nodemon = nodeEnv.buildNodePackage {
     name = "nodemon";
     packageName = "nodemon";
-    version = "1.19.2";
+    version = "1.19.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/nodemon/-/nodemon-1.19.2.tgz";
-      sha512 = "hRLYaw5Ihyw9zK7NF+9EUzVyS6Cvgc14yh8CAYr38tPxJa6UrOxwAQ351GwrgoanHCF0FalQFn6w5eoX/LGdJw==";
+      url = "https://registry.npmjs.org/nodemon/-/nodemon-1.19.4.tgz";
+      sha512 = "VGPaqQBNk193lrJFotBU8nvWZPqEZY2eIzymy2jjY0fJ9qIsxA0sxQ8ATPl0gZC645gijYEc1jtZvpS8QWzJGQ==";
     };
     dependencies = [
       sources."abbrev-1.1.1"
@@ -63382,7 +65484,7 @@ in
       })
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -63605,10 +65707,10 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "6.11.3";
+    version = "6.12.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-6.11.3.tgz";
-      sha512 = "K2h+MPzZiY39Xf6eHEdECe/LKoJXam4UCflz5kIxoskN3LQFeYs5fqBGT5i4TtM/aBk+86Mcf+jgXs/WuWAutQ==";
+      url = "https://registry.npmjs.org/npm/-/npm-6.12.1.tgz";
+      sha512 = "+pMvUpgSXVBythrv//64j4i6DaLLJ1O0y8kwjNgjAE7atBNGzX4rcOEWvmsuiei6J+mA38O0nUZ/P35GuCD/jg==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -63623,10 +65725,10 @@ in
   npm-check-updates = nodeEnv.buildNodePackage {
     name = "npm-check-updates";
     packageName = "npm-check-updates";
-    version = "3.1.23";
+    version = "3.1.26";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.1.23.tgz";
-      sha512 = "Z2dkMdNgue6OPkQDPcAK62Qrwv+G1PaEmKrDrrSAiSP7pRD3u30xOVy1nLukS1XrJ2/zF8XTVxFe9/ubcvlcPQ==";
+      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.1.26.tgz";
+      sha512 = "TQSMJgS7AdbdPsK5TsCNMa+7vdL7HLQrXKrwLMxPLiJtrnye9HEqJZK+U8VdbSq+qrjdt5lgm0g5vRmSSSOcvw==";
     };
     dependencies = [
       sources."@sindresorhus/is-0.14.0"
@@ -63640,7 +65742,7 @@ in
       sources."aproba-1.2.0"
       sources."argparse-1.0.10"
       sources."balanced-match-1.0.0"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."boxen-3.2.0"
       sources."brace-expansion-1.1.11"
       sources."buffer-from-1.1.1"
@@ -63655,7 +65757,7 @@ in
       })
       sources."camelcase-5.3.1"
       sources."chalk-2.4.2"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."ci-info-2.0.0"
       sources."cint-8.2.1"
       sources."cli-boxes-2.2.0"
@@ -63664,7 +65766,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."colors-1.0.3"
-      sources."commander-3.0.1"
+      sources."commander-3.0.2"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
       sources."configstore-4.0.0"
@@ -63691,7 +65793,7 @@ in
       sources."duplexify-3.7.1"
       sources."emoji-regex-7.0.3"
       sources."encoding-0.1.12"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."err-code-1.1.2"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
@@ -63713,21 +65815,21 @@ in
       sources."genfun-5.0.0"
       sources."get-stdin-7.0.0"
       sources."get-stream-4.1.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."global-dirs-0.1.1"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."has-yarn-2.1.0"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-cache-semantics-3.8.1"
       sources."http-proxy-agent-2.1.0"
-      sources."https-proxy-agent-2.2.2"
+      sources."https-proxy-agent-2.2.4"
       sources."humanize-ms-1.2.1"
       sources."iconv-lite-0.4.24"
       sources."iferr-0.1.5"
-      sources."ignore-walk-3.0.2"
+      sources."ignore-walk-3.0.3"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."infer-owner-1.0.4"
@@ -63750,7 +65852,7 @@ in
       sources."json-buffer-3.0.0"
       sources."json-parse-better-errors-1.0.2"
       sources."json-parse-helpfulerror-1.0.3"
-      (sources."json5-2.1.0" // {
+      (sources."json5-2.1.1" // {
         dependencies = [
           sources."minimist-1.2.0"
         ];
@@ -63772,12 +65874,12 @@ in
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-5.1.1"
       sources."make-dir-1.3.0"
-      sources."make-fetch-happen-5.0.0"
+      sources."make-fetch-happen-5.0.1"
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.8.1"
-      sources."minizlib-1.2.2"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
       sources."mississippi-3.0.0"
       sources."mkdirp-0.5.1"
       sources."move-concurrently-1.0.1"
@@ -63796,20 +65898,20 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."normalize-url-4.4.1"
+      sources."normalize-url-4.5.0"
       sources."npm-bundled-1.0.6"
       (sources."npm-package-arg-6.1.1" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
       })
-      sources."npm-packlist-1.4.4"
+      sources."npm-packlist-1.4.6"
       (sources."npm-pick-manifest-3.0.2" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
       })
-      sources."npm-registry-fetch-4.0.1"
+      sources."npm-registry-fetch-4.0.2"
       sources."npm-run-path-2.0.2"
       sources."object-assign-4.1.1"
       sources."object-keys-1.1.1"
@@ -63823,7 +65925,7 @@ in
       sources."p-locate-4.1.0"
       sources."p-try-2.2.0"
       sources."package-json-6.5.0"
-      (sources."pacote-9.5.8" // {
+      (sources."pacote-9.5.9" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
@@ -63922,7 +66024,7 @@ in
       sources."strip-eof-1.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-5.5.0"
-      sources."tar-4.4.11"
+      sources."tar-4.4.13"
       sources."term-size-1.2.0"
       sources."through-2.3.8"
       sources."through2-2.0.5"
@@ -63950,7 +66052,7 @@ in
       sources."xdg-basedir-3.0.0"
       sources."xtend-4.0.2"
       sources."y18n-4.0.0"
-      sources."yallist-3.0.3"
+      sources."yallist-3.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -64028,7 +66130,7 @@ in
       })
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."graceful-fs-2.0.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -64184,20 +66286,20 @@ in
   parcel-bundler = nodeEnv.buildNodePackage {
     name = "parcel-bundler";
     packageName = "parcel-bundler";
-    version = "1.12.3";
+    version = "1.12.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/parcel-bundler/-/parcel-bundler-1.12.3.tgz";
-      sha512 = "8bq6lj0hhQeGxD9f9xEkFMXQ3d8TIlf2+isKxoi9bciB0KVEILRGllaPkUgp++5t0anToBh9+tG6ZyInXOC1/A==";
+      url = "https://registry.npmjs.org/parcel-bundler/-/parcel-bundler-1.12.4.tgz";
+      sha512 = "G+iZGGiPEXcRzw0fiRxWYCKxdt/F7l9a0xkiU4XbcVRJCSlBnioWEwJMutOCCpoQmaQtjB4RBHDGIHN85AIhLQ==";
     };
     dependencies = [
-      sources."@babel/code-frame-7.0.0"
-      (sources."@babel/core-7.3.4" // {
+      sources."@babel/code-frame-7.5.5"
+      (sources."@babel/core-7.6.4" // {
         dependencies = [
-          sources."json5-2.1.0"
+          sources."json5-2.1.1"
           sources."source-map-0.5.7"
         ];
       })
-      (sources."@babel/generator-7.3.4" // {
+      (sources."@babel/generator-7.6.4" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
@@ -64205,82 +66307,34 @@ in
       sources."@babel/helper-annotate-as-pure-7.0.0"
       sources."@babel/helper-builder-binary-assignment-operator-visitor-7.1.0"
       sources."@babel/helper-builder-react-jsx-7.3.0"
-      (sources."@babel/helper-call-delegate-7.4.4" // {
-        dependencies = [
-          sources."@babel/code-frame-7.5.5"
-          sources."@babel/generator-7.6.0"
-          sources."@babel/parser-7.6.0"
-          sources."@babel/traverse-7.6.0"
-          sources."@babel/types-7.6.1"
-          sources."source-map-0.5.7"
-        ];
-      })
-      (sources."@babel/helper-define-map-7.5.5" // {
-        dependencies = [
-          sources."@babel/types-7.6.1"
-        ];
-      })
+      sources."@babel/helper-call-delegate-7.4.4"
+      sources."@babel/helper-define-map-7.5.5"
       sources."@babel/helper-explode-assignable-expression-7.1.0"
       sources."@babel/helper-function-name-7.1.0"
       sources."@babel/helper-get-function-arity-7.0.0"
-      (sources."@babel/helper-hoist-variables-7.4.4" // {
-        dependencies = [
-          sources."@babel/types-7.6.1"
-        ];
-      })
-      (sources."@babel/helper-member-expression-to-functions-7.5.5" // {
-        dependencies = [
-          sources."@babel/types-7.6.1"
-        ];
-      })
+      sources."@babel/helper-hoist-variables-7.4.4"
+      sources."@babel/helper-member-expression-to-functions-7.5.5"
       sources."@babel/helper-module-imports-7.0.0"
-      (sources."@babel/helper-module-transforms-7.5.5" // {
-        dependencies = [
-          sources."@babel/parser-7.6.0"
-          sources."@babel/template-7.6.0"
-          sources."@babel/types-7.6.1"
-        ];
-      })
+      sources."@babel/helper-module-transforms-7.5.5"
       sources."@babel/helper-optimise-call-expression-7.0.0"
       sources."@babel/helper-plugin-utils-7.0.0"
       sources."@babel/helper-regex-7.5.5"
       sources."@babel/helper-remap-async-to-generator-7.1.0"
-      (sources."@babel/helper-replace-supers-7.5.5" // {
-        dependencies = [
-          sources."@babel/code-frame-7.5.5"
-          sources."@babel/generator-7.6.0"
-          sources."@babel/parser-7.6.0"
-          sources."@babel/traverse-7.6.0"
-          sources."@babel/types-7.6.1"
-          sources."source-map-0.5.7"
-        ];
-      })
+      sources."@babel/helper-replace-supers-7.5.5"
       sources."@babel/helper-simple-access-7.1.0"
-      (sources."@babel/helper-split-export-declaration-7.4.4" // {
-        dependencies = [
-          sources."@babel/types-7.6.1"
-        ];
-      })
+      sources."@babel/helper-split-export-declaration-7.4.4"
       sources."@babel/helper-wrap-function-7.2.0"
-      (sources."@babel/helpers-7.6.0" // {
-        dependencies = [
-          sources."@babel/code-frame-7.5.5"
-          sources."@babel/generator-7.6.0"
-          sources."@babel/parser-7.6.0"
-          sources."@babel/template-7.6.0"
-          sources."@babel/traverse-7.6.0"
-          sources."@babel/types-7.6.1"
-          sources."source-map-0.5.7"
-        ];
-      })
+      sources."@babel/helpers-7.6.2"
       sources."@babel/highlight-7.5.0"
-      sources."@babel/parser-7.3.4"
+      sources."@babel/parser-7.6.4"
       sources."@babel/plugin-proposal-async-generator-functions-7.2.0"
+      sources."@babel/plugin-proposal-dynamic-import-7.5.0"
       sources."@babel/plugin-proposal-json-strings-7.2.0"
-      sources."@babel/plugin-proposal-object-rest-spread-7.5.5"
+      sources."@babel/plugin-proposal-object-rest-spread-7.6.2"
       sources."@babel/plugin-proposal-optional-catch-binding-7.2.0"
-      sources."@babel/plugin-proposal-unicode-property-regex-7.4.4"
+      sources."@babel/plugin-proposal-unicode-property-regex-7.6.2"
       sources."@babel/plugin-syntax-async-generators-7.2.0"
+      sources."@babel/plugin-syntax-dynamic-import-7.2.0"
       sources."@babel/plugin-syntax-flow-7.2.0"
       sources."@babel/plugin-syntax-json-strings-7.2.0"
       sources."@babel/plugin-syntax-jsx-7.2.0"
@@ -64289,49 +66343,51 @@ in
       sources."@babel/plugin-transform-arrow-functions-7.2.0"
       sources."@babel/plugin-transform-async-to-generator-7.5.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.2.0"
-      sources."@babel/plugin-transform-block-scoping-7.6.0"
+      sources."@babel/plugin-transform-block-scoping-7.6.3"
       sources."@babel/plugin-transform-classes-7.5.5"
       sources."@babel/plugin-transform-computed-properties-7.2.0"
       sources."@babel/plugin-transform-destructuring-7.6.0"
-      sources."@babel/plugin-transform-dotall-regex-7.4.4"
+      sources."@babel/plugin-transform-dotall-regex-7.6.2"
       sources."@babel/plugin-transform-duplicate-keys-7.5.0"
       sources."@babel/plugin-transform-exponentiation-operator-7.2.0"
-      sources."@babel/plugin-transform-flow-strip-types-7.3.4"
+      sources."@babel/plugin-transform-flow-strip-types-7.6.3"
       sources."@babel/plugin-transform-for-of-7.4.4"
       sources."@babel/plugin-transform-function-name-7.4.4"
       sources."@babel/plugin-transform-literals-7.2.0"
+      sources."@babel/plugin-transform-member-expression-literals-7.2.0"
       sources."@babel/plugin-transform-modules-amd-7.5.0"
-      sources."@babel/plugin-transform-modules-commonjs-7.2.0"
+      sources."@babel/plugin-transform-modules-commonjs-7.6.0"
       sources."@babel/plugin-transform-modules-systemjs-7.5.0"
       sources."@babel/plugin-transform-modules-umd-7.2.0"
-      sources."@babel/plugin-transform-named-capturing-groups-regex-7.6.0"
+      sources."@babel/plugin-transform-named-capturing-groups-regex-7.6.3"
       sources."@babel/plugin-transform-new-target-7.4.4"
       sources."@babel/plugin-transform-object-super-7.5.5"
       sources."@babel/plugin-transform-parameters-7.4.4"
+      sources."@babel/plugin-transform-property-literals-7.2.0"
       sources."@babel/plugin-transform-react-jsx-7.3.0"
       sources."@babel/plugin-transform-regenerator-7.4.5"
+      sources."@babel/plugin-transform-reserved-words-7.2.0"
       sources."@babel/plugin-transform-shorthand-properties-7.2.0"
-      sources."@babel/plugin-transform-spread-7.2.2"
+      sources."@babel/plugin-transform-spread-7.6.2"
       sources."@babel/plugin-transform-sticky-regex-7.2.0"
       sources."@babel/plugin-transform-template-literals-7.4.4"
       sources."@babel/plugin-transform-typeof-symbol-7.2.0"
-      sources."@babel/plugin-transform-unicode-regex-7.4.4"
-      sources."@babel/preset-env-7.3.4"
-      sources."@babel/runtime-7.3.4"
-      sources."@babel/template-7.2.2"
-      sources."@babel/traverse-7.3.4"
-      sources."@babel/types-7.3.4"
+      sources."@babel/plugin-transform-unicode-regex-7.6.2"
+      sources."@babel/preset-env-7.6.3"
+      sources."@babel/runtime-7.6.3"
+      sources."@babel/template-7.6.0"
+      sources."@babel/traverse-7.6.3"
+      sources."@babel/types-7.6.3"
       sources."@iarna/toml-2.2.3"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
       sources."@parcel/fs-1.11.0"
-      sources."@parcel/logger-1.11.0"
+      sources."@parcel/logger-1.11.1"
       sources."@parcel/utils-1.11.0"
-      sources."@parcel/watcher-1.12.0"
+      sources."@parcel/watcher-1.12.1"
       sources."@parcel/workers-1.11.0"
       sources."@types/q-1.5.2"
-      sources."abab-2.0.1"
-      sources."abbrev-1.1.1"
+      sources."abab-2.0.2"
       sources."acorn-5.7.3"
       (sources."acorn-globals-4.3.4" // {
         dependencies = [
@@ -64343,7 +66399,7 @@ in
       sources."alphanum-sort-1.0.2"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
-      sources."ansi-to-html-0.6.11"
+      sources."ansi-to-html-0.6.12"
       (sources."anymatch-2.0.0" // {
         dependencies = [
           sources."normalize-path-2.1.1"
@@ -64410,7 +66466,7 @@ in
           sources."pako-1.0.10"
         ];
       })
-      sources."browserslist-4.7.0"
+      sources."browserslist-4.7.2"
       (sources."buffer-4.9.1" // {
         dependencies = [
           sources."isarray-1.0.0"
@@ -64426,7 +66482,7 @@ in
       sources."caller-path-2.0.0"
       sources."callsites-2.0.0"
       sources."caniuse-api-3.0.0"
-      sources."caniuse-lite-1.0.30000989"
+      sources."caniuse-lite-1.0.30001006"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chokidar-2.1.8"
@@ -64435,7 +66491,6 @@ in
       sources."cli-cursor-2.1.0"
       sources."cli-spinners-1.3.1"
       sources."clone-2.1.2"
-      sources."clones-1.2.0"
       sources."coa-2.0.2"
       sources."collection-visit-1.0.0"
       sources."color-3.1.2"
@@ -64444,16 +66499,20 @@ in
       sources."color-string-1.5.3"
       sources."combined-stream-1.0.8"
       sources."command-exists-1.2.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
-      sources."config-chain-1.1.12"
-      sources."console-browserify-1.1.0"
+      sources."console-browserify-1.2.0"
       sources."constants-browserify-1.0.0"
       sources."convert-source-map-1.6.0"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-2.6.9"
+      sources."core-js-2.6.10"
+      (sources."core-js-compat-3.3.6" // {
+        dependencies = [
+          sources."semver-6.3.0"
+        ];
+      })
       sources."core-util-is-1.0.2"
       sources."cosmiconfig-5.2.1"
       sources."create-ecdh-4.0.3"
@@ -64489,11 +66548,7 @@ in
           sources."regjsparser-0.1.5"
         ];
       })
-      (sources."css-tree-1.0.0-alpha.33" // {
-        dependencies = [
-          sources."source-map-0.5.7"
-        ];
-      })
+      sources."css-tree-1.0.0-alpha.37"
       sources."css-unit-converter-1.1.1"
       sources."css-what-2.1.3"
       sources."cssesc-0.1.0"
@@ -64503,18 +66558,11 @@ in
       sources."cssnano-util-get-match-4.0.0"
       sources."cssnano-util-raw-cache-4.0.1"
       sources."cssnano-util-same-parent-4.0.1"
-      (sources."csso-3.5.1" // {
-        dependencies = [
-          sources."css-tree-1.0.0-alpha.29"
-          sources."mdn-data-1.1.4"
-          sources."source-map-0.5.7"
-        ];
-      })
+      sources."csso-4.0.2"
       sources."cssom-0.3.8"
       sources."cssstyle-1.4.0"
       sources."dashdash-1.14.1"
       sources."data-urls-1.1.0"
-      sources."date-now-0.1.4"
       sources."deasync-0.1.15"
       sources."debug-4.1.1"
       sources."decode-uri-component-0.2.0"
@@ -64559,17 +66607,17 @@ in
       sources."domutils-1.7.0"
       sources."dot-prop-4.2.0"
       sources."dotenv-5.0.1"
-      sources."dotenv-expand-4.2.0"
+      sources."dotenv-expand-5.1.0"
       sources."duplexer2-0.1.4"
       sources."ecc-jsbn-0.1.2"
-      sources."editorconfig-0.15.3"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.264"
+      sources."electron-to-chromium-1.3.298"
       sources."elliptic-6.5.1"
       sources."encodeurl-1.0.2"
       sources."entities-1.1.2"
+      sources."envinfo-7.4.0"
       sources."error-ex-1.3.2"
-      (sources."es-abstract-1.14.2" // {
+      (sources."es-abstract-1.16.0" // {
         dependencies = [
           sources."object-inspect-1.6.0"
         ];
@@ -64618,7 +66666,7 @@ in
       sources."get-port-3.2.0"
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -64626,7 +66674,7 @@ in
       })
       sources."glob-to-regexp-0.3.0"
       sources."globals-11.12.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."grapheme-breaker-0.3.2"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -64655,7 +66703,7 @@ in
       sources."html-tags-1.2.0"
       (sources."htmlnano-0.2.4" // {
         dependencies = [
-          sources."terser-4.3.1"
+          sources."terser-4.3.9"
         ];
       })
       (sources."htmlparser2-3.10.1" // {
@@ -64673,7 +66721,6 @@ in
       sources."indexes-of-1.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
-      sources."ini-1.3.5"
       sources."invariant-2.2.4"
       sources."is-absolute-url-2.1.0"
       (sources."is-accessor-descriptor-1.0.0" // {
@@ -64717,7 +66764,6 @@ in
       sources."isexe-2.0.0"
       sources."isobject-3.0.1"
       sources."isstream-0.1.2"
-      sources."js-beautify-1.10.2"
       sources."js-levenshtein-1.1.6"
       sources."js-tokens-4.0.0"
       (sources."js-yaml-3.13.1" // {
@@ -64749,7 +66795,6 @@ in
       sources."lodash.uniq-4.5.0"
       sources."log-symbols-2.2.0"
       sources."loose-envify-1.4.0"
-      sources."lru-cache-4.1.5"
       sources."magic-string-0.22.5"
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
@@ -64806,8 +66851,11 @@ in
           sources."punycode-1.4.1"
         ];
       })
-      sources."node-releases-1.1.32"
-      sources."nopt-4.0.1"
+      (sources."node-releases-1.1.39" // {
+        dependencies = [
+          sources."semver-6.3.0"
+        ];
+      })
       sources."normalize-html-whitespace-1.0.0"
       sources."normalize-path-3.0.0"
       sources."normalize-url-3.3.0"
@@ -64830,9 +66878,6 @@ in
       sources."optionator-0.8.2"
       sources."ora-2.1.0"
       sources."os-browserify-0.3.0"
-      sources."os-homedir-1.0.2"
-      sources."os-tmpdir-1.0.2"
-      sources."osenv-0.1.5"
       sources."pako-0.2.9"
       sources."parse-asn1-5.1.5"
       sources."parse-json-4.0.0"
@@ -64849,7 +66894,7 @@ in
       sources."physical-cpu-count-2.0.0"
       sources."pn-1.1.0"
       sources."posix-character-classes-0.1.1"
-      (sources."postcss-7.0.18" // {
+      (sources."postcss-7.0.21" // {
         dependencies = [
           sources."supports-color-6.1.0"
         ];
@@ -64922,8 +66967,6 @@ in
       sources."private-0.1.8"
       sources."process-0.11.10"
       sources."process-nextick-args-2.0.1"
-      sources."proto-list-1.2.4"
-      sources."pseudomap-1.0.2"
       sources."psl-1.4.0"
       sources."public-encrypt-4.0.3"
       sources."punycode-2.1.1"
@@ -64943,7 +66986,7 @@ in
       sources."readdirp-2.2.1"
       sources."regenerate-1.4.0"
       sources."regenerate-unicode-properties-8.1.0"
-      sources."regenerator-runtime-0.12.1"
+      sources."regenerator-runtime-0.13.3"
       sources."regenerator-transform-0.14.1"
       (sources."regex-not-1.0.2" // {
         dependencies = [
@@ -64951,9 +66994,8 @@ in
           sources."is-extendable-1.0.1"
         ];
       })
-      sources."regexp-tree-0.1.13"
       sources."regexpu-core-4.6.0"
-      sources."regjsgen-0.5.0"
+      sources."regjsgen-0.5.1"
       (sources."regjsparser-0.6.0" // {
         dependencies = [
           sources."jsesc-0.5.0"
@@ -64982,7 +67024,6 @@ in
       sources."safe-buffer-5.1.2"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."safer-eval-1.3.5"
       sources."sax-1.2.4"
       sources."saxes-3.1.11"
       sources."semver-5.7.1"
@@ -64996,7 +67037,7 @@ in
           sources."ms-2.1.1"
         ];
       })
-      sources."serialize-to-js-1.2.2"
+      sources."serialize-to-js-3.0.0"
       sources."serve-static-1.14.1"
       sources."set-value-2.0.1"
       sources."setimmediate-1.0.5"
@@ -65005,7 +67046,6 @@ in
       sources."shallow-copy-0.0.1"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
-      sources."sigmund-1.0.1"
       sources."signal-exit-3.0.2"
       (sources."simple-swizzle-0.2.2" // {
         dependencies = [
@@ -65027,7 +67067,7 @@ in
       sources."snapdragon-util-3.0.1"
       sources."source-map-0.6.1"
       sources."source-map-resolve-0.5.2"
-      sources."source-map-support-0.5.13"
+      sources."source-map-support-0.5.16"
       sources."source-map-url-0.4.0"
       (sources."split-string-3.1.0" // {
         dependencies = [
@@ -65055,7 +67095,7 @@ in
         ];
       })
       sources."supports-color-5.5.0"
-      sources."svgo-1.3.0"
+      sources."svgo-1.3.2"
       sources."symbol-tree-3.2.4"
       sources."terser-3.17.0"
       sources."through2-2.0.5"
@@ -65076,7 +67116,6 @@ in
       sources."toidentifier-1.0.0"
       sources."tough-cookie-2.5.0"
       sources."tr46-1.0.1"
-      sources."trim-right-1.0.1"
       sources."tty-browserify-0.0.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
@@ -65085,7 +67124,7 @@ in
       (sources."uncss-0.17.2" // {
         dependencies = [
           sources."cssesc-3.0.0"
-          sources."is-absolute-url-3.0.2"
+          sources."is-absolute-url-3.0.3"
           sources."postcss-selector-parser-6.0.2"
         ];
       })
@@ -65137,7 +67176,7 @@ in
       sources."webidl-conversions-4.0.2"
       sources."whatwg-encoding-1.0.5"
       sources."whatwg-mimetype-2.3.0"
-      sources."whatwg-url-7.0.0"
+      sources."whatwg-url-7.1.0"
       sources."which-1.3.1"
       sources."wordwrap-1.0.0"
       sources."wrappy-1.0.2"
@@ -65145,7 +67184,6 @@ in
       sources."xml-name-validator-3.0.0"
       sources."xmlchars-2.2.0"
       sources."xtend-4.0.2"
-      sources."yallist-2.1.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -65182,7 +67220,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base64-js-0.0.8"
       sources."bencode-2.0.1"
-      sources."big-integer-1.6.45"
+      sources."big-integer-1.6.47"
       sources."bitfield-0.1.0"
       (sources."bittorrent-dht-6.4.2" // {
         dependencies = [
@@ -65212,7 +67250,7 @@ in
       sources."camelcase-keys-2.1.0"
       sources."chalk-1.1.3"
       sources."chardet-0.4.2"
-      sources."chrome-dgram-3.0.3"
+      sources."chrome-dgram-3.0.4"
       sources."chrome-dns-1.0.1"
       sources."chrome-net-3.3.3"
       sources."cli-cursor-2.1.0"
@@ -65238,7 +67276,7 @@ in
       sources."dns-equal-1.0.0"
       sources."dns-packet-1.3.1"
       sources."dns-txt-2.0.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."error-ex-1.3.2"
       sources."escape-string-regexp-1.0.5"
       sources."external-editor-2.2.0"
@@ -65256,13 +67294,13 @@ in
       sources."function-bind-1.1.1"
       sources."get-browser-rtc-1.0.2"
       sources."get-stdin-4.0.1"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."hat-0.0.3"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-headers-3.0.2"
       sources."iconv-lite-0.4.24"
       sources."immediate-chunk-store-1.0.8"
@@ -65428,11 +67466,11 @@ in
       sources."symbol-observable-1.0.1"
       sources."thirty-two-1.0.2"
       sources."through-2.3.8"
-      sources."thunky-1.0.3"
+      sources."thunky-1.1.0"
       sources."tmp-0.0.33"
       sources."torrent-discovery-5.4.0"
       sources."torrent-piece-1.1.2"
-      (sources."torrent-stream-1.1.0" // {
+      (sources."torrent-stream-1.2.0" // {
         dependencies = [
           sources."end-of-stream-0.1.5"
           sources."magnet-uri-4.2.3"
@@ -65473,10 +67511,10 @@ in
   peerflix-server = nodeEnv.buildNodePackage {
     name = "peerflix-server";
     packageName = "peerflix-server";
-    version = "0.5.0";
+    version = "0.5.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/peerflix-server/-/peerflix-server-0.5.0.tgz";
-      sha512 = "TmtYwbayKLfzTj4rMIQ5nfGcXqkp8VwsCXkfZz95JdJcfk0+HYhflLDwviq+qOUxgKMYpoggqb129c3KST7zmQ==";
+      url = "https://registry.npmjs.org/peerflix-server/-/peerflix-server-0.5.1.tgz";
+      sha512 = "sXl2KCt8LCUrL6ezEPD4W5D5b+I0/VVOYlfI0K3GfdVUXkNHcb0q7cogPNjAXmoSMhvb57x2nhZN1xwxgGjzuw==";
     };
     dependencies = [
       sources."accepts-1.3.7"
@@ -65534,7 +67572,7 @@ in
       sources."bytes-3.1.0"
       sources."callsite-1.0.0"
       sources."caseless-0.12.0"
-      sources."chrome-dgram-3.0.3"
+      sources."chrome-dgram-3.0.4"
       sources."chrome-dns-1.0.1"
       sources."chrome-net-3.3.3"
       sources."combined-stream-1.0.8"
@@ -65570,7 +67608,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       (sources."engine.io-3.4.0" // {
         dependencies = [
           sources."cookie-0.3.1"
@@ -65607,8 +67645,8 @@ in
       sources."fs.realpath-1.0.0"
       sources."get-browser-rtc-1.0.2"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
@@ -65792,12 +67830,12 @@ in
       sources."string_decoder-1.1.1"
       sources."tar-stream-2.1.0"
       sources."thirty-two-0.0.2"
-      sources."thunky-1.0.3"
+      sources."thunky-1.1.0"
       sources."to-array-0.1.4"
       sources."toidentifier-1.0.0"
       sources."torrent-discovery-5.4.0"
       sources."torrent-piece-1.1.2"
-      (sources."torrent-stream-1.1.0" // {
+      (sources."torrent-stream-1.2.0" // {
         dependencies = [
           sources."end-of-stream-0.1.5"
           sources."mkdirp-0.3.5"
@@ -65825,7 +67863,7 @@ in
       sources."verror-1.10.0"
       sources."which-1.3.1"
       sources."wrappy-1.0.2"
-      sources."ws-7.1.2"
+      sources."ws-7.2.0"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."xtend-4.0.2"
       sources."yeast-0.1.2"
@@ -65844,10 +67882,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "3.8.1";
+    version = "4.1.7";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-3.8.1.tgz";
-      sha512 = "uINy/U+TNvUHInG1l0/NrgDosUtafn9BrHjP5+v+ojpw+zb/lgXjkQmMHB4461LKezlNoBb7+0JOrNnm5JhZFg==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-4.1.7.tgz";
+      sha512 = "0JfrmMLsy5x5nwUULUnXmKz6IbRXLc1r04STPDje6SIwcnyDwiRC5gR4LkC+AgVe2HuIhOSQm/MM1ypC63JDnQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -65887,7 +67925,7 @@ in
     };
     dependencies = [
       sources."JSONStream-1.3.5"
-      sources."acorn-7.0.0"
+      sources."acorn-7.1.0"
       sources."acorn-node-1.8.2"
       sources."acorn-walk-7.0.0"
       sources."asn1.js-4.10.1"
@@ -65942,7 +67980,7 @@ in
           sources."readable-stream-3.4.0"
         ];
       })
-      sources."console-browserify-1.1.0"
+      sources."console-browserify-1.2.0"
       sources."constants-browserify-1.0.0"
       sources."convert-source-map-1.1.3"
       sources."core-util-is-1.0.2"
@@ -65951,9 +67989,8 @@ in
       sources."create-hmac-1.1.7"
       sources."crypto-browserify-3.12.0"
       sources."dash-ast-1.0.0"
-      sources."date-now-0.1.4"
       sources."defined-1.0.0"
-      sources."deps-sort-2.0.0"
+      sources."deps-sort-2.0.1"
       sources."des.js-1.0.0"
       (sources."detective-5.2.0" // {
         dependencies = [
@@ -65967,13 +68004,14 @@ in
       sources."es6-promise-3.3.1"
       sources."events-2.1.0"
       sources."evp_bytestokey-1.0.3"
+      sources."fast-safe-stringify-2.0.7"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."gaze-1.1.3"
       sources."get-assigned-identifiers-1.2.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."globule-1.2.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-1.0.3"
       sources."hash-base-3.0.4"
       sources."hash.js-1.1.7"
@@ -66057,6 +68095,7 @@ in
       sources."sander-0.5.1"
       sources."sha.js-2.4.11"
       sources."shasum-1.0.2"
+      sources."shasum-object-1.0.0"
       sources."shell-quote-1.7.2"
       sources."simple-concat-1.0.0"
       (sources."sorcery-0.10.0" // {
@@ -66081,7 +68120,7 @@ in
         ];
       })
       sources."syntax-error-1.4.0"
-      (sources."temp-0.9.0" // {
+      (sources."temp-0.9.1" // {
         dependencies = [
           sources."rimraf-2.6.3"
         ];
@@ -66145,7 +68184,7 @@ in
       sources."eyes-0.1.8"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."i-0.3.6"
@@ -66211,7 +68250,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base62-0.1.1"
       sources."brace-expansion-1.1.11"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."commoner-0.10.8"
       sources."concat-map-0.0.1"
       sources."defined-1.0.0"
@@ -66219,7 +68258,7 @@ in
       sources."esprima-3.1.3"
       sources."esprima-fb-13001.1001.0-dev-harmony-fb"
       sources."glob-5.0.15"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."iconv-lite-0.4.24"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -66425,10 +68464,10 @@ in
   serve = nodeEnv.buildNodePackage {
     name = "serve";
     packageName = "serve";
-    version = "11.1.0";
+    version = "11.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/serve/-/serve-11.1.0.tgz";
-      sha512 = "+4wpDtOSS+4ZLyDWMxThutA3iOTawX2+yDovOI8cjOUOmemyvNlHyFAsezBlSgbZKTYChI3tzA1Mh0z6XZ62qA==";
+      url = "https://registry.npmjs.org/serve/-/serve-11.2.0.tgz";
+      sha512 = "THZcLzDGk3vJqjhAbLkLag43tiE3V0B7wVe98Xtl+1KyAsr+4iShg+9hke4pLZmrCJu0pUg0TrbhJmdqn/MKoA==";
     };
     dependencies = [
       sources."@zeit/schemas-2.6.0"
@@ -66496,7 +68535,7 @@ in
       sources."registry-auth-token-3.3.2"
       sources."registry-url-3.1.0"
       sources."safe-buffer-5.1.2"
-      (sources."serve-handler-6.1.0" // {
+      (sources."serve-handler-6.1.2" // {
         dependencies = [
           sources."mime-db-1.33.0"
           sources."mime-types-2.1.18"
@@ -66531,25 +68570,25 @@ in
   serverless = nodeEnv.buildNodePackage {
     name = "serverless";
     packageName = "serverless";
-    version = "1.52.2";
+    version = "1.56.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/serverless/-/serverless-1.52.2.tgz";
-      sha512 = "JLRh52heei1kiTg/mdXdVeJXlB26nXI6uK3/jQvG2a16WwrXD+h033azkD9qqk7WgISLgDKPJbvlnsCAXLcX5Q==";
+      url = "https://registry.npmjs.org/serverless/-/serverless-1.56.1.tgz";
+      sha512 = "yLEQbyHdrgM8MG64J7o1jrjaaCaGOoNThRl9PGzBGZmibtDBDzRBlclVcjcWIWDItw35t6OtMRlwQrXYPtgoqw==";
     };
     dependencies = [
-      sources."@serverless/cli-1.2.3"
+      sources."@serverless/cli-1.4.0"
       (sources."@serverless/component-metrics-1.0.8" // {
         dependencies = [
           sources."node-fetch-2.6.0"
         ];
       })
-      (sources."@serverless/core-1.0.0" // {
+      (sources."@serverless/core-1.1.2" // {
         dependencies = [
           sources."fs-extra-7.0.1"
           sources."semver-6.3.0"
         ];
       })
-      (sources."@serverless/enterprise-plugin-3.0.0" // {
+      (sources."@serverless/enterprise-plugin-3.2.1" // {
         dependencies = [
           sources."fs-extra-7.0.1"
           sources."node-fetch-2.6.0"
@@ -66557,24 +68596,22 @@ in
         ];
       })
       sources."@serverless/event-mocks-1.1.1"
-      (sources."@serverless/platform-sdk-2.1.1" // {
+      (sources."@serverless/platform-sdk-2.2.0" // {
         dependencies = [
           sources."ramda-0.25.0"
           sources."uuid-3.3.3"
         ];
       })
-      sources."@serverless/template-1.1.0"
+      sources."@serverless/template-1.1.3"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/lodash-4.14.138"
-      sources."accepts-1.3.7"
+      sources."@types/lodash-4.14.144"
       sources."agent-base-4.3.0"
-      sources."ansi-0.3.1"
       sources."ansi-align-2.0.0"
       sources."ansi-escapes-4.2.1"
       sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
-      sources."anymatch-3.1.0"
+      sources."anymatch-3.1.1"
       (sources."archiver-1.3.0" // {
         dependencies = [
           sources."async-2.6.3"
@@ -66585,19 +68622,18 @@ in
           sources."normalize-path-2.1.1"
         ];
       })
-      sources."are-we-there-yet-1.1.5"
       sources."argparse-1.0.10"
       sources."arr-diff-4.0.0"
       sources."arr-union-3.1.0"
-      sources."array-flatten-1.1.1"
       sources."array-union-1.0.2"
       sources."array-uniq-1.0.3"
       sources."array-unique-0.3.2"
       sources."assign-symbols-1.0.0"
       sources."async-1.5.2"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
-      (sources."aws-sdk-2.533.0" // {
+      (sources."aws-sdk-2.561.0" // {
         dependencies = [
           sources."buffer-4.9.1"
           sources."uuid-3.3.2"
@@ -66612,8 +68648,7 @@ in
       sources."base64-js-1.3.1"
       sources."binary-extensions-2.0.0"
       sources."bl-1.2.2"
-      sources."bluebird-3.5.5"
-      sources."body-parser-1.19.0"
+      sources."bluebird-3.7.1"
       sources."boxen-1.3.0"
       sources."brace-expansion-1.1.11"
       sources."braces-3.0.2"
@@ -66624,7 +68659,6 @@ in
       sources."buffer-fill-1.0.0"
       sources."buffer-from-1.1.1"
       sources."builtin-modules-3.1.0"
-      sources."bytes-3.1.0"
       sources."cache-base-1.0.1"
       (sources."cacheable-request-6.1.0" // {
         dependencies = [
@@ -66638,7 +68672,7 @@ in
       sources."caw-2.0.1"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
-      sources."chokidar-3.1.1"
+      sources."chokidar-3.2.3"
       sources."ci-info-1.6.0"
       (sources."class-utils-0.3.6" // {
         dependencies = [
@@ -66662,7 +68696,6 @@ in
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.0"
       sources."clone-response-1.0.2"
-      sources."code-point-at-1.1.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -66676,17 +68709,9 @@ in
         ];
       })
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.2"
       sources."config-chain-1.1.12"
       sources."configstore-3.1.2"
-      (sources."content-disposition-0.5.3" // {
-        dependencies = [
-          sources."safe-buffer-5.1.2"
-        ];
-      })
-      sources."content-type-1.0.4"
-      sources."cookie-0.4.0"
-      sources."cookie-signature-1.0.6"
+      sources."cookie-0.3.1"
       sources."cookiejar-2.1.2"
       sources."copy-descriptor-0.1.1"
       sources."core-util-is-1.0.2"
@@ -66695,8 +68720,12 @@ in
       sources."create-error-class-3.0.2"
       sources."cross-spawn-5.1.0"
       sources."crypto-random-string-1.0.0"
-      sources."d-1.0.1"
-      sources."debug-2.6.9"
+      (sources."d-1.0.1" // {
+        dependencies = [
+          sources."type-1.2.0"
+        ];
+      })
+      sources."debug-4.1.1"
       sources."decode-uri-component-0.2.0"
       sources."decompress-4.2.0"
       sources."decompress-response-3.3.0"
@@ -66718,11 +68747,8 @@ in
       sources."deferred-0.7.11"
       sources."define-property-2.0.2"
       sources."delayed-stream-1.0.0"
-      sources."delegates-1.0.0"
-      sources."depd-1.1.2"
-      sources."destroy-1.0.4"
       sources."dot-prop-4.2.0"
-      sources."dotenv-8.1.0"
+      sources."dotenv-8.2.0"
       (sources."download-5.0.3" // {
         dependencies = [
           sources."get-stream-3.0.0"
@@ -66732,11 +68758,9 @@ in
         ];
       })
       sources."duplexer3-0.1.4"
-      sources."ee-first-1.1.1"
-      sources."encodeurl-1.0.2"
       sources."encoding-0.1.12"
-      sources."end-of-stream-1.4.1"
-      sources."es5-ext-0.10.51"
+      sources."end-of-stream-1.4.4"
+      sources."es5-ext-0.10.52"
       sources."es6-iterator-2.0.3"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
@@ -66745,13 +68769,11 @@ in
           sources."es6-symbol-3.1.1"
         ];
       })
-      sources."es6-symbol-3.1.2"
+      sources."es6-symbol-3.1.3"
       sources."es6-weak-map-2.0.3"
-      sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."esniff-1.1.0"
       sources."esprima-4.0.1"
-      sources."etag-1.8.1"
       sources."event-emitter-0.3.5"
       sources."events-1.1.1"
       (sources."execa-0.7.0" // {
@@ -66759,32 +68781,24 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."exit-hook-1.1.1"
-      (sources."express-4.17.1" // {
-        dependencies = [
-          sources."safe-buffer-5.1.2"
-        ];
-      })
+      sources."ext-1.1.2"
       sources."extend-3.0.2"
       sources."extend-shallow-3.0.2"
       sources."external-editor-3.1.0"
       sources."fast-levenshtein-2.0.6"
       sources."fd-slicer-1.1.0"
-      sources."figures-3.0.0"
+      sources."figures-3.1.0"
       sources."file-type-5.2.0"
       sources."filename-reserved-regex-2.0.0"
       sources."filenamify-2.1.0"
       sources."filesize-3.6.1"
       sources."fill-range-7.0.1"
-      sources."finalhandler-1.1.2"
       sources."find-requires-1.0.0"
       sources."flat-4.1.0"
       sources."for-in-1.0.2"
       sources."form-data-2.5.1"
       sources."formidable-1.2.1"
-      sources."forwarded-0.1.2"
       sources."fragment-cache-0.2.1"
-      sources."fresh-0.5.2"
       sources."fs-constants-1.0.0"
       (sources."fs-extra-0.30.0" // {
         dependencies = [
@@ -66792,14 +68806,17 @@ in
         ];
       })
       sources."fs.realpath-1.0.0"
-      sources."fs2-0.3.5"
-      sources."fsevents-2.0.7"
-      sources."gauge-1.2.7"
+      (sources."fs2-0.3.6" // {
+        dependencies = [
+          sources."type-1.2.0"
+        ];
+      })
+      sources."fsevents-2.1.1"
       sources."get-proxy-2.1.0"
       sources."get-stdin-5.0.1"
       sources."get-stream-4.1.0"
       sources."get-value-2.0.6"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."glob-parent-5.1.0"
       sources."global-dirs-0.1.1"
       sources."globby-6.1.0"
@@ -66807,15 +68824,9 @@ in
       sources."graceful-fs-4.2.1"
       sources."graceful-readlink-1.0.1"
       sources."graphlib-2.1.7"
-      (sources."has-ansi-2.0.0" // {
-        dependencies = [
-          sources."ansi-regex-2.1.1"
-        ];
-      })
       sources."has-flag-3.0.0"
       sources."has-symbol-support-x-1.4.2"
       sources."has-to-string-tag-x-1.4.1"
-      sources."has-unicode-2.0.1"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -66829,11 +68840,9 @@ in
         ];
       })
       sources."http-cache-semantics-4.0.3"
-      sources."http-errors-1.7.2"
-      (sources."https-proxy-agent-2.2.2" // {
+      (sources."https-proxy-agent-3.0.1" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.2"
         ];
       })
       sources."iconv-lite-0.4.24"
@@ -66843,7 +68852,7 @@ in
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
-      sources."inherits-2.0.3"
+      sources."inherits-2.0.4"
       sources."ini-1.3.5"
       (sources."inquirer-6.5.2" // {
         dependencies = [
@@ -66851,10 +68860,9 @@ in
           sources."figures-2.0.0"
         ];
       })
-      sources."ipaddr.js-1.9.0"
       sources."is-accessor-descriptor-1.0.0"
       sources."is-binary-path-2.1.0"
-      sources."is-buffer-2.0.3"
+      sources."is-buffer-2.0.4"
       sources."is-ci-1.2.1"
       sources."is-data-descriptor-1.0.0"
       sources."is-descriptor-1.0.2"
@@ -66889,7 +68897,7 @@ in
       sources."json-cycle-1.3.0"
       sources."json-refs-2.1.7"
       sources."json-stringify-safe-5.0.1"
-      sources."jsonata-1.6.5"
+      sources."jsonata-1.7.0"
       sources."jsonfile-4.0.0"
       sources."jszip-3.2.2"
       sources."jwt-decode-2.2.0"
@@ -66910,11 +68918,6 @@ in
       sources."lazystream-1.0.0"
       sources."lie-3.3.0"
       sources."lodash-4.17.15"
-      sources."lodash.difference-4.5.0"
-      sources."lodash.pad-4.5.1"
-      sources."lodash.padend-4.6.1"
-      sources."lodash.padstart-4.6.1"
-      sources."lodash.uniq-4.5.0"
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.5"
       sources."lru-queue-0.1.0"
@@ -66926,9 +68929,7 @@ in
       })
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
-      sources."media-typer-0.3.0"
       sources."memoizee-0.4.14"
-      sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
       sources."mime-1.6.0"
       sources."mime-db-1.40.0"
@@ -66944,26 +68945,23 @@ in
         ];
       })
       sources."moment-2.24.0"
-      sources."ms-2.0.0"
+      sources."ms-2.1.2"
       sources."mute-stream-0.0.7"
-      sources."nanoid-2.1.1"
+      sources."nanoid-2.1.6"
       sources."nanomatch-1.2.13"
       sources."native-promise-only-0.8.1"
-      sources."ncjsm-3.0.0"
-      sources."negotiator-0.6.2"
+      sources."ncjsm-4.0.1"
       sources."next-tick-1.0.0"
       sources."node-dir-0.1.17"
       sources."node-fetch-1.7.3"
       sources."normalize-path-3.0.0"
-      sources."normalize-url-4.4.1"
+      sources."normalize-url-4.5.0"
       (sources."npm-conf-1.1.3" // {
         dependencies = [
           sources."pify-3.0.0"
         ];
       })
       sources."npm-run-path-2.0.2"
-      sources."npmlog-2.0.4"
-      sources."number-is-nan-1.0.1"
       sources."object-assign-4.1.1"
       (sources."object-copy-0.1.0" // {
         dependencies = [
@@ -66982,7 +68980,6 @@ in
       sources."object-hash-1.3.1"
       sources."object-visit-1.0.1"
       sources."object.pick-1.3.0"
-      sources."on-finished-2.3.0"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       (sources."opn-5.5.0" // {
@@ -66990,25 +68987,24 @@ in
           sources."is-wsl-1.1.0"
         ];
       })
-      sources."os-shim-0.1.3"
       sources."os-tmpdir-1.0.2"
       sources."p-cancelable-1.1.0"
       sources."p-finally-1.0.0"
+      sources."p-limit-2.2.1"
+      sources."p-try-2.2.0"
       (sources."package-json-6.5.0" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
       })
       sources."pako-1.0.10"
-      sources."parseurl-1.3.3"
       sources."pascalcase-0.1.1"
       sources."path-is-absolute-1.0.1"
       sources."path-is-inside-1.0.2"
       sources."path-key-2.0.1"
       sources."path-loader-1.0.10"
-      sources."path-to-regexp-0.1.7"
       sources."pend-1.2.0"
-      sources."picomatch-2.0.7"
+      sources."picomatch-2.1.0"
       sources."pify-2.3.0"
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
@@ -67017,28 +69013,24 @@ in
       sources."process-nextick-args-2.0.1"
       sources."promise-queue-2.2.5"
       sources."proto-list-1.2.4"
-      sources."proxy-addr-2.0.5"
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
       sources."punycode-1.3.2"
-      sources."qs-6.7.0"
+      sources."qs-6.9.0"
       sources."querystring-0.2.0"
       sources."ramda-0.26.1"
-      sources."range-parser-1.2.1"
       (sources."raven-1.2.1" // {
         dependencies = [
-          sources."cookie-0.3.1"
           sources."uuid-3.0.0"
         ];
       })
-      sources."raw-body-2.4.0"
       sources."rc-1.2.8"
       (sources."readable-stream-2.3.6" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
         ];
       })
-      sources."readdirp-3.1.2"
+      sources."readdirp-3.2.0"
       sources."regenerator-runtime-0.13.3"
       sources."regex-not-1.0.2"
       sources."registry-auth-token-4.0.0"
@@ -67051,7 +69043,6 @@ in
       sources."ret-0.1.15"
       sources."rimraf-2.7.1"
       sources."run-async-2.3.0"
-      sources."rx-4.1.0"
       sources."rxjs-6.5.3"
       sources."safe-buffer-5.2.0"
       sources."safe-regex-1.1.0"
@@ -67065,12 +69056,6 @@ in
       sources."semver-5.7.1"
       sources."semver-diff-2.1.0"
       sources."semver-regex-1.0.0"
-      (sources."send-0.17.1" // {
-        dependencies = [
-          sources."ms-2.1.1"
-        ];
-      })
-      sources."serve-static-1.14.1"
       sources."set-immediate-shim-1.0.1"
       (sources."set-value-2.0.1" // {
         dependencies = [
@@ -67078,20 +69063,15 @@ in
           sources."is-extendable-0.1.1"
         ];
       })
-      sources."setprototypeof-1.1.1"
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."shortid-2.2.15"
       sources."signal-exit-3.0.2"
-      (sources."simple-git-1.126.0" // {
-        dependencies = [
-          sources."debug-4.1.1"
-          sources."ms-2.1.2"
-        ];
-      })
+      sources."simple-git-1.126.0"
       sources."slash-1.0.0"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
+          sources."debug-2.6.9"
           sources."define-property-0.2.5"
           sources."extend-shallow-2.0.1"
           (sources."is-accessor-descriptor-0.1.6" // {
@@ -67108,14 +69088,14 @@ in
           sources."is-descriptor-0.1.6"
           sources."is-extendable-0.1.1"
           sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
           sources."source-map-0.5.7"
         ];
       })
       sources."source-map-0.6.1"
       sources."source-map-resolve-0.5.2"
-      sources."source-map-support-0.5.13"
+      sources."source-map-support-0.5.16"
       sources."source-map-url-0.4.0"
-      sources."spawn-sync-1.0.15"
       sources."split-string-3.1.0"
       sources."sprintf-js-1.0.3"
       sources."stack-trace-0.0.9"
@@ -67137,7 +69117,6 @@ in
           sources."kind-of-5.1.0"
         ];
       })
-      sources."statuses-1.5.0"
       (sources."string-width-2.1.1" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
@@ -67157,28 +69136,12 @@ in
       (sources."superagent-3.8.3" // {
         dependencies = [
           sources."debug-3.2.6"
-          sources."ms-2.1.2"
         ];
       })
       sources."supports-color-5.5.0"
-      (sources."tabtab-2.2.2" // {
+      (sources."tabtab-3.0.2" // {
         dependencies = [
-          sources."ansi-escapes-1.4.0"
-          sources."ansi-regex-2.1.1"
-          sources."ansi-styles-2.2.1"
-          sources."chalk-1.1.3"
-          sources."cli-cursor-1.0.2"
-          sources."external-editor-1.1.1"
-          sources."figures-1.7.0"
-          sources."inquirer-1.2.3"
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."mute-stream-0.0.6"
-          sources."onetime-1.1.0"
-          sources."restore-cursor-1.0.1"
-          sources."string-width-1.0.2"
-          sources."strip-ansi-3.0.1"
-          sources."supports-color-2.0.0"
-          sources."tmp-0.0.29"
+          sources."es6-promisify-6.0.2"
         ];
       })
       sources."tar-stream-1.6.2"
@@ -67197,15 +69160,12 @@ in
       sources."to-readable-stream-1.0.0"
       sources."to-regex-3.0.2"
       sources."to-regex-range-5.0.1"
-      sources."toidentifier-1.0.0"
       sources."traverse-0.6.6"
       sources."trim-repeated-1.0.0"
       sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
-      sources."type-1.2.0"
+      sources."type-2.0.0"
       sources."type-fest-0.5.2"
-      sources."type-is-1.6.18"
-      sources."typedarray-0.0.6"
       sources."unbzip2-stream-1.3.3"
       (sources."union-value-1.0.1" // {
         dependencies = [
@@ -67214,7 +69174,6 @@ in
       })
       sources."unique-string-1.0.0"
       sources."universalify-0.1.2"
-      sources."unpipe-1.0.0"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -67239,15 +69198,14 @@ in
       sources."url-to-options-1.0.1"
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
-      sources."utils-merge-1.0.1"
       sources."uuid-2.0.3"
-      sources."vary-1.1.2"
       sources."walkdir-0.0.11"
       sources."whatwg-fetch-3.0.0"
       sources."which-1.3.1"
       sources."widest-line-2.0.1"
       sources."wrappy-1.0.2"
       sources."write-file-atomic-2.4.3"
+      sources."ws-6.2.1"
       sources."xdg-basedir-3.0.0"
       sources."xml2js-0.4.19"
       sources."xmlbuilder-9.0.7"
@@ -67261,7 +69219,7 @@ in
     buildInputs = globalBuildInputs;
     meta = {
       description = "Serverless Framework - Build web, mobile and IoT applications with serverless architectures using AWS Lambda, Azure Functions, Google CloudFunctions & more";
-      homepage = "https://github.com/serverless/serverless#readme";
+      homepage = https://serverless.com/framework/docs/;
       license = "MIT";
     };
     production = true;
@@ -67301,7 +69259,7 @@ in
       sources."caseless-0.12.0"
       sources."cheerio-0.17.0"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.1.2"
       sources."component-inherit-0.0.3"
@@ -67595,7 +69553,7 @@ in
       sources."for-in-1.0.2"
       sources."fragment-cache-0.2.1"
       sources."get-value-2.0.6"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."graceful-readlink-1.0.1"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -67890,21 +69848,30 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.228.3";
+    version = "1.240.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.228.3.tgz";
-      sha512 = "TwyJcMXBvic1xJ+rVLdIYS1xDYuzcogIXdmyvGvXBZgwIQdjOVMnZBVxUo5igkOIntBL2sCynZiydQtGbe08JA==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.240.3.tgz";
+      sha512 = "9QDKPxxMxpAbZmGjmoxzD/clopbLvAKcY5BftKSe6m6Q4HYQA5Tat6VFpLKZ4A7Kew/6jB6FgtdN5c5Xul5VZQ==";
     };
     dependencies = [
-      sources."@snyk/cli-interface-2.1.0"
+      sources."@snyk/cli-interface-2.2.0"
+      sources."@snyk/cocoapods-lockfile-parser-2.0.4"
       sources."@snyk/composer-lockfile-parser-1.0.3"
-      sources."@snyk/dep-graph-1.12.0"
+      sources."@snyk/dep-graph-1.13.1"
       sources."@snyk/gemfile-1.2.0"
+      sources."@snyk/ruby-semver-2.0.4"
+      (sources."@snyk/snyk-cocoapods-plugin-1.0.3" // {
+        dependencies = [
+          sources."@snyk/cli-interface-1.5.0"
+          sources."@snyk/dep-graph-1.13.0"
+        ];
+      })
       sources."@types/agent-base-4.2.0"
       sources."@types/bunyan-1.8.6"
       sources."@types/debug-4.1.5"
       sources."@types/events-3.0.0"
-      sources."@types/node-12.7.5"
+      sources."@types/js-yaml-3.12.1"
+      sources."@types/node-12.12.3"
       sources."@types/restify-4.3.6"
       sources."@types/semver-5.5.0"
       sources."@types/xml2js-0.4.3"
@@ -67922,6 +69889,13 @@ in
       sources."ast-types-0.13.2"
       sources."async-1.5.2"
       sources."balanced-match-1.0.0"
+      (sources."bl-3.0.0" // {
+        dependencies = [
+          sources."readable-stream-3.4.0"
+          sources."safe-buffer-5.2.0"
+          sources."string_decoder-1.3.0"
+        ];
+      })
       (sources."boxen-1.3.0" // {
         dependencies = [
           sources."camelcase-4.1.0"
@@ -67937,6 +69911,7 @@ in
       sources."ci-info-1.6.0"
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-2.1.0"
+      sources."cli-spinner-0.2.10"
       sources."cli-width-2.2.0"
       (sources."cliui-3.2.0" // {
         dependencies = [
@@ -67954,6 +69929,7 @@ in
       sources."color-name-1.1.3"
       sources."concat-map-0.0.1"
       sources."configstore-3.1.2"
+      sources."core-js-3.3.6"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       (sources."cross-spawn-6.0.5" // {
@@ -67962,22 +69938,22 @@ in
         ];
       })
       sources."crypto-random-string-1.0.0"
-      (sources."data-uri-to-buffer-2.0.1" // {
-        dependencies = [
-          sources."@types/node-8.10.54"
-        ];
-      })
+      sources."data-uri-to-buffer-1.2.0"
       sources."debug-3.2.6"
       sources."decamelize-1.2.0"
       sources."deep-extend-0.6.0"
       sources."deep-is-0.1.3"
       sources."define-properties-1.1.3"
-      sources."degenerator-1.0.4"
+      (sources."degenerator-1.0.4" // {
+        dependencies = [
+          sources."esprima-3.1.3"
+        ];
+      })
       sources."depd-1.1.2"
       sources."diff-4.0.1"
       sources."dockerfile-ast-0.0.16"
       sources."dot-prop-4.2.0"
-      (sources."dotnet-deps-parser-4.5.0" // {
+      (sources."dotnet-deps-parser-4.5.2" // {
         dependencies = [
           sources."xml2js-0.4.19"
         ];
@@ -67985,14 +69961,18 @@ in
       sources."duplexer3-0.1.4"
       sources."email-validator-2.0.4"
       sources."emoji-regex-7.0.3"
-      sources."end-of-stream-1.4.1"
-      sources."es-abstract-1.14.2"
+      sources."end-of-stream-1.4.4"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
-      sources."escodegen-1.12.0"
-      sources."esprima-3.1.3"
+      (sources."escodegen-1.12.0" // {
+        dependencies = [
+          sources."esprima-3.1.3"
+        ];
+      })
+      sources."esprima-4.0.1"
       sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."execa-1.0.0"
@@ -68003,6 +69983,7 @@ in
       sources."file-uri-to-path-1.0.0"
       sources."for-in-1.0.2"
       sources."for-own-1.0.0"
+      sources."fs-constants-1.0.0"
       sources."fs.realpath-1.0.0"
       (sources."ftp-0.3.10" // {
         dependencies = [
@@ -68011,26 +69992,27 @@ in
       })
       sources."function-bind-1.1.1"
       sources."get-stream-4.1.0"
-      (sources."get-uri-2.0.3" // {
+      (sources."get-uri-2.0.4" // {
         dependencies = [
-          sources."debug-4.1.1"
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
         ];
       })
       sources."git-up-4.0.1"
       sources."git-url-parse-11.1.2"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."global-dirs-0.1.1"
       (sources."got-6.7.1" // {
         dependencies = [
           sources."get-stream-3.0.0"
         ];
       })
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."graphlib-2.1.7"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
       sources."has-symbols-1.0.0"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-errors-1.7.3"
       (sources."http-proxy-agent-2.1.0" // {
         dependencies = [
@@ -68038,7 +70020,7 @@ in
           sources."ms-2.0.0"
         ];
       })
-      sources."https-proxy-agent-2.2.2"
+      sources."https-proxy-agent-3.0.1"
       sources."iconv-lite-0.4.24"
       sources."immediate-3.0.6"
       sources."import-lazy-2.1.0"
@@ -68071,19 +70053,8 @@ in
       sources."isarray-0.0.1"
       sources."isexe-2.0.0"
       sources."isobject-3.0.1"
-      (sources."js-yaml-3.13.1" // {
-        dependencies = [
-          sources."esprima-4.0.1"
-        ];
-      })
-      (sources."jszip-3.2.2" // {
-        dependencies = [
-          sources."isarray-1.0.0"
-          sources."readable-stream-2.3.6"
-          sources."safe-buffer-5.1.2"
-          sources."string_decoder-1.1.1"
-        ];
-      })
+      sources."js-yaml-3.13.1"
+      sources."jszip-3.2.2"
       sources."kind-of-3.2.2"
       sources."latest-version-3.1.0"
       sources."lazy-cache-0.2.7"
@@ -68099,7 +70070,7 @@ in
       sources."lodash.get-4.4.2"
       sources."lodash.set-4.3.2"
       sources."lowercase-keys-1.0.1"
-      sources."lru-cache-4.1.5"
+      sources."lru-cache-5.1.1"
       sources."macos-release-2.3.0"
       sources."make-dir-1.3.0"
       sources."mimic-fn-1.2.0"
@@ -68131,7 +70102,11 @@ in
       sources."os-name-3.1.0"
       sources."os-tmpdir-1.0.2"
       sources."p-finally-1.0.0"
-      sources."pac-proxy-agent-3.0.0"
+      (sources."pac-proxy-agent-3.0.1" // {
+        dependencies = [
+          sources."debug-4.1.1"
+        ];
+      })
       sources."pac-resolver-3.0.0"
       (sources."package-json-4.0.1" // {
         dependencies = [
@@ -68150,15 +70125,20 @@ in
       sources."process-nextick-args-2.0.1"
       sources."promise-7.3.1"
       sources."protocols-1.4.7"
-      sources."proxy-agent-3.1.0"
+      (sources."proxy-agent-3.1.1" // {
+        dependencies = [
+          sources."debug-4.1.1"
+        ];
+      })
       sources."proxy-from-env-1.0.0"
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
       sources."raw-body-2.4.1"
       sources."rc-1.2.8"
-      (sources."readable-stream-3.4.0" // {
+      (sources."readable-stream-2.3.6" // {
         dependencies = [
-          sources."string_decoder-1.3.0"
+          sources."isarray-1.0.0"
+          sources."string_decoder-1.1.1"
         ];
       })
       sources."registry-auth-token-3.4.0"
@@ -68167,7 +70147,7 @@ in
       sources."rimraf-2.7.1"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.3"
-      sources."safe-buffer-5.2.0"
+      sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
       sources."secure-keys-1.0.0"
@@ -68189,13 +70169,13 @@ in
       sources."signal-exit-3.0.2"
       sources."smart-buffer-4.0.2"
       sources."snyk-config-2.2.3"
-      (sources."snyk-docker-plugin-1.29.1" // {
+      (sources."snyk-docker-plugin-1.33.1" // {
         dependencies = [
           sources."debug-4.1.1"
         ];
       })
       sources."snyk-go-parser-1.3.1"
-      (sources."snyk-go-plugin-1.11.0" // {
+      (sources."snyk-go-plugin-1.11.1" // {
         dependencies = [
           sources."debug-4.1.1"
         ];
@@ -68212,7 +70192,7 @@ in
         ];
       })
       sources."snyk-nodejs-lockfile-parser-1.16.0"
-      sources."snyk-nuget-plugin-1.12.1"
+      sources."snyk-nuget-plugin-1.13.1"
       sources."snyk-paket-parser-1.5.0"
       (sources."snyk-php-plugin-1.6.4" // {
         dependencies = [
@@ -68220,12 +70200,14 @@ in
         ];
       })
       sources."snyk-policy-1.13.5"
-      sources."snyk-python-plugin-1.13.2"
+      sources."snyk-python-plugin-1.13.3"
       sources."snyk-resolve-1.0.1"
       (sources."snyk-resolve-deps-4.4.0" // {
         dependencies = [
-          sources."@types/node-6.14.7"
+          sources."@types/node-6.14.9"
+          sources."lru-cache-4.1.5"
           sources."semver-5.7.1"
+          sources."yallist-2.1.2"
         ];
       })
       (sources."snyk-sbt-plugin-2.8.0" // {
@@ -68234,7 +70216,12 @@ in
         ];
       })
       sources."snyk-tree-1.0.0"
-      sources."snyk-try-require-1.3.1"
+      (sources."snyk-try-require-1.3.1" // {
+        dependencies = [
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
+        ];
+      })
       sources."socks-2.3.2"
       (sources."socks-proxy-agent-4.0.2" // {
         dependencies = [
@@ -68242,7 +70229,7 @@ in
         ];
       })
       sources."source-map-0.6.1"
-      sources."source-map-support-0.5.13"
+      sources."source-map-support-0.5.16"
       sources."sprintf-js-1.0.3"
       sources."statuses-1.5.0"
       (sources."string-width-2.1.1" // {
@@ -68261,6 +70248,13 @@ in
       sources."strip-eof-1.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-5.5.0"
+      (sources."tar-stream-2.1.0" // {
+        dependencies = [
+          sources."readable-stream-3.4.0"
+          sources."safe-buffer-5.2.0"
+          sources."string_decoder-1.3.0"
+        ];
+      })
       sources."temp-dir-1.0.0"
       sources."tempfile-2.0.0"
       (sources."term-size-1.2.0" // {
@@ -68268,6 +70262,8 @@ in
           sources."cross-spawn-5.1.0"
           sources."execa-0.7.0"
           sources."get-stream-3.0.0"
+          sources."lru-cache-4.1.5"
+          sources."yallist-2.1.2"
         ];
       })
       sources."then-fs-2.0.0"
@@ -68310,7 +70306,7 @@ in
       sources."xmlbuilder-9.0.7"
       sources."xregexp-2.0.0"
       sources."y18n-3.2.1"
-      sources."yallist-2.1.2"
+      sources."yallist-3.1.1"
       (sources."yargs-3.32.0" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
@@ -68385,7 +70381,7 @@ in
       })
       sources."socket.io-parser-3.4.0"
       sources."to-array-0.1.4"
-      sources."ws-7.1.2"
+      sources."ws-7.2.0"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."yeast-0.1.2"
     ];
@@ -68446,7 +70442,7 @@ in
       sources."draftlog-1.0.12"
       sources."duplexer3-0.1.4"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
@@ -68457,13 +70453,13 @@ in
       sources."get-stream-3.0.0"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-1.0.3"
       sources."has-flag-3.0.0"
       sources."has-symbols-1.0.0"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-proxy-agent-2.1.0"
-      sources."https-proxy-agent-2.2.2"
+      sources."https-proxy-agent-3.0.1"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."indent-string-3.2.0"
@@ -68547,7 +70543,7 @@ in
       sources."spdx-exceptions-2.2.0"
       sources."spdx-expression-parse-3.0.0"
       sources."spdx-license-ids-3.0.5"
-      sources."speedtest-net-1.5.1"
+      sources."speedtest-net-1.6.0"
       sources."string-width-2.1.1"
       sources."string.prototype.trimleft-2.1.0"
       sources."string.prototype.trimright-2.1.0"
@@ -68590,10 +70586,10 @@ in
   ssb-server = nodeEnv.buildNodePackage {
     name = "ssb-server";
     packageName = "ssb-server";
-    version = "15.1.1";
+    version = "15.1.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ssb-server/-/ssb-server-15.1.1.tgz";
-      sha512 = "MaQl721UDrU/YM1U2bu6bdLqSg8qPYjkGg/6TevWoohqSLLOfo3CXyE8OARCqX37y9fhKOKXAhhmqj8nPgQ2yw==";
+      url = "https://registry.npmjs.org/ssb-server/-/ssb-server-15.1.2.tgz";
+      sha512 = "lCzCYwQUXQq19kCM59nlF6UY634WCpMqL01gOBp5SuQgawr8DSuuk+RBUZswSTEjwDsL16ltGR8/rtaYvyiZ8A==";
     };
     dependencies = [
       sources."abstract-leveldown-6.0.3"
@@ -68682,7 +70678,7 @@ in
       sources."code-point-at-1.1.0"
       sources."collapse-white-space-1.0.5"
       sources."collection-visit-1.0.0"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."compare-at-paths-1.0.0"
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
@@ -68708,9 +70704,9 @@ in
       sources."decode-uri-component-0.2.0"
       sources."deep-equal-1.1.0"
       sources."deep-extend-0.6.0"
-      (sources."deferred-leveldown-5.2.1" // {
+      (sources."deferred-leveldown-5.3.0" // {
         dependencies = [
-          sources."abstract-leveldown-6.1.1"
+          sources."abstract-leveldown-6.2.2"
         ];
       })
       sources."define-properties-1.1.3"
@@ -68727,14 +70723,14 @@ in
       sources."elegant-spinner-1.0.1"
       sources."emoji-named-characters-1.0.2"
       sources."emoji-server-1.0.0"
-      (sources."encoding-down-6.2.0" // {
+      (sources."encoding-down-6.3.0" // {
         dependencies = [
-          sources."abstract-leveldown-6.1.1"
+          sources."abstract-leveldown-6.2.2"
         ];
       })
       sources."epidemic-broadcast-trees-7.0.0"
       sources."errno-0.1.7"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-string-regexp-1.0.5"
       sources."exit-hook-1.1.1"
@@ -68788,7 +70784,7 @@ in
       sources."glob-parent-2.0.0"
       sources."globby-4.1.0"
       sources."gossip-query-2.0.2"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-network-0.0.1"
@@ -68876,13 +70872,13 @@ in
       sources."level-codec-9.0.1"
       sources."level-concat-iterator-2.0.1"
       sources."level-errors-2.0.1"
-      (sources."level-iterator-stream-4.0.1" // {
+      (sources."level-iterator-stream-4.0.2" // {
         dependencies = [
           sources."readable-stream-3.4.0"
         ];
       })
       sources."level-js-4.0.1"
-      sources."level-packager-5.0.3"
+      sources."level-packager-5.1.0"
       sources."level-post-1.0.7"
       (sources."level-sublevel-6.6.5" // {
         dependencies = [
@@ -68905,15 +70901,16 @@ in
           sources."string_decoder-0.10.31"
         ];
       })
-      (sources."leveldown-5.2.1" // {
+      sources."level-supports-1.0.1"
+      (sources."leveldown-5.4.1" // {
         dependencies = [
-          sources."abstract-leveldown-6.1.1"
+          sources."abstract-leveldown-6.2.2"
         ];
       })
-      sources."levelup-4.2.0"
+      sources."levelup-4.3.2"
       sources."libnested-1.4.1"
-      sources."libsodium-0.7.5"
-      sources."libsodium-wrappers-0.7.5"
+      sources."libsodium-0.7.6"
+      sources."libsodium-wrappers-0.7.6"
       sources."lodash.get-4.4.2"
       sources."log-symbols-1.0.2"
       sources."log-update-1.0.2"
@@ -68947,7 +70944,7 @@ in
       sources."multiblob-1.13.4"
       sources."multiblob-http-1.0.0"
       sources."multicb-1.2.2"
-      sources."multiserver-3.4.0"
+      sources."multiserver-3.6.0"
       sources."multiserver-address-1.0.1"
       sources."multiserver-scopes-1.0.0"
       sources."muxrpc-6.4.2"
@@ -69175,7 +71172,7 @@ in
       sources."right-pad-1.0.1"
       (sources."rimraf-2.7.1" // {
         dependencies = [
-          sources."glob-7.1.4"
+          sources."glob-7.1.5"
         ];
       })
       sources."rng-0.2.2"
@@ -69238,15 +71235,15 @@ in
       sources."source-map-url-0.4.0"
       sources."split-buffer-1.0.0"
       sources."split-string-3.1.0"
-      sources."ssb-blobs-1.2.1"
+      sources."ssb-blobs-1.2.2"
       sources."ssb-caps-1.1.0"
       sources."ssb-client-4.7.8"
-      sources."ssb-config-3.3.2"
+      sources."ssb-config-3.4.2"
       sources."ssb-db-19.2.0"
       sources."ssb-ebt-5.6.7"
       sources."ssb-friends-4.1.4"
-      sources."ssb-gossip-1.1.0"
-      sources."ssb-invite-2.1.3"
+      sources."ssb-gossip-1.1.1"
+      sources."ssb-invite-2.1.4"
       sources."ssb-keys-7.2.0"
       sources."ssb-links-3.0.8"
       sources."ssb-local-1.0.0"
@@ -69309,7 +71306,7 @@ in
       (sources."tape-4.11.0" // {
         dependencies = [
           sources."deep-equal-1.0.1"
-          sources."glob-7.1.4"
+          sources."glob-7.1.5"
         ];
       })
       sources."text-table-0.2.0"
@@ -69413,7 +71410,7 @@ in
       sources."@sailshq/lodash-3.10.4"
       (sources."@slack/client-3.16.0" // {
         dependencies = [
-          sources."bluebird-3.5.5"
+          sources."bluebird-3.7.1"
           sources."request-2.76.0"
           sources."url-join-0.0.1"
           sources."ws-1.1.5"
@@ -69436,7 +71433,7 @@ in
       })
       (sources."adbkit-apkreader-3.1.2" // {
         dependencies = [
-          sources."bluebird-3.5.5"
+          sources."bluebird-3.7.1"
           sources."debug-0.7.4"
         ];
       })
@@ -69469,7 +71466,7 @@ in
       sources."async-1.5.2"
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
-      (sources."aws-sdk-2.533.0" // {
+      (sources."aws-sdk-2.561.0" // {
         dependencies = [
           sources."uuid-3.3.2"
         ];
@@ -69527,7 +71524,7 @@ in
       sources."colors-1.0.3"
       sources."colour-0.7.1"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.2.1"
       sources."component-inherit-0.0.3"
@@ -69559,7 +71556,7 @@ in
       sources."cookie-signature-1.0.6"
       sources."cookiejar-2.1.2"
       sources."cookies-0.7.1"
-      sources."core-js-2.6.9"
+      sources."core-js-2.6.10"
       sources."core-util-is-1.0.2"
       sources."cors-2.8.5"
       sources."cross-spawn-4.0.2"
@@ -69592,12 +71589,12 @@ in
       sources."ee-first-1.1.1"
       sources."ejs-0.8.8"
       sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       (sources."engine.io-3.4.0" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
-          sources."ws-7.1.2"
+          sources."ws-7.2.0"
         ];
       })
       (sources."engine.io-client-3.4.0" // {
@@ -69654,6 +71651,7 @@ in
       sources."formidable-1.2.1"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
+      sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."generate-function-2.3.1"
       sources."generate-object-property-1.2.0"
@@ -69671,7 +71669,7 @@ in
           sources."ms-2.1.2"
         ];
       })
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."graphlib-2.1.7"
       sources."har-schema-2.0.0"
       sources."har-validator-2.0.6"
@@ -69691,7 +71689,7 @@ in
         ];
       })
       sources."hoek-2.16.3"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       (sources."http-errors-1.7.2" // {
         dependencies = [
           sources."inherits-2.0.3"
@@ -69858,7 +71856,6 @@ in
       sources."options-0.0.6"
       sources."optjs-3.2.2"
       sources."os-locale-3.1.0"
-      sources."os-tmpdir-1.0.2"
       sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
       sources."p-is-promise-2.1.0"
@@ -70089,9 +72086,10 @@ in
         ];
       })
       sources."switchback-2.0.5"
-      (sources."temp-0.8.3" // {
+      (sources."temp-0.8.4" // {
         dependencies = [
-          sources."rimraf-2.2.8"
+          sources."glob-7.1.5"
+          sources."rimraf-2.6.3"
         ];
       })
       sources."throttleit-1.0.0"
@@ -70240,10 +72238,10 @@ in
   svgo = nodeEnv.buildNodePackage {
     name = "svgo";
     packageName = "svgo";
-    version = "1.3.0";
+    version = "1.3.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz";
-      sha512 = "MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==";
+      url = "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz";
+      sha512 = "yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==";
     };
     dependencies = [
       sources."@types/q-1.5.2"
@@ -70256,14 +72254,9 @@ in
       sources."color-name-1.1.3"
       sources."css-select-2.0.2"
       sources."css-select-base-adapter-0.1.1"
-      sources."css-tree-1.0.0-alpha.33"
+      sources."css-tree-1.0.0-alpha.37"
       sources."css-what-2.1.3"
-      (sources."csso-3.5.1" // {
-        dependencies = [
-          sources."css-tree-1.0.0-alpha.29"
-          sources."mdn-data-1.1.4"
-        ];
-      })
+      sources."csso-4.0.2"
       sources."define-properties-1.1.3"
       (sources."dom-serializer-0.2.1" // {
         dependencies = [
@@ -70273,7 +72266,7 @@ in
       sources."domelementtype-1.3.1"
       sources."domutils-1.7.0"
       sources."entities-2.0.0"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
@@ -70296,7 +72289,7 @@ in
       sources."object.values-1.1.0"
       sources."q-1.5.1"
       sources."sax-1.2.4"
-      sources."source-map-0.5.7"
+      sources."source-map-0.6.1"
       sources."sprintf-js-1.0.3"
       sources."stable-0.1.8"
       sources."string.prototype.trimleft-2.1.0"
@@ -70413,13 +72406,13 @@ in
       sources."cli-boxes-1.0.0"
       sources."cli-cursor-1.0.2"
       sources."cli-width-1.1.1"
-      sources."clone-2.0.0"
+      sources."clone-2.1.2"
       sources."code-point-at-1.1.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
@@ -70428,7 +72421,7 @@ in
       sources."content-type-1.0.4"
       sources."cookiejar-2.1.2"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-2.6.9"
+      sources."core-js-2.6.10"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       (sources."cross-spawn-5.1.0" // {
@@ -70510,7 +72503,7 @@ in
       sources."fsevents-1.2.9"
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -70518,14 +72511,14 @@ in
       })
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       (sources."graphlib-2.1.7" // {
         dependencies = [
           sources."lodash-4.17.15"
         ];
       })
       sources."growl-1.9.2"
-      (sources."handlebars-4.2.1" // {
+      (sources."handlebars-4.5.1" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -70590,7 +72583,7 @@ in
       sources."js-string-escape-1.0.1"
       sources."js-yaml-3.13.1"
       sources."json-refs-2.1.7"
-      (sources."json-schema-deref-sync-0.3.4" // {
+      (sources."json-schema-deref-sync-0.6.0" // {
         dependencies = [
           sources."lodash-4.17.15"
         ];
@@ -70636,7 +72629,7 @@ in
       sources."map-visit-1.0.0"
       sources."md5-2.2.1"
       sources."media-typer-0.3.0"
-      sources."memory-cache-0.1.6"
+      sources."memory-cache-0.2.0"
       sources."methods-1.1.2"
       sources."micromatch-3.1.10"
       sources."mime-1.6.0"
@@ -70657,7 +72650,7 @@ in
           sources."supports-color-1.2.0"
         ];
       })
-      sources."mpath-0.2.1"
+      sources."mpath-0.5.2"
       sources."ms-2.0.0"
       sources."multer-1.4.2"
       sources."mute-stream-0.0.5"
@@ -70665,7 +72658,7 @@ in
       sources."nanomatch-1.2.13"
       sources."native-promise-only-0.8.1"
       sources."neo-async-2.6.1"
-      (sources."nodemon-1.19.2" // {
+      (sources."nodemon-1.19.4" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
@@ -70858,7 +72851,11 @@ in
       sources."supports-color-2.0.0"
       sources."swagger-converter-0.2.0"
       sources."swagger-editor-2.10.5"
-      sources."swagger-test-templates-1.5.1"
+      (sources."swagger-test-templates-1.6.0" // {
+        dependencies = [
+          sources."lodash-4.17.15"
+        ];
+      })
       (sources."swagger-tools-0.9.16" // {
         dependencies = [
           sources."swagger-converter-0.1.7"
@@ -70881,7 +72878,7 @@ in
       sources."truncate-utf8-bytes-1.0.2"
       sources."type-is-1.6.18"
       sources."typedarray-0.0.6"
-      (sources."uglify-js-3.6.0" // {
+      (sources."uglify-js-3.6.6" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -70952,7 +72949,7 @@ in
       sha256 = "886069ecc5eedf0371b948e8ff66e7f2943c85fe7cfdaa7183e1a3572d55852b";
     };
     dependencies = [
-      sources."@types/node-12.7.5"
+      sources."@types/node-12.12.3"
       sources."ajv-6.10.2"
       sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
@@ -71040,7 +73037,7 @@ in
       })
       sources."string-width-3.1.0"
       sources."strip-ansi-5.2.0"
-      sources."telegraf-3.32.0"
+      sources."telegraf-3.33.3"
       sources."telegram-typings-3.6.1"
       (sources."tough-cookie-2.4.3" // {
         dependencies = [
@@ -71071,10 +73068,10 @@ in
   tern = nodeEnv.buildNodePackage {
     name = "tern";
     packageName = "tern";
-    version = "0.24.1";
+    version = "0.24.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/tern/-/tern-0.24.1.tgz";
-      sha512 = "6jK0DcgziZ0NAitZNncg+do/fKGh8hQJShcVU7dHoAljdckr7qr2oozd4l4kTIA7M+0FoKXy6gvRBLO8oWpTEw==";
+      url = "https://registry.npmjs.org/tern/-/tern-0.24.2.tgz";
+      sha512 = "pVJhZp1vvv2ewgPv6YwNsyCU+ComJdHBtTajDo/EdfGHY2CLCQ53ucgCzvWfFx+KXls0H6sRwnDMY8Qo+aQviw==";
     };
     dependencies = [
       sources."acorn-6.3.0"
@@ -71087,8 +73084,8 @@ in
       sources."enhanced-resolve-2.3.0"
       sources."errno-0.1.7"
       sources."fs.realpath-1.0.0"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."isarray-1.0.0"
@@ -71120,28 +73117,28 @@ in
   textlint = nodeEnv.buildNodePackage {
     name = "textlint";
     packageName = "textlint";
-    version = "11.3.1";
+    version = "11.4.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/textlint/-/textlint-11.3.1.tgz";
-      sha512 = "svbO/fhj7dLTJcdKgrW5fJtNRHoFFVL+sutsKBmNUcSJgvgWteLOUZAKT/dp/4S0QfkwkpNOts7Bzn9T+0h0Cw==";
+      url = "https://registry.npmjs.org/textlint/-/textlint-11.4.0.tgz";
+      sha512 = "RWzN5JdIiBO8BzCxu1uUYhVTxM2Q7ex4y7eBWEpMdkMvFc4sH2RZ5OI5lDK34Gf8M0C76hmMu3IszcsFJgKfug==";
     };
     dependencies = [
       sources."@azu/format-text-1.0.1"
       sources."@azu/style-format-1.0.0"
-      sources."@textlint/ast-node-types-4.2.4"
-      sources."@textlint/ast-traverse-2.1.5"
-      sources."@textlint/feature-flag-3.1.3"
-      sources."@textlint/fixer-formatter-3.1.8"
-      sources."@textlint/kernel-3.1.8"
-      sources."@textlint/linter-formatter-3.1.7"
-      sources."@textlint/markdown-to-ast-6.1.5"
-      sources."@textlint/module-interop-1.0.1"
-      sources."@textlint/text-to-ast-3.1.5"
-      sources."@textlint/textlint-plugin-markdown-5.1.8"
-      sources."@textlint/textlint-plugin-text-4.1.8"
-      sources."@textlint/types-1.2.1"
-      sources."@textlint/utils-1.0.2"
-      sources."@types/bluebird-3.5.27"
+      sources."@textlint/ast-node-types-4.2.5"
+      sources."@textlint/ast-traverse-2.1.6"
+      sources."@textlint/feature-flag-3.1.4"
+      sources."@textlint/fixer-formatter-3.1.9"
+      sources."@textlint/kernel-3.1.9"
+      sources."@textlint/linter-formatter-3.1.8"
+      sources."@textlint/markdown-to-ast-6.1.6"
+      sources."@textlint/module-interop-1.0.2"
+      sources."@textlint/text-to-ast-3.1.6"
+      sources."@textlint/textlint-plugin-markdown-5.1.9"
+      sources."@textlint/textlint-plugin-text-4.1.9"
+      sources."@textlint/types-1.2.2"
+      sources."@textlint/utils-1.0.3"
+      sources."@types/bluebird-3.5.28"
       sources."ajv-4.11.8"
       sources."ajv-keywords-1.5.1"
       sources."ansi-regex-2.1.1"
@@ -71149,7 +73146,7 @@ in
       sources."argparse-1.0.10"
       sources."bail-1.0.4"
       sources."balanced-match-1.0.0"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."boundary-1.0.1"
       sources."brace-expansion-1.1.11"
       sources."buffer-from-1.1.1"
@@ -71171,7 +73168,7 @@ in
       sources."define-properties-1.1.3"
       sources."diff-4.0.1"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
@@ -71186,12 +73183,12 @@ in
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."get-stdin-5.0.1"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."has-symbols-1.0.0"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."is-alphabetical-1.0.3"
@@ -71215,7 +73212,7 @@ in
       sources."js-yaml-3.13.1"
       sources."json-parse-better-errors-1.0.2"
       sources."json-stable-stringify-1.0.1"
-      (sources."json5-2.1.0" // {
+      (sources."json5-2.1.1" // {
         dependencies = [
           sources."minimist-1.2.0"
         ];
@@ -71351,7 +73348,7 @@ in
       sha1 = "9139c65b8da891c983b368a50a286338cd76777a";
     };
     dependencies = [
-      sources."@textlint/ast-node-types-4.2.4"
+      sources."@textlint/ast-node-types-4.2.5"
       sources."txt-to-ast-3.0.3"
     ];
     buildInputs = globalBuildInputs;
@@ -71397,8 +73394,8 @@ in
       sha512 = "TP+dtJcCe0+ZR7Gp1E3iJdf3XtOImrEIcUdaQnok4QJJEutZ1dTiP4rCfnyOxz70NZ+2RdBJgZeZZWGhuJzSwA==";
     };
     dependencies = [
-      sources."@textlint/ast-node-types-4.2.4"
-      sources."@textlint/types-1.2.1"
+      sources."@textlint/ast-node-types-4.2.5"
+      sources."@textlint/types-1.2.2"
       sources."alex-5.1.0"
       sources."ansi-align-2.0.0"
       sources."ansi-regex-3.0.0"
@@ -71444,14 +73441,14 @@ in
       sources."cross-spawn-5.1.0"
       sources."crypto-random-string-1.0.0"
       sources."currently-unhandled-0.4.1"
-      sources."cuss-1.16.0"
+      sources."cuss-1.17.0"
       sources."debug-0.8.1"
       sources."decamelize-1.2.0"
       sources."deep-extend-0.6.0"
       sources."dot-prop-4.2.0"
       sources."duplexer-0.1.1"
       sources."duplexer3-0.1.4"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."error-ex-1.3.2"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
@@ -71468,12 +73465,12 @@ in
       sources."get-stream-3.0.0"
       sources."git-diff-tree-1.0.0"
       sources."git-spawned-stream-0.1.1"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."ignore-3.3.10"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
@@ -71831,14 +73828,14 @@ in
       sha512 = "HydBbkWjnMn4KrnlpnusY1BGjIG+64UySxRCvRphUAIiuJL2nbkdrIIiOjwfQhllKUa7Sf33bs6RAcbEWjZVfg==";
     };
     dependencies = [
-      sources."@textlint/ast-node-types-4.2.4"
-      sources."@textlint/types-1.2.1"
+      sources."@textlint/ast-node-types-4.2.5"
+      sources."@textlint/types-1.2.2"
       sources."boundary-1.0.1"
       sources."buffer-from-1.1.1"
       sources."concat-stream-1.6.2"
       sources."core-util-is-1.0.2"
       sources."define-properties-1.1.3"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
@@ -71856,7 +73853,7 @@ in
       sources."process-nextick-args-2.0.1"
       sources."readable-stream-2.3.6"
       sources."safe-buffer-5.1.2"
-      sources."sentence-splitter-3.0.11"
+      sources."sentence-splitter-3.1.0"
       sources."string.prototype.trimleft-2.1.0"
       sources."string.prototype.trimright-2.1.0"
       sources."string_decoder-1.1.1"
@@ -71892,7 +73889,7 @@ in
       sources."define-properties-1.1.3"
       sources."emoji-regex-6.5.1"
       sources."end-with-1.0.2"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
@@ -71925,8 +73922,8 @@ in
       sha512 = "7m1k3xMwsOw7WyGNINJQ5EX2+mnqAeg6VBfXY7BVUr/y6NOYhPbEj3A3MBJ9Jt9dfC1twL0aI6mKPo+5xLUsVA==";
     };
     dependencies = [
-      sources."@textlint/ast-node-types-4.2.4"
-      sources."@textlint/types-1.2.1"
+      sources."@textlint/ast-node-types-4.2.5"
+      sources."@textlint/types-1.2.2"
       sources."boundary-1.0.1"
       sources."lodash-4.17.15"
       sources."split-lines-2.0.0"
@@ -71949,17 +73946,17 @@ in
   textlint-rule-terminology = nodeEnv.buildNodePackage {
     name = "textlint-rule-terminology";
     packageName = "textlint-rule-terminology";
-    version = "1.1.30";
+    version = "2.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-1.1.30.tgz";
-      sha512 = "PsLiridAdaLyho236adWnTEAbAcxxUsxVqaXWaJce+aRsjCOeyYPBLNRisFGz90KZ0S1NDYT/v5CvzBrgsiuzQ==";
+      url = "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-2.0.1.tgz";
+      sha512 = "UhZjs/I+y93lOeZflPu+yfWB+z3U6LdSBV9K4AEHQb3IkDMEZLk1QW/q+Ct3vQuiMZl2HfoqdQGakPhHmc/YkQ==";
     };
     dependencies = [
-      sources."@textlint/ast-node-types-4.2.4"
-      sources."@textlint/types-1.2.1"
+      sources."@textlint/ast-node-types-4.2.5"
+      sources."@textlint/types-1.2.2"
       sources."boundary-1.0.1"
       sources."lodash-4.17.15"
-      sources."strip-json-comments-2.0.1"
+      sources."strip-json-comments-3.0.1"
       sources."structured-source-3.0.2"
       sources."textlint-rule-helper-2.1.1"
       sources."unist-util-is-3.0.0"
@@ -71987,7 +73984,7 @@ in
     dependencies = [
       sources."array-includes-3.0.3"
       sources."define-properties-1.1.3"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
@@ -72021,8 +74018,8 @@ in
       sha1 = "3c79b04091319d4e8be5fb442c596bf500e8493e";
     };
     dependencies = [
-      sources."@textlint/ast-node-types-4.2.4"
-      sources."@textlint/types-1.2.1"
+      sources."@textlint/ast-node-types-4.2.5"
+      sources."@textlint/types-1.2.2"
       sources."adverb-where-0.0.9"
       sources."boundary-1.0.1"
       sources."define-properties-1.1.3"
@@ -72055,10 +74052,10 @@ in
   thelounge = nodeEnv.buildNodePackage {
     name = "thelounge";
     packageName = "thelounge";
-    version = "3.2.0";
+    version = "3.3.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/thelounge/-/thelounge-3.2.0.tgz";
-      sha512 = "yOS19bt2O0l6DGAiJRad6DFMmDHmDVylfInLthNl9YfMfgSoC7aZcT7fofTe9htAE4SRfac9YsgKEtmywQ+MkA==";
+      url = "https://registry.npmjs.org/thelounge/-/thelounge-3.3.0.tgz";
+      sha512 = "F7qYCmAkb/HPFxZfyKi/gEm24ZzjgUzJb+zI5I5u8b5PNJrfi9RwFb3cmE4pvF2Ft0QejR5O4khuX6DEFFxYDw==";
     };
     dependencies = [
       sources."@sindresorhus/is-0.14.0"
@@ -72082,7 +74079,7 @@ in
       })
       sources."array-flatten-1.1.1"
       sources."arraybuffer.slice-0.0.7"
-      sources."asn1-0.2.3"
+      sources."asn1-0.2.4"
       sources."asn1.js-5.2.0"
       sources."assert-plus-1.0.0"
       sources."async-limiter-1.0.1"
@@ -72093,7 +74090,7 @@ in
       sources."backoff-2.5.0"
       sources."balanced-match-1.0.0"
       sources."base64-arraybuffer-0.1.5"
-      sources."base64id-1.0.0"
+      sources."base64id-2.0.0"
       sources."bcrypt-pbkdf-1.0.2"
       sources."bcryptjs-2.4.3"
       sources."better-assert-1.0.2"
@@ -72115,13 +74112,13 @@ in
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."cheerio-0.22.0"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."clone-response-1.0.2"
       sources."code-point-at-1.1.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."combined-stream-1.0.8"
-      sources."commander-3.0.0"
+      sources."commander-3.0.2"
       sources."component-bind-1.0.0"
       sources."component-emitter-1.2.1"
       sources."component-inherit-0.0.3"
@@ -72135,7 +74132,7 @@ in
       sources."content-type-1.0.4"
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
-      sources."core-js-3.2.1"
+      sources."core-js-3.3.6"
       sources."core-util-is-1.0.2"
       sources."css-select-1.2.0"
       sources."css-what-2.1.3"
@@ -72159,19 +74156,22 @@ in
       sources."ecdsa-sig-formatter-1.0.11"
       sources."ee-first-1.1.1"
       sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
-      (sources."engine.io-3.3.2" // {
+      sources."end-of-stream-1.4.4"
+      (sources."engine.io-3.4.0" // {
         dependencies = [
           sources."cookie-0.3.1"
-          sources."debug-3.1.0"
+          sources."debug-4.1.1"
+          sources."ms-2.1.2"
         ];
       })
-      (sources."engine.io-client-3.3.2" // {
+      (sources."engine.io-client-3.4.0" // {
         dependencies = [
-          sources."debug-3.1.0"
+          sources."debug-4.1.1"
+          sources."ms-2.1.2"
+          sources."ws-6.1.4"
         ];
       })
-      sources."engine.io-parser-2.1.3"
+      sources."engine.io-parser-2.2.0"
       sources."entities-1.1.2"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
@@ -72185,11 +74185,11 @@ in
         ];
       })
       sources."extend-3.0.2"
-      sources."extsprintf-1.2.0"
+      sources."extsprintf-1.4.0"
       sources."fast-deep-equal-2.0.1"
       sources."fast-json-stable-stringify-2.0.0"
       sources."fast-text-encoding-1.0.0"
-      sources."file-type-12.1.0"
+      sources."file-type-12.3.1"
       sources."filename-reserved-regex-2.0.0"
       sources."filenamify-4.1.0"
       sources."finalhandler-1.1.2"
@@ -72203,9 +74203,9 @@ in
       sources."gauge-2.7.4"
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."got-9.6.0"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."grapheme-splitter-1.0.4"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -72222,14 +74222,14 @@ in
       })
       sources."http-signature-1.2.0"
       sources."http_ece-1.1.0"
-      (sources."https-proxy-agent-2.2.2" // {
+      (sources."https-proxy-agent-3.0.1" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
         ];
       })
       sources."iconv-lite-0.4.24"
-      sources."ignore-walk-3.0.2"
+      sources."ignore-walk-3.0.3"
       sources."indexof-0.0.1"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -72256,11 +74256,8 @@ in
       sources."jwa-1.4.1"
       sources."jws-3.2.2"
       sources."keyv-3.1.0"
-      (sources."ldap-filter-0.2.2" // {
-        dependencies = [
-          sources."assert-plus-0.1.5"
-        ];
-      })
+      sources."ldap-filter-0.3.3"
+      sources."ldapjs-2.0.0-pre.2"
       sources."linkify-it-2.2.0"
       sources."lodash-4.17.15"
       sources."lodash.assignin-4.2.0"
@@ -72287,8 +74284,8 @@ in
       sources."minimalistic-assert-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      sources."minipass-2.8.1"
-      sources."minizlib-1.2.2"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
@@ -72310,9 +74307,9 @@ in
         ];
       })
       sources."nopt-4.0.1"
-      sources."normalize-url-4.4.1"
+      sources."normalize-url-4.5.0"
       sources."npm-bundled-1.0.6"
-      sources."npm-packlist-1.4.4"
+      sources."npm-packlist-1.4.6"
       sources."npmlog-4.1.2"
       sources."nth-check-1.0.2"
       sources."number-is-nan-1.0.1"
@@ -72372,21 +74369,29 @@ in
       sources."set-blocking-2.0.0"
       sources."setprototypeof-1.1.1"
       sources."signal-exit-3.0.2"
-      (sources."socket.io-2.2.0" // {
+      (sources."socket.io-2.3.0" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
         ];
       })
       sources."socket.io-adapter-1.1.1"
-      (sources."socket.io-client-2.2.0" // {
+      (sources."socket.io-client-2.3.0" // {
         dependencies = [
-          sources."debug-3.1.0"
+          sources."debug-4.1.1"
+          sources."ms-2.1.2"
+          (sources."socket.io-parser-3.3.0" // {
+            dependencies = [
+              sources."debug-3.1.0"
+              sources."ms-2.0.0"
+            ];
+          })
         ];
       })
-      (sources."socket.io-parser-3.3.0" // {
+      (sources."socket.io-parser-3.4.0" // {
         dependencies = [
-          sources."debug-3.1.0"
+          sources."debug-4.1.1"
+          sources."ms-2.1.2"
         ];
       })
       (sources."socksjs-0.5.0" // {
@@ -72394,7 +74399,7 @@ in
           sources."ipaddr.js-0.1.3"
         ];
       })
-      sources."sqlite3-4.0.9"
+      sources."sqlite3-4.1.0"
       sources."sshpk-1.16.1"
       sources."statuses-1.5.0"
       sources."streamsearch-0.1.2"
@@ -72404,8 +74409,7 @@ in
       sources."strip-json-comments-2.0.1"
       sources."strip-outer-1.0.1"
       sources."supports-color-5.5.0"
-      sources."tar-4.4.11"
-      sources."thelounge-ldapjs-non-maintained-fork-1.0.4"
+      sources."tar-4.4.13"
       sources."tlds-1.203.1"
       sources."to-array-0.1.4"
       sources."to-readable-stream-1.0.0"
@@ -72428,22 +74432,18 @@ in
       sources."urlsafe-base64-1.0.0"
       sources."util-deprecate-1.0.2"
       sources."utils-merge-1.0.1"
-      sources."uuid-3.3.2"
+      sources."uuid-3.3.3"
       sources."vary-1.1.2"
-      (sources."vasync-1.6.4" // {
-        dependencies = [
-          sources."verror-1.6.0"
-        ];
-      })
+      sources."vasync-2.2.0"
       sources."verror-1.10.0"
-      sources."web-push-3.3.5"
+      sources."web-push-3.4.1"
       sources."wide-align-1.1.3"
       sources."with-open-file-0.1.6"
       sources."wrappy-1.0.2"
-      sources."ws-6.1.4"
+      sources."ws-7.2.0"
       sources."xmlhttprequest-ssl-1.5.5"
-      sources."yallist-3.0.3"
-      sources."yarn-1.17.3"
+      sources."yallist-3.1.1"
+      sources."yarn-1.19.1"
       sources."yeast-0.1.2"
     ];
     buildInputs = globalBuildInputs;
@@ -72459,10 +74459,10 @@ in
   three = nodeEnv.buildNodePackage {
     name = "three";
     packageName = "three";
-    version = "0.108.0";
+    version = "0.110.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/three/-/three-0.108.0.tgz";
-      sha512 = "d1ysIXwi8qTlbmMwrTxi5pYiiYIflEr0e48krP0LAY8ndS8c6fkLHn6NvRT+o76/Fs9PBLxFViuI62iGVWwwlg==";
+      url = "https://registry.npmjs.org/three/-/three-0.110.0.tgz";
+      sha512 = "wlurH8XBO9Sd5VIw8nBa+taLR20kqaI4e9FiuMh6tqK8eOS2q2R+ZoUyufbyDTVTHhs8GiTbv0r2CMLkwerFJg==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -72495,24 +74495,23 @@ in
   titanium = nodeEnv.buildNodePackage {
     name = "titanium";
     packageName = "titanium";
-    version = "5.2.1";
+    version = "5.2.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/titanium/-/titanium-5.2.1.tgz";
-      sha512 = "tltnQ41NBjItM+ELsGL2jpaEnsMMeziZe0sGKtUxhwM1tndh7GFMfu2lpDqAFdMLwj+ZplRmlK0kKP4++68rrA==";
+      url = "https://registry.npmjs.org/titanium/-/titanium-5.2.2.tgz";
+      sha512 = "PvlmqvMRwgPReA3tPfExeS1mweQY/KpCIY5+zLP/lp0UEi93wLvSMzqp/5vV5pjK7cwkzhPtc68TszBNM+zv9Q==";
     };
     dependencies = [
       sources."adm-zip-0.4.13"
       sources."ajv-6.10.2"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
-      sources."async-2.6.1"
+      sources."async-2.6.3"
       sources."asynckit-0.4.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."balanced-match-1.0.0"
       sources."bcrypt-pbkdf-1.0.2"
       sources."brace-expansion-1.1.11"
-      sources."buffer-from-1.1.1"
       sources."caseless-0.12.0"
       sources."colors-1.3.3"
       sources."combined-stream-1.0.8"
@@ -72539,8 +74538,8 @@ in
       sources."fs-extra-7.0.1"
       sources."fs.realpath-1.0.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."http-signature-1.2.0"
@@ -72557,22 +74556,19 @@ in
       sources."jsprim-1.4.1"
       sources."keypress-0.2.1"
       sources."lodash-4.17.15"
-      sources."longjohn-0.2.12"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.10"
-      sources."moment-2.22.2"
+      sources."moment-2.24.0"
       (sources."node-appc-0.2.49" // {
         dependencies = [
-          sources."semver-5.5.1"
-          sources."temp-0.8.3"
+          sources."temp-0.8.4"
         ];
       })
       sources."oauth-sign-0.9.0"
       sources."once-1.4.0"
       sources."optimist-0.6.1"
-      sources."os-tmpdir-1.0.2"
       sources."path-is-absolute-1.0.1"
       sources."performance-now-2.1.0"
       sources."pkginfo-0.3.1"
@@ -72580,20 +74576,15 @@ in
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       sources."request-2.88.0"
-      sources."rimraf-2.2.8"
+      sources."rimraf-2.6.3"
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
-      sources."semver-5.6.0"
+      sources."semver-5.5.1"
       sources."source-map-0.6.1"
-      sources."source-map-support-0.5.13"
       sources."sprintf-0.1.5"
       sources."sshpk-1.16.1"
       sources."stack-trace-0.0.10"
-      (sources."temp-0.9.0" // {
-        dependencies = [
-          sources."rimraf-2.6.3"
-        ];
-      })
+      sources."temp-0.9.0"
       (sources."tough-cookie-2.4.3" // {
         dependencies = [
           sources."punycode-1.4.1"
@@ -72827,25 +74818,35 @@ in
       sha512 = "N8E1X543CWEjg0/A70ZnA/kfAfAY/uogILsIuWBhHGxzv9kaJaj7/JCSwDiBH86CPEy37chSgW86KxVeYKsswQ==";
     };
     dependencies = [
-      sources."@types/node-6.14.7"
+      sources."@types/node-6.14.9"
       sources."ansi-0.3.1"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-2.2.1"
+      sources."balanced-match-1.0.0"
+      sources."brace-expansion-1.1.11"
       sources."chalk-1.1.3"
       sources."colors-1.4.0"
+      sources."concat-map-0.0.1"
       sources."diff-2.2.3"
       sources."escape-string-regexp-1.0.5"
+      sources."fs.realpath-1.0.0"
+      sources."glob-7.1.5"
       sources."has-ansi-2.0.0"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.4"
+      sources."minimatch-3.0.4"
       sources."minimist-0.0.10"
       sources."node-color-readline-1.0.1"
+      sources."once-1.4.0"
       sources."optimist-0.6.1"
-      sources."os-tmpdir-1.0.2"
-      sources."rimraf-2.2.8"
+      sources."path-is-absolute-1.0.1"
+      sources."rimraf-2.6.3"
       sources."strip-ansi-3.0.1"
       sources."supports-color-2.0.0"
-      sources."temp-0.8.3"
+      sources."temp-0.8.4"
       sources."tslib-1.10.0"
       sources."wordwrap-0.0.3"
+      sources."wrappy-1.0.2"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -72883,10 +74884,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "3.6.3";
+    version = "3.6.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz";
-      sha512 = "N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==";
+      url = "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz";
+      sha512 = "unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -72908,20 +74909,20 @@ in
     };
     dependencies = [
       sources."command-exists-1.2.6"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."crypto-random-string-1.0.0"
       sources."fs-extra-7.0.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."jsonfile-4.0.0"
       sources."p-debounce-1.0.0"
       sources."temp-dir-1.0.0"
       sources."tempy-0.2.1"
       sources."unique-string-1.0.0"
       sources."universalify-0.1.2"
-      sources."vscode-jsonrpc-4.1.0-next.3"
+      sources."vscode-jsonrpc-5.0.0-next.2"
       sources."vscode-languageserver-5.3.0-next.10"
-      sources."vscode-languageserver-protocol-3.15.0-next.8"
-      sources."vscode-languageserver-types-3.15.0-next.4"
+      sources."vscode-languageserver-protocol-3.15.0-next.9"
+      sources."vscode-languageserver-types-3.15.0-next.5"
       sources."vscode-textbuffer-1.0.0"
       sources."vscode-uri-1.0.8"
     ];
@@ -72937,13 +74938,13 @@ in
   uglify-js = nodeEnv.buildNodePackage {
     name = "uglify-js";
     packageName = "uglify-js";
-    version = "3.6.0";
+    version = "3.6.6";
     src = fetchurl {
-      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz";
-      sha512 = "W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==";
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.6.tgz";
+      sha512 = "q3Zusqd028P8MdbarqL0I1snTZ7+IbIWiKUXVZyXMVdOSxOG2FFqLXyGlgYSqYu46SR7tR3Sk0xqN1VtvxGWnQ==";
     };
     dependencies = [
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."source-map-0.6.1"
     ];
     buildInputs = globalBuildInputs;
@@ -72959,10 +74960,10 @@ in
   ungit = nodeEnv.buildNodePackage {
     name = "ungit";
     packageName = "ungit";
-    version = "1.4.47";
+    version = "1.4.48";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ungit/-/ungit-1.4.47.tgz";
-      sha512 = "aTkH2jg6vCcobdSeElJ2xqRI6zHL8Y+TPLEgE+86BmdSLPyRgvYbqTzvieTXF+4U9y693NtfyALcvKxqHhcmJA==";
+      url = "https://registry.npmjs.org/ungit/-/ungit-1.4.48.tgz";
+      sha512 = "OnChT88XpseexbxagMAL5wqM9dIZxb5oHCwUXaEZ8ERy77GDzhFKko1DZLWZg6uljrOx1yryBGe7ft8eJ5/O9g==";
     };
     dependencies = [
       sources."abbrev-1.1.1"
@@ -73061,7 +75062,7 @@ in
       sources."ee-first-1.1.1"
       sources."emoji-regex-7.0.3"
       sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       (sources."engine.io-3.3.2" // {
         dependencies = [
           sources."debug-3.1.0"
@@ -73123,8 +75124,8 @@ in
       sources."get-stream-4.1.0"
       sources."getmac-1.4.6"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-binary2-1.0.3" // {
@@ -73140,7 +75141,7 @@ in
           sources."mkdirp-0.3.0"
         ];
       })
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-errors-1.7.2"
       sources."http-signature-1.2.0"
       sources."iconv-lite-0.4.24"
@@ -73336,7 +75337,7 @@ in
           sources."semver-6.3.0"
         ];
       })
-      sources."temp-0.9.0"
+      sources."temp-0.9.1"
       sources."to-array-0.1.4"
       sources."toidentifier-1.0.0"
       (sources."tough-cookie-2.4.3" // {
@@ -73495,7 +75496,7 @@ in
       sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."bl-1.2.2"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."brace-expansion-1.1.11"
       sources."buffer-5.4.3"
       sources."buffer-alloc-1.2.0"
@@ -73520,7 +75521,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."concat-map-0.0.1"
       sources."config-chain-1.1.12"
       sources."consolidate-0.14.5"
@@ -73547,7 +75548,7 @@ in
       sources."duplexer3-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."enable-1.3.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
       sources."extend-3.0.2"
@@ -73570,12 +75571,12 @@ in
       sources."get-stream-3.0.0"
       sources."getpass-0.1.7"
       sources."git-clone-0.1.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."graceful-readlink-1.0.1"
       sources."gray-matter-2.1.1"
-      sources."handlebars-4.2.1"
+      sources."handlebars-4.5.1"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       (sources."has-ansi-2.0.0" // {
@@ -73728,7 +75729,7 @@ in
       sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."uglify-js-3.6.0"
+      sources."uglify-js-3.6.6"
       sources."uid-0.0.2"
       sources."unbzip2-stream-1.3.3"
       sources."unyield-0.0.1"
@@ -73763,10 +75764,10 @@ in
   vue-language-server = nodeEnv.buildNodePackage {
     name = "vue-language-server";
     packageName = "vue-language-server";
-    version = "0.0.61";
+    version = "0.0.65";
     src = fetchurl {
-      url = "https://registry.npmjs.org/vue-language-server/-/vue-language-server-0.0.61.tgz";
-      sha512 = "/fBg8FrW2H4CRO/dsr3VuGVYs5RS6zQIT+eG9SEQdo3VRDF8bNmJro1QpszJ0KVC7UxW9+fwf98i+xDBtne2Xw==";
+      url = "https://registry.npmjs.org/vue-language-server/-/vue-language-server-0.0.65.tgz";
+      sha512 = "2yHZGU+KMv7xdEFhh88ZZBlj0i9wAByDxcd1orfNfrRLUDaabjyHNnkhvw4tdne9fOeAj6w43OKxo/YqMXQXiw==";
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
@@ -73784,13 +75785,13 @@ in
       sources."@starptech/rehype-minify-whitespace-0.9.0"
       sources."@starptech/rehype-webparser-0.9.0"
       sources."@starptech/webparser-0.9.0"
-      sources."@types/node-12.7.5"
+      sources."@types/node-12.12.3"
       sources."@types/unist-2.0.3"
       sources."@types/vfile-3.0.2"
       sources."@types/vfile-message-1.0.1"
       sources."abbrev-1.1.1"
       sources."acorn-6.3.0"
-      sources."acorn-jsx-5.0.2"
+      sources."acorn-jsx-5.1.0"
       sources."ajv-6.10.2"
       sources."ajv-keywords-2.1.1"
       sources."ansi-align-2.0.0"
@@ -73919,7 +75920,7 @@ in
         ];
       })
       sources."comma-separated-tokens-1.0.7"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."common-tags-1.8.0"
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
@@ -73927,7 +75928,7 @@ in
       sources."config-chain-1.1.12"
       sources."configstore-3.1.2"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-2.6.9"
+      sources."core-js-2.6.10"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-5.1.0"
@@ -73960,6 +75961,7 @@ in
       sources."editorconfig-0.15.3"
       sources."element-helper-json-2.0.6"
       sources."emoji-regex-7.0.3"
+      sources."end-of-stream-1.4.4"
       sources."error-ex-1.3.2"
       sources."escape-string-regexp-1.0.5"
       (sources."eslint-5.16.0" // {
@@ -73977,7 +75979,7 @@ in
         ];
       })
       sources."eslint-scope-4.0.3"
-      sources."eslint-utils-1.4.2"
+      sources."eslint-utils-1.4.3"
       sources."eslint-visitor-keys-1.1.0"
       sources."espree-5.0.1"
       sources."esprima-4.0.1"
@@ -74057,7 +76059,7 @@ in
       sources."get-caller-file-1.0.3"
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       (sources."glob-base-0.3.0" // {
         dependencies = [
           sources."glob-parent-2.0.0"
@@ -74075,7 +76077,7 @@ in
       sources."globals-11.12.0"
       sources."globby-8.0.2"
       sources."got-6.7.1"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."gridsome-helper-json-1.0.3"
       sources."has-1.0.3"
       (sources."has-ansi-2.0.0" // {
@@ -74098,7 +76100,7 @@ in
       sources."hast-util-parse-selector-2.2.2"
       sources."hast-util-to-string-1.0.2"
       sources."hast-util-whitespace-1.0.3"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."html-void-elements-1.0.4"
       sources."html-whitespace-sensitive-tag-names-1.0.1"
       sources."iconv-lite-0.4.24"
@@ -74120,13 +76122,13 @@ in
           sources."strip-ansi-5.2.0"
         ];
       })
-      sources."invert-kv-1.0.0"
+      sources."invert-kv-2.0.0"
       sources."is-accessor-descriptor-1.0.0"
       sources."is-alphabetical-1.0.3"
       sources."is-alphanumerical-1.0.3"
       sources."is-arrayish-0.2.1"
       sources."is-binary-path-1.0.1"
-      sources."is-buffer-2.0.3"
+      sources."is-buffer-2.0.4"
       sources."is-ci-1.2.1"
       sources."is-data-descriptor-1.0.0"
       sources."is-decimal-1.0.3"
@@ -74171,11 +76173,11 @@ in
       sources."json-parse-better-errors-1.0.2"
       sources."json-schema-traverse-0.4.1"
       sources."json-stable-stringify-without-jsonify-1.0.1"
-      sources."json5-2.1.0"
+      sources."json5-2.1.1"
       sources."jsonc-parser-1.0.3"
       sources."kind-of-6.0.2"
       sources."latest-version-3.1.0"
-      sources."lcid-1.0.0"
+      sources."lcid-2.0.0"
       sources."levn-0.3.0"
       sources."load-json-file-4.0.0"
       sources."load-plugin-2.3.1"
@@ -74203,12 +76205,17 @@ in
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.5"
       sources."make-dir-1.3.0"
+      sources."map-age-cleaner-0.1.3"
       sources."map-cache-0.2.2"
       sources."map-obj-2.0.0"
       sources."map-visit-1.0.0"
       sources."markdown-table-0.4.0"
       sources."math-random-1.0.4"
-      sources."mem-1.1.0"
+      (sources."mem-4.3.0" // {
+        dependencies = [
+          sources."mimic-fn-2.1.0"
+        ];
+      })
       (sources."meow-5.0.0" // {
         dependencies = [
           sources."read-pkg-up-3.0.0"
@@ -74266,10 +76273,18 @@ in
       sources."onetime-2.0.1"
       sources."optionator-0.8.2"
       sources."os-homedir-1.0.2"
-      sources."os-locale-2.1.0"
+      (sources."os-locale-3.1.0" // {
+        dependencies = [
+          sources."cross-spawn-6.0.5"
+          sources."execa-1.0.0"
+          sources."get-stream-4.1.0"
+        ];
+      })
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
+      sources."p-defer-1.0.0"
       sources."p-finally-1.0.0"
+      sources."p-is-promise-2.1.0"
       sources."p-limit-1.3.0"
       sources."p-locate-2.0.0"
       sources."p-try-1.0.0"
@@ -74343,9 +76358,10 @@ in
       sources."pretty-format-23.6.0"
       sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
-      sources."property-information-5.2.2"
+      sources."property-information-5.3.0"
       sources."proto-list-1.2.4"
       sources."pseudomap-1.0.2"
+      sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."quick-lru-1.1.0"
       (sources."randomatic-3.1.1" // {
@@ -74505,7 +76521,9 @@ in
           sources."cliui-3.2.0"
           sources."find-up-1.1.2"
           sources."glob-7.0.4"
+          sources."invert-kv-1.0.0"
           sources."is-fullwidth-code-point-1.0.0"
+          sources."lcid-1.0.0"
           sources."load-json-file-1.1.0"
           sources."os-locale-1.4.0"
           sources."parse-json-2.2.0"
@@ -74532,7 +76550,7 @@ in
           sources."source-map-0.7.3"
         ];
       })
-      sources."stylus-supremacy-2.12.7"
+      sources."stylus-supremacy-2.14.0"
       sources."supports-color-5.5.0"
       sources."symbol-0.2.3"
       (sources."table-5.4.6" // {
@@ -74569,7 +76587,7 @@ in
       sources."tsutils-2.29.0"
       sources."type-check-0.3.2"
       sources."typedarray-0.0.6"
-      sources."typescript-3.6.3"
+      sources."typescript-3.6.4"
       (sources."typescript-eslint-parser-16.0.1" // {
         dependencies = [
           sources."semver-5.5.0"
@@ -74637,15 +76655,15 @@ in
       sources."vfile-sort-2.2.1"
       sources."vfile-statistics-1.1.3"
       sources."vscode-css-languageservice-4.0.2"
-      (sources."vscode-emmet-helper-1.2.15" // {
+      (sources."vscode-emmet-helper-1.2.16" // {
         dependencies = [
           sources."vscode-languageserver-types-3.14.0"
         ];
       })
-      sources."vscode-jsonrpc-4.1.0-next.3"
+      sources."vscode-jsonrpc-5.0.0-next.2"
       sources."vscode-languageserver-5.3.0-next.10"
-      sources."vscode-languageserver-protocol-3.15.0-next.8"
-      sources."vscode-languageserver-types-3.15.0-next.4"
+      sources."vscode-languageserver-protocol-3.15.0-next.9"
+      sources."vscode-languageserver-types-3.15.0-next.5"
       sources."vscode-nls-4.1.1"
       sources."vscode-textbuffer-1.0.0"
       sources."vscode-uri-1.0.8"
@@ -74678,7 +76696,7 @@ in
       sources."xtend-4.0.2"
       sources."y18n-3.2.1"
       sources."yallist-2.1.2"
-      (sources."yargs-11.1.0" // {
+      (sources."yargs-11.1.1" // {
         dependencies = [
           sources."yargs-parser-9.0.2"
         ];
@@ -74698,72 +76716,48 @@ in
   web-ext = nodeEnv.buildNodePackage {
     name = "web-ext";
     packageName = "web-ext";
-    version = "3.1.1";
+    version = "3.2.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/web-ext/-/web-ext-3.1.1.tgz";
-      sha512 = "snTfhuxoplm8QAlv+CwOaF0XSaycDUmxsrLfi4NtZRvZ6J79+ijOu9HyTXP0rd1zT3uagWYOBc3ol/ZOsf1LQQ==";
+      url = "https://registry.npmjs.org/web-ext/-/web-ext-3.2.0.tgz";
+      sha512 = "UM2ucXzEKs6tD+YT6FjmfIeQtLy4t9CwdwyQl8Nthn2BbGgDLht+wBWsU8VYnNXtrObxX24Co8oaF7Id06JbgA==";
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
       sources."@babel/highlight-7.5.0"
-      sources."@babel/polyfill-7.4.4"
-      sources."@babel/runtime-7.4.5"
-      sources."@babel/runtime-corejs2-7.6.0"
+      sources."@babel/polyfill-7.6.0"
+      sources."@babel/runtime-7.6.2"
+      sources."@babel/runtime-corejs2-7.6.3"
       sources."@cliqz-oss/firefox-client-0.3.1"
       sources."@cliqz-oss/node-firefox-connect-1.2.1"
       sources."@sindresorhus/is-0.14.0"
-      sources."@snyk/cli-interface-2.1.0"
-      sources."@snyk/composer-lockfile-parser-1.0.3"
-      sources."@snyk/dep-graph-1.12.0"
-      sources."@snyk/gemfile-1.2.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/agent-base-4.2.0"
-      sources."@types/bunyan-1.8.6"
-      sources."@types/debug-4.1.5"
-      sources."@types/events-3.0.0"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.7.5"
-      sources."@types/restify-4.3.6"
-      sources."@types/semver-5.5.0"
-      sources."@types/xml2js-0.4.3"
-      sources."@yarnpkg/lockfile-1.1.0"
+      sources."@types/node-12.12.3"
       sources."JSONSelect-0.2.1"
-      sources."abbrev-1.1.1"
-      sources."acorn-5.7.3"
-      (sources."acorn-jsx-3.0.1" // {
-        dependencies = [
-          sources."acorn-3.3.0"
-        ];
-      })
+      sources."acorn-6.3.0"
+      sources."acorn-jsx-5.1.0"
       sources."adbkit-2.11.1"
       sources."adbkit-logcat-1.1.0"
       sources."adbkit-monkey-1.0.1"
-      (sources."addons-linter-1.10.0" // {
+      (sources."addons-linter-1.14.0" // {
         dependencies = [
-          sources."regenerator-runtime-0.13.2"
+          sources."decamelize-1.2.0"
+          sources."yargs-14.0.0"
         ];
       })
       sources."adm-zip-0.4.13"
-      (sources."agent-base-4.3.0" // {
-        dependencies = [
-          sources."es6-promise-4.2.8"
-          sources."es6-promisify-5.0.0"
-        ];
-      })
-      sources."ajv-6.10.0"
+      sources."ajv-6.10.2"
       sources."ajv-keywords-1.5.1"
       sources."ajv-merge-patch-4.1.0"
-      sources."ansi-align-2.0.0"
+      sources."ansi-align-3.0.0"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-2.1.1"
       sources."ansi-styles-3.2.1"
-      sources."ansicolors-0.3.2"
       sources."any-promise-1.3.0"
       sources."anymatch-2.0.0"
       (sources."archiver-2.1.1" // {
         dependencies = [
           sources."async-2.6.3"
-          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
@@ -74771,33 +76765,29 @@ in
       })
       (sources."archiver-utils-1.3.0" // {
         dependencies = [
-          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."archy-1.0.0"
       sources."argparse-1.0.10"
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
       sources."arr-union-3.1.0"
       sources."array-differ-3.0.0"
       sources."array-filter-0.0.1"
-      sources."array-from-2.1.1"
       sources."array-map-0.0.0"
       sources."array-reduce-0.0.0"
       sources."array-union-2.1.0"
       sources."array-unique-0.3.2"
       sources."arrify-2.0.1"
-      sources."asap-2.0.6"
       sources."asn1-0.2.4"
       sources."assert-plus-1.0.0"
       sources."assign-symbols-1.0.0"
-      sources."ast-types-0.13.2"
       sources."astral-regex-1.0.0"
       sources."async-0.2.10"
       sources."async-each-1.0.3"
+      sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
       sources."aws-sign2-0.7.0"
@@ -74831,7 +76821,6 @@ in
       sources."binary-extensions-1.13.1"
       (sources."bl-1.2.2" // {
         dependencies = [
-          sources."isarray-1.0.0"
           (sources."readable-stream-2.3.6" // {
             dependencies = [
               sources."safe-buffer-5.1.2"
@@ -74846,15 +76835,12 @@ in
       })
       sources."bluebird-2.9.34"
       sources."boolbase-1.0.0"
-      (sources."boxen-1.3.0" // {
-        dependencies = [
-          sources."camelcase-4.1.0"
-        ];
-      })
+      sources."boxen-3.2.0"
       sources."brace-expansion-1.1.11"
       (sources."braces-2.3.2" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
+          sources."is-extendable-0.1.1"
         ];
       })
       sources."buffer-5.4.3"
@@ -74865,23 +76851,16 @@ in
       sources."buffer-fill-1.0.0"
       sources."buffer-from-1.1.1"
       sources."bunyan-1.8.12"
-      sources."bytes-3.1.0"
       sources."cache-base-1.0.1"
       (sources."cacheable-request-6.1.0" // {
         dependencies = [
           sources."get-stream-5.1.0"
           sources."lowercase-keys-2.0.0"
-          sources."normalize-url-4.4.1"
         ];
       })
-      (sources."caller-path-0.1.0" // {
-        dependencies = [
-          sources."callsites-0.2.0"
-        ];
-      })
-      sources."callsites-3.1.0"
+      sources."caller-path-0.1.0"
+      sources."callsites-0.2.0"
       sources."camelcase-5.3.1"
-      sources."capture-stack-trace-1.0.1"
       sources."caseless-0.12.0"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
@@ -74892,7 +76871,8 @@ in
           sources."normalize-path-3.0.0"
         ];
       })
-      sources."ci-info-1.6.0"
+      sources."chrome-launcher-0.11.2"
+      sources."ci-info-2.0.0"
       sources."circular-json-0.3.3"
       (sources."class-utils-0.3.6" // {
         dependencies = [
@@ -74911,18 +76891,16 @@ in
           sources."kind-of-5.1.0"
         ];
       })
-      sources."cli-boxes-1.0.0"
+      sources."cli-boxes-2.2.0"
       sources."cli-cursor-2.1.0"
       sources."cli-width-2.2.0"
-      (sources."cliui-3.2.0" // {
+      (sources."cliui-5.0.0" // {
         dependencies = [
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."string-width-1.0.2"
-          sources."wrap-ansi-2.1.0"
+          sources."ansi-regex-4.1.0"
+          sources."strip-ansi-5.2.0"
         ];
       })
       sources."clone-1.0.4"
-      sources."clone-deep-0.3.0"
       sources."clone-response-1.0.2"
       sources."co-4.6.0"
       sources."code-point-at-1.1.0"
@@ -74932,12 +76910,11 @@ in
       sources."colors-0.5.1"
       sources."columnify-1.5.4"
       sources."combined-stream-1.0.8"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."common-tags-1.8.0"
       sources."component-emitter-1.3.0"
       (sources."compress-commons-1.2.2" // {
         dependencies = [
-          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
@@ -74946,121 +76923,92 @@ in
       sources."concat-map-0.0.1"
       (sources."concat-stream-1.6.2" // {
         dependencies = [
-          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."configstore-3.1.2"
+      sources."configstore-4.0.0"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-2.6.9"
+      sources."core-js-2.6.10"
       sources."core-util-is-1.0.2"
       sources."crc-3.8.0"
       (sources."crc32-stream-2.0.0" // {
         dependencies = [
-          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."create-error-class-3.0.2"
       (sources."cross-spawn-6.0.5" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
       })
-      sources."crx-parser-0.1.2"
       sources."crypto-random-string-1.0.0"
       sources."css-select-1.2.0"
       sources."css-what-2.1.3"
       sources."d-1.0.1"
       sources."dashdash-1.14.1"
-      (sources."data-uri-to-buffer-2.0.1" // {
-        dependencies = [
-          sources."@types/node-8.10.54"
-        ];
-      })
       sources."debounce-1.2.0"
       sources."debug-2.6.9"
-      (sources."decamelize-3.2.0" // {
-        dependencies = [
-          sources."xregexp-4.2.4"
-        ];
-      })
+      sources."decamelize-3.2.0"
       sources."decode-uri-component-0.2.0"
       sources."decompress-response-3.3.0"
       sources."deep-equal-1.1.0"
       sources."deep-extend-0.6.0"
       sources."deep-is-0.1.3"
       sources."deepcopy-0.6.3"
-      sources."deepmerge-3.2.0"
+      sources."deepmerge-4.0.0"
       sources."defaults-1.0.3"
       sources."defer-to-connect-1.0.2"
       sources."define-properties-1.1.3"
       sources."define-property-2.0.2"
-      (sources."degenerator-1.0.4" // {
-        dependencies = [
-          sources."esprima-3.1.3"
-        ];
-      })
       sources."delayed-stream-1.0.0"
-      sources."depd-1.1.2"
-      sources."diff-4.0.1"
-      (sources."dispensary-0.37.0" // {
+      (sources."dispensary-0.40.0" // {
         dependencies = [
-          sources."async-3.0.1"
+          sources."async-3.1.0"
+          sources."decamelize-1.2.0"
+          sources."yargs-14.0.0"
         ];
       })
-      sources."dockerfile-ast-0.0.16"
       sources."doctrine-3.0.0"
       sources."dom-serializer-0.1.1"
       sources."domelementtype-1.3.1"
       sources."domhandler-2.4.2"
       sources."domutils-1.5.1"
       sources."dot-prop-4.2.0"
-      (sources."dotnet-deps-parser-4.5.0" // {
-        dependencies = [
-          sources."xml2js-0.4.19"
-        ];
-      })
       sources."dtrace-provider-0.8.8"
       sources."duplexer3-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."ecdsa-sig-formatter-1.0.11"
-      sources."email-validator-2.0.4"
       sources."emoji-regex-7.0.3"
       sources."encoding-0.1.12"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
-      sources."es-abstract-1.14.2"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
-      sources."es5-ext-0.10.51"
+      sources."es5-ext-0.10.52"
       sources."es6-error-4.1.1"
       sources."es6-iterator-2.0.3"
       sources."es6-map-0.1.5"
       sources."es6-promise-2.3.0"
-      sources."es6-promisify-6.0.1"
+      sources."es6-promisify-6.0.2"
       (sources."es6-set-0.1.5" // {
         dependencies = [
           sources."es6-symbol-3.1.1"
         ];
       })
-      sources."es6-symbol-3.1.2"
+      sources."es6-symbol-3.1.3"
       sources."es6-weak-map-2.0.3"
       sources."escape-string-regexp-1.0.5"
-      (sources."escodegen-1.12.0" // {
-        dependencies = [
-          sources."esprima-3.1.3"
-        ];
-      })
       sources."escope-3.6.0"
       (sources."eslint-5.16.0" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
           sources."debug-4.1.1"
+          sources."espree-5.0.1"
           sources."ms-2.1.2"
           sources."semver-5.7.1"
           sources."strip-ansi-4.0.0"
@@ -75069,6 +77017,12 @@ in
       })
       (sources."eslint-plugin-no-unsafe-innerhtml-1.0.16" // {
         dependencies = [
+          sources."acorn-5.7.3"
+          (sources."acorn-jsx-3.0.1" // {
+            dependencies = [
+              sources."acorn-3.3.0"
+            ];
+          })
           sources."ajv-4.11.8"
           sources."ansi-escapes-1.4.0"
           sources."ansi-regex-3.0.0"
@@ -75087,13 +77041,12 @@ in
           sources."is-fullwidth-code-point-1.0.0"
           sources."onetime-1.1.0"
           sources."progress-1.1.8"
-          sources."require-uncached-1.0.3"
-          sources."resolve-from-1.0.1"
           sources."restore-cursor-1.0.1"
           sources."run-async-0.1.0"
           sources."slice-ansi-0.0.4"
           sources."string-width-1.0.2"
           sources."strip-ansi-4.0.0"
+          sources."strip-bom-3.0.0"
           sources."strip-json-comments-2.0.1"
           sources."supports-color-2.0.0"
           (sources."table-3.8.3" // {
@@ -75106,12 +77059,11 @@ in
         ];
       })
       sources."eslint-scope-4.0.3"
-      sources."eslint-utils-1.4.2"
-      sources."eslint-visitor-keys-1.0.0"
-      (sources."espree-5.0.1" // {
+      sources."eslint-utils-1.4.3"
+      sources."eslint-visitor-keys-1.1.0"
+      (sources."espree-6.1.1" // {
         dependencies = [
-          sources."acorn-6.3.0"
-          sources."acorn-jsx-5.0.2"
+          sources."acorn-7.1.0"
         ];
       })
       sources."esprima-4.0.1"
@@ -75138,15 +77090,17 @@ in
             ];
           })
           sources."is-descriptor-0.1.6"
+          sources."is-extendable-0.1.1"
           sources."kind-of-5.1.0"
         ];
       })
-      sources."extend-3.0.2"
-      (sources."extend-shallow-3.0.2" // {
+      (sources."ext-1.1.2" // {
         dependencies = [
-          sources."is-extendable-1.0.1"
+          sources."type-2.0.0"
         ];
       })
+      sources."extend-3.0.2"
+      sources."extend-shallow-3.0.2"
       (sources."external-editor-3.1.0" // {
         dependencies = [
           sources."tmp-0.0.33"
@@ -75156,6 +77110,7 @@ in
         dependencies = [
           sources."define-property-1.0.0"
           sources."extend-shallow-2.0.1"
+          sources."is-extendable-0.1.1"
         ];
       })
       sources."extsprintf-1.3.0"
@@ -75168,10 +77123,10 @@ in
       sources."fd-slicer-1.1.0"
       sources."figures-2.0.0"
       sources."file-entry-cache-5.0.1"
-      sources."file-uri-to-path-1.0.0"
       (sources."fill-range-4.0.0" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
+          sources."is-extendable-0.1.1"
         ];
       })
       sources."find-up-3.0.0"
@@ -75186,7 +77141,6 @@ in
       sources."flatted-2.0.1"
       sources."fluent-syntax-0.13.0"
       sources."for-in-1.0.2"
-      sources."for-own-1.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."fragment-cache-0.2.1"
@@ -75194,12 +77148,6 @@ in
       sources."fs-extra-4.0.3"
       sources."fs.realpath-1.0.0"
       sources."fsevents-2.0.7"
-      (sources."ftp-0.3.10" // {
-        dependencies = [
-          sources."readable-stream-1.1.14"
-          sources."string_decoder-0.10.31"
-        ];
-      })
       sources."function-bind-1.1.1"
       sources."functional-red-black-tree-1.0.1"
       (sources."fx-runner-1.0.11" // {
@@ -75213,12 +77161,6 @@ in
       sources."generate-object-property-1.2.0"
       sources."get-caller-file-2.0.5"
       sources."get-stream-4.1.0"
-      (sources."get-uri-2.0.3" // {
-        dependencies = [
-          sources."debug-4.1.1"
-          sources."ms-2.1.2"
-        ];
-      })
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
       sources."gettext-parser-1.1.0"
@@ -75228,8 +77170,6 @@ in
           sources."shelljs-0.7.7"
         ];
       })
-      sources."git-up-4.0.1"
-      sources."git-url-parse-11.1.2"
       sources."glob-7.1.4"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
@@ -75238,14 +77178,9 @@ in
       })
       sources."global-dirs-0.1.1"
       sources."globals-11.12.0"
-      (sources."got-6.7.1" // {
-        dependencies = [
-          sources."get-stream-3.0.0"
-        ];
-      })
-      sources."graceful-fs-4.2.2"
+      sources."got-9.6.0"
+      sources."graceful-fs-4.2.3"
       sources."graceful-readlink-1.0.1"
-      sources."graphlib-2.1.7"
       sources."growly-1.3.0"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -75261,27 +77196,17 @@ in
         ];
       })
       sources."has-yarn-2.1.0"
-      sources."hosted-git-info-2.8.4"
       sources."htmlparser2-3.10.1"
       sources."http-cache-semantics-4.0.3"
-      sources."http-errors-1.7.3"
-      (sources."http-proxy-agent-2.1.0" // {
-        dependencies = [
-          sources."debug-3.1.0"
-        ];
-      })
       sources."http-signature-1.2.0"
-      (sources."https-proxy-agent-2.2.2" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-        ];
-      })
       sources."iconv-lite-0.4.24"
       sources."ieee754-1.1.13"
       sources."ignore-4.0.6"
-      sources."immediate-3.0.6"
-      sources."import-fresh-3.1.0"
+      (sources."import-fresh-3.1.0" // {
+        dependencies = [
+          sources."resolve-from-4.0.0"
+        ];
+      })
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."inflight-1.0.6"
@@ -75289,65 +77214,62 @@ in
       sources."ini-1.3.5"
       (sources."inquirer-6.5.2" // {
         dependencies = [
-          sources."ansi-regex-4.1.0"
-          sources."strip-ansi-5.2.0"
+          sources."ansi-regex-3.0.0"
+          (sources."string-width-2.1.1" // {
+            dependencies = [
+              sources."strip-ansi-4.0.0"
+            ];
+          })
+          (sources."strip-ansi-5.2.0" // {
+            dependencies = [
+              sources."ansi-regex-4.1.0"
+            ];
+          })
         ];
       })
       sources."interpret-1.2.0"
-      sources."invert-kv-1.0.0"
-      sources."ip-1.1.5"
+      sources."invert-kv-3.0.0"
       sources."is-absolute-0.1.7"
-      (sources."is-accessor-descriptor-1.0.0" // {
-        dependencies = [
-          sources."kind-of-6.0.2"
-        ];
-      })
+      sources."is-accessor-descriptor-1.0.0"
       sources."is-arguments-1.0.4"
       sources."is-arrayish-0.2.1"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
       sources."is-callable-1.1.4"
-      sources."is-ci-1.2.1"
-      (sources."is-data-descriptor-1.0.0" // {
-        dependencies = [
-          sources."kind-of-6.0.2"
-        ];
-      })
+      sources."is-ci-2.0.0"
+      sources."is-data-descriptor-1.0.0"
       sources."is-date-object-1.0.1"
-      (sources."is-descriptor-1.0.2" // {
-        dependencies = [
-          sources."kind-of-6.0.2"
-        ];
-      })
-      sources."is-extendable-0.1.1"
+      sources."is-descriptor-1.0.2"
+      sources."is-extendable-1.0.1"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
       sources."is-installed-globally-0.1.0"
-      sources."is-mergeable-object-1.1.0"
+      sources."is-mergeable-object-1.1.1"
       sources."is-my-ip-valid-1.0.0"
       sources."is-my-json-valid-2.20.0"
-      sources."is-npm-1.0.0"
-      sources."is-number-3.0.0"
+      sources."is-npm-3.0.0"
+      (sources."is-number-3.0.0" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
       sources."is-obj-1.0.1"
       sources."is-path-inside-1.0.1"
       sources."is-plain-object-2.0.4"
       sources."is-promise-2.1.0"
       sources."is-property-1.0.2"
-      sources."is-redirect-1.0.0"
       sources."is-regex-1.0.4"
       sources."is-relative-0.1.3"
       sources."is-resolvable-1.1.0"
-      sources."is-retry-allowed-1.2.0"
-      sources."is-ssh-1.3.1"
       sources."is-stream-1.1.0"
       sources."is-symbol-1.0.2"
       sources."is-typedarray-1.0.0"
       sources."is-utf8-0.2.1"
       sources."is-windows-1.0.2"
-      sources."is-wsl-1.1.0"
+      sources."is-wsl-2.1.1"
       sources."is-yarn-global-0.3.0"
-      sources."isarray-0.0.1"
+      sources."isarray-1.0.0"
       sources."isexe-2.0.0"
       sources."isobject-3.0.1"
       sources."isstream-0.1.2"
@@ -75374,39 +77296,25 @@ in
         ];
       })
       sources."jsprim-1.4.1"
-      (sources."jszip-3.2.2" // {
-        dependencies = [
-          sources."isarray-1.0.0"
-          sources."readable-stream-2.3.6"
-          sources."safe-buffer-5.1.2"
-          sources."string_decoder-1.1.1"
-        ];
-      })
+      sources."jszip-2.6.1"
       sources."jwa-1.4.1"
       sources."jws-3.2.2"
       sources."keyv-3.1.0"
-      sources."kind-of-3.2.2"
-      sources."latest-version-3.1.0"
-      sources."lazy-cache-0.2.7"
+      sources."kind-of-6.0.2"
+      sources."latest-version-5.1.0"
       (sources."lazystream-1.0.0" // {
         dependencies = [
-          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."lcid-1.0.0"
+      sources."lcid-3.1.1"
       sources."levn-0.3.0"
-      sources."lie-3.3.0"
+      sources."lighthouse-logger-1.2.0"
+      sources."lines-and-columns-1.1.6"
       sources."locate-path-3.0.0"
       sources."lodash-4.17.15"
-      sources."lodash.assign-4.2.0"
-      sources."lodash.assignin-4.2.0"
-      sources."lodash.clone-4.5.0"
-      sources."lodash.clonedeep-4.5.0"
-      sources."lodash.flatten-4.4.0"
-      sources."lodash.get-4.4.2"
       sources."lodash.includes-4.3.0"
       sources."lodash.isboolean-3.0.3"
       sources."lodash.isinteger-4.0.4"
@@ -75414,42 +77322,28 @@ in
       sources."lodash.isplainobject-4.0.6"
       sources."lodash.isstring-4.0.1"
       sources."lodash.once-4.1.1"
-      sources."lodash.set-4.3.2"
       sources."lodash.sortby-4.7.0"
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.5"
-      sources."macos-release-2.3.0"
       sources."make-dir-1.3.0"
       sources."map-age-cleaner-0.1.3"
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
-      sources."mdn-browser-compat-data-0.0.82"
-      (sources."mem-4.3.0" // {
+      sources."marky-1.2.1"
+      sources."mdn-browser-compat-data-0.0.94"
+      (sources."mem-5.1.1" // {
         dependencies = [
           sources."mimic-fn-2.1.0"
         ];
       })
-      (sources."micromatch-3.1.10" // {
-        dependencies = [
-          sources."kind-of-6.0.2"
-        ];
-      })
+      sources."micromatch-3.1.10"
       sources."mime-db-1.40.0"
       sources."mime-types-2.1.24"
       sources."mimic-fn-1.2.0"
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."mixin-deep-1.3.2" // {
-        dependencies = [
-          sources."is-extendable-1.0.1"
-        ];
-      })
-      (sources."mixin-object-2.0.1" // {
-        dependencies = [
-          sources."for-in-0.1.8"
-        ];
-      })
+      sources."mixin-deep-1.3.2"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
@@ -75467,41 +77361,15 @@ in
       })
       sources."mz-2.7.0"
       sources."nan-2.14.0"
-      (sources."nanomatch-1.2.13" // {
-        dependencies = [
-          sources."kind-of-6.0.2"
-        ];
-      })
+      sources."nanomatch-1.2.13"
       sources."natural-compare-1.4.0"
       sources."natural-compare-lite-1.4.0"
-      (sources."nconf-0.10.0" // {
-        dependencies = [
-          sources."async-1.5.2"
-          sources."camelcase-2.1.1"
-          sources."decamelize-1.2.0"
-          sources."is-fullwidth-code-point-1.0.0"
-          sources."os-locale-1.4.0"
-          sources."string-width-1.0.2"
-          sources."yargs-3.32.0"
-        ];
-      })
       sources."ncp-2.0.0"
-      (sources."needle-2.4.0" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-        ];
-      })
       sources."neo-async-2.6.1"
-      sources."netmask-1.0.6"
       sources."next-tick-1.0.0"
       sources."nice-try-1.0.5"
       sources."node-forge-0.7.6"
-      (sources."node-notifier-5.4.0" // {
-        dependencies = [
-          sources."semver-5.7.1"
-        ];
-      })
+      sources."node-notifier-6.0.0"
       (sources."nomnom-1.8.1" // {
         dependencies = [
           sources."ansi-styles-1.0.0"
@@ -75510,7 +77378,7 @@ in
         ];
       })
       sources."normalize-path-2.1.1"
-      sources."normalize-url-3.3.0"
+      sources."normalize-url-4.5.0"
       sources."npm-run-path-2.0.2"
       sources."nth-check-1.0.2"
       sources."number-is-nan-1.0.1"
@@ -75526,9 +77394,9 @@ in
               sources."kind-of-5.1.0"
             ];
           })
+          sources."kind-of-3.2.2"
         ];
       })
-      sources."object-hash-1.3.1"
       sources."object-inspect-1.6.0"
       sources."object-is-1.0.1"
       sources."object-keys-1.1.1"
@@ -75537,16 +77405,14 @@ in
       sources."object.pick-1.3.0"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
-      sources."opn-5.5.0"
-      sources."optionator-0.8.2"
-      sources."os-homedir-1.0.2"
-      (sources."os-locale-3.1.0" // {
+      (sources."open-6.4.0" // {
         dependencies = [
-          sources."invert-kv-2.0.0"
-          sources."lcid-2.0.0"
+          sources."is-wsl-1.1.0"
         ];
       })
-      sources."os-name-3.1.0"
+      sources."optionator-0.8.2"
+      sources."os-homedir-1.0.2"
+      sources."os-locale-4.0.0"
       sources."os-shim-0.1.3"
       sources."os-tmpdir-1.0.2"
       sources."p-cancelable-1.1.0"
@@ -75556,23 +77422,14 @@ in
       sources."p-limit-2.2.1"
       sources."p-locate-3.0.0"
       sources."p-try-2.2.0"
-      (sources."pac-proxy-agent-3.0.0" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-        ];
-      })
-      sources."pac-resolver-3.0.0"
-      (sources."package-json-4.0.1" // {
-        dependencies = [
-          sources."semver-5.7.1"
-        ];
-      })
+      sources."package-json-6.5.0"
       sources."pako-1.0.10"
-      sources."parent-module-1.0.1"
-      sources."parse-json-4.0.0"
-      sources."parse-path-4.0.1"
-      sources."parse-url-5.0.1"
+      (sources."parent-module-1.0.1" // {
+        dependencies = [
+          sources."callsites-3.1.0"
+        ];
+      })
+      sources."parse-json-5.0.0"
       sources."parse5-3.0.3"
       sources."pascalcase-0.1.1"
       sources."path-dirname-1.0.2"
@@ -75584,41 +77441,27 @@ in
       sources."pend-1.2.0"
       sources."performance-now-2.1.0"
       sources."pify-3.0.0"
-      sources."pino-5.12.6"
+      sources."pino-5.13.3"
       sources."pino-std-serializers-2.4.2"
       sources."pluralize-1.2.1"
       sources."po2json-0.4.5"
       sources."posix-character-classes-0.1.1"
-      (sources."postcss-7.0.16" // {
+      (sources."postcss-7.0.18" // {
         dependencies = [
           sources."supports-color-6.1.0"
         ];
       })
       sources."prelude-ls-1.1.2"
-      sources."prepend-http-1.0.4"
-      (sources."probe-image-size-4.0.0" // {
-        dependencies = [
-          sources."deepmerge-2.2.1"
-        ];
-      })
+      sources."prepend-http-2.0.0"
+      sources."probe-image-size-5.0.0"
       sources."process-nextick-args-2.0.1"
       sources."progress-2.0.3"
-      sources."promise-7.3.1"
-      sources."protocols-1.4.7"
-      (sources."proxy-agent-3.1.0" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-        ];
-      })
-      sources."proxy-from-env-1.0.0"
       sources."pseudomap-1.0.2"
       sources."psl-1.4.0"
       sources."pump-3.0.0"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
-      sources."quick-format-unescaped-3.0.2"
-      sources."raw-body-2.4.1"
+      sources."quick-format-unescaped-3.0.3"
       (sources."rc-1.2.8" // {
         dependencies = [
           sources."strip-json-comments-2.0.1"
@@ -75627,7 +77470,6 @@ in
       sources."readable-stream-3.4.0"
       (sources."readdirp-2.2.1" // {
         dependencies = [
-          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
@@ -75644,8 +77486,8 @@ in
       sources."regex-not-1.0.2"
       sources."regexp.prototype.flags-1.2.0"
       sources."regexpp-2.0.1"
-      sources."registry-auth-token-3.4.0"
-      sources."registry-url-3.1.0"
+      sources."registry-auth-token-4.0.0"
+      sources."registry-url-5.1.0"
       sources."relaxed-json-1.0.3"
       sources."remove-trailing-separator-1.1.0"
       sources."repeat-element-1.1.3"
@@ -75653,13 +77495,9 @@ in
       sources."request-2.88.0"
       sources."require-directory-2.1.1"
       sources."require-main-filename-2.0.0"
-      (sources."require-uncached-2.0.0" // {
-        dependencies = [
-          sources."resolve-from-1.0.1"
-        ];
-      })
+      sources."require-uncached-1.0.3"
       sources."resolve-1.12.0"
-      sources."resolve-from-4.0.0"
+      sources."resolve-from-1.0.1"
       sources."resolve-url-0.2.1"
       sources."responselike-1.0.2"
       sources."restore-cursor-2.0.0"
@@ -75673,27 +77511,20 @@ in
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
-      sources."secure-keys-1.0.0"
-      sources."semver-6.1.1"
+      sources."semver-6.3.0"
       (sources."semver-diff-2.1.0" // {
         dependencies = [
           sources."semver-5.7.1"
         ];
       })
       sources."set-blocking-2.0.0"
-      sources."set-immediate-shim-1.0.1"
       (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
+          sources."is-extendable-0.1.1"
         ];
       })
-      sources."setprototypeof-1.1.1"
       sources."sha.js-2.4.11"
-      (sources."shallow-clone-0.1.2" // {
-        dependencies = [
-          sources."kind-of-2.0.1"
-        ];
-      })
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."shell-quote-1.6.1"
@@ -75719,7 +77550,6 @@ in
       })
       sources."signal-exit-3.0.2"
       sources."slice-ansi-2.1.0"
-      sources."smart-buffer-4.0.2"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -75735,6 +77565,7 @@ in
             ];
           })
           sources."is-descriptor-0.1.6"
+          sources."is-extendable-0.1.1"
           sources."kind-of-5.1.0"
           sources."source-map-0.5.7"
         ];
@@ -75744,116 +77575,15 @@ in
           sources."define-property-1.0.0"
         ];
       })
-      sources."snapdragon-util-3.0.1"
-      (sources."snyk-1.228.3" // {
+      (sources."snapdragon-util-3.0.1" // {
         dependencies = [
-          sources."ansi-regex-4.1.0"
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-          sources."strip-ansi-5.2.0"
-          sources."update-notifier-2.5.0"
-        ];
-      })
-      (sources."snyk-config-2.2.3" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-        ];
-      })
-      (sources."snyk-docker-plugin-1.29.1" // {
-        dependencies = [
-          sources."debug-4.1.1"
-          sources."ms-2.1.2"
-        ];
-      })
-      sources."snyk-go-parser-1.3.1"
-      (sources."snyk-go-plugin-1.11.0" // {
-        dependencies = [
-          sources."debug-4.1.1"
-          sources."ms-2.1.2"
-          sources."tmp-0.0.33"
-        ];
-      })
-      (sources."snyk-gradle-plugin-3.1.0" // {
-        dependencies = [
-          sources."debug-4.1.1"
-          sources."ms-2.1.2"
-          sources."tmp-0.0.33"
-        ];
-      })
-      (sources."snyk-module-1.9.1" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-        ];
-      })
-      (sources."snyk-mvn-plugin-2.4.0" // {
-        dependencies = [
-          sources."tslib-1.9.3"
-        ];
-      })
-      sources."snyk-nodejs-lockfile-parser-1.16.0"
-      (sources."snyk-nuget-plugin-1.12.1" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-        ];
-      })
-      sources."snyk-paket-parser-1.5.0"
-      (sources."snyk-php-plugin-1.6.4" // {
-        dependencies = [
-          sources."tslib-1.9.3"
-        ];
-      })
-      (sources."snyk-policy-1.13.5" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-        ];
-      })
-      (sources."snyk-python-plugin-1.13.2" // {
-        dependencies = [
-          sources."tmp-0.0.33"
-        ];
-      })
-      (sources."snyk-resolve-1.0.1" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-        ];
-      })
-      (sources."snyk-resolve-deps-4.4.0" // {
-        dependencies = [
-          sources."@types/node-6.14.7"
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-          sources."semver-5.7.1"
-        ];
-      })
-      (sources."snyk-sbt-plugin-2.8.0" // {
-        dependencies = [
-          sources."semver-6.3.0"
-        ];
-      })
-      sources."snyk-tree-1.0.0"
-      (sources."snyk-try-require-1.3.1" // {
-        dependencies = [
-          sources."debug-3.2.6"
-          sources."ms-2.1.2"
-        ];
-      })
-      sources."socks-2.3.2"
-      (sources."socks-proxy-agent-4.0.2" // {
-        dependencies = [
-          sources."agent-base-4.2.1"
-          sources."es6-promise-4.2.8"
-          sources."es6-promisify-5.0.0"
+          sources."kind-of-3.2.2"
         ];
       })
       sources."sonic-boom-0.7.6"
       sources."source-map-0.6.1"
       sources."source-map-resolve-0.5.2"
-      sources."source-map-support-0.5.12"
+      sources."source-map-support-0.5.13"
       sources."source-map-url-0.4.0"
       sources."spawn-sync-1.0.15"
       sources."split-0.3.3"
@@ -75877,7 +77607,6 @@ in
           sources."kind-of-5.1.0"
         ];
       })
-      sources."statuses-1.5.0"
       sources."stream-parser-0.3.1"
       sources."stream-to-array-2.3.0"
       (sources."stream-to-promise-2.2.0" // {
@@ -75886,40 +77615,30 @@ in
           sources."once-1.3.3"
         ];
       })
-      (sources."string-width-2.1.1" // {
+      (sources."string-width-3.1.0" // {
         dependencies = [
-          sources."ansi-regex-3.0.0"
-          sources."strip-ansi-4.0.0"
+          sources."ansi-regex-4.1.0"
+          sources."strip-ansi-5.2.0"
         ];
       })
       sources."string.prototype.trimleft-2.1.0"
       sources."string.prototype.trimright-2.1.0"
       sources."string_decoder-1.3.0"
       sources."strip-ansi-3.0.1"
-      sources."strip-bom-3.0.0"
+      sources."strip-bom-4.0.0"
       sources."strip-bom-buf-2.0.0"
       sources."strip-bom-stream-4.0.0"
       sources."strip-eof-1.0.0"
       sources."strip-json-comments-3.0.1"
       sources."supports-color-5.5.0"
-      (sources."table-5.4.6" // {
-        dependencies = [
-          sources."ajv-6.10.2"
-          sources."ansi-regex-4.1.0"
-          sources."string-width-3.1.0"
-          sources."strip-ansi-5.2.0"
-        ];
-      })
+      sources."table-5.4.6"
       (sources."tar-stream-1.6.2" // {
         dependencies = [
-          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."temp-dir-1.0.0"
-      sources."tempfile-2.0.0"
       (sources."term-size-1.2.0" // {
         dependencies = [
           sources."cross-spawn-5.1.0"
@@ -75928,20 +77647,19 @@ in
         ];
       })
       sources."text-table-0.2.0"
-      sources."then-fs-2.0.0"
       sources."thenify-3.3.0"
       sources."thenify-all-1.6.0"
       sources."through-2.3.8"
-      sources."thunkify-2.1.2"
-      sources."timed-out-4.0.1"
       sources."tmp-0.1.0"
       sources."to-buffer-1.1.1"
-      sources."to-object-path-0.3.0"
+      (sources."to-object-path-0.3.0" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
       sources."to-readable-stream-1.0.0"
       sources."to-regex-3.0.2"
       sources."to-regex-range-2.1.1"
-      sources."toidentifier-1.0.0"
-      sources."toml-3.0.0"
       sources."tosource-1.0.0"
       (sources."tough-cookie-2.4.3" // {
         dependencies = [
@@ -75950,7 +77668,6 @@ in
       })
       sources."tr46-1.0.1"
       sources."traverse-0.4.6"
-      sources."tree-kill-1.2.1"
       sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
@@ -75959,10 +77676,13 @@ in
       sources."type-fest-0.3.1"
       sources."typedarray-0.0.6"
       sources."underscore-1.6.0"
-      sources."union-value-1.0.1"
+      (sources."union-value-1.0.1" // {
+        dependencies = [
+          sources."is-extendable-0.1.1"
+        ];
+      })
       sources."unique-string-1.0.0"
       sources."universalify-0.1.2"
-      sources."unpipe-1.0.0"
       (sources."unset-value-1.0.0" // {
         dependencies = [
           (sources."has-value-0.3.1" // {
@@ -75971,43 +77691,19 @@ in
             ];
           })
           sources."has-values-0.1.4"
-          sources."isarray-1.0.0"
         ];
       })
-      sources."unzip-response-2.0.1"
-      sources."upath-1.1.2"
-      (sources."update-notifier-3.0.1" // {
-        dependencies = [
-          sources."ansi-align-3.0.0"
-          sources."ansi-regex-4.1.0"
-          sources."boxen-3.2.0"
-          sources."ci-info-2.0.0"
-          sources."cli-boxes-2.2.0"
-          sources."configstore-4.0.0"
-          sources."got-9.6.0"
-          sources."is-ci-2.0.0"
-          sources."is-npm-3.0.0"
-          sources."latest-version-5.1.0"
-          sources."package-json-6.5.0"
-          sources."prepend-http-2.0.0"
-          sources."registry-auth-token-4.0.0"
-          sources."registry-url-5.1.0"
-          sources."semver-6.3.0"
-          sources."string-width-3.1.0"
-          sources."strip-ansi-5.2.0"
-          sources."url-parse-lax-3.0.0"
-        ];
-      })
+      sources."upath-1.2.0"
+      sources."update-notifier-3.0.1"
       sources."uri-js-4.2.2"
       sources."urix-0.1.0"
-      sources."url-parse-lax-1.0.0"
+      sources."url-parse-lax-3.0.0"
       sources."use-3.1.1"
       sources."user-home-2.0.0"
       sources."util-deprecate-1.0.2"
       sources."util.promisify-1.0.0"
       sources."uuid-3.3.3"
       sources."verror-1.10.0"
-      sources."vscode-languageserver-types-3.14.0"
       sources."watchpack-1.6.0"
       sources."wcwidth-1.0.1"
       sources."webidl-conversions-4.0.2"
@@ -76015,41 +77711,33 @@ in
       sources."when-3.7.7"
       sources."which-1.3.1"
       sources."which-module-2.0.0"
-      sources."widest-line-2.0.1"
-      sources."window-size-0.1.4"
-      sources."windows-release-3.2.0"
+      (sources."widest-line-2.0.1" // {
+        dependencies = [
+          sources."ansi-regex-3.0.0"
+          sources."string-width-2.1.1"
+          sources."strip-ansi-4.0.0"
+        ];
+      })
       sources."winreg-0.0.12"
       sources."wordwrap-1.0.0"
       (sources."wrap-ansi-5.1.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
-          sources."string-width-3.1.0"
           sources."strip-ansi-5.2.0"
         ];
       })
       sources."wrappy-1.0.2"
       sources."write-1.0.3"
       sources."write-file-atomic-2.4.3"
+      sources."ws-7.1.2"
       sources."xdg-basedir-3.0.0"
-      (sources."xml2js-0.4.22" // {
-        dependencies = [
-          sources."xmlbuilder-11.0.1"
-        ];
-      })
-      sources."xmlbuilder-9.0.7"
-      sources."xregexp-2.0.0"
+      sources."xml2js-0.4.22"
+      sources."xmlbuilder-11.0.1"
+      sources."xregexp-4.2.4"
       sources."xtend-4.0.2"
-      sources."y18n-3.2.1"
+      sources."y18n-4.0.0"
       sources."yallist-2.1.2"
-      (sources."yargs-13.2.4" // {
-        dependencies = [
-          sources."ansi-regex-4.1.0"
-          sources."cliui-5.0.0"
-          sources."string-width-3.1.0"
-          sources."strip-ansi-5.2.0"
-          sources."y18n-4.0.0"
-        ];
-      })
+      sources."yargs-13.3.0"
       (sources."yargs-parser-13.1.1" // {
         dependencies = [
           sources."decamelize-1.2.0"
@@ -76059,12 +77747,10 @@ in
       (sources."zip-dir-1.0.2" // {
         dependencies = [
           sources."async-1.5.2"
-          sources."jszip-2.6.1"
         ];
       })
       (sources."zip-stream-1.2.0" // {
         dependencies = [
-          sources."isarray-1.0.0"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
@@ -76084,10 +77770,10 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "4.40.2";
+    version = "4.41.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-4.40.2.tgz";
-      sha512 = "5nIvteTDCUws2DVvP9Qe+JPla7kWPPIDFZv55To7IycHWZ+Z5qBdaBYPyuXWdhggTufZkQwfIK+5rKQTVovm2A==";
+      url = "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz";
+      sha512 = "Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==";
     };
     dependencies = [
       sources."@webassemblyjs/ast-1.8.5"
@@ -76143,7 +77829,7 @@ in
       sources."base64-js-1.3.1"
       sources."big.js-5.2.2"
       sources."binary-extensions-1.13.1"
-      sources."bluebird-3.5.5"
+      sources."bluebird-3.7.1"
       sources."bn.js-4.11.8"
       sources."brace-expansion-1.1.11"
       (sources."braces-2.3.2" // {
@@ -76165,7 +77851,7 @@ in
       sources."cacache-12.0.3"
       sources."cache-base-1.0.1"
       sources."chokidar-2.1.8"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."chrome-trace-event-1.0.2"
       sources."cipher-base-1.0.4"
       (sources."class-utils-0.3.6" // {
@@ -76186,12 +77872,12 @@ in
         ];
       })
       sources."collection-visit-1.0.0"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."commondir-1.0.1"
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
-      sources."console-browserify-1.1.0"
+      sources."console-browserify-1.2.0"
       sources."constants-browserify-1.0.0"
       sources."copy-concurrently-1.0.5"
       sources."copy-descriptor-0.1.1"
@@ -76201,7 +77887,6 @@ in
       sources."create-hmac-1.1.7"
       sources."crypto-browserify-3.12.0"
       sources."cyclist-1.0.1"
-      sources."date-now-0.1.4"
       sources."debug-2.6.9"
       sources."decode-uri-component-0.2.0"
       sources."define-property-2.0.2"
@@ -76211,8 +77896,12 @@ in
       sources."duplexify-3.7.1"
       sources."elliptic-6.5.1"
       sources."emojis-list-2.1.0"
-      sources."end-of-stream-1.4.1"
-      sources."enhanced-resolve-4.1.0"
+      sources."end-of-stream-1.4.4"
+      (sources."enhanced-resolve-4.1.1" // {
+        dependencies = [
+          sources."memory-fs-0.5.0"
+        ];
+      })
       sources."errno-0.1.7"
       sources."eslint-scope-4.0.3"
       sources."esrecurse-4.2.1"
@@ -76266,13 +77955,13 @@ in
       sources."fs.realpath-1.0.0"
       sources."fsevents-1.2.9"
       sources."get-value-2.0.6"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
         ];
       })
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
@@ -76452,7 +78141,7 @@ in
       sources."source-list-map-2.0.1"
       sources."source-map-0.5.7"
       sources."source-map-resolve-0.5.2"
-      (sources."source-map-support-0.5.13" // {
+      (sources."source-map-support-0.5.16" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -76483,7 +78172,7 @@ in
       sources."stream-shift-1.0.0"
       sources."string_decoder-1.1.1"
       sources."tapable-1.1.3"
-      (sources."terser-4.3.1" // {
+      (sources."terser-4.3.9" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -76545,7 +78234,7 @@ in
       sources."wrappy-1.0.2"
       sources."xtend-4.0.2"
       sources."y18n-4.0.0"
-      sources."yallist-3.0.3"
+      sources."yallist-3.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -76560,10 +78249,10 @@ in
   webpack-cli = nodeEnv.buildNodePackage {
     name = "webpack-cli";
     packageName = "webpack-cli";
-    version = "3.3.9";
+    version = "3.3.10";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.9.tgz";
-      sha512 = "xwnSxWl8nZtBl/AFJCOn9pG7s5CYUYdZxmmukv+fAHLcBIHM36dImfpQg3WfShZXeArkWlf6QRw24Klcsv8a5A==";
+      url = "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz";
+      sha512 = "u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==";
     };
     dependencies = [
       sources."ansi-regex-4.1.0"
@@ -76624,7 +78313,7 @@ in
       sources."detect-file-1.0.0"
       sources."emoji-regex-7.0.3"
       sources."emojis-list-2.1.0"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."enhanced-resolve-4.1.0"
       sources."errno-0.1.7"
       sources."escape-string-regexp-1.0.5"
@@ -76677,7 +78366,7 @@ in
         ];
       })
       sources."global-prefix-1.0.2"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -76889,10 +78578,10 @@ in
   webtorrent-cli = nodeEnv.buildNodePackage {
     name = "webtorrent-cli";
     packageName = "webtorrent-cli";
-    version = "3.0.4";
+    version = "3.0.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webtorrent-cli/-/webtorrent-cli-3.0.4.tgz";
-      sha512 = "aIxXrSAtLmENSEfQlg5xs+wV/nRp+wtckilxxpFp22k428L0DHn6jGRBWEDJ99D1lzmm9UD5NvGe2MpbsDOLOg==";
+      url = "https://registry.npmjs.org/webtorrent-cli/-/webtorrent-cli-3.0.5.tgz";
+      sha512 = "+CZvxl0xfjAtWXvJhhcX0W/do/j97KnJCbUwvKPJHQDqfHYAsJE6PZGGLqOlumFvSes+Q7ptVOoA1205lVJfTw==";
     };
     dependencies = [
       sources."@protobufjs/aspromise-1.1.2"
@@ -76906,7 +78595,7 @@ in
       sources."@protobufjs/pool-1.1.0"
       sources."@protobufjs/utf8-1.1.0"
       sources."@types/long-4.0.0"
-      sources."@types/node-10.14.18"
+      sources."@types/node-10.17.2"
       sources."addr-to-ip-port-1.5.1"
       sources."airplay-js-0.3.0"
       sources."async-limiter-1.0.1"
@@ -76955,7 +78644,7 @@ in
       })
       sources."castv2-client-1.2.0"
       sources."charset-1.0.1"
-      sources."chrome-dgram-3.0.3"
+      sources."chrome-dgram-3.0.4"
       sources."chrome-dns-1.0.1"
       sources."chrome-net-3.3.3"
       (sources."chromecasts-1.9.1" // {
@@ -76990,8 +78679,8 @@ in
       sources."ecstatic-4.1.2"
       sources."ee-first-1.1.1"
       sources."elementtree-0.1.7"
-      sources."end-of-stream-1.4.1"
-      sources."es-abstract-1.14.2"
+      sources."end-of-stream-1.4.4"
+      sources."es-abstract-1.16.0"
       sources."es-to-primitive-1.2.0"
       sources."escape-html-1.0.3"
       sources."executable-4.1.1"
@@ -76999,14 +78688,14 @@ in
       sources."freelist-1.0.3"
       (sources."fs-chunk-store-2.0.1" // {
         dependencies = [
-          sources."thunky-1.0.3"
+          sources."thunky-1.1.0"
         ];
       })
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."get-browser-rtc-1.0.2"
       sources."get-stdin-7.0.0"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       sources."has-1.0.3"
       sources."has-symbols-1.0.0"
       sources."he-1.2.0"
@@ -77025,7 +78714,7 @@ in
       sources."is-regex-1.0.4"
       sources."is-symbol-1.0.2"
       sources."is-typedarray-1.0.0"
-      sources."is-wsl-1.1.0"
+      sources."is-wsl-2.1.1"
       sources."isarray-1.0.0"
       sources."junk-3.1.0"
       sources."k-bucket-5.0.0"
@@ -77061,7 +78750,7 @@ in
       sources."ms-2.0.0"
       (sources."multicast-dns-6.2.3" // {
         dependencies = [
-          sources."thunky-1.0.3"
+          sources."thunky-1.1.0"
         ];
       })
       sources."multistream-4.0.0"
@@ -77076,7 +78765,7 @@ in
       sources."object.getownpropertydescriptors-2.0.3"
       sources."on-finished-2.3.0"
       sources."once-1.4.0"
-      sources."open-6.4.0"
+      sources."open-7.0.0"
       sources."package-json-versionify-1.0.4"
       sources."parse-numeric-range-0.0.2"
       (sources."parse-torrent-7.0.1" // {
@@ -77188,7 +78877,7 @@ in
       })
       sources."winreg-1.2.4"
       sources."wrappy-1.0.2"
-      sources."ws-7.1.2"
+      sources."ws-7.2.0"
       sources."xml2js-0.4.22"
       sources."xmlbuilder-11.0.1"
       sources."xmldom-0.1.27"
@@ -77231,7 +78920,7 @@ in
     };
     dependencies = [
       sources."adverb-where-0.2.1"
-      sources."commander-2.20.0"
+      sources."commander-2.20.3"
       sources."e-prime-0.10.2"
       sources."no-cliches-0.2.2"
       sources."passive-voice-0.1.0"
@@ -77251,10 +78940,10 @@ in
   yarn = nodeEnv.buildNodePackage {
     name = "yarn";
     packageName = "yarn";
-    version = "1.17.3";
+    version = "1.19.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/yarn/-/yarn-1.17.3.tgz";
-      sha512 = "CgA8o7nRZaQvmeF/WBx2FC7f9W/0X59T2IaLYqgMo6637wfp5mMEsM3YXoJtKUspnpmDJKl/gGFhnqS+sON7hA==";
+      url = "https://registry.npmjs.org/yarn/-/yarn-1.19.1.tgz";
+      sha512 = "gBnfbL9rYY05Gt0cjJhs/siqQXHYlZalTjK3nXn2QO20xbkIFPob+LlH44ML47GcR4VU9/2dYck1BWFM0Javxw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -77316,7 +79005,7 @@ in
         ];
       })
       sources."bin-version-check-3.0.0"
-      sources."boolean-1.0.0"
+      sources."boolean-2.0.3"
       (sources."boxen-1.3.0" // {
         dependencies = [
           sources."camelcase-4.1.0"
@@ -77381,7 +79070,7 @@ in
       sources."config-chain-1.1.12"
       sources."configstore-3.1.2"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-3.2.1"
+      sources."core-js-3.3.6"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-6.0.5"
@@ -77411,7 +79100,7 @@ in
       sources."duplexer3-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."encodeurl-1.0.2"
-      sources."end-of-stream-1.4.1"
+      sources."end-of-stream-1.4.4"
       sources."env-paths-1.0.0"
       sources."error-ex-1.3.2"
       sources."es6-error-4.1.1"
@@ -77483,14 +79172,14 @@ in
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
+      sources."glob-7.1.5"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
         ];
       })
       sources."glob-to-regexp-0.3.0"
-      (sources."global-agent-2.1.1" // {
+      (sources."global-agent-2.1.5" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -77500,7 +79189,7 @@ in
       sources."globalthis-1.0.0"
       sources."globby-8.0.2"
       sources."got-8.3.2"
-      sources."graceful-fs-4.2.2"
+      sources."graceful-fs-4.2.3"
       sources."grouped-queue-0.3.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -77519,7 +79208,7 @@ in
           sources."kind-of-4.0.0"
         ];
       })
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-cache-semantics-3.8.1"
       sources."http-signature-1.2.0"
       sources."humanize-string-1.0.2"
@@ -77782,7 +79471,7 @@ in
       sources."responselike-1.0.2"
       sources."restore-cursor-2.0.0"
       sources."ret-0.1.15"
-      sources."roarr-2.14.1"
+      sources."roarr-2.14.3"
       sources."root-check-1.0.0"
       sources."run-async-2.3.0"
       sources."rx-4.1.0"
@@ -77796,7 +79485,7 @@ in
       sources."semver-diff-2.1.0"
       sources."semver-regex-1.0.0"
       sources."semver-truncate-1.1.2"
-      sources."serialize-error-4.1.0"
+      sources."serialize-error-5.0.0"
       (sources."set-value-2.0.1" // {
         dependencies = [
           sources."extend-shallow-2.0.1"
@@ -77947,7 +79636,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."twig-1.13.3"
-      sources."type-fest-0.3.1"
+      sources."type-fest-0.8.1"
       sources."typedarray-0.0.6"
       sources."union-value-1.0.1"
       sources."unique-string-1.0.0"
@@ -78009,7 +79698,7 @@ in
         ];
       })
       sources."yeoman-doctor-4.0.0"
-      (sources."yeoman-environment-2.4.0" // {
+      (sources."yeoman-environment-2.6.0" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"

--- a/pkgs/development/node-packages/node-packages-v12.nix
+++ b/pkgs/development/node-packages/node-packages-v12.nix
@@ -256,13 +256,13 @@ let
         sha1 = "1b681c21ff84033c826543090689420d187151dc";
       };
     };
-    "chownr-1.1.2" = {
+    "chownr-1.1.3" = {
       name = "chownr";
       packageName = "chownr";
-      version = "1.1.2";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz";
-        sha512 = "GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==";
+        url = "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz";
+        sha512 = "i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==";
       };
     };
     "class-utils-0.3.6" = {
@@ -697,13 +697,13 @@ let
         sha1 = "5eff8e3e684d569ae4cb2b1282604e8ba62149fa";
       };
     };
-    "glob-7.1.4" = {
+    "glob-7.1.5" = {
       name = "glob";
       packageName = "glob";
-      version = "7.1.4";
+      version = "7.1.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz";
-        sha512 = "hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==";
+        url = "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz";
+        sha512 = "J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==";
       };
     };
     "global-modules-1.0.0" = {
@@ -724,13 +724,13 @@ let
         sha1 = "dbf743c6c14992593c655568cb66ed32c0122ebe";
       };
     };
-    "graceful-fs-4.2.2" = {
+    "graceful-fs-4.2.3" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.2.2";
+      version = "4.2.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz";
-        sha512 = "IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz";
+        sha512 = "a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==";
       };
     };
     "grunt-known-options-1.1.1" = {
@@ -814,13 +814,13 @@ let
         sha512 = "eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==";
       };
     };
-    "hosted-git-info-2.8.4" = {
+    "hosted-git-info-2.8.5" = {
       name = "hosted-git-info";
       packageName = "hosted-git-info";
-      version = "2.8.4";
+      version = "2.8.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz";
-        sha512 = "pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==";
+        url = "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz";
+        sha512 = "kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==";
       };
     };
     "http-signature-1.2.0" = {
@@ -1255,22 +1255,22 @@ let
         sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
       };
     };
-    "minipass-2.8.1" = {
+    "minipass-2.9.0" = {
       name = "minipass";
       packageName = "minipass";
-      version = "2.8.1";
+      version = "2.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minipass/-/minipass-2.8.1.tgz";
-        sha512 = "QCG523ParRcE2+9A6wYh9UI3uy2FFLw4DQaVYQrY5HPfszc5M6VDD+j0QCwHm19LI2imes4RB+NBD8cOJccyCg==";
+        url = "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz";
+        sha512 = "wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==";
       };
     };
-    "minizlib-1.2.2" = {
+    "minizlib-1.3.3" = {
       name = "minizlib";
       packageName = "minizlib";
-      version = "1.2.2";
+      version = "1.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minizlib/-/minizlib-1.2.2.tgz";
-        sha512 = "hR3At21uSrsjjDTWrbu0IMLTpnkpv8IIMFDFaoz43Tmu4LkmAXfH44vNNzpTnf+OAQQCHrb91y/wc2J4x5XgSQ==";
+        url = "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz";
+        sha512 = "6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==";
       };
     };
     "mixin-deep-1.3.2" = {
@@ -2038,22 +2038,22 @@ let
         sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
       };
     };
-    "tar-4.4.11" = {
+    "tar-4.4.13" = {
       name = "tar";
       packageName = "tar";
-      version = "4.4.11";
+      version = "4.4.13";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tar/-/tar-4.4.11.tgz";
-        sha512 = "iI4zh3ktLJKaDNZKZc+fUONiQrSn9HkCFzamtb7k8FFmVilHVob7QsLX/VySAW8lAviMzMbFw4QtFb4errwgYA==";
+        url = "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz";
+        sha512 = "w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==";
       };
     };
-    "temp-0.9.0" = {
+    "temp-0.9.1" = {
       name = "temp";
       packageName = "temp";
-      version = "0.9.0";
+      version = "0.9.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz";
-        sha512 = "YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==";
+        url = "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz";
+        sha512 = "WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==";
       };
     };
     "to-object-path-0.3.0" = {
@@ -2272,13 +2272,13 @@ let
         sha1 = "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f";
       };
     };
-    "yallist-3.0.3" = {
+    "yallist-3.1.1" = {
       name = "yallist";
       packageName = "yallist";
-      version = "3.0.3";
+      version = "3.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz";
-        sha512 = "S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==";
+        url = "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz";
+        sha512 = "a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==";
       };
     };
   };
@@ -2616,7 +2616,7 @@ in
       sources."buffer-from-1.1.1"
       sources."builtins-1.0.3"
       sources."caseless-0.12.0"
-      sources."chownr-1.1.2"
+      sources."chownr-1.1.3"
       sources."code-point-at-1.1.0"
       sources."combined-stream-1.0.8"
       sources."concat-map-0.0.1"
@@ -2651,12 +2651,12 @@ in
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.4"
-      sources."graceful-fs-4.2.2"
+      sources."glob-7.1.5"
+      sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-unicode-2.0.1"
-      sources."hosted-git-info-2.8.4"
+      sources."hosted-git-info-2.8.5"
       sources."http-signature-1.2.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -2675,8 +2675,8 @@ in
       sources."mime-types-2.1.24"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.8.1"
-      sources."minizlib-1.2.2"
+      sources."minipass-2.9.0"
+      sources."minizlib-1.3.3"
       sources."mkdirp-0.5.1"
       sources."ncp-0.4.2"
       sources."nijs-0.0.25"
@@ -2748,8 +2748,8 @@ in
         ];
       })
       sources."strip-ansi-3.0.1"
-      sources."tar-4.4.11"
-      sources."temp-0.9.0"
+      sources."tar-4.4.13"
+      sources."temp-0.9.1"
       (sources."tough-cookie-2.4.3" // {
         dependencies = [
           sources."punycode-1.4.1"
@@ -2768,7 +2768,7 @@ in
       sources."walk-2.3.14"
       sources."wide-align-1.1.3"
       sources."wrappy-1.0.2"
-      sources."yallist-3.0.3"
+      sources."yallist-3.1.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {


### PR DESCRIPTION
###### Motivation for this change

Needed by `vimPlugins.coc-prettier` (see discussion [here](https://github.com/NixOS/nixpkgs/issues/64560) and [here](https://github.com/NixOS/nixpkgs/pull/64426)).

_Fuller context_

[Coc](https://github.com/neoclide/coc.nvim) is a plugin that integrates Intellisense and other async language engines with Neovim/Vim 8 to provide type checking, formatting and other similar capabilities for Vim.

Coc has a modular structure and depends on installing extensions for different languages. Normally, these are installed using `:CocInstall` within Vim, but [there has been an effort to Nix-ify the process by moving the extensions into Nixpkgs](https://github.com/NixOS/nixpkgs/pull/64426): `vimPlugins.coc-go`, `vimPlugins.coc-prettier`, etc.

(Many? All?) Coc extensions are essentially NPM packages. Many of the ones that are currently in `vimPlugins` are broken because they exposing raw source code rather than a properly built NPM package (i.e., one that's had `npm run build` executed). Hence, we need to do two things to fix them:

1. Add the underlying NPM packages to `nodePackages`, then
2. Re-export the resulting package within `vimPlugins` using `buildVimPluginFrom2Nix` with the package output as the source.

~This PR addresses the first step for one extension, `coc-prettier`. A subsequent PR will fix the plugin on the Vim side using an override.~ This PR has been closed in favor of https://github.com/NixOS/nixpkgs/pull/72506, which combines steps 1 and 2 above.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @adisbladis @rvolosatovs 
