### PR TITLE
protocol: 20171226 -> 2019-03-28

### DIFF
--- a/pkgs/applications/networking/protocol/default.nix
+++ b/pkgs/applications/networking/protocol/default.nix
@@ -1,14 +1,14 @@
 { stdenv, buildPythonApplication, fetchFromGitHub }:
 
 buildPythonApplication {
-  pname = "protocol";
-  version = "20171226";
+  pname = "protocol-unstable";
+  version = "2019-03-28";
 
   src = fetchFromGitHub {
     owner = "luismartingarcia";
     repo = "protocol";
-    rev = "d450da7d8a58595d8ef82f1d199a80411029fc7d";
-    sha256 = "1g31s2xx0bw8ak5ag1c6mv0p0b8bj5dp3lkk9mxaf2ndj1m1qdkw";
+    rev = "4e8326ea6c2d288be5464c3a7d9398df468c0ada";
+    sha256 = "13l10jhf4vghanmhh3pn91b2jdciispxy0qadz4n08blp85qn9cm";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
It's been quite a while.

###### Things done

Tested the newly supported DHCP protocol:

```
./result/bin/protocol dhcp
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @teto
