### PR TITLE
kismet: 2016-07-R1 -> 2019-09-R1

### DIFF
--- a/pkgs/applications/networking/sniffers/kismet/default.nix
+++ b/pkgs/applications/networking/sniffers/kismet/default.nix
@@ -1,16 +1,48 @@
-{ stdenv, fetchurl, pkgconfig, libpcap, ncurses, expat, pcre, libnl }:
+{ stdenv, fetchurl
+, pkgconfig
+, libpcap
+, ncurses
+, expat
+, pcre
+, python3
+, libnl
+, zlib
+, libmicrohttpd
+, sqlite
+, protobuf
+, protobufc
+, libusb1
+}:
 
+let
+  py3 = python3.withPackages(ps: with ps; [ setuptools ]);
+in
 stdenv.mkDerivation rec {
   pname = "kismet";
-  version = "2016-07-R1";
+  version = "2019-09-R1";
 
   src = fetchurl {
     url = "https://www.kismetwireless.net/code/${pname}-${version}.tar.xz";
-    sha256 = "0dz28y4ay4lskhl0lawqy2dkcrhgfkbg06v22qxzzw8i6caizcmx";
+    sha256 = "0vffcvyx777kd65acm9hzcxbf689k33ifkszkwgrbaab0kj3mwy3";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libpcap ncurses expat pcre libnl ];
+
+  buildInputs = [
+    expat
+    libmicrohttpd
+    libnl
+    libpcap
+    libusb1
+    ncurses
+    pcre
+    protobuf
+    protobufc
+    py3
+    sqlite
+    zlib
+  ];
+
   postConfigure = ''
     sed -e 's/-o $(INSTUSR)//' \
         -e 's/-g $(INSTGRP)//' \


### PR DESCRIPTION
###### Motivation for this change
noticed @r-ryantm couldn't update this

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
