### PR TITLE
nixos/tinydns: port test to python

### DIFF
--- a/nixos/modules/services/networking/tinydns.nix
+++ b/nixos/modules/services/networking/tinydns.nix
@@ -37,6 +37,7 @@ with lib;
     systemd.services.tinydns = {
       description = "djbdns tinydns server";
       wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
       path = with pkgs; [ daemontools djbdns ];
       preStart = ''
         rm -rf /var/lib/tinydns

--- a/nixos/tests/tinydns.nix
+++ b/nixos/tests/tinydns.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ...} : {
+import ./make-test-python.nix ({ lib, ...} : {
   name = "tinydns";
   meta = {
     maintainers = with lib.maintainers; [ basvandijk ];
@@ -19,8 +19,8 @@ import ./make-test.nix ({ lib, ...} : {
     };
   };
   testScript = ''
-    $nameserver->start;
-    $nameserver->waitForUnit("tinydns.service");
-    $nameserver->succeed("host bla.foo.bar | grep '1\.2\.3\.4'");
+    nameserver.start()
+    nameserver.wait_for_unit("tinydns.service")
+    nameserver.succeed("host bla.foo.bar | grep '1\.2\.3\.4'")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace @tfc 