### PR TITLE
apache-directory-studio: 2.0.0.v20170904-M13 -> 2.0.0-M14

### DIFF
--- a/pkgs/applications/networking/apache-directory-studio/default.nix
+++ b/pkgs/applications/networking/apache-directory-studio/default.nix
@@ -14,22 +14,23 @@ let
     genericName = "Apache Directory Studio";
     categories = "Java;Network";
   };
-
+  version = "2.0.0-M14";
+  versionWithDate = "2.0.0.v20180908-M14";
 in
 stdenv.mkDerivation rec {
   pname = "apache-directory-studio";
-  version = "2.0.0.v20170904-M13";
+  inherit version;
 
   src =
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
-        url = "mirror://apache/directory/studio/${version}/ApacheDirectoryStudio-${version}-linux.gtk.x86_64.tar.gz";
-        sha256 = "1jfnm6m0ijk31r30hhrxxnizk742dm317iny041p29v897rma7aq";
+        url = "mirror://apache/directory/studio/${versionWithDate}/ApacheDirectoryStudio-${versionWithDate}-linux.gtk.x86_64.tar.gz";
+        sha256 = "0kq4l3755q69p7bry9xpm5xxw56ksncp76fdqqd1xzbvsg309bps";
       }
     else if stdenv.hostPlatform.system == "i686-linux" then
       fetchurl {
-        url = "mirror://apache/directory/studio/${version}/ApacheDirectoryStudio-${version}-linux.gtk.x86.tar.gz";
-        sha256 = "1bxmgram42qyhrqkgp5k8770f5mjjdd4c6xl4gj09smiycm1qa4n";
+        url = "mirror://apache/directory/studio/${versionWithDate}/ApacheDirectoryStudio-${versionWithDate}-linux.gtk.x86.tar.gz";
+        sha256 = "038dy8jjgq5gj5r56y9ps3ycqi9gn57i4q1r3mmjx1b1950wmh1q";
       }
     else throw "Unsupported system: ${stdenv.hostPlatform.system}";
 


### PR DESCRIPTION
###### Motivation for this change
New release :)
https://directory.apache.org/studio/changelog.html

Removed the date in version because upstream only has that in their download URL, not really in the version number.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bjornfor 
