### PR TITLE
nixos/phpfpm: fix apply global phpOptions

### DIFF
--- a/nixos/modules/services/web-servers/phpfpm/default.nix
+++ b/nixos/modules/services/web-servers/phpfpm/default.nix
@@ -31,7 +31,7 @@ let
     '';
     passAsFile = [ "nixDefaults" "phpOptions" ];
   } ''
-    cat $phpPackage/etc/php.ini $nixDefaultsPath $phpOptionsPath > $out
+    cat ${poolOpts.phpPackage}/etc/php.ini $nixDefaultsPath $phpOptionsPath > $out
   '';
 
   poolOpts = { name, ... }:
@@ -69,8 +69,6 @@ let
 
         phpOptions = mkOption {
           type = types.lines;
-          default = cfg.phpOptions;
-          defaultText = "config.services.phpfpm.phpOptions";
           description = ''
             "Options appended to the PHP configuration file <filename>php.ini</filename> used for this PHP-FPM pool."
           '';
@@ -137,6 +135,7 @@ let
       config = {
         socket = if poolOpts.listen == "" then "${runtimeDir}/${name}.sock" else poolOpts.listen;
         group = mkDefault poolOpts.user;
+        phpOptions = mkBefore cfg.phpOptions;
 
         settings = mapAttrs (name: mkDefault){
           listen = poolOpts.socket;


### PR DESCRIPTION
###### Motivation for this change
Fixed apply of parameter `config.services.phpfpm.phpOptions`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
