### PR TITLE
treewide: add missing descriptions & homepages

### DIFF
--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -33,6 +33,8 @@ mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
+    homepage = "https://amarok.kde.org";
+    description = "A powerful music player with an intuitive interface";
     license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];
   };

--- a/pkgs/development/tools/misc/gputils/default.nix
+++ b/pkgs/development/tools/misc/gputils/default.nix
@@ -10,7 +10,8 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = https://gputils.sourceforge.io/;
+    homepage = "https://gputils.sourceforge.io";
+    description = "A collection of tools for the Microchip (TM) PIC microcontrollers. It includes gpasm, gplink, and gplib";
     license = licenses.gpl2;
     maintainers = with maintainers; [ yorickvp ];
     platforms = platforms.linux;

--- a/pkgs/shells/oh/default.nix
+++ b/pkgs/shells/oh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchgit }:
+{ stdenv, buildGoPackage, fetchgit, lib }:
 
 buildGoPackage rec {
   pname = "oh";
@@ -14,4 +14,10 @@ buildGoPackage rec {
   };
 
   goDeps = ./deps.nix;
+
+  meta = with lib;{
+    homepage = "https://github.com/michaelmacinnis/oh";
+    description = "A Unix shell";
+    license = stdenv.lib.licenses.mit;
+  };
 }

--- a/pkgs/tools/misc/peruse/default.nix
+++ b/pkgs/tools/misc/peruse/default.nix
@@ -26,6 +26,8 @@ in mkDerivation {
   pathsToLink = [ "/etc/xdg/peruse.knsrc"];
 
   meta = with lib; {
+    homepage = "https://peruse.kde.org";
+    description = "A comic book reader";
     license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];
   };


### PR DESCRIPTION
###### Motivation for this change
Add missing meta data.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

