### PR TITLE
grass: fix mysql_config query

### DIFF
--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
   # directory
   patches = [ ./no_symbolic_links.patch ];
 
+  # Correct mysql_config query
+  patchPhase = ''
+      substituteInPlace configure --replace "--libmysqld-libs" "--libs"
+  '';
+
   configureFlags = [
     "--with-proj-share=${proj}/share/proj"
     "--with-proj-includes=${proj.dev}/include"


### PR DESCRIPTION
###### Motivation for this change
Fix this error:
```
checking whether to use MySQL... yes
checking for location of MySQL includes... /nix/store/550i6lsdrdrank2kxq8xnv5njsxl4qf6-mariadb-connector-c-3.1.4/include/mysql
checking for mysql.h... yes
checking for location of MySQL library... /nix/store/550i6lsdrdrank2kxq8xnv5njsxl4qf6-mariadb-connector-c-3.1.4/lib/mysql
checking for mysql_query in -lmysqlclient... yes
checking for mysql_config... /nix/store/550i6lsdrdrank2kxq8xnv5njsxl4qf6-mariadb-connector-c-3.1.4/bin/mysql_config
/nix/store/550i6lsdrdrank2kxq8xnv5njsxl4qf6-mariadb-connector-c-3.1.4/bin/mysql_config: unrecognized option '--libmysqld-libs'
checking for mysql_server_init... no
configure: warning: libmysqld not found
```
Partial correction this issue - https://github.com/NixOS/nixpkgs/issues/72772
Please backport to 19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
