### PR TITLE
Prevent `mkIf`'s from being `//`'d, and co.

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -497,6 +497,30 @@ rec {
 
   /* Properties. */
 
+  /*
+  These functions wrap/unwrap some value into/from an opaque container that
+  only has a very minimal way of possible interactions. Specifically the
+  container is a function, meaning it's not possible to use // on it or get
+  values from it with .<attrname>
+
+  opaqueWrap :: Any -> OpaqueWrapper
+  opaqueUnwrap :: OpaqueWrapper -> Any
+
+  Examples:
+    > opaqueWrap { x = true; }
+    «lambda @ (string):1:5»
+
+    > opaqueWrap { x = true; } // opaqueWrap { x = false; }
+    error: value is a function while a set was expected
+
+    > opaqueUnwrap (opaqueWrap { x = true; })
+    { x = true; }
+
+  */
+  opaqueWrap = value: { _opaqueWrapper }: value;
+  isOpaqueWrapper = x: builtins.isFunction x && builtins.functionArgs x ? _opaqueWrapper;
+  opaqueUnwrap = wrapper: wrapper { _opaqueWrapper = null; };
+
   mkIf = condition: content:
     { _type = "if";
       inherit condition content;


### PR DESCRIPTION
###### Motivation for this change

`mkIf` can be very deceiving, since the following doesn't do what you might expect:

```nix
{
  some.option = {
    foo = "foo";
  } // mkIf cond {
    bar = "bar";
  };
}
```

Because in fact, this results in exactly the same behavior as

```nix
{
  some.option = mkIf cond {
    bar = "bar";
  };
}
```

The assigment to `foo` gets completely ignored! This is because of the implementation of `mkIf`: https://github.com/NixOS/nixpkgs/blob/92216681ccb5b4424bdcab14e0081ba8209a4186/lib/modules.nix#L500-L503

which makes the resulting value in the above example be of the form
```nix
{ _type = "if"; condition = <cond>; content = { bar = "bar"; }; foo = "foo"; }
```

`mkIf` creates an attribute set with some special keys the module system uses to figure out whether it's a `mkIf` and allow lazy evaluation of the condition and contents. So using `//` on these attribute sets makes no sense because the keys don't represent the actual values, but some meta attributes!

This has led to at least one annoying bug in NixOS, see https://github.com/NixOS/nixpkgs/pull/72916. In addition I've seen this a couple times when reviewing NixOS module PRs too.

With this change, doing such mistakes gives the error
```
error: value is a function while a set was expected
```

which admittedly is pretty bad, but any error is better than incorrect behavior that potentially never gets noticed, and this is the only way I could come up with an error being produced at all that doesn't require changing everything.

Now when the user sees this error they have to fix their conditionals by using `mkMerge` which correctly handles this:

```nix
{
  some.option = mkMerge [
    { foo = "foo"; }
    (mkIf cond { bar = "bar"; })
  ];
}
```

This problem can also occur with other such functions like `mkMerge`, `mkOverride` and `mkOrder` combined with `//` or attribute access. This PR will make all of those throw an error when used incorrectly.

See the commits for an explanation of the implementation.

Ping @jtojnar @JohnAZoidberg @worldofpeace @rycee 

###### Things done

- [x] Tested that this indeed produces an error for such incorrect assignments
- [x] Made sure that the minimal graphical installer still evaluates
- [ ] Found and eliminated all uses of `mkIf` + `//` (and similar) in nixpkgs