### PR TITLE
dino: unstable-2019-09-12 -> unstable-2019-10-28

### DIFF
--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -15,13 +15,13 @@
  }:
 
 stdenv.mkDerivation {
-  name = "dino-unstable-2019-09-12";
+  name = "dino-unstable-2019-10-28";
 
   src = fetchFromGitHub {
     owner = "dino";
     repo = "dino";
-    rev = "c8f2b80978706c4c53deb7ddfb8188c751bcb291";
-    sha256 = "17lc6xiarb174g1hgjfh1yjrr0l2nzc3kba8xp5niwakbx7qicqr";
+    rev = "388cc56674487e7b9e339637369fc55f0e271daf";
+    sha256 = "1v8rnjbzi8qhwb1fv787byxk8ygfs16z2j64h0s6sd3asr4n0kz1";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
This fixes a crash when receiving files via OMEMO.

###### Motivation for this change

Fixing a crash when receiving OMEMO encrypted files.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Mic92
