### PR TITLE
dcpj1100dw-cups: init at 1.0.5-0

### DIFF
--- a/pkgs/misc/cups/drivers/dcpj1100dw/default.nix
+++ b/pkgs/misc/cups/drivers/dcpj1100dw/default.nix
@@ -1,0 +1,47 @@
+{ pkgsi686Linux, stdenv, fetchurl, dpkg, makeWrapper }:
+
+let
+  pdrv = stdenv.mkDerivation rec {
+    name = "dcpj1100dwpdrv-${version}";
+    version = "1.0.5-0";
+    src = fetchurl {
+      url = "https://download.brother.com/welcome/dlf103809/dcpj1100dwpdrv-${version}.i386.deb";
+      sha256 = "0i34p0cfmv05w1y1f8fj88qjira094cyh7y5im22i1dg6002ib85";
+    };
+    nativeBuildInputs = [ dpkg ];
+    phases = [ "installPhase" ];
+    installPhase = "dpkg-deb -x $src $out";
+  };
+  fhsEnv = pkgsi686Linux.buildFHSUserEnv {
+    name = "dcpj1100dwpdrv-fhs-env";
+    targetPkgs = pkgs: [ pdrv pkgs.perl pkgs.file pkgs.which pkgs.ghostscript ];
+    extraBuildCommands = "ln -s ${pdrv}/opt $out/opt";
+    runScript = "/opt/brother/Printers/dcpj1100dw/lpd/filter_dcpj1100dw";
+  };
+in
+stdenv.mkDerivation rec {
+  name = "dcpj1100dw-cups-${version}";
+  version = "1.0.5-0";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/share/cups/model
+    ln -s ${pdrv}/opt/brother/Printers/dcpj1100dw/cupswrapper/brother_dcpj1100dw_printer_en.ppd \
+      $out/share/cups/model/
+
+    makeWrapper ${fhsEnv}/bin/dcpj1100dwpdrv-fhs-env \
+      $out/lib/cups/filter/brother_lpdwrapper_dcpj1100dw
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.brother.com/";
+    description = "Brother DCP-J1100DW combined print driver";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=au&lang=en&prod=dcpj1100dw_eu_as&os=128";
+    maintainers = [ maintainers.puffnfresh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24730,6 +24730,8 @@ in
 
   canon-cups-ufr2 = callPackage ../misc/cups/drivers/canon { };
 
+  dcpj1100dw = callPackage ../misc/cups/drivers/dcpj1100dw { };
+
   hll2390dw-cups = callPackage ../misc/cups/drivers/hll2390dw-cups { };
 
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };


### PR DESCRIPTION
Unlike past Brother drivers, this contains binaries which reference
absolute /opt paths. I could have added an rpath hack to override
syscalls like stat but I decided the driver should just run in a
simple FHS environment. Works great for me.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
