### PR TITLE
Backport nlohmann_json: disable tests for now since they timeout

### DIFF
--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -21,7 +21,9 @@ stdenv.mkDerivation rec {
     [ "-DBuildTests=${if doCheck then "ON" else "OFF"}" ]
     ++ stdenv.lib.optional multipleHeaders "-DJSON_MultipleHeaders=ON";
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  # A test cause the build to timeout https://github.com/nlohmann/json/issues/1816
+  #doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Header only C++ library for the JSON file format";


### PR DESCRIPTION
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/72925 to NixOS 19.09

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @grahamc 
