### PR TITLE
nixos/pppd: port test to python

### DIFF
--- a/nixos/tests/pppd.nix
+++ b/nixos/tests/pppd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix (
+import ./make-test-python.nix (
   let
     chap-secrets = {
       text = ''"flynn" * "reindeerflotilla" *'';
@@ -53,10 +53,10 @@ import ./make-test.nix (
         environment.etc."ppp/chap-secrets" = chap-secrets;
       };
     };
-  
+
     testScript = ''
-      startAll;
-      $client->waitUntilSucceeds("ping -c1 -W1 192.0.2.1");
-      $server->waitUntilSucceeds("ping -c1 -W1 192.0.2.2");
+      start_all()
+      client.wait_until_succeeds("ping -c1 -W1 192.0.2.1")
+      server.wait_until_succeeds("ping -c1 -W1 192.0.2.2")
     '';
-  })  
+  })


### PR DESCRIPTION
###### Motivation for this change
#72828


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc @worldofpeace 
