### PR TITLE
nixos/tests: Ignore shutdown/crash if not booted

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -611,14 +611,14 @@ class Machine:
         self.log("QEMU running (pid {})".format(self.pid))
 
     def shutdown(self):
-        if self.booted:
+        if not self.booted:
             return
 
         self.shell.send("poweroff\n".encode())
         self.wait_for_shutdown()
 
     def crash(self):
-        if self.booted:
+        if not self.booted:
             return
 
         self.log("forced crash")


### PR DESCRIPTION
###### Motivation for this change
Condition seems to be inverted. Crash and shutdown only make sense, when
the machine is booted; i.e. we return immediately otherwise.
In the Perl test driver this is:
```pl
    return unless $self->{booted};
```

I hope that the ported tests get properly reviewed, as not to cause to many false positives and failing tests.

cc #72828 @tfc @flokli  @jonringer 
