### PR TITLE
rng-tools: 6.7 -> 6.8

### DIFF
--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -1,13 +1,12 @@
 { stdenv, fetchFromGitHub, libtool, autoreconfHook, pkgconfig
 , sysfsutils
+, argp-standalone
   # WARNING: DO NOT USE BEACON GENERATED VALUES AS SECRET CRYPTOGRAPHIC KEYS
   # https://www.nist.gov/programs-projects/nist-randomness-beacon
 , curl ? null, libxml2 ? null, openssl ? null, withNistBeacon ? false
   # Systems that support RDRAND but not AES-NI require libgcrypt to use RDRAND as an entropy source
 , libgcrypt ? null, withGcrypt ? true
-  # Not sure if jitterentropy is safe to use for cryptography
-  # and thus a default entropy source
-, jitterentropy ? null, withJitterEntropy ? false
+, jitterentropy ? null, withJitterEntropy ? true
 , libp11 ? null, opensc ? null, withPkcs11 ? true
 }:
 
@@ -15,18 +14,16 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "rng-tools";
-  version = "6.7";
+  version = "6.8";
 
   src = fetchFromGitHub {
     owner = "nhorman";
     repo = "rng-tools";
     rev = "v${version}";
-    sha256 = "19f75m6mzg8h7b4snzg7d6ypvkz6nq32lrpi9ja95gqz4wsd18a5";
+    sha256 = "1clm9i9xg3j79q0d6vinn6dx0nwh1fvzcmkqpcbay7mwsgkknvw2";
   };
 
   postPatch = ''
-    cp README.md README
-
     ${optionalString withPkcs11 ''
       substituteInPlace rngd.c \
         --replace /usr/lib64/opensc-pkcs11.so ${opensc}/lib/opensc-pkcs11.so
@@ -42,25 +39,27 @@ stdenv.mkDerivation rec {
     (withFeature   withPkcs11        "pkcs11")
   ];
 
+  # argp-standalone is only used when libc lacks argp parsing (musl)
   buildInputs = [ sysfsutils ]
+    ++ optionals stdenv.hostPlatform.isx86_64 [ argp-standalone ]
     ++ optionals withGcrypt        [ libgcrypt ]
     ++ optionals withJitterEntropy [ jitterentropy ]
     ++ optionals withNistBeacon    [ curl libxml2 openssl ]
     ++ optionals withPkcs11        [ libp11 openssl ];
-
-  # This shouldn't be necessary but is as of 6.7
-  NIX_LDFLAGS = optionalString withPkcs11 "-lcrypto";
 
   enableParallelBuilding = true;
 
   # For cross-compilation
   makeFlags = [ "AR:=$(AR)" ];
 
+  doCheck = true;
+  preCheck = "patchShebangs tests/*.sh";
+
   meta = {
     description = "A random number generator daemon";
     homepage = https://github.com/nhorman/rng-tools;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ johnazoidberg ];
+    maintainers = with maintainers; [ johnazoidberg c0bw3b ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update
\+ enable tests
\+ enable jitterentropy by default
\+ add c0bw3b to maintainers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @JohnAZoidberg 
