### PR TITLE
lib.systems: handle mips family properly

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -91,10 +91,6 @@ rec {
           powerpcle = "ppc";
           powerpc64 = "ppc64";
           powerpc64le = "ppc64le";
-          mips = "mips";
-          mipsel = "mipsel";
-          mips64 = "mips64";
-          mips64el = "mips64el";
         }.${final.parsed.cpu.name} or final.parsed.cpu.name;
 
       emulator = pkgs: let

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -79,6 +79,7 @@ rec {
         else if final.isAarch64 then "arm64"
         else if final.isx86_32 then "x86"
         else if final.isx86_64 then "ia64"
+        else if final.isMips then "mips"
         else final.parsed.cpu.name;
 
       qemuArch =
@@ -90,6 +91,10 @@ rec {
           powerpcle = "ppc";
           powerpc64 = "ppc64";
           powerpc64le = "ppc64le";
+          mips = "mips";
+          mipsel = "mipsel";
+          mips64 = "mips64";
+          mips64el = "mips64el";
         }.${final.parsed.cpu.name} or final.parsed.cpu.name;
 
       emulator = pkgs: let

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -327,6 +327,7 @@ rec {
         }
       ];
     };
+    gnuabi64     = { abi = "64"; };
 
     musleabi     = { float = "soft"; };
     musleabihf   = { float = "hard"; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix "Unknown abi" error for system `mips64{el,}-unknown-linux-gnuabi64`. (When specified `crossSystem`)
Fix `kernelArch` and `qemuArch` for system `mips{64,}{el,}-unknown-linux-*`

Note that this **just fix parsing**. Packages are not tested on these platforms yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
