### PR TITLE
org-packages: 9.2.3 -> 9.2.6

### DIFF
--- a/pkgs/applications/editors/emacs-modes/org-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/org-generated.nix
@@ -4,10 +4,10 @@
       elpaBuild {
         pname = "org";
         ename = "org";
-        version = "20190527";
+        version = "20190904";
         src = fetchurl {
-          url = "http://orgmode.org/elpa/org-20190527.tar";
-          sha256 = "1fc2nyylzpikjikyb24xq2mcilridcahmjwmg0s426dqrgqpm9ij";
+          url = "http://orgmode.org/elpa/org-20190904.tar";
+          sha256 = "0ah5zgbxp4j3mfgriw9liamy73npp9zbkq0zrg6cfhf8l3xwbnxn";
         };
         packageRequires = [];
         meta = {
@@ -19,10 +19,10 @@
       elpaBuild {
         pname = "org-plus-contrib";
         ename = "org-plus-contrib";
-        version = "20190527";
+        version = "20190904";
         src = fetchurl {
-          url = "http://orgmode.org/elpa/org-plus-contrib-20190527.tar";
-          sha256 = "16kf47ij25fijf6pbfxzq9xzildj1asdzhnkf5zv5pn4312pvgnq";
+          url = "http://orgmode.org/elpa/org-plus-contrib-20190904.tar";
+          sha256 = "08s3fk3jim0y2v00l6ah8y08ba8wbcf29z6fxqzyaxj58a5sq81a";
         };
         packageRequires = [];
         meta = {


### PR DESCRIPTION
Note that the update-org script couldn't be used, as it is currently
broken. The upgrade was thus done by hand.

I also intend to backport this, as org-mode appears to be conservative with patch-level upgrades, and the git log between the two versions is basically only backports. Please confirm that's ok with you.

I have checked that the `emacs` of `nix-build -E 'with import [...]/nixpkgs {}; pkgs.emacsWithPackages (epkgs: [ epkgs.orgPackages.org-plus-contrib epkgs.orgPackages.org ])'` appears to be parsing correctly and to be parsing a file OK and to be using my org config.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rasendubi @ttuegel 
