### PR TITLE
gnome2.gnome_vfs: openssl-1.1 patch

### DIFF
--- a/pkgs/desktops/gnome-2/default.nix
+++ b/pkgs/desktops/gnome-2/default.nix
@@ -37,9 +37,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   gnome_python_desktop = callPackage ./bindings/gnome-python-desktop { };
 
-  gnome_vfs = callPackage ./platform/gnome-vfs {
-    openssl = pkgs.openssl_1_0_2;
-  };
+  gnome_vfs = callPackage ./platform/gnome-vfs { };
 
   libgnome = callPackage ./platform/libgnome { };
 

--- a/pkgs/desktops/gnome-2/platform/gnome-vfs/default.nix
+++ b/pkgs/desktops/gnome-2/platform/gnome-vfs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libxml2, bzip2, openssl, dbus-glib
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libxml2, bzip2, openssl, dbus-glib
 , glib, gamin, cdparanoia, intltool, GConf, gnome_mime_data, avahi, acl }:
 
 stdenv.mkDerivation rec {
@@ -19,6 +19,18 @@ stdenv.mkDerivation rec {
     ];
 
   propagatedBuildInputs = [ GConf glib ];
+
+  # struct SSL is opaque in openssl-1.1; and the SSL_free() man page
+  # says that one should not free members of it manually (in both
+  # the openssl-1.0 and openssl-1.1 man pages).
+  # https://bugs.gentoo.org/592540
+  patches = [ (fetchpatch {
+                name = "gnome-vfs-2.24.4-openssl-1.1.patch";
+                url = "https://bugs.gentoo.org/attachment.cgi?id=535944";
+                sha256 = "1q4icapvmwmd5rjah7rr0bqazzk5cg36znmjlpra20n9y27nz040";
+                extraPrefix = "";
+              })
+            ];
 
   postPatch = "find . -name Makefile.in | xargs sed 's/-DG_DISABLE_DEPRECATED//g' -i ";
 


### PR DESCRIPTION
###### Motivation for this change

Get rid of openssl-1.0 for java projects, I'm struggling to package java apps where openssl-1.1 is mandatory. I have override it successfully and think is interesting commit upstream.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @globin @jtojnar 
