### PR TITLE
enlightenment.efl: 1.23.1 -> 1.23.2

### DIFF
--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, SDL, SDL2, alsaLib, avahi, bullet, check, curl, dbus,
-  doxygen, expat, fontconfig, freetype, fribidi, ghostscript, giflib,
-  glib, gst_all_1, gtk3, harfbuzz, ibus, jbig2dec, libGL, libdrm, libinput,
-  libjpeg, libpng, libpulseaudio, libraw, librsvg, libsndfile,
-  libspectre, libtiff, libwebp, libxkbcommon, luajit, lz4, mesa,
-  openjpeg, openssl, poppler, python27Packages, systemd, udev,
-  utillinux, writeText, xorg, zlib
+{ stdenv, fetchurl, meson, ninja, pkgconfig, SDL, SDL2, alsaLib,
+  avahi, bullet, check, curl, dbus, doxygen, expat, fontconfig,
+  freetype, fribidi, ghostscript, giflib, glib, gst_all_1, gtk3,
+  harfbuzz, ibus, jbig2dec, libGL, libdrm, libinput, libjpeg, libpng,
+  libpulseaudio, libraw, librsvg, libsndfile, libspectre, libtiff,
+  libwebp, libxkbcommon, luajit, lz4, mesa, openjpeg, openssl,
+  poppler, python27Packages, systemd, udev, utillinux, writeText,
+  xorg, zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "efl";
-  version = "1.23.1";
+  version = "1.23.2";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/libs/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0q9g4j7k10s1a8rv2ca9v9lydh7ml3zsrqvgncc4qhvdl76208nn";
+    sha256 = "14yljnnmb89s8j6ip08ip5d01zkgzbzr1h4fr4bwk9lh8r59x3ds";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to version [1.23.2](https://www.enlightenment.org/news/efl-1.23.2)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).