### PR TITLE
[r19.03] pythonPackages.koji: 1.13.0 -> 1.14.3 (security)

### DIFF
--- a/pkgs/development/python-modules/koji/default.nix
+++ b/pkgs/development/python-modules/koji/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchurl, buildPythonPackage, pycurl, six, rpm, dateutil }:
+{ stdenv, fetchurl, buildPythonPackage, isPy3k, pycurl, six, rpm, dateutil }:
 
 buildPythonPackage rec {
   pname = "koji";
-  version = "1.13.0";
+  version = "1.14.3";
   format = "other";
 
   src = fetchurl {
     url = "https://releases.pagure.org/koji/${pname}-${version}.tar.bz2";
-    sha256 = "18b18rcbdqqw33g7h20hf5bpbci2ixdi05yda1fvpv30c1kkzd8w";
+    sha256 = "0a3kn3qvspvx15imgzzzjsbvw6bqmbk29apbliqwifa9cj7pvb40";
   };
 
   propagatedBuildInputs = [ pycurl six rpm dateutil ];
 
   # Judging from SyntaxError
-  #disabled = isPy3k;
+  disabled = isPy3k;
 
   makeFlags = "DESTDIR=$(out)";
 
@@ -24,7 +24,9 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    maintainers = [ ];
+    description = "An RPM-based build system";
+    homepage = https://pagure.io/koji;
+    license = stdenv.lib.licenses.lgpl21;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/fedpkg/default.nix
+++ b/pkgs/development/tools/fedpkg/default.nix
@@ -31,5 +31,6 @@ in buildPythonApplication rec {
     homepage = https://pagure.io/fedpkg;
     license = licenses.gpl2;
     maintainers = with maintainers; [ ];
+    broken = true;
   };
 }


### PR DESCRIPTION
##### Motivation for this change
Backport of #72202. Requires marking `fedpkg` as broken, but it has been broken without this patch since Feb so I don't think it's the end of the world.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ekleog 
