### PR TITLE
picat: 1.9 -> 2.7

### DIFF
--- a/pkgs/development/compilers/picat/default.nix
+++ b/pkgs/development/compilers/picat/default.nix
@@ -1,27 +1,29 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, zlib, gcc7Stdenv }:
 
-stdenv.mkDerivation {
-  name = "picat-1.9-4";
+gcc7Stdenv.mkDerivation {
+  name = "picat-2.7b12";
 
   src = fetchurl {
-    url = http://picat-lang.org/download/picat19_src.tar.gz;
-    sha256 = "0wvl95gf4pjs93632g4wi0mw1glzzhjp9g4xg93ll2zxggbxibli";
+    url = http://picat-lang.org/download/picat27b12_src.tar.gz;
+    sha256 = "0hqfrgi5qlq3l5wnpxfk8spk9zly13npzaas57fbhsn7sdaksjj6";
   };
 
-  ARCH = if stdenv.hostPlatform.system == "i686-linux" then "linux32"
-         else if stdenv.hostPlatform.system == "x86_64-linux" then "linux64"
-         else throw "Unsupported system";
+  ARCH = if stdenv.hostPlatform.system == "x86_64-linux" then "linux64"
+    else if stdenv.hostPlatform.system == "x86_64-darwin" then "mac64"
+    else throw "Unsupported system";
 
   hardeningDisable = [ "format" ];
 
+  buildInputs = [ zlib ];
+
   buildPhase = ''
     cd emu
-    make -f Makefile.picat.$ARCH
+    make -f Makefile.$ARCH
   '';
 
   installPhase = ''
     mkdir -p $out/bin
-    cp picat_$ARCH $out/bin/picat
+    cp picat $out/bin/picat
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Version bump.

Haven't tested on darwin, though.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @earldouglas 
