### PR TITLE
pythonPackages.pwntools: 3.12 -> 4.0b0

### DIFF
--- a/pkgs/development/python-modules/pwntools/default.nix
+++ b/pkgs/development/python-modules/pwntools/default.nix
@@ -5,27 +5,17 @@
 , requests, tox, unicorn, intervaltree, fetchpatch }:
 
 buildPythonPackage rec {
-  version = "3.12.0";
+  version = "4.0.0b0";
   pname = "pwntools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "09a7yhsyqxb4xf2r6mbn3p5zx1wp89lxq7lj34y4zbin6ns5929s";
+    sha256 = "11f7x7rjad1nawn3r524lzxgz3nk89c6s3xycrscn3n86hh0zgid";
   };
 
   propagatedBuildInputs = [ Mako packaging pysocks pygments ROPGadget capstone paramiko pip psutil pyelftools pyserial dateutil requests tox unicorn intervaltree ];
 
-  disabled = isPy3k;
   doCheck = false; # no setuptools tests for the package
-
-  # Can be removed when 3.13.0 is released
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/Gallopsled/pwntools/commit/9859f54a21404174dd17efee02f91521a2dd09c5.patch";
-      sha256 = "0p0h87npn1mwsd8ciab7lg74bk3ahlk5r0mjbvx4jhihl2gjc3z2";
-    })
-  ];
-
 
   meta = with stdenv.lib; {
     homepage = "http://pwntools.com";


### PR DESCRIPTION
###### Motivation for this change
Fixes the broken build. I chose to go directly to 4.0 beta because stable is pretty old, and because 4.0 has python3 support.

Closes  #72172 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).