### PR TITLE
comic-neue: 2.2 -> 2.3

### DIFF
--- a/pkgs/data/fonts/comic-neue/default.nix
+++ b/pkgs/data/fonts/comic-neue/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 
 let
-  version = "2.2";
+  version = "2.3";
 in fetchzip rec {
   name = "comic-neue-${version}";
 
@@ -9,15 +9,15 @@ in fetchzip rec {
 
   postFetch = ''
     mkdir -vp $out/share/{doc,fonts}
-    unzip -j $downloadedFile comic-neue-2.2/\*.otf   -d $out/share/fonts/opentype
-    unzip -j $downloadedFile comic-neue-2.2/\*.ttf   -d $out/share/fonts/truetype
-    unzip -j $downloadedFile comic-neue-2.2/\*.eot   -d $out/share/fonts/EOT
-    unzip -j $downloadedFile comic-neue-2.2/\*.woff  -d $out/share/fonts/WOFF
-    unzip -j $downloadedFile comic-neue-2.2/\*.woff2 -d $out/share/fonts/WOFF2
-    unzip -j $downloadedFile comic-neue-2.2/\*.pdf comic-neue-2.2/FONTLOG.txt comic-neue-2.2/OFL-FAQ.txt comic-neue-2.2/SIL-License.txt -d $out/share/doc/${name}
+    unzip -j $downloadedFile OTF/\*.otf   -d $out/share/fonts/opentype
+    unzip -j $downloadedFile Web/\*.ttf   -d $out/share/fonts/truetype
+    unzip -j $downloadedFile Web/\*.eot   -d $out/share/fonts/EOT
+    unzip -j $downloadedFile Web/\*.woff  -d $out/share/fonts/WOFF
+    unzip -j $downloadedFile Web/\*.woff2 -d $out/share/fonts/WOFF2
+    unzip -j $downloadedFile \*.pdf FONTLOG.txt OFL-FAQ.txt SIL-License.txt -d $out/share/doc/${name}
   '';
 
-  sha256 = "1yypq5aqqzv3q1c6vx5130mi2iwihzzvrawhwqpwsfjl0p25sq9q";
+  sha256 = "1gs4vhys0m3qsw06qaxzyi81f06w5v66kbyl64yw3pq2rb656779";
 
   meta = with lib; {
     homepage = http://comicneue.com/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @AndersonTorres
