### PR TITLE
cri-o: 1.15.2 -> 1.16.0

### DIFF
--- a/pkgs/applications/virtualization/cri-o/default.nix
+++ b/pkgs/applications/virtualization/cri-o/default.nix
@@ -17,7 +17,7 @@
 
 buildGoPackage rec {
   project = "cri-o";
-  version = "1.15.2";
+  version = "1.16.0";
   name = "${project}-${version}${flavor}";
 
   goPackagePath = "github.com/${project}/${project}";
@@ -26,7 +26,7 @@ buildGoPackage rec {
     owner = "cri-o";
     repo = "cri-o";
     rev = "v${version}";
-    sha256 = "0fiizxwxdq87h943421ivgw49jndk23yjz3saf1rzmn7g3xh2pn4";
+    sha256 = "1kbg544v7c1apaxrpndgrap0pb5c67d8fazbkgykg6ynskx6n344";
   };
 
   outputs = [ "bin" "out" ];
@@ -42,17 +42,23 @@ buildGoPackage rec {
     pushd go/src/${goPackagePath}
 
     # Build pause
-    go build -tags ${makeFlags} -o bin/crio-config -buildmode=pie \
-      -ldflags '-s -w ${ldflags}' ${goPackagePath}/cmd/crio-config
-
     make -C pause
 
-    # Build the crio binary
-    go build -tags ${makeFlags} -o bin/crio -buildmode=pie \
-      -ldflags '-s -w ${ldflags}' ${goPackagePath}/cmd/crio
+    # Build the crio binaries
+    function build() {
+      go build \
+        -tags ${makeFlags} \
+        -o bin/"$1" \
+        -buildmode=pie \
+        -ldflags '-s -w ${ldflags}' \
+        ${goPackagePath}/cmd/"$1"
+    }
+    build crio
+    build crio-status
   '';
   installPhase = ''
     install -Dm755 bin/crio $bin/bin/crio${flavor}
+    install -Dm755 bin/crio-status $bin/bin/crio-status${flavor}
 
     mkdir -p $bin/libexec/crio
     install -Dm755 bin/pause $bin/libexec/crio/pause${flavor}


### PR DESCRIPTION
###### Motivation for this change

Update CRI-O to the latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
