### PR TITLE
haproxy: 1.9.8 -> 2.0.8

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -128,7 +128,7 @@
       tcpcryptd = 93; # tcpcryptd uses a hard-coded uid. We patch it in Nixpkgs to match this choice.
       firebird = 95;
       #keys = 96; # unused
-      haproxy = 97;
+      #haproxy = 97; # DynamicUser as of 2019-11-08
       mongodb = 98;
       openldap = 99;
       #users = 100; # unused
@@ -443,7 +443,7 @@
       #tcpcryptd = 93; # unused
       firebird = 95;
       keys = 96;
-      haproxy = 97;
+      #haproxy = 97; # DynamicUser as of 2019-11-08
       #mongodb = 98; # unused
       openldap = 99;
       munin = 102;

--- a/nixos/modules/services/networking/haproxy.nix
+++ b/nixos/modules/services/networking/haproxy.nix
@@ -1,7 +1,16 @@
 { config, lib, pkgs, ... }:
+
 let
   cfg = config.services.haproxy;
-  haproxyCfg = pkgs.writeText "haproxy.conf" cfg.config;
+
+  haproxyCfg = pkgs.writeText "haproxy.conf" ''
+    global
+      # needed for hot-reload to work without dropping packets in multi-worker mode
+      stats socket /run/haproxy/haproxy.sock mode 600 expose-fd listeners level user
+
+    ${cfg.config}
+  '';
+
 in
 with lib;
 {
@@ -25,9 +34,7 @@ with lib;
           <filename>haproxy.conf</filename>.
         '';
       };
-
     };
-
   };
 
   config = mkIf cfg.enable {
@@ -42,21 +49,16 @@ with lib;
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        Type = "forking";
-        PIDFile = "/run/haproxy.pid";
-        ExecStartPre = "${pkgs.haproxy}/sbin/haproxy -c -q -f ${haproxyCfg}";
-        ExecStart = "${pkgs.haproxy}/sbin/haproxy -D -f ${haproxyCfg} -p /run/haproxy.pid";
-        ExecReload = "-${pkgs.bash}/bin/bash -c \"exec ${pkgs.haproxy}/sbin/haproxy -D -f ${haproxyCfg} -p /run/haproxy.pid -sf $MAINPID\"";
+        DynamicUser = true;
+        Type = "notify";
+        # when running the config test, don't be quiet so we can see what goes wrong
+        ExecStartPre = "${pkgs.haproxy}/sbin/haproxy -c -f ${haproxyCfg}";
+        ExecStart = "${pkgs.haproxy}/sbin/haproxy -Ws -f ${haproxyCfg}";
+        Restart = "on-failure";
+        RuntimeDirectory = "haproxy";
+        # needed in case we bind to port < 1024
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
       };
     };
-
-    environment.systemPackages = [ pkgs.haproxy ];
-
-    users.users.haproxy = {
-      group = "haproxy";
-      uid = config.ids.uids.haproxy;
-    };
-
-    users.groups.haproxy.gid = config.ids.uids.haproxy;
   };
 }

--- a/nixos/tests/haproxy.nix
+++ b/nixos/tests/haproxy.nix
@@ -16,6 +16,8 @@ import ./make-test.nix ({ pkgs, ...}: {
           frontend http
             bind *:80
             mode http
+            option http-use-htx
+            http-request use-service prometheus-exporter if { path /metrics }
             use_backend http_server
         '';
       };
@@ -36,6 +38,6 @@ import ./make-test.nix ({ pkgs, ...}: {
     $machine->waitForUnit('haproxy.service');
     $machine->waitForUnit('httpd.service');
     $machine->succeed('curl -k http://localhost:80/index.txt | grep "We are all good!"');
-
+    $machine->succeed('curl -k http://localhost:80/metrics | grep haproxy_process_pool_allocated_bytes');
   '';
 })

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,7 +1,9 @@
 { useLua ? !stdenv.isDarwin
 , usePcre ? true
-, stdenv, fetchurl
-, openssl, zlib, lua5_3 ? null, pcre ? null
+, withPrometheusExporter ? true
+, stdenv, lib, fetchurl
+, openssl, zlib
+, lua5_3 ? null, pcre ? null, systemd ? null
 }:
 
 assert useLua -> lua5_3 != null;
@@ -9,39 +11,47 @@ assert usePcre -> pcre != null;
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
-  version = "1.9.8";
+  version = "2.0.8";
 
   src = fetchurl {
     url = "https://www.haproxy.org/download/${stdenv.lib.versions.majorMinor version}/src/${pname}-${version}.tar.gz";
-    sha256 = "1via9k84ycrdr8qh4qchcbqgpv0gynm3ra23nwsvqwfqvc0376id";
+    sha256 = "02i87hr1dfhrk6nvvcig4m9bpww7hyl6qcxcl20rfvxd2n2iwzn3";
   };
 
   buildInputs = [ openssl zlib ]
-    ++ stdenv.lib.optional useLua lua5_3
-    ++ stdenv.lib.optional usePcre pcre;
+    ++ lib.optional useLua lua5_3
+    ++ lib.optional usePcre pcre
+    ++ lib.optional stdenv.isLinux systemd;
 
   # TODO: make it work on bsd as well
   makeFlags = [
     "PREFIX=\${out}"
     ("TARGET=" + (if stdenv.isSunOS  then "solaris"
-             else if stdenv.isLinux  then "linux2628"
+             else if stdenv.isLinux  then "linux-glibc"
              else if stdenv.isDarwin then "osx"
              else "generic"))
   ];
+
   buildFlags = [
     "USE_OPENSSL=yes"
     "USE_ZLIB=yes"
-  ] ++ stdenv.lib.optionals usePcre [
+  ] ++ lib.optionals usePcre [
     "USE_PCRE=yes"
     "USE_PCRE_JIT=yes"
-  ] ++ stdenv.lib.optionals useLua [
+  ] ++ lib.optionals useLua [
     "USE_LUA=yes"
     "LUA_LIB=${lua5_3}/lib"
     "LUA_INC=${lua5_3}/include"
-  ] ++ stdenv.lib.optional stdenv.isDarwin "CC=cc"
-    ++ stdenv.lib.optional stdenv.isLinux "USE_GETADDRINFO=1";
+  ] ++ lib.optionals stdenv.isLinux [
+    "USE_SYSTEMD=yes"
+    "USE_GETADDRINFO=1"
+  ] ++ lib.optionals withPrometheusExporter [
+    "EXTRA_OBJS=contrib/prometheus-exporter/service-prometheus.o"
+  ] ++ lib.optional stdenv.isDarwin "CC=cc";
 
-  meta = {
+  enableParallelBuilding = true;
+
+  meta = with lib; {
     description = "Reliable, high performance TCP/HTTP load balancer";
     longDescription = ''
       HAProxy is a free, very fast and reliable solution offering high
@@ -51,9 +61,9 @@ stdenv.mkDerivation rec {
       tens of thousands of connections is clearly realistic with todays
       hardware.
     '';
-    homepage = http://haproxy.1wt.eu;
-    maintainers = with stdenv.lib.maintainers; [ fuzzy-id ];
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
-    license = stdenv.lib.licenses.gpl2;
+    homepage = "https://haproxy.org";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ fuzzy-id ];
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

New LTS release.

Also add support for the builtin prometheus exporter, so we don't have to use an external service.

The nixos test doesn't complete but currently on unstable *all* nixos tests are broken...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fuzzy-id 
