### PR TITLE
arrow-cpp: 0.15.0 -> 0.15.1

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -12,12 +12,12 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "arrow-cpp";
-  version = "0.15.0";
+  version = "0.15.1";
 
   src = fetchurl {
     url =
       "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "0n7xrn5490r2snjl45pm2a4pr2x8a29sh8mpyi4nj5pr9f62s1yi";
+    sha256 = "1jbghpppabsix2rkxbnh41inj9lcxfz4q94p96xzxshh4g3mhb4s";
   };
 
   sourceRoot = "apache-arrow-${version}/cpp";


### PR DESCRIPTION
###### Motivation for this change
noticed @r-ryantm couldn't update it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

failures are broken on master
```
[4 built (2 failed), 48 copied (101.5 MiB), 48.1 MiB DL]
error: build of '/nix/store/mc1ir421415ssw0mvsx31nk9mgc7y3vq-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/72845
2 package failed to build:
python37Packages.google_cloud_bigquery python37Packages.ibis-framework

5 package were build:
arrow-cpp python37Packages.awkward python37Packages.pyarrow python37Packages.uproot python37Packages.uproot-methods
```