### PR TITLE
nomacs: switch to using opencv4

### DIFF
--- a/pkgs/applications/graphics/nomacs/default.nix
+++ b/pkgs/applications/graphics/nomacs/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , mkDerivation
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , pkgconfig
 
@@ -9,7 +10,7 @@
 , qtsvg
 
 , exiv2
-, opencv
+, opencv4
 , libraw
 , libtiff
 , quazip
@@ -28,6 +29,12 @@ mkDerivation rec {
 
   patches = [
     ./nomacs-iostream.patch
+    (fetchpatch {
+      name = "darwin-less-restrictive-opencv.patch";
+      url = "https://github.com/nomacs/nomacs/commit/d182fce4bcd9a25bd15e3de065ca67849a32458c.patch";
+      sha256 = "0j6sviwrjn69nqf59hjn30c4j838h8az7rnlwcx8ymlb21vd9x2h";
+      stripLen = 1;
+    })
   ];
 
   enableParallelBuilding = true;
@@ -43,7 +50,7 @@ mkDerivation rec {
                  qttools
                  qtsvg
                  exiv2
-                 opencv
+                 opencv4
                  libraw
                  libtiff
                  quazip];


### PR DESCRIPTION
###### Motivation for this change
opencv 2.x has known, unfixed security vulnerabilities and is reaching EOL. nomacs itself states the minimum supported version is 3.4 & includes a script to install opencv 4.x, suggesting it is supported.

Darwin requires an extra patch to update its cmake file to make it less restrictive over this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ahmedtd 
