### PR TITLE
nixos/gnome3: add gnome-flashback to systemd.packages

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -184,6 +184,13 @@ in
         enableGnomeKeyring = true;
       };
 
+      systemd.packages = with pkgs.gnome3; [
+        gnome-flashback
+      ] ++ (map
+        (wm: gnome-flashback.mkSystemdTargetForWm {
+          inherit (wm) wmName;
+        }) cfg.flashback.customSessions);
+
       services.dbus.packages = [
         pkgs.gnome3.gnome-screensaver
       ];

--- a/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
@@ -22,6 +22,7 @@
 , writeTextFile
 , writeShellScriptBin
 , xkeyboard_config
+, runCommand
 }:
 
 let
@@ -141,6 +142,13 @@ let
           DesktopNames=GNOME-Flashback;GNOME;
         '';
       };
+
+      mkSystemdTargetForWm = { wmName }:
+        runCommand "gnome-flashback-${wmName}.target" {} ''
+          mkdir -p $out/lib/systemd/user
+          cp "${gnome-flashback}/lib/systemd/user/gnome-session-x11@gnome-flashback-metacity.target" \
+            "$out/lib/systemd/user/gnome-session-x11@gnome-flashback-${wmName}.target"
+        '';
     };
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
When we did the revert of adding gnome-flashback to systemd.packages [0]
I forgot to test with other display managers. If we use GDM with gnome-flashback
it appears it doesn't try to fallback to non-systemd startup and always fails and
starts the regular gnome-session. So adding gnome-flashback to systemd.packages
was perfectly fine, but we did forgot one detail. We need systemd targets for the
customSessions which is added using  mkSystemdTargetForWm in the gnome-
flashback package.

[0]: https://github.com/NixOS/nixpkgs/commit/42f567b30def552337bf17a6d30410c16c2b47cc

This fixes starting gnome-flashback-metacity with gdm and all customSessions with GDM.
Though we still have the issue confirmed in https://github.com/NixOS/nixpkgs/pull/71212#issuecomment-544303107.

###### Edit: I have no idea what was going on with my grammar when I wrote this message :smile: I should probably rewrite it. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
