### PR TITLE
python-packages.pyswip: init at 0.2.9

### DIFF
--- a/pkgs/development/python-modules/pyswip/default.nix
+++ b/pkgs/development/python-modules/pyswip/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestcov
+, pytest
+, swiProlog
+}:
+
+buildPythonPackage rec {
+  pname = "pyswip";
+  version = "0.2.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4591414006340ad8f033f9f0ee4c4c9151cd5a309ed19741a9c79b9ffce8b58e";
+  };
+
+  propagatedNativeBuildInputs = [ swiProlog ];
+  checkInputs = [ pytest pytestcov ];
+  postFixup = ''
+  set -o pipefail -o errexit
+  path="$(python -c 'import pyswip.core; print(pyswip.core._path)')"
+  home_dir="$(python -c 'import pyswip.core; print(pyswip.core.SWI_HOME_DIR)')"
+  find $out -name core.py | xargs -n 1 sed -i "s:(_path, SWI_HOME_DIR) = _findSwipl():(_path, SWI_HOME_DIR) = ('$path', '$home_dir'):"
+  '';
+
+  meta = with lib; {
+    description = "PySwip enables querying SWI-Prolog in your Python programs";
+    homepage = https://github.com/yuce/pyswip;
+    license = licenses.mit;
+    maintainers = [ maintainers.catern ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1062,6 +1062,8 @@ in {
 
   pystache = callPackage ../development/python-modules/pystache { };
 
+  pyswip = callPackage ../development/python-modules/pyswip { };
+
   pytesseract = callPackage ../development/python-modules/pytesseract { };
 
   pytest-click = callPackage ../development/python-modules/pytest-click { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
