### PR TITLE
nixos/tests: port some tests to python (loki, grafana, pgjwt, initrd-ssh, exporters)

### DIFF
--- a/nixos/tests/grafana.nix
+++ b/nixos/tests/grafana.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, pkgs, ... }:
+import ./make-test-python.nix ({ lib, pkgs, ... }:
 
 let
   inherit (lib) mkMerge nameValuePair maintainers;
@@ -64,28 +64,34 @@ in {
   inherit nodes;
 
   testScript = ''
-    startAll();
+    start_all()
 
-    subtest "Grafana sqlite", sub {
-      $sqlite->waitForUnit("grafana.service");
-      $sqlite->waitForOpenPort(3000);
-      $sqlite->succeed("curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost");
-    };
+    with subtest("Successful API query as admin user with sqlite db"):
+        sqlite.wait_for_unit("grafana.service")
+        sqlite.wait_for_open_port(3000)
+        sqlite.succeed(
+            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost"
+        )
+        sqlite.shutdown()
 
-    subtest "Grafana postgresql", sub {
-      $postgresql->waitForUnit("grafana.service");
-      $postgresql->waitForUnit("postgresql.service");
-      $postgresql->waitForOpenPort(3000);
-      $postgresql->waitForOpenPort(5432);
-      $postgresql->succeed("curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost");
-    };
+    with subtest("Successful API query as admin user with postgresql db"):
+        postgresql.wait_for_unit("grafana.service")
+        postgresql.wait_for_unit("postgresql.service")
+        postgresql.wait_for_open_port(3000)
+        postgresql.wait_for_open_port(5432)
+        postgresql.succeed(
+            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost"
+        )
+        postgresql.shutdown()
 
-    subtest "Grafana mysql", sub {
-      $mysql->waitForUnit("grafana.service");
-      $mysql->waitForUnit("mysql.service");
-      $mysql->waitForOpenPort(3000);
-      $mysql->waitForOpenPort(3306);
-      $mysql->succeed("curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost");
-    };
+    with subtest("Successful API query as admin user with mysql db"):
+        mysql.wait_for_unit("grafana.service")
+        mysql.wait_for_unit("mysql.service")
+        mysql.wait_for_open_port(3000)
+        mysql.wait_for_open_port(3306)
+        mysql.succeed(
+            "curl -sSfN -u testadmin:snakeoilpwd http://127.0.0.1:3000/api/org/users | grep -q testadmin\@localhost"
+        )
+        mysql.shutdown()
   '';
 })

--- a/nixos/tests/initrd-network-ssh/default.nix
+++ b/nixos/tests/initrd-network-ssh/default.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ lib, ... }:
+import ../make-test-python.nix ({ lib, ... }:
 
 {
   name = "initrd-network-ssh";
@@ -35,25 +35,31 @@ import ../make-test.nix ({ lib, ... }:
     client =
       { config, ... }:
       {
-        environment.etc.knownHosts = {
-          text = concatStrings [
-            "server,"
-            "${toString (head (splitString " " (
-              toString (elemAt (splitString "\n" config.networking.extraHosts) 2)
-            )))} "
-            "${readFile ./dropbear.pub}"
-          ];
+        environment.etc = {
+          knownHosts = {
+            text = concatStrings [
+              "server,"
+              "${toString (head (splitString " " (
+                toString (elemAt (splitString "\n" config.networking.extraHosts) 2)
+              )))} "
+              "${readFile ./dropbear.pub}"
+            ];
+          };
+          sshKey = {
+            source = ./openssh.priv; # dont use this anywhere else
+            mode = "0600";
+          };
         };
       };
   };
 
   testScript = ''
-    startAll;
-    $client->waitForUnit("network.target");
-    $client->copyFileFromHost("${./openssh.priv}","/etc/sshKey");
-    $client->succeed("chmod 0600 /etc/sshKey");
-    $client->waitUntilSucceeds("ping -c 1 server");
-    $client->succeed("ssh -i /etc/sshKey -o UserKnownHostsFile=/etc/knownHosts server 'touch /fnord'");
-    $client->shutdown;
+    start_all()
+    client.wait_for_unit("network.target")
+    client.wait_until_succeeds("ping -c 1 server")
+    client.succeed(
+        "ssh -i /etc/sshKey -o UserKnownHostsFile=/etc/knownHosts server 'touch /fnord'"
+    )
+    client.shutdown()
   '';
 })

--- a/nixos/tests/loki.nix
+++ b/nixos/tests/loki.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, pkgs, ... }:
+import ./make-test-python.nix ({ lib, pkgs, ... }:
 
 {
   name = "loki";
@@ -26,12 +26,14 @@ import ./make-test.nix ({ lib, pkgs, ... }:
   };
 
   testScript = ''
-    $machine->start;
-    $machine->waitForUnit("loki.service");
-    $machine->waitForUnit("promtail.service");
-    $machine->waitForOpenPort(3100);
-    $machine->waitForOpenPort(9080);
-    $machine->succeed("echo 'Loki Ingestion Test' > /var/log/testlog");
-    $machine->waitUntilSucceeds("${pkgs.grafana-loki}/bin/logcli --addr='http://localhost:3100' query --no-labels '{job=\"varlogs\",filename=\"/var/log/testlog\"}' | grep -q 'Loki Ingestion Test'");
+    machine.start
+    machine.wait_for_unit("loki.service")
+    machine.wait_for_unit("promtail.service")
+    machine.wait_for_open_port(3100)
+    machine.wait_for_open_port(9080)
+    machine.succeed("echo 'Loki Ingestion Test' > /var/log/testlog")
+    machine.wait_until_succeeds(
+        "${pkgs.grafana-loki}/bin/logcli --addr='http://localhost:3100' query --no-labels '{job=\"varlogs\",filename=\"/var/log/testlog\"}' | grep -q 'Loki Ingestion Test'"
+    )
   '';
 })

--- a/nixos/tests/pgjwt.nix
+++ b/nixos/tests/pgjwt.nix
@@ -1,12 +1,5 @@
-import ./make-test.nix ({ pkgs, lib, ...}:
-let
-  test = with pkgs; runCommand "patch-test" {
-    nativeBuildInputs = [ pgjwt ];
-  }
-  ''
-    sed -e '12 i CREATE EXTENSION pgcrypto;\nCREATE EXTENSION pgtap;\nSET search_path TO tap,public;' ${pgjwt.src}/test.sql > $out;
-  '';
-in
+import ./make-test-python.nix ({ pkgs, lib, ...}:
+
 with pkgs; {
   name = "pgjwt";
   meta = with lib.maintainers; {
@@ -29,9 +22,13 @@ with pkgs; {
     pgProve = "${pkgs.perlPackages.TAPParserSourceHandlerpgTAP}";
   in
   ''
-    startAll;
-    $master->waitForUnit("postgresql");
-    $master->copyFileFromHost("${test}","/tmp/test.sql");
-    $master->succeed("${pkgs.sudo}/bin/sudo -u ${sqlSU} PGOPTIONS=--search_path=tap,public ${pgProve}/bin/pg_prove -d postgres -v -f /tmp/test.sql");
+    start_all()
+    master.wait_for_unit("postgresql")
+    master.succeed(
+        "${pkgs.gnused}/bin/sed -e '12 i CREATE EXTENSION pgcrypto;\\nCREATE EXTENSION pgtap;\\nSET search_path TO tap,public;' ${pgjwt.src}/test.sql > /tmp/test.sql"
+    )
+    master.succeed(
+        "${pkgs.sudo}/bin/sudo -u ${sqlSU} PGOPTIONS=--search_path=tap,public ${pgProve}/bin/pg_prove -d postgres -v -f /tmp/test.sql"
+    )
   '';
 })

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -4,11 +4,9 @@
 }:
 
 let
-  inherit (import ../lib/testing.nix { inherit system pkgs; }) makeTest;
+  inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
   inherit (pkgs.lib) concatStringsSep maintainers mapAttrs mkMerge
                      removeSuffix replaceChars singleton splitString;
-
-  escape' = str: replaceChars [''"'' "$" "\n"] [''\\\"'' "\\$" ""] str;
 
 /*
  * The attrset `exporterTests` contains one attribute
@@ -33,9 +31,9 @@ let
  *        services.<metricProvider>.enable = true;
  *      };
  *      exporterTest = ''
- *        waitForUnit("prometheus-<exporterName>-exporter.service");
- *        waitForOpenPort("1234");
- *        succeed("curl -sSf 'localhost:1234/metrics'");
+ *        wait_for_unit("prometheus-<exporterName>-exporter.service")
+ *        wait_for_open_port("1234")
+ *        succeed("curl -sSf 'localhost:1234/metrics'")
  *      '';
  *    };
  *
@@ -49,11 +47,11 @@ let
  *    };
  *
  *    testScript = ''
- *      $<exporterName>->start();
- *      $<exporterName>->waitForUnit("prometheus-<exporterName>-exporter.service");
- *      $<exporterName>->waitForOpenPort("1234");
- *      $<exporterName>->succeed("curl -sSf 'localhost:1234/metrics'");
- *      $<exporterName>->shutdown();
+ *      <exporterName>.start()
+ *      <exporterName>.wait_for_unit("prometheus-<exporterName>-exporter.service")
+ *      <exporterName>.wait_for_open_port("1234")
+ *      <exporterName>.succeed("curl -sSf 'localhost:1234/metrics'")
+ *      <exporterName>.shutdown()
  *    '';
  */
 
@@ -72,9 +70,11 @@ let
         '';
       };
       exporterTest = ''
-        waitForUnit("prometheus-bind-exporter.service");
-        waitForOpenPort(9119);
-        succeed("curl -sSf http://localhost:9119/metrics | grep -q 'bind_query_recursions_total 0'");
+        wait_for_unit("prometheus-bind-exporter.service")
+        wait_for_open_port(9119)
+        succeed(
+            "curl -sSf http://localhost:9119/metrics | grep -q 'bind_query_recursions_total 0'"
+        )
       '';
     };
 
@@ -89,9 +89,11 @@ let
         });
       };
       exporterTest = ''
-        waitForUnit("prometheus-blackbox-exporter.service");
-        waitForOpenPort(9115);
-        succeed("curl -sSf 'http://localhost:9115/probe?target=localhost&module=icmp_v6' | grep -q 'probe_success 1'");
+        wait_for_unit("prometheus-blackbox-exporter.service")
+        wait_for_open_port(9115)
+        succeed(
+            "curl -sSf 'http://localhost:9115/probe?target=localhost&module=icmp_v6' | grep -q 'probe_success 1'"
+        )
       '';
     };
 
@@ -100,7 +102,7 @@ let
         enable = true;
         extraFlags = [ "--web.collectd-push-path /collectd" ];
       };
-      exporterTest =let postData = escape' ''
+      exporterTest = let postData = replaceChars [ "\n" ] [ "" ] ''
         [{
           "values":[23],
           "dstypes":["gauge"],
@@ -108,13 +110,21 @@ let
           "interval":1000,
           "host":"testhost",
           "plugin":"testplugin",
-          "time":$(date +%s)
+          "time":DATE
         }]
         ''; in ''
-        waitForUnit("prometheus-collectd-exporter.service");
-        waitForOpenPort(9103);
-        succeed("curl -sSfH 'Content-Type: application/json' -X POST --data \"${postData}\" localhost:9103/collectd");
-        succeed("curl -sSf localhost:9103/metrics | grep -q 'collectd_testplugin_gauge{instance=\"testhost\"} 23'");
+        wait_for_unit("prometheus-collectd-exporter.service")
+        wait_for_open_port(9103)
+        succeed(
+            'echo \'${postData}\'> /tmp/data.json'
+        )
+        succeed('sed -ie "s DATE $(date +%s) " /tmp/data.json')
+        succeed(
+            "curl -sSfH 'Content-Type: application/json' -X POST --data @/tmp/data.json localhost:9103/collectd"
+        )
+        succeed(
+            "curl -sSf localhost:9103/metrics | grep -q 'collectd_testplugin_gauge{instance=\"testhost\"} 23'"
+        )
       '';
     };
 
@@ -127,9 +137,9 @@ let
         services.dnsmasq.enable = true;
       };
       exporterTest = ''
-        waitForUnit("prometheus-dnsmasq-exporter.service");
-        waitForOpenPort(9153);
-        succeed("curl -sSf http://localhost:9153/metrics | grep -q 'dnsmasq_leases 0'");
+        wait_for_unit("prometheus-dnsmasq-exporter.service")
+        wait_for_open_port(9153)
+        succeed("curl -sSf http://localhost:9153/metrics | grep -q 'dnsmasq_leases 0'")
       '';
     };
 
@@ -144,9 +154,11 @@ let
         services.dovecot2.enable = true;
       };
       exporterTest = ''
-        waitForUnit("prometheus-dovecot-exporter.service");
-        waitForOpenPort(9166);
-        succeed("curl -sSf http://localhost:9166/metrics | grep -q 'dovecot_up{scope=\"global\"} 1'");
+        wait_for_unit("prometheus-dovecot-exporter.service")
+        wait_for_open_port(9166)
+        succeed(
+            "curl -sSf http://localhost:9166/metrics | grep -q 'dovecot_up{scope=\"global\"} 1'"
+        )
       '';
     };
 
@@ -155,9 +167,11 @@ let
         enable = true;
       };
       exporterTest = ''
-        waitForUnit("prometheus-fritzbox-exporter.service");
-        waitForOpenPort(9133);
-        succeed("curl -sSf http://localhost:9133/metrics | grep -q 'fritzbox_exporter_collect_errors 0'");
+        wait_for_unit("prometheus-fritzbox-exporter.service")
+        wait_for_open_port(9133)
+        succeed(
+            "curl -sSf http://localhost:9133/metrics | grep -q 'fritzbox_exporter_collect_errors 0'"
+        )
       '';
     };
 
@@ -180,11 +194,11 @@ let
         };
       };
       exporterTest = ''
-        waitForUnit("nginx.service");
-        waitForOpenPort(80);
-        waitForUnit("prometheus-json-exporter.service");
-        waitForOpenPort(7979);
-        succeed("curl -sSf localhost:7979/metrics | grep -q 'json_test_metric 1'");
+        wait_for_unit("nginx.service")
+        wait_for_open_port(80)
+        wait_for_unit("prometheus-json-exporter.service")
+        wait_for_open_port(7979)
+        succeed("curl -sSf localhost:7979/metrics | grep -q 'json_test_metric 1'")
       '';
     };
 
@@ -222,10 +236,12 @@ let
         users.users.mailexporter.isSystemUser = true;
       };
       exporterTest = ''
-        waitForUnit("postfix.service")
-        waitForUnit("prometheus-mail-exporter.service")
-        waitForOpenPort(9225)
-        waitUntilSucceeds("curl -sSf http://localhost:9225/metrics | grep -q 'mail_deliver_success{configname=\"testserver\"} 1'")
+        wait_for_unit("postfix.service")
+        wait_for_unit("prometheus-mail-exporter.service")
+        wait_for_open_port(9225)
+        wait_until_succeeds(
+            "curl -sSf http://localhost:9225/metrics | grep -q 'mail_deliver_success{configname=\"testserver\"} 1'"
+        )
       '';
     };
 
@@ -256,9 +272,9 @@ let
         };
       };
       exporterTest = ''
-        waitForUnit("nginx.service")
-        waitForUnit("prometheus-nextcloud-exporter.service")
-        waitForOpenPort(9205)
+        wait_for_unit("nginx.service")
+        wait_for_unit("prometheus-nextcloud-exporter.service")
+        wait_for_open_port(9205)
         succeed("curl -sSf http://localhost:9205/metrics | grep -q 'nextcloud_up 1'")
       '';
     };
@@ -275,9 +291,9 @@ let
         };
       };
       exporterTest = ''
-        waitForUnit("nginx.service")
-        waitForUnit("prometheus-nginx-exporter.service")
-        waitForOpenPort(9113)
+        wait_for_unit("nginx.service")
+        wait_for_unit("prometheus-nginx-exporter.service")
+        wait_for_open_port(9113)
         succeed("curl -sSf http://localhost:9113/metrics | grep -q 'nginx_up 1'")
       '';
     };
@@ -287,9 +303,11 @@ let
         enable = true;
       };
       exporterTest = ''
-        waitForUnit("prometheus-node-exporter.service");
-        waitForOpenPort(9100);
-        succeed("curl -sSf http://localhost:9100/metrics | grep -q 'node_exporter_build_info{.\\+} 1'");
+        wait_for_unit("prometheus-node-exporter.service")
+        wait_for_open_port(9100)
+        succeed(
+            "curl -sSf http://localhost:9100/metrics | grep -q 'node_exporter_build_info{.\\+} 1'"
+        )
       '';
     };
 
@@ -301,9 +319,11 @@ let
         services.postfix.enable = true;
       };
       exporterTest = ''
-        waitForUnit("prometheus-postfix-exporter.service");
-        waitForOpenPort(9154);
-        succeed("curl -sSf http://localhost:9154/metrics | grep -q 'postfix_smtpd_connects_total 0'");
+        wait_for_unit("prometheus-postfix-exporter.service")
+        wait_for_open_port(9154)
+        succeed(
+            "curl -sSf http://localhost:9154/metrics | grep -q 'postfix_smtpd_connects_total 0'"
+        )
       '';
     };
 
@@ -316,18 +336,24 @@ let
         services.postgresql.enable = true;
       };
       exporterTest = ''
-        waitForUnit("prometheus-postgres-exporter.service");
-        waitForOpenPort(9187);
-        waitForUnit("postgresql.service");
-        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_exporter_last_scrape_error 0'");
-        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_up 1'");
-        systemctl("stop postgresql.service");
-        succeed("curl -sSf http://localhost:9187/metrics | grep -qv 'pg_exporter_last_scrape_error 0'");
-        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_up 0'");
-        systemctl("start postgresql.service");
-        waitForUnit("postgresql.service");
-        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_exporter_last_scrape_error 0'");
-        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_up 1'");
+        wait_for_unit("prometheus-postgres-exporter.service")
+        wait_for_open_port(9187)
+        wait_for_unit("postgresql.service")
+        succeed(
+            "curl -sSf http://localhost:9187/metrics | grep -q 'pg_exporter_last_scrape_error 0'"
+        )
+        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_up 1'")
+        systemctl("stop postgresql.service")
+        succeed(
+            "curl -sSf http://localhost:9187/metrics | grep -qv 'pg_exporter_last_scrape_error 0'"
+        )
+        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_up 0'")
+        systemctl("start postgresql.service")
+        wait_for_unit("postgresql.service")
+        succeed(
+            "curl -sSf http://localhost:9187/metrics | grep -q 'pg_exporter_last_scrape_error 0'"
+        )
+        succeed("curl -sSf http://localhost:9187/metrics | grep -q 'pg_up 1'")
       '';
     };
 
@@ -339,11 +365,13 @@ let
         services.rspamd.enable = true;
       };
       exporterTest = ''
-        waitForUnit("rspamd.service");
-        waitForUnit("prometheus-rspamd-exporter.service");
-        waitForOpenPort(11334);
-        waitForOpenPort(7980);
-        waitUntilSucceeds("curl -sSf localhost:7980/metrics | grep -q 'rspamd_scanned{host=\"rspamd\"} 0'");
+        wait_for_unit("rspamd.service")
+        wait_for_unit("prometheus-rspamd-exporter.service")
+        wait_for_open_port(11334)
+        wait_for_open_port(7980)
+        wait_until_succeeds(
+            "curl -sSf localhost:7980/metrics | grep -q 'rspamd_scanned{host=\"rspamd\"} 0'"
+        )
       '';
     };
 
@@ -356,9 +384,9 @@ let
         };
       };
       exporterTest = ''
-        waitForUnit("prometheus-snmp-exporter.service");
-        waitForOpenPort(9116);
-        succeed("curl -sSf localhost:9116/metrics | grep -q 'snmp_request_errors_total 0'");
+        wait_for_unit("prometheus-snmp-exporter.service")
+        wait_for_open_port(9116)
+        succeed("curl -sSf localhost:9116/metrics | grep -q 'snmp_request_errors_total 0'")
       '';
     };
 
@@ -377,11 +405,11 @@ let
         };
       };
       exporterTest = ''
-        waitForUnit("nginx.service");
-        waitForOpenPort(80);
-        waitForUnit("prometheus-surfboard-exporter.service");
-        waitForOpenPort(9239);
-        succeed("curl -sSf localhost:9239/metrics | grep -q 'surfboard_up 1'");
+        wait_for_unit("nginx.service")
+        wait_for_open_port(80)
+        wait_for_unit("prometheus-surfboard-exporter.service")
+        wait_for_open_port(9239)
+        succeed("curl -sSf localhost:9239/metrics | grep -q 'surfboard_up 1'")
       '';
     };
 
@@ -396,11 +424,11 @@ let
         services.tor.controlPort = 9051;
       };
       exporterTest = ''
-        waitForUnit("tor.service");
-        waitForOpenPort(9051);
-        waitForUnit("prometheus-tor-exporter.service");
-        waitForOpenPort(9130);
-        succeed("curl -sSf localhost:9130/metrics | grep -q 'tor_version{.\\+} 1'");
+        wait_for_unit("tor.service")
+        wait_for_open_port(9051)
+        wait_for_unit("prometheus-tor-exporter.service")
+        wait_for_open_port(9130)
+        succeed("curl -sSf localhost:9130/metrics | grep -q 'tor_version{.\\+} 1'")
       '';
     };
 
@@ -426,10 +454,12 @@ let
         };
       };
       exporterTest = ''
-        waitForUnit("prometheus-varnish-exporter.service");
-        waitForOpenPort(6081);
-        waitForOpenPort(9131);
-        succeed("curl -sSf http://localhost:9131/metrics | grep -q 'varnish_up 1'");
+        wait_for_unit("prometheus-varnish-exporter.service")
+        wait_for_open_port(6081)
+        wait_for_open_port(9131)
+        succeed(
+            "curl -sSf http://localhost:9131/metrics | grep -q 'varnish_up 1'"
+        )
       '';
     };
 
@@ -451,9 +481,11 @@ let
         systemd.services.prometheus-wireguard-exporter.after = [ "wireguard-wg0.service" ];
       };
       exporterTest = ''
-        waitForUnit("prometheus-wireguard-exporter.service");
-        waitForOpenPort(9586);
-        waitUntilSucceeds("curl -sSf http://localhost:9586/metrics | grep '${snakeoil.peer1.publicKey}'");
+        wait_for_unit("prometheus-wireguard-exporter.service")
+        wait_for_open_port(9586)
+        wait_until_succeeds(
+            "curl -sSf http://localhost:9586/metrics | grep '${snakeoil.peer1.publicKey}'"
+        )
       '';
     };
   };
@@ -466,11 +498,13 @@ mapAttrs (exporter: testConfig: (makeTest {
   } testConfig.metricProvider or {}];
 
   testScript = ''
-    ${"$"+exporter}->start();
-    ${concatStringsSep "  " (map (line: ''
-      ${"$"+exporter}->${line};
-    '') (splitString "\n" (removeSuffix "\n" testConfig.exporterTest)))}
-    ${"$"+exporter}->shutdown();
+    ${exporter}.start()
+    ${concatStringsSep "\n" (map (line:
+      if (builtins.substring 0 1 line == " " || builtins.substring 0 1 line == ")")
+      then line
+      else "${exporter}.${line}"
+    ) (splitString "\n" (removeSuffix "\n" testConfig.exporterTest)))}
+    ${exporter}.shutdown()
   '';
 
   meta = with maintainers; {


### PR DESCRIPTION
###### Things done
Migrated most of the tests I maintain from the perl driver to python.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc #72828