### PR TITLE
python3Packages.hdbscan: add missing dependency

### DIFF
--- a/pkgs/development/python-modules/hdbscan/default.nix
+++ b/pkgs/development/python-modules/hdbscan/default.nix
@@ -7,6 +7,7 @@
 , scikitlearn
 , fetchPypi
 , joblib
+, six
 }:
 
 buildPythonPackage rec {
@@ -21,7 +22,7 @@ buildPythonPackage rec {
   checkInputs = [ nose ];
 
   nativeBuildInputs = [ cython ];
-  propagatedBuildInputs = [ numpy scipy scikitlearn joblib ];
+  propagatedBuildInputs = [ numpy scipy scikitlearn joblib six ];
 
   meta = with lib; {
     description = "Hierarchical Density-Based Spatial Clustering of Applications with Noise, a clustering algorithm with a scikit-learn compatible API";


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[3 built, 6 copied (118.2 MiB), 22.6 MiB DL]
https://github.com/NixOS/nixpkgs/pull/72840
3 package were build:
python27Packages.hdbscan python37Packages.hdbscan python38Packages.hdbscan
```