### PR TITLE
esphome: 1.13.6 -> 1.14.1

### DIFF
--- a/pkgs/servers/home-assistant/esphome.nix
+++ b/pkgs/servers/home-assistant/esphome.nix
@@ -1,4 +1,4 @@
-{ lib, python3, platformio, esptool, git, protobuf3_7, fetchpatch }:
+{ lib, python3, platformio, esptool, git, protobuf3_10, fetchpatch }:
 
 let
   python = python3.override {
@@ -11,24 +11,19 @@ let
         };
       });
       protobuf = super.protobuf.override {
-        protobuf = protobuf3_7;
+        protobuf = protobuf3_10;
       };
+
     };
   };
 
 in python.pkgs.buildPythonApplication rec {
   pname = "esphome";
-  version = "1.13.6";
+  version = "1.14.1";
 
   src = python.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "53148fc43c6cc6736cb7aa4cc1189caa305812061f55289ff916f8bd731ac623";
-  };
-
-  patches = fetchpatch {
-    url = https://github.com/esphome/esphome/pull/694.patch;
-    includes = [ "esphome/voluptuous_schema.py" ];
-    sha256 = "0i2v1d6mcgc94i9rkaqmls7iyfbaisdji41sfc7bh7cf2j824im9";
+    sha256 = "1hw1q2fck9429077w207rk65a1krzyi6qya5pzjkpw4av5s0v0g3";
   };
 
   ESPHOME_USE_SUBPROCESS = "";
@@ -36,7 +31,15 @@ in python.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python.pkgs; [
     voluptuous pyyaml paho-mqtt colorlog
     tornado protobuf tzlocal pyserial ifaddr
+    protobuf
   ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "protobuf==3.10.0" "protobuf~=3.10" \
+      --replace "paho-mqtt==1.4.0" "paho-mqtt~=1.4" \
+      --replace "tornado==5.1.1" "tornado~=5.1"
+  '';
 
   makeWrapperArgs = [
     # platformio is used in esphomeyaml/platformio_api.py


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date while reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
