### PR TITLE
cargo-geiger: init at 0.7.3

### DIFF
--- a/pkgs/development/tools/rust/cargo-geiger/default.nix
+++ b/pkgs/development/tools/rust/cargo-geiger/default.nix
@@ -13,9 +13,18 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1lm8dx19svdpg99zbpfcm1272n18y63sq756hf6k99zi51av17xc";
   };
 
-  doCheck = false;
-
   cargoSha256 = "16zvm2y0j7ywv6fx0piq99g8q1sayf3qipd6adrwyqyg8rbf4cw6";
+
+  # Multiple tests require internet connectivity, so they are disabled here.
+  # If we ever get cargo-insta (https://crates.io/crates/insta) in tree,
+  # we might be able to run these with something like
+  # `cargo insta review` in the `preCheck` phase.
+  checkPhase = ''
+    cargo test -- \
+    --skip test_package::case_2 \
+    --skip test_package::case_3 \
+    --skip test_package::case_6
+  '';
 
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/tools/rust/cargo-geiger/default.nix
+++ b/pkgs/development/tools/rust/cargo-geiger/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, fetchFromGitHub
+, rustPlatform, pkgconfig
+, openssl, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-geiger";
+  version = "0.7.3";
+
+  src = fetchFromGitHub {
+    owner = "anderejd";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "1lm8dx19svdpg99zbpfcm1272n18y63sq756hf6k99zi51av17xc";
+  };
+
+  doCheck = false;
+
+  cargoSha256 = "16zvm2y0j7ywv6fx0piq99g8q1sayf3qipd6adrwyqyg8rbf4cw6";
+
+  buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  meta = with lib; {
+    description = "Detects usage of unsafe Rust in a Rust crate and its dependencies.";
+    homepage = https://github.com/anderejd/cargo-geiger;
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = with maintainers; [ evanjs ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8523,6 +8523,9 @@ in
   cargo-bloat = callPackage ../development/tools/rust/cargo-bloat { };
   cargo-expand = callPackage ../development/tools/rust/cargo-expand { };
   cargo-fuzz = callPackage ../development/tools/rust/cargo-fuzz { };
+  cargo-geiger = callPackage ../development/tools/rust/cargo-geiger {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-inspect = callPackage ../development/tools/rust/cargo-inspect {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[cargo-geiger](https://github.com/anderejd/cargo-geiger): Detects usage of unsafe Rust in a Rust crate and its dependencies.

I recently discovered [safety-dance](https://github.com/rust-secure-code/safety-dance) and figured cargo-geiger would be a nice utility to have on nixpkgs.
___
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
___
Seems to work fine without any tweaks.

Some sample output from the [url](https://github.com/servo/rust-url) crate:
```
    Checking matches v0.1.8
    Checking smallvec v0.6.12
    Checking percent-encoding v2.1.0 (/home/evanjs/src/crates/rust-url/percent_encoding)
    Checking unicode-bidi v0.3.4
    Checking unicode-normalization v0.1.8
    Checking idna v0.2.0 (/home/evanjs/src/crates/rust-url/idna)
    Checking url v2.1.0 (/home/evanjs/src/crates/rust-url)
     Finished dev [unoptimized + debuginfo] target(s) in 4.10s
    Scanning done

Metric output format: x/y
    x = unsafe code used by the build
    y = total unsafe code found in the crate

Symbols: 
    :) = No `unsafe` usage found, declares #![forbid(unsafe_code)]
    ?  = No `unsafe` usage found, missing #![forbid(unsafe_code)]
    !  = `unsafe` usage found

Functions  Expressions  Impls  Traits  Methods  Dependency

0/0        6/6          0/0    0/0     0/0      !  url 2.1.0
0/0        1/1          0/0    0/0     0/0      !  ├── idna 0.2.0
0/0        0/0          0/0    0/0     0/0      ?  │   ├── matches 0.1.8
0/0        0/0          0/0    0/0     0/0      :) │   ├── unicode-bidi 0.3.4
0/0        0/0          0/0    0/0     0/0      ?  │   │   └── matches 0.1.8
0/0        20/20        0/0    0/0     0/0      !  │   └── unicode-normalization 0.1.8
2/2        322/322      4/4    1/1     13/13    !  │       └── smallvec 0.6.12
0/0        0/0          0/0    0/0     0/0      ?  ├── matches 0.1.8
0/0        3/3          0/0    0/0     0/0      !  └── percent-encoding 2.1.0
```
___
I had to use `rev = "${pname}-${version}";` for `rev` as there are two programs in the repository (including the releases section): cargo-geiger and geiger.

I'm following the updates for `cargo-geiger`, so I have to use this rather than e.g. `v${version}`.
Happy to do whatever is cleanest, though.
___
Also, I have not tested on a Mac, but would be happy if somebody was able to do so.

Aside from installation, all that needs to be done for testing is running `cargo geiger` from a "normal" (/singular) Rust project -- e.g. not a virtual workspace, such as the root of the main Rust repo.
___
Finally, I noticed there are categories for `development/tools/rust` and  `tools/package-management`.  
There seemed to be some overlap between the two categories, so I just settled with `development/tools/rust` for now. 
Happy to modify this if there is a better option.