### PR TITLE
Fix package metadata like version and homepage

### DIFF
--- a/pkgs/applications/misc/wego/default.nix
+++ b/pkgs/applications/misc/wego/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "wego";
-  version = "20170403-${stdenv.lib.strings.substring 0 7 rev}";
+  version = "unstable-2017-04-03";
   rev = "415efdfab5d5ee68300bf261a0c6f630c6c2584c";
   
   goPackagePath = "github.com/schachmat/wego";

--- a/pkgs/development/tools/wiiload/default.nix
+++ b/pkgs/development/tools/wiiload/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, autoconf, automake, zlib }:
 stdenv.mkDerivation rec {
-  version = "v0.5.1";
+  version = "0.5.1";
   pname = "wiiload";
 
   nativeBuildInputs = [ autoconf automake ];
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "devkitPro";
     repo  = "wiiload";
-    rev = version;
+    rev = "v${version}";
     sha256 = "0dffy603zggkqv7g1a2jninmi64vy519gpgkdfhjnijhdm9gs5m3";
   };
 

--- a/pkgs/os-specific/linux/xf86-input-cmt/default.nix
+++ b/pkgs/os-specific/linux/xf86-input-cmt/default.nix
@@ -2,7 +2,7 @@
   utilmacros, libgestures, libevdevc }:
 
 stdenv.mkDerivation rec {
-  name = "xf86-input-cmt-${version}";
+  pname = "xf86-input-cmt";
   version = "2.0.2";
   src = fetchFromGitHub {
     owner = "hugegreenbug";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "Chromebook touchpad driver.";
     license = licenses.bsd3;
     platforms = platforms.linux;
-    homepage = "www.github.com/hugegreenbug/xf86-input-cmt";
+    homepage = "https://www.github.com/hugegreenbug/xf86-input-cmt";
     maintainers = with maintainers; [ kcalvinalvin ];
   };
 }

--- a/pkgs/tools/misc/venus/default.nix
+++ b/pkgs/tools/misc/venus/default.nix
@@ -1,16 +1,14 @@
-{ stdenv, fetchurl, python, pythonPackages, libxslt, libxml2, makeWrapper }:
-
-let
-  rev = "9de21094a8cf565bdfcf75688e121a5ad1f5397b";
-in
+{ stdenv, fetchFromGitHub, python, pythonPackages, libxslt, libxml2, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "venus-${rev}";
+  pname = "venus";
+  version = "unstable-2011-02-18";
 
-  src = fetchurl {
-    url = "https://github.com/rubys/venus/tarball/${rev}";
-    name = "${name}.tar.bz";
-    sha256 = "0lsc9d83grbi3iwm8ppaig4h9vbmd5h4vvz83lmpnyp7zqfka7dy";
+  src = fetchFromGitHub {
+    owner = "rubys";
+    repo = "venus";
+    rev = "9de21094a8cf565bdfcf75688e121a5ad1f5397b";
+    sha256 = "10yyx4jaxxbwhica12aiw119aywghcr7b24gs9lrmafpa6xd3an2";
   };
 
   preConfigure = ''

--- a/pkgs/tools/misc/vimpager/build.nix
+++ b/pkgs/tools/misc/vimpager/build.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Use Vim as PAGER";
-    homepage    = "https://www.vim.org/scripts/script.php?script_id = 1723";
+    homepage    = "https://www.vim.org/scripts/script.php?script_id=1723";
     license     = with licenses; [ bsd2 mit vim ];
     platforms   = platforms.unix;
   };

--- a/pkgs/tools/system/yeshup/default.nix
+++ b/pkgs/tools/system/yeshup/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "yeshup-${builtins.substring 0 7 rev}";
-  rev = "5461a8f957c686ccd0240be3f0fd8124d7381b08";
+  pname = "yeshup";
+  version = "unstable-2013-10-29";
 
   src = fetchFromGitHub {
     owner = "RhysU";
     repo  = "yeshup";
-    inherit rev;
+    rev = "5461a8f957c686ccd0240be3f0fd8124d7381b08";
     sha256 = "1wwbc158y46jsmdi1lp0m3dlbr9kvzvwxfvzj6646cpy9d6h21v9";
   };
 

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -81,7 +81,8 @@ rec {
     });            
   
   xmlmirror = pkgs.buildEmscriptenPackage rec {
-    name = "xmlmirror";
+    pname = "xmlmirror";
+    version = "unstable-2016-06-05";
 
     buildInputs = [ pkgconfig autoconf automake libtool gnumake libxml2 nodejs openjdk json_c ];
     nativeBuildInputs = [ pkgconfig zlib ];
@@ -113,7 +114,7 @@ rec {
     
     installPhase = ''
       mkdir -p $out/share
-      mkdir -p $doc/share/${name}
+      mkdir -p $doc/share/${pname}
       
       cp Demo* $out/share
       cp -R codemirror-5.12 $out/share
@@ -124,7 +125,7 @@ rec {
       cp *.html $out/share
       cp *.json $out/share
       cp *.rng $out/share
-      cp README.md $doc/share/${name}
+      cp README.md $doc/share/${pname}
     '';
     checkPhase = ''
       


### PR DESCRIPTION
###### Motivation for this change

Fix issues repology reported, so they detect our package versions correctly.

With such changes we will have even more up-to-date packages and be the best distro :)

https://repology.org/repositories/graphs

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
