### PR TITLE
sclack: init at unstable-2019-07-15

### DIFF
--- a/pkgs/development/python-modules/sclack/default.nix
+++ b/pkgs/development/python-modules/sclack/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, fetchFromGitHub
+, pythonOlder
+, pythonPackages
+, buildPythonPackage
+, writeTextFile
+, libcaca
+}:
+buildPythonPackage rec {
+  pname = "sclack";
+  version = "unstable-2019-07-15";
+  disabled = pythonOlder "3.4";
+
+  src = fetchFromGitHub {
+    owner = "haskellcamargo";
+    repo = "sclack";
+    rev = "4825249f9706ded585ac0d42ac7d86262fa14fd7";
+    sha256 = "1dc3s3jn2ig55d8955fnjyppjkaw92mrzwpkv2hd0r8v1mffavi6";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    libcaca
+    pyperclip
+    requests
+    slackclient
+    urwid
+    urwid_readline
+  ];
+
+  patchPhase = ''
+    substituteInPlace app.py --replace "'./config.json'" "'$out/bin/config.json'"
+    substituteInPlace setup.py --replace  "'asyncio'," ' '
+  '';
+
+  postInstall = ''
+    mv $out/bin/app.py $out/bin/sclack
+    cp config.json $out/bin/
+  '';
+
+
+  meta = with stdenv.lib; {
+    description = "The best CLI client for Slack, because everything is terrible!";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    homepage = https://github.com/haskellcamargo/sclack/;
+    maintainers = with maintainers; [ evanjs ];
+  };
+}

--- a/pkgs/development/python-modules/sclack/default.nix
+++ b/pkgs/development/python-modules/sclack/default.nix
@@ -5,11 +5,15 @@
 , buildPythonPackage
 , writeTextFile
 , libcaca
+, glibcLocales
+, pytestCheckHook
 }:
 buildPythonPackage rec {
   pname = "sclack";
   version = "unstable-2019-07-15";
-  disabled = pythonOlder "3.4";
+
+  # slackclient 2.0 requires python 3.6 or higher -- https://github.com/slackapi/python-slackclient/wiki/Migrating-to-2.x#minimum-python-versions
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "haskellcamargo";
@@ -27,14 +31,41 @@ buildPythonPackage rec {
     urwid_readline
   ];
 
-  patchPhase = ''
-    substituteInPlace app.py --replace "'./config.json'" "'$out/bin/config.json'"
-    substituteInPlace setup.py --replace  "'asyncio'," ' '
+  LC_ALL = "en_US.UTF-8";
+  checkInputs = [ glibcLocales pytestCheckHook ];
+
+  # disable tests that prompt for user input and require network access
+  disabledTests = [
+    "test_workspace_token"
+    "test_auth"
+    "test_get_channels"
+    "test_get_members"
+    "test_get_members_pagination_1"
+    "test_get_members_pagination_2"
+  ];
+
+  prePatch = ''
+    # remove the dependency on asyncio from setup.py
+    # asyncio is included with python3.7+
+    substituteInPlace setup.py \
+      --replace  "'asyncio'," ' '
+
+    # slackclient renamed several major components in 2.x
+    # see the Migration Guide for more information -- https://github.com/slackapi/python-slackclient/wiki/Migrating-to-2.x#import-changes
+    for file in {sclack/store,tests/test_api}.py; do
+      substituteInPlace $file \
+      --replace 'slackclient' 'slack' \
+      --replace 'SlackClient' 'WebClient'
+    done
   '';
 
   postInstall = ''
-    mv $out/bin/app.py $out/bin/sclack
-    cp config.json $out/bin/
+    mkdir $out/share
+    # make the relative path for config.json absolute
+    substituteInPlace app.py --replace "'./config.json'" "'$out/share/config.json'"
+    cp config.json $out/share/
+    
+    install -m755 app.py $out/bin/sclack
   '';
 
 

--- a/pkgs/development/python-modules/sclack/default.nix
+++ b/pkgs/development/python-modules/sclack/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     # make the relative path for config.json absolute
     substituteInPlace app.py --replace "'./config.json'" "'$out/share/config.json'"
     cp config.json $out/share/
-    
+
     install -m755 app.py $out/bin/sclack
   '';
 

--- a/pkgs/development/python-modules/urwid/default.nix
+++ b/pkgs/development/python-modules/urwid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, glibcLocales }:
+{ stdenv, buildPythonPackage, fetchPypi, glibcLocales, pythonPackages, setuptools }:
 
 buildPythonPackage rec {
   pname = "urwid";
@@ -9,9 +9,11 @@ buildPythonPackage rec {
     sha256 = "09nmi2nmvpcmbh3w3fb0dn0c7yp7r20i5pfcr6q722xh6mp8cw3q";
   };
 
+  propagatedBuildInputs = [ setuptools ];
+
   # tests need to be able to set locale
   LC_ALL = "en_US.UTF-8";
-  checkInputs = [ glibcLocales ];
+  checkInputs = [ glibcLocales pythonPackages.tox ];
 
   meta = with stdenv.lib; {
     description = "A full-featured console (xterm et al.) user interface library";

--- a/pkgs/development/python-modules/urwid_readline/default.nix
+++ b/pkgs/development/python-modules/urwid_readline/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonPackages, pytest }:
+
+buildPythonPackage rec {
+  pname = "urwid_readline";
+  version = "0.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0i7rwxhs686lgzgbwfvl2niw5yhzwjncx8ql7n0sdpk7n6sxq9xq";
+  };
+
+  checkInputs = [ pytest ];
+
+  buildInputs = with pythonPackages; [ urwid ];
+
+  meta = with stdenv.lib; {
+    description = "A textbox edit widget for urwid that supports readline shortcuts";
+    homepage = https://github.com/rr-/urwid_readline;
+    repositories.git = git://github.com/rr-/urwid_readline.git;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/urwid_readline/default.nix
+++ b/pkgs/development/python-modules/urwid_readline/default.nix
@@ -1,17 +1,20 @@
-{ stdenv, buildPythonPackage, fetchPypi, pythonPackages, pytest }:
+{ stdenv, buildPythonPackage, fetchPypi, pythonPackages, pytest, glibcLocales, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "urwid_readline";
-  version = "0.10";
+  version = "0.11";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0i7rwxhs686lgzgbwfvl2niw5yhzwjncx8ql7n0sdpk7n6sxq9xq";
+    sha256 = "1dgxd9gwh5nx93v6h3snvbagi0ykwm5jc768ifgd2h2rnza7dqr4";
   };
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytestCheckHook glibcLocales ];
 
   buildInputs = with pythonPackages; [ urwid ];
+
+  # tests need to be able to set locale
+  LC_ALL = "en_US.UTF-8";
 
   meta = with stdenv.lib; {
     description = "A textbox edit widget for urwid that supports readline shortcuts";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20545,6 +20545,8 @@ in
       '' + (drv.postInstall or "");
     });
 
+  sclack = with python3Packages; toPythonApplication sclack;
+
   slack = callPackage ../applications/networking/instant-messengers/slack { };
 
   slack-cli = callPackage ../tools/networking/slack-cli { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1537,7 +1537,7 @@ in {
   sanic-auth = callPackage ../development/python-modules/sanic-auth { };
 
   sapi-python-client = callPackage ../development/python-modules/sapi-python-client { };
-  
+
   sclack = callPackage ../development/python-modules/sclack { };
 
   seekpath = callPackage ../development/python-modules/seekpath { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6270,6 +6270,8 @@ in {
 
   urwid = callPackage ../development/python-modules/urwid {};
 
+  urwid_readline = callPackage ../development/python-modules/urwid_readline {};
+
   user-agents = callPackage ../development/python-modules/user-agents { };
 
   variants = callPackage ../development/python-modules/variants { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1537,6 +1537,8 @@ in {
   sanic-auth = callPackage ../development/python-modules/sanic-auth { };
 
   sapi-python-client = callPackage ../development/python-modules/sapi-python-client { };
+  
+  sclack = callPackage ../development/python-modules/sclack { };
 
   seekpath = callPackage ../development/python-modules/seekpath { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
#59900 -- add sclack package
Stumbled across this issue and hadn't heard of sclack before. 
Works pretty well, especially compared to e.g. slack-term.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

___

## TODO
- [ ]  config.json
  - I'm just copying over the default config.json, is this enough? Or should this have a module with `extraConfig`, etc?  Maybe configuring this option could be deferred to home-manager, etc.
- [ ] Mac Support
  - While `urwid` lists support for linux and darwin, `urwid_readline` only lists support for linux.  Can a darwin user confirm whether this works on mac?
- [ ] app.py
  - Is there a cleaner way to install the executable (vs moving `app.py` to `sclack`)?
- [ ] asyncio
  - @exarkun recommended filing a bug upstream since `asyncio` should be a conditional dependency.  Which is still odd to me as the repo requires 3.4+ anyway...  Should I block on that and leave my workaround in if the author declines? Or is there a better way to handle it here, anyway?
- [x] emoji
  - ~~emoji don't seem to work right away, do we need to do something with fontconfig, or at least provide a font option, etc?~~ This seems to be the case for only a few emoji, e.g. :man_shrugging:, most emoji seem to work fine.  
  - [sclack - Nerd Fonts](https://github.com/haskellcamargo/sclack#nerd-fonts)

I think that's it, but I'm happy to address anything else I missed.