### PR TITLE
paperwork: add missing dependency

### DIFF
--- a/pkgs/applications/office/paperwork/default.nix
+++ b/pkgs/applications/office/paperwork/default.nix
@@ -61,7 +61,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = with python3Packages; [
-    paperwork-backend pypillowfight gtk3 cairo pyxdg dateutil setuptools
+    paperwork-backend pypillowfight gtk3 cairo pyxdg dateutil setuptools pandas
   ];
 
   makeWrapperArgs = [


### PR DESCRIPTION
###### Motivation for this change
noticed it didn't work while reviewing #72638 

before:
```
[nix-shell:/home/jon/.cache/nix-review/pr-72638-1]$ ./results/paperwork/bin/paperwork --help
/nix/store/2cj2np0bkyjpqgvjwdx1dhwdi37agml6-paperwork-1.2.4/lib/python3.7/site-packages/paperwork/paperwork.py:27: PyGIWarning: Notify was imported without specifying a version first. Use gi.require_version('Notify', '0.7') before import to ensure that the right version gets loaded.
  from gi.repository import Notify  # noqa: E402
Traceback (most recent call last):
  File "/nix/store/2cj2np0bkyjpqgvjwdx1dhwdi37agml6-paperwork-1.2.4/bin/.paperwork-wrapped", line 6, in <module>
    from paperwork.paperwork import main
  File "/nix/store/2cj2np0bkyjpqgvjwdx1dhwdi37agml6-paperwork-1.2.4/lib/python3.7/site-packages/paperwork/paperwork.py", line 33, in <module>
    import pyinsane2  # noqa: E402
  File "/nix/store/cv5wbnlb925snbgj3idw0cnzzmlidmh4-python3.7-pyinsane2-2.0.13/lib/python3.7/site-packages/pyinsane2/__init__.py", line 15, in <module>
    from .sane.abstract_proc import *  # noqa
  File "/nix/store/cv5wbnlb925snbgj3idw0cnzzmlidmh4-python3.7-pyinsane2-2.0.13/lib/python3.7/site-packages/pyinsane2/sane/abstract_proc.py", line 9, in <module>
    import PIL.Image
  File "/nix/store/0nwifhd9n01pwg858rbr7xnqgh93r4hv-python3.8-Pillow-6.2.1/lib/python3.8/site-packages/PIL/Image.py", line 90, in <module>
    from . import _imaging as core
ImportError: cannot import name '_imaging' from 'PIL' (/nix/store/0nwifhd9n01pwg858rbr7xnqgh93r4hv-python3.8-Pillow-6.2.1/lib/python3.8/site-packages/PIL/__init__.py)
```
after:
```
[16:44:20] jon@jon-desktop /home/jon/projects/nixpkgs (master)
$ ./result/bin/paperless

Type 'manage.py help <subcommand>' for help on a specific subcommand.

Available subcommands:
...
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
