### PR TITLE
[r19.03] varnish6: add patch for CVE-2019-15892

### DIFF
--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, fetchurl, pcre, libxslt, groff, ncurses, pkgconfig, readline, libedit
+{ stdenv, fetchurl, fetchpatch, pcre, libxslt, groff, ncurses, pkgconfig, readline, libedit
 , python2, makeWrapper }:
 
 let
-  common = { version, sha256, extraBuildInputs ? [] }:
+  common = { version, sha256, extraBuildInputs ? [], patches ? null }:
     stdenv.mkDerivation rec {
+      inherit patches;
       name = "varnish-${version}";
 
       src = fetchurl {
@@ -50,5 +51,11 @@ in
     version = "6.1.1";
     sha256 = "0gf9hzzrr1lndbbqi8cwlfasi7l517cy3nbgna88i78lm247rvp0";
     extraBuildInputs = [ python2.pkgs.sphinx ];
+    patches = [
+      (fetchpatch {
+        url = "https://sources.debian.org/data/main/v/varnish/6.1.1-1+deb10u1/debian/patches/CVE-2019-15892.patch";
+        sha256 = "03jlflgry4j9f34kxni64j6583jqr828zgy68ywdmglpxkgpyma7";
+      })
+    ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-15892

Fixed for 19.09 in #70532

No point release for 6.1, so borrowing patch from debian.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
