### PR TITLE
gitlab: 12.4.1 -> 12.4.2

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,9 +1,9 @@
 {
-  "version": "12.4.1",
-  "repo_hash": "0dmb8ds6c5paxg35nricaywfhsgmp5rr46kk21hy2hsddgwkyb4k",
+  "version": "12.4.2",
+  "repo_hash": "00y8n0y7wydwxq62fyf7hcpx90zz5sw458m2773lz7pdgnpnrdc2",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v12.4.1-ee",
+  "rev": "v12.4.2-ee",
   "passthru": {
     "GITALY_SERVER_VERSION": "1.67.0",
     "GITLAB_PAGES_VERSION": "1.11.0",

--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -76,7 +76,7 @@ let
 
       bundle exec rake gettext:po_to_json RAILS_ENV=production NODE_ENV=production
       bundle exec rake rake:assets:precompile RAILS_ENV=production NODE_ENV=production
-      bundle exec rake webpack:compile RAILS_ENV=production NODE_ENV=production NODE_OPTIONS="--max_old_space_size=4096"
+      bundle exec rake webpack:compile RAILS_ENV=production NODE_ENV=production NODE_OPTIONS="--max_old_space_size=2048"
       bundle exec rake gitlab:assets:fix_urls RAILS_ENV=production NODE_ENV=production
 
       runHook postBuild

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -55,7 +55,7 @@ in buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = https://gitlab.com/gitlab-org/gitaly;
     description = "A Git RPC service for handling all the git calls made by GitLab";
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ roblabla globin fpletz ];
     license = licenses.mit;
   };

--- a/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
@@ -25,7 +25,7 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     description = "SSH access and repository management app for GitLab";
     homepage = http://www.gitlab.com/;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ fpletz globin talyz ];
     license = licenses.mit;
   };

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -29,7 +29,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     homepage = http://www.gitlab.com/;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ fpletz globin talyz ];
     license = licenses.mit;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
- Update GitLab from 12.4.1 -> 12.4.2
- Stop building GitLab components on macOS, since it, seemingly at random, [fails to fetch the sources on Hydra](https://hydra.nixos.org/build/104616339). This can cause Linux builds to fail too, since the failure gets cached. Since we don't build the rails app for macOS, I don't see any reason why the rest should be built.
- Lower the allowed memory usage when compiling webpack assets to give the i686 build on Hydra a chance of succeeding. Is there any way to test this before merging?

###### Things done

- Tested basic functionality in local VM

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli @fpletz @globin @krav @bgamari 
