### PR TITLE
mm-common: 0.9.12 → 1.0.0

### DIFF
--- a/pkgs/development/libraries/mm-common/default.nix
+++ b/pkgs/development/libraries/mm-common/default.nix
@@ -1,13 +1,25 @@
-{ stdenv, fetchurl, gnome3 }:
+{ stdenv
+, fetchurl
+, gnome3
+, meson
+, python3
+, ninja
+}:
 
 stdenv.mkDerivation rec {
   pname = "mm-common";
-  version = "0.9.12";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "02vwgv404b56wxy0gnm9xq9fvzgn9dhfqcy2hhl78ljv3v7drzyf";
+    sha256 = "1m4w33da9f4rx2d6kdj3ix3kl0gn16ml82v2mdn4hljr3q29nzdr";
   };
+
+  nativeBuildInputs = [
+    meson
+    python3
+    ninja
+  ];
 
   passthru = {
     updateScript = gnome3.updateScript {
@@ -25,7 +37,7 @@ stdenv.mkDerivation rec {
       control repository. An installation of mm-common is not required for
       building tarball releases, unless configured to use maintainer-mode.
     '';
-    homepage = https://www.gtkmm.org;
+    homepage = "https://www.gtkmm.org";
     license = licenses.gpl2Plus;
     maintainers = gnome3.maintainers;
     platforms = platforms.linux;


### PR DESCRIPTION
https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.0.news

- [x] glom builds