### PR TITLE
pythonPackages.checkmanifest: fix build

### DIFF
--- a/pkgs/development/python-modules/check-manifest/default.nix
+++ b/pkgs/development/python-modules/check-manifest/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi }:
+{ stdenv, buildPythonPackage, fetchPypi, toml }:
 
 buildPythonPackage rec {
   pname = "check-manifest";
@@ -8,6 +8,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "42de6eaab4ed149e60c9b367ada54f01a3b1e4d6846784f9b9710e770ff5572c";
   };
+
+  propagatedBuildInputs = [ toml ];
 
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing #72475

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

original error:
```
builder for '/nix/store/j3xhy6hmv970calgxarhq2xgk52wz8ny-python3.7-check-manifest-0.40.drv' failed with exit code 1; last 10 log lines:
  adding 'check_manifest-0.40.dist-info/top_level.txt'
  adding 'check_manifest-0.40.dist-info/RECORD'
  removing build/bdist.linux-x86_64/wheel
  Finished executing setuptoolsInstallPhase
  installing
  Executing pipInstallPhase
  /build/check-manifest-0.40/dist /build/check-manifest-0.40
  Processing ./check_manifest-0.40-py2.py3-none-any.whl
  ERROR: Could not find a version that satisfies the requirement toml (from check-manifest==0.40) (from versions: none)
  ERROR: No matching distribution found for toml (from check-manifest==0.40)
cannot build derivation '/nix/store/wkkk69aiby4p53442q4j4hcc91phsvp5-devpi-client-5.0.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/k1dmrw7mkkvc0krc2gws4jsdhnx7k39v-env.drv': 1 dependencies couldn't be built
```
```
[4 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/72607
4 package were build:
devpi-client python27Packages.check-manifest python37Packages.check-manifest python38Packages.check-manifest
```