### PR TITLE
wire-desktop: Add arianvp to maintainer list

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -569,6 +569,12 @@
     githubId = 718812;
     name = "Antoine R. Dumont";
   };
+  arianvp = {
+    email = "arian.vanputten@gmail.com";
+    github = "arianvp";
+    githubId = 628387;
+    name = "Arian van Putten";
+  };
   aristid = {
     email = "aristidb@gmail.com";
     github = "aristidb";

--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -43,7 +43,7 @@ let
     homepage = https://wire.com/;
     downloadPage = https://wire.com/download/;
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ toonn worldofpeace ];
+    maintainers = with maintainers; [ arianvp toonn worldofpeace ];
     platforms = [ "x86_64-darwin" "x86_64-linux" ];
   };
 


### PR DESCRIPTION
I'm currently employed there, so could communicate nixpkgs-specific breakages to colleagues, to keep the desktop client as up-to-date as possible .

I was also thinking of trying a from-source build at some point; but haven't had much look with the `node2nix` tooling and `electron` so far.


###### Notify maintainers

cc @worldofpeace @toonn 
