### PR TITLE
nixos/bitcoind: remove PermissionsStartOnly

### DIFF
--- a/nixos/modules/services/networking/bitcoind.nix
+++ b/nixos/modules/services/networking/bitcoind.nix
@@ -177,9 +177,6 @@ in {
         NoNewPrivileges = "true";
         PrivateDevices = "true";
         MemoryDenyWriteExecute = "true";
-
-        # Permission for preStart
-        PermissionsStartOnly = "true";
       };
     };
     users.users.${cfg.user} = {


### PR DESCRIPTION
Unneded because there are no extra commands like `ExecStartPre`

