### PR TITLE
notekit: init at unstable-FIXME

### DIFF
--- a/pkgs/applications/editors/notekit/default.nix
+++ b/pkgs/applications/editors/notekit/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, wrapGAppsHook
+, cmake, pkgconfig
+, gtkmm3, gtksourceviewmm, gtksourceview3
+, jsoncpp
+}:
+
+stdenv.mkDerivation rec {
+  pname = "notekit-unstable";
+  version = "6c7aa1c37b494ba10a33ed0709a902b6f56ea76c";
+
+  src = fetchFromGitHub {
+    owner = "blackhole89";
+    repo = "notekit";
+    rev = version;
+    sha256 = "0dsnkdjhs0qpp4v075xnjb5jjmccp84bv5rl5c8r5790rply6yc7";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig cmake wrapGAppsHook
+    #cmake ninja libxml2
+    #python3 perl itstool desktop-file-utils
+  ];
+
+  buildInputs = [
+    gtkmm3 gtksourceviewmm
+    jsoncpp gtksourceview3
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/blackhole89/notekit";
+    description = "A GTK3 hierarchical markdown notetaking application with tablet support";
+    maintainers = [];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20124,6 +20124,8 @@ in
 
   nomacs = libsForQt5.callPackage ../applications/graphics/nomacs { };
 
+  notekit = callPackage ../applications/editors/notekit { };
+
   notepadqq = libsForQt5.callPackage ../applications/editors/notepadqq { };
 
   notbit = callPackage ../applications/networking/mailreaders/notbit { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
