### PR TITLE
nixos/ceph: run unprivileged, use state directories, handle non-initialized clusters without config switch

### DIFF
--- a/nixos/modules/services/network-filesystems/ceph.nix
+++ b/nixos/modules/services/network-filesystems/ceph.nix
@@ -401,7 +401,9 @@ in
         mkMerge targets;
 
     systemd.tmpfiles.rules = [
+      "d /etc/ceph - ceph ceph - -"
       "d /run/ceph 0770 ceph ceph -"
+      "d /var/lib/ceph - ceph ceph - -"
     ];
   };
 }

--- a/nixos/tests/ceph-multi-node.nix
+++ b/nixos/tests/ceph-multi-node.nix
@@ -104,6 +104,10 @@ let
     };
   }; };
 
+  # Following deployment is based on the manual deployment described here:
+  # https://docs.ceph.com/docs/master/install/manual-deployment/
+  # For other ways to deploy a ceph cluster, look at the documentation at
+  # https://docs.ceph.com/docs/master/
   testscript = { ... }: ''
     startAll;
 

--- a/nixos/tests/ceph-multi-node.nix
+++ b/nixos/tests/ceph-multi-node.nix
@@ -118,21 +118,12 @@ let
     $monA->mustSucceed(
       "mkdir -p /var/lib/ceph/mgr/ceph-${cfg.monA.name}",
       "mkdir -p /var/lib/ceph/mon/ceph-${cfg.monA.name}",
-      "chown ceph:ceph -R /var/lib/ceph/",
-      "mkdir -p /etc/ceph",
-      "chown ceph:ceph -R /etc/ceph"
     );
     $osd0->mustSucceed(
       "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd0.name}",
-      "chown ceph:ceph -R /var/lib/ceph/",
-      "mkdir -p /etc/ceph",
-      "chown ceph:ceph -R /etc/ceph"
     );
     $osd1->mustSucceed(
       "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd1.name}",
-      "chown ceph:ceph -R /var/lib/ceph/",
-      "mkdir -p /etc/ceph",
-      "chown ceph:ceph -R /etc/ceph"
     );
 
     # Bootstrap ceph-mon daemon
@@ -216,7 +207,7 @@ let
       "systemctl stop ceph-mgr-${cfg.monA.name}",
       "systemctl stop ceph-mon-${cfg.monA.name}"
     );
-    
+
     $monA->succeed("systemctl start ceph.target");
     $monA->waitForUnit("ceph-mon-${cfg.monA.name}");
     $monA->waitForUnit("ceph-mgr-${cfg.monA.name}");
@@ -224,7 +215,7 @@ let
     $osd0->waitForUnit("ceph-osd-${cfg.osd0.name}");
     $osd1->succeed("systemctl start ceph.target");
     $osd1->waitForUnit("ceph-osd-${cfg.osd1.name}");
-    
+
     $monA->succeed("ceph -s | grep 'mon: 1 daemons'");
     $monA->waitUntilSucceeds("ceph -s | grep 'quorum ${cfg.monA.name}'");
     $monA->waitUntilSucceeds("ceph osd stat | grep -e '2 osds: 2 up[^,]*, 2 in'");

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -83,9 +83,6 @@ let
       "mkdir -p /var/lib/ceph/mon/ceph-${cfg.monA.name}",
       "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd0.name}",
       "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd1.name}",
-      "mkdir -p /etc/ceph",
-      "chown ceph:ceph -R /etc/ceph",
-      "chown ceph:ceph -R /var/lib/ceph/",
     );
 
     # Bootstrap ceph-mon daemon
@@ -166,13 +163,13 @@ let
       "systemctl stop ceph-mgr-${cfg.monA.name}",
       "systemctl stop ceph-mon-${cfg.monA.name}"
     );
-    
+
     $monA->succeed("systemctl start ceph.target");
     $monA->waitForUnit("ceph-mon-${cfg.monA.name}");
     $monA->waitForUnit("ceph-mgr-${cfg.monA.name}");
     $monA->waitForUnit("ceph-osd-${cfg.osd0.name}");
     $monA->waitForUnit("ceph-osd-${cfg.osd1.name}");
-    
+
     $monA->succeed("ceph -s | grep 'mon: 1 daemons'");
     $monA->waitUntilSucceeds("ceph -s | grep 'quorum ${cfg.monA.name}'");
     $monA->waitUntilSucceeds("ceph osd stat | grep -e '2 osds: 2 up[^,]*, 2 in'");

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -69,6 +69,10 @@ let
     };
   }; };
 
+  # Following deployment is based on the manual deployment described here:
+  # https://docs.ceph.com/docs/master/install/manual-deployment/
+  # For other ways to deploy a ceph cluster, look at the documentation at
+  # https://docs.ceph.com/docs/master/
   testscript = { ... }: ''
     startAll;
 


### PR DESCRIPTION
###### Motivation for this change
    nixos/ceph: create /etc/ceph and /var/lib/ceph via tmpfiles
    
    We seem to be relying on those being present during runtime anyways.

    nixos/ceph: run unprivileged, use StateDirectory and tmpfiles, don't pass extraServiceConfig
    
    Don't pass user and group to ceph, and rely on it to drop ceps, but let
    systemd handle running it as the appropriate user.
    
    Use StateDirectory to create directories in
    /var/lib/ceph/${daemonType}/${clusterName}-${daemonId}.
    
    There previously was a condition on daemonType being one of mds,mon,rgw
    or mgr. We only instantiate makeServices with these types, and "osd" was
    special.
    
    In the osd case, test examples suggest it'd be in something like
    /var/lib/ceph/osd/ceph-${cfg.osd0.name} - so it's not special at all,
    but exactly the same. Worst case, we'd end up with a directory we're
    simply not using.
    
    Unfortunately, that's not enough, as some of these directories already
    need to exist during initialization, so we use some tmpfiles rules to
    ensure they already exist on boot, too.
    
    After that, we however can remove all the manual steps needed to create
    these directories.
    
    This also inlines the extraServiceConfig into the makeService function,
    as we have conditionals depending on daemonType there anyways.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
