### PR TITLE
python3Packages.crypto-commons: init at unstable-2019-11-08

### DIFF
--- a/pkgs/development/python-modules/crypto-commons/default.nix
+++ b/pkgs/development/python-modules/crypto-commons/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, gmpy2
+, isPy3k
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "crypto-commons";
+  version = "unstable-2019-11-08";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "p4-team";
+    repo = pname;
+    rev = "8f54fae30c71fddbc75a6eab3b8bca1fee56fb69";
+    sha256 = "1f5xwcqwc55b4ap2z173h38x5dny126iikp7rji0sfap6jm6gvxk";
+  };
+
+  checkInputs = [ gmpy2 ];
+
+  meta = with lib; {
+    description = "A small python module for common CTF crypto functions";
+    homepage = "https://github.com/p4-team/crypto-commons";
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -497,6 +497,8 @@ in {
 
   codespell = callPackage ../development/python-modules/codespell { };
 
+  crypto-commons = callPackage ../development/python-modules/crypto-commons { };
+
   curio = callPackage ../development/python-modules/curio { };
 
   dendropy = callPackage ../development/python-modules/dendropy { };


### PR DESCRIPTION
###### Motivation for this change

Make the awesome p4-team/crypto-commons available for CTF players using NixOS!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).