### PR TITLE
nixos/cassandra: Port test to python

### DIFF
--- a/nixos/tests/cassandra.nix
+++ b/nixos/tests/cassandra.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test-python.nix ({ pkgs, lib, ... }:
 let
   # Change this to test a different version of Cassandra:
   testPackage = pkgs.cassandra;
@@ -9,13 +9,16 @@ let
   jmxRolesFile = ./cassandra-jmx-roles;
   jmxAuthArgs = "-u ${(builtins.elemAt jmxRoles 0).username} -pw ${(builtins.elemAt jmxRoles 0).password}";
   jmxPort = 7200;  # Non-standard port so it doesn't accidentally work
+  jmxPortStr = toString jmxPort;
 
-  # Would usually be assigned to 512M
+  # Would usually be assigned to 512M.
+  # Set it to a different value, so that we can check whether our config
+  # actually changes it.
   numMaxHeapSize = "400";
   getHeapLimitCommand = ''
-    nodetool info -p ${toString jmxPort} | grep "^Heap Memory" | awk \'{print $NF}\'
+    nodetool info -p ${jmxPortStr} | grep "^Heap Memory" | awk '{print $NF}'
   '';
-  checkHeapLimitCommand = ''
+  checkHeapLimitCommand = pkgs.writeShellScript "check-heap-limit.sh" ''
     [ 1 -eq "$(echo "$(${getHeapLimitCommand}) < ${numMaxHeapSize}" | ${pkgs.bc}/bin/bc)" ]
   '';
 
@@ -44,7 +47,10 @@ let
   };
 in
 {
-  name = "cassandra-ci";
+  name = "cassandra";
+  meta = {
+    maintainers = with lib.maintainers; [ johnazoidberg ];
+  };
 
   nodes = {
     cass0 = nodeCfg "192.168.1.1" {};
@@ -52,66 +58,74 @@ in
     cass2 = nodeCfg "192.168.1.3" { jvmOpts = [ "-Dcassandra.replace_address=cass1" ]; };
   };
 
-  testScript = let
-    jmxPortS = toString jmxPort;
-  in ''
+  testScript = ''
     # Check configuration
-    subtest "Timers exist", sub {
-      $cass0->succeed("systemctl list-timers | grep cassandra-full-repair.timer");
-      $cass0->succeed("systemctl list-timers | grep cassandra-incremental-repair.timer");
-    };
-    subtest "Can connect via cqlsh", sub {
-      $cass0->waitForUnit("cassandra.service");
-      $cass0->waitUntilSucceeds("nc -z cass0 9042");
-      $cass0->succeed("echo 'show version;' | cqlsh cass0");
-    };
-    subtest "Nodetool is operational", sub {
-      $cass0->waitForUnit("cassandra.service");
-      $cass0->waitUntilSucceeds("nc -z localhost ${jmxPortS}");
-      $cass0->succeed("nodetool status -p ${jmxPortS} --resolve-ip | egrep '^UN[[:space:]]+cass0'");
-    };
-    subtest "Cluster name was set", sub {
-      $cass0->waitForUnit("cassandra.service");
-      $cass0->waitUntilSucceeds("nc -z localhost ${jmxPortS}");
-      $cass0->waitUntilSucceeds("nodetool describecluster -p ${jmxPortS} | grep 'Name: ${clusterName}'");
-    };
-    subtest "Heap limit set correctly", sub {
-      # Nodetool takes a while until it can display info
-      $cass0->waitUntilSucceeds('nodetool info -p ${jmxPortS}');
-      $cass0->succeed('${checkHeapLimitCommand}');
-    };
+    with subtest("Timers exist"):
+        cass0.succeed("systemctl list-timers | grep cassandra-full-repair.timer")
+        cass0.succeed("systemctl list-timers | grep cassandra-incremental-repair.timer")
+
+    with subtest("Can connect via cqlsh"):
+        cass0.wait_for_unit("cassandra.service")
+        cass0.wait_until_succeeds("nc -z cass0 9042")
+        cass0.succeed("echo 'show version;' | cqlsh cass0")
+
+    with subtest("Nodetool is operational"):
+        cass0.wait_for_unit("cassandra.service")
+        cass0.wait_until_succeeds("nc -z localhost ${jmxPortStr}")
+        cass0.succeed("nodetool status -p ${jmxPortStr} --resolve-ip | egrep '^UN[[:space:]]+cass0'")
+
+    with subtest("Cluster name was set"):
+        cass0.wait_for_unit("cassandra.service")
+        cass0.wait_until_succeeds("nc -z localhost ${jmxPortStr}")
+        cass0.wait_until_succeeds(
+            "nodetool describecluster -p ${jmxPortStr} | grep 'Name: ${clusterName}'"
+        )
+
+    with subtest("Heap limit set correctly"):
+        # Nodetool takes a while until it can display info
+        cass0.wait_until_succeeds("nodetool info -p ${jmxPortStr}")
+        cass0.succeed("${checkHeapLimitCommand}")
 
     # Check cluster interaction
-    subtest "Bring up cluster", sub {
-      $cass1->waitForUnit("cassandra.service");
-      $cass1->waitUntilSucceeds("nodetool -p ${jmxPortS} ${jmxAuthArgs} status | egrep -c '^UN' | grep 2");
-      $cass0->succeed("nodetool status -p ${jmxPortS} --resolve-ip | egrep '^UN[[:space:]]+cass1'");
-    };
+    with subtest("Bring up cluster"):
+        cass1.wait_for_unit("cassandra.service")
+        cass1.wait_until_succeeds(
+            "nodetool -p ${jmxPortStr} ${jmxAuthArgs} status | egrep -c '^UN' | grep 2"
+        )
+        cass0.succeed("nodetool status -p ${jmxPortStr} --resolve-ip | egrep '^UN[[:space:]]+cass1'")
   '' + lib.optionalString testRemoteAuth ''
-    subtest "Remote authenticated jmx", sub {
-      # Doesn't work if not enabled
-      $cass0->waitUntilSucceeds("nc -z localhost ${jmxPortS}");
-      $cass1->fail("nc -z 192.168.1.1 ${toString jmxPort}");
-      $cass1->fail("nodetool -p ${jmxPortS} -h 192.168.1.1 status");
+    with subtest("Remote authenticated jmx"):
+        # Doesn't work if not enabled
+        cass0.wait_until_succeeds("nc -z localhost ${jmxPortStr}")
+        cass1.fail("nc -z 192.168.1.1 ${jmxPortStr}")
+        cass1.fail("nodetool -p ${jmxPortStr} -h 192.168.1.1 status")
 
-      # Works if enabled
-      $cass1->waitUntilSucceeds("nc -z localhost ${toString jmxPort}");
-      $cass0->succeed("nodetool -p ${jmxPortS} -h 192.168.1.2 ${jmxAuthArgs} status");
-    };
+        # Works if enabled
+        cass1.wait_until_succeeds("nc -z localhost ${jmxPortStr}")
+        cass0.succeed("nodetool -p ${jmxPortStr} -h 192.168.1.2 ${jmxAuthArgs} status")
   '' + ''
-    subtest "Break and fix node", sub {
-      $cass1->block;
-      $cass0->waitUntilSucceeds("nodetool status -p ${jmxPortS} --resolve-ip | egrep -c '^DN[[:space:]]+cass1'");
-      $cass0->succeed("nodetool status -p ${jmxPortS} | egrep -c '^UN'  | grep 1");
-      $cass1->unblock;
-      $cass1->waitUntilSucceeds("nodetool -p ${jmxPortS} ${jmxAuthArgs} status | egrep -c '^UN'  | grep 2");
-      $cass0->succeed("nodetool status -p ${jmxPortS} | egrep -c '^UN'  | grep 2");
-    };
-    subtest "Replace crashed node", sub {
-      $cass1->crash;
-      $cass2->waitForUnit("cassandra.service");
-      $cass0->waitUntilFails("nodetool status -p ${jmxPortS} --resolve-ip | egrep '^UN[[:space:]]+cass1'");
-      $cass0->waitUntilSucceeds("nodetool status -p ${jmxPortS} --resolve-ip | egrep '^UN[[:space:]]+cass2'");
-    };
+    with subtest("Break and fix node"):
+        cass1.block()
+        cass0.wait_until_succeeds(
+            "nodetool status -p ${jmxPortStr} --resolve-ip | egrep -c '^DN[[:space:]]+cass1'"
+        )
+        cass0.succeed("nodetool status -p ${jmxPortStr} | egrep -c '^UN'  | grep 1")
+        cass1.unblock()
+        cass1.wait_until_succeeds(
+            "nodetool -p ${jmxPortStr} ${jmxAuthArgs} status | egrep -c '^UN'  | grep 2"
+        )
+        cass0.succeed("nodetool status -p ${jmxPortStr} | egrep -c '^UN'  | grep 2")
+
+    with subtest("Replace crashed node"):
+        cass1.block()  # .crash() waits until it's fully shutdown
+        cass2.start()
+        cass0.wait_until_fails(
+            "nodetool status -p ${jmxPortStr} --resolve-ip | egrep '^UN[[:space:]]+cass1'"
+        )
+
+        cass2.wait_for_unit("cassandra.service")
+        cass0.wait_until_succeeds(
+            "nodetool status -p ${jmxPortStr} --resolve-ip | egrep '^UN[[:space:]]+cass2'"
+        )
   '';
 })


### PR DESCRIPTION
#### Motivation for this change
#72828

###### Things done
`nix-build nixos/tests/cassandra.nix` prints

```
...
(109.46 seconds)
(130.68 seconds)
(359.99 seconds)
9 out of 9 tests succeeded
test script finished in 360.14s
cleaning up
killing cass0 (pid 22390)
killing cass1 (pid 22503)
killing cass2 (pid 22589)
(0.01 seconds)
/nix/store/j3ilad34hsp88m8zxsd5lz1nxcf8a19r-vm-test-run-cassandra-ci
```

###### Notify maintainers

cc myself
