### PR TITLE
paraview: 5.6.0 -> 5.6.3 (and fix it)

### DIFF
--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -2,11 +2,12 @@
 stdenv, fetchFromGitHub, cmake, makeWrapper
 ,qtbase, qttools, python, libGLU_combined
 ,libXt, qtx11extras, qtxmlpatterns
+, mkDerivation
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "paraview";
-  version = "5.6.0";
+  version = "5.6.3";
 
   # fetching from GitHub instead of taking an "official" source
   # tarball because of missing submodules there
@@ -14,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "Kitware";
     repo = "ParaView";
     rev = "v${version}";
-    sha256 = "1j13yfdgcv4yzfr449i4c8r4rs1c9zr6qd3igr4vv3ani8zixkzi";
+    sha256 = "0zcij59pg47c45gfddnpbin13w16smzhcbivzm1k4pg4366wxq1q";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Would fail with
```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Aborted (core dumped)
```

Future todo: Remove the vendored vtk and use the one in nixpkgs. Otherwise 95% of the build time is spent on building vtk. (Or maybe extract their vtk into its own derivation, if it's too heavily forked)

###### Things done
I have no idea how to use it, but now it starts at least.
![image](https://user-images.githubusercontent.com/5307138/68298017-a6b30300-0098-11ea-9af5-160e20206bd0.png)

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @guserav @dguibert @acowley @SFrijters 
