### PR TITLE
ccloud-cli: init at 0.202.0

### DIFF
--- a/pkgs/development/tools/ccloud-cli/default.nix
+++ b/pkgs/development/tools/ccloud-cli/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, autoPatchelfHook, fetchurl, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "ccloud-cli";
+  version = "0.202.0";
+
+  # To get the latest version:
+  # curl -L 'https://s3-us-west-2.amazonaws.com/confluent.cloud?prefix=ccloud-cli/archives/&delimiter=/' | nix run nixpkgs.libxml2 -c xmllint --format -
+  src = fetchurl (if stdenv.hostPlatform.isDarwin then {
+      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/ccloud-cli/archives/${version}/ccloud_v${version}_darwin_amd64.tar.gz";
+      sha256 = "1w7c7fwpjj6f26nmcgm6rkrl4v9zhdpygkh02la77n23lg8wxah5";
+    } else {
+      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/ccloud-cli/archives/${version}/ccloud_v${version}_linux_amd64.tar.gz";
+      sha256 = "1xbhv2viw8cbwv03rfq99jddnw5lwy812a8xby348290l323xi89";
+    });
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/doc/ccloud-cli}
+    cp ccloud $out/bin/
+    cp LICENSE $out/share/doc/ccloud-cli/
+    cp -r legal $out/share/doc/ccloud-cli/
+  '';
+
+  meta = with lib; {
+    description = "Confluent Cloud CLI";
+    homepage = https://docs.confluent.io/current/cloud/cli/index.html;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10006,6 +10006,8 @@ in
     nodejs = nodejs-10_x;
   };
 
+  ccloud-cli = callPackage ../development/tools/ccloud-cli { };
+
   htmlunit-driver = callPackage ../development/tools/selenium/htmlunit-driver { };
 
   hyenae = callPackage ../tools/networking/hyenae { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

At work, we're using Confluent cloud for our Kafka cluster. This tool allows us to interact with our clusters.

This tool is not free, it's pre-compiled!

**NOTE** Please do not merge yet. I'm in the process of requesting permissions from Confluent for distributing this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
