### PR TITLE
 nixos/dnschain: use forwardZonesRecurse in pdns-recursor

### DIFF
--- a/nixos/modules/services/networking/dnschain.nix
+++ b/nixos/modules/services/networking/dnschain.nix
@@ -137,7 +137,7 @@ in
       ];
 
     services.pdns-recursor = mkIf cfgs.pdns-recursor.resolveDNSChainQueries {
-      forwardZones =
+      forwardZonesRecurse =
         { bit = "127.0.0.1:${toString cfg.dns.port}";
           dns = "127.0.0.1:${toString cfg.dns.port}";
         };

--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -91,10 +91,18 @@ in {
 
     forwardZones = mkOption {
       type = types.attrs;
+      default = {};
+      description = ''
+        DNS zones to be forwarded to other authoritative servers.
+      '';
+    };
+
+    forwardZonesRecurse = mkOption {
+      type = types.attrs;
       example = { eth = "127.0.0.1:5353"; };
       default = {};
       description = ''
-        DNS zones to be forwarded to other servers.
+        DNS zones to be forwarded to other recursive servers.
       '';
     };
 
@@ -158,7 +166,8 @@ in {
       webserver-port       = cfg.api.port;
       webserver-allow-from = cfg.api.allowFrom;
 
-      forward-zones    = mapAttrsToList (zone: uri: "${zone}.=${uri}") cfg.forwardZones;
+      forward-zones         = mapAttrsToList (zone: uri: "${zone}.=${uri}") cfg.forwardZones;
+      forward-zones-recurse = mapAttrsToList (zone: uri: "${zone}.=${uri}") cfg.forwardZonesRecurse;
       export-etc-hosts = cfg.exportHosts;
       dnssec           = cfg.dnssecValidation;
       serve-rfc1918    = cfg.serveRFC1918;


### PR DESCRIPTION
###### Motivation for this change
The resolution of .bit domains is currently broken due to a change in pdns-recursor 4.2.0.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test (pdns-recursor.nix)
- [x] Tested on my server
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
