### PR TITLE
topgrade: init at 3.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2227,6 +2227,16 @@
     githubId = 8182846;
     name = "Francesco Gazzetta";
   };
+  filalex77 = {
+    email = "brightone@protonmail.com";
+    github = "filalex77";
+    githubId = 12615679;
+    name = "Oleksii Filonenko";
+    keys = [{
+      longkeyid = "rsa3072/0xA1BC8428323ECFE8";
+      fingerpript = "F549 3B7F 9372 5578 FDD3  D0B8 A1BC 8428 323E CFE8";
+    }];
+  };
   FireyFly = {
     email = "nix@firefly.nu";
     github = "FireyFly";

--- a/pkgs/tools/misc/topgrade/default.nix
+++ b/pkgs/tools/misc/topgrade/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "topgrade";
+  version = "3.2.0";
+
+  src = fetchFromGitHub {
+    owner = "r-darwish";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "18pgpdrkcyb1fjy8gxisc0bp688wa2jrs744hw0kj1mjmghwp6bi";
+  };
+
+  cargoSha256 = "0nwhv7j2wbzh6h4jrxsgcyvqi4sj021k74myj5y44asignacvx3i";
+
+  meta = with stdenv.lib; {
+    description = "Upgrade all the things";
+    homepage = "https://github.com/r-darwish/topgrade";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ filalex77 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6631,6 +6631,8 @@ in
 
   toml2nix = (callPackage ../tools/toml2nix { }).toml2nix { };
 
+  topgrade = callPackage ../tools/misc/topgrade {  };
+
   tor = callPackage ../tools/security/tor {
     # remove this, when libevent's openssl is upgraded to 1_1_0 or newer.
     libevent = libevent.override {


### PR DESCRIPTION
## Summary of changes
- maintainers: add filalex77
- topgrade: init at 3.2.0

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/72555)
<!-- Reviewable:end -->
