### PR TITLE
coqPackages.InteractionTrees: init at 1.0.0

### DIFF
--- a/pkgs/development/coq-modules/InteractionTrees/default.nix
+++ b/pkgs/development/coq-modules/InteractionTrees/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchFromGitHub, coq, mk-coq-ext-lib, mk-paco, version ? null }:
+
+let
+  InteractionTrees-versions = {
+    "1_0_0" = {
+      version = "1.0.0";
+      rev = "1.0.0";
+      sha256 = "1g59844fcypk7fq7l8zvh6vk1gziaq79byvihahamhcy7yq60dr5";
+      coq-ext-lib-version = "0_10_0";
+      paco-version = "2_1_0";
+    };
+    "20191104" = {
+      version = "20191104";
+      rev = "d408b9151f7f77d1ab0b8a0f2d57f210e16206ae";
+      sha256 = "1pjad3y6y7nmmjd9hyw6zn1314igkxd3vcj1rmnariff69slcpdk";
+      coq-ext-lib-version = "0_10_2";
+      paco-version = "4_0_0";
+    };
+  };
+  default-versions = {
+    "8.8" = InteractionTrees-versions."1_0_0";
+    "8.9" = InteractionTrees-versions."1_0_0";
+  };
+  param =
+    if version == null
+    then default-versions.${coq.coq-version}
+    else InteractionTrees-versions.${version};
+
+  coq-ext-lib = mk-coq-ext-lib { version = param.coq-ext-lib-version; };
+  paco = mk-paco { version = param.paco-version; };
+
+in
+
+stdenv.mkDerivation rec {
+  inherit (param) version;
+  name = "coq${coq.coq-version}-InteractionTrees-${version}";
+
+  src = fetchFromGitHub {
+    inherit (param) rev sha256;
+    owner = "DeepSpec";
+    repo = "InteractionTrees";
+  };
+
+  buildInputs = [ coq ];
+  propagatedBuildInputs = [ coq-ext-lib paco ];
+
+  enableParallelBuilding = true;
+
+  installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/DeepSpec/InteractionTrees;
+    description = "A library for representing recursive and impure programs in Coq";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ptival ];
+    platforms = coq.meta.platforms;
+  };
+
+  passthru = {
+    compatibleCoqVersions = v: builtins.hasAttr v default-versions;
+  };
+}

--- a/pkgs/development/coq-modules/coq-ext-lib/default.nix
+++ b/pkgs/development/coq-modules/coq-ext-lib/default.nix
@@ -1,14 +1,27 @@
-{ stdenv, fetchFromGitHub, coq }:
+{ stdenv, fetchFromGitHub, coq, version ? null }:
 
-let params =
-  {
-    "8.5" = { version = "0.9.4"; sha256 = "1y66pamgsdxlq2w1338lj626ln70cwj7k53hxcp933g8fdsa4hp0"; };
-    "8.6" = { version = "0.9.5"; sha256 = "1b4cvz3llxin130g13calw5n1zmvi6wdd5yb8a41q7yyn2hd3msg"; };
-    "8.7" = { version = "0.9.7"; sha256 = "00v4bm4glv1hy08c8xsm467az6d1ashrznn8p2bmbmmp52lfg7ag"; };
-    "8.8" = { version = "0.10.3"; sha256 = "0795gs2dlr663z826mp63c8h2zfadn541dr8q0fvnvi2z7kfyslb"; };
-    "8.9" = { version = "0.10.3"; sha256 = "0795gs2dlr663z826mp63c8h2zfadn541dr8q0fvnvi2z7kfyslb"; };
+let
+  coq-ext-lib-versions = {
+    "0_9_4" = { version = "0.9.4"; sha256 = "1y66pamgsdxlq2w1338lj626ln70cwj7k53hxcp933g8fdsa4hp0"; };
+    "0_9_5" = { version = "0.9.5"; sha256 = "1b4cvz3llxin130g13calw5n1zmvi6wdd5yb8a41q7yyn2hd3msg"; };
+    "0_9_7" = { version = "0.9.7"; sha256 = "00v4bm4glv1hy08c8xsm467az6d1ashrznn8p2bmbmmp52lfg7ag"; };
+    "0_10_0" = { version = "0.10.0"; sha256 = "1kxi5bmjwi5zqlqgkyzhhxwgcih7wf60cyw9398k2qjkmi186r4a"; };
+    "0_10_1" = { version = "0.10.1"; sha256 = "0r1vspad8fb8bry3zliiz4hfj4w1iib1l2gm115a94m6zbiksd95"; };
+    "0_10_2" = { version = "0.10.2"; sha256 = "1b150rc5bmz9l518r4m3vwcrcnnkkn9q5lrwygkh0a7mckgg2k9f"; };
+    "0_10_3" = { version = "0.10.3"; sha256 = "0795gs2dlr663z826mp63c8h2zfadn541dr8q0fvnvi2z7kfyslb"; };
   };
-  param = params.${coq.coq-version};
+  default-versions =
+  {
+    "8.5" = coq-ext-lib-versions."0_9_4";
+    "8.6" = coq-ext-lib-versions."0_9_5";
+    "8.7" = coq-ext-lib-versions."0_9_7";
+    "8.8" = coq-ext-lib-versions."0_10_3";
+    "8.9" = coq-ext-lib-versions."0_10_3";
+  };
+  param =
+    if version != null
+    then coq-ext-lib-versions.${version}
+    else default-versions.${coq.coq-version};
 in
 
 stdenv.mkDerivation rec {
@@ -38,6 +51,6 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.hasAttr v params;
+    compatibleCoqVersions = v: builtins.hasAttr v default-versions;
   };
 }

--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -1,26 +1,39 @@
-{stdenv, fetchFromGitHub, coq, unzip}:
+{ stdenv, fetchFromGitHub, coq, unzip, version ? null }:
 
 let
-  versions = {
-    pre_8_6 = rec {
+  paco-versions = {
+    "1_2_8" = rec {
       rev = "v${version}";
       version = "1.2.8";
       sha256 = "05fskx5x1qgaf9qv626m38y5izichzzqc7g2rglzrkygbskrrwsb";
     };
-    post_8_6 = rec {
+    "2_1_0" = rec {
+      rev = "v${version}";
+      version = "2.1.0";
+      sha256 = "0dra0wigdrr6sdy1c76b0v8pvkd447ri5r59vrvab1ww9rk7y2da";
+    };
+    "3_0_0" = rec {
+      rev = "v${version}";
+      version = "3.0.0";
+      sha256 = "1riqycr4wkzsgybn143066vk71w1n2i889ffc3a9j9y5f9bbn2pd";
+    };
+    "4_0_0" = rec {
       rev = "v${version}";
       version = "4.0.0";
       sha256 = "1ncrdyijkgf0s2q4rg1s9r2nrcb17gq3jz63iqdlyjq3ylv8gyx0";
     };
   };
-  params = {
-    "8.5" = versions.pre_8_6;
-    "8.6" = versions.post_8_6;
-    "8.7" = versions.post_8_6;
-    "8.8" = versions.post_8_6;
-    "8.9" = versions.post_8_6;
+  default-versions = {
+    "8.5" = paco-versions."1_2_8";
+    "8.6" = paco-versions."4_0_0";
+    "8.7" = paco-versions."4_0_0";
+    "8.8" = paco-versions."4_0_0";
+    "8.9" = paco-versions."4_0_0";
   };
-  param = params.${coq.coq-version};
+  param =
+    if version == null
+    then default-versions.${coq.coq-version}
+    else paco-versions.${version};
 in
 
 stdenv.mkDerivation rec {
@@ -52,7 +65,7 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.5" "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: builtins.hasAttr v default-versions;
   };
 
 }

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -5,6 +5,8 @@ let
     let callPackage = self.callPackage; in {
       inherit coq;
       coqPackages = self;
+      mk-coq-ext-lib = callPackage ../development/coq-modules/coq-ext-lib;
+      mk-paco = callPackage ../development/coq-modules/paco;
 
       contribs = recurseIntoAttrs
         (callPackage ../development/coq-modules/contribs {});
@@ -34,6 +36,10 @@ let
       HoTT = callPackage ../development/coq-modules/HoTT {};
       interval = callPackage ../development/coq-modules/interval {};
       InfSeqExt = callPackage ../development/coq-modules/InfSeqExt {};
+      InteractionTrees = callPackage ../development/coq-modules/InteractionTrees {};
+      InteractionTrees_20191104 = callPackage ../development/coq-modules/InteractionTrees {
+        version = "20191104";
+      };
       iris = callPackage ../development/coq-modules/iris {};
       ltac2 = callPackage ../development/coq-modules/ltac2 {};
       math-classes = callPackage ../development/coq-modules/math-classes { };


### PR DESCRIPTION
This package required a bit of refactoring, I would love for someone to double-check and comment on that.

`InteractionTrees` has only one release, version 1.0.0. It dates from a while back, so I wanted to package both it, and a more recent version pointing at the current master branch.

Sadly, those have pretty different requirements on `paco` and `coq-ext-lib`. In particular, while I recently made `coq-ext-lib` be at version 0.10.3 for recent Coq versions, they supposedly have made a breaking change as far as InteractionTrees is concerned between 0.10.2 and 0.10.3.

So `InteractionTrees_20191104` wants `coq-ext-lib=0.10.2`, which meant I had to make that available. In order to get that flexibility, I have parameterized `InteractionTrees` over builders for `paco` and `coq-ext-lib` (see in `coq-packages.nix`). I'm not sure that this is the way to go, so feedback on this would be appreciated.