### PR TITLE
tre: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1563,6 +1563,12 @@
     githubId = 14032;
     name = "Daniel Brockman";
   };
+  dduan = {
+    email = "daniel@duan.ca";
+    github = "dduan";
+    githubId = 75067;
+    name = "Daniel Duan"
+  };
   deepfire = {
     email = "_deepfire@feelingofgreen.ru";
     github = "deepfire";

--- a/pkgs/tools/system/tre/default.nix
+++ b/pkgs/tools/system/tre/default.nix
@@ -1,0 +1,24 @@
+with import <nixpkgs> {};
+
+rustPlatform.buildRustPackage rec {
+  name = "tre-${version}";
+  version = "v0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "dduan";
+    repo = "tre";
+    rev = "${version}";
+    sha256 = "1fazw2wn738iknbv54gv7qll7d4q2gy9bq1s3f3cv21cdv6bqral";
+  };
+
+  cargoSha256 = "1lf7g96jh7apw537a0sm3a1ivf36bbxqbzllldjkbrh0x0fb4wpb";
+  verifyCargoDeps = true;
+
+  meta = with stdenv.lib; {
+    description = "Tree command, improved";
+    homepage = https://github.com/dduan/tre;
+    license = licenses.mit;
+    maintainers = [ maintainers.dduan ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
tre is a improved version of the command `tree`. It's main additions:

1. colored output
2. ignores paths specified in .gitignore
3. editor alias for each entity listed

Source/Homepage: https://github.com/dduan/tre

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

As the author, I'd love to make this CLI tool available to Nix/NixOS users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

(I'd like to be the maintainer of this package. I'm the author of this command line tool)
