### PR TITLE
[19.09] accountsservice: fix vendor extensions

### DIFF
--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation rec {
     })
     ./no-create-dirs.patch
     ./Disable-methods-that-change-files-in-etc.patch
+    # Fixes https://github.com/NixOS/nixpkgs/issues/72396
+    ./drop-prefix-check-extensions.patch
     # Systemd unit improvements. Notably using StateDirectory eliminating the
     # need of an ad-hoc script.
     (fetchpatch {

--- a/pkgs/development/libraries/accountsservice/drop-prefix-check-extensions.patch
+++ b/pkgs/development/libraries/accountsservice/drop-prefix-check-extensions.patch
@@ -1,0 +1,22 @@
+diff --git a/src/extensions.c b/src/extensions.c
+index 038dcb2..830465d 100644
+--- a/src/extensions.c
++++ b/src/extensions.c
+@@ -121,16 +121,7 @@ daemon_read_extension_directory (GHashTable  *ifaces,
+                         continue;
+                 }
+ 
+-                /* Ensure it looks like "../../dbus-1/interfaces/${name}" */
+-                const gchar * const prefix = "../../dbus-1/interfaces/";
+-                if (g_str_has_prefix (symlink, prefix) && g_str_equal (symlink + strlen (prefix), name)) {
+-                        daemon_read_extension_file (ifaces, filename);
+-                }
+-                else {
+-                        g_warning ("Found accounts service vendor extension symlink %s, but it must be exactly "
+-                                   "equal to '../../dbus-1/interfaces/%s' for forwards-compatibility reasons.",
+-                                   filename, name);
+-                }
++                daemon_read_extension_file (ifaces, filename);
+         }
+ 
+         g_dir_close (dir);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
backports  #72400

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
