### PR TITLE
pythonPackages.wurlitzer: add missing python2 dependencies

### DIFF
--- a/pkgs/development/python-modules/wurlitzer/default.nix
+++ b/pkgs/development/python-modules/wurlitzer/default.nix
@@ -1,8 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , mock
 , pytest
+, selectors2
 }:
 
 buildPythonPackage rec {
@@ -13,6 +15,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0xndv47iwc9k8cp5r9r1z3r0xww0r5x5b7qsmn39gk2gsg0119c6";
   };
+
+  propagatedBuildInputs = lib.optionals isPy27 [ selectors2 ];
 
   checkInputs = [ mock pytest ];
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was a new failure in hydra logs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[3 built, 4 copied (0.2 MiB), 0.1 MiB DL]
https://github.com/NixOS/nixpkgs/pull/72928
2 package were build:
python27Packages.spyder-kernels python27Packages.wurlitzer
```