### PR TITLE
Revert "stdenv/check-meta: getEnv if the attribute is unset"

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -13,7 +13,8 @@ let
   # for why this defaults to false, but I (@copumpkin) want to default it to true soon.
   shouldCheckMeta = config.checkMeta or false;
 
-  allowUnfree = config.allowUnfree or false;
+  allowUnfree = config.allowUnfree or false
+    || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
 
   whitelist = config.whitelistedLicenses or [];
   blacklist = config.blacklistedLicenses or [];
@@ -40,9 +41,11 @@ let
   hasBlacklistedLicense = assert areLicenseListsValid; attrs:
     hasLicense attrs && lib.lists.any (l: builtins.elem l blacklist) (lib.lists.toList attrs.meta.license);
 
-  allowBroken = config.allowBroken or false;
+  allowBroken = config.allowBroken or false
+    || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
 
-  allowUnsupportedSystem = config.allowUnsupportedSystem or false;
+  allowUnsupportedSystem = config.allowUnsupportedSystem or false
+    || builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
 
   isUnfree = licenses: lib.lists.any (l: !l.free or true) licenses;
 
@@ -70,7 +73,7 @@ let
   hasAllowedInsecure = attrs:
     (attrs.meta.knownVulnerabilities or []) == [] ||
     allowInsecurePredicate attrs ||
-    config.allowInsecure or false;
+    builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
 
   showLicense = license: toString (map (l: l.shortName or "unknown") (lib.lists.toList license));
 

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -10,14 +10,6 @@ let
   # Return ‘x’ if it evaluates, or ‘def’ if it throws an exception.
   try = x: def: let res = tryEval x; in if res.success then res.value else def;
 
-  defaultConfig = {
-    # These attributes are used in pkgs/stdenv/generic/check-meta.nix
-    allowBroken = builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
-    allowInsecure = builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
-    allowUnfree = builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
-    allowUnsupportedSystem = builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
-  };
-
 in
 
 { # We combine legacy `system` and `platform` into `localSystem`, if
@@ -90,10 +82,7 @@ in
 assert args ? localSystem -> !(args ? system || args ? platform);
 
 import ./. (builtins.removeAttrs args [ "system" "platform" ] // {
-  inherit overlays crossSystem crossOverlays;
-
-  config = defaultConfig // config;
-
+  inherit config overlays crossSystem crossOverlays;
   # Fallback: Assume we are building packages on the current (build, in GNU
   # Autotools parlance) system.
   localSystem = if builtins.isString localSystem then localSystem


### PR DESCRIPTION
Reverts NixOS/nixpkgs#72376
Fixes: #72754

That broke nix-review.