### PR TITLE
python3Packages.black: 19.03b0 -> 19.10b0

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     sha256 = "0f8mr0yzj78q1dx7v6ggbgfir2wv0n5z2shfbbvfdq7910xbgvf2";
   };
 
-  buildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools_scm ];
   checkInputs =  [ pytest glibcLocales ];
 
   # Necessary for the tests to pass on Darwin with sandbox enabled.

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -1,18 +1,20 @@
 { stdenv, buildPythonPackage, fetchPypi, pythonOlder
 , attrs, click, toml, appdirs, aiohttp, aiohttp-cors
-, glibcLocales, pytest }:
+, glibcLocales, typed-ast, pathspec, regex
+, setuptools_scm, pytest }:
 
 buildPythonPackage rec {
   pname = "black";
-  version = "19.3b0";
+  version = "19.10b0";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "073kd5rs02lisp6n3h7yai9lix520xnaa6c7rdmp2sci9pyhz5b8";
+    sha256 = "0f8mr0yzj78q1dx7v6ggbgfir2wv0n5z2shfbbvfdq7910xbgvf2";
   };
 
+  buildInputs = [ setuptools_scm ];
   checkInputs =  [ pytest glibcLocales ];
 
   # Necessary for the tests to pass on Darwin with sandbox enabled.
@@ -22,12 +24,11 @@ buildPythonPackage rec {
   # Don't know why these tests fails
   checkPhase = ''
     LC_ALL="en_US.UTF-8" pytest \
-      --deselect tests/test_black.py::BlackTestCase::test_expression_diff \
       --deselect tests/test_black.py::BlackTestCase::test_cache_multiple_files \
       --deselect tests/test_black.py::BlackTestCase::test_failed_formatting_does_not_get_cached
   '';
 
-  propagatedBuildInputs = [ attrs appdirs click toml aiohttp aiohttp-cors ];
+  propagatedBuildInputs = [ attrs appdirs click toml aiohttp aiohttp-cors pathspec regex typed-ast ];
 
   meta = with stdenv.lib; {
     description = "The uncompromising Python code formatter";

--- a/pkgs/development/python-modules/portend/black-19.10b0.patch
+++ b/pkgs/development/python-modules/portend/black-19.10b0.patch
@@ -1,0 +1,13 @@
+diff --git a/test_portend.py b/test_portend.py
+index b2de8c2..3f90276 100644
+--- a/test_portend.py
++++ b/test_portend.py
+@@ -21,7 +21,7 @@ def socket_infos():
+ 
+ 
+ def id_for_info(info):
+-    af, = info[:1]
++    (af,) = info[:1]
+     return str(af)
+ 
+ 

--- a/pkgs/development/python-modules/portend/default.nix
+++ b/pkgs/development/python-modules/portend/default.nix
@@ -10,6 +10,7 @@ buildPythonPackage rec {
     sha256 = "19dc27bfb3c72471bd30a235a4d5fbefef8a7e31cab367744b5d87a205e7bfd9";
   };
 
+  patches = [ ./black-19.10b0.patch ];
   postPatch = ''
     substituteInPlace pytest.ini --replace "--flake8" ""
   '';

--- a/pkgs/development/python-modules/pytest-black/black-version.patch
+++ b/pkgs/development/python-modules/pytest-black/black-version.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 5c9ce5f..84b148a 100644
+--- a/setup.py
++++ b/setup.py
+@@ -26,6 +26,6 @@ setup(
+     python_requires=">=2.7",
+     install_requires=[
+         "pytest>=3.5.0",
+-        'black==19.3b0; python_version >= "3.6"',
++        'black; python_version >= "3.6"',
+         "toml",
+     ],
+     use_scm_version=True,

--- a/pkgs/development/python-modules/pytest-black/default.nix
+++ b/pkgs/development/python-modules/pytest-black/default.nix
@@ -14,6 +14,7 @@ buildPythonPackage rec {
     sha256 = "03gwwy1h3qnfh6vpfhgsa5ag53a9sw1g42sc2s8a2hilwb7yrfvm";
   };
 
+  patches = [ ./black-version.patch ];
   nativeBuildInputs = [ setuptools_scm ];
 
   propagatedBuildInputs = [ black pytest toml ];


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @sveitser 
