### PR TITLE
makeFullPerlPath: closePropagation -> requiredPerlModules

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -82,7 +82,7 @@ let
        makeFullPerlPath [ pkgs.perlPackages.CGI ]
        => "/nix/store/fddivfrdc1xql02h9q500fpnqy12c74n-perl-CGI-4.38/lib/perl5/site_perl:/nix/store/8hsvdalmsxqkjg0c5ifigpf31vc4vsy2-perl-HTML-Parser-3.72/lib/perl5/site_perl:/nix/store/zhc7wh0xl8hz3y3f71nhlw1559iyvzld-perl-HTML-Tagset-3.20/lib/perl5/site_perl"
   */
-  makeFullPerlPath = deps: makePerlPath (stdenv.lib.misc.closePropagation deps);
+  makeFullPerlPath = deps: makePerlPath (requiredPerlModules deps);
 
 
   ack = buildPerlPackage {


### PR DESCRIPTION
`closePropagation` is marked as deprecated, so use `requiredPerlModules` instead.
It is effectively the same but it returns only the derivation which have `passthru.perlModule` declaring they have a perl module.

All derivations created with `buildPerlPackage` or `buildPerlModule` are already have it.

There are few which have to be fixed: https://github.com/NixOS/nixpkgs/pull/59976 https://github.com/NixOS/nixpkgs/pull/59978 https://github.com/NixOS/nixpkgs/issues/72783

This also makes `makeFullPerlPath` consistent with `perl.withPackages`, which also uses `requiredPerlModules` to find all dependencies

cc @alyssais