### PR TITLE
rictydiminished-with-firacode: fonttools requires python3

### DIFF
--- a/pkgs/data/fonts/rictydiminished-with-firacode/default.nix
+++ b/pkgs/data/fonts/rictydiminished-with-firacode/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, fontforge, python3Full }:
+{ stdenv, fetchgit, fontforge, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "rictydiminished-with-firacode";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     fontforge
-    (python3Full.withPackages (ps: [
+    (python3.withPackages (ps: [
       ps.jinja2
       ps.py3to2
       ps.fonttools

--- a/pkgs/data/fonts/rictydiminished-with-firacode/default.nix
+++ b/pkgs/data/fonts/rictydiminished-with-firacode/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, fontforge, pythonFull }:
+{ stdenv, fetchgit, fontforge, python3Full }:
 
 stdenv.mkDerivation rec {
   pname = "rictydiminished-with-firacode";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     fontforge
-    (pythonFull.withPackages (ps: [
+    (python3Full.withPackages (ps: [
       ps.jinja2
       ps.py3to2
       ps.fonttools


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix #72164 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mt-caret 
