### PR TITLE
shogun: switch to using opencv3

### DIFF
--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -7,11 +7,11 @@
 , libarchive, libxml2
 # extra support
 , pythonSupport ? true, pythonPackages ? null
-, opencvSupport ? false, opencv ? null
+, opencvSupport ? false, opencv3 ? null
 }:
 
 assert pythonSupport -> pythonPackages != null;
-assert opencvSupport -> opencv != null;
+assert opencvSupport -> opencv3 != null;
 
 stdenv.mkDerivation rec {
   pname = "shogun";
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       protobuf nlopt snappy swig (libarchive.dev) libxml2
     ]
     ++ optionals (pythonSupport) (with pythonPackages; [ python ply numpy ])
-    ++ optional  (opencvSupport) opencv;
+    ++ optional  (opencvSupport) opencv3;
 
   cmakeFlags = with lib; []
     ++ (optional (pythonSupport) "-DPythonModular=ON")


### PR DESCRIPTION
###### Motivation for this change
opencv 2.x has known, unfixed security vulnerabilities and is reaching EOL.

This _builds_ for me (if I force `opencvSupport` `true` of course), but I have no idea if this works correctly and the tests aren't enabled. @edwtjo are you able to test this?

Incidentally I had a go at enabling the tests and it looks like it'll be a bit of fun... after giving cmake the `-DENABLE_TESTING=ON` flag and setting `installCheckPhase` to `ctest` you realize it wants to start downloading copies of googlemock etc...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
