### PR TITLE
podman: 1.6.2 -> 1.6.3

### DIFF
--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -5,13 +5,13 @@
 
 buildGoPackage rec {
   pname = "podman";
-  version = "1.6.2";
+  version = "1.6.3";
 
   src = fetchFromGitHub {
     owner  = "containers";
     repo   = "libpod";
     rev    = "v${version}";
-    sha256 = "0cwyrzjjgxclnzc1yx6vm2bvq73mldwxfwalkprzlg8vpqbxji8y";
+    sha256 = "0y87pylpff2xl796n5s2vrm90pspzqfw8h4a5gndn1mx18s09s69";
   };
 
   goPackagePath = "github.com/containers/libpod";

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
 
   goPackagePath = "github.com/containers/libpod";
 
-  outputs = [ "bin" "out" "man" ];
+  outputs = [ "out" "man" ];
 
   nativeBuildInputs = [ pkgconfig go-md2man ];
 
@@ -29,7 +29,7 @@ buildGoPackage rec {
   '';
 
   installPhase = ''
-    install -Dm555 bin/podman $bin/bin/podman
+    install -Dm555 -t $out/bin bin/podman
     MANDIR=$man/share/man make install.man
   '';
 

--- a/pkgs/tools/networking/slirp4netns/default.nix
+++ b/pkgs/tools/networking/slirp4netns/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, glib }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, glib, libcap, libseccomp }:
 
 stdenv.mkDerivation rec {
   pname = "slirp4netns";
-  version = "0.3.0";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "rootless-containers";
     repo = "slirp4netns";
     rev = "v${version}";
-    sha256 = "079m44l4l0p1c2sbkpzsy6zpv94glwmrc72ip2djcscnaq4b1763";
+    sha256 = "0i0rhb7n2i2nmbvdqdx83vi3kw4r17p7p099sr857cr3f3c221qx";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  buildInputs = [ glib ];
+  buildInputs = [ glib libcap libseccomp ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

The slirp4netns change is needed for proper rootless containers to work. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
