### PR TITLE
python3Packages.cliff: fix build and add tests

### DIFF
--- a/pkgs/development/python-modules/cliff/default.nix
+++ b/pkgs/development/python-modules/cliff/default.nix
@@ -9,6 +9,10 @@
 , pyyaml
 , unicodecsv
 , cmd2
+, pytest
+, mock
+, testtools
+, fixtures
 }:
 
 buildPythonPackage rec {
@@ -31,10 +35,17 @@ buildPythonPackage rec {
     unicodecsv
   ];
 
-  # test dependencies are complex
-  # and would require about 20 packages
-  # to be added
-  doCheck = false;
+  # remove version constraints
+  postPatch = ''
+    sed -i '/cmd2/c\cmd2' requirements.txt
+  '';
+
+  checkInputs = [ fixtures mock pytest testtools ];
+  # add some tests
+  checkPhase = ''
+    pytest cliff/tests/test_{utils,app,command,help,lister}.py \
+      -k 'not interactive_mode'
+  '';
 
   meta = with lib; {
     description = "Command Line Interface Formulation Framework";


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing other packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built (1 failed), 100 copied (707.8 MiB), 103.7 MiB DL]
error: build of '/nix/store/0r1nfh4h5w0ybk5spvdhixnj5gfw2wx2-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/72957
1 package failed to build:
python37Packages.optuna

2 package were build:
python37Packages.cliff python38Packages.cliff
```