### PR TITLE
octoprint: 1.3.11 -> 1.3.12

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -56,17 +56,18 @@ let
     "websocket-client"
     "wrapt"
     "sentry-sdk"
+    "werkzeug" # 0.16 just deprecates some stuff
   ];
 
 in py.pkgs.buildPythonApplication rec {
   pname = "OctoPrint";
-  version = "1.3.11";
+  version = "1.3.12";
 
   src = fetchFromGitHub {
     owner  = "foosel";
     repo   = "OctoPrint";
     rev    = version;
-    sha256 = "1102ki1819wsmkfg4riz4i0hjlr3w6nsvk8wrzqq0lc0s5ycf4jx";
+    sha256 = "1lmqssgwjyhknjf3x58g7cr0fqz7fs5a3rl07r69wfpch63ranyd";
   };
 
   propagatedBuildInputs = with py.pkgs; [
@@ -75,7 +76,7 @@ in py.pkgs.buildPythonApplication rec {
     psutil pyserial flask_login netaddr markdown sockjs-tornado
     pylru pyyaml sarge feedparser netifaces click websocket_client
     scandir chainmap future futures wrapt monotonic emoji
-    frozendict cachelib sentry-sdk typing
+    frozendict cachelib sentry-sdk typing filetype
   ] ++ lib.optionals stdenv.isDarwin [ py.pkgs.appdirs ];
 
   checkInputs = with py.pkgs; [ nose mock ddt ];
@@ -96,6 +97,6 @@ in py.pkgs.buildPythonApplication rec {
     homepage = https://octoprint.org/;
     description = "The snappy web interface for your 3D printer";
     license = licenses.agpl3;
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ abbradar gebner ];
   };
 }

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -87,13 +87,13 @@ let
 
     stlviewer = buildPlugin rec {
       pname = "STLViewer";
-      version = "0.4.1";
+      version = "0.4.2";
 
       src = fetchFromGitHub {
         owner = "jneilliii";
         repo = "OctoPrint-STLViewer";
-        rev = "v${version}";
-        sha256 = "1f64s37g2d79g76v0vjnjrc2jp2gwrsnfgx7w3n0hkf1lz1pjkm0";
+        rev = version;
+        sha256 = "0mkvh44fn2ch4z2avsdjwi1rp353ylmk9j5fln4x7rx8ph8y7g2b";
       };
 
       meta = with stdenv.lib; {

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -47,13 +47,13 @@ let
 
     mqtt = buildPlugin rec {
       pname = "MQTT";
-      version = "0.8.0";
+      version = "0.8.6";
 
       src = fetchFromGitHub {
         owner = "OctoPrint";
         repo = "OctoPrint-MQTT";
         rev = version;
-        sha256 = "1318pgwy39gkdqgll3q5lwm7avslgdwyiwb5v8m23cgyh5w8cjq7";
+        sha256 = "0y1jnfplcy8mh3szrfbbvngl02j49cbdizglrfsry4fvqg50zjxd";
       };
 
       propagatedBuildInputs = with python2Packages; [ paho-mqtt ];

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -168,13 +168,13 @@ let
 
     printtimegenius = buildPlugin rec {
       pname = "PrintTimeGenius";
-      version = "1.3.1";
+      version = "2.0.2";
 
       src = fetchFromGitHub {
         owner = "eyal0";
         repo = "OctoPrint-${pname}";
         rev = version;
-        sha256 = "0ijv1nxmikv06a00hqqkqri6wnydqh6lwcx07pmvw6jy706jhy28";
+        sha256 = "1w4jm42434x87sbih45brkb9krik851vxkz153w3w5c8p74kgg6f";
       };
 
       preConfigure = ''

--- a/pkgs/tools/misc/marlin-calc/default.nix
+++ b/pkgs/tools/misc/marlin-calc/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "marlin-calc";
-  version = "2019-06-04";
+  version = "2019-10-17";
 
   src = fetchFromGitHub {
     owner = "eyal0";
     repo = "Marlin";
-    rev = "4120d1c72d6c32e9c5cc745c05d20963ba4bbca3";
-    sha256 = "06aly7s4k1r31njm43sbxq9a0127sw43pnaddh92a3cc39rbj2va";
+    rev = "3d5a5c86bea35a2a169eb56c70128bf2d070feef";
+    sha256 = "14sqajm361gnrcqv84g7kbmyqm8pppbhqsabszc4j2cn7vbwkdg5";
   };
 
   buildPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New upstream version.  I also updated all the plugins to the latest versions.

I didn't print anything yet, but octoprint is running fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar @peterhoeg 
