### PR TITLE
ensemble-chorus: init at unstable-15-02-2019

### DIFF
--- a/pkgs/applications/audio/ensemble-chorus/default.nix
+++ b/pkgs/applications/audio/ensemble-chorus/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, fltk, alsaLib, freetype, libXrandr, libXinerama, libXcursor, lv2, libjack2, cmake, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "ensemble-chorus";
+  version = "unstable-15-02-2019";
+
+  src = fetchFromGitHub {
+    owner = "jpcima";
+    repo = pname;
+    rev = "59baeb86b8851f521bc8162e22e3f15061662cc3";
+    sha256 = "0c1y10vyhrihcjvxqpqf6b52yk5yhwh813cfp6nla5ax2w88dbhr";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  buildInputs = [
+    fltk alsaLib freetype libXrandr libXinerama libXcursor lv2 libjack2
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jpcima/ensemble-chorus;
+    description = "Digital model of electronic string ensemble chorus";
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+    license = licenses.boost;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3011,6 +3011,8 @@ in
 
   enscript = callPackage ../tools/text/enscript { };
 
+  ensemble-chorus = callPackage ../applications/audio/ensemble-chorus { };
+
   entr = callPackage ../tools/misc/entr { };
 
   eot_utilities = callPackage ../tools/misc/eot-utilities { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
