### PR TITLE
twmn: Use QT's makeDerivation

### DIFF
--- a/pkgs/applications/misc/twmn/default.nix
+++ b/pkgs/applications/misc/twmn/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, qtbase, qtx11extras, qmake, pkgconfig, boost }:
+{ lib, mkDerivation, fetchFromGitHub, qtbase, qtx11extras, qmake, pkgconfig, boost }:
 
-stdenv.mkDerivation {
+mkDerivation {
   name = "twmn-git-2018-10-01";
 
   src = fetchFromGitHub {
@@ -29,8 +29,8 @@ stdenv.mkDerivation {
   meta = {
     description = "A notification system for tiling window managers";
     homepage = https://github.com/sboli/twmn;
-    platforms = with stdenv.lib.platforms; linux;
-    maintainers = [ stdenv.lib.maintainers.matejc ];
-    license = stdenv.lib.licenses.lgpl3;
+    platforms = with lib.platforms; linux;
+    maintainers = [ lib.maintainers.matejc ];
+    license = lib.licenses.lgpl3;
   };
 }


### PR DESCRIPTION
##### Motivation for this change
Could not find libQt5Widgets.so.5 and SIBABRTs.
Fixes #20387

###### Things done

The binaries run and produce sensible output, put I haven't tried to use it for its intended purpose.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matejc 
