### PR TITLE
darwin: fix adoptopenjdk-hotspot-bin-8 build

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -29,7 +29,7 @@ let cpuName = stdenv.hostPlatform.parsed.cpu.name;
     rm -rf $out/Home/man/ja*
 
     # for backward compatibility
-    ln -s $out/Contents/Home $out/jre
+    [ ! -d "$out/Contents/Home/jre" ] && ln -s $out/Contents/Home $out/jre
 
     ln -s $out/Contents/Home/* $out/
 


### PR DESCRIPTION
###### Motivation for this change

On current master, running ` nix-build . -A adoptopenjdk-hotspot-bin-8` results in `ln: failed to create symbolic link '/nix/store/fkhmgiyh6sh65x0x27wwlsz1m2nv5wrw-adoptopenjdk-hotspot-bin-8.0.222/jre': File exists`.

###### Things done

I make sure that this backwards compatability mechanism isn't breaking builds on older jdk versions, by checking first if the directory exists (and hence the need for this ln -s call).

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ x ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @taku0 
