### PR TITLE
[19.09] nixos/networkmanager: fix merging options

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -515,16 +515,20 @@ in {
       aliases = [ "dbus-org.freedesktop.nm-dispatcher.service" ];
     };
 
-    # Turn off NixOS' network management
-    networking = {
-      useDHCP = false;
-      # use mkDefault to trigger the assertion about the conflict above
-      wireless.enable = mkDefault false;
-    } // (mkIf cfg.enableStrongSwan {
-      networkmanager.packages = [ pkgs.networkmanager_strongswan ];
-    }) // (mkIf enableIwd {
-      wireless.iwd.enable = true;
-    });
+    # Turn off NixOS' network management when networking is managed entirely by NetworkManager
+    networking = mkMerge [
+      {
+        useDHCP = false;
+      }
+
+      (mkIf cfg.enableStrongSwan {
+        networkmanager.packages = [ pkgs.networkmanager_strongswan ];
+      })
+
+      (mkIf enableIwd {
+        wireless.iwd.enable = true;
+      })
+    ];
 
     security.polkit.extraConfig = polkitConf;
 


### PR DESCRIPTION
Backports: #72916

Incorrect merging of modules resulted in dhcpcd being enabled causing flaky network connection.

https://github.com/NixOS/nixpkgs/pull/64364

Fixing it uncovered an infinite recursion from the same commit, previously masked by the incorrect merge.

While this is not a problem in 19.09, we can still drop the `mkDefault` for `networking.wireless.enable` as it is already `false` by default.

Closes: https://github.com/NixOS/nixpkgs/issues/72416

(cherry picked from commit 894fdfaf1fbcdd9e584ca655a2229f62d9d7c830)