### PR TITLE
tdrop: 2018-11-13 -> 2019-10-04

### DIFF
--- a/pkgs/applications/misc/tdrop/default.nix
+++ b/pkgs/applications/misc/tdrop/default.nix
@@ -1,24 +1,34 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper
-, xwininfo, xdotool, xprop }:
+, xwininfo, xdotool, xprop, gawk, coreutils
+, gnugrep, procps-ng }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "tdrop";
-  version = "unstable-2018-11-13";
+  version = "unstable-2019-10-04";
 
   src = fetchFromGitHub {
     owner = "noctuid";
     repo = "tdrop";
-    rev = "198795c0d2573a31979330d6a2ae946eb81deebf";
-    sha256 = "1fhibqgmls64mylcb6q46ipmg1q6pvaqm26vz933gqav6cqsbdzs";
+    rev = "60435d240f47719a69ab1f7b2be68ca3ef1df1df";
+    sha256 = "1krry5p17hzp0lpilylch8v1f485kgxkx4lmwpghzj4vpgvwk8k4";
   };
 
   dontBuild = true;
 
   installFlags = [ "PREFIX=$(out)" ];
 
-  postInstall = ''
-    wrapProgram $out/bin/tdrop \
-      --prefix PATH : ${lib.makeBinPath [ xwininfo xdotool xprop ]}
+  postInstall = let
+    binPath = lib.makeBinPath [
+      xwininfo
+      xdotool
+      xprop
+      gawk
+      coreutils
+      gnugrep
+      procps-ng
+    ];
+  in ''
+    wrapProgram $out/bin/tdrop --prefix PATH : ${binPath}
   '';
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
