### PR TITLE
lounge-gtk-theme: init at 1.22

### DIFF
--- a/pkgs/data/themes/lounge/default.nix
+++ b/pkgs/data/themes/lounge/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, meson, ninja, sassc, gtk3, gnome3, gdk-pixbuf, librsvg, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  pname = "lounge-gtk-theme";
+  version = "1.22";
+
+  src = fetchFromGitHub {
+    owner = "monday15";
+    repo = pname;
+    rev = version;
+    sha256 = "1y1wkfsv2zrxqcqr53lmr9743mvzcy4swi5j6sxmk1aykx6ccs1p";
+  };
+
+  nativeBuildInputs = [ meson ninja sassc gtk3 ];
+
+  buildInputs = [ gdk-pixbuf librsvg ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  mesonFlags = [
+    "-D gnome_version=${stdenv.lib.versions.majorMinor gnome3.gnome-shell.version}"
+  ];
+
+  postFixup = ''
+    gtk-update-icon-cache "$out"/share/icons/Lounge-aux;
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple and clean GTK theme with vintage scrollbars, inspired by Absolute, based on Adwaita";
+    homepage = https://github.com/monday15/lounge-gtk-theme;
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17195,6 +17195,8 @@ in
   # lohit-fonts.kashmiri lohit-fonts.konkani lohit-fonts.maithili lohit-fonts.sindhi
   lohit-fonts = recurseIntoAttrs ( callPackages ../data/fonts/lohit-fonts { } );
 
+  lounge-gtk-theme = callPackage ../data/themes/lounge { };
+
   luculent = callPackage ../data/fonts/luculent { };
 
   maia-icon-theme = callPackage ../data/icons/maia-icon-theme { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [lounge-gtk-theme](https://github.com/monday15/lounge-gtk-theme), a GTK theme with a vintage scrollbars, inspired by Absolute, based on Adwaita.

Supported desktop environments: GNOME, XFCE.

![lounge](https://user-images.githubusercontent.com/1217934/68070556-ccfe3900-fd4e-11e9-9de3-191636fef579.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).