### PR TITLE
llvm_9: disable failing tests on 32-bit ARM

### DIFF
--- a/pkgs/development/compilers/llvm/9/llvm.nix
+++ b/pkgs/development/compilers/llvm/9/llvm.nix
@@ -75,6 +75,12 @@ in stdenv.mkDerivation (rec {
     rm unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
     # valgrind unhappy with musl or glibc, but fails w/musl only
     rm test/CodeGen/AArch64/wineh4.mir
+  '' + optionalString stdenv.hostPlatform.isAarch32 ''
+    # skip failing X86 test cases on 32-bit ARM
+    rm test/DebugInfo/X86/convert-debugloc.ll
+    rm test/DebugInfo/X86/convert-inlined.ll
+    rm test/DebugInfo/X86/convert-linked.ll
+    rm test/tools/dsymutil/X86/op-convert.test
   '' + ''
     patchShebangs test/BugPoint/compile-custom.ll.py
 

--- a/pkgs/development/compilers/llvm/9/llvm.nix
+++ b/pkgs/development/compilers/llvm/9/llvm.nix
@@ -81,6 +81,9 @@ in stdenv.mkDerivation (rec {
     rm test/DebugInfo/X86/convert-inlined.ll
     rm test/DebugInfo/X86/convert-linked.ll
     rm test/tools/dsymutil/X86/op-convert.test
+  '' + optionalString (stdenv.hostPlatform.system == "armv6l-linux") ''
+    # Seems to require certain floating point hardware (NEON?)
+    rm test/ExecutionEngine/frem.ll
   '' + ''
     patchShebangs test/BugPoint/compile-custom.ll.py
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Some of LLVM 9's tests fail on armv7l. LLVM 7 has a [similar set of tests that fail on 32-bit ARM](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/llvm/7/llvm.nix#L89).

I manually ran the tests and copied the errors, in case someone wants to debug this further or submit a fix upstream:
```
convert-debugloc.ll:69:19: error: DW4-CHECK-NEXT: expected string not found in input
; DW4-CHECK-NEXT: 0x00000000: Compile Unit: length = 0x0000007a version = 0x0004 abbr_offset = 0x0000 addr_size = 0x08 (next unit at 0x0000007e)
                  ^
<stdin>:4:1: note: scanning from here
0x00000000: Compile Unit: length = 0x00000064 version = 0x0005 unit_type = DW_UT_compile abbr_offset = 0x0000 addr_size = 0x08 (next unit at 0x00000068)
^
```

```
convert-inlined.ll:32:19: error: DW5-CHECK-NEXT: expected string not found in input
; DW5-CHECK-NEXT: DW_AT_location (DW_OP_addrx 0x0, DW_OP_deref, DW_OP_convert (0x0000001e) "DW_ATE_signed_8", DW_OP_convert (0x00000022) "DW_ATE_signed_32", DW_OP_stack_value)
                  ^
<stdin>:31:2: note: scanning from here
 DW_AT_location (DW_OP_addrx 0x0, DW_OP_deref, DW_OP_convert (0xbef12c10) "DW_ATE_signed_8", DW_OP_convert (0x00000000) "DW_ATE_signed_32", DW_OP_stack_value)
 ^
```

```
convert-linked.ll:9:10: error: CHECK: expected string not found in input
; CHECK: DW_OP_convert ([[CU0BT0]]) "DW_ATE_signed_8", DW_OP_convert ([[CU0BT1]]) "DW_ATE_signed_32"
         ^
<stdin>:46:2: note: scanning from here
 DW_AT_location (DW_OP_breg5 RDI+0, DW_OP_constu 0xff, DW_OP_and, DW_OP_convert (0xb6a18aba) "DW_ATE_signed_8", DW_OP_convert (0x00000000) "DW_ATE_signed_32", DW_OP_stack_value)
 ^
<stdin>:46:2: note: with "CU0BT0" equal to "0x00000023"
 DW_AT_location (DW_OP_breg5 RDI+0, DW_OP_constu 0xff, DW_OP_and, DW_OP_convert (0xb6a18aba) "DW_ATE_signed_8", DW_OP_convert (0x00000000) "DW_ATE_signed_32", DW_OP_stack_value)
 ^
<stdin>:46:2: note: with "CU0BT1" equal to "0x00000027"
 DW_AT_location (DW_OP_breg5 RDI+0, DW_OP_constu 0xff, DW_OP_and, DW_OP_convert (0xb6a18aba) "DW_ATE_signed_8", DW_OP_convert (0x00000000) "DW_ATE_signed_32", DW_OP_stack_value)
 ^
<stdin>:46:83: note: possible intended match here
 DW_AT_location (DW_OP_breg5 RDI+0, DW_OP_constu 0xff, DW_OP_and, DW_OP_convert (0xb6a18aba) "DW_ATE_signed_8", DW_OP_convert (0x00000000) "DW_ATE_signed_32", DW_OP_stack_value)
                                                                                  ^
```

```
op-convert.test:26:13: error: CHECK-NEXT: expected string not found in input
CHECK-NEXT: [0x0000000000001000, 0x0000000000001002): DW_OP_breg5 RDI+0, DW_OP_constu 0xffffffff, DW_OP_and, DW_OP_convert (0x0000002a) "DW_ATE_signed_8", DW_OP_convert (0x00000031) "DW_ATE_signed_32", DW_OP_stack_value
            ^
<stdin>:46:18: note: scanning from here
 DW_AT_location (0x00000036
                 ^
<stdin>:47:2: note: possible intended match here
 [0x0000000000001000, 0x0000000000001002): DW_OP_breg5 RDI+0, DW_OP_constu 0xffffffff, DW_OP_and, DW_OP_convert (0xb6a28aba) "DW_ATE_signed_8", DW_OP_convert (0xbe8bf588) "DW_ATE_signed_32", DW_OP_stack_value
 ^
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lovek323 @7c6f434c @dtzWill
