### PR TITLE
[r19.03] opencv4: add patches for CVE-2019-14491, CVE-2019-14492, CVE-2019-14493 & CVE-2019-15939

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -1,5 +1,5 @@
 { lib, stdenv
-, fetchurl, fetchFromGitHub
+, fetchurl, fetchFromGitHub, fetchpatch
 , cmake, pkgconfig, unzip, zlib, pcre, hdf5
 , glog, boost, google-gflags, protobuf
 , config
@@ -159,6 +159,24 @@ stdenv.mkDerivation rec {
   postUnpack = lib.optionalString buildContrib ''
     cp --no-preserve=mode -r "${contribSrc}/modules" "$NIX_BUILD_TOP/source/opencv_contrib"
   '';
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-14491.CVE-2019-14492.patch";
+      url = "https://github.com/opencv/opencv/pull/15150/commits/321c74ccd6077bdea1d47450ca4fe955cb5b6330.patch";
+      sha256 = "03nxq24wsyszpl24i9fz3k06np75g9p4pqgnn1iw0nqdn7qds8pm";
+    })
+    (fetchpatch {
+      name = "CVE-2019-14493.patch";
+      url = "https://github.com/opencv/opencv/pull/15145/commits/5691d998ead1d9b0542bcfced36c2dceb3a59023.patch";
+      sha256 = "14qva9f5z10apz5q0skdyiclr9sgkhab4fzksy1w3b6j6hg4wm7m";
+    })
+    (fetchpatch {
+      name = "CVE-2019-15939.patch";
+      url = "https://github.com/opencv/opencv/pull/15382/commits/5a497077f109d543ab86dfdf8add1c76c0e47d29.patch";
+      sha256 = "18wqsss5zz3f6i1ih8gd17h2zrrqpgfd7jmc45v70gk30nmhcj5b";
+    })
+  ];
 
   # This prevents cmake from using libraries in impure paths (which
   # causes build failure on non NixOS)


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-14491
https://nvd.nist.gov/vuln/detail/CVE-2019-14492
https://nvd.nist.gov/vuln/detail/CVE-2019-14493
https://nvd.nist.gov/vuln/detail/CVE-2019-15939

Fixes for master in #72600, for 19.09 in #72649.

No point release for 4.0 series, so patching.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
