### PR TITLE
Fix allowUnfreePredicate example following the introduction of pname.

### DIFF
--- a/doc/using/configuration.xml
+++ b/doc/using/configuration.xml
@@ -142,7 +142,7 @@
 <programlisting>
 {
   allowUnfreePredicate = (pkg: builtins.elem
-    (builtins.parseDrvName pkg.name).name [
+    (pkg.pname or (builtins.parseDrvName pkg.name).name) [
       "flashplayer"
       "vscode"
     ]);


### PR DESCRIPTION
###### Motivation for this change

The introduction of `pname` (making `name` optional) apparently broke the example code provided in the documentation (tested with package `skype` which only defines a `pname` and no `name`). This change fixes it. Note that if specifying a `pname` became compulsory, we could further simplify the example.