### PR TITLE
cfn-lint: propagate setuptools

### DIFF
--- a/pkgs/development/python-modules/cfn-lint/default.nix
+++ b/pkgs/development/python-modules/cfn-lint/default.nix
@@ -8,6 +8,7 @@
 , jsonpatch
 , jsonschema
 , pathlib2
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -27,6 +28,7 @@ buildPythonPackage rec {
     jsonpatch
     jsonschema
     pathlib2
+    setuptools
   ];
 
   # No tests included in archive


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
`cfn-lint` fails:

```
Traceback (most recent call last):
  File "/nix/store/xmg2xz7n128fwhl9hw06hp1qf3x42cs7-python3.7-cfn-lint-0.24.5/bin/.cfn-lint-wrapped", line 6, in <module>
    from cfnlint.__main__ import main
  File "/nix/store/xmg2xz7n128fwhl9hw06hp1qf3x42cs7-python3.7-cfn-lint-0.24.5/lib/python3.7/site-packages/cfnlint/__init__.py", line 27, in <module>
    import cfnlint.helpers
  File "/nix/store/xmg2xz7n128fwhl9hw06hp1qf3x42cs7-python3.7-cfn-lint-0.24.5/lib/python3.7/site-packages/cfnlint/helpers.py", line 32, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
