### PR TITLE
firefox-esr v52: build on Hydra

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -1,6 +1,8 @@
-{ lib, callPackage, fetchurl, fetchFromGitHub, overrideCC, gccStdenv, gcc6 }:
+{ lib, callPackage, fetchurl, fetchFromGitHub, overrideCC, gccStdenv, gcc6, config }:
 
 let
+
+  inHydra = config.inHydra or false;
 
   common = opts: callPackage (import ./common.nix opts) {};
 
@@ -62,6 +64,7 @@ rec {
 
     meta = firefox.meta // {
       description = "A web browser built from Firefox Extended Support Release source tree";
+    } // lib.optionalAttrs (!inHydra) {
       knownVulnerabilities = [ "Support ended in August 2018." ];
     };
   }).override {


### PR DESCRIPTION
The firefox v52 is indeed unmaintained, insecure FF release, but still the
easiest way to get old Java-based sites working. My bank account site is an
example. It has vulnerabilities defined, so it is not built by Hydra.

Because of pragmatic reasons (avoid building Firefox on laptops) I propose
to bring back build on Hydra. `icedtea` project is still supported and gets
better with time, so to make use of it would be great to have a ready-to-use
browser.

Unfortunately, I can't use firefox-esr-52 from old Nixpkgs checkout
(which still has binaries in Hydra cache), as Glibc version was changed
and is now incompatible with NixOS 19.09 (segfaults).

cc @oxij @grahamc 