### PR TITLE
llvm_7: disable failing test on armv6l

### DIFF
--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -94,6 +94,9 @@ in stdenv.mkDerivation ({
     rm test/tools/llvm-dwarfdump/X86/debug_addr_dwarf4.s
     rm test/tools/llvm-dwarfdump/X86/debug_addr_unsupported_version.s
     rm test/tools/llvm-dwarfdump/X86/debug_addr_version_mismatch.s
+  '' + optionalString (stdenv.hostPlatform.system == "armv6l-linux") ''
+    # Seems to require certain floating point hardware (NEON?)
+    rm test/ExecutionEngine/frem.ll
   '' + ''
     patchShebangs test/BugPoint/compile-custom.ll.py
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Disables a test that fails on armv6l. https://reviews.llvm.org/D41859 suggests that the failure may be due to the lack of NEON. LLVM 9 may need this same fix, but I probably won't get around to testing it until #71430 is merged, because my only use of LLVM on armv6l is Rust.

This is the error printed by the test:
```
frem.ll:22:10: error: CHECK: expected string not found in input
; CHECK: Double value: 2.0
         ^
<stdin>:1:1: note: scanning from here
Double value: 0.000000
^
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lovek323 @7c6f434c @dtzWill 
