### PR TITLE
cadaver: Enable readline support

### DIFF
--- a/pkgs/tools/networking/cadaver/default.nix
+++ b/pkgs/tools/networking/cadaver/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, openssl }:
+{ stdenv, fetchurl, fetchpatch, openssl, readline }:
 
 stdenv.mkDerivation rec {
   name = "cadaver-0.23.3";
@@ -16,9 +16,9 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  configureFlags = [ "--with-ssl" ];
+  configureFlags = [ "--with-ssl" "--with-readline" ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl readline ];
 
   meta = with stdenv.lib; {
     description = "A command-line WebDAV client";


### PR DESCRIPTION
###### Motivation for this change
It's a pain to use, without readline. With it, common niceties, such as arrow-up for last command, work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @wavewave 
