### PR TITLE
python3Packages.dictances: init at 1.5.0

### DIFF
--- a/pkgs/development/python-modules/dictances/default.nix
+++ b/pkgs/development/python-modules/dictances/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage
+, fetchPypi
+, isPy3k
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "dictances";
+  version = "1.5.1";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1xc89j6n5j9i8jk6qv2y87wcny3aq5g06w26b91z1ycm8mkyayzy";
+  };
+
+  # Missing some nixpkgs
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Distances and divergences between distributions implemented in python";
+    homepage = "https://github.com/LucaCappelletti94/dictances";
+    license = licenses.mit;
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -525,6 +525,8 @@ in {
 
   dkimpy = callPackage ../development/python-modules/dkimpy { };
 
+  dictances = callPackage ../development/python-modules/dictances { };
+
   dictionaries = callPackage ../development/python-modules/dictionaries { };
 
   diff_cover = callPackage ../development/python-modules/diff_cover { };


### PR DESCRIPTION
###### Motivation for this change

Make this package is available.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
