### PR TITLE
Port tests to Python

### DIFF
--- a/nixos/tests/atd.nix
+++ b/nixos/tests/atd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "atd";
@@ -14,18 +14,18 @@ import ./make-test.nix ({ pkgs, ... }:
 
   # "at" has a resolution of 1 minute
   testScript = ''
-    startAll;
+    start_all()
 
-    $machine->waitForUnit('atd.service'); # wait for atd to start
-    $machine->fail("test -f ~root/at-1");
-    $machine->fail("test -f ~alice/at-1");
+    machine.wait_for_unit("atd.service")  # wait for atd to start
+    machine.fail("test -f ~root/at-1")
+    machine.fail("test -f ~alice/at-1")
 
-    $machine->succeed("echo 'touch ~root/at-1' | at now+1min");
-    $machine->succeed("su - alice -c \"echo 'touch at-1' | at now+1min\"");
+    machine.succeed("echo 'touch ~root/at-1' | at now+1min")
+    machine.succeed("su - alice -c \"echo 'touch at-1' | at now+1min\"")
 
-    $machine->succeed("sleep 1.5m");
+    machine.succeed("sleep 1.5m")
 
-    $machine->succeed("test -f ~root/at-1");
-    $machine->succeed("test -f ~alice/at-1");
+    machine.succeed("test -f ~root/at-1")
+    machine.succeed("test -f ~alice/at-1")
   '';
 })

--- a/nixos/tests/avahi.nix
+++ b/nixos/tests/avahi.nix
@@ -1,5 +1,5 @@
 # Test whether `avahi-daemon' and `libnss-mdns' work as expected.
-import ./make-test.nix ({ pkgs, ... } : {
+import ./make-test-python.nix ({ pkgs, ... } : {
   name = "avahi";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco ];
@@ -23,45 +23,45 @@ import ./make-test.nix ({ pkgs, ... } : {
     two = cfg;
   };
 
-  testScript =
-    '' startAll;
+  testScript = ''
+    start_all()
 
-       # mDNS.
-       $one->waitForUnit("network.target");
-       $two->waitForUnit("network.target");
+    # mDNS.
+    one.wait_for_unit("network.target")
+    two.wait_for_unit("network.target")
 
-       $one->succeed("avahi-resolve-host-name one.local | tee out >&2");
-       $one->succeed("test \"`cut -f1 < out`\" = one.local");
-       $one->succeed("avahi-resolve-host-name two.local | tee out >&2");
-       $one->succeed("test \"`cut -f1 < out`\" = two.local");
+    one.succeed("avahi-resolve-host-name one.local | tee out >&2")
+    one.succeed('test "`cut -f1 < out`" = one.local')
+    one.succeed("avahi-resolve-host-name two.local | tee out >&2")
+    one.succeed('test "`cut -f1 < out`" = two.local')
 
-       $two->succeed("avahi-resolve-host-name one.local | tee out >&2");
-       $two->succeed("test \"`cut -f1 < out`\" = one.local");
-       $two->succeed("avahi-resolve-host-name two.local | tee out >&2");
-       $two->succeed("test \"`cut -f1 < out`\" = two.local");
+    two.succeed("avahi-resolve-host-name one.local | tee out >&2")
+    two.succeed('test "`cut -f1 < out`" = one.local')
+    two.succeed("avahi-resolve-host-name two.local | tee out >&2")
+    two.succeed('test "`cut -f1 < out`" = two.local')
 
-       # Basic DNS-SD.
-       $one->succeed("avahi-browse -r -t _workstation._tcp | tee out >&2");
-       $one->succeed("test `wc -l < out` -gt 0");
-       $two->succeed("avahi-browse -r -t _workstation._tcp | tee out >&2");
-       $two->succeed("test `wc -l < out` -gt 0");
+    # Basic DNS-SD.
+    one.succeed("avahi-browse -r -t _workstation._tcp | tee out >&2")
+    one.succeed("test `wc -l < out` -gt 0")
+    two.succeed("avahi-browse -r -t _workstation._tcp | tee out >&2")
+    two.succeed("test `wc -l < out` -gt 0")
 
-       # More DNS-SD.
-       $one->execute("avahi-publish -s \"This is a test\" _test._tcp 123 one=1 &");
-       $one->sleep(5);
-       $two->succeed("avahi-browse -r -t _test._tcp | tee out >&2");
-       $two->succeed("test `wc -l < out` -gt 0");
+    # More DNS-SD.
+    one.execute('avahi-publish -s "This is a test" _test._tcp 123 one=1 &')
+    one.sleep(5)
+    two.succeed("avahi-browse -r -t _test._tcp | tee out >&2")
+    two.succeed("test `wc -l < out` -gt 0")
 
-       # NSS-mDNS.
-       $one->succeed("getent hosts one.local >&2");
-       $one->succeed("getent hosts two.local >&2");
-       $two->succeed("getent hosts one.local >&2");
-       $two->succeed("getent hosts two.local >&2");
+    # NSS-mDNS.
+    one.succeed("getent hosts one.local >&2")
+    one.succeed("getent hosts two.local >&2")
+    two.succeed("getent hosts one.local >&2")
+    two.succeed("getent hosts two.local >&2")
 
-       # extra service definitions
-       $one->succeed("avahi-browse -r -t _ssh._tcp | tee out >&2");
-       $one->succeed("test `wc -l < out` -gt 0");
-       $two->succeed("avahi-browse -r -t _ssh._tcp | tee out >&2");
-       $two->succeed("test `wc -l < out` -gt 0");
-    '';
+    # extra service definitions
+    one.succeed("avahi-browse -r -t _ssh._tcp | tee out >&2")
+    one.succeed("test `wc -l < out` -gt 0")
+    two.succeed("avahi-browse -r -t _ssh._tcp | tee out >&2")
+    two.succeed("test `wc -l < out` -gt 0")
+  '';
 })

--- a/nixos/tests/bcachefs.nix
+++ b/nixos/tests/bcachefs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test-python.nix ({ pkgs, ... }: {
   name = "bcachefs";
   meta.maintainers = with pkgs.stdenv.lib.maintainers; [ chiiruno ];
 
@@ -10,29 +10,25 @@ import ./make-test.nix ({ pkgs, ... }: {
   };
 
   testScript = ''
-    $machine->succeed("modprobe bcachefs");
-    $machine->succeed("bcachefs version");
-    $machine->succeed("ls /dev");
+    machine.succeed("modprobe bcachefs")
+    machine.succeed("bcachefs version")
+    machine.succeed("ls /dev")
     
-    $machine->succeed(
-      "mkdir /tmp/mnt",
-
-      "udevadm settle",
-      "parted --script /dev/vdb mklabel msdos",
-      "parted --script /dev/vdb -- mkpart primary 1024M -1s",
-      "udevadm settle",
-
-      # Due to #32279, we cannot use encryption for this test yet
-      # "echo password | bcachefs format --encrypted /dev/vdb1",
-      # "echo password | bcachefs unlock /dev/vdb1",
-      "bcachefs format /dev/vdb1",
-      "mount -t bcachefs /dev/vdb1 /tmp/mnt",
-      "udevadm settle",
-
-      "bcachefs fs usage /tmp/mnt",
-
-      "umount /tmp/mnt",
-      "udevadm settle"
-    );
+    machine.succeed(
+        "mkdir /tmp/mnt",
+        "udevadm settle",
+        "parted --script /dev/vdb mklabel msdos",
+        "parted --script /dev/vdb -- mkpart primary 1024M -1s",
+        "udevadm settle",
+        # Due to #32279, we cannot use encryption for this test yet
+        # "echo password | bcachefs format --encrypted /dev/vdb1",
+        # "echo password | bcachefs unlock /dev/vdb1",
+        "bcachefs format /dev/vdb1",
+        "mount -t bcachefs /dev/vdb1 /tmp/mnt",
+        "udevadm settle",
+        "bcachefs fs usage /tmp/mnt",
+        "umount /tmp/mnt",
+        "udevadm settle",
+    )
   '';
 })

--- a/nixos/tests/beanstalkd.nix
+++ b/nixos/tests/beanstalkd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test-python.nix ({ pkgs, lib, ... }:
 
 let
   pythonEnv = pkgs.python3.withPackages (p: [p.beanstalkc]);
@@ -34,12 +34,16 @@ in
     };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $machine->waitForUnit('beanstalkd.service');
+    machine.wait_for_unit("beanstalkd.service")
 
-    $machine->succeed("${produce}");
-    $machine->succeed("${consume}") eq "this is a job\n" or die;
-    $machine->succeed("${consume}") eq "this is another job\n" or die;
+    machine.succeed("${produce}")
+    assert "this is a job\n" == machine.succeed(
+        "${consume}"
+    )
+    assert "this is another job\n" == machine.succeed(
+        "${consume}"
+    )
   '';
 })

--- a/nixos/tests/bind.nix
+++ b/nixos/tests/bind.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix {
+import ./make-test-python.nix {
   name = "bind";
 
   machine = { pkgs, lib, ... }: {
@@ -20,8 +20,8 @@ import ./make-test.nix {
   };
 
   testScript = ''
-    $machine->waitForUnit('bind.service');
-    $machine->waitForOpenPort(53);
-    $machine->succeed('host 192.168.0.1 127.0.0.1 | grep -qF ns.example.org');
+    machine.wait_for_unit("bind.service")
+    machine.wait_for_open_port(53)
+    machine.succeed("host 192.168.0.1 127.0.0.1 | grep -qF ns.example.org")
   '';
 }

--- a/nixos/tests/boot-stage1.nix
+++ b/nixos/tests/boot-stage1.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test-python.nix ({ pkgs, ... }: {
   name = "boot-stage1";
 
   machine = { config, pkgs, lib, ... }: {
@@ -150,12 +150,12 @@ import ./make-test.nix ({ pkgs, ... }: {
   };
 
   testScript = ''
-    $machine->waitForUnit("multi-user.target");
-    $machine->succeed('test -s /run/canary2.pid');
-    $machine->fail('pgrep -a canary1');
-    $machine->fail('kill -0 $(< /run/canary2.pid)');
-    $machine->succeed('pgrep -a -f \'^@canary3$\''');
-    $machine->succeed('pgrep -a -f \'^kcanary$\''');
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("test -s /run/canary2.pid")
+    machine.fail("pgrep -a canary1")
+    machine.fail("kill -0 $(< /run/canary2.pid)")
+    machine.succeed('pgrep -a -f "^@canary3$"')
+    machine.succeed('pgrep -a -f "^kcanary$"')
   '';
 
   meta.maintainers = with pkgs.stdenv.lib.maintainers; [ aszlig ];

--- a/nixos/tests/borgbackup.nix
+++ b/nixos/tests/borgbackup.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
 
 let
   passphrase = "supersecret";
@@ -106,60 +106,70 @@ in {
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $client->fail('test -d "${remoteRepo}"');
+    client.fail('test -d "${remoteRepo}"')
 
-    $client->succeed("cp ${privateKey} /root/id_ed25519");
-    $client->succeed("chmod 0600 /root/id_ed25519");
-    $client->succeed("cp ${privateKeyAppendOnly} /root/id_ed25519.appendOnly");
-    $client->succeed("chmod 0600 /root/id_ed25519.appendOnly");
+    client.succeed(
+        "cp ${privateKey} /root/id_ed25519"
+    )
+    client.succeed("chmod 0600 /root/id_ed25519")
+    client.succeed(
+        "cp ${privateKeyAppendOnly} /root/id_ed25519.appendOnly"
+    )
+    client.succeed("chmod 0600 /root/id_ed25519.appendOnly")
 
-    $client->succeed("mkdir -p ${dataDir}");
-    $client->succeed("touch ${dataDir}/${excludeFile}");
-    $client->succeed("echo '${keepFileData}' > ${dataDir}/${keepFile}");
+    client.succeed("mkdir -p ${dataDir}")
+    client.succeed("touch ${dataDir}/${excludeFile}")
+    client.succeed("echo '${keepFileData}' > ${dataDir}/${keepFile}")
 
-    subtest "local", sub {
-      my $borg = "BORG_PASSPHRASE='${passphrase}' borg";
-      $client->systemctl("start --wait borgbackup-job-local");
-      $client->fail("systemctl is-failed borgbackup-job-local");
-      # Make sure exactly one archive has been created
-      $client->succeed("c=\$($borg list '${localRepo}' | wc -l) && [[ \$c == '1' ]]");
-      # Make sure excludeFile has been excluded
-      $client->fail("$borg list '${localRepo}::${archiveName}' | grep -qF '${excludeFile}'");
-      # Make sure keepFile has the correct content
-      $client->succeed("$borg extract '${localRepo}::${archiveName}'");
-      $client->succeed('c=$(cat ${dataDir}/${keepFile}) && [[ "$c" == "${keepFileData}" ]]');
-      # Make sure the same is true when using `borg mount`
-      $client->succeed("mkdir -p /mnt/borg && $borg mount '${localRepo}::${archiveName}' /mnt/borg");
-      $client->succeed('c=$(cat /mnt/borg/${dataDir}/${keepFile}) && [[ "$c" == "${keepFileData}" ]]');
-    };
+    with subtest("local"):
+        borg = "BORG_PASSPHRASE='${passphrase}' borg"
+        client.systemctl("start --wait borgbackup-job-local")
+        client.fail("systemctl is-failed borgbackup-job-local")
+        # Make sure exactly one archive has been created
+        assert int(client.succeed("{} list '${localRepo}' | wc -l".format(borg))) > 0
+        # Make sure excludeFile has been excluded
+        client.fail(
+            "{} list '${localRepo}::${archiveName}' | grep -qF '${excludeFile}'".format(borg)
+        )
+        # Make sure keepFile has the correct content
+        client.succeed("{} extract '${localRepo}::${archiveName}'".format(borg))
+        assert "${keepFileData}" in client.succeed("cat ${dataDir}/${keepFile}")
+        # Make sure the same is true when using `borg mount`
+        client.succeed(
+            "mkdir -p /mnt/borg && {} mount '${localRepo}::${archiveName}' /mnt/borg".format(
+                borg
+            )
+        )
+        assert "${keepFileData}" in client.succeed(
+            "cat /mnt/borg/${dataDir}/${keepFile}"
+        )
 
-    subtest "remote", sub {
-      my $borg = "BORG_RSH='ssh -oStrictHostKeyChecking=no -i /root/id_ed25519' borg";
-      $server->waitForUnit("sshd.service");
-      $client->waitForUnit("network.target");
-      $client->systemctl("start --wait borgbackup-job-remote");
-      $client->fail("systemctl is-failed borgbackup-job-remote");
+    with subtest("remote"):
+        borg = "BORG_RSH='ssh -oStrictHostKeyChecking=no -i /root/id_ed25519' borg"
+        server.wait_for_unit("sshd.service")
+        client.wait_for_unit("network.target")
+        client.systemctl("start --wait borgbackup-job-remote")
+        client.fail("systemctl is-failed borgbackup-job-remote")
 
-      # Make sure we can't access repos other than the specified one
-      $client->fail("$borg list borg\@server:wrong");
+        # Make sure we can't access repos other than the specified one
+        client.fail("{} list borg\@server:wrong".format(borg))
 
-      #TODO: Make sure that data is actually deleted
-    };
+        # TODO: Make sure that data is actually deleted
 
-    subtest "remoteAppendOnly", sub {
-      my $borg = "BORG_RSH='ssh -oStrictHostKeyChecking=no -i /root/id_ed25519.appendOnly' borg";
-      $server->waitForUnit("sshd.service");
-      $client->waitForUnit("network.target");
-      $client->systemctl("start --wait borgbackup-job-remoteAppendOnly");
-      $client->fail("systemctl is-failed borgbackup-job-remoteAppendOnly");
+    with subtest("remoteAppendOnly"):
+        borg = (
+            "BORG_RSH='ssh -oStrictHostKeyChecking=no -i /root/id_ed25519.appendOnly' borg"
+        )
+        server.wait_for_unit("sshd.service")
+        client.wait_for_unit("network.target")
+        client.systemctl("start --wait borgbackup-job-remoteAppendOnly")
+        client.fail("systemctl is-failed borgbackup-job-remoteAppendOnly")
 
-      # Make sure we can't access repos other than the specified one
-      $client->fail("$borg list borg\@server:wrong");
+        # Make sure we can't access repos other than the specified one
+        client.fail("{} list borg\@server:wrong".format(borg))
 
-      #TODO: Make sure that data is not actually deleted
-    };
-
+        # TODO: Make sure that data is not actually deleted
   '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Processing the task list in issue https://github.com/NixOS/nixpkgs/issues/72828.

Now that PR https://github.com/NixOS/nixpkgs/pull/71684 (nixos: add python testing support) by @tfc got merged, I would like to port some of the tests to Python.

###### Things done
Ported several tests to Python, which also conform the Black code style.
Tests have been run and all of them succeed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc @flokli 
