### PR TITLE
libjpeg-turbo: Add flag to build static libraries as well

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, nasm }:
+{ stdenv, fetchurl, cmake, nasm, enableStatic ? false }:
 
 stdenv.mkDerivation rec {
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake nasm ];
 
   cmakeFlags = [
-    "-DENABLE_STATIC=0"
+    "-DENABLE_STATIC=${if enableStatic then "1" else "0"}"
   ];
 
   doInstallCheck = true;


### PR DESCRIPTION
#### Motivation for this change

Being able to link `libjpeg` statically.

Tested in https://github.com/nh2/static-haskell-nix/pull/65.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vcunat 

FYI @matthewbauer 
