### PR TITLE
sage: fix tests

### DIFF
--- a/pkgs/applications/science/math/sage/patches/ignore-cmp-deprecation.patch
+++ b/pkgs/applications/science/math/sage/patches/ignore-cmp-deprecation.patch
@@ -1,13 +1,24 @@
 diff --git a/src/sage/tests/cmdline.py b/src/sage/tests/cmdline.py
-index bd6b76ab82..f8340a8c66 100644
+index bd6b76ab82..ccf1203dec 100644
 --- a/src/sage/tests/cmdline.py
 +++ b/src/sage/tests/cmdline.py
-@@ -872,7 +872,7 @@ def test_executable(args, input="", timeout=100.0, **kwds):
+@@ -837,8 +837,6 @@ def test_executable(args, input="", timeout=100.0, **kwds):
+         ///
+         4
+         }}}
+-        sage: err # py2
+-        ''
+         sage: ret
+         0
+ 
+@@ -871,8 +869,8 @@ def test_executable(args, input="", timeout=100.0, **kwds):
+         sage: output = tmp_filename(ext='.sws')
          sage: with open(input, 'w') as F:
          ....:     _ = F.write(s)
-         sage: test_executable(["sage", "--rst2sws", input, output]) # py2
+-        sage: test_executable(["sage", "--rst2sws", input, output]) # py2
 -        ('', '', 0)
-+        ('', '...', 0)
++        sage: test_executable(["sage", "--rst2sws", input, output])[2] # py2
++        0
          sage: import tarfile # py2
          sage: f = tarfile.open(output, 'r') # py2
          sage: print(f.extractfile('sage_worksheet/worksheet.html').read()) # py2

--- a/pkgs/applications/science/math/sage/patches/ignore-werkzeug-immutable-dict-deprecation.patch
+++ b/pkgs/applications/science/math/sage/patches/ignore-werkzeug-immutable-dict-deprecation.patch
@@ -1,0 +1,12 @@
+diff --git a/src/sage/all.py b/src/sage/all.py
+index c87c9372e9..862fca4fcc 100644
+--- a/src/sage/all.py
++++ b/src/sage/all.py
+@@ -306,6 +306,7 @@ warnings.filters.remove(('ignore', None, DeprecationWarning, None, 0))
+ # Ignore all deprecations from IPython etc.
+ warnings.filterwarnings('ignore', category=DeprecationWarning,
+     module='.*(IPython|ipykernel|jupyter_client|jupyter_core|nbformat|notebook|ipywidgets|storemagic)')
++warnings.filterwarnings('ignore', category=DeprecationWarning, message=r".*The import 'werkzeug.ImmutableDict' is deprecated")
+ # Ignore collections.abc warnings, there are a lot of them but they are
+ # harmless.
+ warnings.filterwarnings('ignore', category=DeprecationWarning,

--- a/pkgs/applications/science/math/sage/patches/sagenb-cmp-deprecation.patch
+++ b/pkgs/applications/science/math/sage/patches/sagenb-cmp-deprecation.patch
@@ -1,0 +1,13 @@
+diff --git a/sagenb/__init__.py b/sagenb/__init__.py
+index 4db0d2cb..2fc5f01e 100644
+--- a/sagenb/__init__.py
++++ b/sagenb/__init__.py
+@@ -1,3 +1,8 @@
+ # -*- coding: utf-8 -*
+   # init
++import warnings
+ from . import storage
++
++# deprecation in attrs, needs to be fixed in twisted
++warnings.filterwarnings('ignore', category=DeprecationWarning,
++    message=r'The usage of `cmp` is deprecated and will be removed.*')

--- a/pkgs/applications/science/math/sage/sage-env.nix
+++ b/pkgs/applications/science/math/sage/sage-env.nix
@@ -18,6 +18,12 @@
 , ecl
 , maxima-ecl
 , singular
+, fflas-ffpack
+, givaro
+, gd
+, libpng
+, linbox
+, m4ri
 , giac
 , palp
 , rWrapper
@@ -101,14 +107,21 @@ writeTextFile rec {
   name = "sage-env";
   destination = "/${name}";
   text = ''
-    export PKG_CONFIG_PATH='${lib.concatStringsSep ":" (map (pkg: "${pkg}/lib/pkgconfig") [
-        # This is only needed in the src/sage/misc/cython.py test and I'm not
-        # sure if there's really a usecase for it outside of the tests. However
-        # since singular and openblas are runtime dependencies anyways, it doesn't
-        # really hurt to include.
+    export PKG_CONFIG_PATH='${lib.makeSearchPathOutput "dev" "lib/pkgconfig" [
+        # This should only be needed during build. However, since the  doctests
+        # also test the cython build (for example in src/sage/misc/cython.py),
+        # it is also needed for the testsuite to pass. We could fix the
+        # testsuite instead, but since all the packages are also runtime
+        # dependencies it doesn't really hurt to include them here.
         singular
         openblasCompat
-      ])
+        fflas-ffpack givaro
+        gd
+        libpng zlib
+        gsl
+        linbox
+        m4ri
+      ]
     }'
     export SAGE_ROOT='${sagelib.src}'
     export SAGE_LOCAL='@sage-local@'

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -107,6 +107,10 @@ stdenv.mkDerivation rec {
 
     # ignore a deprecation warning for usage of `cmp` in the attrs library in the doctests
     ./patches/ignore-cmp-deprecation.patch
+
+    # Werkzeug has deprecated ImmutableDict, but it is still used in legacy
+    # sagenb. That's no big issue since sagenb will be removed soon anyways.
+    ./patches/ignore-werkzeug-immutable-dict-deprecation.patch
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -111,6 +111,13 @@ stdenv.mkDerivation rec {
     # Werkzeug has deprecated ImmutableDict, but it is still used in legacy
     # sagenb. That's no big issue since sagenb will be removed soon anyways.
     ./patches/ignore-werkzeug-immutable-dict-deprecation.patch
+
+    # threejs r109 (#28560)
+    (fetchpatch {
+      name = "threejs-r109.patch";
+      url = "https://git.sagemath.org/sage.git/patch?id=fcc11d6effa39f375bc5f4ea5831fb7a2f2767da";
+      sha256 = "0hnmc8ld3bblks0hcjvjjaydkgwdr1cs3dbl2ys4gfq964pjgqwc";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/applications/science/math/sage/sagenb.nix
+++ b/pkgs/applications/science/math/sage/sagenb.nix
@@ -26,6 +26,11 @@ buildPythonPackage rec {
     sha256 = "0bxvhr03qh2nsjdfc4pyfiqrn9jhp3vf7irsc9gqx0185jlblbxs";
   };
 
+  patches = [
+    # cmp deprecation in attrs needs to be handled in twisted
+    ./patches/sagenb-cmp-deprecation.patch
+  ];
+
   propagatedBuildInputs = [
     twisted
     flask


### PR DESCRIPTION
###### Motivation for this change

Breakage caused by a breaking change in pkgconfig (updated by 1efa71616fadd5c7f852173445b2db824534b99b) and a deprecation warning in attrs (b74344c07550ad56d5c8288ac686ae5eaffff919).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
