### PR TITLE
python3Packages.monty: 1.0.4 -> 3.0.2

### DIFF
--- a/pkgs/development/python-modules/monty/default.nix
+++ b/pkgs/development/python-modules/monty/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "monty";
-  version = "1.0.4";
+  version = "3.0.2";
 
   # No tests in Pypi
   src = fetchFromGitHub {
     owner = "materialsvirtuallab";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0vqaaz0dw0ypl6sfwbycpb0qs3ap04c4ghbggklxih66spdlggh6";
+    sha256 = "1wxqxp0j7i6czdpr2r1imgmy3qbgn2l7d4za2h1lg3hllvx6jra1";
   };
 
   checkInputs = [ lsof nose numpy msgpack coverage coveralls pymongo];


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date when reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

could be a slight regression with python2Packages.monty

```
[4 built (2 failed), 13 copied (9.8 MiB), 1.9 MiB DL]
error: build of '/nix/store/nhqi7qbxa5dkrnxy389qjwfp5483bwjn-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/72841
2 package failed to build:
python27Packages.monty python37Packages.sumo

6 package were build:
python37Packages.dftfit python37Packages.lammps-cython python37Packages.monty python37Packages.pymatgen python37Packages.pymatgen-lammps python38Packages.monty
```