### PR TITLE
Tweak cross-compilation of some netbsd stuff

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -127,9 +127,10 @@ let
     nativeBuildInputs = [ makeMinimal ];
     buildInputs = [ zlib ];
 
-    # for some reason the build system re-runs configure with HOST_CC
+    # the build system re-runs `./configure` with `HOST_CC` (which is their
+    # name for Build CC) as a compiler to make `defs.mk`, which is installed
     depsBuildBuild = [ buildPackages.stdenv.cc ] ++ buildInputs;
-    HOST_CC = "${buildPackages.stdenv.cc}/bin/cc";
+    HOST_CC = "${buildPackages.stdenv.cc.targetPrefix}cc";
 
     # temporarily use gnuinstall for bootstrapping
     # bsdinstall will be built later
@@ -215,7 +216,6 @@ let
     version = "8.0";
     nativeBuildInputs = [ ];
     propagatedBuildInputs = [ compat ];
-    buildInputs = [ stdenv.cc ];
     extraPaths = [
       (fetchNetBSD "lib/libc/gen/fts.c" "8.0" "1a8hmf26242nmv05ipn3ircxb0jqmmi66rh78kkyi9vjwkfl3qn7")
       (fetchNetBSD "lib/libc/include/namespace.h" "8.0" "1sjvh9nw3prnk4rmdwrfsxh6gdb9lmilkn46jcfh3q5c8glqzrd7")

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -127,6 +127,10 @@ let
     nativeBuildInputs = [ makeMinimal ];
     buildInputs = [ zlib ];
 
+    # for some reason the build system re-runs configure with HOST_CC
+    depsBuildBuild = [ buildPackages.stdenv.cc ] ++ buildInputs;
+    HOST_CC = "${buildPackages.stdenv.cc}/bin/cc";
+
     # temporarily use gnuinstall for bootstrapping
     # bsdinstall will be built later
     makeFlags = [
@@ -211,6 +215,7 @@ let
     version = "8.0";
     nativeBuildInputs = [ ];
     propagatedBuildInputs = [ compat ];
+    buildInputs = [ stdenv.cc ];
     extraPaths = [
       (fetchNetBSD "lib/libc/gen/fts.c" "8.0" "1a8hmf26242nmv05ipn3ircxb0jqmmi66rh78kkyi9vjwkfl3qn7")
       (fetchNetBSD "lib/libc/include/namespace.h" "8.0" "1sjvh9nw3prnk4rmdwrfsxh6gdb9lmilkn46jcfh3q5c8glqzrd7")
@@ -218,9 +223,9 @@ let
     ];
     skipIncludesPhase = true;
     buildPhase = ''
-      cc  -c -Iinclude -Ilib/libc/include lib/libc/gen/fts.c \
+      "$CC" -c -Iinclude -Ilib/libc/include lib/libc/gen/fts.c \
           -o lib/libc/gen/fts.o
-      ar -rsc libfts.a lib/libc/gen/fts.o
+      "$AR" -rsc libfts.a lib/libc/gen/fts.o
     '';
     installPhase = ''
       runHook preInstall


### PR DESCRIPTION
###### Motivation for this change

_I have no idea what I am doing._

I am dead set on getting systemd compiled with musl (almost there), and these things stood on my way, so I had to do _something_.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matthewbauer or @Ericson2314 or I don’t even know