### PR TITLE
multipath-tools: Fix prefix

### DIFF
--- a/pkgs/os-specific/linux/multipath-tools/default.nix
+++ b/pkgs/os-specific/linux/multipath-tools/default.nix
@@ -27,10 +27,10 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "LIB=lib"
     "prefix=$(out)"
-    "mandir=$(out)/share/man/man8"
+    "man8dir=$(out)/share/man/man8"
     "man5dir=$(out)/share/man/man5"
     "man3dir=$(out)/share/man/man3"
-    "unitdir=$(out)/lib/systemd/system"
+    "SYSTEMDPATH=lib"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
udev rules and manpages in section 8 were installed into `$out/usr`.

Note that there is no `mandir` variable in the Makefiles and `SYSTEMDPATH` is used for systemd units and udev rules.

Results in the following derivation output diff:

```diff
 lib/systemd/system
 lib/systemd/system/multipathd.service
 lib/systemd/system/multipathd.socket
+lib/udev
+lib/udev/kpartx_id
+lib/udev/rules.d
+lib/udev/rules.d/11-dm-mpath.rules
+lib/udev/rules.d/11-dm-parts.rules
+lib/udev/rules.d/56-multipath.rules
+lib/udev/rules.d/66-kpartx.rules
+lib/udev/rules.d/68-del-part-nodes.rules
 sbin
 share
 share/man
@@ -79,25 +87,14 @@
 share/man/man3/mpath_persistent_reserve_out.3.gz
 share/man/man5
 share/man/man5/multipath.conf.5.gz
+share/man/man8
+share/man/man8/kpartx.8.gz
+share/man/man8/mpathpersist.8.gz
+share/man/man8/multipath.8.gz
+share/man/man8/multipathd.8.gz
 usr
 usr/include
 usr/include/libdmmp
 usr/include/libdmmp/libdmmp.h
 usr/include/mpath_cmd.h
 usr/include/mpath_persist.h
-usr/lib
-usr/lib/udev
-usr/lib/udev/kpartx_id
-usr/lib/udev/rules.d
-usr/lib/udev/rules.d/11-dm-mpath.rules
-usr/lib/udev/rules.d/11-dm-parts.rules
-usr/lib/udev/rules.d/56-multipath.rules
-usr/lib/udev/rules.d/66-kpartx.rules
-usr/lib/udev/rules.d/68-del-part-nodes.rules
-usr/share
-usr/share/man
-usr/share/man/man8
-usr/share/man/man8/kpartx.8.gz
-usr/share/man/man8/mpathpersist.8.gz
-usr/share/man/man8/multipath.8.gz
-usr/share/man/man8/multipathd.8.gz
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
