### PR TITLE
nixos/systemd: Allow unit options to have multiple equal defs

### DIFF
--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -24,7 +24,7 @@ in rec {
       in
         if isList (head defs'')
         then concatLists defs''
-        else mergeOneOption loc defs';
+        else mergeEqualOption loc defs';
   };
 
   sharedOptions = {


### PR DESCRIPTION
###### Motivation for this change

E.g. this allows

```nix
  systemd.services.<name?>.serviceConfig.DynamicUser =
    mkMerge [ true true ];
```

Ping @srhb 

Related is https://github.com/NixOS/nixpkgs/pull/65380

###### Things done

- [x] Made sure this actually works by instantiating a NixOS system with above config