### PR TITLE
nfstrace: init at 0.4.3.2

### DIFF
--- a/pkgs/tools/networking/nfstrace/default.nix
+++ b/pkgs/tools/networking/nfstrace/default.nix
@@ -1,0 +1,37 @@
+{ cmake, fetchFromGitHub, fetchpatch, json_c, libpcap, ncurses, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "nfstrace";
+  version = "0.4.3.2";
+
+  src = fetchFromGitHub {
+    owner = "epam";
+    repo = "nfstrace";
+    rev = "${version}";
+    sha256 = "1djsyn7i3xp969rnmsdaf5vwjiik9wylxxrc5nm7by00i76c1vsg";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/nfstrace/raw/debian/0.4.3.1-3/debian/patches/reproducible_build.patch";
+      sha256 = "0fd96r8xi142kjwibqkd46s6jwsg5kfc5v28bqsj9rdlc2aqmay5";
+    })
+  ];
+
+  buildInputs = [ json_c libpcap ncurses ];
+  nativeBuildInputs = [ cmake ];
+
+  # To build with GCC 8+ it needs:
+  CXXFLAGS = [ "-Wno-class-memaccess" "-Wno-ignored-qualifiers" ];
+  # CMake can't find json_c without:
+  NIX_CFLAGS_COMPILE = [ "-I${json_c.dev}/include/json-c" ];
+
+  doCheck = false; # requires network access
+
+  meta = with stdenv.lib; {
+    homepage = "http://epam.github.io/nfstrace/";
+    description = "NFS and CIFS tracing/monitoring/capturing/analyzing tool";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1906,6 +1906,8 @@ in
 
   nfdump = callPackage ../tools/networking/nfdump { };
 
+  nfstrace = callPackage ../tools/networking/nfstrace { };
+
   nixpkgs-pytools = with python3.pkgs; toPythonApplication nixpkgs-pytools;
 
   noteshrink = callPackage ../tools/misc/noteshrink { };


### PR DESCRIPTION
###### Motivation for this change

nfstrace is a tcpdump style tool that speaks native nfs (and cifs). It's the best tool out there (in my own view) to diagnose NFS network problems.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] (not applicable - new pkg)  ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`~~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

