### PR TITLE
gripgen: init at 0.8

### DIFF
--- a/pkgs/tools/text/gripgen/default.nix
+++ b/pkgs/tools/text/gripgen/default.nix
@@ -1,0 +1,25 @@
+{ boost, catch2, cmake, fetchFromGitHub, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "gripgen";
+  version = "0.8";
+
+  src = fetchFromGitHub {
+    owner = "sc0ty";
+    repo = "grip";
+    rev = "v${version}";
+    sha256 = "0bkqarylgzhis6fpj48qbifcd6a26cgnq8784hgnm707rq9kb0rx";
+  };
+
+  buildInputs = [ boost catch2 ];
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/sc0ty/grip/";
+    description = "Indexed grep - fast search (grep like) in huge stack of files.";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1774,6 +1774,8 @@ in
 
   gringo = callPackage ../tools/misc/gringo { };
 
+  gripgen = callPackage ../tools/text/gripgen { };
+
   grobi = callPackage ../tools/X11/grobi { };
 
   gscan2pdf = callPackage ../applications/graphics/gscan2pdf { };


### PR DESCRIPTION
###### Motivation for this change

grip (gripgen) was missing in nixpkgs,
http://sc0ty.pl/2016/12/grip-indexed-grep/

grip allows me to grep through a 120GB source codebase in less than 10 secs
```
 >>> du -sm .
121056	.

 >>> time /home/azul/tmp/grip-on-nixpkgs/azulinho-nixpkgs/result/bin/grip 'stuff'  >/dev/null

real	0m9.658s
user	0m8.131s
sys	0m0.778s

```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] (not-applicable - new pkg) ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`~~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


