### PR TITLE
python3Packages.cytoolz: 0.10.0 -> 0.10.1

### DIFF
--- a/pkgs/development/python-modules/cytoolz/default.nix
+++ b/pkgs/development/python-modules/cytoolz/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "cytoolz";
-  version = "0.10.0";
+  version = "0.10.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ed9f6a07c2bac70d6c597df360d0666d11d2adc90141d54c5c2db08b380a4fac";
+    sha256 = "0p4a9nadsy1337gy2cnb5yanbn03j3zm6d9adyqad9bk3nlbpxc2";
   };
 
   # Extension types


### PR DESCRIPTION
###### Motivation for this change
cytoolz with python38 support was release :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[19 built (2 failed), 94 copied (444.5 MiB), 94.4 MiB DL]
error: build of '/nix/store/zymnx6rfcfl68ny0lp2rymfd7mdzxg6y-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/72769
3 package failed to build:
python37Packages.blaze python38Packages.spacy python38Packages.textacy

20 package were build:
electron-cash electrum python27Packages.cytoolz python27Packages.thinc python37Packages.cytoolz python37Packages.eth-utils python37Packages.keepkey python37Packages.rlp python37Packages.spacy python37Packages.textacy python37Packages.thinc python37Packages.trezor python37Packages.trezor_agent python38Packages.cytoolz python38Packages.eth-utils python38Packages.keepkey python38Packages.rlp python38Packages.thinc python38Packages.trezor python38Packages.trezor_agent
```
failures seem to be unrelated to cytoolz