### PR TITLE
cglm: init at 0.6.0

### DIFF
--- a/pkgs/development/libraries/cglm/default.nix
+++ b/pkgs/development/libraries/cglm/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub
+, pkgconfig, autoconf, automake, libtool }:
+
+stdenv.mkDerivation rec {
+  version = "0.6.0";
+  pname = "cglm";
+
+  src = fetchFromGitHub {
+    owner = "recp";
+    repo = "cglm";
+    rev = "v${version}";
+    sha256 = "02z6zpdgli43y9bh9an643w5vxgn89kk2771zk5mdl6hdk45yzkq";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ autoconf automake libtool ];
+  enableParallelBuilding = true;
+  preConfigure = ''
+    chmod +x ./autogen.sh
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Highly Optimized Graphics Math (glm) for C";
+    homepage = "https://github.com/recp/cglm";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10676,6 +10676,8 @@ in
 
   cgui = callPackage ../development/libraries/cgui {};
 
+  cglm = callPackage ../development/libraries/cglm { };
+
   check = callPackage ../development/libraries/check {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION

https://github.com/recp/cglm


"{film_projector} Highly Optimized Graphics Math (glm) for C"

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
