### PR TITLE
skypeforlinux: 8.51.0.72 -> 8.51.0.86 [19.09]

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -7,7 +7,7 @@ let
 
   # Please keep the version x.y.0.z and do not update to x.y.76.z because the
   # source of the latter disappears much faster.
-  version = "8.51.0.72";
+  version = "8.51.0.86";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -60,7 +60,7 @@ let
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb";
-        sha256 = "1rv3jxirlfy0gvphw8cxmwmghbak5m5wj0y3bgamcvma48mzdfk3";
+        sha256 = "0c00i2fg55vkycly9wqy8qss9wsils3n0apl8kqisk0ihghds814";
       }
     else
       throw "Skype for linux is not supported on ${stdenv.hostPlatform.system}";


### PR DESCRIPTION
##### Motivation for this change

In current stable branch, skypeforlinux tries to download a package that does not exist anymore:

```bash
$ nix run -f channel:nixos-19.09 skype
builder for '/nix/store/kjji0nvxp0bfdayxy1mkr41k15h33ljn-skypeforlinux_8.51.0.72_amd64.deb.drv' failed with exit code 1; last 7 log lines:
  
  trying https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_8.51.0.72_amd64.deb
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  curl: (22) The requested URL returned error: 404 Not Found
  error: cannot download skypeforlinux_8.51.0.72_amd64.deb from any mirror
cannot build derivation '/nix/store/p3p4z5h6f224547s66bzcampp3gk9gyv-skypeforlinux-8.51.0.72.drv': 1 dependencies couldn't be built
[0 built (1 failed)]
error: build of '/nix/store/p3p4z5h6f224547s66bzcampp3gk9gyv-skypeforlinux-8.51.0.72.drv' failed
```
This PR updates skype to a version available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @PanAeon @jraygauthier 
