### PR TITLE
jasmin: init at 2.4

### DIFF
--- a/pkgs/development/compilers/jasmin/default.nix
+++ b/pkgs/development/compilers/jasmin/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchurl
+, unzip
+, jdk
+, ant
+, makeWrapper
+, jre
+, callPackage
+}:
+
+stdenv.mkDerivation rec {
+  pname = "jasmin";
+  version = "2.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/jasmin/jasmin-${version}/jasmin-${version}.zip";
+    sha256 = "17a41vr96glcdrdbk88805wwvv1r6w8wg7if23yhd0n6rrl0r8ga";
+  };
+
+  nativeBuildInputs = [ unzip jdk ant makeWrapper ];
+
+  buildPhase = "ant all";
+  installPhase =
+  ''
+    install -Dm644 jasmin.jar $out/share/java/jasmin.jar
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/jasmin \
+      --add-flags "-jar $out/share/java/jasmin.jar"
+  '';
+
+  passthru.tests = {
+    minimal-module = callPackage ./test-assemble-hello-world {};
+  };
+
+  meta = with stdenv.lib; {
+    description = "An assembler for the Java Virtual Machine";
+    homepage = "http://jasmin.sourceforge.net/";
+    downloadPage = "https://sourceforge.net/projects/jasmin/files/latest/download";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/development/compilers/jasmin/test-assemble-hello-world/HelloWorld.j
+++ b/pkgs/development/compilers/jasmin/test-assemble-hello-world/HelloWorld.j
@@ -1,0 +1,31 @@
+.class public HelloWorld
+.super java/lang/Object
+
+;
+; standard initializer (calls java.lang.Object's initializer)
+;
+.method public <init>()V
+   aload_0
+   invokenonvirtual java/lang/Object/<init>()V
+   return
+.end method
+
+;
+; main() - prints out Hello World
+;
+.method public static main([Ljava/lang/String;)V
+   .limit stack 2   ; up to two items can be pushed
+
+   ; push System.out onto the stack
+   getstatic java/lang/System/out Ljava/io/PrintStream;
+
+   ; push a string onto the stack
+   ldc "Hello World!"
+
+   ; call the PrintStream.println() method.
+   invokevirtual java/io/PrintStream/println(Ljava/lang/String;)V
+
+   ; done
+   return
+.end method
+

--- a/pkgs/development/compilers/jasmin/test-assemble-hello-world/default.nix
+++ b/pkgs/development/compilers/jasmin/test-assemble-hello-world/default.nix
@@ -1,0 +1,12 @@
+{ stdenv, jasmin, jre }:
+
+stdenv.mkDerivation {
+  name = "jasmin-test-assemble-hello-world";
+  meta.timeout = 60;
+  buildCommand = ''
+    ${jasmin}/bin/jasmin ${./HelloWorld.j}
+    ${jre}/bin/java HelloWorld | grep "Hello World"
+    touch $out
+  '';
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8226,6 +8226,8 @@ in
         inherit installjdk pluginSupport;
       });
 
+  jasmin = callPackage ../development/compilers/jasmin { };
+
   javacard-devkit = pkgsi686Linux.callPackage ../development/compilers/javacard-devkit { };
 
   julia_07 = callPackage ../development/compilers/julia/0.7.nix {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
