### PR TITLE
Mattermost-desktop: 4.2.3 -> 4.3.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
@@ -2,11 +2,13 @@
 freetype, fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage,
 libXrandr, libXcomposite, libXext, libXfixes, libXrender, libXtst,
 libXScrnSaver, nss, nspr, alsaLib, cups, expat, udev, wrapGAppsHook,
-hicolor-icon-theme }:
+hicolor-icon-theme, libuuid, at-spi2-core, at-spi2-atk }:
 
 let
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
+    at-spi2-atk
+    at-spi2-core
     atk
     cairo
     cups
@@ -19,6 +21,7 @@ let
     gnome2.GConf
     gtk3
     pango
+    libuuid
     libX11
     libXScrnSaver
     libXcomposite
@@ -40,18 +43,18 @@ let
 in
   stdenv.mkDerivation rec {
     pname = "mattermost-desktop";
-    version = "4.2.3";
+    version = "4.3.1";
 
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-x64.tar.gz";
-          sha256 = "14xyn8dp0xxl4j9xdsjik9p6srqdxbirgcgym2sv64p01w3kc9wf";
+          sha256 = "076nv5h6xscbw1987az00x493qhqgrli87gnn57zbvz0acgvlhfv";
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
           url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-ia32.tar.gz";
-          sha256 = "063rrxw76mjz71wp9xd3ppkq3s017vrzms879r2cilypmay7fhgs";
+          sha256 = "19ps9g8j6kp4haj6r3yfy4ma2wm6isq5fa8zlcz6g042ajkqq0ij";
         }
       else
         throw "Mattermost-Desktop is not currently supported on ${stdenv.hostPlatform.system}";

--- a/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
@@ -1,7 +1,9 @@
 { stdenv, fetchurl, gnome2, gtk3, pango, atk, cairo, gdk-pixbuf, glib,
 freetype, fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage,
 libXrandr, libXcomposite, libXext, libXfixes, libXrender, libXtst,
-libXScrnSaver, nss, nspr, alsaLib, cups, expat, udev }:
+libXScrnSaver, nss, nspr, alsaLib, cups, expat, udev, wrapGAppsHook,
+hicolor-icon-theme }:
+
 let
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -57,6 +59,8 @@ in
     dontBuild = true;
     dontConfigure = true;
     dontPatchELF = true;
+
+    buildInputs = [ wrapGAppsHook gtk3 hicolor-icon-theme ];
 
     installPhase = ''
       mkdir -p $out/share/mattermost-desktop


### PR DESCRIPTION
###### Motivation for this change
mattermost-desktop crashed on opening the file chooser

###### Things done
add wrapGAppsHook and pass dependencies
bump version (unrelated)

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jokogr 
