### PR TITLE
terraform-providers: update and improve update script

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/data.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/data.nix
@@ -792,6 +792,14 @@
       version = "0.2.0";
       sha256  = "0ic5b9djhnb1bs2bz3zdprgy3r55dng09xgc4d9l9fyp85g2amaz";
     };
+  pass =
+    {
+      owner   = "camptocamp";
+      repo    = "terraform-provider-pass";
+      rev     = "1.2.1";
+      version = "1.2.1";
+      sha256  = "1hf5mvgz5ycp7shiy8px205d9kwswfjmclg7mlh9a55bkraffahk";
+    };
   matchbox =
     {
       owner   = "poseidon";

--- a/pkgs/applications/networking/cluster/terraform-providers/data.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/data.nix
@@ -4,27 +4,31 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-acme";
-      version = "1.3.5";
-      sha256  = "0xjxxz3vxq7vk7sv6b5p57z5x92dmrm44v6ksffcg76ngc40nrxk";
+      rev     = "v1.5.0";
+      version = "1.5.0";
+      sha256  = "1h53bgflchavnn4laf801d920bsgqqg0ph4slnf7y1fpb0mz5vdv";
     };
   alicloud =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-alicloud";
-      version = "1.54.0";
-      sha256  = "01pmhwdnhfsk785ja11hxn5l5fmklnkiv12kv2pw2280cdljfcv4";
+      rev     = "v1.60.0";
+      version = "1.60.0";
+      sha256  = "14k96ccjrjiqfrdrj9kd090ms1p15z71qv60gm05bhffviyplmgw";
     };
   archive =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-archive";
-      version = "1.2.2";
-      sha256  = "1saprj2r74b63z03n80m3mfj3vhgvlm4gp2hzqzjbdgibxsz4jaw";
+      rev     = "v1.3.0";
+      version = "1.3.0";
+      sha256  = "1hwg8ai4bvsmgnl669608lr4v940xnyig1xshps490f47c8hqy6y";
     };
   arukas =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-arukas";
+      rev     = "v1.1.0";
       version = "1.1.0";
       sha256  = "1akl9fzgm5qv01vz18xjzyqjnlxw699qq4x8vr96j16l1zf10h99";
     };
@@ -32,6 +36,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-atlas";
+      rev     = "v0.1.1";
       version = "0.1.1";
       sha256  = "0k73vv14vnjl5qm33w54s5zzi0mmk1kn2zs3qkfq71aqi9ml7d14";
     };
@@ -39,41 +44,47 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-aws";
-      version = "2.23.0";
-      sha256  = "0yscy0qmdl07air0b16i6zd0w8y3z20pk5l53pwm78ssdxn3w6qc";
+      rev     = "v2.34.0";
+      version = "2.34.0";
+      sha256  = "1kmy6hn1d3padfnix17ibmrm1339q4li0740dlfgjlxjv179bv34";
     };
   azuread =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-azuread";
-      version = "0.5.1";
-      sha256  = "0bjy6wdfzsxchqclgp7c06b49b5h60nips69hcpwd45564iql5fh";
+      rev     = "v0.6.0";
+      version = "0.6.0";
+      sha256  = "1s3k2plka1lzfij4vhr30vc549zysa6v8j5mphra7fjxy236v40j";
     };
   azurerm =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-azurerm";
-      version = "1.32.1";
-      sha256  = "0ydzibmvz52i62pk0g96rl7vxhff5izrsgdwk6lgc56nw63w2l8g";
+      rev     = "v1.36.1";
+      version = "1.36.1";
+      sha256  = "1mnbmbfsnc859j6ahcph80z0v1jl82dnbjqmqg2q0kiappz2g2lm";
     };
   azurestack =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-azurestack";
-      version = "0.8.1";
-      sha256  = "1sbmjrqzzn8rf9xhaax2ykyg199sggx80apx0xvd4ab82c3ldyfw";
+      rev     = "v0.9.0";
+      version = "0.9.0";
+      sha256  = "1msm7jwzry0vmas3l68h6p0migrsm6d18zpxcncv197m8xbvg324";
     };
   bigip =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-bigip";
-      version = "0.12.3";
-      sha256  = "1zlwk7jp5r45b3rwkxsq9mqf4nym3ifx56vhcvyc9a3w25s0ss8p";
+      rev     = "v1.0.0";
+      version = "1.0.0";
+      sha256  = "0dz5dfv3glx7898a9bi9vi3g0ghyi96pc45brrj41and5835jvdc";
     };
   bitbucket =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-bitbucket";
+      rev     = "v1.1.0";
       version = "1.1.0";
       sha256  = "06bjagbgpgfphwym015wl00wx6qf7lsdig0fhpxqaykvlkn3sg49";
     };
@@ -81,6 +92,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-brightbox";
+      rev     = "v1.2.0";
       version = "1.2.0";
       sha256  = "0s1b2k58r2kmjrdqrkw2dlfpby79i81gml9rpa10y372bwq314zd";
     };
@@ -88,6 +100,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-chef";
+      rev     = "v0.2.0";
       version = "0.2.0";
       sha256  = "0ihn4706fflmf0585w22l7arzxsa9biq4cgh8nlhlp5y0zy934ns";
     };
@@ -95,6 +108,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-circonus";
+      rev     = "v0.2.0";
       version = "0.2.0";
       sha256  = "1vcia3p31cgdwjs06k4244bk7ib2qp1f2lhc7hmyhdfi1c8jym45";
     };
@@ -102,6 +116,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-clc";
+      rev     = "v0.1.0";
       version = "0.1.0";
       sha256  = "0gvsjnwk6xkgxai1gxsjf0hsjxbv8d8jg5hq8yd3hjhc6785fgnf";
     };
@@ -109,13 +124,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-cloudflare";
-      version = "1.17.1";
-      sha256  = "0kmkk5fhgsvjakqrfs7p92dcljn04asxq15af1r9n5csq54q7na3";
+      rev     = "v2.0.1";
+      version = "2.0.1";
+      sha256  = "18cxyxgv6x5s1xsd5l460hnl1xdvrvkwb36lhvk3dgziaw2xxr81";
     };
   cloudscale =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-cloudscale";
+      rev     = "v2.0.0";
       version = "2.0.0";
       sha256  = "145hj4pbi5zrkgamicy3m1n3380fpd2ndd6ym7mwd65d95g39vwb";
     };
@@ -123,6 +140,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-cloudstack";
+      rev     = "v0.3.0";
       version = "0.3.0";
       sha256  = "0zmyww6z3j839ydlmv254hr8gcsixng4lcvmiwkhxb3hj1nw8hcw";
     };
@@ -130,6 +148,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-cobbler";
+      rev     = "v1.1.0";
       version = "1.1.0";
       sha256  = "08ljqibfi6alpvv8f7pzvjl2k4w6br6g6ac755x4xw4ycrr24xw9";
     };
@@ -137,27 +156,31 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-consul";
-      version = "2.5.0";
-      sha256  = "1nmldxn4y87fyb308dajjzcyvxrr6ka5nicyw84a8s7pixzbqh6q";
+      rev     = "v2.6.0";
+      version = "2.6.0";
+      sha256  = "1c7qpgf2vh4crs69alzwwaicsz29b2y72x4xjmfb9dg5cy7gk1i5";
     };
   datadog =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-datadog";
-      version = "2.1.0";
-      sha256  = "0k7apad2r07gw9kf0zzqc8wa2wcmxihi3x8sdssl32qjib20qwv1";
+      rev     = "v2.5.0";
+      version = "2.5.0";
+      sha256  = "0l5jix165ghfj72l3mr76d5b5lx5pgr45zimk8lr0fwn79f4bs74";
     };
   digitalocean =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-digitalocean";
-      version = "1.6.0";
-      sha256  = "06cxm3qcym8jwp4nl1bzk3p9fbaz26bvddqzn3p8l57c802qqds6";
+      rev     = "v1.10.0";
+      version = "1.10.0";
+      sha256  = "1c53g32mk41lvq4ikfj04m89nhzrdk8d6h35aq3z07yyqp6ap2a0";
     };
   dme =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-dme";
+      rev     = "v0.1.0";
       version = "0.1.0";
       sha256  = "1ipqw1sbx0i9rhxawsysrqxvf10z8ra2y86xwd4iz0f12x9drblv";
     };
@@ -165,6 +188,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-dns";
+      rev     = "v2.2.0";
       version = "2.2.0";
       sha256  = "11xdxj6hfclaq9glbh14nihmrsk220crm9ld8bdv77w0bppmrrch";
     };
@@ -172,6 +196,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-dnsimple";
+      rev     = "v0.2.0";
       version = "0.2.0";
       sha256  = "0jj82fffqaz7gramj5d4avx7vka6w190yz4r9q7628qh8ih2pfhz";
     };
@@ -179,13 +204,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-docker";
-      version = "2.1.1";
-      sha256  = "0px3xj76ay5ixpmynas49z31xmk4zmpn0917y6a20kr2x2abi9zb";
+      rev     = "v2.5.0";
+      version = "2.5.0";
+      sha256  = "1nril7qy1nm1dq19vg6mm0zc0sgkjrm1s39n7p9gxf4s4j78ig1n";
     };
   dyn =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-dyn";
+      rev     = "v1.2.0";
       version = "1.2.0";
       sha256  = "1a3kxmbib2y0nl7gnxknbhsflj5kfknxnm3gjxxrb2h5d2kvqy48";
     };
@@ -193,6 +220,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-external";
+      rev     = "v1.2.0";
       version = "1.2.0";
       sha256  = "1kx28bffhd1pg3m0cbldclc8l9zic16mqrk7gybcls9vyds5gbvc";
     };
@@ -200,48 +228,55 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-fastly";
-      version = "0.9.0";
-      sha256  = "0g3rgi6s9hyb6vzl682n8zqz5virdxvxh04v88n9iy5r7hwrxxzg";
+      rev     = "v0.11.0";
+      version = "0.11.0";
+      sha256  = "0wq8l1lkfpv5nfd04dsjaa9wv09373i6wwnapifx1wncjyhs4jd4";
     };
   flexibleengine =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-flexibleengine";
-      version = "1.6.0";
-      sha256  = "0vz68nhpy93zsdssxzr41flrwhjqh7wcjrc4nklg6kmr99n6jcc6";
+      rev     = "v1.9.0";
+      version = "1.9.0";
+      sha256  = "1y66xy5yqdjdrh3zkw1q7ml5b2rsyy4ayc4m026c4mmh0x1vfk9y";
     };
   github =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-github";
-      version = "2.2.0";
-      sha256  = "1h44v7428z3v3hv6ywi3n0yhnvgx9cr6vgqb1n2w1qf7k2f0jkzx";
+      rev     = "v2.2.1";
+      version = "2.2.1";
+      sha256  = "1dg5jgd3cdz98wfd71l58wsp949mvs2lrcqh1amgql0s90pwjmvg";
     };
   gitlab =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-gitlab";
-      version = "2.2.0";
-      sha256  = "0iz5ggjkcip86cz2zmsryad34hly542grwzlm5rvpcmfw5csjadw";
+      rev     = "v2.3.0";
+      version = "2.3.0";
+      sha256  = "012pbgfdmwyq8y8ddrhyf14jc6s7v24f1w3mrpi6mp4glqc5yfqx";
     };
   google =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-google";
-      version = "2.12.0";
-      sha256  = "15fdpmdikm77hlfksdbcblysb82sd51vw4ninx60hzgddqp6ll4m";
+      rev     = "v2.19.0";
+      version = "2.19.0";
+      sha256  = "00pqkysic3x8iygcxb232dwbpmy5ldf7fdfi6ldiv3g6gbvlcaf7";
     };
   google-beta =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-google-beta";
-      version = "2.12.0";
-      sha256  = "11aky7jvm7i39pnj3ypy42d9yk9akqb3wjb03hyllzfddwhvay5q";
+      rev     = "v2.19.0";
+      version = "2.19.0";
+      sha256  = "03im9h7r2vyx4y9qnc3l0hsvcqy7rai5dlkmj1za3npm98vpx2d7";
     };
   grafana =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-grafana";
+      rev     = "v1.5.0";
       version = "1.5.0";
       sha256  = "0zy3bqgpxymp2zygaxzllk1ysdankwxa1sy1djfgr4fs2nlggkwi";
     };
@@ -249,13 +284,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-hcloud";
-      version = "1.12.0";
-      sha256  = "1r61s7chq636fcjv67g0vjlc35xx0ycy58hg6b5i5rdc9737v7hp";
+      rev     = "v1.14.0";
+      version = "1.14.0";
+      sha256  = "13zxrjx4im25g7m45z95d3py85nzs2k8r9grilxshr6x95bxk2f0";
     };
   hedvig =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-hedvig";
+      rev     = "v1.0.4";
       version = "1.0.4";
       sha256  = "0y6brzznxp8khdfbnpmnbjqf140411z0pvnp88p8mj2kmbk7kkjd";
     };
@@ -263,20 +300,23 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-helm";
-      version = "0.10.2";
-      sha256  = "1xp8dx6ncskmfa9bjd54434f4a7pnjz5r3yvnh1hmv3i5ykfxzdn";
+      rev     = "v0.10.4";
+      version = "0.10.4";
+      sha256  = "0xl0wgh1j6yhymadqvlj21qddxfzaxk3d5wpzskfmhfk732795rc";
     };
   heroku =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-heroku";
-      version = "2.1.2";
-      sha256  = "0n8id5rw4hzsiic9yv4rzm709npagv9sfp6dd1ax6np5kai78b87";
+      rev     = "v2.2.1";
+      version = "2.2.1";
+      sha256  = "145kfm4asca0ksprb076mjdhs5ahrlrad8cqz8spxra5fa3j46sq";
     };
   http =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-http";
+      rev     = "v1.1.1";
       version = "1.1.1";
       sha256  = "0ah4wi9gm5m7z0wyy6vn3baz2iw2sq7ah7q0lb9srwr887aai3x0";
     };
@@ -284,13 +324,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-huaweicloud";
-      version = "1.7.0";
-      sha256  = "1yhyyh33hvzs74pryb383p1w0c0d4vn23pnm6snxi1cw49wgiiyf";
+      rev     = "v1.9.0";
+      version = "1.9.0";
+      sha256  = "06blhsbv5pxlb1m07qanrq5qmbai33dlk89ghzscrqwnvv1nnszr";
     };
   icinga2 =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-icinga2";
+      rev     = "v0.2.0";
       version = "0.2.0";
       sha256  = "02ladn2w75k35vn8llj3zh9hbpnnnvpm47c9f29zshfs04acwbq0";
     };
@@ -298,6 +340,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-ignition";
+      rev     = "v1.1.0";
       version = "1.1.0";
       sha256  = "0vpjbb70wnlrvw7z2zc92fbisgjk49ivdmv10ahyqlgvc23js5va";
     };
@@ -305,6 +348,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-influxdb";
+      rev     = "v1.3.0";
       version = "1.3.0";
       sha256  = "19af40g8hgz2rdz6523v0fs71ww7qdlf2mh5j9vb7pfzriqwa5k9";
     };
@@ -312,13 +356,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-kubernetes";
-      version = "1.8.1";
-      sha256  = "0jcc3i10x0qz7sj8l5yv98jc2g32a6yhdpc45sq33wmhcvp1fsn4";
+      rev     = "v1.9.0";
+      version = "1.9.0";
+      sha256  = "1ai8w853k4pgr43g9dwdsimw0g0c6vg6vg2f20d9ch7bx8ii4nhf";
     };
   librato =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-librato";
+      rev     = "v0.1.0";
       version = "0.1.0";
       sha256  = "0bxadwj5s7bvc4vlymn3w6qckf14hz82r7q98w2nh55sqr52d923";
     };
@@ -326,6 +372,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-linode";
+      rev     = "v1.8.0";
       version = "1.8.0";
       sha256  = "1jgh2ij58a5mr6ns604cfpvfvr19qr0q51j57gvchz53iv683m9q";
     };
@@ -333,13 +380,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-local";
-      version = "1.3.0";
-      sha256  = "1z6b52vdq7wzzipldys28z45glwgj9k15ighjix1dy78mzi0p99n";
+      rev     = "v1.4.0";
+      version = "1.4.0";
+      sha256  = "1k1kbdn99ypn1pi6vqbs1l9a8vvf4vs32wl8waa16i26514sz1wk";
     };
   logentries =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-logentries";
+      rev     = "v1.0.0";
       version = "1.0.0";
       sha256  = "04xprkb9zwdjyzmsdf10bgmn8sa8q7jw0izz8lw0cc9hag97qgbq";
     };
@@ -347,6 +396,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-logicmonitor";
+      rev     = "v1.2.1";
       version = "1.2.1";
       sha256  = "1fcv5g92l6xr4x69h9rg48zazjr99wrz9mkmr122fyq9s7kdd98y";
     };
@@ -354,20 +404,23 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-mailgun";
-      version = "0.1.0";
-      sha256  = "1hjhjfxqbr43wa248c6hc91lx5b2gdw4vl92l2i6aqp17rbc0wfj";
+      rev     = "v0.4.1";
+      version = "0.4.1";
+      sha256  = "1l76pg4hmww9zg2n4rkhm5dwjh42fxri6d41ih1bf670krkxwsmz";
     };
   mysql =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-mysql";
-      version = "1.7.0";
-      sha256  = "19l1ihp5jlaahm8zncjlrnfw8d8gcpnq3z6pn421j1x0d5v5vw9b";
+      rev     = "v1.8.0";
+      version = "1.8.0";
+      sha256  = "1llcg2mp6jbj386liinly62pgy934v0c2g5z976n0xwfdiybyhwx";
     };
   netlify =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-netlify";
+      rev     = "v0.3.0";
       version = "0.3.0";
       sha256  = "0mmbli6d3fbpyvvdfsg32f1w83g8ga3x21b36rgmx3mn156r7yij";
     };
@@ -375,27 +428,31 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-newrelic";
-      version = "1.5.1";
-      sha256  = "1xrwh9m1sig4hd2vvb7apy2gh8rz15wdrajggzmmpc1z1rlhf90p";
+      rev     = "v1.5.2";
+      version = "1.5.2";
+      sha256  = "1q2vlpzxz04xhmf2wi5pc501454qwzh59kdhfhs8yjg1d1489jng";
     };
   nomad =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-nomad";
-      version = "1.4.1";
-      sha256  = "1v4wwinnb2qc71jgil4607kgdccjivssabqgb5l3yk8pwfidgdnr";
+      rev     = "v1.4.2";
+      version = "1.4.2";
+      sha256  = "0h0snkzqdi4g5lp78f5pq98x6556ldwgkg9p9jkmrg04y7928w5v";
     };
   ns1 =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-ns1";
-      version = "1.5.0";
-      sha256  = "1m6f1hsx2gcb5b50sm8cj04hkmn71xlxji8qwlswasz2sg1sllrx";
+      rev     = "v1.6.0";
+      version = "1.6.0";
+      sha256  = "1v075wc48pq9kp9rp4kanlfshnxgan9h914nqalq90xgzyl2gf3v";
     };
   nsxt =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-nsxt";
+      rev     = "v1.1.1";
       version = "1.1.1";
       sha256  = "19bbycify25bshpyq65qjxnl72b6wmwwwdb7hxl94hhbgx2c9z29";
     };
@@ -403,6 +460,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-null";
+      rev     = "v2.1.2";
       version = "2.1.2";
       sha256  = "0di1hxmd3s80sz8hl5q2i425by8fbk15f0r4jmnm6vra0cq89jw2";
     };
@@ -410,20 +468,23 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-nutanix";
-      version = "1.0.1";
-      sha256  = "1g7p6qg32g75x8fgspgxcdsa086mz3yabdgv1k68rykhw3zbri5d";
+      rev     = "v1.0.2";
+      version = "1.0.2";
+      sha256  = "17sgsxsh8minirks08c6gz52cf7ndn220sx4xzi6bq64yi6qw2yc";
     };
   oci =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-oci";
-      version = "3.37.0-rc1";
-      sha256  = "0ahqnh9qzixp434qn2ckj8p32kb9x26l1xz8yr84h6sqfrn58bcv";
+      rev     = "v3.50.0-rc1";
+      version = "3.50.0-rc1";
+      sha256  = "0nzz62zyx5xf2qlvjcbsqnafdhmq194yhyipcab1n2ckji8zb03z";
     };
   oneandone =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-oneandone";
+      rev     = "v1.3.0";
       version = "1.3.0";
       sha256  = "0c412nqg3k17124i51nn3ffra6gcll904h37h7hyvz97cdblcncn";
     };
@@ -431,6 +492,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-opc";
+      rev     = "v1.3.7";
       version = "1.3.7";
       sha256  = "01g09w8mqfp1d8phplsdj0vz63q5bgq9fqwy2kp4vrnwb70dq52w";
     };
@@ -438,34 +500,39 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-openstack";
-      version = "1.21.1";
-      sha256  = "0nvhn2bnk11sz4i98yw7rpxi8b3c2y04qq37ybvqx2jyi3n9kj30";
+      rev     = "v1.24.0";
+      version = "1.24.0";
+      sha256  = "1w82ix6l6ad7q0zl00hys8c4gm27nnk12wm2n8i3prwpjnrar70m";
     };
   opentelekomcloud =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-opentelekomcloud";
-      version = "1.11.0";
-      sha256  = "175j2bbw3bdbjq1b7b1kwsr8iay9aafz165d0brfpb8gf096y7xa";
+      rev     = "v1.13.1";
+      version = "1.13.1";
+      sha256  = "1mxbfskxf9zwm55r3s6fhk634pnyk0sx5pgwk3kmw4sgjv88i1ny";
     };
   opsgenie =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-opsgenie";
-      version = "0.1.0";
-      sha256  = "0zs0cl6jl4rijcs6vv5k8k5pyf0zs52dlgqcnb1gzslh8sg5pdkm";
+      rev     = "v0.2.4";
+      version = "0.2.4";
+      sha256  = "1kgvbx39v6f3hszwrqjsaq3wvwzkxf4gwwfix2m6bprfr5q5vn0d";
     };
   oraclepaas =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-oraclepaas";
-      version = "1.5.2";
-      sha256  = "0m886wfg5ski8s1zr7g1h1m6q5ai08jk35ymipxpb6ipx781qvvk";
+      rev     = "v1.5.3";
+      version = "1.5.3";
+      sha256  = "0xb03b5jgm06rgrllib6zj1nkh54zv2mqjnyfflgnazpf4c1ia15";
     };
   ovh =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-ovh";
+      rev     = "v0.5.0";
       version = "0.5.0";
       sha256  = "07n8ismxbv0gngh4kibqhr4ndqkrg6gxbpj3zl764rrwp54gwgbw";
     };
@@ -473,41 +540,47 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-packet";
-      version = "2.3.0";
-      sha256  = "1v2758wjhrn7rhwdx658w3sf1q5lp4cawl6llbv4p16c5fyzwwc2";
+      rev     = "v2.6.1";
+      version = "2.6.1";
+      sha256  = "198lkw5b4xfyf82yzym66fna7j0wl3hzvkdr9b9q7f0nffx47xri";
     };
   pagerduty =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-pagerduty";
-      version = "1.3.1";
-      sha256  = "1x29ya0xcjj2b3x2q2q7iyqric8vswf18a5bwhwv2017c1g4n299";
+      rev     = "v1.4.1";
+      version = "1.4.1";
+      sha256  = "0dmafnlziyczad907isjqzsn1fyjzc8pdigp3m6114bbnca0ry5k";
     };
   panos =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-panos";
-      version = "1.5.2";
-      sha256  = "0sycgr4k4dlhxj5klmgg2xcw3xha06332ij8cfzz4xvgdq0xky3j";
+      rev     = "v1.6.0";
+      version = "1.6.0";
+      sha256  = "0qszdyrj84c8i195y45cnanzmkn8ypi1gi5a03pf3gsf2fdcj9gq";
     };
   postgresql =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-postgresql";
-      version = "1.1.0";
-      sha256  = "1dxspqajfy8dmplasazi4s34f47n1qz7qg2dr9ypdvd3jp63072w";
+      rev     = "v1.3.0";
+      version = "1.3.0";
+      sha256  = "14ma5lm6ng52dfl8bl4rmpy8ylnkbvnbskvkr6r5sn28x51p601y";
     };
   powerdns =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-powerdns";
-      version = "1.0.0";
-      sha256  = "1qh4z69b0sqxwjjgc8xis165gdszav9yc85ba6pgyl3wbymkld30";
+      rev     = "v1.2.0";
+      version = "1.2.0";
+      sha256  = "1108hq4z4is305hnbkn95gv0f5lx5l27wvxvq0g03fcdqdimkrfn";
     };
   profitbricks =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-profitbricks";
+      rev     = "v1.4.4";
       version = "1.4.4";
       sha256  = "0pzcl3pdhaykihvv1v38zrv607mydchvkzrzhwcakgmdkp3vq54i";
     };
@@ -515,6 +588,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-rabbitmq";
+      rev     = "v1.1.0";
       version = "1.1.0";
       sha256  = "0xihc44923kx8c3v6wrvczzbhmbjkhy7dhgx3sy5sqhmm22y0gys";
     };
@@ -522,6 +596,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-rancher";
+      rev     = "v1.4.0";
       version = "1.4.0";
       sha256  = "106arszmdjmgrz4iv01bbf72jarn7zjqvmc43b6n1s3lzd7jnfpc";
     };
@@ -529,13 +604,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-random";
-      version = "2.2.0";
-      sha256  = "0vg33jbvyxvg4dwcwjb2p57jjkq7qj50d356r4a1f2ysl2axwwjw";
+      rev     = "v2.2.1";
+      version = "2.2.1";
+      sha256  = "1qklsxj443vsj61lwl7qf7xwgnllwcvb2yk6s0kn9g3iq63pcv30";
     };
   rightscale =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-rightscale";
+      rev     = "v1.3.1";
       version = "1.3.1";
       sha256  = "0abwxaghrxpahpsk6kd02fjh0rhck4xsdrzcpv629yh8ip9rzcaj";
     };
@@ -543,6 +620,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-rundeck";
+      rev     = "v0.4.0";
       version = "0.4.0";
       sha256  = "1x131djsny8w84yf7w2il33wlc3ysy3k399dziii2lmq4h8sgrpr";
     };
@@ -550,6 +628,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-runscope";
+      rev     = "v0.6.0";
       version = "0.6.0";
       sha256  = "1fsph2cnyvzdwa5hwdjabfk4azmc3x8a7afpwpawxfdvqhgpr595";
     };
@@ -557,20 +636,23 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-scaleway";
-      version = "1.10.0";
-      sha256  = "0sbcvcd413f53b25piymmh4rfmlmqsxdscpar8gf2dx6mrsacgf0";
+      rev     = "v1.12.0";
+      version = "1.12.0";
+      sha256  = "0044fq5jkdx2ryc2bxqajkrngs6z81kd2narg4zxvfn0r1bfswvc";
     };
   selectel =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-selectel";
-      version = "2.3.0";
-      sha256  = "0n0nqlajcx44zxbc2k58lv3jy2y6p9zqkby2vy5a2856kcksm7pf";
+      rev     = "v3.0.0";
+      version = "3.0.0";
+      sha256  = "0fr97j85inaqvdqmlfk3xcq73zvncn001nsd03pp2ws30qqa8p7r";
     };
   skytap =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-skytap";
+      rev     = "v0.11.1";
       version = "0.11.1";
       sha256  = "1mlv6jp6lp47chcnsmx8dzy01bxpb9jx1wl122lxd88app9nxq1k";
     };
@@ -578,6 +660,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-softlayer";
+      rev     = "v0.0.1";
       version = "0.0.1";
       sha256  = "1xcg5zm2n1pc3l7ng94k589r7ykv6fxsmr5qn9xmmpdf912rdnfq";
     };
@@ -585,13 +668,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-spotinst";
-      version = "1.13.3";
-      sha256  = "0s75xlw8y3rz1ik11dnh3dzkk1jfklvq3wsf2fam0789z2j1zr1m";
+      rev     = "v1.13.4";
+      version = "1.13.4";
+      sha256  = "063lhm065y6qh9b2k11qjnqyfg5zrx6wa3bqrm7d1dqcha1i6d9f";
     };
   statuscake =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-statuscake";
+      rev     = "v1.0.0";
       version = "1.0.0";
       sha256  = "1x295va6c72465cxps0kx3rrb7s9aip2cniy6icsg1b2yrsb9b26";
     };
@@ -599,6 +684,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-telefonicaopencloud";
+      rev     = "v1.0.0";
       version = "1.0.0";
       sha256  = "1761wkjz3d2458xl7855lxklyxgyk05fddh92rp6975y0ca6xa5m";
     };
@@ -606,6 +692,7 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-template";
+      rev     = "v2.1.2";
       version = "2.1.2";
       sha256  = "18w1mmma81m9j7yf6q500w8v9ss28w6sw2ynssl99pyw2gwmd04q";
     };
@@ -613,13 +700,15 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-tencentcloud";
-      version = "1.15.0";
-      sha256  = "1ics91fxsl1z1wqd961wdn2s22ck25yphp341qlbs8ln2dcwk8r7";
+      rev     = "v1.22.0";
+      version = "1.22.0";
+      sha256  = "0lamj77n9b5m80201wim0zcjgdcbihcaq27z49himh2qi5j8lxiz";
     };
   terraform =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-terraform";
+      rev     = "v1.0.2";
       version = "1.0.2";
       sha256  = "1aj6g6l68n9kqmxfjlkwwxnac7fhha6wrmvsw4yylf0qyssww75v";
     };
@@ -627,34 +716,39 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-tfe";
-      version = "0.10.1";
-      sha256  = "09hrdschgydnziq1sv6ql7gc4qwx8j4dnmx4fdw8452qpszk17n2";
+      rev     = "v0.11.1";
+      version = "0.11.1";
+      sha256  = "0iagddaivpd7cxgf8ha2pk0m66gi4a804s86fsxla0j1knmmyra0";
     };
   tls =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-tls";
-      version = "2.0.1";
-      sha256  = "08fh4k5fvkijl2ds8mxdc5fxlwhs11y5s48vvxdskklvkjhygzc7";
+      rev     = "v2.1.1";
+      version = "2.1.1";
+      sha256  = "1qsx540pjcq4ra034q2dwnw5nmzab5h1c3vm20ppg5dkhhyiizq8";
     };
   triton =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-triton";
-      version = "0.5.1";
-      sha256  = "1bn5x6nmhfkrzpxhyfclls85l9qqffvzx1xsgcb3368lhwzarn2f";
+      rev     = "v0.6.0";
+      version = "0.6.0";
+      sha256  = "10z032fa64sd8d6r4v2f4m7gp93v8wb2zk2r13fflzg5rfk5740z";
     };
   ucloud =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-ucloud";
-      version = "1.11.1";
-      sha256  = "1la5kapdwpd2f6x00yc9j25rl8qkrndgqpzp2jp6mcbj5zif82ns";
+      rev     = "v1.14.1";
+      version = "1.14.1";
+      sha256  = "04vi87q2fhy907l7rwsbq5p6l9vm6avm1hbf9qwddkbxx2kjjf64";
     };
   ultradns =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-ultradns";
+      rev     = "v0.1.0";
       version = "0.1.0";
       sha256  = "0bq2y6bxdax7qnmq6vxh8pz9sqy1r3m05dv7q5dbv2xvba1b88hj";
     };
@@ -662,41 +756,63 @@
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-vault";
-      version = "2.2.0";
-      sha256  = "0k9frx29pjrrx67cwzsrnj0x90ff5k99l5yzfgb58sajkz1j8nln";
+      rev     = "v2.5.0";
+      version = "2.5.0";
+      sha256  = "0h3q2zifjgm05kvdans88dl8wx9hr21c1s64fmfs4an07gkg8947";
     };
   vcd =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-vcd";
-      version = "2.4.0";
-      sha256  = "020wmdl5cbma9r7sv3bx6v8b59w5nwkzgwj4xm7a2s6kn8jygr2x";
+      rev     = "v2.5.0";
+      version = "2.5.0";
+      sha256  = "0h78ij9rkx43i9kdcfy7waa6xyn2j40zgm6im3zp0yswy6vjlcyq";
     };
   vsphere =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-vsphere";
-      version = "1.12.0";
-      sha256  = "0g3pnk2b4dmz5bkr7xjpp45dwy767k6a02rjva38xls185qs7i7c";
+      rev     = "v1.13.0";
+      version = "1.13.0";
+      sha256  = "10gl042l5mlmklhjjknwln1qcwl65xz8sbg1acyv8xkb6nsaxcf1";
     };
   yandex =
     {
       owner   = "terraform-providers";
       repo    = "terraform-provider-yandex";
-      version = "0.9.0";
-      sha256  = "0x3l0pbpdsm43jsx42xzc46r9j40l7szkcf851q16wsxf70lchqr";
+      rev     = "v0.23.0";
+      version = "0.23.0";
+      sha256  = "0vv8lp834q8i7fam2s8pvs7slfwlf8m4g080i9cij5z2lgipja32";
+    };
+  segment =
+    {
+      owner   = "ajbosco";
+      repo    = "terraform-provider-segment";
+      rev     = "v0.2.0";
+      version = "0.2.0";
+      sha256  = "0ic5b9djhnb1bs2bz3zdprgy3r55dng09xgc4d9l9fyp85g2amaz";
     };
   matchbox =
     {
       owner   = "poseidon";
       repo    = "terraform-provider-matchbox";
+      rev     = "v0.3.0";
       version = "0.3.0";
       sha256  = "1nq7k8qa7rv8xyryjigwpwcwvj1sw85c4j46rkfdv70b6js25jz3";
+    };
+  wavefront =
+    {
+      owner   = "spaceapegames";
+      repo    = "terraform-provider-wavefront";
+      rev     = "v2.1.1";
+      version = "2.1.1";
+      sha256  = "0cbs74kd820i8f13a9jfbwh2y5zmmx3c2mp07qy7m0xx3m78jksn";
     };
   nixos =
     {
       owner   = "tweag";
       repo    = "terraform-provider-nixos";
+      rev     = "v0.0.1";
       version = "0.0.1";
       sha256  = "00vz6qjq1pk39iqg4356b8g3c6slla9jifkv2knk46gc9q93q0lf";
     };
@@ -704,21 +820,8 @@
     {
       owner   = "tweag";
       repo    = "terraform-provider-secret";
-      version = "1.0.0";
-      sha256  = "03q78d0g3b4j4213qjlacj1adh7hjwcqcqrwm8c2r2k5w9kb25k0";
-    };
-  segment =
-    {
-      owner   = "ajbosco";
-      repo    = "terraform-provider-segment";
-      version = "0.2.0";
-      sha256  = "0ic5b9djhnb1bs2bz3zdprgy3r55dng09xgc4d9l9fyp85g2amaz";
-    };
-  wavefront =
-    {
-      owner   = "spaceapegames";
-      repo    = "terraform-provider-wavefront";
-      version = "2.1.0";
-      sha256  = "1ir2wkg5mfng7h5544kar1arkjb5ffjhki5qr25a5x0rpwlg99sx";
+      rev     = "v1.1.0";
+      version = "1.1.0";
+      sha256  = "09gv0fpsrxzgna0xrhrdk8d4va9s0gvdbz596r306qxb4mip4w3r";
     };
 }

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -9,13 +9,12 @@ let
 
   toDrv = data:
     buildGoPackage rec {
-      inherit (data) owner repo version sha256;
+      inherit (data) owner repo rev version sha256;
       name = "${repo}-${version}";
       goPackagePath = "github.com/${owner}/${repo}";
       subPackages = [ "." ];
       src = fetchFromGitHub {
-        inherit owner repo sha256;
-        rev = "v${version}";
+        inherit owner repo rev sha256;
       };
 
 

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.txt
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.txt
@@ -11,6 +11,7 @@ terraform-providers terraform-provider- terraform-provider-\\(azure-classic\\|sc
 
 # include providers from individual repos
 ajbosco/terraform-provider-segment
+camptocamp/terraform-provider-pass
 poseidon/terraform-provider-matchbox
 spaceapegames/terraform-provider-wavefront
 tweag/terraform-provider-nixos

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.txt
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.txt
@@ -9,17 +9,9 @@
 # include all terraform-providers
 terraform-providers terraform-provider- terraform-provider-\\(azure-classic\\|scaffolding\\)
 
-# include terraform-provider-matchbox
-poseidon/terraform-provider-matchbox
-
-# include terraform-provider-nixos
-tweag/terraform-provider-nixos
-
-# include terraform-provider-secret
-tweag/terraform-provider-secret
-
-# include terraform-provider-segment
+# include providers from individual repos
 ajbosco/terraform-provider-segment
-
-# include terraform-provider-wavefront
+poseidon/terraform-provider-matchbox
 spaceapegames/terraform-provider-wavefront
+tweag/terraform-provider-nixos
+tweag/terraform-provider-secret

--- a/pkgs/applications/networking/cluster/terraform-providers/update-all
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-all
@@ -58,12 +58,14 @@ prefetch_github() {
 echo_entry() {
   local owner=$1
   local repo=$2
-  local version=${3:1}
+  local rev=$3
+  local version=$(echo $3 | sed 's/^v//')
   local sha256=$4
   cat <<EOF
 {
   owner   = "$owner";
   repo    = "$repo";
+  rev     = "$rev";
   version = "$version";
   sha256  = "$sha256";
 };


### PR DESCRIPTION
###### Motivation for this change

Adding terraform-provider-pass and making it work with the `update-all` script required some changes to the way the update mechanism works. In the course of this I also updated all registered providers. See individual commit messages for a detailed description of reasons and measures taken.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
