### PR TITLE
displaylink: 4.4.24 -> 5.2.14

### DIFF
--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -11,22 +11,22 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "displaylink";
-  version = "4.4.24";
+  version = "5.2.14";
 
   src = requireFile rec {
     name = "displaylink.zip";
-    sha256 = "0c02mg7vbijpfpk9imh0hmls1yiglc216zfllw5ar86r1slhd5y0";
+    sha256 = "03b176y95f04rg3lcnjps9llsjbvd8yksh1fpvjwaciz48mnxh2i";
     message = ''
       In order to install the DisplayLink drivers, you must first
       comply with DisplayLink's EULA and download the binaries and
       sources from here:
 
-      http://www.displaylink.com/downloads/file?id=1261
+      http://www.displaylink.com/downloads/file?id=1369
 
       Once you have downloaded the file, please use the following
       commands and re-run the installation:
 
-      mv \$PWD/"DisplayLink USB Graphics Software for Ubuntu ${version}.zip" \$PWD/${name}
+      mv \$PWD/"DisplayLink USB Graphics Software for Ubuntu ${lib.versions.majorMinor version}.zip" \$PWD/${name}
       nix-prefetch-url file://\$PWD/${name}
     '';
   };
@@ -67,8 +67,9 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "DisplayLink DL-5xxx, DL-41xx and DL-3x00 Driver for Linux";
+    maintainers = with maintainers; [ nshalman abbradar peterhoeg ];
     platforms = [ "x86_64-linux" "i686-linux" ];
     license = licenses.unfree;
-    homepage = https://www.displaylink.com/;
+    homepage = "https://www.displaylink.com/";
   };
 }

--- a/pkgs/os-specific/linux/displaylink/udev-installer.patch
+++ b/pkgs/os-specific/linux/displaylink/udev-installer.patch
@@ -4,13 +4,13 @@
    cat <<'EOF'
  start_service()
  {
--  systemctl start dlm
+-  systemctl start displaylink-driver
 +  @systemd@/bin/systemctl start --no-block dlm
  }
  
  stop_service()
  {
--  systemctl stop dlm
+-  systemctl stop displaylink-driver
 +  @systemd@/bin/systemctl stop dlm
  }
  


### PR DESCRIPTION
###### Motivation for this change
Update to latest version.

The commit was pushed from my NixOS VM which uses a displaylink device as its only X11 display while running with this change applied.

Related issues/PRs that this likely addresses:
* #67631 
* #62871 

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar @peterhoeg