### PR TITLE
squashfs-tools-ng: init at 0.7

### DIFF
--- a/pkgs/tools/filesystems/squashfs-tools-ng/0001-Fix-build-on-BSD-systems.patch
+++ b/pkgs/tools/filesystems/squashfs-tools-ng/0001-Fix-build-on-BSD-systems.patch
@@ -1,0 +1,103 @@
+From ea1bc0fcfd33191002c5d1f7072c1c02bb7ec4af Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Thu, 14 Nov 2019 15:45:46 +0000
+Subject: [PATCH] Fix build on BSD systems
+
+I tested FreeBSD, DragonflyBSD, NetBSD and OpenBSD and the endian
+macros weren't necessary (and in fact caused errors) on all of them.
+
+Because OpenBSD ships with an ancient GCC that doesn't support the
+checked addition/multiplication builtins, the build there would fail
+unless built with CC=cc or CC=clang.  I changed configure.ac to prefer
+cc over gcc, so that the distribution's compiler preference is
+respected.  (The default is [gcc cc]).  I had to move AC_PROG_CC above
+LT_INIT because otherwise LT_INIT would run AC_PROG_CC first, and we
+wouldn't have a chance to use non-default parameters.
+---
+ configure.ac          |  2 +-
+ include/util/compat.h | 13 +++++--------
+ lib/common/dirstack.c |  1 +
+ lib/common/mkdir_p.c  |  2 +-
+ 4 files changed, 8 insertions(+), 10 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 018b3f6..19ea0ed 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3,8 +3,8 @@ AC_INIT([squashfs-tools-ng], [0.7], [goliath@infraroot.at], squashfs-tools-ng)
+ AC_CONFIG_MACRO_DIR([m4])
+ AM_INIT_AUTOMAKE([foreign dist-xz subdir-objects])
+ AM_SILENT_RULES([yes])
++AC_PROG_CC([cc gcc clang])
+ LT_INIT
+-AC_PROG_CC
+ AC_PROG_CC_C99
+ AC_PROG_INSTALL
+ AC_SYS_LARGEFILE
+diff --git a/include/util/compat.h b/include/util/compat.h
+index 74d0b6f..f53fd0e 100644
+--- a/include/util/compat.h
++++ b/include/util/compat.h
+@@ -7,6 +7,10 @@
+ #ifndef COMPAT_H
+ #define COMPAT_H
+ 
++#ifndef __linux__
++#define O_PATH 0
++#endif
++
+ #if defined(__APPLE__)
+ #include <libkern/OSByteOrder.h>
+ 
+@@ -17,14 +21,8 @@
+ #define le32toh(x) OSSwapLittleToHostInt32(x)
+ #define le16toh(x) OSSwapLittleToHostInt16(x)
+ #define le64toh(x) OSSwapLittleToHostInt64(x)
+-#elif defined(__OpenBSD__)
++#elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <sys/endian.h>
+-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+-#include <sys/endian.h>
+-
+-#define le16toh(x) letoh16(x)
+-#define le32toh(x) letoh32(x)
+-#define le64toh(x) letoh64(x)
+ #elif defined(_WIN32) || defined(__WINDOWS__)
+ #define htole16(x) (x)
+ #define htole32(x) (x)
+@@ -89,7 +87,6 @@
+ #else
+ #include <sys/types.h>
+ #include <sys/stat.h>
+-#include <sys/sysmacros.h>
+ #endif
+ 
+ #endif /* COMPAT_H */
+diff --git a/lib/common/dirstack.c b/lib/common/dirstack.c
+index 8f73898..f8d1278 100644
+--- a/lib/common/dirstack.c
++++ b/lib/common/dirstack.c
+@@ -5,6 +5,7 @@
+  * Copyright (C) 2019 David Oberhollenzer <goliath@infraroot.at>
+  */
+ #include "common.h"
++#include "util/compat.h"
+ 
+ #include <string.h>
+ #include <stdlib.h>
+diff --git a/lib/common/mkdir_p.c b/lib/common/mkdir_p.c
+index cb433b3..95187ba 100644
+--- a/lib/common/mkdir_p.c
++++ b/lib/common/mkdir_p.c
+@@ -7,7 +7,7 @@
+ #include "common.h"
+ 
+ #include <string.h>
+-#include <alloca.h>
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <errno.h>
+ 
+-- 
+2.23.0
+

--- a/pkgs/tools/filesystems/squashfs-tools-ng/default.nix
+++ b/pkgs/tools/filesystems/squashfs-tools-ng/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchurl, fetchpatch, autoreconfHook, doxygen, graphviz, perl
+, pkgconfig, lz4, xz, zlib, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "squashfs-tools-ng";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "https://infraroot.at/pub/squashfs/squashfs-tools-ng-${version}.tar.xz";
+    sha256 = "01yn621dnsfhrah3qj1xh6ynag7r3nvihc510sa5frapkyg9nw8n";
+  };
+
+  patches = lib.optional (!stdenv.isLinux) ./0001-Fix-build-on-BSD-systems.patch;
+
+  nativeBuildInputs = [ doxygen graphviz pkgconfig perl ]
+                      ++ lib.optional (!stdenv.isLinux) autoreconfHook;
+  buildInputs = [ zlib xz lz4 zstd ];
+
+  meta = with lib; {
+    homepage = https://github.com/AgentD/squashfs-tools-ng;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ qyliss ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6415,6 +6415,8 @@ in
 
   squashfsTools = callPackage ../tools/filesystems/squashfs { };
 
+  squashfs-tools-ng = callPackage ../tools/filesystems/squashfs-tools-ng { };
+
   squashfuse = callPackage ../tools/filesystems/squashfuse { };
 
   srcml = callPackage ../applications/version-management/srcml { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
