### PR TITLE
nixos: default `environment.homeBinInPath` to false

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -186,6 +186,13 @@
      The osquery module has been removed.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      Going forward, <literal>~/bin/<literal> in the users home directory will no longer be in <literal>PATH</literal> by default.
+      If you depend on this you should set the option <literal>environment.homeBinInPath</literal> to <literal>true</literal>.
+      The aforementioned option was added this release.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -122,7 +122,7 @@ in
       description = ''
         Include ~/bin/ in $PATH.
       '';
-      default = true;
+      default = false;
       type = types.bool;
     };
 


### PR DESCRIPTION

###### Motivation for this change

This is a more sane default since we do not magically (without opt-in)
pull in binaries from `~/bin`. That is not really an expected behavior
for many users. Users that still want that behavior can now just flip
that switch.

cc @chkno @worldofpeace both have been involved in #68483

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).