### PR TITLE
signal-cli: enable dbus functionality

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-cli/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-cli/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/AsamK/signal-cli;
     description = "Command-line and dbus interface for communicating with the Signal messaging service";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ ivan ];
+    maintainers = with maintainers; [ ivan erictapen ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/signal-cli/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeWrapper, jre_headless }:
+{ stdenv, lib, fetchurl, makeWrapper, jre_headless, libmatthew_java, dbus, dbus_java }:
 
 stdenv.mkDerivation rec {
   pname = "signal-cli";
@@ -10,16 +10,24 @@ stdenv.mkDerivation rec {
     sha256 = "1gvdifscyxmxn2dwlkqi684ahy5kbcj84mqda0m8l4aa8iaq1d59";
   };
 
-  buildInputs = [ makeWrapper ];
+  buildInputs = lib.optional stdenv.isLinux [ libmatthew_java dbus dbus_java ];
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
     cp -r lib $out/lib
     cp bin/signal-cli $out/bin/signal-cli
+  '' + (if stdenv.isLinux then ''
+    makeWrapper ${jre_headless}/bin/java $out/bin/signal-cli \
+      --set JAVA_HOME "${jre_headless}" \
+      --add-flags "-classpath '$out/lib/*:${libmatthew_java}/lib/jni'" \
+      --add-flags "-Djava.library.path=${libmatthew_java}/lib/jni:${dbus_java}/share/java/dbus:$out/lib" \
+      --add-flags "org.asamk.signal.Main"
+  '' else ''
     wrapProgram $out/bin/signal-cli \
       --prefix PATH : ${lib.makeBinPath [ jre_headless ]} \
       --set JAVA_HOME ${jre_headless}
-  '';
+  '');
 
   # Execution in the macOS (10.13) sandbox fails with
   # dyld: Library not loaded: /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
@@ -29,6 +37,7 @@ stdenv.mkDerivation rec {
   #         /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa: file system sandbox blocked stat()
   # /nix/store/in41dz8byyyz4c0w132l7mqi43liv4yr-stdenv-darwin/setup: line 1310:  2231 Abort trap: 6           signal-cli --version
   doInstallCheck = stdenv.isLinux;
+
   installCheckPhase = ''
     export PATH=$PATH:$out/bin
     # --help returns non-0 exit code even when working


### PR DESCRIPTION
###### Motivation for this change

Close #72737
 
###### Things done

Refined the code from https://github.com/NixOS/nixpkgs/issues/72737#issuecomment-549170143.

Now the following should work:

```
# Starting the daemon
./result/bin/signal-cli -u MY_NUMBER daemon
```

```
# Sending messages while the daemon is running
./result/bin/signal-cli --dbus send -m "test message" RECIPIENT_NUMBER
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ivan
