### PR TITLE
manim: init at 0.1.10

### DIFF
--- a/pkgs/applications/video/manim/default.nix
+++ b/pkgs/applications/video/manim/default.nix
@@ -1,0 +1,64 @@
+{ lib, buildPythonApplication, fetchFromGitHub, pythonOlder, file, fetchpatch
+, cairo, ffmpeg, sox, xdg_utils, texlive
+, colour, numpy, pillow, progressbar, scipy, tqdm, opencv , pycairo, pydub
+, pbr, fetchPypi
+}:
+buildPythonApplication rec {
+  pname = "manim";
+  version = "0.1.10";
+
+  src = fetchPypi {
+    pname = "manimlib";
+    inherit version;
+    sha256 = "0vg9b3rwypq5zir74pi0pmj47yqlcg7hrvscwrpjzjbqq2yihn49";
+  };
+
+  patches = [ ./remove-dependency-constraints.patch ];
+
+  nativeBuildInputs = [ pbr ];
+
+  propagatedBuildInputs = [
+    colour
+    numpy
+    pillow
+    progressbar
+    scipy
+    tqdm
+    opencv
+    pycairo
+    pydub
+
+    cairo sox ffmpeg xdg_utils
+  ];
+
+  # Test with texlive to see whether it works but don't propagate
+  # because it's huge and optional
+  # TODO: Use smaller TexLive distribution
+  #       Doesn't need everything but it's hard to figure out what it needs
+  checkInputs = [ cairo sox ffmpeg xdg_utils texlive.combined.scheme-full ];
+
+  # Simple test and complex test with LaTeX
+  checkPhase = ''
+    for scene in SquareToCircle OpeningManimExample
+    do
+      python3 manim.py example_scenes.py $scene -l
+      tail -n 20 files/Tex/*.log  # Print potential LaTeX erorrs
+      ${file}/bin/file videos/example_scenes/480p15/$scene.mp4 \
+        | tee | grep -F "ISO Media, MP4 Base Media v1 [IS0 14496-12:2003]"
+    done
+  '';
+
+  disabled = pythonOlder "3.7";
+
+  meta = {
+    description = "Animation engine for explanatory math videos";
+    longDescription = ''
+      Manim is an animation engine for explanatory math videos. It's used to
+      create precise animations programmatically, as seen in the videos of
+      3Blue1Brown on YouTube.
+    '';
+    homepage = https://github.com/3b1b/manim;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ johnazoidberg ];
+  };
+}

--- a/pkgs/applications/video/manim/remove-dependency-constraints.patch
+++ b/pkgs/applications/video/manim/remove-dependency-constraints.patch
@@ -1,0 +1,26 @@
+diff --git i/requirements.txt w/requirements.txt
+index 556122ad..11fd49d5 100644
+--- i/requirements.txt
++++ w/requirements.txt
+@@ -1,11 +1,10 @@
+-argparse==1.4.0
+-colour==0.1.5
+-numpy==1.15.0
+-Pillow==5.2.0
+-progressbar==2.5
+-scipy==1.1.0
+-tqdm==4.24.0
+-opencv-python==3.4.2.17
+-pycairo==1.17.1; sys_platform == 'linux'
+-pycairo>=1.18.0; sys_platform == 'win32'
+-pydub==0.23.0
++colour
++numpy
++Pillow
++progressbar
++scipy
++tqdm
++pycairo
++pycairo>=1.18.1; sys_platform == 'win32'
++pydub
++pyreadline==2.1; sys_platform == 'win32'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19002,6 +19002,10 @@ in
 
   m32edit = callPackage ../applications/audio/midas/m32edit.nix {};
 
+  manim = python37Packages.callPackage ../applications/video/manim {
+    opencv = python37Packages.opencv3;
+  };
+
   manuskript = libsForQt5.callPackage ../applications/editors/manuskript { };
 
   manul = callPackage ../development/tools/manul { };


### PR DESCRIPTION
###### Motivation for this change
#60284

cc @ajs124 @matthew-piziak

Please try to use it. Should I add some documentation, to make clear, that it can only be run with `manim example.py FooScene` and not `python -m manim example.py FooScene`? (I'm not even sure if the latter works upstream, but they've got it in some documentation).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).