### PR TITLE
python3Packages.google_cloud_vision: fix tests

### DIFF
--- a/pkgs/development/python-modules/google_cloud_vision/default.nix
+++ b/pkgs/development/python-modules/google_cloud_vision/default.nix
@@ -3,7 +3,6 @@
 , fetchPypi
 , enum34
 , google_api_core
-, pytest
 , mock
 }:
 
@@ -16,11 +15,13 @@ buildPythonPackage rec {
     sha256 = "f33aea6721d453901ded268dee61a01ab77d4cd215a76edc3cc61b6028299d3e";
   };
 
-  checkInputs = [ pytest mock ];
+  checkInputs = [ mock ];
   propagatedBuildInputs = [ enum34 google_api_core ];
 
+  # pytest seems to pick up some file which overrides PYTHONPATH
   checkPhase = ''
-    pytest tests/unit
+    cd tests/unit
+    python -m unittest discover
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 2 copied (6.1 MiB), 1.8 MiB DL]
https://github.com/NixOS/nixpkgs/pull/72940
2 package were build:
python37Packages.google_cloud_vision python38Packages.google_cloud_vision
```