### PR TITLE
boxfort: unstable-2019-09-19 -> unstable-2019-10-09

### DIFF
--- a/pkgs/development/libraries/boxfort/default.nix
+++ b/pkgs/development/libraries/boxfort/default.nix
@@ -1,36 +1,25 @@
-{ stdenv, fetchFromGitHub, cmake, pkg-config, gettext, libcsptr, dyncall
-, nanomsg, python37Packages }:
+{ stdenv, fetchFromGitHub, meson, ninja, python37Packages }:
 
 stdenv.mkDerivation rec {
-  version = "unstable-2019-09-19";
+  version = "unstable-2019-10-09";
   pname = "boxfort";
 
   src = fetchFromGitHub {
     owner = "Snaipe";
     repo = "BoxFort";
-    rev = "926bd4ce968592dbbba97ec1bb9aeca3edf29b0d";
-    sha256 = "0mzy4f8qij6ckn5578y3l4rni2470pdkjy5xww7ak99l1kh3p3v6";
+    rev = "356f047db08b7344ea7980576b705e65b9fc8772";
+    sha256 = "1p0llz7n0p5gzpvqszmra9p88vnr0j88sp5ixhgbfz89bswg62ss";
   };
 
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ meson ninja ];
 
-  nativeBuildInputs = [ cmake pkg-config ];
-
-  buildInputs = [
-    dyncall
-    gettext
-    libcsptr
-    nanomsg
-  ];
+  preConfigure = ''
+    patchShebangs ci/isdir.py
+  '';
 
   checkInputs = with python37Packages; [ cram ];
 
-  cmakeFlags = [ "-DBXF_FORK_RESILIENCE=OFF" ];
-
   doCheck = true;
-  preCheck = ''
-    export LD_LIBRARY_PATH=`pwd`''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
-  '';
 
   outputs = [ "dev" "out" ];
 
@@ -38,10 +27,7 @@ stdenv.mkDerivation rec {
     description = "Convenient & cross-platform sandboxing C library";
     homepage = "https://github.com/Snaipe/BoxFort";
     license = licenses.mit;
-    maintainers = with maintainers; [
-      thesola10
-      Yumasi
-    ];
+    maintainers = with maintainers; [ thesola10 Yumasi ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
An update to the latest BoxFort version. This switches the build system to meson, and fixes a bug with the latest versions of gdb preventing its use for debugging Criterion unit tests.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Thesola10
