### PR TITLE
facetimehd-firmware: 1.43_4 -> 1.43_5

### DIFF
--- a/pkgs/os-specific/linux/firmware/facetimehd-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/facetimehd-firmware/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "1.43_4";
+  version = "1.43_5";
 
 
   # Updated according to https://github.com/patjak/bcwc_pcie/pull/81/files
@@ -10,8 +10,8 @@ let
   # and https://github.com/patjak/bcwc_pcie/blob/5a7083bd98b38ef3bd223f7ee531d58f4fb0fe7c/firmware/extract-firmware.sh
 
   # From the Makefile:
-  dmgUrl = "https://support.apple.com/downloads/DL1877/en_US/osxupd10.11.5.dmg";
-  dmgRange = "205261917-208085450"; # the whole download is 1.3GB, this cuts it down to 2MB
+  dmgUrl = "https://updates.cdn-apple.com/2019/cert/041-88431-20191011-e7ee7d98-2878-4cd9-bc0a-d98b3a1e24b1/OSXUpd10.11.5.dmg";
+  dmgRange = "204909802-207733123"; # the whole download is 1.3GB, this cuts it down to 2MB
   # Notes:
   # 1. Be sure to update the sha256 below in the fetch_url
   # 2. Be sure to update the homepage in the meta
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
   inherit version;
   src = fetchurl {
     url = dmgUrl;
-    sha256 = "0xqkl4yds0n9fdjvnk0v5mj382q02crry6wm2q7j3ncdqwsv02sv";
+    sha256 = "0s8crlh8rvpanzk1w4z3hich0a3mw0m5xhpcg07bxy02calhpdk1";
     curlOpts = "-r ${dmgRange}";
   };
 
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "facetimehd firmware";
-    homepage = https://support.apple.com/downloads/DL1877;
+    homepage = https://support.apple.com/kb/DL1877;
     license = licenses.unfree;
     maintainers = with maintainers; [ womfoo grahamc ];
     platforms = [ "i686-linux" "x86_64-linux" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes: #71952
Fix NixOS kernel as it does not build due missing firmware link. I can't be sure if offsets of firmware inside file are correct  (i'm sure downloaded ranges are correct) as i cannot test as i do not have required hardware, but i guess it should do the trick.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @womfoo @grahamc 