### PR TITLE
denemo: add WrapGAppsHook

### DIFF
--- a/pkgs/applications/audio/denemo/default.nix
+++ b/pkgs/applications/audio/denemo/default.nix
@@ -2,7 +2,7 @@
 , libjack2, gettext, intltool, guile_2_0, lilypond
 , glib, libxml2, librsvg, libsndfile, aubio
 , gtk3, gtksourceview, evince, fluidsynth, rubberband
-, portaudio, portmidi, fftw, makeWrapper }:
+, portaudio, portmidi, fftw, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "denemo";
@@ -14,17 +14,21 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libjack2 gettext guile_2_0 lilypond pkgconfig glib libxml2 librsvg libsndfile
+    libjack2 guile_2_0 lilypond glib libxml2 librsvg libsndfile
     aubio gtk3 gtksourceview evince fluidsynth rubberband portaudio fftw portmidi
-    makeWrapper
   ];
 
-  postInstall = ''
-    wrapProgram $out/bin/denemo --prefix PATH : ${lilypond}/bin
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lilypond}/bin"
+    )
   '';
 
   nativeBuildInputs = [
+    wrapGAppsHook
     intltool
+    gettext
+    pkgconfig
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
closes #52958

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
