### PR TITLE
coqPackages.coq-ext-lib: 0.10.1 -> 0.10.3

### DIFF
--- a/pkgs/development/coq-modules/coq-ext-lib/default.nix
+++ b/pkgs/development/coq-modules/coq-ext-lib/default.nix
@@ -5,8 +5,8 @@ let params =
     "8.5" = { version = "0.9.4"; sha256 = "1y66pamgsdxlq2w1338lj626ln70cwj7k53hxcp933g8fdsa4hp0"; };
     "8.6" = { version = "0.9.5"; sha256 = "1b4cvz3llxin130g13calw5n1zmvi6wdd5yb8a41q7yyn2hd3msg"; };
     "8.7" = { version = "0.9.7"; sha256 = "00v4bm4glv1hy08c8xsm467az6d1ashrznn8p2bmbmmp52lfg7ag"; };
-    "8.8" = { version = "0.9.8"; sha256 = "0z1ix855kdjl7zw5ca664h5njd1x8mmvf5wi37fck4dj9dgamwlz"; };
-    "8.9" = { version = "0.10.1"; sha256 = "0r1vspad8fb8bry3zliiz4hfj4w1iib1l2gm115a94m6zbiksd95"; };
+    "8.8" = { version = "0.10.3"; sha256 = "0795gs2dlr663z826mp63c8h2zfadn541dr8q0fvnvi2z7kfyslb"; };
+    "8.9" = { version = "0.10.3"; sha256 = "0795gs2dlr663z826mp63c8h2zfadn541dr8q0fvnvi2z7kfyslb"; };
   };
   param = params.${coq.coq-version};
 in
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/coq-ext-lib/coq-ext-lib;
     description = "A collection of theories and plugins that may be useful in other Coq developments";
-    maintainers = with maintainers; [ jwiegley ];
+    maintainers = with maintainers; [ jwiegley ptival ];
     platforms = coq.meta.platforms;
   };
 


### PR DESCRIPTION
Tested:
[x] Build coq-ext-lib for Coq 8.8 and 8.9
[x] Built packages that depend on coq-ext-lib (QuickChick, simple-io)

I figured 0.10.3 builds on 8.8 so unless that's controversial, 8.8 could also provide this more recent version.