### PR TITLE
gnumeric: 1.12.45 → 1.12.46; goffice: 0.10.45 → 0.10.46

### DIFF
--- a/pkgs/applications/office/gnumeric/default.nix
+++ b/pkgs/applications/office/gnumeric/default.nix
@@ -1,31 +1,22 @@
 { stdenv, fetchurl, pkgconfig, intltool, perlPackages
 , goffice, gnome3, wrapGAppsHook, gtk3, bison, pythonPackages
-, itstool, autoreconfHook
+, itstool
 }:
 
 let
   inherit (pythonPackages) python pygobject3;
 in stdenv.mkDerivation rec {
   pname = "gnumeric";
-  version = "1.12.45"; # TODO next release: remove gamma patch and autoreconfHook
+  version = "1.12.46";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0c8dl1kvnj3g32qy3s92qpqpqfy0in59cx005gjvvzsflahav61h";
+    sha256 = "9fdc67377af52dfe69a7db4f533938024a75f454fc5d25ab43b8e6739be0b5e1";
   };
-
-  patches = stdenv.lib.optional stdenv.isDarwin
-    # https://gitlab.gnome.org/GNOME/gnumeric/issues/402
-    (fetchurl {
-      name = "math-gamma.patch";
-      url = "https://gitlab.gnome.org/GNOME/gnumeric/uploads/cf8d162bc719de92e97d01cb0ba5b637/ppp";
-      sha256 = "17wiigs06qc86a1nghwcg3pcnpa28123jblgsxpy3j7drardgnlp";
-    });
 
   configureFlags = [ "--disable-component" ];
 
-  nativeBuildInputs = [ pkgconfig intltool bison itstool wrapGAppsHook ]
-    ++ stdenv.lib.optional stdenv.isDarwin autoreconfHook;
+  nativeBuildInputs = [ pkgconfig intltool bison itstool wrapGAppsHook ];
 
   # ToDo: optional libgda, introspection?
   buildInputs = [

--- a/pkgs/development/libraries/goffice/default.nix
+++ b/pkgs/development/libraries/goffice/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "goffice";
-  version = "0.10.45";
+  version = "0.10.46";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "702ba567e9ec0bbdd9b1a8161cd24648b4868d57a6cb89128f13c125f6f31947";
+    sha256 = "058d6d3a40e1f60525682ec6b857c441d5deb50d0d30a76804f9f36f865a13a9";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];


### PR DESCRIPTION
###### Motivation for this change

Bugfix release: http://gnumeric.org/announcements/1.12/gnumeric-1.12.46.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
