### PR TITLE
Port tests to Python

### DIFF
--- a/nixos/tests/fsck.nix
+++ b/nixos/tests/fsck.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix {
+import ./make-test-python.nix {
   name = "fsck";
 
   machine = { lib, ... }: {
@@ -14,16 +14,18 @@ import ./make-test.nix {
   };
 
   testScript = ''
-    $machine->waitForUnit('default.target');
+    machine.wait_for_unit("default.target")
 
-    subtest "root fs is fsckd", sub {
-      $machine->succeed('journalctl -b | grep "fsck.ext4.*/dev/vda"');
-    };
+    with subtest("root fs is fsckd"):
+        machine.succeed("journalctl -b | grep 'fsck.ext4.*/dev/vda'")
 
-    subtest "mnt fs is fsckd", sub {
-      $machine->succeed('journalctl -b | grep "fsck.*/dev/vdb.*clean"');
-      $machine->succeed('grep "Requires=systemd-fsck@dev-vdb.service" /run/systemd/generator/mnt.mount');
-      $machine->succeed('grep "After=systemd-fsck@dev-vdb.service" /run/systemd/generator/mnt.mount');
-    };
+    with subtest("mnt fs is fsckd"):
+        machine.succeed("journalctl -b | grep 'fsck.*/dev/vdb.*clean'")
+        machine.succeed(
+            "grep 'Requires=systemd-fsck@dev-vdb.service' /run/systemd/generator/mnt.mount"
+        )
+        machine.succeed(
+            "grep 'After=systemd-fsck@dev-vdb.service' /run/systemd/generator/mnt.mount"
+        )
   '';
 }

--- a/nixos/tests/nixos-generate-config.nix
+++ b/nixos/tests/nixos-generate-config.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... } : {
+import ./make-test-python.nix ({ lib, ... } : {
   name = "nixos-generate-config";
   meta.maintainers = with lib.maintainers; [ basvandijk ];
   machine = {
@@ -11,14 +11,16 @@ import ./make-test.nix ({ lib, ... } : {
     '';
   };
   testScript = ''
-    startAll;
-    $machine->waitForUnit("multi-user.target");
-    $machine->succeed("nixos-generate-config");
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("nixos-generate-config")
 
     # Test if the configuration really is overridden
-    $machine->succeed("grep 'OVERRIDDEN' /etc/nixos/configuration.nix");
+    machine.succeed("grep 'OVERRIDDEN' /etc/nixos/configuration.nix")
 
     # Test of if the Perl variable $bootLoaderConfig is spliced correctly:
-    $machine->succeed("grep 'boot\\.loader\\.grub\\.enable = true;' /etc/nixos/configuration.nix");
+    machine.succeed(
+        "grep 'boot\\.loader\\.grub\\.enable = true;' /etc/nixos/configuration.nix"
+    )
   '';
 })

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
 
 let inherit (import ./ssh-keys.nix pkgs)
       snakeOilPrivateKey snakeOilPublicKey;
@@ -58,47 +58,55 @@ in {
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    my $key=`${pkgs.openssh}/bin/ssh-keygen -t ed25519 -f key -N ""`;
+    server.wait_for_unit("sshd")
 
-    $server->waitForUnit("sshd");
+    with subtest("manual-authkey"):
+        client.succeed("mkdir -m 700 /root/.ssh")
+        client.succeed(
+            '${pkgs.openssh}/bin/ssh-keygen -t ed25519 -f /root/.ssh/id_ed25519 -N ""'
+        )
+        public_key = client.succeed(
+            "${pkgs.openssh}/bin/ssh-keygen -y -f /root/.ssh/id_ed25519"
+        )
+        public_key = public_key.strip()
+        client.succeed("chmod 600 /root/.ssh/id_ed25519")
 
-    subtest "manual-authkey", sub {
-      $server->succeed("mkdir -m 700 /root/.ssh");
-      $server->copyFileFromHost("key.pub", "/root/.ssh/authorized_keys");
-      $server_lazy->succeed("mkdir -m 700 /root/.ssh");
-      $server_lazy->copyFileFromHost("key.pub", "/root/.ssh/authorized_keys");
+        server.succeed("mkdir -m 700 /root/.ssh")
+        server.succeed("echo '{}' > /root/.ssh/authorized_keys".format(public_key))
+        server_lazy.succeed("mkdir -m 700 /root/.ssh")
+        server_lazy.succeed("echo '{}' > /root/.ssh/authorized_keys".format(public_key))
 
-      $client->succeed("mkdir -m 700 /root/.ssh");
-      $client->copyFileFromHost("key", "/root/.ssh/id_ed25519");
-      $client->succeed("chmod 600 /root/.ssh/id_ed25519");
+        client.wait_for_unit("network.target")
+        client.succeed(
+            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server 'echo hello world' >&2"
+        )
+        client.succeed(
+            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server 'ulimit -l' | grep 1024"
+        )
 
-      $client->waitForUnit("network.target");
-      $client->succeed("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server 'echo hello world' >&2");
-      $client->succeed("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server 'ulimit -l' | grep 1024");
+        client.succeed(
+            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server_lazy 'echo hello world' >&2"
+        )
+        client.succeed(
+            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server_lazy 'ulimit -l' | grep 1024"
+        )
 
-      $client->succeed("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server_lazy 'echo hello world' >&2");
-      $client->succeed("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server_lazy 'ulimit -l' | grep 1024");
+    with subtest("configured-authkey"):
+        client.succeed(
+            "cat ${snakeOilPrivateKey} > privkey.snakeoil"
+        )
+        client.succeed("chmod 600 privkey.snakeoil")
+        client.succeed(
+            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server true"
+        )
+        client.succeed(
+            "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server_lazy true"
+        )
 
-    };
-
-    subtest "configured-authkey", sub {
-      $client->succeed("cat ${snakeOilPrivateKey} > privkey.snakeoil");
-      $client->succeed("chmod 600 privkey.snakeoil");
-      $client->succeed("ssh -o UserKnownHostsFile=/dev/null" .
-                       " -o StrictHostKeyChecking=no -i privkey.snakeoil" .
-                       " server true");
-
-      $client->succeed("ssh -o UserKnownHostsFile=/dev/null" .
-                       " -o StrictHostKeyChecking=no -i privkey.snakeoil" .
-                       " server_lazy true");
-
-    };
-
-    subtest "localhost-only", sub {
-      $server_localhost_only->succeed("ss -nlt | grep '127.0.0.1:22'");
-      $server_localhost_only_lazy->succeed("ss -nlt | grep '127.0.0.1:22'");
-    }
+    with subtest("localhost-only"):
+        server_localhost_only.succeed("ss -nlt | grep '127.0.0.1:22'")
+        server_localhost_only_lazy.succeed("ss -nlt | grep '127.0.0.1:22'")
   '';
 })

--- a/nixos/tests/simple.nix
+++ b/nixos/tests/simple.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "simple";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco ];
@@ -10,8 +10,8 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   testScript =
     ''
-      startAll;
-      $machine->waitForUnit("multi-user.target");
-      $machine->shutdown;
+      start_all()
+      machine.wait_for_unit("multi-user.target")
+      machine.shutdown()
     '';
 })

--- a/nixos/tests/tor.nix
+++ b/nixos/tests/tor.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }: with lib;
+import ./make-test-python.nix ({ lib, ... }: with lib;
 
 rec {
   name = "tor";
@@ -21,8 +21,10 @@ rec {
     };
 
   testScript = ''
-    $client->waitForUnit("tor.service");
-    $client->waitForOpenPort(9051);
-    $client->succeed("echo GETINFO version | nc 127.0.0.1 9051") =~ /514 Authentication required./ or die;
+    client.wait_for_unit("tor.service")
+    client.wait_for_open_port(9051)
+    assert "514 Authentication required." in client.succeed(
+        "echo GETINFO version | nc 127.0.0.1 9051"
+    )
   '';
 })

--- a/nixos/tests/transmission.nix
+++ b/nixos/tests/transmission.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "transmission";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ coconnor ];
@@ -14,8 +14,8 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   testScript =
     ''
-      startAll;
-      $machine->waitForUnit("transmission");
-      $machine->shutdown;
+      start_all()
+      machine.wait_for_unit("transmission")
+      machine.shutdown()
     '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Now that PR https://github.com/NixOS/nixpkgs/pull/71684 (nixos: add python testing support) by @tfc got merged, I would like to port some/all of the tests to Python.

###### Things done
Ported the copy_file_from_host function to Python.
Ported several tests to Python, which also conform the Black code style.
Tests have been run and all of them succeed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
