### PR TITLE
ruby.withPackages: preserve setup hooks

### DIFF
--- a/pkgs/development/ruby-modules/with-packages/default.nix
+++ b/pkgs/development/ruby-modules/with-packages/default.nix
@@ -64,6 +64,8 @@ let
           rm -f $out/bin/$(basename "$i")
           makeWrapper "$i" $out/bin/$(basename "$i") --set GEM_PATH ${gemEnv}/${ruby.gemPath}
         done
+
+        ln -s ${ruby}/nix-support $out/nix-support
       '';
 
       passthru = {


### PR DESCRIPTION
This fixes

    nix-shell -p 'ruby.withPackages (const [])' ruby.devdoc

which otherwise wouldn't find documentation, unlike

    nix-shell -p ruby ruby.devdoc

which would, because ruby has setup hooks to accomodate for this, that
were being masked by the withPackages wrapper.