### PR TITLE
lkvm: init from https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git

### DIFF
--- a/pkgs/os-specific/linux/kvmtool/default.nix
+++ b/pkgs/os-specific/linux/kvmtool/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchgit, libbfd, zlib, libaio, glibc }:
+
+stdenv.mkDerivation {
+  name = "kvmtool";
+  version = "unstable-2020-05-19";
+
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git";
+    rev = "b4fc4f605fc66a0942e88f37b3a4b18671e32b0c";
+    sha256 = "0kyb3rm98wzwgjs06crcgb39547rr4px4vap8ivm7yqnwbphr67f";
+  };
+
+  buildInputs = [ libbfd zlib libaio glibc glibc.static];
+
+  buildPhase = ''
+    make all
+  '';
+  makeFlags = [ "prefix=${placeholder "out"}" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git";
+    description = "Native Linux KVM tool";
+    longDescription = ''
+      kvmtool is a lightweight tool for hosting KVM guests. As a pure virtualization
+      tool it only supports guests using the same architecture, though it supports
+      running 32-bit guests on those 64-bit architectures that allow this.
+
+      From the original announcement email:
+      -------------------------------------------------------
+      The goal of this tool is to provide a clean, from-scratch, lightweight
+      KVM host tool implementation that can boot Linux guest images (just a
+      hobby, won't be big and professional like QEMU) with no BIOS
+      dependencies and with only the minimal amount of legacy device
+      emulation.
+
+      It's great as a learning tool if you want to get your feet wet in
+      virtualization land: it's only 5 KLOC of clean C code that can already
+      boot a guest Linux image.
+
+      Right now it can boot a Linux image and provide you output via a serial
+      console, over the host terminal, i.e. you can use it to boot a guest
+      Linux image in a terminal or over ssh and log into the guest without
+      much guest or host side setup work needed.
+    '';
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ zokrezyl ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17480,6 +17480,8 @@ in
 
   qemu_kvm = lowPrio (qemu.override { hostCpuOnly = true; });
 
+  kvmtool = callPackage ../os-specific/linux/kvmtool {};
+
   # See `xenPackages` source for explanations.
   # Building with `xen` instead of `xen-slim` is possible, but makes no sense.
   qemu_xen = lowPrio (qemu.override { hostCpuOnly = true; xenSupport = true; xen = xen-slim; });


### PR DESCRIPTION
#### Motivation for this change

New expression

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


