### PR TITLE
digimend drivers for graphics tablets

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -863,6 +863,7 @@
   ./services/x11/hardware/multitouch.nix
   ./services/x11/hardware/synaptics.nix
   ./services/x11/hardware/wacom.nix
+  ./services/x11/hardware/digimend.nix
   ./services/x11/hardware/cmt.nix
   ./services/x11/gdk-pixbuf.nix
   ./services/x11/redshift.nix

--- a/nixos/modules/services/x11/hardware/digimend.nix
+++ b/nixos/modules/services/x11/hardware/digimend.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.xserver.digimend;
+
+  pkg = config.boot.kernelPackages.digimend;
+
+in
+
+{
+
+  options = {
+
+    services.xserver.digimend = {
+
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to enable the digimend drivers for Huion/XP-Pen/etc. tablets.
+        '';
+      };
+
+    };
+
+  };
+
+
+  config = mkIf cfg.enable {
+
+    # digimend drivers use xsetwacom and wacom X11 drivers
+    services.xserver.wacom.enable = true;
+
+    boot.extraModulePackages = [ pkg ];
+
+    environment.etc."X11/xorg.conf.d/50-digimend.conf".source =
+      "${pkg}/usr/share/X11/xorg.conf.d/50-digimend.conf";
+
+  };
+
+}

--- a/pkgs/os-specific/linux/digimend/default.nix
+++ b/pkgs/os-specific/linux/digimend/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, kernel }:
+
+assert stdenv.lib.versionAtLeast kernel.version "3.5";
+
+stdenv.mkDerivation rec {
+  pname = "digimend";
+  version = "unstable-2019-06-18";
+
+  src = fetchFromGitHub {
+    owner = "digimend";
+    repo = "digimend-kernel-drivers";
+    rev = "8b228a755e44106c11f9baaadb30ce668eede5d4";
+    sha256 = "1l54j85540386a8aypqka7p5hy1b63cwmpsscv9rmmf10f78v8mm";
+  };
+
+  INSTALL_MOD_PATH = "\${out}";
+
+  postPatch = ''
+    sed 's/udevadm /true /' -i Makefile
+    sed 's/depmod /true /' -i Makefile
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  postInstall = ''
+    # Remove module reload hack.
+    # The hid-rebind unloads and then reloads the hid-* module to ensure that
+    # the extra/ module is loaded.
+    rm -r $out/lib/udev
+  '';
+
+  makeFlags = [
+    "KVERSION=${kernel.modDirVersion}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "DESTDIR=${placeholder "out"}"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "DIGImend graphics tablet drivers for the Linux kernel";
+    homepage = "https://digimend.github.io/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ gebner ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/kmod/aggregator.nix
+++ b/pkgs/os-specific/linux/kmod/aggregator.nix
@@ -29,7 +29,7 @@ buildEnv {
       # kernel version number, otherwise depmod will use `uname -r'.
       if test -w $out/lib/modules/$kernelVersion; then
           rm -f $out/lib/modules/$kernelVersion/modules.!(builtin*|order*)
-          ${kmod}/bin/depmod -b $out -a $kernelVersion
+          ${kmod}/bin/depmod -b $out -C $out/etc/depmod.d -a $kernelVersion
       fi
     '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16120,6 +16120,8 @@ in
 
     deepin-anything = callPackage ../os-specific/linux/deepin-anything { };
 
+    digimend = callPackage ../os-specific/linux/digimend { };
+
     dpdk = callPackage ../os-specific/linux/dpdk { };
 
     exfat-nofuse = callPackage ../os-specific/linux/exfat { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This adds the [digimend drivers](https://digimend.github.io/) for Huion/etc. graphics tablets.  These are only kernel modules; the userspace part uses the same `xsetwacom` tool and X11 drivers as wacom tablets.

The upstream kernel already contains an `hid-uclogic` module which supports some tablets.  The digimend drivers contain an updated version of this module.  The original module is overriden via a configuration file in `/etc/depmod.d`.  To support this override, I had to add an extra argument to our `depmod` invocation so that it searches for configuration files in `$out/etc/depmod.d`.

Tested with a Huion HS610.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
