### PR TITLE
libco-canonical: fix pkgconfig includedir

### DIFF
--- a/pkgs/development/libraries/libco-canonical/default.nix
+++ b/pkgs/development/libraries/libco-canonical/default.nix
@@ -19,6 +19,17 @@ stdenv.mkDerivation rec {
 
   outputs = [ "dev" "out" ];
 
+  patchPhase = ''
+    # upstream project assumes all build products will go into single directory
+    # `$prefix` but we need `includedir` to point to "dev", not "out"
+    #
+    # pkgs/build-support/setup-hooks/multiple-outputs.sh would normally patch
+    # this automatically, but it fails here due to use of absolute paths
+
+    substituteInPlace Makefile \
+      --replace "@includedir@|\$(PREFIX)" "@includedir@|${placeholder "dev"}"
+  '';
+
   meta = {
     description = "A cooperative multithreading library written in C89";
     homepage = "https://github.com/canonical/libco";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

libco.pc (pkgconfig file) was incorrectly setting includedir to the "out" path, instead of the "dev" path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @wucke13 
