### PR TITLE
nixos/networkmanager: fix merging options

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -456,15 +456,19 @@ in {
     };
 
     # Turn off NixOS' network management when networking is managed entirely by NetworkManager
-    networking = (mkIf (!delegateWireless) {
-      useDHCP = false;
-      # Use mkDefault to trigger the assertion about the conflict above
-      wireless.enable = mkDefault false;
-    }) // (mkIf cfg.enableStrongSwan {
-      networkmanager.packages = [ pkgs.networkmanager_strongswan ];
-    }) // (mkIf enableIwd {
-      wireless.iwd.enable = true;
-    });
+    networking = mkMerge [
+      (mkIf (!delegateWireless) {
+        useDHCP = false;
+      })
+
+      (mkIf cfg.enableStrongSwan {
+        networkmanager.packages = [ pkgs.networkmanager_strongswan ];
+      })
+
+      (mkIf enableIwd {
+        wireless.iwd.enable = true;
+      })
+    ];
 
     security.polkit.extraConfig = polkitConf;
 


### PR DESCRIPTION
Incorrect merging of modules in https://github.com/NixOS/nixpkgs/pull/64364 resulted in dhcpcd being enabled causing flaky network connection.

Fixing it uncovered an infinite recursion from the same commit, previously masked by the incorrect merge.

We can just drop the `mkDefault` for `networking.wireless.enable` as it is already `false` by default.

Closes: https://github.com/NixOS/nixpkgs/issues/72416

cc @laikq, @alexeymuranov ([reporters](https://github.com/NixOS/nixpkgs/issues/72416)), @JohnAZoidberg ([cause of breakage](https://github.com/NixOS/nixpkgs/pull/64364)),  @worldofpeace ([backporter](https://github.com/NixOS/nixpkgs/commit/dcc4078492574089a92fef38db8cda527b375e0f))
