### PR TITLE
nixos/tests: migrate my tests to python

### DIFF
--- a/nixos/tests/babeld.nix
+++ b/nixos/tests/babeld.nix
@@ -1,5 +1,5 @@
 
-import ./make-test.nix ({ pkgs, lib, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ...} : {
   name = "babeld";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ hexa ];
@@ -21,7 +21,7 @@ import ./make-test.nix ({ pkgs, lib, ...} : {
         };
       };
 
-      localRouter = { pkgs, lib, ... }:
+      local_router = { pkgs, lib, ... }:
       {
         virtualisation.vlans = [ 10 20 ];
 
@@ -70,7 +70,7 @@ import ./make-test.nix ({ pkgs, lib, ...} : {
           '';
         };
       };
-      remoteRouter = { pkgs, lib, ... }:
+      remote_router = { pkgs, lib, ... }:
       {
         virtualisation.vlans = [ 20 30 ];
 
@@ -124,25 +124,25 @@ import ./make-test.nix ({ pkgs, lib, ...} : {
 
   testScript =
     ''
-      startAll;
+      start_all()
 
-      $client->waitForUnit("network-online.target");
-      $localRouter->waitForUnit("network-online.target");
-      $remoteRouter->waitForUnit("network-online.target");
+      client.wait_for_unit("network-online.target")
+      local_router.wait_for_unit("network-online.target")
+      remote_router.wait_for_unit("network-online.target")
 
-      $localRouter->waitForUnit("babeld.service");
-      $remoteRouter->waitForUnit("babeld.service");
+      local_router.wait_for_unit("babeld.service")
+      remote_router.wait_for_unit("babeld.service")
 
-      $localRouter->waitUntilSucceeds("ip route get 192.168.30.1");
-      $localRouter->waitUntilSucceeds("ip route get 2001:db8:30::1");
+      local_router.wait_until_succeeds("ip route get 192.168.30.1")
+      local_router.wait_until_succeeds("ip route get 2001:db8:30::1")
 
-      $remoteRouter->waitUntilSucceeds("ip route get 192.168.10.1");
-      $remoteRouter->waitUntilSucceeds("ip route get 2001:db8:10::1");
+      remote_router.wait_until_succeeds("ip route get 192.168.10.1")
+      remote_router.wait_until_succeeds("ip route get 2001:db8:10::1")
 
-      $client->succeed("ping -c1 192.168.30.1");
-      $client->succeed("ping -c1 2001:db8:30::1");
+      client.succeed("ping -c1 192.168.30.1")
+      client.succeed("ping -c1 2001:db8:30::1")
 
-      $remoteRouter->succeed("ping -c1 192.168.10.2");
-      $remoteRouter->succeed("ping -c1 2001:db8:10::2");
+      remote_router.succeed("ping -c1 192.168.10.2")
+      remote_router.succeed("ping -c1 2001:db8:10::2")
     '';
 })

--- a/nixos/tests/knot.nix
+++ b/nixos/tests/knot.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ...} :
+import ./make-test-python.nix ({ pkgs, lib, ...} :
 let
   common = {
     networking.firewall.enable = false;
@@ -161,37 +161,35 @@ in {
     slave4 = (lib.head nodes.slave.config.networking.interfaces.eth1.ipv4.addresses).address;
     slave6 = (lib.head nodes.slave.config.networking.interfaces.eth1.ipv6.addresses).address;
   in ''
-    startAll;
+    import re
 
-    $client->waitForUnit("network.target");
-    $master->waitForUnit("knot.service");
-    $slave->waitForUnit("knot.service");
+    start_all()
 
-    sub assertResponse {
-      my ($knot, $query_type, $query, $expected) = @_;
-      my $out = $client->succeed("khost -t $query_type $query $knot");
-      $client->log("$knot replies with: $out");
-      chomp $out;
-      die "DNS query for $query ($query_type) against $knot gave '$out' instead of '$expected'"
-        if ($out !~ $expected);
-    }
+    client.wait_for_unit("network.target")
+    master.wait_for_unit("knot.service")
+    slave.wait_for_unit("knot.service")
 
-    foreach ("${master4}", "${master6}", "${slave4}", "${slave6}") {
-      subtest $_, sub {
-        assertResponse($_, "SOA", "example.com", qr/start of authority.*?noc\.example\.com/);
-        assertResponse($_, "A", "example.com", qr/has no [^ ]+ record/);
-        assertResponse($_, "AAAA", "example.com", qr/has no [^ ]+ record/);
 
-        assertResponse($_, "A", "www.example.com", qr/address 192.0.2.1$/);
-        assertResponse($_, "AAAA", "www.example.com", qr/address 2001:db8::1$/);
+    def test(host, query_type, query, pattern):
+        out = client.succeed(f"khost -t {query_type} {query} {host}").strip()
+        client.log(f"{host} replied with: {out}")
+        assert re.search(pattern, out), f'Did not match "{pattern}"'
 
-        assertResponse($_, "NS", "sub.example.com", qr/nameserver is ns\d\.example\.com.$/);
-        assertResponse($_, "A", "sub.example.com", qr/address 192.0.2.2$/);
-        assertResponse($_, "AAAA", "sub.example.com", qr/address 2001:db8::2$/);
 
-        assertResponse($_, "RRSIG", "www.example.com", qr/RR set signature is/);
-        assertResponse($_, "DNSKEY", "example.com", qr/DNSSEC key is/);
-      };
-    }
+    for host in ("${master4}", "${master6}", "${slave4}", "${slave6}"):
+        with subtest(f"Interrogate {host}"):
+            test(host, "SOA", "example.com", r"start of authority.*noc\.example\.com\.")
+            test(host, "A", "example.com", r"has no [^ ]+ record")
+            test(host, "AAAA", "example.com", r"has no [^ ]+ record")
+
+            test(host, "A", "www.example.com", r"address 192.0.2.1$")
+            test(host, "AAAA", "www.example.com", r"address 2001:db8::1$")
+
+            test(host, "NS", "sub.example.com", r"nameserver is ns\d\.example\.com.$")
+            test(host, "A", "sub.example.com", r"address 192.0.2.2$")
+            test(host, "AAAA", "sub.example.com", r"address 2001:db8::2$")
+
+            test(host, "RRSIG", "www.example.com", r"RR set signature is")
+            test(host, "DNSKEY", "example.com", r"DNSSEC key is")
   '';
 })

--- a/nixos/tests/knot.nix
+++ b/nixos/tests/knot.nix
@@ -30,6 +30,10 @@ let
   };
 in {
   name = "knot";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ hexa ];
+  };
+
 
   nodes = {
     master = { lib, ... }: {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli @marijanp
