### PR TITLE
sqlite-replication: fix build + CVE-2019-16168

### DIFF
--- a/pkgs/development/libraries/sqlite/CVE-2019-16168_3_27_backport.patch
+++ b/pkgs/development/libraries/sqlite/CVE-2019-16168_3_27_backport.patch
@@ -1,0 +1,70 @@
+This is a backport of https://www.sqlite.org/src/vpatch?from=4f5b2d938194fab7&to=98357d8c1263920b
+with a tiny adjustment for 3.27.2 for the sqlite-replication package.
+
+Index: src/analyze.c
+==================================================================
+--- src/analyze.c
++++ src/analyze.c
+@@ -1495,11 +1495,13 @@
+     pIndex->noSkipScan = 0;
+     while( z[0] ){
+       if( sqlite3_strglob("unordered*", z)==0 ){
+         pIndex->bUnordered = 1;
+       }else if( sqlite3_strglob("sz=[0-9]*", z)==0 ){
+-        pIndex->szIdxRow = sqlite3LogEst(sqlite3Atoi(z+3));
++        int sz = sqlite3Atoi(z+3);
++        if( sz<2 ) sz = 2;
++        pIndex->szIdxRow = sqlite3LogEst(sz);
+       }else if( sqlite3_strglob("noskipscan*", z)==0 ){
+         pIndex->noSkipScan = 1;
+       }
+ #ifdef SQLITE_ENABLE_COSTMULT
+       else if( sqlite3_strglob("costmult=[0-9]*",z)==0 ){
+
+Index: src/where.c
+==================================================================
+--- src/where.c
++++ src/where.c
+@@ -2668,10 +2668,11 @@
+
+     /* Set rCostIdx to the cost of visiting selected rows in index. Add
+     ** it to pNew->rRun, which is currently set to the cost of the index
+     ** seek only. Then, if this is a non-covering index, add the cost of
+     ** visiting the rows in the main table.  */
++    assert( pSrc->pTab->szTabRow>0 );
+     rCostIdx = pNew->nOut + 1 + (15*pProbe->szIdxRow)/pSrc->pTab->szTabRow;
+     pNew->rRun = sqlite3LogEstAdd(rLogSize, rCostIdx);
+     if( (pNew->wsFlags & (WHERE_IDX_ONLY|WHERE_IPK))==0 ){
+       pNew->rRun = sqlite3LogEstAdd(pNew->rRun, pNew->nOut + 16);
+     }
+
+Index: test/analyzeC.test
+==================================================================
+--- test/analyzeC.test
++++ test/analyzeC.test
+@@ -129,10 +129,24 @@
+ } {6}
+ do_execsql_test 4.3 {
+   EXPLAIN QUERY PLAN
+   SELECT count(a) FROM t1;
+ } {/.*INDEX t1ca.*/}
++
++# 2019-08-15.
++# Ticket https://www.sqlite.org/src/tktview/e4598ecbdd18bd82945f602901
++# The sz=N parameter in the sqlite_stat1 table needs to have a value of
++# 2 or more to avoid a division by zero in the query planner.
++#
++do_execsql_test 4.4 {
++  DROP TABLE IF EXISTS t44;
++  CREATE TABLE t44(a PRIMARY KEY);
++  INSERT INTO sqlite_stat1 VALUES('t44',null,'sz=0');
++  ANALYZE sqlite_master;
++  SELECT 0 FROM t44 WHERE a IN(1,2,3);
++} {}
++
+
+
+ # The sz=NNN parameter works even if there is other extraneous text
+ # in the sqlite_stat1.stat column.
+ #
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13677,6 +13677,14 @@ in
       echo "D 2019-03-09T15:45:46" > manifest
       echo -n "8250984a368079bb1838d48d99f8c1a6282e00bc" > manifest.uuid
     '';
+
+    patchFlags = "-p0";
+    patches = [
+      # Fixes CVE-2019-16168 for non-amalgamated 3.27.2 as the other patch used
+      # within the sqlite package itself does not apply here.
+      ../development/libraries/sqlite/CVE-2019-16168_3_27_backport.patch
+    ];
+
   });
 
   dqlite = callPackage ../development/libraries/dqlite { };


### PR DESCRIPTION
###### Motivation for this change

CVE fix in #71695 broke this package, as it's an older
version and additionaly disables amalgamation.

Related: 
Fixes: https://github.com/NixOS/nixpkgs/issues/72992
Closes: https://github.com/NixOS/nixpkgs/pull/72997

The supplied patch is modified minimally to fit this version (slight
line number change for analyze.c).

The fix was verified using
https://www.sqlite.org/src/info/e4598ecbdd18bd82945f6029013296690e719a62
as for the previous fix.

@otwieracz: Could you maybe try this one out and see how this one works for you?
  
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jokogr @dtzWill   @andir 