### PR TITLE
texlab: init at 1.6.0

### DIFF
--- a/pkgs/development/node-packages/node-packages-v10.json
+++ b/pkgs/development/node-packages/node-packages-v10.json
@@ -15,6 +15,7 @@
 , "bower2nix"
 , "browserify"
 , "castnow"
+, { "texlab-citeproc-build-deps": "../tools/misc/texlab/citeproc" }
 , "clean-css"
 , "coffee-script"
 , "coinmon"

--- a/pkgs/development/node-packages/node-packages-v10.nix
+++ b/pkgs/development/node-packages/node-packages-v10.nix
@@ -13,31 +13,31 @@ let
         sha512 = "t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==";
       };
     };
-    "@angular-devkit/architect-0.803.17" = {
+    "@angular-devkit/architect-0.803.18" = {
       name = "_at_angular-devkit_slash_architect";
       packageName = "@angular-devkit/architect";
-      version = "0.803.17";
+      version = "0.803.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.803.17.tgz";
-        sha512 = "QbuWJhjh78Pb/9574OIjR38hhJCRBd0BtdrRRdTjP7By6liXURnA/OH6iZ9o1jA8It1NvoJQtM2flr8dQf83Mw==";
+        url = "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.803.18.tgz";
+        sha512 = "/oNutcuUduXH/4nxHSDRTYK3VGP0PkVUniPdo0yjpg8c2dbfoNkt1ILIV82LPaC8sDwjuXGLx0EH70ETtcnBwg==";
       };
     };
-    "@angular-devkit/core-8.3.17" = {
+    "@angular-devkit/core-8.3.18" = {
       name = "_at_angular-devkit_slash_core";
       packageName = "@angular-devkit/core";
-      version = "8.3.17";
+      version = "8.3.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.17.tgz";
-        sha512 = "cR2H/7OxxqagwGfzxwNWDOYN4QpOZ56Fei9JED/2p/K/5UDAowl20o3qP9mTfia/lEhFeyjMBcM8gsHxhJNYJQ==";
+        url = "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.18.tgz";
+        sha512 = "SPlQmBlrcaKZeE9srvuFElcen9iOled4lkD3M4cGwe56u6YoJ71oTAtmGiw9nofTtW0PghGVq8WdDQG5BRqX8Q==";
       };
     };
-    "@angular-devkit/schematics-8.3.17" = {
+    "@angular-devkit/schematics-8.3.18" = {
       name = "_at_angular-devkit_slash_schematics";
       packageName = "@angular-devkit/schematics";
-      version = "8.3.17";
+      version = "8.3.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.3.17.tgz";
-        sha512 = "1ttzYGnw5Ux7Nfr/TGyWx3C/rarq5l+dn+5SpKof/8ctvQU1gJaswF492ngPs/jDjaPq5MucKYoX+wTUJHnUhg==";
+        url = "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.3.18.tgz";
+        sha512 = "J9sf/6cSUx2kdXppo/69uZ1gBeM5fcXfnP7MCJCVnsk09QCD9Kr+Xeh8h4WEmLtne7XzI9dcCttHQ5WDNuRulA==";
       };
     };
     "@antora/asciidoc-loader-2.2.0" = {
@@ -238,13 +238,13 @@ let
         sha512 = "27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==";
       };
     };
-    "@babel/core-7.6.4" = {
+    "@babel/core-7.7.2" = {
       name = "_at_babel_slash_core";
       packageName = "@babel/core";
-      version = "7.6.4";
+      version = "7.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz";
-        sha512 = "Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==";
+        url = "https://registry.npmjs.org/@babel/core/-/core-7.7.2.tgz";
+        sha512 = "eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==";
       };
     };
     "@babel/generator-7.0.0-beta.38" = {
@@ -265,130 +265,148 @@ let
         sha512 = "jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==";
       };
     };
-    "@babel/helper-annotate-as-pure-7.0.0" = {
+    "@babel/generator-7.7.2" = {
+      name = "_at_babel_slash_generator";
+      packageName = "@babel/generator";
+      version = "7.7.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz";
+        sha512 = "WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==";
+      };
+    };
+    "@babel/helper-annotate-as-pure-7.7.0" = {
       name = "_at_babel_slash_helper-annotate-as-pure";
       packageName = "@babel/helper-annotate-as-pure";
-      version = "7.0.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz";
-        sha512 = "3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==";
+        url = "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.0.tgz";
+        sha512 = "k50CQxMlYTYo+GGyUGFwpxKVtxVJi9yh61sXZji3zYHccK9RYliZGSTOgci85T+r+0VFN2nWbGM04PIqwfrpMg==";
       };
     };
-    "@babel/helper-builder-binary-assignment-operator-visitor-7.1.0" = {
+    "@babel/helper-builder-binary-assignment-operator-visitor-7.7.0" = {
       name = "_at_babel_slash_helper-builder-binary-assignment-operator-visitor";
       packageName = "@babel/helper-builder-binary-assignment-operator-visitor";
-      version = "7.1.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz";
-        sha512 = "qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==";
+        url = "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.0.tgz";
+        sha512 = "Cd8r8zs4RKDwMG/92lpZcnn5WPQ3LAMQbCw42oqUh4s7vsSN5ANUZjMel0OOnxDLq57hoDDbai+ryygYfCTOsw==";
       };
     };
-    "@babel/helper-builder-react-jsx-7.3.0" = {
+    "@babel/helper-builder-react-jsx-7.7.0" = {
       name = "_at_babel_slash_helper-builder-react-jsx";
       packageName = "@babel/helper-builder-react-jsx";
-      version = "7.3.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz";
-        sha512 = "MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==";
+        url = "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.0.tgz";
+        sha512 = "LSln3cexwInTMYYoFeVLKnYPPMfWNJ8PubTBs3hkh7wCu9iBaqq1OOyW+xGmEdLxT1nhsl+9SJ+h2oUDYz0l2A==";
       };
     };
-    "@babel/helper-call-delegate-7.4.4" = {
+    "@babel/helper-call-delegate-7.7.0" = {
       name = "_at_babel_slash_helper-call-delegate";
       packageName = "@babel/helper-call-delegate";
-      version = "7.4.4";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz";
-        sha512 = "l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==";
+        url = "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.0.tgz";
+        sha512 = "Su0Mdq7uSSWGZayGMMQ+z6lnL00mMCnGAbO/R0ZO9odIdB/WNU/VfQKqMQU0fdIsxQYbRjDM4BixIa93SQIpvw==";
       };
     };
-    "@babel/helper-create-class-features-plugin-7.6.0" = {
+    "@babel/helper-create-class-features-plugin-7.7.0" = {
       name = "_at_babel_slash_helper-create-class-features-plugin";
       packageName = "@babel/helper-create-class-features-plugin";
-      version = "7.6.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz";
-        sha512 = "O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==";
+        url = "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.0.tgz";
+        sha512 = "MZiB5qvTWoyiFOgootmRSDV1udjIqJW/8lmxgzKq6oDqxdmHUjeP2ZUOmgHdYjmUVNABqRrHjYAYRvj8Eox/UA==";
       };
     };
-    "@babel/helper-define-map-7.5.5" = {
+    "@babel/helper-create-regexp-features-plugin-7.7.2" = {
+      name = "_at_babel_slash_helper-create-regexp-features-plugin";
+      packageName = "@babel/helper-create-regexp-features-plugin";
+      version = "7.7.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.2.tgz";
+        sha512 = "pAil/ZixjTlrzNpjx+l/C/wJk002Wo7XbbZ8oujH/AoJ3Juv0iN/UTcPUHXKMFLqsfS0Hy6Aow8M31brUYBlQQ==";
+      };
+    };
+    "@babel/helper-define-map-7.7.0" = {
       name = "_at_babel_slash_helper-define-map";
       packageName = "@babel/helper-define-map";
-      version = "7.5.5";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz";
-        sha512 = "fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==";
+        url = "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.0.tgz";
+        sha512 = "kPKWPb0dMpZi+ov1hJiwse9dWweZsz3V9rP4KdytnX1E7z3cTNmFGglwklzFPuqIcHLIY3bgKSs4vkwXXdflQA==";
       };
     };
-    "@babel/helper-explode-assignable-expression-7.1.0" = {
+    "@babel/helper-explode-assignable-expression-7.7.0" = {
       name = "_at_babel_slash_helper-explode-assignable-expression";
       packageName = "@babel/helper-explode-assignable-expression";
-      version = "7.1.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz";
-        sha512 = "NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==";
+        url = "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.0.tgz";
+        sha512 = "CDs26w2shdD1urNUAji2RJXyBFCaR+iBEGnFz3l7maizMkQe3saVw9WtjG1tz8CwbjvlFnaSLVhgnu1SWaherg==";
       };
     };
-    "@babel/helper-function-name-7.1.0" = {
+    "@babel/helper-function-name-7.7.0" = {
       name = "_at_babel_slash_helper-function-name";
       packageName = "@babel/helper-function-name";
-      version = "7.1.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz";
-        sha512 = "A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==";
+        url = "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz";
+        sha512 = "tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==";
       };
     };
-    "@babel/helper-get-function-arity-7.0.0" = {
+    "@babel/helper-get-function-arity-7.7.0" = {
       name = "_at_babel_slash_helper-get-function-arity";
       packageName = "@babel/helper-get-function-arity";
-      version = "7.0.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz";
-        sha512 = "r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==";
+        url = "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz";
+        sha512 = "tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==";
       };
     };
-    "@babel/helper-hoist-variables-7.4.4" = {
+    "@babel/helper-hoist-variables-7.7.0" = {
       name = "_at_babel_slash_helper-hoist-variables";
       packageName = "@babel/helper-hoist-variables";
-      version = "7.4.4";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz";
-        sha512 = "VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==";
+        url = "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.0.tgz";
+        sha512 = "LUe/92NqsDAkJjjCEWkNe+/PcpnisvnqdlRe19FahVapa4jndeuJ+FBiTX1rcAKWKcJGE+C3Q3tuEuxkSmCEiQ==";
       };
     };
-    "@babel/helper-member-expression-to-functions-7.5.5" = {
+    "@babel/helper-member-expression-to-functions-7.7.0" = {
       name = "_at_babel_slash_helper-member-expression-to-functions";
       packageName = "@babel/helper-member-expression-to-functions";
-      version = "7.5.5";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz";
-        sha512 = "5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==";
+        url = "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.0.tgz";
+        sha512 = "QaCZLO2RtBcmvO/ekOLp8p7R5X2JriKRizeDpm5ChATAFWrrYDcDxPuCIBXKyBjY+i1vYSdcUTMIb8psfxHDPA==";
       };
     };
-    "@babel/helper-module-imports-7.0.0" = {
+    "@babel/helper-module-imports-7.7.0" = {
       name = "_at_babel_slash_helper-module-imports";
       packageName = "@babel/helper-module-imports";
-      version = "7.0.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz";
-        sha512 = "aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==";
+        url = "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz";
+        sha512 = "Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==";
       };
     };
-    "@babel/helper-module-transforms-7.5.5" = {
+    "@babel/helper-module-transforms-7.7.0" = {
       name = "_at_babel_slash_helper-module-transforms";
       packageName = "@babel/helper-module-transforms";
-      version = "7.5.5";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz";
-        sha512 = "jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==";
+        url = "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.0.tgz";
+        sha512 = "rXEefBuheUYQyX4WjV19tuknrJFwyKw0HgzRwbkyTbB+Dshlq7eqkWbyjzToLrMZk/5wKVKdWFluiAsVkHXvuQ==";
       };
     };
-    "@babel/helper-optimise-call-expression-7.0.0" = {
+    "@babel/helper-optimise-call-expression-7.7.0" = {
       name = "_at_babel_slash_helper-optimise-call-expression";
       packageName = "@babel/helper-optimise-call-expression";
-      version = "7.0.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz";
-        sha512 = "u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==";
+        url = "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.0.tgz";
+        sha512 = "48TeqmbazjNU/65niiiJIJRc5JozB8acui1OS7bSd6PgxfuovWsvjfWSzlgx+gPFdVveNzUdpdIg5l56Pl5jqg==";
       };
     };
     "@babel/helper-plugin-utils-7.0.0" = {
@@ -409,58 +427,58 @@ let
         sha512 = "CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==";
       };
     };
-    "@babel/helper-remap-async-to-generator-7.1.0" = {
+    "@babel/helper-remap-async-to-generator-7.7.0" = {
       name = "_at_babel_slash_helper-remap-async-to-generator";
       packageName = "@babel/helper-remap-async-to-generator";
-      version = "7.1.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz";
-        sha512 = "3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==";
+        url = "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.0.tgz";
+        sha512 = "pHx7RN8X0UNHPB/fnuDnRXVZ316ZigkO8y8D835JlZ2SSdFKb6yH9MIYRU4fy/KPe5sPHDFOPvf8QLdbAGGiyw==";
       };
     };
-    "@babel/helper-replace-supers-7.5.5" = {
+    "@babel/helper-replace-supers-7.7.0" = {
       name = "_at_babel_slash_helper-replace-supers";
       packageName = "@babel/helper-replace-supers";
-      version = "7.5.5";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz";
-        sha512 = "XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==";
+        url = "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.0.tgz";
+        sha512 = "5ALYEul5V8xNdxEeWvRsBzLMxQksT7MaStpxjJf9KsnLxpAKBtfw5NeMKZJSYDa0lKdOcy0g+JT/f5mPSulUgg==";
       };
     };
-    "@babel/helper-simple-access-7.1.0" = {
+    "@babel/helper-simple-access-7.7.0" = {
       name = "_at_babel_slash_helper-simple-access";
       packageName = "@babel/helper-simple-access";
-      version = "7.1.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz";
-        sha512 = "Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==";
+        url = "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.0.tgz";
+        sha512 = "AJ7IZD7Eem3zZRuj5JtzFAptBw7pMlS3y8Qv09vaBWoFsle0d1kAn5Wq6Q9MyBXITPOKnxwkZKoAm4bopmv26g==";
       };
     };
-    "@babel/helper-split-export-declaration-7.4.4" = {
+    "@babel/helper-split-export-declaration-7.7.0" = {
       name = "_at_babel_slash_helper-split-export-declaration";
       packageName = "@babel/helper-split-export-declaration";
-      version = "7.4.4";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz";
-        sha512 = "Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==";
+        url = "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz";
+        sha512 = "HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==";
       };
     };
-    "@babel/helper-wrap-function-7.2.0" = {
+    "@babel/helper-wrap-function-7.7.0" = {
       name = "_at_babel_slash_helper-wrap-function";
       packageName = "@babel/helper-wrap-function";
-      version = "7.2.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz";
-        sha512 = "o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==";
+        url = "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz";
+        sha512 = "sd4QjeMgQqzshSjecZjOp8uKfUtnpmCyQhKQrVJBBgeHAB/0FPi33h3AbVlVp07qQtMD4QgYSzaMI7VwncNK/w==";
       };
     };
-    "@babel/helpers-7.6.2" = {
+    "@babel/helpers-7.7.0" = {
       name = "_at_babel_slash_helpers";
       packageName = "@babel/helpers";
-      version = "7.6.2";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz";
-        sha512 = "3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==";
+        url = "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz";
+        sha512 = "VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==";
       };
     };
     "@babel/highlight-7.5.0" = {
@@ -472,13 +490,13 @@ let
         sha512 = "7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==";
       };
     };
-    "@babel/parser-7.6.4" = {
+    "@babel/parser-7.7.3" = {
       name = "_at_babel_slash_parser";
       packageName = "@babel/parser";
-      version = "7.6.4";
+      version = "7.7.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz";
-        sha512 = "D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==";
+        url = "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz";
+        sha512 = "bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==";
       };
     };
     "@babel/plugin-external-helpers-7.0.0" = {
@@ -490,31 +508,31 @@ let
         sha512 = "tZKTMdhZvTy0KCEX5EGQQm1RHr7jUa36q/yax1baEA0yZapVYmu10yW7LTqijITgSq416gPVjrcexiA6y4pJlA==";
       };
     };
-    "@babel/plugin-proposal-async-generator-functions-7.2.0" = {
+    "@babel/plugin-proposal-async-generator-functions-7.7.0" = {
       name = "_at_babel_slash_plugin-proposal-async-generator-functions";
       packageName = "@babel/plugin-proposal-async-generator-functions";
-      version = "7.2.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz";
-        sha512 = "+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==";
+        url = "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.0.tgz";
+        sha512 = "ot/EZVvf3mXtZq0Pd0+tSOfGWMizqmOohXmNZg6LNFjHOV+wOPv7BvVYh8oPR8LhpIP3ye8nNooKL50YRWxpYA==";
       };
     };
-    "@babel/plugin-proposal-class-properties-7.5.5" = {
+    "@babel/plugin-proposal-class-properties-7.7.0" = {
       name = "_at_babel_slash_plugin-proposal-class-properties";
       packageName = "@babel/plugin-proposal-class-properties";
-      version = "7.5.5";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz";
-        sha512 = "AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==";
+        url = "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.0.tgz";
+        sha512 = "tufDcFA1Vj+eWvwHN+jvMN6QsV5o+vUlytNKrbMiCeDL0F2j92RURzUsUMWE5EJkLyWxjdUslCsMQa9FWth16A==";
       };
     };
-    "@babel/plugin-proposal-dynamic-import-7.5.0" = {
+    "@babel/plugin-proposal-dynamic-import-7.7.0" = {
       name = "_at_babel_slash_plugin-proposal-dynamic-import";
       packageName = "@babel/plugin-proposal-dynamic-import";
-      version = "7.5.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz";
-        sha512 = "x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==";
+        url = "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.0.tgz";
+        sha512 = "7poL3Xi+QFPC7sGAzEIbXUyYzGJwbc2+gSD0AkiC5k52kH2cqHdqxm5hNFfLW3cRSTcx9bN0Fl7/6zWcLLnKAQ==";
       };
     };
     "@babel/plugin-proposal-json-strings-7.2.0" = {
@@ -544,13 +562,13 @@ let
         sha512 = "mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==";
       };
     };
-    "@babel/plugin-proposal-unicode-property-regex-7.6.2" = {
+    "@babel/plugin-proposal-unicode-property-regex-7.7.0" = {
       name = "_at_babel_slash_plugin-proposal-unicode-property-regex";
       packageName = "@babel/plugin-proposal-unicode-property-regex";
-      version = "7.6.2";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz";
-        sha512 = "NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==";
+        url = "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.0.tgz";
+        sha512 = "mk34H+hp7kRBWJOOAR0ZMGCydgKMD4iN9TpDRp3IIcbunltxEY89XSimc6WbtSLCDrwcdy/EEw7h5CFCzxTchw==";
       };
     };
     "@babel/plugin-syntax-async-generators-7.2.0" = {
@@ -571,13 +589,13 @@ let
         sha512 = "mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==";
       };
     };
-    "@babel/plugin-syntax-flow-7.2.0" = {
+    "@babel/plugin-syntax-flow-7.7.0" = {
       name = "_at_babel_slash_plugin-syntax-flow";
       packageName = "@babel/plugin-syntax-flow";
-      version = "7.2.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz";
-        sha512 = "r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==";
+        url = "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.7.0.tgz";
+        sha512 = "vQMV07p+L+jZeUnvX3pEJ9EiXGCjB5CTTvsirFD9rpEuATnoAvLBLoYbw1v5tyn3d2XxSuvEKi8cV3KqYUa0vQ==";
       };
     };
     "@babel/plugin-syntax-json-strings-7.2.0" = {
@@ -616,6 +634,15 @@ let
         sha512 = "bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==";
       };
     };
+    "@babel/plugin-syntax-top-level-await-7.7.0" = {
+      name = "_at_babel_slash_plugin-syntax-top-level-await";
+      packageName = "@babel/plugin-syntax-top-level-await";
+      version = "7.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.0.tgz";
+        sha512 = "hi8FUNiFIY1fnUI2n1ViB1DR0R4QeK4iHcTlW6aJkrPoTdb8Rf1EMQ6GT3f67DDkYyWgew9DFoOZ6gOoEsdzTA==";
+      };
+    };
     "@babel/plugin-syntax-typescript-7.3.3" = {
       name = "_at_babel_slash_plugin-syntax-typescript";
       packageName = "@babel/plugin-syntax-typescript";
@@ -634,13 +661,13 @@ let
         sha512 = "ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==";
       };
     };
-    "@babel/plugin-transform-async-to-generator-7.5.0" = {
+    "@babel/plugin-transform-async-to-generator-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-async-to-generator";
       packageName = "@babel/plugin-transform-async-to-generator";
-      version = "7.5.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz";
-        sha512 = "mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.0.tgz";
+        sha512 = "vLI2EFLVvRBL3d8roAMqtVY0Bm9C1QzLkdS57hiKrjUBSqsQYrBsMCeOg/0KK7B0eK9V71J5mWcha9yyoI2tZw==";
       };
     };
     "@babel/plugin-transform-block-scoped-functions-7.2.0" = {
@@ -661,13 +688,13 @@ let
         sha512 = "7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==";
       };
     };
-    "@babel/plugin-transform-classes-7.5.5" = {
+    "@babel/plugin-transform-classes-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-classes";
       packageName = "@babel/plugin-transform-classes";
-      version = "7.5.5";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz";
-        sha512 = "U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.0.tgz";
+        sha512 = "/b3cKIZwGeUesZheU9jNYcwrEA7f/Bo4IdPmvp7oHgvks2majB5BoT5byAql44fiNQYOPzhk2w8DbgfuafkMoA==";
       };
     };
     "@babel/plugin-transform-computed-properties-7.2.0" = {
@@ -688,13 +715,13 @@ let
         sha512 = "2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==";
       };
     };
-    "@babel/plugin-transform-dotall-regex-7.6.2" = {
+    "@babel/plugin-transform-dotall-regex-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-dotall-regex";
       packageName = "@babel/plugin-transform-dotall-regex";
-      version = "7.6.2";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz";
-        sha512 = "KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.0.tgz";
+        sha512 = "3QQlF7hSBnSuM1hQ0pS3pmAbWLax/uGNCbPBND9y+oJ4Y776jsyujG2k0Sn2Aj2a0QwVOiOFL5QVPA7spjvzSA==";
       };
     };
     "@babel/plugin-transform-duplicate-keys-7.5.0" = {
@@ -733,13 +760,13 @@ let
         sha512 = "9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==";
       };
     };
-    "@babel/plugin-transform-function-name-7.4.4" = {
+    "@babel/plugin-transform-function-name-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-function-name";
       packageName = "@babel/plugin-transform-function-name";
-      version = "7.4.4";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz";
-        sha512 = "iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.0.tgz";
+        sha512 = "P5HKu0d9+CzZxP5jcrWdpe7ZlFDe24bmqP6a6X8BHEBl/eizAsY8K6LX8LASZL0Jxdjm5eEfzp+FIrxCm/p8bA==";
       };
     };
     "@babel/plugin-transform-literals-7.2.0" = {
@@ -769,40 +796,40 @@ let
         sha512 = "n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==";
       };
     };
-    "@babel/plugin-transform-modules-commonjs-7.6.0" = {
+    "@babel/plugin-transform-modules-commonjs-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-modules-commonjs";
       packageName = "@babel/plugin-transform-modules-commonjs";
-      version = "7.6.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz";
-        sha512 = "Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.0.tgz";
+        sha512 = "KEMyWNNWnjOom8vR/1+d+Ocz/mILZG/eyHHO06OuBQ2aNhxT62fr4y6fGOplRx+CxCSp3IFwesL8WdINfY/3kg==";
       };
     };
-    "@babel/plugin-transform-modules-systemjs-7.5.0" = {
+    "@babel/plugin-transform-modules-systemjs-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-modules-systemjs";
       packageName = "@babel/plugin-transform-modules-systemjs";
-      version = "7.5.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz";
-        sha512 = "Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.0.tgz";
+        sha512 = "ZAuFgYjJzDNv77AjXRqzQGlQl4HdUM6j296ee4fwKVZfhDR9LAGxfvXjBkb06gNETPnN0sLqRm9Gxg4wZH6dXg==";
       };
     };
-    "@babel/plugin-transform-modules-umd-7.2.0" = {
+    "@babel/plugin-transform-modules-umd-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-modules-umd";
       packageName = "@babel/plugin-transform-modules-umd";
-      version = "7.2.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz";
-        sha512 = "BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.0.tgz";
+        sha512 = "u7eBA03zmUswQ9LQ7Qw0/ieC1pcAkbp5OQatbWUzY1PaBccvuJXUkYzoN1g7cqp7dbTu6Dp9bXyalBvD04AANA==";
       };
     };
-    "@babel/plugin-transform-named-capturing-groups-regex-7.6.3" = {
+    "@babel/plugin-transform-named-capturing-groups-regex-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-named-capturing-groups-regex";
       packageName = "@babel/plugin-transform-named-capturing-groups-regex";
-      version = "7.6.3";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz";
-        sha512 = "jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.0.tgz";
+        sha512 = "+SicSJoKouPctL+j1pqktRVCgy+xAch1hWWTMy13j0IflnyNjaoskj+DwRQFimHbLqO3sq2oN2CXMvXq3Bgapg==";
       };
     };
     "@babel/plugin-transform-new-target-7.4.4" = {
@@ -841,22 +868,22 @@ let
         sha512 = "9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==";
       };
     };
-    "@babel/plugin-transform-react-jsx-7.3.0" = {
+    "@babel/plugin-transform-react-jsx-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-react-jsx";
       packageName = "@babel/plugin-transform-react-jsx";
-      version = "7.3.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz";
-        sha512 = "a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.0.tgz";
+        sha512 = "mXhBtyVB1Ujfy+0L6934jeJcSXj/VCg6whZzEcgiiZHNS0PGC7vUCsZDQCxxztkpIdF+dY1fUMcjAgEOC3ZOMQ==";
       };
     };
-    "@babel/plugin-transform-regenerator-7.4.5" = {
+    "@babel/plugin-transform-regenerator-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-regenerator";
       packageName = "@babel/plugin-transform-regenerator";
-      version = "7.4.5";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz";
-        sha512 = "gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.0.tgz";
+        sha512 = "AXmvnC+0wuj/cFkkS/HFHIojxH3ffSXE+ttulrqWjZZRaUOonfJc60e1wSNT4rV8tIunvu/R3wCp71/tLAa9xg==";
       };
     };
     "@babel/plugin-transform-reserved-words-7.2.0" = {
@@ -922,22 +949,22 @@ let
         sha512 = "2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==";
       };
     };
-    "@babel/plugin-transform-typescript-7.6.3" = {
+    "@babel/plugin-transform-typescript-7.7.2" = {
       name = "_at_babel_slash_plugin-transform-typescript";
       packageName = "@babel/plugin-transform-typescript";
-      version = "7.6.3";
+      version = "7.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.3.tgz";
-        sha512 = "aiWINBrPMSC3xTXRNM/dfmyYuPNKY/aexYqBgh0HBI5Y+WO5oRAqW/oROYeYHrF4Zw12r9rK4fMk/ZlAmqx/FQ==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.7.2.tgz";
+        sha512 = "UWhDaJRqdPUtdK1s0sKYdoRuqK0NepjZto2UZltvuCgMoMZmdjhgz5hcRokie/3aYEaSz3xvusyoayVaq4PjRg==";
       };
     };
-    "@babel/plugin-transform-unicode-regex-7.6.2" = {
+    "@babel/plugin-transform-unicode-regex-7.7.0" = {
       name = "_at_babel_slash_plugin-transform-unicode-regex";
       packageName = "@babel/plugin-transform-unicode-regex";
-      version = "7.6.2";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz";
-        sha512 = "orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==";
+        url = "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.0.tgz";
+        sha512 = "RrThb0gdrNwFAqEAAx9OWgtx6ICK69x7i9tCnMdVrxQwSDp/Abu9DXFU5Hh16VP33Rmxh04+NGW28NsIkFvFKA==";
       };
     };
     "@babel/polyfill-7.6.0" = {
@@ -949,13 +976,13 @@ let
         sha512 = "q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==";
       };
     };
-    "@babel/preset-env-7.6.3" = {
+    "@babel/preset-env-7.7.1" = {
       name = "_at_babel_slash_preset-env";
       packageName = "@babel/preset-env";
-      version = "7.6.3";
+      version = "7.7.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz";
-        sha512 = "CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==";
+        url = "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.1.tgz";
+        sha512 = "/93SWhi3PxcVTDpSqC+Dp4YxUu3qZ4m7I76k0w73wYfn7bGVuRIO4QUz95aJksbS+AD1/mT1Ie7rbkT0wSplaA==";
       };
     };
     "@babel/preset-flow-7.0.0" = {
@@ -976,22 +1003,22 @@ let
         sha512 = "A8ia2Wus0OAP6hh28ZgPSCBJEX3Jnql3kg9di/I+Lmg1gbJXgDZBrHr/UGZXl20Vi1lXgMuUq8c8J899KFr5gA==";
       };
     };
-    "@babel/preset-typescript-7.6.0" = {
+    "@babel/preset-typescript-7.7.2" = {
       name = "_at_babel_slash_preset-typescript";
       packageName = "@babel/preset-typescript";
-      version = "7.6.0";
+      version = "7.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.6.0.tgz";
-        sha512 = "4xKw3tTcCm0qApyT6PqM9qniseCE79xGHiUnNdKGdxNsGUc2X7WwZybqIpnTmoukg3nhPceI5KPNzNqLNeIJww==";
+        url = "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.7.2.tgz";
+        sha512 = "1B4HthAelaLGfNRyrWqJtBEjXX1ulThCrLQ5B2VOtEAznWFIFXFJahgXImqppy66lx/Oh+cOSCQdJzZqh2Jh5g==";
       };
     };
-    "@babel/register-7.6.2" = {
+    "@babel/register-7.7.0" = {
       name = "_at_babel_slash_register";
       packageName = "@babel/register";
-      version = "7.6.2";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/register/-/register-7.6.2.tgz";
-        sha512 = "xgZk2LRZvt6i2SAUWxc7ellk4+OYRgS3Zpsnr13nMS1Qo25w21Uu8o6vTOAqNaxiqrnv30KTYzh9YWY2k21CeQ==";
+        url = "https://registry.npmjs.org/@babel/register/-/register-7.7.0.tgz";
+        sha512 = "HV3GJzTvSoyOMWGYn2TAh6uL6g+gqKTgEZ99Q3+X9UURT1VPT/WcU46R61XftIc5rXytcOHZ4Z0doDlsjPomIg==";
       };
     };
     "@babel/runtime-7.6.2" = {
@@ -1003,40 +1030,40 @@ let
         sha512 = "EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==";
       };
     };
-    "@babel/runtime-7.6.3" = {
+    "@babel/runtime-7.7.2" = {
       name = "_at_babel_slash_runtime";
       packageName = "@babel/runtime";
-      version = "7.6.3";
+      version = "7.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz";
-        sha512 = "kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==";
+        url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz";
+        sha512 = "JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==";
       };
     };
-    "@babel/runtime-corejs2-7.6.3" = {
+    "@babel/runtime-corejs2-7.7.2" = {
       name = "_at_babel_slash_runtime-corejs2";
       packageName = "@babel/runtime-corejs2";
-      version = "7.6.3";
+      version = "7.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.6.3.tgz";
-        sha512 = "nuA2o+rgX2+PrNTZ063ehncVcg7sn+tU71BB81SaWRVUbGwCOlb0+yQA1e0QqmzOfRSYOxfvf8cosYqFbJEiwQ==";
+        url = "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.2.tgz";
+        sha512 = "GfVnHchOBvIMsweQ13l4jd9lT4brkevnavnVOej5g2y7PpTRY+R4pcQlCjWMZoUla5rMLFzaS/Ll2s59cB1TqQ==";
       };
     };
-    "@babel/template-7.6.0" = {
+    "@babel/template-7.7.0" = {
       name = "_at_babel_slash_template";
       packageName = "@babel/template";
-      version = "7.6.0";
+      version = "7.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz";
-        sha512 = "5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==";
+        url = "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz";
+        sha512 = "OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==";
       };
     };
-    "@babel/traverse-7.6.3" = {
+    "@babel/traverse-7.7.2" = {
       name = "_at_babel_slash_traverse";
       packageName = "@babel/traverse";
-      version = "7.6.3";
+      version = "7.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz";
-        sha512 = "unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==";
+        url = "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz";
+        sha512 = "TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==";
       };
     };
     "@babel/types-7.0.0-beta.38" = {
@@ -1057,6 +1084,15 @@ let
         sha512 = "CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==";
       };
     };
+    "@babel/types-7.7.2" = {
+      name = "_at_babel_slash_types";
+      packageName = "@babel/types";
+      version = "7.7.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz";
+        sha512 = "YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==";
+      };
+    };
     "@calebboyd/semaphore-1.3.1" = {
       name = "_at_calebboyd_slash_semaphore";
       packageName = "@calebboyd/semaphore";
@@ -1064,6 +1100,51 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@calebboyd/semaphore/-/semaphore-1.3.1.tgz";
         sha512 = "17z9me12RgAEcMhIgR7f+BiXKbzwF9p1VraI69OxrUUSWGuSMOyOTEHQNVtMKuVrkEDVD0/Av5uiGZPBMYZljw==";
+      };
+    };
+    "@citation-js/core-0.4.9" = {
+      name = "_at_citation-js_slash_core";
+      packageName = "@citation-js/core";
+      version = "0.4.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@citation-js/core/-/core-0.4.9.tgz";
+        sha512 = "nVfoZQqJjTsEMIAzUFkJMFqoZuUA03vadiTGBsq0jrbmonTGDVtk50D0/bzwAZVjjoxSWjs5w/DqXXrpcFqFkQ==";
+      };
+    };
+    "@citation-js/date-0.4.4" = {
+      name = "_at_citation-js_slash_date";
+      packageName = "@citation-js/date";
+      version = "0.4.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@citation-js/date/-/date-0.4.4.tgz";
+        sha512 = "wD195pZPwCCN8idhxz4HYZbf5mMnPZMRhOipcU8v1orZWqZp6YDRjOplNKo6yX7tf6fB4ZO8QLuNaNjuic5AWQ==";
+      };
+    };
+    "@citation-js/name-0.4.2" = {
+      name = "_at_citation-js_slash_name";
+      packageName = "@citation-js/name";
+      version = "0.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@citation-js/name/-/name-0.4.2.tgz";
+        sha512 = "brSPsjs2fOVzSnARLKu0qncn6suWjHVQtrqSUrnqyaRH95r/Ad4wPF5EsoWr+Dx8HzkCGb/ogmoAzfCsqlTwTQ==";
+      };
+    };
+    "@citation-js/plugin-bibtex-0.4.9" = {
+      name = "_at_citation-js_slash_plugin-bibtex";
+      packageName = "@citation-js/plugin-bibtex";
+      version = "0.4.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@citation-js/plugin-bibtex/-/plugin-bibtex-0.4.9.tgz";
+        sha512 = "PGfyn8GeJMvhcpr1PiWkJR25N2rH7+t6JQYoN35ngT3KzIIVcpC81dG2jQOy+t10D55tu7H61KfJZGFAnhgpWg==";
+      };
+    };
+    "@citation-js/plugin-csl-0.4.10" = {
+      name = "_at_citation-js_slash_plugin-csl";
+      packageName = "@citation-js/plugin-csl";
+      version = "0.4.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@citation-js/plugin-csl/-/plugin-csl-0.4.10.tgz";
+        sha512 = "8AnlLKZ9sAK/p2L3vi9IBDxB9D0vXukFC7hjS16WNW5HkHNfb2FN91APEXQfvHbJ0RePy5xvHe5Ou8T1muFeoQ==";
       };
     };
     "@cliqz-oss/firefox-client-0.3.1" = {
@@ -1390,31 +1471,31 @@ let
         sha512 = "CNVsCrMge/jq6DCT5buNZ8PACY9RTvPJbCNoIcndfkJOCsNxOx9dnc5qw4pHZdHi8GS6l3qlgkuFKp33iD8J2Q==";
       };
     };
-    "@lerna/add-3.18.0" = {
+    "@lerna/add-3.18.4" = {
       name = "_at_lerna_slash_add";
       packageName = "@lerna/add";
-      version = "3.18.0";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/add/-/add-3.18.0.tgz";
-        sha512 = "Z5EaQbBnJn1LEPb0zb0Q2o9T8F8zOnlCsj6JYpY6aSke17UUT7xx0QMN98iBK+ueUHKjN/vdFdYlNCYRSIdujA==";
+        url = "https://registry.npmjs.org/@lerna/add/-/add-3.18.4.tgz";
+        sha512 = "R+9RmYrSbcmnmaFL2aB0HJtTq95ePEa0FMS4r4NnA7Xw07l5buVBPOfxv6P8kFrVvIcNpaa7S0Eo/KkbycMhKA==";
       };
     };
-    "@lerna/bootstrap-3.18.0" = {
+    "@lerna/bootstrap-3.18.4" = {
       name = "_at_lerna_slash_bootstrap";
       packageName = "@lerna/bootstrap";
-      version = "3.18.0";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.18.0.tgz";
-        sha512 = "3DZKWIaKvr7sUImoKqSz6eqn84SsOVMnA5QHwgzXiQjoeZ/5cg9x2r+Xj3+3w/lvLoh0j8U2GNtrIaPNis4bKQ==";
+        url = "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.18.4.tgz";
+        sha512 = "mvqMyionPSqhbeGhoUQYEBTgbJ47LkONHfQ1AKBET0fJOjIZf6x0pWC17KvfCjsiE017325ySLKDH23z1Kb9ww==";
       };
     };
-    "@lerna/changed-3.18.3" = {
+    "@lerna/changed-3.18.4" = {
       name = "_at_lerna_slash_changed";
       packageName = "@lerna/changed";
-      version = "3.18.3";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/changed/-/changed-3.18.3.tgz";
-        sha512 = "xZW7Rm+DlDIGc0EvKGyJZgT9f8FFa4d52mr/Y752dZuXR2qRmf9tXhVloRG39881s2A6yi3jqLtXZggKhsQW4Q==";
+        url = "https://registry.npmjs.org/@lerna/changed/-/changed-3.18.4.tgz";
+        sha512 = "Ui4UsneDk9gCuJRfTpR5js+Ctt9Je+j+3Q4z7H7HhBn6WeWDTp6FBGJZ7SfrBCdQ47EKK27Mr95LbJ4I77xFfQ==";
       };
     };
     "@lerna/check-working-tree-3.16.5" = {
@@ -1435,13 +1516,13 @@ let
         sha512 = "vdcI7mzei9ERRV4oO8Y1LHBZ3A5+ampRKg1wq5nutLsUA4mEBN6H7JqjWOMY9xZemv6+kATm2ofjJ3lW5TszQg==";
       };
     };
-    "@lerna/clean-3.18.0" = {
+    "@lerna/clean-3.18.4" = {
       name = "_at_lerna_slash_clean";
       packageName = "@lerna/clean";
-      version = "3.18.0";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/clean/-/clean-3.18.0.tgz";
-        sha512 = "BiwBELZNkarRQqj+v5NPB1aIzsOX+Y5jkZ9a5UbwHzEdBUQ5lQa0qaMLSOve/fSkaiZQxe6qnTyatN75lOcDMg==";
+        url = "https://registry.npmjs.org/@lerna/clean/-/clean-3.18.4.tgz";
+        sha512 = "puuL0sBHIv3Tvq8cdu3kCGfRpdsXuaDGIRha33GVmRPfMBi2GN8nPPysVyWmP99PfgfafO6eT5R3jqXjvASAZA==";
       };
     };
     "@lerna/cli-3.18.0" = {
@@ -1525,22 +1606,22 @@ let
         sha512 = "3iLNlpurc2nV9k22w8ini2Zjm2UPo3xtQgWyqdA6eJjvge0+5AlNAWfPoV6cV+Hc1xDbJD2YDSFpZPJ1ZGilRw==";
       };
     };
-    "@lerna/exec-3.18.0" = {
+    "@lerna/exec-3.18.4" = {
       name = "_at_lerna_slash_exec";
       packageName = "@lerna/exec";
-      version = "3.18.0";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/exec/-/exec-3.18.0.tgz";
-        sha512 = "hwkuzg1+38+pbzdZPhGtLIYJ59z498/BCNzR8d4/nfMYm8lFbw9RgJJajLcdbuJ9LJ08cZ93hf8OlzetL84TYg==";
+        url = "https://registry.npmjs.org/@lerna/exec/-/exec-3.18.4.tgz";
+        sha512 = "BpBFxyCQXcfess9Nmj/OwQ9e1IhzPzNxqF5JK7dPIjko5oBn5Hm2EWVAcgUGSHKPZGLiOWPu3Wx/C92NtDBS1w==";
       };
     };
-    "@lerna/filter-options-3.18.0" = {
+    "@lerna/filter-options-3.18.4" = {
       name = "_at_lerna_slash_filter-options";
       packageName = "@lerna/filter-options";
-      version = "3.18.0";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.18.0.tgz";
-        sha512 = "UGVcixs3TGzD8XSmFSbwUVVQnAjaZ6Rmt8Vuq2RcR98ULkGB1LiGNMY89XaNBhaaA8vx7yQWiLmJi2AfmD63Qg==";
+        url = "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.18.4.tgz";
+        sha512 = "4giVQD6tauRwweO/322LP2gfVDOVrt/xN4khkXyfkJDfcsZziFXq+668otD9KSLL8Ps+To4Fah3XbK0MoNuEvA==";
       };
     };
     "@lerna/filter-packages-3.18.0" = {
@@ -1633,22 +1714,22 @@ let
         sha512 = "FbbIpH0EpsC+dpAbvxCoF3cn7F1MAyJjEa5Lh3XkDGATOlinMFuKCbmX0NLpOPQZ5zghvrui97cx+jz5F2IlHw==";
       };
     };
-    "@lerna/list-3.18.0" = {
+    "@lerna/list-3.18.4" = {
       name = "_at_lerna_slash_list";
       packageName = "@lerna/list";
-      version = "3.18.0";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/list/-/list-3.18.0.tgz";
-        sha512 = "mpB7Q6T+n2CaiPFz0LuOE+rXphDfHm0mKIwShnyS/XDcii8jXv+z9Iytj8p3rfCH2I1L80j2qL6jWzyGy/uzKA==";
+        url = "https://registry.npmjs.org/@lerna/list/-/list-3.18.4.tgz";
+        sha512 = "bgtlhAwhjHOTLq0iIuPs30abeuLbwZvVB60Ym8kPp+chh939obKU3vy2KMyX+Gpxf8pzuQG+k986YXcUBvXVsw==";
       };
     };
-    "@lerna/listable-3.18.0" = {
+    "@lerna/listable-3.18.4" = {
       name = "_at_lerna_slash_listable";
       packageName = "@lerna/listable";
-      version = "3.18.0";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/listable/-/listable-3.18.0.tgz";
-        sha512 = "9gLGKYNLSKeurD+sJ2RA+nz4Ftulr91U127gefz0RlmAPpYSjwcJkxwa0UfJvpQTXv9C7yzHLnn0BjyAQRjuew==";
+        url = "https://registry.npmjs.org/@lerna/listable/-/listable-3.18.4.tgz";
+        sha512 = "EKSsnST5k3dZfw+UTwBH1/sHQ1YfgjYjGxXCabyn55mMgc2GjoDekODMYzZ1TNF2NNy6RgIZ24X2JI8G22nZUw==";
       };
     };
     "@lerna/log-packed-3.16.0" = {
@@ -1777,13 +1858,13 @@ let
         sha512 = "P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==";
       };
     };
-    "@lerna/publish-3.18.3" = {
+    "@lerna/publish-3.18.4" = {
       name = "_at_lerna_slash_publish";
       packageName = "@lerna/publish";
-      version = "3.18.3";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/publish/-/publish-3.18.3.tgz";
-        sha512 = "XlfWOWIhaSK0Y2sX5ppNWI5Y3CDtlxMcQa1hTbZlC5rrDA6vD32iutbmH6Ix3c6wtvVbSkgA39GWsQEXxPS+7w==";
+        url = "https://registry.npmjs.org/@lerna/publish/-/publish-3.18.4.tgz";
+        sha512 = "Q+MqM5DUZvk+uT6hdEyO3khXET6LwED0YEuCu8fRwtHad03HkZ9i8PtTY5h8Sn6D6RCyCOlHTuf8O0KKAUy3ow==";
       };
     };
     "@lerna/pulse-till-done-3.13.0" = {
@@ -1822,13 +1903,13 @@ let
         sha512 = "bQlKmO0pXUsXoF8lOLknhyQjOZsCc0bosQDoX4lujBXSWxHVTg1VxURtWf2lUjz/ACsJVDfvHZbDm8kyBk5okA==";
       };
     };
-    "@lerna/run-3.18.0" = {
+    "@lerna/run-3.18.4" = {
       name = "_at_lerna_slash_run";
       packageName = "@lerna/run";
-      version = "3.18.0";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/run/-/run-3.18.0.tgz";
-        sha512 = "sblxHBZ9djaaG7wefPcfEicDqzrB7CP1m/jIB0JvPEQwG4C2qp++ewBpkjRw/mBtjtzg0t7v0nNMXzaWYrQckQ==";
+        url = "https://registry.npmjs.org/@lerna/run/-/run-3.18.4.tgz";
+        sha512 = "u2ZNO2fVk5kVEpbpn4DLJZZxZ08LFnIFuaXJMAhxvOgvm12ZF2rabA9kZc3NXp5+DedG5nHHgyoyLVVbStKzBA==";
       };
     };
     "@lerna/run-lifecycle-3.16.2" = {
@@ -1885,13 +1966,13 @@ let
         sha512 = "SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==";
       };
     };
-    "@lerna/version-3.18.3" = {
+    "@lerna/version-3.18.4" = {
       name = "_at_lerna_slash_version";
       packageName = "@lerna/version";
-      version = "3.18.3";
+      version = "3.18.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@lerna/version/-/version-3.18.3.tgz";
-        sha512 = "IXXRlyM3Q/jrc+QZio+bgjG4ZaK+4LYmY4Yql1xyY0wZhAKsWP/Q6ho7e1EJNjNC5dUJO99Fq7qB05MkDf2OcQ==";
+        url = "https://registry.npmjs.org/@lerna/version/-/version-3.18.4.tgz";
+        sha512 = "+gR9H89qSP8iqzNi4tRVQUbWlFMOlhbY6+5TXkP72Ibb/z87O+C46DBqizSMVaPQYdSYjS1c9Xfa1oOhEWxGaw==";
       };
     };
     "@lerna/write-log-file-3.13.0" = {
@@ -2110,22 +2191,22 @@ let
         sha512 = "5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==";
       };
     };
-    "@octokit/request-error-1.1.0" = {
+    "@octokit/request-error-1.2.0" = {
       name = "_at_octokit_slash_request-error";
       packageName = "@octokit/request-error";
-      version = "1.1.0";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.1.0.tgz";
-        sha512 = "06lt8PulL3rKpmwzYLCeLEt1iHFoj8l0PLkObAtp5Cx0Wwd1+5FAa9u6UXjA0kzYsfbjBKF9TtO9CuXelKiYlw==";
+        url = "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.0.tgz";
+        sha512 = "DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==";
       };
     };
-    "@octokit/rest-16.34.1" = {
+    "@octokit/rest-16.35.0" = {
       name = "_at_octokit_slash_rest";
       packageName = "@octokit/rest";
-      version = "16.34.1";
+      version = "16.35.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@octokit/rest/-/rest-16.34.1.tgz";
-        sha512 = "JUoS12cdktf1fv86rgrjC/RvYLuL+o7p57W7zX1x7ANFJ7OvdV8emvUNkFlcidEaOkYrxK3SoWgQFt3FhNmabA==";
+        url = "https://registry.npmjs.org/@octokit/rest/-/rest-16.35.0.tgz";
+        sha512 = "9ShFqYWo0CLoGYhA1FdtdykJuMzS/9H6vSbbQWDX4pWr4p9v+15MsH/wpd/3fIU+tSxylaNO48+PIHqOkBRx3w==";
       };
     };
     "@octokit/types-2.0.1" = {
@@ -2180,6 +2261,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@parcel/workers/-/workers-1.11.0.tgz";
         sha512 = "USSjRAAQYsZFlv43FUPdD+jEGML5/8oLF0rUzPQTtK4q9kvaXr49F5ZplyLz5lox78cLZ0TxN2bIDQ1xhOkulQ==";
+      };
+    };
+    "@primer/octicons-9.2.0" = {
+      name = "_at_primer_slash_octicons";
+      packageName = "@primer/octicons";
+      version = "9.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@primer/octicons/-/octicons-9.2.0.tgz";
+        sha512 = "3vv7bBqVUHhU7ChpmQhmzz3WmHEKKSk9z/xEK5KnU8Egh96RoqKIim07geRj825ISa+IWj9cPdOA1ShqW5k3Yw==";
       };
     };
     "@protobufjs/aspromise-1.1.2" = {
@@ -2290,22 +2380,22 @@ let
         sha512 = "MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==";
       };
     };
-    "@schematics/angular-8.3.17" = {
+    "@schematics/angular-8.3.18" = {
       name = "_at_schematics_slash_angular";
       packageName = "@schematics/angular";
-      version = "8.3.17";
+      version = "8.3.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.17.tgz";
-        sha512 = "Ot++j7vpEBKUD+D6eQxIJto+PYR2HPR9hmBoshZ2nt1/mU3OPEpIMIO/OBnbVtGmuzKXdq2n2NvbPtnhlxWplA==";
+        url = "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.18.tgz";
+        sha512 = "3cQYcmzsWD/MnqauoSozIu1R7DJvty13BH6+XIorEfguWqOwOwgNIWLMsa0iIcy0+TV3vWFI0KZpCKup2u/I1Q==";
       };
     };
-    "@schematics/update-0.803.17" = {
+    "@schematics/update-0.803.18" = {
       name = "_at_schematics_slash_update";
       packageName = "@schematics/update";
-      version = "0.803.17";
+      version = "0.803.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@schematics/update/-/update-0.803.17.tgz";
-        sha512 = "42CqIcm0i1BfBXYm6YuE8Q6kEEb0ATYiPYJQTgmb+bZSF2Sl9eAzPBaackW2EwVK1JP3Rdyl2S31OwGvgAk6xA==";
+        url = "https://registry.npmjs.org/@schematics/update/-/update-0.803.18.tgz";
+        sha512 = "vJxyL1pbn2lcgSH6HUqgA373iJRXQWxdrxuUaQ56qyq1EoicG7EppKz7OlGyKs+nHR9HhtK0eJc35E7I0lEWgA==";
       };
     };
     "@serverless/cli-1.4.0" = {
@@ -2335,13 +2425,13 @@ let
         sha512 = "PY7gH+7aQ+MltcUD7SRDuQODJ9Sav9HhFJsgOiyf8IVo7XVD6FxZIsSnpMI6paSkptOB7n+0Jz03gNlEkKetQQ==";
       };
     };
-    "@serverless/enterprise-plugin-3.2.1" = {
+    "@serverless/enterprise-plugin-3.2.3" = {
       name = "_at_serverless_slash_enterprise-plugin";
       packageName = "@serverless/enterprise-plugin";
-      version = "3.2.1";
+      version = "3.2.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.2.1.tgz";
-        sha512 = "CLTuvtEYhmvV7qiYuHkDJxoIIdcRU8OQBUhoBhUscK6UVdsKB2Y4ykz8su0rGg5rdgcaaluJF0+H87oBNw77ag==";
+        url = "https://registry.npmjs.org/@serverless/enterprise-plugin/-/enterprise-plugin-3.2.3.tgz";
+        sha512 = "YBk+Fa+u2zrS6/3t7bEsSpHPoZ7ubac1snibxS81IcrhJTCX6zYVsnvgoSMdKkor5QW/vPaK7p/M9wWP3sWc4w==";
       };
     };
     "@serverless/event-mocks-1.1.1" = {
@@ -2353,13 +2443,13 @@ let
         sha512 = "YAV5V/y+XIOfd+HEVeXfPWZb8C6QLruFk9tBivoX2roQLWVq145s4uxf8D0QioCueuRzkukHUS4JIj+KVoS34A==";
       };
     };
-    "@serverless/platform-sdk-2.2.0" = {
+    "@serverless/platform-sdk-2.2.1" = {
       name = "_at_serverless_slash_platform-sdk";
       packageName = "@serverless/platform-sdk";
-      version = "2.2.0";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-2.2.0.tgz";
-        sha512 = "w5A/szD0ZMUIuqUt5HyHllQ9LKO9/mpgv3rtJjLRI5ZJq1GvY4pv2pyQQPxGLT1gv0ER+b5vF+4tfrkx6MEuEw==";
+        url = "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-2.2.1.tgz";
+        sha512 = "XOpYzV9AKrWuW1IJqLxhwZZbspUTCe+f/bmkdMCzWZX7HpHtasYWCcAwZN/DsYq/3af/tBp8gkEsYh0GnaAaYg==";
       };
     };
     "@serverless/template-1.1.3" = {
@@ -2416,31 +2506,22 @@ let
         sha512 = "sA7V2JhgqJB9z5uYotgQc5iNDv//y+Mdm39rANxmFjtZMSYJZHkP80arzPjw1mB5ni/sWec7ieYUUFeySZBfVg==";
       };
     };
-    "@snyk/cocoapods-lockfile-parser-2.0.4" = {
+    "@snyk/cocoapods-lockfile-parser-3.0.0" = {
       name = "_at_snyk_slash_cocoapods-lockfile-parser";
       packageName = "@snyk/cocoapods-lockfile-parser";
-      version = "2.0.4";
+      version = "3.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/cocoapods-lockfile-parser/-/cocoapods-lockfile-parser-2.0.4.tgz";
-        sha512 = "d57bajPjqCiNXMuyMmt9Zt98zbjABZUFw+91B705flzV6oB7OThgtA40Eoin6iatYoStIx28bC3T6b0mScy/iA==";
+        url = "https://registry.npmjs.org/@snyk/cocoapods-lockfile-parser/-/cocoapods-lockfile-parser-3.0.0.tgz";
+        sha512 = "AebCc+v9vtOL9tFkU4/tommgVsXxqdx6t45kCkBW+FC4PaYvfYEg9Eg/9GqlY9+nFrLFo/uTr+E/aR0AF/KqYA==";
       };
     };
-    "@snyk/composer-lockfile-parser-1.0.3" = {
+    "@snyk/composer-lockfile-parser-1.2.0" = {
       name = "_at_snyk_slash_composer-lockfile-parser";
       packageName = "@snyk/composer-lockfile-parser";
-      version = "1.0.3";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/composer-lockfile-parser/-/composer-lockfile-parser-1.0.3.tgz";
-        sha512 = "hb+6E7kMzWlcwfe//ILDoktBPKL2a3+RnJT/CXnzRXaiLQpsdkf5li4q2v0fmvd+4v7L3tTN8KM+//lJyviEkg==";
-      };
-    };
-    "@snyk/dep-graph-1.13.0" = {
-      name = "_at_snyk_slash_dep-graph";
-      packageName = "@snyk/dep-graph";
-      version = "1.13.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.13.0.tgz";
-        sha512 = "e0XcLH6Kgs/lunf6iDjbxEnm9+JYFEJn6eo/PlEUW+SMWBZ2uEXHBTDNp9oxjJou48PngzWMveEkniBAN+ulOQ==";
+        url = "https://registry.npmjs.org/@snyk/composer-lockfile-parser/-/composer-lockfile-parser-1.2.0.tgz";
+        sha512 = "kZT+HTqgNcQMeoE5NM9M3jj463M8zI7ZxqZXLw9WoyVs5JTt9g0qFWxIG1cNwZdGVI+y7tzZbNWw9BlMD1vCCQ==";
       };
     };
     "@snyk/dep-graph-1.13.1" = {
@@ -2470,13 +2551,13 @@ let
         sha512 = "ceMD4CBS3qtAg+O0BUvkKdsheUNCqi+/+Rju243Ul8PsUgZnXmGiqfk/2z7DCprRQnxUTra4+IyeDQT7wAheCQ==";
       };
     };
-    "@snyk/snyk-cocoapods-plugin-1.0.3" = {
+    "@snyk/snyk-cocoapods-plugin-2.0.1" = {
       name = "_at_snyk_slash_snyk-cocoapods-plugin";
       packageName = "@snyk/snyk-cocoapods-plugin";
-      version = "1.0.3";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@snyk/snyk-cocoapods-plugin/-/snyk-cocoapods-plugin-1.0.3.tgz";
-        sha512 = "AHAA7z23nPi1eHODsDxeSkl73Ze3yphuqJjMl39ie323EzBDcb9g6uAACrk0Qn2K/K2D8uyxMAf2zDtc+JGQfw==";
+        url = "https://registry.npmjs.org/@snyk/snyk-cocoapods-plugin/-/snyk-cocoapods-plugin-2.0.1.tgz";
+        sha512 = "XVkvaMvMzQ3miJi/YZmsRJSAUfDloYhfg6pXPgzAeAugB4p+cNi01Z68pT62ypB8U/Ugh1Xx2pb9aoOFqBbSjA==";
       };
     };
     "@starptech/expression-parser-0.9.0" = {
@@ -2713,6 +2794,15 @@ let
         sha512 = "8mrhPstU+ZX0Ugya8tl5DsDZ1I5ZwQzbL/8PA0z8Gj0k9nql7nkaMzmPVLj+l/nixWaliXi+EBiLA8bptw3z7Q==";
       };
     };
+    "@types/anymatch-1.3.1" = {
+      name = "_at_types_slash_anymatch";
+      packageName = "@types/anymatch";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz";
+        sha512 = "/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==";
+      };
+    };
     "@types/babel-types-7.0.7" = {
       name = "_at_types_slash_babel-types";
       packageName = "@types/babel-types";
@@ -2731,13 +2821,13 @@ let
         sha512 = "xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==";
       };
     };
-    "@types/bluebird-3.5.28" = {
+    "@types/bluebird-3.5.29" = {
       name = "_at_types_slash_bluebird";
       packageName = "@types/bluebird";
-      version = "3.5.28";
+      version = "3.5.29";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.28.tgz";
-        sha512 = "0Vk/kqkukxPKSzP9c8WJgisgGDx5oZDbsLLWIP5t70yThO/YleE+GEm2S1GlRALTaack3O7U5OS5qEm7q2kciA==";
+        url = "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz";
+        sha512 = "kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw==";
       };
     };
     "@types/body-parser-1.17.1" = {
@@ -2756,6 +2846,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.6.tgz";
         sha512 = "YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==";
+      };
+    };
+    "@types/color-name-1.1.1" = {
+      name = "_at_types_slash_color-name";
+      packageName = "@types/color-name";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz";
+        sha512 = "rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==";
+      };
+    };
+    "@types/concat-stream-1.6.0" = {
+      name = "_at_types_slash_concat-stream";
+      packageName = "@types/concat-stream";
+      version = "1.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz";
+        sha1 = "394dbe0bb5fee46b38d896735e8b68ef2390d00d";
       };
     };
     "@types/connect-3.4.32" = {
@@ -2839,6 +2947,15 @@ let
         sha512 = "K8d2M5t3tBQimkyaYTXxtHYyoJPUEhy2/omVRnTAKw5FEdT+Ft6lTaTOpoJdHeG+mIwQXXtqiTcYZ6IR8LTzjQ==";
       };
     };
+    "@types/form-data-0.0.33" = {
+      name = "_at_types_slash_form-data";
+      packageName = "@types/form-data";
+      version = "0.0.33";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz";
+        sha1 = "c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8";
+      };
+    };
     "@types/fs-capacitor-2.0.0" = {
       name = "_at_types_slash_fs-capacitor";
       packageName = "@types/fs-capacitor";
@@ -2902,31 +3019,31 @@ let
         sha1 = "ff540462d2fb4d0a88441ceaf27d287b01c3d878";
       };
     };
-    "@types/koa-2.0.51" = {
+    "@types/koa-2.0.52" = {
       name = "_at_types_slash_koa";
       packageName = "@types/koa";
-      version = "2.0.51";
+      version = "2.0.52";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/koa/-/koa-2.0.51.tgz";
-        sha512 = "L5e/l6Z+SR9Jk6HM0wNYdkvWhSUBOvi+7Q5Uwn7kE/VmBXX7NIxARMigARWAyXAtXiv5Ry1P2HmebolFdvuIVg==";
+        url = "https://registry.npmjs.org/@types/koa/-/koa-2.0.52.tgz";
+        sha512 = "cp/GTOhOYwomlSKqEoG0kaVEVJEzP4ojYmfa7EKaGkmkkRwJ4B/1VBLbQZ49Z+WJNvzXejQB/9GIKqMo9XLgFQ==";
       };
     };
-    "@types/koa-compose-3.2.4" = {
+    "@types/koa-compose-3.2.5" = {
       name = "_at_types_slash_koa-compose";
       packageName = "@types/koa-compose";
-      version = "3.2.4";
+      version = "3.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.4.tgz";
-        sha512 = "ioou0rxkuWL+yBQYsHUQAzRTfVxAg8Y2VfMftU+Y3RA03/MzuFL0x/M2sXXj3PkfnENbHsjeHR1aMdezLYpTeA==";
+        url = "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz";
+        sha512 = "B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==";
       };
     };
-    "@types/lodash-4.14.144" = {
+    "@types/lodash-4.14.146" = {
       name = "_at_types_slash_lodash";
       packageName = "@types/lodash";
-      version = "4.14.144";
+      version = "4.14.146";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz";
-        sha512 = "ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==";
+        url = "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.146.tgz";
+        sha512 = "JzJcmQ/ikHSv7pbvrVNKJU5j9jL9VLf3/gqs048CEnBVVVEv4kve3vLxoPHGvclutS+Il4SBIuQQ087m1eHffw==";
       };
     };
     "@types/long-4.0.0" = {
@@ -2956,22 +3073,31 @@ let
         sha512 = "tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==";
       };
     };
-    "@types/node-10.17.3" = {
+    "@types/node-10.17.5" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "10.17.3";
+      version = "10.17.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-10.17.3.tgz";
-        sha512 = "QZ9CjUB3QoA3f2afw3utKlfRPhpmufB7jC2+oDhLWnXqoyx333fhKSQDLQu2EK7OE0a15X67eYiRAaJsHXrpMA==";
+        url = "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz";
+        sha512 = "RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA==";
       };
     };
-    "@types/node-12.12.5" = {
+    "@types/node-11.15.2" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "12.12.5";
+      version = "11.15.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-12.12.5.tgz";
-        sha512 = "KEjODidV4XYUlJBF3XdjSH5FWoMCtO0utnhtdLf1AgeuZLOrRbvmU/gaRCVg7ZaQDjVf3l84egiY0mRNe5xE4A==";
+        url = "https://registry.npmjs.org/@types/node/-/node-11.15.2.tgz";
+        sha512 = "BqCU9uIFkUH9Sgo2uLYbmIiFB1T+VBiM8AI/El3LIAI5KzwtckeSG+3WOYZr9aMoX4UIvRFBWBeSaOu6hFue2Q==";
+      };
+    };
+    "@types/node-12.12.7" = {
+      name = "_at_types_slash_node";
+      packageName = "@types/node";
+      version = "12.12.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz";
+        sha512 = "E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==";
       };
     };
     "@types/node-6.14.9" = {
@@ -2983,6 +3109,24 @@ let
         sha512 = "leP/gxHunuazPdZaCvsCefPQxinqUDsCxCR5xaDUrY2MkYxQRFZZwU5e7GojyYsGB7QVtCi7iVEl/hoFXQYc+w==";
       };
     };
+    "@types/node-7.10.9" = {
+      name = "_at_types_slash_node";
+      packageName = "@types/node";
+      version = "7.10.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/node/-/node-7.10.9.tgz";
+        sha512 = "usSpgoUsRtO5xNV5YEPU8PPnHisFx8u0rokj1BPVn/hDF7zwUDzVLiuKZM38B7z8V2111Fj6kd4rGtQFUZpNOw==";
+      };
+    };
+    "@types/node-8.10.59" = {
+      name = "_at_types_slash_node";
+      packageName = "@types/node";
+      version = "8.10.59";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz";
+        sha512 = "8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==";
+      };
+    };
     "@types/q-1.5.2" = {
       name = "_at_types_slash_q";
       packageName = "@types/q";
@@ -2990,6 +3134,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz";
         sha512 = "ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==";
+      };
+    };
+    "@types/qs-6.9.0" = {
+      name = "_at_types_slash_qs";
+      packageName = "@types/qs";
+      version = "6.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/qs/-/qs-6.9.0.tgz";
+        sha512 = "c4zji5CjWv1tJxIZkz1oUtGcdOlsH3aza28Nqmm+uNDWBRHoMsjooBEN4czZp1V3iXPihE/VRUOBqg+4Xq0W4g==";
       };
     };
     "@types/range-parser-1.2.3" = {
@@ -3028,6 +3181,15 @@ let
         sha512 = "oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==";
       };
     };
+    "@types/source-list-map-0.1.2" = {
+      name = "_at_types_slash_source-list-map";
+      packageName = "@types/source-list-map";
+      version = "0.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz";
+        sha512 = "K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==";
+      };
+    };
     "@types/superagent-3.8.2" = {
       name = "_at_types_slash_superagent";
       packageName = "@types/superagent";
@@ -3035,6 +3197,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/@types/superagent/-/superagent-3.8.2.tgz";
         sha512 = "kdU8ydio1weSvhIIh9rptZ6MdMiR2NQGFnlnZ5qQ7OiQS1ej79zK4GaJ9qX3naSTpOA7iWqwUnZCQpd7SpD1NA==";
+      };
+    };
+    "@types/tapable-1.0.4" = {
+      name = "_at_types_slash_tapable";
+      packageName = "@types/tapable";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.4.tgz";
+        sha512 = "78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==";
+      };
+    };
+    "@types/uglify-js-3.0.4" = {
+      name = "_at_types_slash_uglify-js";
+      packageName = "@types/uglify-js";
+      version = "3.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz";
+        sha512 = "SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==";
       };
     };
     "@types/unist-2.0.3" = {
@@ -3055,13 +3235,31 @@ let
         sha512 = "b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==";
       };
     };
-    "@types/vfile-message-1.0.1" = {
+    "@types/vfile-message-2.0.0" = {
       name = "_at_types_slash_vfile-message";
       packageName = "@types/vfile-message";
-      version = "1.0.1";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz";
-        sha512 = "mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==";
+        url = "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz";
+        sha512 = "GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==";
+      };
+    };
+    "@types/webpack-4.39.8" = {
+      name = "_at_types_slash_webpack";
+      packageName = "@types/webpack";
+      version = "4.39.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/webpack/-/webpack-4.39.8.tgz";
+        sha512 = "lkJvwNJQUPW2SbVwAZW9s9whJp02nzLf2yTNwMULa4LloED9MYS1aNnGeoBCifpAI1pEBkTpLhuyRmBnLEOZAA==";
+      };
+    };
+    "@types/webpack-sources-0.1.5" = {
+      name = "_at_types_slash_webpack-sources";
+      packageName = "@types/webpack-sources";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.5.tgz";
+        sha512 = "zfvjpp7jiafSmrzJ2/i3LqOyTYTuJ7u1KOXlKgDlvsj9Rr0x7ZiYu5lZbXwobL7lmsRNtPXlBfmaUD8eU2Hu8w==";
       };
     };
     "@types/ws-6.0.3" = {
@@ -4351,6 +4549,15 @@ let
         sha512 = "1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==";
       };
     };
+    "ansi-regex-5.0.0" = {
+      name = "ansi-regex";
+      packageName = "ansi-regex";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz";
+        sha512 = "bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==";
+      };
+    };
     "ansi-split-1.0.1" = {
       name = "ansi-split";
       packageName = "ansi-split";
@@ -4396,13 +4603,13 @@ let
         sha512 = "VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==";
       };
     };
-    "ansi-styles-4.1.0" = {
+    "ansi-styles-4.2.0" = {
       name = "ansi-styles";
       packageName = "ansi-styles";
-      version = "4.1.0";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.1.0.tgz";
-        sha512 = "Qts4KCLKG+waHc9C4m07weIY8qyeixoS0h6RnbsNVD6Fw+pEZGW3vTyObL3WXpE09Mq4Oi7/lBEyLmOiLtlYWQ==";
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz";
+        sha512 = "7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==";
       };
     };
     "ansi-term-0.0.2" = {
@@ -4414,13 +4621,13 @@ let
         sha1 = "fd753efa4beada0eac99981bc52a3f6ff019deb7";
       };
     };
-    "ansi-to-html-0.6.12" = {
+    "ansi-to-html-0.6.13" = {
       name = "ansi-to-html";
       packageName = "ansi-to-html";
-      version = "0.6.12";
+      version = "0.6.13";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.12.tgz";
-        sha512 = "qBkIqLW979675mP76yB7yVkzeAWtATegdnDQ0RA3CZzknx0yUlNxMSML4xFdBfTs2GWYFQ1FELfbGbVSPzJ+LA==";
+        url = "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.13.tgz";
+        sha512 = "Ys2/umuaTlQvP9DLkaa7UzRKF2FLrfod/hNHXS9QhXCrw7seObG6ksOGmNz3UoK+adwM8L9vQfG7mvaxfJ3Jvw==";
       };
     };
     "ansi-wrap-0.1.0" = {
@@ -5989,13 +6196,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.563.0" = {
+    "aws-sdk-2.569.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.563.0";
+      version = "2.569.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.563.0.tgz";
-        sha512 = "ygpsr2jL36Y7gctR1jr6gmHuyk4So3I52H2iOAIIO2bNRKbwse6sBy7vI89JhF5W5NtV3drM7lGcao0DCZ9uEQ==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.569.0.tgz";
+        sha512 = "9i4n/8kR1cq+Ge1n9FzqEBE1kpF8uLEI24wssy0dQD1fks+eNoZ6b3bGMCR1OfYB0KVgIN7ZkUrng1Zu9M4fcA==";
       };
     };
     "aws-sign2-0.6.0" = {
@@ -6032,15 +6239,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz";
         sha1 = "2d8e3e5d0bdbd7327f91bc814f5c57660f81824d";
-      };
-    };
-    "axios-0.18.1" = {
-      name = "axios";
-      packageName = "axios";
-      version = "0.18.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz";
-        sha512 = "0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==";
       };
     };
     "babel-code-frame-6.26.0" = {
@@ -6925,13 +7123,13 @@ let
         sha1 = "159a49b9a9714c1fb102f2e0ed1906fab6a450f4";
       };
     };
-    "big-integer-1.6.47" = {
+    "big-integer-1.6.48" = {
       name = "big-integer";
       packageName = "big-integer";
-      version = "1.6.47";
+      version = "1.6.48";
       src = fetchurl {
-        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.47.tgz";
-        sha512 = "9t9f7X3as2XGX8b52GqG6ox0GvIdM86LyIXASJnDCFhYNgt+A+MByQZ3W2PyMRZjEvG5f8TEbSPfEotVuMJnQg==";
+        url = "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz";
+        sha512 = "j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==";
       };
     };
     "big.js-5.2.2" = {
@@ -7798,13 +7996,13 @@ let
         sha512 = "HniEmRONcLP8qKJEw/DXZGwyHfRedYX1HGqhNZ5N2zhn+xIrAjhptkAbXRBGV0GhPb+YTbzObGn3GlAHaBiVnQ==";
       };
     };
-    "buffer-4.9.1" = {
+    "buffer-4.9.2" = {
       name = "buffer";
       packageName = "buffer";
-      version = "4.9.1";
+      version = "4.9.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz";
-        sha1 = "6d1bb601b07a4efced97094132093027c95bc298";
+        url = "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz";
+        sha512 = "xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==";
       };
     };
     "buffer-5.4.3" = {
@@ -8419,13 +8617,13 @@ let
         sha1 = "a2aa5fb1af688758259c32c141426d78923b9b77";
       };
     };
-    "camelcase-keys-6.1.0" = {
+    "camelcase-keys-6.1.1" = {
       name = "camelcase-keys";
       packageName = "camelcase-keys";
-      version = "6.1.0";
+      version = "6.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.1.0.tgz";
-        sha512 = "43tBGDIs3SBDA5R5mYzkiBP3lt2IKhLDp1wVGS9XTq6SR3+7ZNdi/VwBJsk4NKgySoaziTrKM+N8hhT04NBVUA==";
+        url = "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.1.1.tgz";
+        sha512 = "kEPCddRFChEzO0d6w61yh0WbBiSv9gBnfZWGfXRYPlGqIdIGef6HMR6pgqVSEWCYkrp8B0AtEpEXNY+Jx0xk1A==";
       };
     };
     "caniuse-api-3.0.0" = {
@@ -9065,6 +9263,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz";
         sha512 = "UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==";
+      };
+    };
+    "citeproc-2.2.27" = {
+      name = "citeproc";
+      packageName = "citeproc";
+      version = "2.2.27";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/citeproc/-/citeproc-2.2.27.tgz";
+        sha512 = "AQIxcXD6ZZch5V9BPaMpwRTjiRgyOvw80OS9bLWEIHwm7E9b5CXoLj9s7LS+cjkD1iuWGYf1qRK1pd40ymzNmQ==";
       };
     };
     "class-utils-0.3.6" = {
@@ -10048,13 +10255,13 @@ let
         sha512 = "Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==";
       };
     };
-    "commander-4.0.0" = {
+    "commander-4.0.1" = {
       name = "commander";
       packageName = "commander";
-      version = "4.0.0";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/commander/-/commander-4.0.0.tgz";
-        sha512 = "SEa2abMBTZuEjLVYpNrAFoRgxPwG4rXP3+SGY6CM/HZGeDzIA7Pzp+7H3AHDukKEpyy2SoSGGPShKqqfH9T9AQ==";
+        url = "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz";
+        sha512 = "IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA==";
       };
     };
     "commist-1.1.0" = {
@@ -10264,13 +10471,13 @@ let
         sha512 = "bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==";
       };
     };
-    "conf-2.2.0" = {
+    "conf-6.2.0" = {
       name = "conf";
       packageName = "conf";
-      version = "2.2.0";
+      version = "6.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conf/-/conf-2.2.0.tgz";
-        sha512 = "93Kz74FOMo6aWRVpAZsonOdl2I57jKtHrNmxhumehFQw4X8Sk37SohNY11PG7Q8Okta+UnrVaI006WLeyp8/XA==";
+        url = "https://registry.npmjs.org/conf/-/conf-6.2.0.tgz";
+        sha512 = "fvl40R6YemHrFsNiyP7TD0tzOe3pQD2dfT2s20WvCaq57A1oV+RImbhn2Y4sQGDz1lB0wNSb7dPcPIvQB69YNA==";
       };
     };
     "config-1.31.0" = {
@@ -10561,13 +10768,13 @@ let
         sha1 = "3243397ae93a71d655b3026834a51590b958b9e8";
       };
     };
-    "conventional-changelog-angular-5.0.5" = {
+    "conventional-changelog-angular-5.0.6" = {
       name = "conventional-changelog-angular";
       packageName = "conventional-changelog-angular";
-      version = "5.0.5";
+      version = "5.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.5.tgz";
-        sha512 = "RrkdWnL/TVyWV1ayWmSsrWorsTDqjL/VwG5ZSEneBQrd65ONcfeA1cW7FLtNweQyMiKOyriCMTKRSlk18DjTrw==";
+        url = "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.6.tgz";
+        sha512 = "QDEmLa+7qdhVIv8sFZfVxU1VSyVvnXPsxq8Vam49mKUcO1Z8VTLEJk9uI21uiJUsnmm0I4Hrsdc9TgkOQo9WSA==";
       };
     };
     "conventional-changelog-core-3.2.3" = {
@@ -10606,13 +10813,13 @@ let
         sha512 = "WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==";
       };
     };
-    "conventional-commits-parser-3.0.6" = {
+    "conventional-commits-parser-3.0.7" = {
       name = "conventional-commits-parser";
       packageName = "conventional-commits-parser";
-      version = "3.0.6";
+      version = "3.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.6.tgz";
-        sha512 = "9FDoCTnNQRhiDRhlRx6UEaxpcKPy6hiHYWZqJO80BAmFlbovAnMcCkdcxGyJGTe8sDidVHEiqPkLoJuG/aUs0A==";
+        url = "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.7.tgz";
+        sha512 = "4mx/FRC92z0yIiXGyRVYQFhn0jWDwvxnj2UuLaUi3hJSG4Thall6GXA8YOPHQK2qvotciJandJIVmuSvLgDLbQ==";
       };
     };
     "conventional-recommended-bump-5.0.1" = {
@@ -10633,13 +10840,13 @@ let
         sha1 = "4829c877e9fe49b3161f3bf3673888e204699860";
       };
     };
-    "convert-source-map-1.6.0" = {
+    "convert-source-map-1.7.0" = {
       name = "convert-source-map";
       packageName = "convert-source-map";
-      version = "1.6.0";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz";
-        sha512 = "eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==";
+        url = "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz";
+        sha512 = "4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==";
       };
     };
     "convert-to-ecmascript-compatible-varname-0.1.5" = {
@@ -10822,13 +11029,13 @@ let
         sha512 = "hTNYHUJT5YyMa1cQQE1naGyU6Eh5D5Jl33sMnCh3+q15ZwWTL/TOy3k8+mUvjTp8bwhO5eECGKULYoVO+fp9ZA==";
       };
     };
-    "cordova-common-3.2.0" = {
+    "cordova-common-3.2.1" = {
       name = "cordova-common";
       packageName = "cordova-common";
-      version = "3.2.0";
+      version = "3.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cordova-common/-/cordova-common-3.2.0.tgz";
-        sha512 = "EvlQ6PirfR65hGDoQvsluW00uSS2MTVIRKQ3c1Xvsddx7D5T5JgF3fHWkGik/Y/8yNcpI0zI2NcJyie2z/ak2A==";
+        url = "https://registry.npmjs.org/cordova-common/-/cordova-common-3.2.1.tgz";
+        sha512 = "xg0EnjnA6EipxXG8cupdlYQYeDA6+ghbN+Pjq88xN1LInwP6Bo7IyGBdSV5QnfjOvzShF9BBwSxBAv0FOO0C2Q==";
       };
     };
     "cordova-create-2.0.0" = {
@@ -10876,22 +11083,22 @@ let
         sha512 = "I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==";
       };
     };
-    "core-js-3.3.6" = {
+    "core-js-3.4.1" = {
       name = "core-js";
       packageName = "core-js";
-      version = "3.3.6";
+      version = "3.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-3.3.6.tgz";
-        sha512 = "u4oM8SHwmDuh5mWZdDg9UwNVq5s1uqq6ZDLLIs07VY+VJU91i3h4f3K/pgFvtUQPGdeStrZ+odKyfyt4EnKHfA==";
+        url = "https://registry.npmjs.org/core-js/-/core-js-3.4.1.tgz";
+        sha512 = "KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg==";
       };
     };
-    "core-js-compat-3.3.6" = {
+    "core-js-compat-3.4.1" = {
       name = "core-js-compat";
       packageName = "core-js-compat";
-      version = "3.3.6";
+      version = "3.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.6.tgz";
-        sha512 = "YnwZG/+0/f7Pf6Lr3jxtVAFjtGBW9lsLYcqrxhYJai1GfvrP8DEyEpnNzj/FRQfIkOOfk1j5tTBvPBLWVVJm4A==";
+        url = "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.1.tgz";
+        sha512 = "YdeJI26gLc0CQJ9asLE5obEgBz2I0+CIgnoTbS2T0d5IPQw/OCgCIFR527RmpduxjrB3gSEHoGOCTq9sigOyfw==";
       };
     };
     "core-util-is-1.0.2" = {
@@ -11299,13 +11506,13 @@ let
         sha1 = "2b3a110539c5355f1cd8d314623e870b121ec858";
       };
     };
-    "css-select-2.0.2" = {
+    "css-select-2.1.0" = {
       name = "css-select";
       packageName = "css-select";
-      version = "2.0.2";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz";
-        sha512 = "dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==";
+        url = "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz";
+        sha512 = "Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==";
       };
     };
     "css-select-base-adapter-0.1.1" = {
@@ -11351,6 +11558,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz";
         sha512 = "a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==";
+      };
+    };
+    "css-what-3.2.1" = {
+      name = "css-what";
+      packageName = "css-what";
+      version = "3.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz";
+        sha512 = "WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==";
       };
     };
     "cssauron-1.4.0" = {
@@ -11927,6 +12143,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz";
         sha512 = "mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==";
+      };
+    };
+    "debounce-fn-3.0.1" = {
+      name = "debounce-fn";
+      packageName = "debounce-fn";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debounce-fn/-/debounce-fn-3.0.1.tgz";
+        sha512 = "aBoJh5AhpqlRoHZjHmOzZlRx+wz2xVwGL9rjs+Kj0EWUrL4/h4K7OD176thl2Tdoqui/AaA4xhHrNArGLAaI3Q==";
       };
     };
     "debounced-seeker-1.0.0" = {
@@ -13162,13 +13387,13 @@ let
         sha512 = "l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==";
       };
     };
-    "dom-serializer-0.2.1" = {
+    "dom-serializer-0.2.2" = {
       name = "dom-serializer";
       packageName = "dom-serializer";
-      version = "0.2.1";
+      version = "0.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz";
-        sha512 = "sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==";
+        url = "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz";
+        sha512 = "2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==";
       };
     };
     "dom-walk-0.1.1" = {
@@ -13304,6 +13529,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz";
         sha512 = "tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==";
+      };
+    };
+    "dot-prop-5.2.0" = {
+      name = "dot-prop";
+      packageName = "dot-prop";
+      version = "5.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz";
+        sha512 = "uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==";
       };
     };
     "dotenv-4.0.0" = {
@@ -13558,15 +13792,6 @@ let
         sha1 = "3a83a904e54353287874c564b7549386849a98c9";
       };
     };
-    "ecc-jsbn-0.2.0" = {
-      name = "ecc-jsbn";
-      packageName = "ecc-jsbn";
-      version = "0.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.2.0.tgz";
-        sha1 = "7c98afab245f6df32290473c0abee2f2d39334c7";
-      };
-    };
     "ecdsa-sig-formatter-1.0.11" = {
       name = "ecdsa-sig-formatter";
       packageName = "ecdsa-sig-formatter";
@@ -13684,13 +13909,13 @@ let
         sha512 = "kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ==";
       };
     };
-    "electron-to-chromium-1.3.302" = {
+    "electron-to-chromium-1.3.306" = {
       name = "electron-to-chromium";
       packageName = "electron-to-chromium";
-      version = "1.3.302";
+      version = "1.3.306";
       src = fetchurl {
-        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.302.tgz";
-        sha512 = "1qConyiVEbj4xZRBXqtGR003+9tV0rJF0PS6aeO0Ln/UL637js9hdwweCl07meh/kJoI2N4W8q3R3g3F5z46ww==";
+        url = "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz";
+        sha512 = "frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==";
       };
     };
     "elegant-spinner-1.0.1" = {
@@ -14225,13 +14450,13 @@ let
         sha512 = "xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==";
       };
     };
-    "es-to-primitive-1.2.0" = {
+    "es-to-primitive-1.2.1" = {
       name = "es-to-primitive";
       packageName = "es-to-primitive";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz";
-        sha512 = "qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==";
+        url = "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz";
+        sha512 = "QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==";
       };
     };
     "es5-ext-0.10.52" = {
@@ -15143,13 +15368,13 @@ let
         sha512 = "adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==";
       };
     };
-    "execa-3.2.0" = {
+    "execa-3.3.0" = {
       name = "execa";
       packageName = "execa";
-      version = "3.2.0";
+      version = "3.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/execa/-/execa-3.2.0.tgz";
-        sha512 = "kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==";
+        url = "https://registry.npmjs.org/execa/-/execa-3.3.0.tgz";
+        sha512 = "j5Vit5WZR/cbHlqU97+qcnw9WHRCIL4V1SVe75VcHcD1JRBdt8fv0zw89b7CQHQdUHTt2VjuhcF5ibAgVOxqpg==";
       };
     };
     "execall-1.0.0" = {
@@ -15341,13 +15566,13 @@ let
         sha1 = "f5fc2f9fa9e9a8578634f10e86ba5a4346b96f4f";
       };
     };
-    "ext-1.1.2" = {
+    "ext-1.2.0" = {
       name = "ext";
       packageName = "ext";
-      version = "1.1.2";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ext/-/ext-1.1.2.tgz";
-        sha512 = "/KLjJdTNyDepCihrk4HQt57nAE1IRCEo5jUt+WgWGCr1oARhibDvmI2DMcSNWood1T9AUWwq+jaV1wvRqaXfnA==";
+        url = "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz";
+        sha512 = "0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==";
       };
     };
     "ext-list-2.2.2" = {
@@ -16358,13 +16583,13 @@ let
         sha512 = "ougBA2q6Rn9sZrjZQ9r5pTFxCotlGouySpD2yRIuq5AYwwfIT8HHhVMeSwrN5qJayjHINLJyrnsSkkPCZyfMrQ==";
       };
     };
-    "flow-parser-0.111.1" = {
+    "flow-parser-0.111.3" = {
       name = "flow-parser";
       packageName = "flow-parser";
-      version = "0.111.1";
+      version = "0.111.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.111.1.tgz";
-        sha512 = "yo+C0a/fMsGwooxA2xd4kK/kuzSnFC8JZLsIB68mkTllLrF/nSQ8llwD82o8Vxwvisw9IPC/ZC8zqrWmkir9jQ==";
+        url = "https://registry.npmjs.org/flow-parser/-/flow-parser-0.111.3.tgz";
+        sha512 = "iEjGZ94OBMcESxnLorXNjJmtd/JtQYXUVrQpfwvtAKkuyawRmv+2LM6nqyOsOJkISEYbyY6ziudRE0u4VyPSVA==";
       };
     };
     "fluent-ffmpeg-2.1.2" = {
@@ -16482,15 +16707,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz";
         sha1 = "5214d7537a4d06a4a301c0cc262feb84188002e7";
-      };
-    };
-    "follow-redirects-1.5.10" = {
-      name = "follow-redirects";
-      packageName = "follow-redirects";
-      version = "1.5.10";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz";
-        sha512 = "0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==";
       };
     };
     "follow-redirects-1.9.0" = {
@@ -16826,15 +17042,6 @@ let
         sha512 = "y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==";
       };
     };
-    "fs-copy-file-sync-1.1.1" = {
-      name = "fs-copy-file-sync";
-      packageName = "fs-copy-file-sync";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fs-copy-file-sync/-/fs-copy-file-sync-1.1.1.tgz";
-        sha512 = "2QY5eeqVv4m2PfyMiEuy9adxNP+ajf+8AR05cEi+OAzPcOj90hvFImeZhTmKLBgSd9EvG33jsD7ZRxsx9dThkQ==";
-      };
-    };
     "fs-exists-sync-0.1.0" = {
       name = "fs-exists-sync";
       packageName = "fs-exists-sync";
@@ -17006,13 +17213,13 @@ let
         sha1 = "1504ad2523158caa40db4a2787cb01411994ea4f";
       };
     };
-    "fs2-0.3.6" = {
+    "fs2-0.3.7" = {
       name = "fs2";
       packageName = "fs2";
-      version = "0.3.6";
+      version = "0.3.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fs2/-/fs2-0.3.6.tgz";
-        sha512 = "Zs7c3SBPiiNEEg+w3PTIgxTbWA6ZWVJP+1DlwUCxNDtwQD2qM5pfdho7IaiR0ceu4UVvXRj9l6Ml+X6rs21ERw==";
+        url = "https://registry.npmjs.org/fs2/-/fs2-0.3.7.tgz";
+        sha512 = "fwfd9MBI/fnXtR/ClVTyeuPXJ+oI5WNyXvBQPmc4btgqLYTKOuBRTRUVjmVpDUri0C88HLwMlc5ESg48fEAGjw==";
       };
     };
     "fsevents-1.2.9" = {
@@ -17033,13 +17240,13 @@ let
         sha512 = "a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==";
       };
     };
-    "fsevents-2.1.1" = {
+    "fsevents-2.1.2" = {
       name = "fsevents";
       packageName = "fsevents";
-      version = "2.1.1";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fsevents/-/fsevents-2.1.1.tgz";
-        sha512 = "4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==";
+        url = "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz";
+        sha512 = "R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==";
       };
     };
     "fstream-0.1.31" = {
@@ -17672,13 +17879,13 @@ let
         sha512 = "hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==";
       };
     };
-    "glob-7.1.5" = {
+    "glob-7.1.6" = {
       name = "glob";
       packageName = "glob";
-      version = "7.1.5";
+      version = "7.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz";
-        sha512 = "J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==";
+        url = "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz";
+        sha512 = "LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==";
       };
     };
     "glob-base-0.3.0" = {
@@ -17780,13 +17987,13 @@ let
         sha1 = "e76989268a6c74c38908b1305b10fc0e394e9d0f";
       };
     };
-    "global-agent-2.1.5" = {
+    "global-agent-2.1.6" = {
       name = "global-agent";
       packageName = "global-agent";
-      version = "2.1.5";
+      version = "2.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/global-agent/-/global-agent-2.1.5.tgz";
-        sha512 = "pYJjCxxNBzYxo6iNO62JZn8iCFVbvpiM0zE4w/G5hBNIvLjnvzIeCVQPMKc3aK8ju5L7Q8NNI/oBSosU0eeSYw==";
+        url = "https://registry.npmjs.org/global-agent/-/global-agent-2.1.6.tgz";
+        sha512 = "fL+xfraAlc1MXU8Gs0DAg/eHH+H1CjxbK+BLU3Qt55dAVMAQ8fH8k/UrLwV4A+Vk/hl/TePWuTxFnqJzCV1/Kw==";
       };
     };
     "global-dirs-0.1.1" = {
@@ -18888,13 +19095,13 @@ let
         sha512 = "C62CVn7jbjp89yOhhy7vrkSaB7Vk906Gtcw/Ihd+Iufnq+2pwOZjdPmpzpKLWJXPJBMDX3wXg4FqmdOayPcewA==";
       };
     };
-    "hast-util-parse-selector-2.2.2" = {
+    "hast-util-parse-selector-2.2.3" = {
       name = "hast-util-parse-selector";
       packageName = "hast-util-parse-selector";
-      version = "2.2.2";
+      version = "2.2.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.2.tgz";
-        sha512 = "jIMtnzrLTjzqgVEQqPEmwEZV+ea4zHRFTP8Z2Utw0I5HuBOXHzUPPQWr6ouJdJqDKLbFU/OEiYwZ79LalZkmmw==";
+        url = "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.3.tgz";
+        sha512 = "nxbeqjQNxsvo/uYYAw9kij6td05YVUlf1qti09rVfbWSLT5H6wo3c+USIwX6nzXWk5kFZzXnEqO82856r0aM2Q==";
       };
     };
     "hast-util-to-string-1.0.2" = {
@@ -19212,13 +19419,13 @@ let
         sha1 = "3a03edc2214bca3b66424a3e7959349509cb0351";
       };
     };
-    "htmlnano-0.2.4" = {
+    "htmlnano-0.2.5" = {
       name = "htmlnano";
       packageName = "htmlnano";
-      version = "0.2.4";
+      version = "0.2.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.4.tgz";
-        sha512 = "wsg7+Hjyi1gHpMUixkeOjeRUNhBBTnEDB//kzvVHR+LUK4p+/31DAyE+pEACT0SQk3W0KE7Xdylk9+uNxdHXLg==";
+        url = "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.5.tgz";
+        sha512 = "X1iPSwXG/iF9bVs+/obt2n6F64uH0ETkA8zp7qFDmLW9/+A6ueHGeb/+qD67T21qUY22owZPMdawljN50ajkqA==";
       };
     };
     "htmlparser2-3.10.1" = {
@@ -19264,6 +19471,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/http-auth/-/http-auth-3.1.3.tgz";
         sha1 = "945cfadd66521eaf8f7c84913d377d7b15f24e31";
+      };
+    };
+    "http-basic-6.0.0" = {
+      name = "http-basic";
+      packageName = "http-basic";
+      version = "6.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-basic/-/http-basic-6.0.0.tgz";
+        sha512 = "7ScbVjuiReYe8S+OZOpNjoKGXrbhJHIrQQe7eq1TpLTJkxH8MPKvnTUzq/TNLjww1hdFQy8yUIC42wuLhCjYcQ==";
       };
     };
     "http-cache-semantics-3.8.1" = {
@@ -19393,6 +19609,15 @@ let
         sha512 = "qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==";
       };
     };
+    "http-response-object-3.0.2" = {
+      name = "http-response-object";
+      packageName = "http-response-object";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz";
+        sha512 = "bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==";
+      };
+    };
     "http-signature-0.11.0" = {
       name = "http-signature";
       packageName = "http-signature";
@@ -19418,6 +19643,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz";
         sha1 = "9aecd925114772f3d95b65a60abb8f7c18fbace1";
+      };
+    };
+    "http-signature-1.3.1" = {
+      name = "http-signature";
+      packageName = "http-signature";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-signature/-/http-signature-1.3.1.tgz";
+        sha512 = "Y29YKEc8MQsjch/VzkUVJ+2MXd9WcR42fK5u36CZf4G8bXw2DXMTWuESiB0R6m59JAWxlPPw5/Fri/t/AyyueA==";
       };
     };
     "http_ece-1.1.0" = {
@@ -21121,6 +21355,15 @@ let
         sha1 = "3e4729ac1f5fde025cd7d83a896dab9f4f67db0f";
       };
     };
+    "is-obj-2.0.0" = {
+      name = "is-obj";
+      packageName = "is-obj";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz";
+        sha512 = "drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==";
+      };
+    };
     "is-object-1.0.1" = {
       name = "is-object";
       packageName = "is-object";
@@ -21850,13 +22093,13 @@ let
         sha1 = "06d4912255093419477d425633606e0e90782967";
       };
     };
-    "joplin-turndown-4.0.18" = {
+    "joplin-turndown-4.0.19" = {
       name = "joplin-turndown";
       packageName = "joplin-turndown";
-      version = "4.0.18";
+      version = "4.0.19";
       src = fetchurl {
-        url = "https://registry.npmjs.org/joplin-turndown/-/joplin-turndown-4.0.18.tgz";
-        sha512 = "YD0pkj2a7+XjjNNI1X9ZIwYthFwNsswvO4gl5aAoWdwJj5m8tunnoSyVenvqleXzAcaURIi/q9EOAQ1jw7xDiQ==";
+        url = "https://registry.npmjs.org/joplin-turndown/-/joplin-turndown-4.0.19.tgz";
+        sha512 = "B9XeR7bjsPWhwevnCk+EN8VQmaesDqGP3sjkk+ROMuNoQAj0p0RMkZB3actv6Ej6Q9EnRJm3JokfM3Ua4TVYvA==";
       };
     };
     "joplin-turndown-plugin-gfm-1.0.11" = {
@@ -22102,13 +22345,13 @@ let
         sha512 = "OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==";
       };
     };
-    "jshint-2.10.2" = {
+    "jshint-2.10.3" = {
       name = "jshint";
       packageName = "jshint";
-      version = "2.10.2";
+      version = "2.10.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jshint/-/jshint-2.10.2.tgz";
-        sha512 = "e7KZgCSXMJxznE/4WULzybCMNXNAd/bf5TSrvVEq78Q/K8ZwFpmBqQeDtNiHc3l49nV4E/+YeHU/JZjSUIrLAA==";
+        url = "https://registry.npmjs.org/jshint/-/jshint-2.10.3.tgz";
+        sha512 = "d8AoXcNNYzmm7cdmulQ3dQApbrPYArtVBO6n4xOICe4QsXGNHCAKDcFORzqP52LhK61KX0VhY39yYzCsNq+bxQ==";
       };
     };
     "json-buffer-2.0.11" = {
@@ -22253,6 +22496,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz";
         sha512 = "xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==";
+      };
+    };
+    "json-schema-typed-7.0.2" = {
+      name = "json-schema-typed";
+      packageName = "json-schema-typed";
+      version = "7.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.2.tgz";
+        sha512 = "40FRIcBSz4y0Ego3gMpbkhtIgebpxKRgW/7i1FfDNL4/xEPQKBM12tKSiCZFNQvad5K4IS3I5Sc8cxza/KSwog==";
       };
     };
     "json-stable-stringify-0.0.1" = {
@@ -22841,13 +23093,13 @@ let
         sha512 = "eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==";
       };
     };
-    "knockout-3.5.0" = {
+    "knockout-3.5.1" = {
       name = "knockout";
       packageName = "knockout";
-      version = "3.5.0";
+      version = "3.5.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/knockout/-/knockout-3.5.0.tgz";
-        sha512 = "vBUF/IsBDzaejHkNpiquKdc5uPrImXuQ4Mb9lEfNNJ5cyHGI8ThDupR+h3eMFZhfmPE/brfwcIAn/fm0yOvJUg==";
+        url = "https://registry.npmjs.org/knockout/-/knockout-3.5.1.tgz";
+        sha512 = "wRJ9I4az0QcsH7A4v4l0enUpkS++MBx0BnL/68KaLzJg7x1qmbjSlwEoCNol7KTYZ+pmtI7Eh2J0Nu6/2Z5J/Q==";
       };
     };
     "kuler-1.0.1" = {
@@ -24668,13 +24920,13 @@ let
         sha512 = "+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==";
       };
     };
-    "loglevel-1.6.4" = {
+    "loglevel-1.6.6" = {
       name = "loglevel";
       packageName = "loglevel";
-      version = "1.6.4";
+      version = "1.6.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz";
-        sha512 = "p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==";
+        url = "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz";
+        sha512 = "Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==";
       };
     };
     "loglevel-colored-level-prefix-1.0.0" = {
@@ -25125,6 +25377,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz";
         sha512 = "LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==";
+      };
+    };
+    "make-dir-3.0.0" = {
+      name = "make-dir";
+      packageName = "make-dir";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz";
+        sha512 = "grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==";
       };
     };
     "make-error-1.3.5" = {
@@ -27063,13 +27324,13 @@ let
         sha512 = "Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==";
       };
     };
-    "nanoguard-1.2.1" = {
+    "nanoguard-1.2.2" = {
       name = "nanoguard";
       packageName = "nanoguard";
-      version = "1.2.1";
+      version = "1.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nanoguard/-/nanoguard-1.2.1.tgz";
-        sha512 = "XowCxURA68arCQEypYKAxyIvBUP2EkqA8mZCXqJ2yzLpFblxSjiP06PUUpVK2no3cgGhsbRlBrsEuYIflxu79w==";
+        url = "https://registry.npmjs.org/nanoguard/-/nanoguard-1.2.2.tgz";
+        sha512 = "IMVIZkHP7Ep01foXurcJR59Hj/0yyApNK3JWpVHq2QVdLgo8wGU/ZsodlpL7jJ/m24+lxT0eyavrLCEuYQK2fg==";
       };
     };
     "nanoid-2.1.6" = {
@@ -28247,13 +28508,13 @@ let
         sha1 = "df7c3ed5a277c3f9d4b5d819b05311d10a200ae6";
       };
     };
-    "npm-6.9.2" = {
+    "npm-6.12.1" = {
       name = "npm";
       packageName = "npm";
-      version = "6.9.2";
+      version = "6.12.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npm/-/npm-6.9.2.tgz";
-        sha512 = "b0sEGRYrVdcV/DedLrqV4VMpdMHJbvpt9bopivh4K9RisHFMbj+G6RNbB6lRdr9rpYIoqHG9YP9CYmxdI9k81g==";
+        url = "https://registry.npmjs.org/npm/-/npm-6.12.1.tgz";
+        sha512 = "+pMvUpgSXVBythrv//64j4i6DaLLJ1O0y8kwjNgjAE7atBNGzX4rcOEWvmsuiei6J+mA38O0nUZ/P35GuCD/jg==";
       };
     };
     "npm-bundled-1.0.6" = {
@@ -28508,6 +28769,15 @@ let
         sha512 = "WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==";
       };
     };
+    "null-loader-0.1.1" = {
+      name = "null-loader";
+      packageName = "null-loader";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/null-loader/-/null-loader-0.1.1.tgz";
+        sha1 = "17be9abfcd3ff0e1512f6fc4afcb1f5039378fae";
+      };
+    };
     "num-sort-1.0.0" = {
       name = "num-sort";
       packageName = "num-sort";
@@ -28698,6 +28968,15 @@ let
         sha512 = "GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==";
       };
     };
+    "object-inspect-1.7.0" = {
+      name = "object-inspect";
+      packageName = "object-inspect";
+      version = "1.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz";
+        sha512 = "a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==";
+      };
+    };
     "object-is-1.0.1" = {
       name = "object-is";
       packageName = "object-is";
@@ -28858,15 +29137,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz";
         sha1 = "cb236106341536f0dac4815e06708221cad7fb5e";
-      };
-    };
-    "octicons-3.5.0" = {
-      name = "octicons";
-      packageName = "octicons";
-      version = "3.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/octicons/-/octicons-3.5.0.tgz";
-        sha1 = "f7ff5935674d8b114f6d80c454bfaa01797a4e30";
       };
     };
     "octokit-pagination-methods-1.1.0" = {
@@ -29202,13 +29472,13 @@ let
         sha1 = "9715a8b5f5e7586cff06c8249e039cd7364d3f54";
       };
     };
-    "optionator-0.8.2" = {
+    "optionator-0.8.3" = {
       name = "optionator";
       packageName = "optionator";
-      version = "0.8.2";
+      version = "0.8.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz";
-        sha1 = "364c5e409d3f4d6301d6c0b4c05bba50180aeb64";
+        url = "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz";
+        sha512 = "+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==";
       };
     };
     "options-0.0.6" = {
@@ -29598,13 +29868,13 @@ let
         sha512 = "3cRXXn3/O0o3+eVmUroJPSj/esxoEFIm0ZOno/T+NzG/VZgPOqQ8WKmlNqubSEpZmCIngEy34unkHGg83ZIBmg==";
       };
     };
-    "p-queue-6.2.0" = {
+    "p-queue-6.2.1" = {
       name = "p-queue";
       packageName = "p-queue";
-      version = "6.2.0";
+      version = "6.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/p-queue/-/p-queue-6.2.0.tgz";
-        sha512 = "B2LXNONcyn/G6uz2UBFsGjmSa0e/br3jznlzhEyCXg56c7VhEpiT2pZxGOfv32Q3FSyugAdys9KGpsv3kV+Sbg==";
+        url = "https://registry.npmjs.org/p-queue/-/p-queue-6.2.1.tgz";
+        sha512 = "wV8yC/rkuWpgu9LGKJIb48OynYSrE6lVl2Bx6r8WjbyVKrFAzzQ/QevAvwnDjlD+mLt8xy0LTDOU1freOvMTCg==";
       };
     };
     "p-reduce-1.0.0" = {
@@ -29832,15 +30102,6 @@ let
         sha512 = "b6t7ORo/MwT6xvRiuu1c1do3+CAUd7/0rgc1d3qNHUeP64zxy4ttLIvK7SEHzyfyDLvD9pPuV9mYKHf6MgUkmg==";
       };
     };
-    "parent-dirs-1.0.0" = {
-      name = "parent-dirs";
-      packageName = "parent-dirs";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/parent-dirs/-/parent-dirs-1.0.0.tgz";
-        sha1 = "b88851d1534013db421ce1695766906d0fbfb392";
-      };
-    };
     "parent-module-1.0.1" = {
       name = "parent-module";
       packageName = "parent-module";
@@ -29866,6 +30127,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz";
         sha512 = "jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==";
+      };
+    };
+    "parse-cache-control-1.0.1" = {
+      name = "parse-cache-control";
+      packageName = "parse-cache-control";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz";
+        sha1 = "8eeab3e54fa56920fe16ba38f77fa21aacc2d74e";
       };
     };
     "parse-english-4.1.2" = {
@@ -30480,13 +30750,13 @@ let
         sha1 = "df604178005f522f15eb4490e7247a1bfaa67f8c";
       };
     };
-    "path-to-regexp-1.7.0" = {
+    "path-to-regexp-1.8.0" = {
       name = "path-to-regexp";
       packageName = "path-to-regexp";
-      version = "1.7.0";
+      version = "1.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz";
-        sha1 = "59fde0f435badacba103a84e9d3bc64e96b9937d";
+        url = "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz";
+        sha512 = "n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==";
       };
     };
     "path-to-regexp-2.2.1" = {
@@ -30660,13 +30930,13 @@ let
         sha1 = "18de2f97e4bf7a9551ad7511942b5496f7aba660";
       };
     };
-    "picomatch-2.1.0" = {
+    "picomatch-2.1.1" = {
       name = "picomatch";
       packageName = "picomatch";
-      version = "2.1.0";
+      version = "2.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/picomatch/-/picomatch-2.1.0.tgz";
-        sha512 = "uhnEDzAbrcJ8R3g2fANnSuXZMBtkpSjxTTgn2LeSiQlfmq72enQJWdQllXW24MBLYnA1SBD2vfvx2o0Zw3Ielw==";
+        url = "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz";
+        sha512 = "OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==";
       };
     };
     "picture-tuber-1.0.2" = {
@@ -30829,6 +31099,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz";
         sha1 = "c819ac728059a461cab1c3889a2be3c49a004d7f";
+      };
+    };
+    "pkg-up-3.1.0" = {
+      name = "pkg-up";
+      packageName = "pkg-up";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz";
+        sha512 = "nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==";
       };
     };
     "pkginfo-0.2.3" = {
@@ -31399,13 +31678,22 @@ let
         sha512 = "C2hrAPzmRdpuL3iH0TDdQ6XCc9M7Dcc3zEW5BLerY65G4tWWszwv6nG/ksi6ul5i2mx22ubdljgktXCtNkydkw==";
       };
     };
-    "posthtml-parser-0.4.1" = {
+    "posthtml-0.12.0" = {
+      name = "posthtml";
+      packageName = "posthtml";
+      version = "0.12.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/posthtml/-/posthtml-0.12.0.tgz";
+        sha512 = "aNUEP/SfKUXAt+ghG51LC5MmafChBZeslVe/SSdfKIgLGUVRE68mrMF4V8XbH07ZifM91tCSuxY3eHIFLlecQw==";
+      };
+    };
+    "posthtml-parser-0.4.2" = {
       name = "posthtml-parser";
       packageName = "posthtml-parser";
-      version = "0.4.1";
+      version = "0.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.4.1.tgz";
-        sha512 = "h7vXIQ21Ikz2w5wPClPakNP6mJeJCK6BT0GpqnQrNNABdR7/TchNlFyryL1Bz6Ww53YWCKkr6tdZuHlxY1AVdQ==";
+        url = "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.4.2.tgz";
+        sha512 = "BUIorsYJTvS9UhXxPTzupIztOMVNPa/HtAm9KHni9z6qEfiJ1bpOBL5DfUOL9XAc3XkLIEzBzpph+Zbm4AdRAg==";
       };
     };
     "posthtml-render-1.1.5" = {
@@ -31480,13 +31768,13 @@ let
         sha512 = "4rgV2hyc/5Pk0XHH4VjJWHRgVjgRbpMfLQjREAhHBtyW1UvTFkjJEsueGYNYYZd9mn97K+1qv0EBwm11zoaSgA==";
       };
     };
-    "prettier-1.18.2" = {
+    "prettier-1.19.1" = {
       name = "prettier";
       packageName = "prettier";
-      version = "1.18.2";
+      version = "1.19.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz";
-        sha512 = "OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==";
+        url = "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz";
+        sha512 = "s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==";
       };
     };
     "prettier-bytes-1.0.4" = {
@@ -31750,6 +32038,15 @@ let
         sha512 = "nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==";
       };
     };
+    "promise-8.0.3" = {
+      name = "promise";
+      packageName = "promise";
+      version = "8.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz";
+        sha512 = "HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==";
+      };
+    };
     "promise-inflight-1.0.1" = {
       name = "promise-inflight";
       packageName = "promise-inflight";
@@ -31831,13 +32128,13 @@ let
         sha1 = "8e57123c396ab988897fb327fd3aedc3e735e4fe";
       };
     };
-    "prompts-2.2.1" = {
+    "prompts-2.3.0" = {
       name = "prompts";
       packageName = "prompts";
-      version = "2.2.1";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz";
-        sha512 = "VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==";
+        url = "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz";
+        sha512 = "NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==";
       };
     };
     "promzard-0.3.0" = {
@@ -32776,6 +33073,15 @@ let
         sha512 = "XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==";
       };
     };
+    "purgecss-1.4.1" = {
+      name = "purgecss";
+      packageName = "purgecss";
+      version = "1.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/purgecss/-/purgecss-1.4.1.tgz";
+        sha512 = "5jONV/D/3nfa+lC425+LA+OWe5/LDn4a79cac+TnzJq3VczwnWlpIDdW275hHsGhkzIlqATQsYFLW7or0cSwNQ==";
+      };
+    };
     "push-stream-10.1.2" = {
       name = "push-stream";
       packageName = "push-stream";
@@ -32938,13 +33244,13 @@ let
         sha512 = "VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==";
       };
     };
-    "qs-6.9.0" = {
+    "qs-6.9.1" = {
       name = "qs";
       packageName = "qs";
-      version = "6.9.0";
+      version = "6.9.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz";
-        sha512 = "27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==";
+        url = "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz";
+        sha512 = "Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==";
       };
     };
     "query-string-1.0.1" = {
@@ -33388,13 +33694,13 @@ let
         sha512 = "CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==";
       };
     };
-    "read-cmd-shim-1.0.4" = {
+    "read-cmd-shim-1.0.5" = {
       name = "read-cmd-shim";
       packageName = "read-cmd-shim";
-      version = "1.0.4";
+      version = "1.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.4.tgz";
-        sha512 = "Pqpl3qJ/QdOIjRYA0q5DND/gLvGOfpIz/fYVDGYpOXfW/lFrIttmLsBnd6IkyK10+JHU9zhsaudfvrQTBB9YFQ==";
+        url = "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz";
+        sha512 = "v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==";
       };
     };
     "read-metadata-1.0.0" = {
@@ -34612,13 +34918,13 @@ let
         sha512 = "M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==";
       };
     };
-    "retext-english-3.0.3" = {
+    "retext-english-3.0.4" = {
       name = "retext-english";
       packageName = "retext-english";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/retext-english/-/retext-english-3.0.3.tgz";
-        sha512 = "qltUsSjHMvCvpAm90qRvzK1DEBOnhSK3tUQk5aHFCBtiMHccp6FhlCH0mQ9vFcBf5BsG7GEBdPysTlY3g9Lchg==";
+        url = "https://registry.npmjs.org/retext-english/-/retext-english-3.0.4.tgz";
+        sha512 = "yr1PgaBDde+25aJXrnt3p1jvT8FVLVat2Bx8XeAWX13KXo8OT+3nWGU3HWxM4YFJvmfqvJYJZG2d7xxaO774gw==";
       };
     };
     "retext-equality-3.2.0" = {
@@ -34846,13 +35152,13 @@ let
         sha1 = "df43e80d9bc82ad4430bcfef03f49c717e8b2e8c";
       };
     };
-    "roarr-2.14.3" = {
+    "roarr-2.14.4" = {
       name = "roarr";
       packageName = "roarr";
-      version = "2.14.3";
+      version = "2.14.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/roarr/-/roarr-2.14.3.tgz";
-        sha512 = "D4BpKVruUDCJ9DJWcC7T+fx4o10IUYJ7MdmjM4Skx1aqc42CE7LGzPDUAfczibhavNGcnY1IHqJdq16NmiG4rQ==";
+        url = "https://registry.npmjs.org/roarr/-/roarr-2.14.4.tgz";
+        sha512 = "QMzRAQGZFPgnx4nNWp4Q+WHfiZh2HTSEjNaxFLrEIj3PmcQ1GHL5OjaaIyF9ybUDD2aZ9t3Awc/obrRPils9ng==";
       };
     };
     "rollup-0.67.0" = {
@@ -35258,15 +35564,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz";
         sha1 = "74b6d33c9ae1e001510f179a91168588f1aedaa9";
-      };
-    };
-    "sax-1.2.1" = {
-      name = "sax";
-      packageName = "sax";
-      version = "1.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz";
-        sha1 = "7b8e656190b228e81a66aea748480d828cd2d37a";
       };
     };
     "sax-1.2.4" = {
@@ -35872,13 +36169,13 @@ let
         sha1 = "415f42702d73d810330292cc5ee86eae1a11a170";
       };
     };
-    "sharp-0.22.1" = {
+    "sharp-0.23.2" = {
       name = "sharp";
       packageName = "sharp";
-      version = "0.22.1";
+      version = "0.23.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sharp/-/sharp-0.22.1.tgz";
-        sha512 = "lXzSk/FL5b/MpWrT1pQZneKe25stVjEbl6uhhJcTULm7PhmJgKKRbTDM/vtjyUuC/RLqL2PRyC4rpKwbv3soEw==";
+        url = "https://registry.npmjs.org/sharp/-/sharp-0.23.2.tgz";
+        sha512 = "BSo0tq6Jtzwa6GDKvVMNNPCP/HLczrFLGVcorYv7OtxlKx4UPHy7x9DdfT8F+PK7FCFDemVRwtsjWpvaJI9v6w==";
       };
     };
     "shasum-1.0.2" = {
@@ -36124,13 +36421,13 @@ let
         sha1 = "4e421f485ac7b13b08077a4476934d52c5ba3bb3";
       };
     };
-    "simple-peer-9.6.0" = {
+    "simple-peer-9.6.1" = {
       name = "simple-peer";
       packageName = "simple-peer";
-      version = "9.6.0";
+      version = "9.6.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-peer/-/simple-peer-9.6.0.tgz";
-        sha512 = "NYqSKPu75xhkZYKGJhCbLCG5kfBtDHf8U9ddk4EKFfYNU7XgIisov+V8wMbVVgyMCfn8pm8uOqQQmE50FPDFWA==";
+        url = "https://registry.npmjs.org/simple-peer/-/simple-peer-9.6.1.tgz";
+        sha512 = "/8IOtaXnnVhCkgHFBQKZ+hfx/s0+Ybo0Ijon7OrKUuEf8dEcRZJrrfjkNNgzogLM/mixI2EvnTSpOiKR6cts+w==";
       };
     };
     "simple-sha1-2.1.2" = {
@@ -36169,13 +36466,13 @@ let
         sha1 = "5d3d5751bb39aeba2f710d8eec78768df821f38d";
       };
     };
-    "simple-websocket-8.0.1" = {
+    "simple-websocket-8.1.0" = {
       name = "simple-websocket";
       packageName = "simple-websocket";
-      version = "8.0.1";
+      version = "8.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-websocket/-/simple-websocket-8.0.1.tgz";
-        sha512 = "2QKSRjf+tqFXLVmOQjf95gHeKhuyx2k1ouDjtnE0uKCYw84HfN85HsXo+GmPH+2PIh5BQql++g2AIbHgGAZU4w==";
+        url = "https://registry.npmjs.org/simple-websocket/-/simple-websocket-8.1.0.tgz";
+        sha512 = "24cIbqvC+E2VTgfDqRCWMTthAeZwzwvl5VoehQku6DJE8sYb/s7V/GXr0JplR92mhwsMxAeXnj0UBnyVfLfGhg==";
       };
     };
     "single-line-log-0.4.1" = {
@@ -36205,13 +36502,13 @@ let
         sha512 = "dKKwjIoTOa587TARYLlBRXq2lkbu5Iz35XrEVWpelhBP1m8r2BGOy1QlaZe84GTFHG/BTucEUd2btnNc8QzIVA==";
       };
     };
-    "sisteransi-1.0.3" = {
+    "sisteransi-1.0.4" = {
       name = "sisteransi";
       packageName = "sisteransi";
-      version = "1.0.3";
+      version = "1.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz";
-        sha512 = "SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==";
+        url = "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz";
+        sha512 = "/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==";
       };
     };
     "skin-tone-1.0.0" = {
@@ -36322,13 +36619,13 @@ let
         sha1 = "56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707";
       };
     };
-    "smart-buffer-4.0.2" = {
+    "smart-buffer-4.1.0" = {
       name = "smart-buffer";
       packageName = "smart-buffer";
-      version = "4.0.2";
+      version = "4.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz";
-        sha512 = "JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==";
+        url = "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz";
+        sha512 = "iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==";
       };
     };
     "smartdc-auth-2.3.1" = {
@@ -36520,13 +36817,13 @@ let
         sha512 = "1CYMPChJ9D9LBy3NLqHyv8TY7pR/LMISSr08LhfFw/FpfRZ+gTH8W6bbxCmybAYrOFNCqZkRprqOYDqZQFHipA==";
       };
     };
-    "snyk-php-plugin-1.6.4" = {
+    "snyk-php-plugin-1.7.0" = {
       name = "snyk-php-plugin";
       packageName = "snyk-php-plugin";
-      version = "1.6.4";
+      version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.6.4.tgz";
-        sha512 = "FFQeimtbwq17nDUS0o0zuKgyjXSX7SpoC9iYTeKvxTXrmKf2QlxTtPvmMM4/hQxehEu1i40ow1Ozw0Ahxm8Dpw==";
+        url = "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.7.0.tgz";
+        sha512 = "mDe90xkqSEVrpx1ZC7ItqCOc6fZCySbE+pHVI+dAPUmf1C1LSWZrZVmAVeo/Dw9sJzJfzmcdAFQl+jZP8/uV0A==";
       };
     };
     "snyk-policy-1.13.5" = {
@@ -36727,13 +37024,13 @@ let
         sha512 = "/G/VOI+3DBp0+DJKW4KesGnQkQPFmUCbA/oO2QGT6CWxU7hLGWqU3tyuzeSK/dqcyeHsQg1vTe9jiZI8GU9SCQ==";
       };
     };
-    "socks-2.3.2" = {
+    "socks-2.3.3" = {
       name = "socks";
       packageName = "socks";
-      version = "2.3.2";
+      version = "2.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz";
-        sha512 = "pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==";
+        url = "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz";
+        sha512 = "o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==";
       };
     };
     "socks-proxy-agent-4.0.2" = {
@@ -38194,13 +38491,13 @@ let
         sha1 = "5ea211cd92d228e184294990a6cc97b366a77cb0";
       };
     };
-    "string-kit-0.10.1" = {
+    "string-kit-0.10.3" = {
       name = "string-kit";
       packageName = "string-kit";
-      version = "0.10.1";
+      version = "0.10.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/string-kit/-/string-kit-0.10.1.tgz";
-        sha512 = "qxIqv5bJqYoWzJa0WJFdw9CCoPJ3/9EixXQXVerIYMghd45w0XiESgUchYCEeGg8bQQWHS+TYZW1DcJmHwAxZA==";
+        url = "https://registry.npmjs.org/string-kit/-/string-kit-0.10.3.tgz";
+        sha512 = "Pn7887wnmb9N0uAYKzqKGj1FWN2GBryiZBkM8mGqQWHoZsTUKDY574RT7ajXbRz4kf0TRKJm1JY5b0bDW0B4cw==";
       };
     };
     "string-length-2.0.0" = {
@@ -38275,13 +38572,13 @@ let
         sha512 = "vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==";
       };
     };
-    "string-width-4.1.0" = {
+    "string-width-4.2.0" = {
       name = "string-width";
       packageName = "string-width";
-      version = "4.1.0";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz";
-        sha512 = "NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==";
+        url = "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz";
+        sha512 = "zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==";
       };
     };
     "string.prototype.padstart-3.0.0" = {
@@ -38453,6 +38750,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz";
         sha512 = "DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==";
+      };
+    };
+    "strip-ansi-6.0.0" = {
+      name = "strip-ansi";
+      packageName = "strip-ansi";
+      version = "6.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz";
+        sha512 = "AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==";
       };
     };
     "strip-bom-1.0.0" = {
@@ -39067,6 +39373,24 @@ let
         sha1 = "717d22cc53f0ce1def5594362f3a89a2ebb91105";
       };
     };
+    "sync-request-5.0.0" = {
+      name = "sync-request";
+      packageName = "sync-request";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sync-request/-/sync-request-5.0.0.tgz";
+        sha512 = "NKhEA4WacR3mRBIFz1niXrIUTrUVFtP2spzrLMINangebvJ/EFyVv+LMJKvVl6UIrJM4Fburnnj91lRnqb4WkA==";
+      };
+    };
+    "sync-rpc-1.3.4" = {
+      name = "sync-rpc";
+      packageName = "sync-rpc";
+      version = "1.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.4.tgz";
+        sha512 = "Iug+t1ICVFenUcTnDu8WXFnT+k8IVoLKGh8VA3eXUtl2Rt9SjKX3YEv33OenABqpTPL9QEaHv1+CNn2LK8vMow==";
+      };
+    };
     "syntax-error-1.4.0" = {
       name = "syntax-error";
       packageName = "syntax-error";
@@ -39076,13 +39400,13 @@ let
         sha512 = "YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==";
       };
     };
-    "systeminformation-4.14.17" = {
+    "systeminformation-4.15.3" = {
       name = "systeminformation";
       packageName = "systeminformation";
-      version = "4.14.17";
+      version = "4.15.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.14.17.tgz";
-        sha512 = "CQbT5vnkqNb3JNl41xr8sYA8AX7GoaWP55/jnmFNQY0XQmUuoFshSNUkCkxiDdEC1qu2Vg9s0jR6LLmVSmNJUw==";
+        url = "https://registry.npmjs.org/systeminformation/-/systeminformation-4.15.3.tgz";
+        sha512 = "Fx2ARGHtLl2/xLeNoTR8/doXSxUXuAzIN+dyCK9O43j/UETLBt77yTEbTxmYsVD47PYjX1iQTdcY41CZckY+zg==";
       };
     };
     "syswide-cas-5.3.0" = {
@@ -39464,13 +39788,13 @@ let
         sha512 = "I42EWhJ+2aeNQawGx1VtpO0DFI9YcfuvAMNIdKyf/6sRbHJ4P+ZQ/zIT87tE+ln1ymAGcCJds4dolfSAS0AcNg==";
       };
     };
-    "terminal-kit-1.31.4" = {
+    "terminal-kit-1.31.7" = {
       name = "terminal-kit";
       packageName = "terminal-kit";
-      version = "1.31.4";
+      version = "1.31.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.31.4.tgz";
-        sha512 = "alrT1vDcKamNxdU8HrN25hTsHBuSWb++HVPVy98xbbUJBTw5l+NiF+ILAO56fl0XQLPOMqVUs0lhqf0B20Lucg==";
+        url = "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.31.7.tgz";
+        sha512 = "n5WkVXaPnJC7CfqC424lwPt2/ILWks7yFZi24fjiyaT+L23E1urRdjvALHtX1F3Iyjxso54vp86VHvdbXnf84A==";
       };
     };
     "terser-3.17.0" = {
@@ -39482,13 +39806,13 @@ let
         sha512 = "/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==";
       };
     };
-    "terser-4.3.9" = {
+    "terser-4.4.0" = {
       name = "terser";
       packageName = "terser";
-      version = "4.3.9";
+      version = "4.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz";
-        sha512 = "NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==";
+        url = "https://registry.npmjs.org/terser/-/terser-4.4.0.tgz";
+        sha512 = "oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==";
       };
     };
     "terser-webpack-plugin-1.4.1" = {
@@ -39570,6 +39894,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz";
         sha1 = "72f792dd9d31705a91ae19ebfcf8b3f968c81da2";
+      };
+    };
+    "then-request-5.0.0" = {
+      name = "then-request";
+      packageName = "then-request";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/then-request/-/then-request-5.0.0.tgz";
+        sha512 = "A3uIVLD33SAvB10PfsxLuQBMV8GVC/6xKBMPOvkJchi6251e5AMJ+Yy+RVKsVsnj0iYNhN2E5SkNSi58H19wsw==";
       };
     };
     "thenify-3.3.0" = {
@@ -40535,13 +40868,22 @@ let
         sha512 = "uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==";
       };
     };
-    "ts-node-8.4.1" = {
+    "ts-loader-5.4.5" = {
+      name = "ts-loader";
+      packageName = "ts-loader";
+      version = "5.4.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ts-loader/-/ts-loader-5.4.5.tgz";
+        sha512 = "XYsjfnRQCBum9AMRZpk2rTYSVpdZBpZK+kDh0TeT3kxmQNBDVIeUjdPjY5RZry4eIAb8XHc4gYSUiUWPYvzSRw==";
+      };
+    };
+    "ts-node-8.5.0" = {
       name = "ts-node";
       packageName = "ts-node";
-      version = "8.4.1";
+      version = "8.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz";
-        sha512 = "5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==";
+        url = "https://registry.npmjs.org/ts-node/-/ts-node-8.5.0.tgz";
+        sha512 = "fbG32iZEupNV2E2Fd2m2yt1TdAwR3GTCrJQBHDevIiEBNy1A8kqnyl1fv7jmRmmbtcapFab2glZXHJvfD1ed0Q==";
       };
     };
     "ts-process-promises-1.0.2" = {
@@ -40571,13 +40913,22 @@ let
         sha512 = "4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==";
       };
     };
-    "tslint-5.20.0" = {
+    "tslint-5.20.1" = {
       name = "tslint";
       packageName = "tslint";
-      version = "5.20.0";
+      version = "5.20.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/tslint/-/tslint-5.20.0.tgz";
-        sha512 = "2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==";
+        url = "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz";
+        sha512 = "EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==";
+      };
+    };
+    "tslint-config-prettier-1.18.0" = {
+      name = "tslint-config-prettier";
+      packageName = "tslint-config-prettier";
+      version = "1.18.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz";
+        sha512 = "xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==";
       };
     };
     "tsscmp-1.0.6" = {
@@ -40814,13 +41165,13 @@ let
         sha512 = "TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==";
       };
     };
-    "typechecker-4.7.0" = {
+    "typechecker-4.8.0" = {
       name = "typechecker";
       packageName = "typechecker";
-      version = "4.7.0";
+      version = "4.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/typechecker/-/typechecker-4.7.0.tgz";
-        sha512 = "4LHc1KMNJ6NDGO+dSM/yNfZQRtp8NN7psYrPHUblD62Dvkwsp3VShsbM78kOgpcmMkRTgvwdKOTjctS+uMllgQ==";
+        url = "https://registry.npmjs.org/typechecker/-/typechecker-4.8.0.tgz";
+        sha512 = "TjffTvOgY4JUHE2FU6fYB/C5+NkERPEoB/JmcZSiVP0s/dykDtFfErlH8xSgH2DnnLDgnE+HMjh5zpCseg0liQ==";
       };
     };
     "typed-function-1.1.0" = {
@@ -40868,13 +41219,13 @@ let
         sha512 = "kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==";
       };
     };
-    "typescript-3.6.4" = {
+    "typescript-3.7.2" = {
       name = "typescript";
       packageName = "typescript";
-      version = "3.6.4";
+      version = "3.7.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz";
-        sha512 = "unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==";
+        url = "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz";
+        sha512 = "ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==";
       };
     };
     "typescript-eslint-parser-16.0.1" = {
@@ -40976,13 +41327,13 @@ let
         sha512 = "W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==";
       };
     };
-    "uglify-js-3.6.7" = {
+    "uglify-js-3.6.8" = {
       name = "uglify-js";
       packageName = "uglify-js";
-      version = "3.6.7";
+      version = "3.6.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.7.tgz";
-        sha512 = "4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==";
+        url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz";
+        sha512 = "XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==";
       };
     };
     "uglify-to-browserify-1.0.2" = {
@@ -41489,31 +41840,31 @@ let
         sha512 = "dFil/AN6vqhnQWNCZk0GF/G3+Q5YwsB+PqjnzvpO2wzdRtUJ1E8PN+XRE/PRr/G3FzKjRTJU0haqE0Ekl+O3Ag==";
       };
     };
-    "unist-util-modify-children-1.1.4" = {
+    "unist-util-modify-children-1.1.5" = {
       name = "unist-util-modify-children";
       packageName = "unist-util-modify-children";
-      version = "1.1.4";
+      version = "1.1.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.4.tgz";
-        sha512 = "8iey9wkoB62C7Vi/8zcRUmi4b1f5AYKTwMkyEgLduo2D8+OY65RoSvbn6k9tVNri6qumXxAwXDVlXWQi0sENTw==";
+        url = "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.5.tgz";
+        sha512 = "XeL5qqyoS3TEueCKEzHusWXE9JBDJPE4rl6LmcLOwlzv0RIZrcMNqKx02GSK3Ms4v45ldu+ltPxG42FBMVdPZw==";
       };
     };
-    "unist-util-position-3.0.3" = {
+    "unist-util-position-3.0.4" = {
       name = "unist-util-position";
       packageName = "unist-util-position";
-      version = "3.0.3";
+      version = "3.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.3.tgz";
-        sha512 = "28EpCBYFvnMeq9y/4w6pbnFmCUfzlsc41NJui5c51hOFjBA1fejcwc+5W4z2+0ECVbScG3dURS3JTVqwenzqZw==";
+        url = "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.4.tgz";
+        sha512 = "tWvIbV8goayTjobxDIr4zVTyG+Q7ragMSMeKC3xnPl9xzIc0+she8mxXLM3JVNDDsfARPbCd3XdzkyLdo7fF3g==";
       };
     };
-    "unist-util-remove-position-1.1.3" = {
+    "unist-util-remove-position-1.1.4" = {
       name = "unist-util-remove-position";
       packageName = "unist-util-remove-position";
-      version = "1.1.3";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz";
-        sha512 = "CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==";
+        url = "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz";
+        sha512 = "tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==";
       };
     };
     "unist-util-stringify-position-1.1.2" = {
@@ -41525,13 +41876,13 @@ let
         sha512 = "pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==";
       };
     };
-    "unist-util-stringify-position-2.0.1" = {
+    "unist-util-stringify-position-2.0.2" = {
       name = "unist-util-stringify-position";
       packageName = "unist-util-stringify-position";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz";
-        sha512 = "Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==";
+        url = "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz";
+        sha512 = "nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==";
       };
     };
     "unist-util-visit-1.4.1" = {
@@ -42218,15 +42569,6 @@ let
         sha1 = "6728fc0459c450d796a99c31837569bdf672d728";
       };
     };
-    "uuid-3.3.2" = {
-      name = "uuid";
-      packageName = "uuid";
-      version = "3.3.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz";
-        sha512 = "yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==";
-      };
-    };
     "uuid-3.3.3" = {
       name = "uuid";
       packageName = "uuid";
@@ -42560,13 +42902,13 @@ let
         sha512 = "y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==";
       };
     };
-    "vfile-4.0.1" = {
+    "vfile-4.0.2" = {
       name = "vfile";
       packageName = "vfile";
-      version = "4.0.1";
+      version = "4.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile/-/vfile-4.0.1.tgz";
-        sha512 = "lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==";
+        url = "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz";
+        sha512 = "yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==";
       };
     };
     "vfile-find-down-1.0.0" = {
@@ -42596,13 +42938,13 @@ let
         sha512 = "kYGgsSNpYjPxcEoud1aHNFfchsV0Z6Pyc8M5LfD1wX/tV0/bn32MKHDfv4fqV9DBLVuw2YSGOs31nRY/42DfUA==";
       };
     };
-    "vfile-location-2.0.5" = {
+    "vfile-location-2.0.6" = {
       name = "vfile-location";
       packageName = "vfile-location";
-      version = "2.0.5";
+      version = "2.0.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz";
-        sha512 = "Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==";
+        url = "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz";
+        sha512 = "sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==";
       };
     };
     "vfile-message-1.1.1" = {
@@ -42614,13 +42956,13 @@ let
         sha512 = "1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==";
       };
     };
-    "vfile-message-2.0.1" = {
+    "vfile-message-2.0.2" = {
       name = "vfile-message";
       packageName = "vfile-message";
-      version = "2.0.1";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.1.tgz";
-        sha512 = "KtasSV+uVU7RWhUn4Lw+wW1Zl/nW8JWx7JCPps10Y9JRRIDeDXf8wfBLoOSsJLyo27DqMyAi54C6Jf/d6Kr2Bw==";
+        url = "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz";
+        sha512 = "gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==";
       };
     };
     "vfile-reporter-1.5.0" = {
@@ -42866,13 +43208,13 @@ let
         sha512 = "perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==";
       };
     };
-    "vscode-jsonrpc-5.0.0-next.2" = {
+    "vscode-jsonrpc-5.0.0-next.4" = {
       name = "vscode-jsonrpc";
       packageName = "vscode-jsonrpc";
-      version = "5.0.0-next.2";
+      version = "5.0.0-next.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.0-next.2.tgz";
-        sha512 = "Q3/jabZUNviCG9hhF6hHWjhrABevPF9mv0aiE2j8BYCAP2k+aHTpjMyk+04MzaAqWYwXdQuZkLSbcYCCqbzJLg==";
+        url = "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.0-next.4.tgz";
+        sha512 = "Tos3tXP62ZTB9WowWwhvfVNdu1mEwQF/j7DqJuVL4QKhk311gH+mda0PZpG95LWyh5CCRpHMns4vNmMgZQrvXQ==";
       };
     };
     "vscode-languageclient-4.0.1" = {
@@ -42929,13 +43271,13 @@ let
         sha512 = "IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==";
       };
     };
-    "vscode-languageserver-protocol-3.15.0-next.10" = {
+    "vscode-languageserver-protocol-3.15.0-next.11" = {
       name = "vscode-languageserver-protocol";
       packageName = "vscode-languageserver-protocol";
-      version = "3.15.0-next.10";
+      version = "3.15.0-next.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.10.tgz";
-        sha512 = "TmbBhKrBoYNX+/pQGwoXmy2qlOfjGBUhwUGIzQoWpj8qtDzYuLof8bi19rGLZ9sVuSHh3anvIyVpGJEqT0QODQ==";
+        url = "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.11.tgz";
+        sha512 = "tpRnPtyS6q0EYH5RH12AtdMecgu3HVL2bBdBGzeQRN8Tf93I9LY4Fl5TXUNkIBjuxjMshkCM8ikhb+hlnWvB2w==";
       };
     };
     "vscode-languageserver-protocol-3.6.0" = {
@@ -42965,13 +43307,13 @@ let
         sha512 = "lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==";
       };
     };
-    "vscode-languageserver-types-3.15.0-next.6" = {
+    "vscode-languageserver-types-3.15.0-next.8" = {
       name = "vscode-languageserver-types";
       packageName = "vscode-languageserver-types";
-      version = "3.15.0-next.6";
+      version = "3.15.0-next.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.6.tgz";
-        sha512 = "+4jfvmZ26oFMSX6EgPRB75PWHoT8pzyWuSSWk0erC4hTzmJq2gWxVLh20bZutZjMmiivawvPshtM3XZhX2SttA==";
+        url = "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.8.tgz";
+        sha512 = "AEfWrSNyeamWMKPehh/kd3nBnKD9ZGCPhzfxMnW9YNqElSh28G2+Puk3knIQWyaWyV6Bzh28ok9BRJsPzXFCkQ==";
       };
     };
     "vscode-languageserver-types-3.6.0" = {
@@ -43073,13 +43415,13 @@ let
         sha512 = "JlHVZwBBTNVvzmifwjpZYn0oPWH2SgWv5dojlZBsrhablDu95VFD+hriB1rQGwbD+bms6g+rAFhQHk6+NyiS6g==";
       };
     };
-    "vue-eslint-parser-6.0.4" = {
+    "vue-eslint-parser-6.0.5" = {
       name = "vue-eslint-parser";
       packageName = "vue-eslint-parser";
-      version = "6.0.4";
+      version = "6.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-6.0.4.tgz";
-        sha512 = "GYsDsDWwKaGtnkW4nGUxr01wqIO2FB9/QHQTW1Gl5SUr5OyQvpnR90/D+Gq2cIxURX7aJ7+VyD+37Yx9eFwTgw==";
+        url = "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-6.0.5.tgz";
+        sha512 = "Bvjlx7rH1Ulvus56KHeLXOjEi3JMOYTa1GAqZr9lBQhd8weK8mV7U7V2l85yokBZEWHJQjLn6X3nosY8TzkOKg==";
       };
     };
     "vue-jscodeshift-adapter-2.0.2" = {
@@ -43685,13 +44027,13 @@ let
         sha1 = "fa4daa92daf32c4ea94ed453c81f04686b575dfe";
       };
     };
-    "with-open-file-0.1.6" = {
+    "with-open-file-0.1.7" = {
       name = "with-open-file";
       packageName = "with-open-file";
-      version = "0.1.6";
+      version = "0.1.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.6.tgz";
-        sha512 = "SQS05JekbtwQSgCYlBsZn/+m2gpn4zWsqpCYIrCHva0+ojXcnmUEPsBN6Ipoz3vmY/81k5PvYEWSxER2g4BTqA==";
+        url = "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.7.tgz";
+        sha512 = "ecJS2/oHtESJ1t3ZfMI3B7KIDKyfN0O16miWxdn30zdh66Yd3LsRFebXZXq6GU4xfxLf6nVxp9kIqElb5fqczA==";
       };
     };
     "word-wrap-1.2.3" = {
@@ -43784,13 +44126,13 @@ let
         sha512 = "QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==";
       };
     };
-    "wrap-ansi-6.1.0" = {
+    "wrap-ansi-6.2.0" = {
       name = "wrap-ansi";
       packageName = "wrap-ansi";
-      version = "6.1.0";
+      version = "6.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.1.0.tgz";
-        sha512 = "y8j9eJaotnWgJkysmwld5GkLH2KE9srRvqQE2bu1tZb0O9Qgk1mLyz4Q4KIWyjZAi2+6NRqkM/A580IsUseDdw==";
+        url = "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz";
+        sha512 = "r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==";
       };
     };
     "wrap-fn-0.1.5" = {
@@ -44871,17 +45213,17 @@ in
   "@angular/cli" = nodeEnv.buildNodePackage {
     name = "_at_angular_slash_cli";
     packageName = "@angular/cli";
-    version = "8.3.17";
+    version = "8.3.18";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@angular/cli/-/cli-8.3.17.tgz";
-      sha512 = "1R4IlPnrm6B9drhrCHTu9fBFIqCvOXK1zqYLsdobz6KfdkBcLSFqRqRfgEqADLChkxMo4tedtsftkuqY5Xinrg==";
+      url = "https://registry.npmjs.org/@angular/cli/-/cli-8.3.18.tgz";
+      sha512 = "IWiGlAmVPkl/xWCrki3N45uqdYcjUvtWw9bRM53FF1EKLLbjue6DAVD1HktqgqjTyck0P7QkOXWRilT8rXKcEQ==";
     };
     dependencies = [
-      sources."@angular-devkit/architect-0.803.17"
-      sources."@angular-devkit/core-8.3.17"
-      sources."@angular-devkit/schematics-8.3.17"
-      sources."@schematics/angular-8.3.17"
-      sources."@schematics/update-0.803.17"
+      sources."@angular-devkit/architect-0.803.18"
+      sources."@angular-devkit/core-8.3.18"
+      sources."@angular-devkit/schematics-8.3.18"
+      sources."@schematics/angular-8.3.18"
+      sources."@schematics/update-0.803.18"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONStream-1.3.5"
       sources."agent-base-4.3.0"
@@ -44889,7 +45231,7 @@ in
       sources."ajv-6.10.2"
       sources."ansi-colors-4.1.1"
       sources."ansi-escapes-4.2.1"
-      sources."ansi-regex-4.1.0"
+      sources."ansi-regex-5.0.0"
       sources."ansi-styles-3.2.1"
       sources."aproba-1.2.0"
       sources."asap-2.0.6"
@@ -44940,7 +45282,7 @@ in
       sources."end-of-stream-1.4.4"
       sources."err-code-1.1.2"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
@@ -44962,7 +45304,7 @@ in
       sources."genfun-5.0.0"
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -45052,7 +45394,7 @@ in
       })
       sources."npm-registry-fetch-4.0.2"
       sources."oauth-sign-0.9.0"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object.getownpropertydescriptors-2.0.3"
       sources."once-1.4.0"
@@ -45111,8 +45453,8 @@ in
       })
       sources."signal-exit-3.0.2"
       sources."slash-1.0.0"
-      sources."smart-buffer-4.0.2"
-      sources."socks-2.3.2"
+      sources."smart-buffer-4.1.0"
+      sources."socks-2.3.3"
       (sources."socks-proxy-agent-4.0.2" // {
         dependencies = [
           sources."agent-base-4.2.1"
@@ -45128,7 +45470,11 @@ in
       sources."ssri-6.0.1"
       sources."stream-each-1.2.3"
       sources."stream-shift-1.0.0"
-      sources."string-width-4.1.0"
+      (sources."string-width-4.2.0" // {
+        dependencies = [
+          sources."strip-ansi-6.0.0"
+        ];
+      })
       sources."string.prototype.trimleft-2.1.0"
       sources."string.prototype.trimright-2.1.0"
       (sources."string_decoder-1.1.1" // {
@@ -45136,7 +45482,11 @@ in
           sources."safe-buffer-5.1.2"
         ];
       })
-      sources."strip-ansi-5.2.0"
+      (sources."strip-ansi-5.2.0" // {
+        dependencies = [
+          sources."ansi-regex-4.1.0"
+        ];
+      })
       sources."supports-color-5.5.0"
       sources."symbol-observable-1.2.0"
       sources."tar-4.4.13"
@@ -45196,7 +45546,7 @@ in
       sources."@iarna/toml-2.2.3"
       sources."argparse-1.0.10"
       sources."camelcase-5.3.1"
-      sources."camelcase-keys-6.1.0"
+      sources."camelcase-keys-6.1.1"
       sources."commander-3.0.2"
       (sources."convict-5.2.0" // {
         dependencies = [
@@ -45271,7 +45621,7 @@ in
         ];
       })
       sources."camelcase-5.3.1"
-      sources."camelcase-keys-6.1.0"
+      sources."camelcase-keys-6.1.1"
       sources."clean-git-ref-2.0.1"
       sources."clone-2.1.2"
       sources."clone-buffer-1.0.0"
@@ -45290,7 +45640,7 @@ in
       })
       sources."commander-2.20.3"
       sources."concat-map-0.0.1"
-      (sources."convert-source-map-1.6.0" // {
+      (sources."convert-source-map-1.7.0" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
         ];
@@ -45353,7 +45703,7 @@ in
       sources."glob-parent-3.1.0"
       (sources."glob-stream-6.1.0" // {
         dependencies = [
-          sources."glob-7.1.5"
+          sources."glob-7.1.6"
           sources."readable-stream-2.3.6"
           sources."safe-buffer-5.1.2"
           sources."string_decoder-1.1.1"
@@ -45512,7 +45862,7 @@ in
         ];
       })
       sources."to-utf8-0.0.1"
-      sources."uglify-js-3.6.7"
+      sources."uglify-js-3.6.8"
       sources."unc-path-regex-0.1.2"
       sources."unique-stream-2.3.1"
       sources."universalify-0.1.2"
@@ -45568,97 +45918,189 @@ in
       sources."@apollographql/graphql-language-service-utils-2.0.2"
       sources."@apollographql/graphql-playground-html-1.6.24"
       sources."@babel/code-frame-7.5.5"
-      (sources."@babel/core-7.6.4" // {
+      (sources."@babel/core-7.7.2" // {
         dependencies = [
+          sources."@babel/generator-7.7.2"
+          sources."@babel/types-7.7.2"
           sources."semver-5.7.1"
         ];
       })
       sources."@babel/generator-7.6.4"
-      sources."@babel/helper-annotate-as-pure-7.0.0"
-      sources."@babel/helper-builder-binary-assignment-operator-visitor-7.1.0"
-      sources."@babel/helper-call-delegate-7.4.4"
-      sources."@babel/helper-create-class-features-plugin-7.6.0"
-      sources."@babel/helper-define-map-7.5.5"
-      sources."@babel/helper-explode-assignable-expression-7.1.0"
-      sources."@babel/helper-function-name-7.1.0"
-      sources."@babel/helper-get-function-arity-7.0.0"
-      sources."@babel/helper-hoist-variables-7.4.4"
-      sources."@babel/helper-member-expression-to-functions-7.5.5"
-      sources."@babel/helper-module-imports-7.0.0"
-      sources."@babel/helper-module-transforms-7.5.5"
-      sources."@babel/helper-optimise-call-expression-7.0.0"
+      (sources."@babel/helper-annotate-as-pure-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-builder-binary-assignment-operator-visitor-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-call-delegate-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      sources."@babel/helper-create-class-features-plugin-7.7.0"
+      sources."@babel/helper-create-regexp-features-plugin-7.7.2"
+      (sources."@babel/helper-define-map-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-explode-assignable-expression-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-function-name-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-get-function-arity-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-hoist-variables-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-member-expression-to-functions-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-module-imports-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-module-transforms-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-optimise-call-expression-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
       sources."@babel/helper-plugin-utils-7.0.0"
       sources."@babel/helper-regex-7.5.5"
-      sources."@babel/helper-remap-async-to-generator-7.1.0"
-      sources."@babel/helper-replace-supers-7.5.5"
-      sources."@babel/helper-simple-access-7.1.0"
-      sources."@babel/helper-split-export-declaration-7.4.4"
-      sources."@babel/helper-wrap-function-7.2.0"
-      sources."@babel/helpers-7.6.2"
+      (sources."@babel/helper-remap-async-to-generator-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-replace-supers-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-simple-access-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-split-export-declaration-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helper-wrap-function-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/helpers-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
       sources."@babel/highlight-7.5.0"
-      sources."@babel/parser-7.6.4"
-      sources."@babel/plugin-proposal-async-generator-functions-7.2.0"
-      sources."@babel/plugin-proposal-class-properties-7.5.5"
-      sources."@babel/plugin-proposal-dynamic-import-7.5.0"
+      sources."@babel/parser-7.7.3"
+      sources."@babel/plugin-proposal-async-generator-functions-7.7.0"
+      sources."@babel/plugin-proposal-class-properties-7.7.0"
+      sources."@babel/plugin-proposal-dynamic-import-7.7.0"
       sources."@babel/plugin-proposal-json-strings-7.2.0"
       sources."@babel/plugin-proposal-object-rest-spread-7.6.2"
       sources."@babel/plugin-proposal-optional-catch-binding-7.2.0"
-      sources."@babel/plugin-proposal-unicode-property-regex-7.6.2"
+      sources."@babel/plugin-proposal-unicode-property-regex-7.7.0"
       sources."@babel/plugin-syntax-async-generators-7.2.0"
       sources."@babel/plugin-syntax-dynamic-import-7.2.0"
-      sources."@babel/plugin-syntax-flow-7.2.0"
+      sources."@babel/plugin-syntax-flow-7.7.0"
       sources."@babel/plugin-syntax-json-strings-7.2.0"
       sources."@babel/plugin-syntax-object-rest-spread-7.2.0"
       sources."@babel/plugin-syntax-optional-catch-binding-7.2.0"
+      sources."@babel/plugin-syntax-top-level-await-7.7.0"
       sources."@babel/plugin-syntax-typescript-7.3.3"
       sources."@babel/plugin-transform-arrow-functions-7.2.0"
-      sources."@babel/plugin-transform-async-to-generator-7.5.0"
+      sources."@babel/plugin-transform-async-to-generator-7.7.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.2.0"
       sources."@babel/plugin-transform-block-scoping-7.6.3"
-      sources."@babel/plugin-transform-classes-7.5.5"
+      sources."@babel/plugin-transform-classes-7.7.0"
       sources."@babel/plugin-transform-computed-properties-7.2.0"
       sources."@babel/plugin-transform-destructuring-7.6.0"
-      sources."@babel/plugin-transform-dotall-regex-7.6.2"
+      sources."@babel/plugin-transform-dotall-regex-7.7.0"
       sources."@babel/plugin-transform-duplicate-keys-7.5.0"
       sources."@babel/plugin-transform-exponentiation-operator-7.2.0"
       sources."@babel/plugin-transform-flow-strip-types-7.6.3"
       sources."@babel/plugin-transform-for-of-7.4.4"
-      sources."@babel/plugin-transform-function-name-7.4.4"
+      sources."@babel/plugin-transform-function-name-7.7.0"
       sources."@babel/plugin-transform-literals-7.2.0"
       sources."@babel/plugin-transform-member-expression-literals-7.2.0"
       sources."@babel/plugin-transform-modules-amd-7.5.0"
-      sources."@babel/plugin-transform-modules-commonjs-7.6.0"
-      sources."@babel/plugin-transform-modules-systemjs-7.5.0"
-      sources."@babel/plugin-transform-modules-umd-7.2.0"
-      sources."@babel/plugin-transform-named-capturing-groups-regex-7.6.3"
+      sources."@babel/plugin-transform-modules-commonjs-7.7.0"
+      sources."@babel/plugin-transform-modules-systemjs-7.7.0"
+      sources."@babel/plugin-transform-modules-umd-7.7.0"
+      sources."@babel/plugin-transform-named-capturing-groups-regex-7.7.0"
       sources."@babel/plugin-transform-new-target-7.4.4"
       sources."@babel/plugin-transform-object-super-7.5.5"
       sources."@babel/plugin-transform-parameters-7.4.4"
       sources."@babel/plugin-transform-property-literals-7.2.0"
-      sources."@babel/plugin-transform-regenerator-7.4.5"
+      sources."@babel/plugin-transform-regenerator-7.7.0"
       sources."@babel/plugin-transform-reserved-words-7.2.0"
       sources."@babel/plugin-transform-shorthand-properties-7.2.0"
       sources."@babel/plugin-transform-spread-7.6.2"
       sources."@babel/plugin-transform-sticky-regex-7.2.0"
       sources."@babel/plugin-transform-template-literals-7.4.4"
       sources."@babel/plugin-transform-typeof-symbol-7.2.0"
-      sources."@babel/plugin-transform-typescript-7.6.3"
-      sources."@babel/plugin-transform-unicode-regex-7.6.2"
-      (sources."@babel/preset-env-7.6.3" // {
+      sources."@babel/plugin-transform-typescript-7.7.2"
+      sources."@babel/plugin-transform-unicode-regex-7.7.0"
+      (sources."@babel/preset-env-7.7.1" // {
         dependencies = [
+          sources."@babel/types-7.7.2"
           sources."semver-5.7.1"
         ];
       })
       sources."@babel/preset-flow-7.0.0"
-      sources."@babel/preset-typescript-7.6.0"
-      sources."@babel/register-7.6.2"
-      (sources."@babel/runtime-7.6.3" // {
+      sources."@babel/preset-typescript-7.7.2"
+      (sources."@babel/register-7.7.0" // {
+        dependencies = [
+          sources."make-dir-2.1.0"
+          sources."pify-4.0.1"
+          sources."semver-5.7.1"
+        ];
+      })
+      (sources."@babel/runtime-7.7.2" // {
         dependencies = [
           sources."regenerator-runtime-0.13.3"
         ];
       })
-      sources."@babel/template-7.6.0"
-      sources."@babel/traverse-7.6.3"
+      (sources."@babel/template-7.7.0" // {
+        dependencies = [
+          sources."@babel/types-7.7.2"
+        ];
+      })
+      (sources."@babel/traverse-7.7.2" // {
+        dependencies = [
+          sources."@babel/generator-7.7.2"
+          sources."@babel/types-7.7.2"
+        ];
+      })
       sources."@babel/types-7.6.3"
       sources."@endemolshinegroup/cosmiconfig-typescript-loader-1.0.1"
       sources."@hapi/address-2.1.2"
@@ -45737,12 +46179,12 @@ in
       sources."@types/graphql-upload-8.0.3"
       sources."@types/http-assert-1.5.1"
       sources."@types/keygrip-1.0.1"
-      sources."@types/koa-2.0.51"
-      sources."@types/koa-compose-3.2.4"
+      sources."@types/koa-2.0.52"
+      sources."@types/koa-compose-3.2.5"
       sources."@types/long-4.0.0"
       sources."@types/mime-2.0.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.12.5"
+      sources."@types/node-12.12.7"
       sources."@types/range-parser-1.2.3"
       sources."@types/serve-static-1.13.3"
       sources."@types/ws-6.0.3"
@@ -45870,11 +46312,13 @@ in
               sources."string-width-3.1.0"
             ];
           })
+          sources."ansi-regex-5.0.0"
           sources."camelcase-5.3.1"
           sources."cli-boxes-2.2.0"
           sources."emoji-regex-8.0.0"
           sources."is-fullwidth-code-point-3.0.0"
-          sources."string-width-4.1.0"
+          sources."string-width-4.2.0"
+          sources."strip-ansi-6.0.0"
           sources."term-size-2.1.0"
           sources."type-fest-0.5.2"
           sources."widest-line-3.1.0"
@@ -45966,12 +46410,12 @@ in
       sources."constant-case-2.0.0"
       sources."content-disposition-0.5.3"
       sources."content-type-1.0.4"
-      sources."convert-source-map-1.6.0"
+      sources."convert-source-map-1.7.0"
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-3.3.6"
-      sources."core-js-compat-3.3.6"
+      sources."core-js-3.4.1"
+      sources."core-js-compat-3.4.1"
       sources."core-util-is-1.0.2"
       sources."cors-2.8.5"
       sources."cosmiconfig-5.2.1"
@@ -46042,7 +46486,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."ejs-2.7.1"
-      sources."electron-to-chromium-1.3.302"
+      sources."electron-to-chromium-1.3.306"
       sources."elegant-spinner-1.0.1"
       sources."emoji-regex-7.0.3"
       sources."encodeurl-1.0.2"
@@ -46052,7 +46496,7 @@ in
       sources."envinfo-7.4.0"
       sources."error-ex-1.3.2"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."esm-3.2.25"
@@ -46132,7 +46576,7 @@ in
       })
       sources."find-up-3.0.0"
       sources."fkill-6.2.0"
-      sources."flow-parser-0.111.1"
+      sources."flow-parser-0.111.3"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
@@ -46473,7 +46917,7 @@ in
           sources."kind-of-3.2.2"
         ];
       })
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object-path-0.11.4"
       sources."object-visit-1.0.1"
@@ -46546,7 +46990,7 @@ in
       sources."proto-list-1.2.4"
       (sources."protobufjs-6.8.8" // {
         dependencies = [
-          sources."@types/node-10.17.3"
+          sources."@types/node-10.17.5"
         ];
       })
       sources."proxy-addr-2.0.5"
@@ -46805,14 +47249,14 @@ in
       sources."treeify-1.1.0"
       sources."trim-repeated-1.0.0"
       sources."ts-invariant-0.4.4"
-      sources."ts-node-8.4.1"
+      sources."ts-node-8.5.0"
       sources."tslib-1.10.0"
       sources."tty-1.0.1"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-fest-0.3.1"
       sources."type-is-1.6.18"
-      sources."typescript-3.6.4"
+      sources."typescript-3.7.2"
       sources."unbzip2-stream-1.3.3"
       (sources."undefsafe-2.0.2" // {
         dependencies = [
@@ -46868,7 +47312,7 @@ in
         dependencies = [
           sources."cross-spawn-7.0.1"
           sources."deepmerge-4.2.2"
-          sources."execa-3.2.0"
+          sources."execa-3.3.0"
           sources."fs-extra-8.1.0"
           sources."get-stream-5.1.0"
           sources."is-stream-2.0.0"
@@ -47053,11 +47497,11 @@ in
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
-      sources."@babel/generator-7.6.4"
+      sources."@babel/generator-7.7.2"
       sources."@babel/highlight-7.5.0"
-      sources."@babel/parser-7.6.4"
-      sources."@babel/template-7.6.0"
-      sources."@babel/types-7.6.3"
+      sources."@babel/parser-7.7.3"
+      sources."@babel/template-7.7.0"
+      sources."@babel/types-7.7.2"
       sources."@webassemblyjs/ast-1.8.5"
       sources."@webassemblyjs/floating-point-hex-parser-1.8.5"
       sources."@webassemblyjs/helper-api-error-1.8.5"
@@ -47131,32 +47575,32 @@ in
   alloy = nodeEnv.buildNodePackage {
     name = "alloy";
     packageName = "alloy";
-    version = "1.14.1";
+    version = "1.14.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/alloy/-/alloy-1.14.1.tgz";
-      sha512 = "AbKwsUIrmy4jj6QbQr9QZcDRtmEw1vp+cx9BoX+0KHi+pDu9ZoFFYN1hIkojlnGWzd1R2xZshB/p8LsMyZ1ndw==";
+      url = "https://registry.npmjs.org/alloy/-/alloy-1.14.2.tgz";
+      sha512 = "Mrx+RXcXYUgI/Di5Rx7NFMsvbkhqp7To6SA4LzWgwokyvGnDeGbosXsOE0cl0Uel0P5GuRuiAk/a+KwNJhM5NQ==";
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
-      (sources."@babel/core-7.6.4" // {
+      (sources."@babel/core-7.7.2" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
       })
-      (sources."@babel/generator-7.6.4" // {
+      (sources."@babel/generator-7.7.2" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
       })
-      sources."@babel/helper-function-name-7.1.0"
-      sources."@babel/helper-get-function-arity-7.0.0"
-      sources."@babel/helper-split-export-declaration-7.4.4"
-      sources."@babel/helpers-7.6.2"
+      sources."@babel/helper-function-name-7.7.0"
+      sources."@babel/helper-get-function-arity-7.7.0"
+      sources."@babel/helper-split-export-declaration-7.7.0"
+      sources."@babel/helpers-7.7.0"
       sources."@babel/highlight-7.5.0"
-      sources."@babel/parser-7.6.4"
-      sources."@babel/template-7.6.0"
-      sources."@babel/traverse-7.6.3"
-      sources."@babel/types-7.6.3"
+      sources."@babel/parser-7.7.3"
+      sources."@babel/template-7.7.0"
+      sources."@babel/traverse-7.7.2"
+      sources."@babel/types-7.7.2"
       sources."JSV-4.0.2"
       sources."ansi-styles-3.2.1"
       sources."array-unique-0.3.2"
@@ -47170,7 +47614,7 @@ in
       sources."colors-1.4.0"
       sources."commander-2.20.3"
       sources."concat-map-0.0.1"
-      sources."convert-source-map-1.6.0"
+      sources."convert-source-map-1.7.0"
       sources."debug-4.1.1"
       sources."ejs-2.5.7"
       sources."ensure-posix-path-1.1.1"
@@ -47261,7 +47705,7 @@ in
       sources."concat-map-0.0.1"
       sources."cuint-0.2.2"
       sources."fs.realpath-1.0.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."minimatch-3.0.4"
@@ -47342,7 +47786,7 @@ in
       sources."form-data-2.3.3"
       sources."fs.realpath-1.0.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."html-encoding-sniffer-1.0.2"
@@ -47368,7 +47812,7 @@ in
       sources."nwsapi-2.2.0"
       sources."oauth-sign-0.9.0"
       sources."once-1.4.0"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."parse5-4.0.0"
       sources."path-is-absolute-1.0.1"
       sources."performance-now-2.1.0"
@@ -47412,7 +47856,7 @@ in
       sources."whatwg-encoding-1.0.5"
       sources."whatwg-mimetype-2.3.0"
       sources."whatwg-url-6.5.0"
-      sources."wordwrap-1.0.0"
+      sources."word-wrap-1.2.3"
       sources."wrappy-1.0.2"
       sources."ws-5.2.2"
       sources."xml-name-validator-3.0.0"
@@ -47547,7 +47991,7 @@ in
       sources."resolve-1.12.0"
       (sources."rimraf-2.7.1" // {
         dependencies = [
-          sources."glob-7.1.5"
+          sources."glob-7.1.6"
         ];
       })
       sources."semver-5.7.1"
@@ -47653,7 +48097,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."get-assigned-identifiers-1.2.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."has-1.0.3"
       sources."hash-base-3.0.4"
       sources."hash.js-1.1.7"
@@ -47782,7 +48226,7 @@ in
       sources."@protobufjs/pool-1.1.0"
       sources."@protobufjs/utf8-1.1.0"
       sources."@types/long-4.0.0"
-      sources."@types/node-10.17.3"
+      sources."@types/node-10.17.5"
       sources."addr-to-ip-port-1.5.1"
       sources."airplay-js-0.2.16"
       sources."ajv-6.10.2"
@@ -47843,7 +48287,7 @@ in
       sources."co-3.1.0"
       sources."codepage-1.4.0"
       sources."combined-stream-1.0.8"
-      sources."commander-4.0.0"
+      sources."commander-4.0.1"
       sources."compact2string-1.4.1"
       sources."concat-map-0.0.1"
       (sources."concat-stream-2.0.0" // {
@@ -47877,7 +48321,7 @@ in
       })
       sources."error-ex-1.3.2"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."exit-on-epipe-1.0.1"
       sources."extend-3.0.2"
@@ -47906,7 +48350,7 @@ in
       sources."get-browser-rtc-1.0.2"
       sources."get-stdin-4.0.1"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."got-1.2.2"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
@@ -47986,7 +48430,7 @@ in
       sources."numeral-1.5.6"
       sources."oauth-sign-0.9.0"
       sources."object-assign-1.0.0"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object.getownpropertydescriptors-2.0.3"
       sources."once-1.4.0"
@@ -48202,6 +48646,771 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
+  "texlab-citeproc-build-deps-../tools/misc/texlab/citeproc" = nodeEnv.buildNodePackage {
+    name = "citeproc";
+    packageName = "citeproc";
+    version = "0.1.0";
+    src = ../tools/misc/texlab/citeproc;
+    dependencies = [
+      sources."@babel/code-frame-7.5.5"
+      sources."@babel/core-7.7.2"
+      sources."@babel/generator-7.7.2"
+      sources."@babel/helper-annotate-as-pure-7.7.0"
+      sources."@babel/helper-builder-binary-assignment-operator-visitor-7.7.0"
+      sources."@babel/helper-call-delegate-7.7.0"
+      sources."@babel/helper-create-regexp-features-plugin-7.7.2"
+      sources."@babel/helper-define-map-7.7.0"
+      sources."@babel/helper-explode-assignable-expression-7.7.0"
+      sources."@babel/helper-function-name-7.7.0"
+      sources."@babel/helper-get-function-arity-7.7.0"
+      sources."@babel/helper-hoist-variables-7.7.0"
+      sources."@babel/helper-member-expression-to-functions-7.7.0"
+      sources."@babel/helper-module-imports-7.7.0"
+      sources."@babel/helper-module-transforms-7.7.0"
+      sources."@babel/helper-optimise-call-expression-7.7.0"
+      sources."@babel/helper-plugin-utils-7.0.0"
+      sources."@babel/helper-regex-7.5.5"
+      sources."@babel/helper-remap-async-to-generator-7.7.0"
+      sources."@babel/helper-replace-supers-7.7.0"
+      sources."@babel/helper-simple-access-7.7.0"
+      sources."@babel/helper-split-export-declaration-7.7.0"
+      sources."@babel/helper-wrap-function-7.7.0"
+      sources."@babel/helpers-7.7.0"
+      sources."@babel/highlight-7.5.0"
+      sources."@babel/parser-7.7.3"
+      sources."@babel/plugin-proposal-async-generator-functions-7.7.0"
+      sources."@babel/plugin-proposal-dynamic-import-7.7.0"
+      sources."@babel/plugin-proposal-json-strings-7.2.0"
+      sources."@babel/plugin-proposal-object-rest-spread-7.6.2"
+      sources."@babel/plugin-proposal-optional-catch-binding-7.2.0"
+      sources."@babel/plugin-proposal-unicode-property-regex-7.7.0"
+      sources."@babel/plugin-syntax-async-generators-7.2.0"
+      sources."@babel/plugin-syntax-dynamic-import-7.2.0"
+      sources."@babel/plugin-syntax-json-strings-7.2.0"
+      sources."@babel/plugin-syntax-object-rest-spread-7.2.0"
+      sources."@babel/plugin-syntax-optional-catch-binding-7.2.0"
+      sources."@babel/plugin-syntax-top-level-await-7.7.0"
+      sources."@babel/plugin-transform-arrow-functions-7.2.0"
+      sources."@babel/plugin-transform-async-to-generator-7.7.0"
+      sources."@babel/plugin-transform-block-scoped-functions-7.2.0"
+      sources."@babel/plugin-transform-block-scoping-7.6.3"
+      sources."@babel/plugin-transform-classes-7.7.0"
+      sources."@babel/plugin-transform-computed-properties-7.2.0"
+      sources."@babel/plugin-transform-destructuring-7.6.0"
+      sources."@babel/plugin-transform-dotall-regex-7.7.0"
+      sources."@babel/plugin-transform-duplicate-keys-7.5.0"
+      sources."@babel/plugin-transform-exponentiation-operator-7.2.0"
+      sources."@babel/plugin-transform-for-of-7.4.4"
+      sources."@babel/plugin-transform-function-name-7.7.0"
+      sources."@babel/plugin-transform-literals-7.2.0"
+      sources."@babel/plugin-transform-member-expression-literals-7.2.0"
+      sources."@babel/plugin-transform-modules-amd-7.5.0"
+      sources."@babel/plugin-transform-modules-commonjs-7.7.0"
+      sources."@babel/plugin-transform-modules-systemjs-7.7.0"
+      sources."@babel/plugin-transform-modules-umd-7.7.0"
+      sources."@babel/plugin-transform-named-capturing-groups-regex-7.7.0"
+      sources."@babel/plugin-transform-new-target-7.4.4"
+      sources."@babel/plugin-transform-object-super-7.5.5"
+      sources."@babel/plugin-transform-parameters-7.4.4"
+      sources."@babel/plugin-transform-property-literals-7.2.0"
+      sources."@babel/plugin-transform-regenerator-7.7.0"
+      sources."@babel/plugin-transform-reserved-words-7.2.0"
+      sources."@babel/plugin-transform-shorthand-properties-7.2.0"
+      sources."@babel/plugin-transform-spread-7.6.2"
+      sources."@babel/plugin-transform-sticky-regex-7.2.0"
+      sources."@babel/plugin-transform-template-literals-7.4.4"
+      sources."@babel/plugin-transform-typeof-symbol-7.2.0"
+      sources."@babel/plugin-transform-unicode-regex-7.7.0"
+      sources."@babel/preset-env-7.7.1"
+      sources."@babel/template-7.7.0"
+      sources."@babel/traverse-7.7.2"
+      sources."@babel/types-7.7.2"
+      sources."@citation-js/core-0.4.9"
+      sources."@citation-js/date-0.4.4"
+      sources."@citation-js/name-0.4.2"
+      sources."@citation-js/plugin-bibtex-0.4.9"
+      sources."@citation-js/plugin-csl-0.4.10"
+      sources."@types/anymatch-1.3.1"
+      sources."@types/concat-stream-1.6.0"
+      sources."@types/form-data-0.0.33"
+      sources."@types/node-11.15.2"
+      sources."@types/qs-6.9.0"
+      sources."@types/source-list-map-0.1.2"
+      sources."@types/tapable-1.0.4"
+      (sources."@types/uglify-js-3.0.4" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."@types/webpack-4.39.8" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."@types/webpack-sources-0.1.5" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      sources."@webassemblyjs/ast-1.8.5"
+      sources."@webassemblyjs/floating-point-hex-parser-1.8.5"
+      sources."@webassemblyjs/helper-api-error-1.8.5"
+      sources."@webassemblyjs/helper-buffer-1.8.5"
+      sources."@webassemblyjs/helper-code-frame-1.8.5"
+      sources."@webassemblyjs/helper-fsm-1.8.5"
+      sources."@webassemblyjs/helper-module-context-1.8.5"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.8.5"
+      sources."@webassemblyjs/helper-wasm-section-1.8.5"
+      sources."@webassemblyjs/ieee754-1.8.5"
+      sources."@webassemblyjs/leb128-1.8.5"
+      sources."@webassemblyjs/utf8-1.8.5"
+      sources."@webassemblyjs/wasm-edit-1.8.5"
+      sources."@webassemblyjs/wasm-gen-1.8.5"
+      sources."@webassemblyjs/wasm-opt-1.8.5"
+      sources."@webassemblyjs/wasm-parser-1.8.5"
+      sources."@webassemblyjs/wast-parser-1.8.5"
+      sources."@webassemblyjs/wast-printer-1.8.5"
+      sources."@xtuc/ieee754-1.2.0"
+      sources."@xtuc/long-4.2.2"
+      sources."acorn-6.3.0"
+      sources."ajv-6.10.2"
+      sources."ajv-errors-1.0.1"
+      sources."ajv-keywords-3.4.1"
+      sources."ansi-regex-4.1.0"
+      sources."ansi-styles-3.2.1"
+      (sources."anymatch-2.0.0" // {
+        dependencies = [
+          sources."normalize-path-2.1.1"
+        ];
+      })
+      sources."aproba-1.2.0"
+      sources."arg-4.1.1"
+      sources."argparse-1.0.10"
+      sources."arr-diff-4.0.0"
+      sources."arr-flatten-1.1.0"
+      sources."arr-union-3.1.0"
+      sources."array-unique-0.3.2"
+      sources."asap-2.0.6"
+      sources."asn1.js-4.10.1"
+      (sources."assert-1.5.0" // {
+        dependencies = [
+          sources."inherits-2.0.1"
+          sources."util-0.10.3"
+        ];
+      })
+      sources."assign-symbols-1.0.0"
+      sources."async-each-1.0.3"
+      sources."asynckit-0.4.0"
+      sources."atob-2.1.2"
+      sources."babel-loader-8.0.6"
+      sources."babel-plugin-dynamic-import-node-2.3.0"
+      sources."babel-polyfill-6.26.0"
+      (sources."babel-runtime-6.26.0" // {
+        dependencies = [
+          sources."regenerator-runtime-0.11.1"
+        ];
+      })
+      sources."balanced-match-1.0.0"
+      (sources."base-0.11.2" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+        ];
+      })
+      sources."base64-js-1.3.1"
+      sources."big.js-5.2.2"
+      sources."binary-extensions-1.13.1"
+      sources."bluebird-3.7.1"
+      sources."bn.js-4.11.8"
+      sources."brace-expansion-1.1.11"
+      (sources."braces-2.3.2" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."brorand-1.1.0"
+      sources."browserify-aes-1.2.0"
+      sources."browserify-cipher-1.0.1"
+      sources."browserify-des-1.0.2"
+      sources."browserify-rsa-4.0.1"
+      sources."browserify-sign-4.0.4"
+      sources."browserify-zlib-0.2.0"
+      sources."browserslist-4.7.2"
+      sources."buffer-4.9.2"
+      sources."buffer-from-1.1.1"
+      sources."buffer-xor-1.0.3"
+      sources."builtin-modules-1.1.1"
+      sources."builtin-status-codes-3.0.0"
+      sources."cacache-12.0.3"
+      sources."cache-base-1.0.1"
+      sources."camelcase-5.3.1"
+      sources."caniuse-lite-1.0.30001008"
+      sources."caseless-0.12.0"
+      sources."chalk-2.4.2"
+      sources."chokidar-2.1.8"
+      sources."chownr-1.1.3"
+      sources."chrome-trace-event-1.0.2"
+      sources."cipher-base-1.0.4"
+      sources."citeproc-2.2.27"
+      (sources."class-utils-0.3.6" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."cliui-5.0.0"
+      sources."collection-visit-1.0.0"
+      sources."color-convert-1.9.3"
+      sources."color-name-1.1.3"
+      sources."combined-stream-1.0.8"
+      sources."commander-2.20.3"
+      sources."commondir-1.0.1"
+      sources."component-emitter-1.3.0"
+      sources."concat-map-0.0.1"
+      sources."concat-stream-1.6.2"
+      sources."console-browserify-1.2.0"
+      sources."constants-browserify-1.0.0"
+      sources."convert-source-map-1.7.0"
+      sources."copy-concurrently-1.0.5"
+      sources."copy-descriptor-0.1.1"
+      sources."core-js-2.6.10"
+      (sources."core-js-compat-3.4.1" // {
+        dependencies = [
+          sources."semver-6.3.0"
+        ];
+      })
+      sources."core-util-is-1.0.2"
+      sources."create-ecdh-4.0.3"
+      sources."create-hash-1.2.0"
+      sources."create-hmac-1.1.7"
+      sources."cross-spawn-6.0.5"
+      sources."crypto-browserify-3.12.0"
+      sources."cyclist-1.0.1"
+      sources."debug-4.1.1"
+      sources."decamelize-1.2.0"
+      sources."decode-uri-component-0.2.0"
+      sources."define-properties-1.1.3"
+      sources."define-property-2.0.2"
+      sources."delayed-stream-1.0.0"
+      sources."des.js-1.0.0"
+      sources."detect-file-1.0.0"
+      sources."diff-4.0.1"
+      sources."diffie-hellman-5.0.3"
+      sources."domain-browser-1.2.0"
+      sources."duplexify-3.7.1"
+      sources."electron-to-chromium-1.3.306"
+      sources."elliptic-6.5.1"
+      sources."emoji-regex-7.0.3"
+      sources."emojis-list-2.1.0"
+      sources."encoding-0.1.12"
+      sources."end-of-stream-1.4.4"
+      sources."enhanced-resolve-4.1.1"
+      sources."errno-0.1.7"
+      sources."escape-string-regexp-1.0.5"
+      sources."eslint-scope-4.0.3"
+      sources."esprima-4.0.1"
+      sources."esrecurse-4.2.1"
+      sources."estraverse-4.3.0"
+      sources."esutils-2.0.3"
+      sources."events-3.0.0"
+      sources."evp_bytestokey-1.0.3"
+      sources."execa-1.0.0"
+      (sources."expand-brackets-2.1.4" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."expand-tilde-2.0.2"
+      (sources."extend-shallow-3.0.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      (sources."extglob-2.0.4" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."fast-deep-equal-2.0.1"
+      sources."fast-json-stable-stringify-2.0.0"
+      sources."figgy-pudding-3.5.1"
+      (sources."fill-range-4.0.0" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."find-cache-dir-2.1.0"
+      sources."find-up-3.0.0"
+      sources."findup-sync-3.0.0"
+      sources."flush-write-stream-1.1.1"
+      sources."for-in-1.0.2"
+      sources."form-data-2.5.1"
+      sources."fragment-cache-0.2.1"
+      sources."from2-2.3.0"
+      sources."fs-write-stream-atomic-1.0.10"
+      sources."fs.realpath-1.0.0"
+      sources."fsevents-1.2.9"
+      sources."function-bind-1.1.1"
+      sources."get-caller-file-2.0.5"
+      sources."get-port-3.2.0"
+      sources."get-stream-4.1.0"
+      sources."get-value-2.0.6"
+      sources."glob-7.1.6"
+      (sources."glob-parent-3.1.0" // {
+        dependencies = [
+          sources."is-glob-3.1.0"
+        ];
+      })
+      (sources."global-modules-2.0.0" // {
+        dependencies = [
+          sources."global-prefix-3.0.0"
+        ];
+      })
+      sources."global-prefix-1.0.2"
+      sources."globals-11.12.0"
+      sources."graceful-fs-4.2.3"
+      sources."has-flag-3.0.0"
+      sources."has-symbols-1.0.0"
+      sources."has-value-1.0.0"
+      (sources."has-values-1.0.0" // {
+        dependencies = [
+          sources."kind-of-4.0.0"
+        ];
+      })
+      sources."hash-base-3.0.4"
+      sources."hash.js-1.1.7"
+      sources."hmac-drbg-1.0.1"
+      sources."homedir-polyfill-1.0.3"
+      (sources."http-basic-6.0.0" // {
+        dependencies = [
+          sources."@types/node-7.10.9"
+        ];
+      })
+      (sources."http-response-object-3.0.2" // {
+        dependencies = [
+          sources."@types/node-10.17.5"
+        ];
+      })
+      sources."https-browserify-1.0.0"
+      sources."iconv-lite-0.4.24"
+      sources."ieee754-1.1.13"
+      sources."iferr-0.1.5"
+      sources."import-local-2.0.0"
+      sources."imurmurhash-0.1.4"
+      sources."infer-owner-1.0.4"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.4"
+      sources."ini-1.3.5"
+      sources."interpret-1.2.0"
+      sources."invariant-2.2.4"
+      sources."invert-kv-2.0.0"
+      sources."is-accessor-descriptor-1.0.0"
+      sources."is-binary-path-1.0.1"
+      sources."is-buffer-1.1.6"
+      sources."is-data-descriptor-1.0.0"
+      sources."is-descriptor-1.0.2"
+      sources."is-extendable-0.1.1"
+      sources."is-extglob-2.1.1"
+      sources."is-fullwidth-code-point-2.0.0"
+      sources."is-glob-4.0.1"
+      (sources."is-number-3.0.0" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."is-plain-object-2.0.4"
+      sources."is-stream-1.1.0"
+      sources."is-windows-1.0.2"
+      sources."is-wsl-1.1.0"
+      sources."isarray-1.0.0"
+      sources."isexe-2.0.0"
+      sources."isobject-3.0.1"
+      sources."isomorphic-fetch-2.2.1"
+      sources."js-levenshtein-1.1.6"
+      sources."js-tokens-4.0.0"
+      sources."js-yaml-3.13.1"
+      sources."jsesc-2.5.2"
+      sources."json-parse-better-errors-1.0.2"
+      sources."json-schema-traverse-0.4.1"
+      sources."json5-2.1.1"
+      sources."kind-of-6.0.2"
+      sources."lcid-2.0.0"
+      sources."loader-runner-2.4.0"
+      (sources."loader-utils-1.2.3" // {
+        dependencies = [
+          sources."json5-1.0.1"
+        ];
+      })
+      sources."locate-path-3.0.0"
+      sources."lodash-4.17.15"
+      sources."loose-envify-1.4.0"
+      sources."lru-cache-5.1.1"
+      sources."make-dir-2.1.0"
+      sources."make-error-1.3.5"
+      sources."mamacro-0.0.3"
+      sources."map-age-cleaner-0.1.3"
+      sources."map-cache-0.2.2"
+      sources."map-visit-1.0.0"
+      sources."md5.js-1.3.5"
+      sources."mem-4.3.0"
+      sources."memory-fs-0.5.0"
+      sources."micromatch-3.1.10"
+      sources."miller-rabin-4.0.1"
+      sources."mime-db-1.40.0"
+      sources."mime-types-2.1.24"
+      sources."mimic-fn-2.1.0"
+      sources."minimalistic-assert-1.0.1"
+      sources."minimalistic-crypto-utils-1.0.1"
+      sources."minimatch-3.0.4"
+      sources."minimist-1.2.0"
+      sources."mississippi-3.0.0"
+      (sources."mixin-deep-1.3.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      (sources."mkdirp-0.5.1" // {
+        dependencies = [
+          sources."minimist-0.0.8"
+        ];
+      })
+      sources."move-concurrently-1.0.1"
+      sources."ms-2.1.2"
+      sources."nan-2.14.0"
+      sources."nanomatch-1.2.13"
+      sources."neo-async-2.6.1"
+      sources."nice-try-1.0.5"
+      sources."node-fetch-1.7.3"
+      (sources."node-libs-browser-2.2.1" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
+      (sources."node-releases-1.1.39" // {
+        dependencies = [
+          sources."semver-6.3.0"
+        ];
+      })
+      sources."normalize-path-3.0.0"
+      sources."npm-run-path-2.0.2"
+      sources."null-loader-0.1.1"
+      sources."object-assign-4.1.1"
+      (sources."object-copy-0.1.0" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          sources."is-accessor-descriptor-0.1.6"
+          sources."is-data-descriptor-0.1.4"
+          (sources."is-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-5.1.0"
+            ];
+          })
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."object-keys-1.1.1"
+      sources."object-visit-1.0.1"
+      sources."object.assign-4.1.0"
+      sources."object.pick-1.3.0"
+      sources."once-1.4.0"
+      sources."os-browserify-0.3.0"
+      sources."os-locale-3.1.0"
+      sources."p-defer-1.0.0"
+      sources."p-finally-1.0.0"
+      sources."p-is-promise-2.1.0"
+      sources."p-limit-2.2.1"
+      sources."p-locate-3.0.0"
+      sources."p-try-2.2.0"
+      sources."pako-1.0.10"
+      sources."parallel-transform-1.2.0"
+      sources."parse-asn1-5.1.5"
+      sources."parse-cache-control-1.0.1"
+      sources."parse-passwd-1.0.0"
+      sources."pascalcase-0.1.1"
+      sources."path-browserify-0.0.1"
+      sources."path-dirname-1.0.2"
+      sources."path-exists-3.0.0"
+      sources."path-is-absolute-1.0.1"
+      sources."path-key-2.0.1"
+      sources."path-parse-1.0.6"
+      sources."pbkdf2-3.0.17"
+      sources."pify-4.0.1"
+      sources."pkg-dir-3.0.0"
+      sources."posix-character-classes-0.1.1"
+      sources."prettier-1.19.1"
+      sources."private-0.1.8"
+      sources."process-0.11.10"
+      sources."process-nextick-args-2.0.1"
+      sources."promise-8.0.3"
+      sources."promise-inflight-1.0.1"
+      sources."prr-1.0.1"
+      sources."public-encrypt-4.0.3"
+      sources."pump-3.0.0"
+      (sources."pumpify-1.5.1" // {
+        dependencies = [
+          sources."pump-2.0.1"
+        ];
+      })
+      sources."punycode-2.1.1"
+      sources."qs-6.9.1"
+      sources."querystring-0.2.0"
+      sources."querystring-es3-0.2.1"
+      sources."randombytes-2.1.0"
+      sources."randomfill-1.0.4"
+      sources."readable-stream-2.3.6"
+      sources."readdirp-2.2.1"
+      sources."regenerate-1.4.0"
+      sources."regenerate-unicode-properties-8.1.0"
+      sources."regenerator-runtime-0.10.5"
+      sources."regenerator-transform-0.14.1"
+      sources."regex-not-1.0.2"
+      sources."regexpu-core-4.6.0"
+      sources."regjsgen-0.5.1"
+      (sources."regjsparser-0.6.0" // {
+        dependencies = [
+          sources."jsesc-0.5.0"
+        ];
+      })
+      sources."remove-trailing-separator-1.1.0"
+      sources."repeat-element-1.1.3"
+      sources."repeat-string-1.6.1"
+      sources."require-directory-2.1.1"
+      sources."require-main-filename-2.0.0"
+      sources."resolve-1.12.0"
+      sources."resolve-cwd-2.0.0"
+      (sources."resolve-dir-1.0.1" // {
+        dependencies = [
+          sources."global-modules-1.0.0"
+        ];
+      })
+      sources."resolve-from-3.0.0"
+      sources."resolve-url-0.2.1"
+      sources."ret-0.1.15"
+      sources."rimraf-2.7.1"
+      sources."ripemd160-2.0.2"
+      sources."run-queue-1.0.3"
+      sources."safe-buffer-5.1.2"
+      sources."safe-regex-1.1.0"
+      sources."safer-buffer-2.1.2"
+      sources."schema-utils-1.0.0"
+      sources."semver-5.7.1"
+      sources."serialize-javascript-1.9.1"
+      sources."set-blocking-2.0.0"
+      (sources."set-value-2.0.1" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."setimmediate-1.0.5"
+      sources."sha.js-2.4.11"
+      sources."shebang-command-1.2.0"
+      sources."shebang-regex-1.0.0"
+      sources."signal-exit-3.0.2"
+      (sources."snapdragon-0.8.2" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
+        ];
+      })
+      (sources."snapdragon-node-2.1.1" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+        ];
+      })
+      (sources."snapdragon-util-3.0.1" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."source-list-map-2.0.1"
+      sources."source-map-0.5.7"
+      sources."source-map-resolve-0.5.2"
+      (sources."source-map-support-0.5.16" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      sources."source-map-url-0.4.0"
+      sources."split-string-3.1.0"
+      sources."sprintf-js-1.0.3"
+      sources."ssri-6.0.1"
+      (sources."static-extend-0.1.2" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."stream-browserify-2.0.2"
+      sources."stream-each-1.2.3"
+      sources."stream-http-2.8.3"
+      sources."stream-shift-1.0.0"
+      sources."string-width-3.1.0"
+      sources."string_decoder-1.1.1"
+      sources."strip-ansi-5.2.0"
+      sources."strip-eof-1.0.0"
+      sources."supports-color-5.5.0"
+      sources."sync-request-5.0.0"
+      sources."sync-rpc-1.3.4"
+      sources."tapable-1.1.3"
+      (sources."terser-4.4.0" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."terser-webpack-plugin-1.4.1" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      (sources."then-request-5.0.0" // {
+        dependencies = [
+          sources."@types/node-8.10.59"
+        ];
+      })
+      sources."through2-2.0.5"
+      sources."timers-browserify-2.0.11"
+      sources."to-arraybuffer-1.0.1"
+      sources."to-fast-properties-2.0.0"
+      (sources."to-object-path-0.3.0" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."to-regex-3.0.2"
+      sources."to-regex-range-2.1.1"
+      sources."ts-loader-5.4.5"
+      sources."ts-node-8.5.0"
+      sources."tslib-1.10.0"
+      sources."tslint-5.20.1"
+      sources."tslint-config-prettier-1.18.0"
+      sources."tsutils-2.29.0"
+      sources."tty-browserify-0.0.0"
+      sources."typedarray-0.0.6"
+      sources."unicode-canonical-property-names-ecmascript-1.0.4"
+      sources."unicode-match-property-ecmascript-1.0.4"
+      sources."unicode-match-property-value-ecmascript-1.1.0"
+      sources."unicode-property-aliases-ecmascript-1.0.5"
+      sources."union-value-1.0.1"
+      sources."unique-filename-1.1.1"
+      sources."unique-slug-2.0.2"
+      (sources."unset-value-1.0.0" // {
+        dependencies = [
+          (sources."has-value-0.3.1" // {
+            dependencies = [
+              sources."isobject-2.1.0"
+            ];
+          })
+          sources."has-values-0.1.4"
+        ];
+      })
+      sources."upath-1.2.0"
+      sources."uri-js-4.2.2"
+      sources."urix-0.1.0"
+      (sources."url-0.11.0" // {
+        dependencies = [
+          sources."punycode-1.3.2"
+        ];
+      })
+      sources."use-3.1.1"
+      (sources."util-0.11.1" // {
+        dependencies = [
+          sources."inherits-2.0.3"
+        ];
+      })
+      sources."util-deprecate-1.0.2"
+      sources."v8-compile-cache-2.0.3"
+      sources."vm-browserify-1.1.2"
+      sources."watchpack-1.6.0"
+      (sources."webpack-4.41.2" // {
+        dependencies = [
+          sources."memory-fs-0.4.1"
+        ];
+      })
+      (sources."webpack-cli-3.3.10" // {
+        dependencies = [
+          sources."enhanced-resolve-4.1.0"
+          sources."memory-fs-0.4.1"
+          sources."supports-color-6.1.0"
+        ];
+      })
+      (sources."webpack-sources-1.4.3" // {
+        dependencies = [
+          sources."source-map-0.6.1"
+        ];
+      })
+      sources."whatwg-fetch-3.0.0"
+      sources."which-1.3.1"
+      sources."which-module-2.0.0"
+      sources."worker-farm-1.7.0"
+      sources."wrap-ansi-5.1.0"
+      sources."wrappy-1.0.2"
+      sources."xtend-4.0.2"
+      sources."y18n-4.0.0"
+      sources."yallist-3.1.1"
+      sources."yargs-13.2.4"
+      sources."yargs-parser-13.1.1"
+      sources."yn-3.1.1"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Render BibTeX citations";
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
   clean-css = nodeEnv.buildNodePackage {
     name = "clean-css";
     packageName = "clean-css";
@@ -48376,7 +49585,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.12.5"
+      sources."@types/node-12.12.7"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       sources."ajv-6.10.2"
@@ -48409,7 +49618,7 @@ in
       })
       sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
-      sources."big-integer-1.6.47"
+      sources."big-integer-1.6.48"
       (sources."body-parser-1.19.0" // {
         dependencies = [
           sources."bytes-3.1.0"
@@ -48470,7 +49679,7 @@ in
       sources."cookie-signature-1.0.6"
       sources."copy-descriptor-0.1.1"
       sources."cordova-app-hello-world-4.0.0"
-      sources."cordova-common-3.2.0"
+      sources."cordova-common-3.2.1"
       (sources."cordova-create-2.0.0" // {
         dependencies = [
           sources."fs-extra-7.0.1"
@@ -48523,7 +49732,7 @@ in
       sources."endent-1.3.0"
       sources."env-paths-1.0.0"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."etag-1.8.1"
@@ -48586,7 +49795,7 @@ in
       sources."get-stream-4.1.0"
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -48974,7 +50183,7 @@ in
       sources."which-1.3.1"
       sources."widest-line-2.0.1"
       sources."windows-release-3.2.0"
-      (sources."with-open-file-0.1.6" // {
+      (sources."with-open-file-0.1.7" // {
         dependencies = [
           sources."pify-4.0.1"
         ];
@@ -49010,7 +50219,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.12.5"
+      sources."@types/node-12.12.7"
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
       sources."arr-union-3.1.0"
@@ -49112,7 +50321,7 @@ in
       sources."fragment-cache-0.2.1"
       sources."fs.realpath-1.0.0"
       sources."get-value-2.0.6"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -49338,7 +50547,7 @@ in
       sources."@cycle/run-3.4.0"
       sources."@cycle/time-0.10.1"
       sources."@types/cookiejar-2.1.1"
-      sources."@types/node-12.12.5"
+      sources."@types/node-12.12.7"
       sources."@types/superagent-3.8.2"
       sources."ansi-escapes-3.2.0"
       sources."ansi-regex-2.1.1"
@@ -49378,7 +50587,7 @@ in
       sources."es6-symbol-3.1.3"
       sources."escape-string-regexp-1.0.5"
       sources."event-emitter-0.3.5"
-      (sources."ext-1.1.2" // {
+      (sources."ext-1.2.0" // {
         dependencies = [
           sources."type-2.0.0"
         ];
@@ -49426,7 +50635,7 @@ in
       sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.1"
       sources."pseudomap-1.0.2"
-      sources."qs-6.9.0"
+      sources."qs-6.9.1"
       sources."quicktask-1.1.0"
       sources."raf-3.3.2"
       sources."readable-stream-2.3.6"
@@ -49518,7 +50727,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."fstream-1.0.12"
       sources."fstream-ignore-1.0.5"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
       sources."hyperquest-2.1.3"
@@ -49851,7 +51060,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."end-of-stream-1.4.4"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."execa-0.7.0"
       (sources."expand-brackets-2.1.4" // {
@@ -49911,7 +51120,7 @@ in
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."global-4.3.2"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
@@ -50049,7 +51258,7 @@ in
       sources."nan-2.14.0"
       sources."nanoassert-1.1.0"
       sources."nanobus-4.4.0"
-      sources."nanoguard-1.2.1"
+      sources."nanoguard-1.2.2"
       sources."nanomatch-1.2.13"
       sources."nanoscheduler-1.0.3"
       sources."nanotiming-7.3.1"
@@ -50078,7 +51287,7 @@ in
           sources."kind-of-3.2.2"
         ];
       })
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
       sources."object.pick-1.3.0"
@@ -50566,12 +51775,12 @@ in
       sources."assert-plus-1.0.0"
       sources."async-2.6.3"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.563.0"
+      sources."aws-sdk-2.569.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
-      sources."buffer-4.9.1"
+      sources."buffer-4.9.2"
       sources."buffer-queue-1.0.0"
       sources."bytes-3.1.0"
       sources."caseless-0.12.0"
@@ -50579,10 +51788,13 @@ in
       sources."core-util-is-1.0.2"
       sources."dashdash-1.14.1"
       sources."decimal.js-10.2.0"
+      sources."define-properties-1.1.3"
       sources."delay-4.3.0"
       sources."delayed-stream-1.0.0"
       sources."ecc-jsbn-0.1.2"
       sources."end-of-stream-1.4.4"
+      sources."es-abstract-1.16.0"
+      sources."es-to-primitive-1.2.1"
       sources."eventemitter3-4.0.0"
       sources."events-1.1.1"
       sources."extend-3.0.2"
@@ -50591,9 +51803,12 @@ in
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
+      sources."function-bind-1.1.1"
       sources."getpass-0.1.7"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
+      sources."has-1.0.3"
+      sources."has-symbols-1.0.0"
       sources."http-signature-1.2.0"
       sources."ieee754-1.1.13"
       sources."inherits-2.0.4"
@@ -50603,6 +51818,10 @@ in
           sources."jsbn-1.1.0"
         ];
       })
+      sources."is-callable-1.1.4"
+      sources."is-date-object-1.0.1"
+      sources."is-regex-1.0.4"
+      sources."is-symbol-1.0.2"
       sources."is-typedarray-1.0.0"
       sources."isarray-1.0.0"
       sources."isstream-0.1.2"
@@ -50619,10 +51838,13 @@ in
       sources."mime-types-2.1.24"
       sources."minimist-0.0.10"
       sources."oauth-sign-0.9.0"
+      sources."object-inspect-1.7.0"
+      sources."object-keys-1.1.1"
+      sources."object.getownpropertydescriptors-2.0.3"
       sources."once-1.4.0"
       sources."optimist-0.6.1"
       sources."p-finally-1.0.0"
-      sources."p-queue-6.2.0"
+      sources."p-queue-6.2.1"
       sources."p-timeout-3.2.0"
       sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.1"
@@ -50647,12 +51869,14 @@ in
       })
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
-      sources."sax-1.2.1"
+      sources."sax-1.2.4"
       sources."socks5-client-1.2.8"
       sources."socks5-http-client-1.0.4"
       sources."socks5-https-client-1.2.1"
       sources."sprintf-js-1.1.2"
       sources."sshpk-1.16.1"
+      sources."string.prototype.trimleft-2.1.0"
+      sources."string.prototype.trimright-2.1.0"
       (sources."string_decoder-1.1.1" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
@@ -50673,13 +51897,14 @@ in
       })
       sources."url-0.10.3"
       sources."util-deprecate-1.0.2"
-      sources."uuid-3.3.2"
+      sources."util.promisify-1.0.0"
+      sources."uuid-3.3.3"
       sources."verror-1.10.0"
       sources."when-3.7.8"
       sources."wordwrap-0.0.3"
       sources."wrappy-1.0.2"
-      sources."xml2js-0.4.19"
-      sources."xmlbuilder-9.0.7"
+      sources."xml2js-0.4.22"
+      sources."xmlbuilder-11.0.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -50761,7 +51986,7 @@ in
       sources."color-name-1.1.3"
       sources."concat-map-0.0.1"
       sources."conf-1.4.0"
-      (sources."convert-source-map-1.6.0" // {
+      (sources."convert-source-map-1.7.0" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
         ];
@@ -50983,7 +52208,7 @@ in
       sources."acorn-jsx-5.1.0"
       sources."ajv-6.10.2"
       sources."ansi-escapes-4.2.1"
-      sources."ansi-regex-4.1.0"
+      sources."ansi-regex-5.0.0"
       sources."ansi-styles-3.2.1"
       sources."argparse-1.0.10"
       sources."astral-regex-1.0.0"
@@ -51026,7 +52251,7 @@ in
       sources."flatted-2.0.1"
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."glob-parent-5.1.0"
       sources."globals-11.12.0"
       sources."has-flag-3.0.0"
@@ -51058,7 +52283,7 @@ in
       sources."nice-try-1.0.5"
       sources."once-1.4.0"
       sources."onetime-5.1.0"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."os-tmpdir-1.0.2"
       sources."parent-module-1.0.1"
       sources."path-is-absolute-1.0.1"
@@ -51083,8 +52308,16 @@ in
         ];
       })
       sources."sprintf-js-1.0.3"
-      sources."string-width-4.1.0"
-      sources."strip-ansi-5.2.0"
+      (sources."string-width-4.2.0" // {
+        dependencies = [
+          sources."strip-ansi-6.0.0"
+        ];
+      })
+      (sources."strip-ansi-5.2.0" // {
+        dependencies = [
+          sources."ansi-regex-4.1.0"
+        ];
+      })
       sources."strip-json-comments-3.0.1"
       sources."supports-color-5.5.0"
       (sources."table-5.4.6" // {
@@ -51103,7 +52336,7 @@ in
       sources."uri-js-4.2.2"
       sources."v8-compile-cache-2.1.0"
       sources."which-1.3.1"
-      sources."wordwrap-1.0.0"
+      sources."word-wrap-1.2.3"
       sources."wrappy-1.0.2"
       sources."write-1.0.3"
     ];
@@ -51132,7 +52365,7 @@ in
       sources."acorn-jsx-5.1.0"
       sources."ajv-6.10.2"
       sources."ansi-escapes-4.2.1"
-      sources."ansi-regex-4.1.0"
+      sources."ansi-regex-5.0.0"
       sources."ansi-styles-3.2.1"
       sources."argparse-1.0.10"
       sources."astral-regex-1.0.0"
@@ -51177,7 +52410,7 @@ in
       sources."flatted-2.0.1"
       sources."fs.realpath-1.0.0"
       sources."functional-red-black-tree-1.0.1"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."glob-parent-5.1.0"
       sources."globals-11.12.0"
       sources."has-flag-3.0.0"
@@ -51210,7 +52443,7 @@ in
       sources."nice-try-1.0.5"
       sources."once-1.4.0"
       sources."onetime-5.1.0"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."os-tmpdir-1.0.2"
       sources."parent-module-1.0.1"
       sources."path-is-absolute-1.0.1"
@@ -51237,8 +52470,16 @@ in
         ];
       })
       sources."sprintf-js-1.0.3"
-      sources."string-width-4.1.0"
-      sources."strip-ansi-5.2.0"
+      (sources."string-width-4.2.0" // {
+        dependencies = [
+          sources."strip-ansi-6.0.0"
+        ];
+      })
+      (sources."strip-ansi-5.2.0" // {
+        dependencies = [
+          sources."ansi-regex-4.1.0"
+        ];
+      })
       sources."strip-json-comments-3.0.1"
       sources."supports-color-5.5.0"
       (sources."table-5.4.6" // {
@@ -51257,7 +52498,7 @@ in
       sources."uri-js-4.2.2"
       sources."v8-compile-cache-2.1.0"
       sources."which-1.3.1"
-      sources."wordwrap-1.0.0"
+      sources."word-wrap-1.2.3"
       sources."wrappy-1.0.2"
       sources."write-1.0.3"
     ];
@@ -51767,7 +53008,7 @@ in
       sources."fsevents-1.2.9"
       sources."function-bind-1.1.1"
       sources."get-value-2.0.6"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
       sources."graceful-fs-4.2.3"
@@ -52247,8 +53488,8 @@ in
       sources."semver-5.7.1"
       sources."separator-escape-0.0.0"
       sources."sha.js-2.4.5"
-      sources."smart-buffer-4.0.2"
-      sources."socks-2.3.2"
+      sources."smart-buffer-4.1.0"
+      sources."socks-2.3.3"
       sources."sodium-browserify-1.3.0"
       (sources."sodium-browserify-tweetnacl-0.2.6" // {
         dependencies = [
@@ -52329,151 +53570,219 @@ in
   gitmoji-cli = nodeEnv.buildNodePackage {
     name = "gitmoji-cli";
     packageName = "gitmoji-cli";
-    version = "2.2.0";
+    version = "3.0.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/gitmoji-cli/-/gitmoji-cli-2.2.0.tgz";
-      sha512 = "1eYIuRcKtKtnktW/4D0043qMW2Q1iIv90q+gWsStW3i9Uo6hEC8wWjmHu9047pNvcmYEeK7XuPrYzFvq+FfVyw==";
+      url = "https://registry.npmjs.org/gitmoji-cli/-/gitmoji-cli-3.0.0.tgz";
+      sha512 = "eRb/bUvC5E5TXSD0/A6DJffPP+g7gcpn572XhC/sQnWW0B3fopeegldE++pM2bfKuUGGsObRThsbuU5NqR8P9Q==";
     };
     dependencies = [
-      sources."ansi-align-2.0.0"
-      sources."ansi-escapes-3.2.0"
-      sources."ansi-regex-3.0.0"
+      sources."@sindresorhus/is-0.14.0"
+      sources."@szmarczak/http-timer-1.1.2"
+      sources."ajv-6.10.2"
+      (sources."ansi-align-3.0.0" // {
+        dependencies = [
+          sources."emoji-regex-7.0.3"
+          sources."is-fullwidth-code-point-2.0.0"
+          sources."string-width-3.1.0"
+        ];
+      })
+      sources."ansi-escapes-4.2.1"
+      sources."ansi-regex-5.0.0"
       sources."ansi-styles-3.2.1"
       sources."array-find-index-1.0.2"
       sources."arrify-1.0.1"
-      sources."axios-0.18.1"
-      sources."boxen-1.3.0"
+      (sources."boxen-3.2.0" // {
+        dependencies = [
+          sources."camelcase-5.3.1"
+          sources."emoji-regex-7.0.3"
+          sources."is-fullwidth-code-point-2.0.0"
+          sources."string-width-3.1.0"
+          sources."type-fest-0.3.1"
+        ];
+      })
+      (sources."cacheable-request-6.1.0" // {
+        dependencies = [
+          sources."lowercase-keys-2.0.0"
+        ];
+      })
       sources."camelcase-4.1.0"
       sources."camelcase-keys-4.2.0"
-      sources."capture-stack-trace-1.0.1"
       sources."chalk-2.4.2"
       sources."chardet-0.7.0"
-      sources."ci-info-1.6.0"
-      sources."cli-boxes-1.0.0"
-      sources."cli-cursor-2.1.0"
+      sources."ci-info-2.0.0"
+      sources."cli-boxes-2.2.0"
+      sources."cli-cursor-3.1.0"
+      sources."cli-spinners-2.2.0"
       sources."cli-width-2.2.0"
+      sources."clone-1.0.4"
+      sources."clone-response-1.0.2"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
-      sources."conf-2.2.0"
-      sources."configstore-3.1.2"
-      sources."create-error-class-3.0.2"
-      sources."cross-spawn-6.0.5"
+      sources."conf-6.2.0"
+      (sources."configstore-4.0.0" // {
+        dependencies = [
+          sources."dot-prop-4.2.0"
+          sources."is-obj-1.0.1"
+          sources."make-dir-1.3.0"
+          sources."write-file-atomic-2.4.3"
+        ];
+      })
+      sources."cross-spawn-7.0.1"
       sources."crypto-random-string-1.0.0"
       sources."currently-unhandled-0.4.1"
-      sources."debug-3.1.0"
+      sources."debounce-fn-3.0.1"
       sources."decamelize-1.2.0"
       (sources."decamelize-keys-1.1.0" // {
         dependencies = [
           sources."map-obj-1.0.1"
         ];
       })
+      sources."decompress-response-3.3.0"
       sources."deep-extend-0.6.0"
-      sources."dot-prop-4.2.0"
+      sources."defaults-1.0.3"
+      sources."defer-to-connect-1.1.0"
+      sources."dot-prop-5.2.0"
       sources."duplexer3-0.1.4"
+      sources."emoji-regex-8.0.0"
       sources."end-of-stream-1.4.4"
-      sources."env-paths-1.0.0"
+      sources."env-paths-2.2.0"
       sources."error-ex-1.3.2"
       sources."escape-string-regexp-1.0.5"
-      sources."execa-1.0.0"
+      sources."execa-3.3.0"
       sources."external-editor-3.1.0"
-      sources."figures-2.0.0"
-      sources."find-up-2.1.0"
-      sources."follow-redirects-1.5.10"
-      sources."get-stream-4.1.0"
+      sources."fast-deep-equal-2.0.1"
+      sources."fast-json-stable-stringify-2.0.0"
+      sources."figures-3.1.0"
+      sources."find-up-3.0.0"
+      sources."get-stream-5.1.0"
       sources."global-dirs-0.1.1"
-      (sources."got-6.7.1" // {
+      (sources."got-9.6.0" // {
         dependencies = [
-          sources."get-stream-3.0.0"
+          sources."get-stream-4.1.0"
         ];
       })
       sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
+      sources."has-yarn-2.1.0"
       sources."hosted-git-info-2.8.5"
+      sources."http-cache-semantics-4.0.3"
+      sources."human-signals-1.1.1"
       sources."iconv-lite-0.4.24"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
       sources."indent-string-3.2.0"
       sources."ini-1.3.5"
-      sources."inquirer-6.5.2"
-      sources."inquirer-autocomplete-prompt-1.0.1"
+      sources."inquirer-7.0.0"
+      (sources."inquirer-autocomplete-prompt-1.0.1" // {
+        dependencies = [
+          sources."ansi-escapes-3.2.0"
+          sources."figures-2.0.0"
+        ];
+      })
       sources."is-arrayish-0.2.1"
-      sources."is-buffer-2.0.4"
-      sources."is-ci-1.2.1"
-      sources."is-fullwidth-code-point-2.0.0"
+      sources."is-ci-2.0.0"
+      sources."is-fullwidth-code-point-3.0.0"
       sources."is-installed-globally-0.1.0"
-      sources."is-npm-1.0.0"
-      sources."is-obj-1.0.1"
+      sources."is-interactive-1.0.0"
+      sources."is-npm-3.0.0"
+      sources."is-obj-2.0.0"
       sources."is-path-inside-1.0.1"
       sources."is-plain-obj-1.1.0"
       sources."is-promise-2.1.0"
-      sources."is-redirect-1.0.0"
-      sources."is-retry-allowed-1.2.0"
-      sources."is-stream-1.1.0"
+      sources."is-stream-2.0.0"
+      sources."is-typedarray-1.0.0"
+      sources."is-yarn-global-0.3.0"
       sources."isexe-2.0.0"
+      sources."json-buffer-3.0.0"
       sources."json-parse-better-errors-1.0.2"
-      sources."latest-version-3.1.0"
+      sources."json-schema-traverse-0.4.1"
+      sources."json-schema-typed-7.0.2"
+      sources."keyv-3.1.0"
+      sources."latest-version-5.1.0"
       sources."load-json-file-4.0.0"
-      sources."locate-path-2.0.0"
+      sources."locate-path-3.0.0"
       sources."lodash-4.17.15"
+      sources."log-symbols-3.0.0"
       sources."loud-rejection-1.6.0"
       sources."lowercase-keys-1.0.1"
       sources."lru-cache-4.1.5"
-      sources."make-dir-1.3.0"
+      sources."make-dir-3.0.0"
       sources."map-obj-2.0.0"
       sources."meow-5.0.0"
-      sources."mimic-fn-1.2.0"
+      sources."merge-stream-2.0.0"
+      sources."mimic-fn-2.1.0"
+      sources."mimic-response-1.0.1"
       sources."minimist-1.2.0"
       sources."minimist-options-3.0.2"
-      sources."ms-2.0.0"
-      sources."mute-stream-0.0.7"
-      sources."nice-try-1.0.5"
-      sources."normalize-package-data-2.5.0"
-      sources."npm-run-path-2.0.2"
+      sources."mute-stream-0.0.8"
+      sources."node-fetch-2.6.0"
+      (sources."normalize-package-data-2.5.0" // {
+        dependencies = [
+          sources."semver-5.7.1"
+        ];
+      })
+      sources."normalize-url-4.5.0"
+      sources."npm-run-path-4.0.0"
       sources."once-1.4.0"
-      sources."onetime-2.0.1"
+      sources."onetime-5.1.0"
+      sources."ora-4.0.2"
       sources."os-tmpdir-1.0.2"
-      sources."p-finally-1.0.0"
-      sources."p-limit-1.3.0"
-      sources."p-locate-2.0.0"
-      sources."p-try-1.0.0"
-      sources."package-json-4.0.1"
-      sources."parent-dirs-1.0.0"
+      sources."p-cancelable-1.1.0"
+      sources."p-finally-2.0.1"
+      sources."p-limit-2.2.1"
+      sources."p-locate-3.0.0"
+      sources."p-try-2.2.0"
+      sources."package-json-6.5.0"
       sources."parse-json-4.0.0"
       sources."path-exists-3.0.0"
       sources."path-is-inside-1.0.2"
-      sources."path-key-2.0.1"
+      sources."path-key-3.1.0"
       sources."path-parse-1.0.6"
       sources."path-type-3.0.0"
       sources."pify-3.0.0"
-      sources."pkg-up-2.0.0"
-      sources."prepend-http-1.0.4"
+      sources."pkg-up-3.1.0"
+      sources."prepend-http-2.0.0"
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
+      sources."punycode-2.1.1"
       sources."quick-lru-1.1.0"
       sources."rc-1.2.8"
       sources."read-pkg-3.0.0"
-      sources."read-pkg-up-3.0.0"
+      (sources."read-pkg-up-3.0.0" // {
+        dependencies = [
+          sources."find-up-2.1.0"
+          sources."locate-path-2.0.0"
+          sources."p-limit-1.3.0"
+          sources."p-locate-2.0.0"
+          sources."p-try-1.0.0"
+        ];
+      })
       sources."redent-2.0.0"
-      sources."registry-auth-token-3.4.0"
-      sources."registry-url-3.1.0"
+      sources."registry-auth-token-4.0.0"
+      sources."registry-url-5.1.0"
       sources."resolve-1.12.0"
-      sources."restore-cursor-2.0.0"
+      sources."responselike-1.0.2"
+      sources."restore-cursor-3.1.0"
       sources."run-async-2.3.0"
       sources."rxjs-6.5.3"
       sources."safe-buffer-5.2.0"
       sources."safer-buffer-2.1.2"
-      sources."semver-5.7.1"
-      sources."semver-diff-2.1.0"
-      sources."shebang-command-1.2.0"
-      sources."shebang-regex-1.0.0"
+      sources."semver-6.3.0"
+      (sources."semver-diff-2.1.0" // {
+        dependencies = [
+          sources."semver-5.7.1"
+        ];
+      })
+      sources."shebang-command-2.0.0"
+      sources."shebang-regex-3.0.0"
       sources."signal-exit-3.0.2"
       sources."spdx-correct-3.1.0"
       sources."spdx-exceptions-2.2.0"
       sources."spdx-expression-parse-3.0.0"
       sources."spdx-license-ids-3.0.5"
-      (sources."string-width-2.1.1" // {
+      (sources."string-width-4.2.0" // {
         dependencies = [
-          sources."strip-ansi-4.0.0"
+          sources."strip-ansi-6.0.0"
         ];
       })
       (sources."strip-ansi-5.2.0" // {
@@ -52483,6 +53792,7 @@ in
       })
       sources."strip-bom-3.0.0"
       sources."strip-eof-1.0.0"
+      sources."strip-final-newline-2.0.0"
       sources."strip-indent-2.0.0"
       sources."strip-json-comments-2.0.1"
       sources."supports-color-5.5.0"
@@ -52491,22 +53801,39 @@ in
           sources."cross-spawn-5.1.0"
           sources."execa-0.7.0"
           sources."get-stream-3.0.0"
+          sources."is-stream-1.1.0"
+          sources."npm-run-path-2.0.2"
+          sources."p-finally-1.0.0"
+          sources."path-key-2.0.1"
+          sources."shebang-command-1.2.0"
+          sources."shebang-regex-1.0.0"
+          sources."which-1.3.1"
         ];
       })
       sources."through-2.3.8"
-      sources."timed-out-4.0.1"
       sources."tmp-0.0.33"
+      sources."to-readable-stream-1.0.0"
       sources."trim-newlines-2.0.0"
       sources."tslib-1.10.0"
+      sources."type-fest-0.5.2"
+      sources."typedarray-to-buffer-3.1.5"
       sources."unique-string-1.0.0"
-      sources."unzip-response-2.0.1"
-      sources."update-notifier-2.5.0"
-      sources."url-parse-lax-1.0.0"
+      sources."update-notifier-3.0.1"
+      sources."uri-js-4.2.2"
+      sources."url-parse-lax-3.0.0"
       sources."validate-npm-package-license-3.0.4"
-      sources."which-1.3.1"
-      sources."widest-line-2.0.1"
+      sources."wcwidth-1.0.1"
+      sources."which-2.0.1"
+      (sources."widest-line-2.0.1" // {
+        dependencies = [
+          sources."ansi-regex-3.0.0"
+          sources."is-fullwidth-code-point-2.0.0"
+          sources."string-width-2.1.1"
+          sources."strip-ansi-4.0.0"
+        ];
+      })
       sources."wrappy-1.0.2"
-      sources."write-file-atomic-2.4.3"
+      sources."write-file-atomic-3.0.1"
       sources."xdg-basedir-3.0.0"
       sources."yallist-2.1.2"
       sources."yargs-parser-10.1.0"
@@ -52662,12 +53989,20 @@ in
       sources."create-error-class-3.0.2"
       (sources."creato-1.1.0" // {
         dependencies = [
-          sources."ansi-regex-4.1.0"
+          sources."ansi-regex-5.0.0"
           sources."inquirer-7.0.0"
           sources."is-fullwidth-code-point-3.0.0"
           sources."ora-4.0.2"
-          sources."string-width-4.1.0"
-          sources."strip-ansi-5.2.0"
+          (sources."string-width-4.2.0" // {
+            dependencies = [
+              sources."strip-ansi-6.0.0"
+            ];
+          })
+          (sources."strip-ansi-5.2.0" // {
+            dependencies = [
+              sources."ansi-regex-4.1.0"
+            ];
+          })
           sources."update-notifier-3.0.1"
         ];
       })
@@ -52740,7 +54075,7 @@ in
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
-          sources."path-to-regexp-1.7.0"
+          sources."path-to-regexp-1.8.0"
         ];
       })
       sources."extend-3.0.2"
@@ -52767,7 +54102,7 @@ in
       sources."get-caller-file-1.0.3"
       sources."get-stream-3.0.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."global-dirs-0.1.1"
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
@@ -53554,7 +54889,7 @@ in
       sources."drawille-blessed-contrib-1.0.0"
       sources."drawille-canvas-blessed-contrib-0.1.3"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-3.0.0"
       (sources."event-stream-0.9.8" // {
@@ -53584,7 +54919,7 @@ in
       sources."memorystream-0.3.1"
       sources."node-emoji-1.10.0"
       sources."nopt-2.1.2"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object.getownpropertydescriptors-2.0.3"
       sources."optimist-0.3.7"
@@ -53599,7 +54934,7 @@ in
       sources."string_decoder-0.10.31"
       sources."strip-ansi-3.0.1"
       sources."supports-color-2.0.0"
-      sources."systeminformation-4.14.17"
+      sources."systeminformation-4.15.3"
       sources."term-canvas-0.0.5"
       sources."util.promisify-1.0.0"
       sources."wordwrap-0.0.3"
@@ -53713,7 +55048,7 @@ in
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
-      sources."convert-source-map-1.6.0"
+      sources."convert-source-map-1.7.0"
       sources."copy-descriptor-0.1.1"
       sources."copy-props-2.0.4"
       sources."core-util-is-1.0.2"
@@ -53757,7 +55092,7 @@ in
         ];
       })
       sources."expand-tilde-2.0.2"
-      (sources."ext-1.1.2" // {
+      (sources."ext-1.2.0" // {
         dependencies = [
           sources."type-2.0.0"
         ];
@@ -53794,7 +55129,7 @@ in
       sources."function-bind-1.1.1"
       sources."get-caller-file-1.0.3"
       sources."get-value-2.0.6"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -54152,7 +55487,7 @@ in
         ];
       })
       sources."expand-tilde-2.0.2"
-      (sources."ext-1.1.2" // {
+      (sources."ext-1.2.0" // {
         dependencies = [
           sources."type-2.0.0"
         ];
@@ -54438,7 +55773,7 @@ in
       sources."param-case-2.1.1"
       sources."relateurl-0.2.7"
       sources."source-map-0.6.1"
-      sources."uglify-js-3.6.7"
+      sources."uglify-js-3.6.8"
       sources."upper-case-1.1.3"
     ];
     buildInputs = globalBuildInputs;
@@ -54483,7 +55818,7 @@ in
       sources."dashdash-1.14.1"
       sources."date-now-0.1.4"
       sources."delayed-stream-1.0.0"
-      (sources."dom-serializer-0.2.1" // {
+      (sources."dom-serializer-0.2.2" // {
         dependencies = [
           sources."domelementtype-2.0.1"
           sources."entities-2.0.0"
@@ -54519,7 +55854,7 @@ in
       sources."isarray-0.0.1"
       sources."isstream-0.1.2"
       sources."jsbn-0.1.1"
-      (sources."jshint-2.10.2" // {
+      (sources."jshint-2.10.3" // {
         dependencies = [
           sources."strip-json-comments-1.0.4"
         ];
@@ -54648,7 +55983,7 @@ in
       sources."extsprintf-1.4.0"
       sources."fs.realpath-1.0.0"
       sources."fuzzyset.js-0.0.1"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."hue-sdk-0.1.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -54789,9 +56124,10 @@ in
       sources."@ionic/utils-stream-2.0.4"
       sources."@ionic/utils-subprocess-1.0.9"
       sources."@ionic/utils-terminal-1.0.5"
+      sources."@types/color-name-1.1.1"
       sources."agent-base-4.3.0"
       sources."ansi-escapes-3.2.0"
-      sources."ansi-regex-4.1.0"
+      sources."ansi-regex-5.0.0"
       sources."ansi-styles-3.2.1"
       sources."ast-types-0.13.2"
       sources."astral-regex-1.0.0"
@@ -54875,7 +56211,7 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."has-flag-3.0.0"
       sources."http-errors-1.7.3"
@@ -54965,7 +56301,7 @@ in
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."open-7.0.0"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."os-name-3.1.0"
       sources."os-tmpdir-1.0.2"
       sources."p-finally-1.0.0"
@@ -54978,7 +56314,7 @@ in
       sources."proxy-agent-3.1.1"
       sources."proxy-from-env-1.0.0"
       sources."pump-3.0.0"
-      sources."qs-6.9.0"
+      sources."qs-6.9.1"
       sources."raw-body-2.4.1"
       sources."readable-stream-3.4.0"
       sources."restore-cursor-2.0.0"
@@ -54995,8 +56331,8 @@ in
       sources."shebang-regex-3.0.0"
       sources."signal-exit-3.0.2"
       sources."slice-ansi-2.1.0"
-      sources."smart-buffer-4.0.2"
-      sources."socks-2.3.2"
+      sources."smart-buffer-4.1.0"
+      sources."socks-2.3.3"
       (sources."socks-proxy-agent-4.0.2" // {
         dependencies = [
           sources."agent-base-4.2.1"
@@ -55013,14 +56349,19 @@ in
           sources."string_decoder-1.1.1"
         ];
       })
-      (sources."string-width-4.1.0" // {
+      (sources."string-width-4.2.0" // {
         dependencies = [
           sources."emoji-regex-8.0.0"
           sources."is-fullwidth-code-point-3.0.0"
+          sources."strip-ansi-6.0.0"
         ];
       })
       sources."string_decoder-1.3.0"
-      sources."strip-ansi-5.2.0"
+      (sources."strip-ansi-5.2.0" // {
+        dependencies = [
+          sources."ansi-regex-4.1.0"
+        ];
+      })
       sources."strip-eof-1.0.0"
       sources."superagent-4.1.0"
       (sources."superagent-proxy-2.0.0" // {
@@ -55047,12 +56388,13 @@ in
       sources."uuid-3.3.3"
       sources."which-2.0.1"
       sources."windows-release-3.2.0"
-      sources."wordwrap-1.0.0"
-      (sources."wrap-ansi-6.1.0" // {
+      sources."word-wrap-1.2.3"
+      (sources."wrap-ansi-6.2.0" // {
         dependencies = [
-          sources."ansi-styles-4.1.0"
+          sources."ansi-styles-4.2.0"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
+          sources."strip-ansi-6.0.0"
         ];
       })
       sources."wrappy-1.0.2"
@@ -55173,7 +56515,6 @@ in
           sources."levn-0.2.5"
           sources."optionator-0.3.0"
           sources."source-map-0.1.43"
-          sources."wordwrap-0.0.3"
         ];
       })
       sources."esprima-3.1.3"
@@ -55211,7 +56552,7 @@ in
       sources."get-caller-file-1.0.3"
       sources."get-stream-3.0.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -55273,7 +56614,7 @@ in
       sources."object-assign-4.1.1"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."os-homedir-1.0.2"
       sources."os-locale-2.1.0"
       sources."os-tmpdir-1.0.2"
@@ -55429,7 +56770,8 @@ in
       sources."which-1.3.1"
       sources."which-module-2.0.0"
       sources."wide-align-1.1.3"
-      sources."wordwrap-1.0.0"
+      sources."word-wrap-1.2.3"
+      sources."wordwrap-0.0.3"
       (sources."wrap-ansi-2.1.0" // {
         dependencies = [
           sources."string-width-1.0.2"
@@ -55472,10 +56814,10 @@ in
   jake = nodeEnv.buildNodePackage {
     name = "jake";
     packageName = "jake";
-    version = "10.1.6";
+    version = "10.3.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/jake/-/jake-10.1.6.tgz";
-      sha512 = "gGnRHch3G461ryAnrBEeepuoyBHtqOfskwTWJntwF9hfzhe5kfcYbIpZKqFDniBWkyoUqktigvoTn+tysnjJdg==";
+      url = "https://registry.npmjs.org/jake/-/jake-10.3.1.tgz";
+      sha512 = "//GIzuTPZOAyvwf8U+/xjbzkNu+QMXoW0k3p1bPlbq43kGZD0WDJO9uhTDQ0mX6I+Sct4Is7TdvmSAqX2mrR/g==";
     };
     dependencies = [
       sources."ansi-styles-3.2.1"
@@ -55538,7 +56880,7 @@ in
       sources."fast-json-patch-2.2.1"
       sources."fs.realpath-1.0.0"
       sources."get-func-name-2.0.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."has-flag-3.0.0"
       sources."hexer-1.5.0"
       sources."inflight-1.0.6"
@@ -55596,10 +56938,10 @@ in
   joplin = nodeEnv.buildNodePackage {
     name = "joplin";
     packageName = "joplin";
-    version = "1.0.149";
+    version = "1.0.150";
     src = fetchurl {
-      url = "https://registry.npmjs.org/joplin/-/joplin-1.0.149.tgz";
-      sha512 = "DDMvPmNgsp3yQtwsIvxeCrE5MByDaUojKGfFH4vYTAbboO7jB34rwknwW3efVoOjQVtLmMH6OpBajArci9q8tQ==";
+      url = "https://registry.npmjs.org/joplin/-/joplin-1.0.150.tgz";
+      sha512 = "CVQp6OFc3pJOnjjQHcRwQZ5HMh25xtVZTgLvzW+UyamtlkRVCqvw1tp7yitSxIC9AjhTIS4kBPzsC32XWm7lew==";
     };
     dependencies = [
       sources."@cronvel/get-pixels-3.3.1"
@@ -55699,7 +57041,7 @@ in
       sources."detect-libc-1.0.3"
       sources."diacritics-1.3.0"
       sources."diff-match-patch-1.0.4"
-      (sources."dom-serializer-0.2.1" // {
+      (sources."dom-serializer-0.2.2" // {
         dependencies = [
           sources."domelementtype-2.0.1"
           sources."entities-2.0.0"
@@ -55722,7 +57064,7 @@ in
       sources."end-of-stream-1.4.4"
       sources."entities-1.1.2"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."es6-promise-pool-2.5.0"
       sources."escape-string-regexp-1.0.5"
       sources."escodegen-1.12.0"
@@ -55747,9 +57089,8 @@ in
       sources."form-data-2.5.1"
       sources."format-0.2.2"
       sources."fs-constants-1.0.0"
-      sources."fs-copy-file-sync-1.1.1"
       sources."fs-extra-5.0.0"
-      sources."fs-minipass-1.2.7"
+      sources."fs-minipass-2.0.0"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       (sources."gauge-2.7.4" // {
@@ -55761,7 +57102,7 @@ in
       sources."get-stdin-5.0.1"
       sources."getpass-0.1.7"
       sources."github-from-package-0.0.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -55838,7 +57179,7 @@ in
       sources."isarray-1.0.0"
       sources."isexe-2.0.0"
       sources."isstream-0.1.2"
-      sources."joplin-turndown-4.0.18"
+      sources."joplin-turndown-4.0.19"
       sources."joplin-turndown-plugin-gfm-1.0.11"
       sources."jpeg-js-0.1.2"
       sources."js-tokens-4.0.0"
@@ -55875,8 +57216,8 @@ in
       sources."mimic-response-2.0.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      sources."minipass-2.9.0"
-      sources."minizlib-1.3.3"
+      sources."minipass-3.1.1"
+      sources."minizlib-2.1.0"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
           sources."minimist-0.0.8"
@@ -55919,7 +57260,7 @@ in
       sources."nwsapi-2.2.0"
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       (sources."object-to-arguments-0.0.8" // {
         dependencies = [
@@ -55930,7 +57271,7 @@ in
       sources."object.getownpropertydescriptors-2.0.3"
       sources."omggif-1.0.10"
       sources."once-1.4.0"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
@@ -55989,7 +57330,11 @@ in
       sources."setimmediate-1.0.5"
       sources."setprototypeof-1.1.1"
       sources."seventh-0.7.30"
-      sources."sharp-0.22.1"
+      (sources."sharp-0.23.2" // {
+        dependencies = [
+          sources."tar-5.0.5"
+        ];
+      })
       sources."shebang-command-2.0.0"
       sources."shebang-regex-3.0.0"
       sources."signal-exit-3.0.2"
@@ -56011,7 +57356,7 @@ in
       sources."statuses-1.5.0"
       sources."stealthy-require-1.1.1"
       sources."strict-uri-encode-1.1.0"
-      sources."string-kit-0.10.1"
+      sources."string-kit-0.10.3"
       sources."string-padding-1.0.2"
       (sources."string-to-stream-1.1.1" // {
         dependencies = [
@@ -56044,7 +57389,14 @@ in
       sources."symbol-tree-3.2.4"
       sources."syswide-cas-5.3.0"
       sources."table-layout-0.4.5"
-      sources."tar-4.4.13"
+      (sources."tar-4.4.13" // {
+        dependencies = [
+          sources."fs-minipass-1.2.7"
+          sources."minipass-2.9.0"
+          sources."minizlib-1.3.3"
+          sources."yallist-3.1.1"
+        ];
+      })
       sources."tar-fs-2.0.0"
       sources."tar-stream-2.1.0"
       (sources."tcp-port-used-0.1.2" // {
@@ -56053,7 +57405,7 @@ in
           sources."q-0.9.7"
         ];
       })
-      sources."terminal-kit-1.31.4"
+      sources."terminal-kit-1.31.7"
       (sources."tkwidgets-0.5.26" // {
         dependencies = [
           sources."is-fullwidth-code-point-2.0.0"
@@ -56098,7 +57450,6 @@ in
       sources."which-pm-runs-1.0.0"
       sources."wide-align-1.1.3"
       sources."word-wrap-1.2.3"
-      sources."wordwrap-1.0.0"
       sources."wordwrapjs-3.0.0"
       (sources."wrap-ansi-3.0.1" // {
         dependencies = [
@@ -56111,7 +57462,7 @@ in
       sources."xml-name-validator-3.0.0"
       sources."xml2js-0.4.22"
       sources."xmlbuilder-11.0.1"
-      sources."yallist-3.1.1"
+      sources."yallist-4.0.0"
       sources."yargs-parser-7.0.0"
     ];
     buildInputs = globalBuildInputs;
@@ -56141,7 +57492,7 @@ in
       sources."config-chain-1.1.12"
       sources."editorconfig-0.15.3"
       sources."fs.realpath-1.0.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
       sources."ini-1.3.5"
@@ -56204,7 +57555,7 @@ in
       sha512 = "Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==";
     };
     dependencies = [
-      sources."@babel/parser-7.6.4"
+      sources."@babel/parser-7.7.3"
       sources."argparse-1.0.10"
       sources."bluebird-3.7.1"
       sources."catharsis-0.8.11"
@@ -56242,10 +57593,10 @@ in
   jshint = nodeEnv.buildNodePackage {
     name = "jshint";
     packageName = "jshint";
-    version = "2.10.2";
+    version = "2.10.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/jshint/-/jshint-2.10.2.tgz";
-      sha512 = "e7KZgCSXMJxznE/4WULzybCMNXNAd/bf5TSrvVEq78Q/K8ZwFpmBqQeDtNiHc3l49nV4E/+YeHU/JZjSUIrLAA==";
+      url = "https://registry.npmjs.org/jshint/-/jshint-2.10.3.tgz";
+      sha512 = "d8AoXcNNYzmm7cdmulQ3dQApbrPYArtVBO6n4xOICe4QsXGNHCAKDcFORzqP52LhK61KX0VhY39yYzCsNq+bxQ==";
     };
     dependencies = [
       sources."balanced-match-1.0.0"
@@ -56255,7 +57606,7 @@ in
       sources."console-browserify-1.1.0"
       sources."core-util-is-1.0.2"
       sources."date-now-0.1.4"
-      (sources."dom-serializer-0.2.1" // {
+      (sources."dom-serializer-0.2.2" // {
         dependencies = [
           sources."domelementtype-2.0.1"
           sources."entities-2.0.0"
@@ -56267,7 +57618,7 @@ in
       sources."entities-1.0.0"
       sources."exit-0.1.2"
       sources."fs.realpath-1.0.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."htmlparser2-3.8.3"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -56370,7 +57721,7 @@ in
       sources."path-loader-1.0.10"
       sources."process-nextick-args-2.0.1"
       sources."punycode-2.1.1"
-      sources."qs-6.9.0"
+      sources."qs-6.9.1"
       sources."readable-stream-2.3.6"
       sources."safe-buffer-5.1.2"
       sources."slash-2.0.0"
@@ -56473,7 +57824,7 @@ in
       sources."express-4.17.1"
       (sources."express-urlrewrite-1.2.0" // {
         dependencies = [
-          sources."path-to-regexp-1.7.0"
+          sources."path-to-regexp-1.8.0"
         ];
       })
       sources."extend-3.0.2"
@@ -56776,8 +58127,8 @@ in
       })
       sources."fs-extra-7.0.1"
       sources."fs.realpath-1.0.0"
-      sources."fsevents-2.1.1"
-      sources."glob-7.1.5"
+      sources."fsevents-2.1.2"
+      sources."glob-7.1.6"
       sources."glob-parent-5.1.0"
       sources."graceful-fs-4.2.3"
       sources."has-binary2-1.0.3"
@@ -56821,7 +58172,7 @@ in
       sources."parseuri-0.0.5"
       sources."parseurl-1.3.3"
       sources."path-is-absolute-1.0.1"
-      sources."picomatch-2.1.0"
+      sources."picomatch-2.1.1"
       sources."pseudomap-1.0.2"
       sources."qjobs-1.2.0"
       sources."qs-6.7.0"
@@ -56908,7 +58259,7 @@ in
       sources."clone-stats-1.0.0"
       sources."cloneable-readable-1.1.3"
       sources."concat-map-0.0.1"
-      sources."convert-source-map-1.6.0"
+      sources."convert-source-map-1.7.0"
       sources."core-util-is-1.0.2"
       sources."define-properties-1.1.3"
       sources."duplexify-3.7.1"
@@ -56918,7 +58269,7 @@ in
       sources."fs-mkdirp-stream-1.0.0"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."glob-parent-3.1.0"
       sources."glob-stream-6.1.0"
       sources."graceful-fs-4.2.3"
@@ -57062,7 +58413,7 @@ in
       sources."get-caller-file-1.0.3"
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
       sources."has-flag-3.0.0"
@@ -57123,7 +58474,7 @@ in
       sources."oauth-sign-0.9.0"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       (sources."ora-3.0.0" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
@@ -57207,6 +58558,7 @@ in
           sources."pkginfo-0.3.1"
         ];
       })
+      sources."word-wrap-1.2.3"
       sources."wordwrap-1.0.0"
       sources."wrap-ansi-2.1.0"
       sources."wrappy-1.0.2"
@@ -57243,10 +58595,10 @@ in
   lerna = nodeEnv.buildNodePackage {
     name = "lerna";
     packageName = "lerna";
-    version = "3.18.3";
+    version = "3.18.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/lerna/-/lerna-3.18.3.tgz";
-      sha512 = "Bnr/RjyDSVA2Vu+NArK7do4UIpyy+EShOON7tignfAekPbi7cNDnMMGgSmbCQdKITkqPACMfCMdyq0hJlg6n3g==";
+      url = "https://registry.npmjs.org/lerna/-/lerna-3.18.4.tgz";
+      sha512 = "DiU53cvMxaU07Bj2HwBwUQ2O3c/ORNq/QwKj1vGJH4vSkZSTUxPryp2baSNlt8PmnLNXOVpw0vOTRkEF+6n/cA==";
     };
     dependencies = [
       (sources."@evocateur/libnpmaccess-3.1.2" // {
@@ -57266,12 +58618,12 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."@lerna/add-3.18.0"
-      sources."@lerna/bootstrap-3.18.0"
-      sources."@lerna/changed-3.18.3"
+      sources."@lerna/add-3.18.4"
+      sources."@lerna/bootstrap-3.18.4"
+      sources."@lerna/changed-3.18.4"
       sources."@lerna/check-working-tree-3.16.5"
       sources."@lerna/child-process-3.16.5"
-      sources."@lerna/clean-3.18.0"
+      sources."@lerna/clean-3.18.4"
       sources."@lerna/cli-3.18.0"
       sources."@lerna/collect-uncommitted-3.16.5"
       sources."@lerna/collect-updates-3.18.0"
@@ -57289,8 +58641,8 @@ in
       sources."@lerna/create-symlink-3.16.2"
       sources."@lerna/describe-ref-3.16.5"
       sources."@lerna/diff-3.18.0"
-      sources."@lerna/exec-3.18.0"
-      sources."@lerna/filter-options-3.18.0"
+      sources."@lerna/exec-3.18.4"
+      sources."@lerna/filter-options-3.18.4"
       sources."@lerna/filter-packages-3.18.0"
       sources."@lerna/get-npm-exec-opts-3.13.0"
       sources."@lerna/get-packed-3.16.0"
@@ -57301,8 +58653,8 @@ in
       sources."@lerna/import-3.18.0"
       sources."@lerna/init-3.18.0"
       sources."@lerna/link-3.18.0"
-      sources."@lerna/list-3.18.0"
-      sources."@lerna/listable-3.18.0"
+      sources."@lerna/list-3.18.4"
+      sources."@lerna/listable-3.18.4"
       sources."@lerna/log-packed-3.16.0"
       (sources."@lerna/npm-conf-3.16.0" // {
         dependencies = [
@@ -57325,19 +58677,19 @@ in
       sources."@lerna/prerelease-id-from-version-3.16.0"
       sources."@lerna/project-3.18.0"
       sources."@lerna/prompt-3.13.0"
-      sources."@lerna/publish-3.18.3"
+      sources."@lerna/publish-3.18.4"
       sources."@lerna/pulse-till-done-3.13.0"
       sources."@lerna/query-graph-3.18.0"
       sources."@lerna/resolve-symlink-3.16.0"
       sources."@lerna/rimraf-dir-3.16.5"
-      sources."@lerna/run-3.18.0"
+      sources."@lerna/run-3.18.4"
       sources."@lerna/run-lifecycle-3.16.2"
       sources."@lerna/run-topologically-3.18.0"
       sources."@lerna/symlink-binary-3.17.0"
       sources."@lerna/symlink-dependencies-3.17.0"
       sources."@lerna/timer-3.13.0"
       sources."@lerna/validation-error-3.13.0"
-      sources."@lerna/version-3.18.3"
+      sources."@lerna/version-3.18.4"
       sources."@lerna/write-log-file-3.13.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
@@ -57354,13 +58706,13 @@ in
           sources."isobject-4.0.0"
         ];
       })
-      sources."@octokit/request-error-1.1.0"
-      sources."@octokit/rest-16.34.1"
+      sources."@octokit/request-error-1.2.0"
+      sources."@octokit/rest-16.35.0"
       sources."@octokit/types-2.0.1"
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.12.5"
+      sources."@types/node-12.12.7"
       sources."@zkochan/cmd-shim-3.1.0"
       sources."JSONStream-1.3.5"
       sources."abbrev-1.1.1"
@@ -57474,7 +58826,7 @@ in
       sources."concat-stream-1.6.2"
       sources."config-chain-1.1.12"
       sources."console-control-strings-1.1.0"
-      sources."conventional-changelog-angular-5.0.5"
+      sources."conventional-changelog-angular-5.0.6"
       (sources."conventional-changelog-core-3.2.3" // {
         dependencies = [
           sources."through2-3.0.1"
@@ -57487,7 +58839,7 @@ in
         ];
       })
       sources."conventional-commits-filter-2.0.2"
-      (sources."conventional-commits-parser-3.0.6" // {
+      (sources."conventional-commits-parser-3.0.7" // {
         dependencies = [
           sources."through2-3.0.1"
         ];
@@ -57546,7 +58898,7 @@ in
       sources."err-code-1.1.2"
       sources."error-ex-1.3.2"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
@@ -57662,7 +59014,7 @@ in
       sources."git-up-4.0.1"
       sources."git-url-parse-11.1.2"
       sources."gitconfiglocal-1.0.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."glob-parent-5.1.0"
       sources."glob-to-regexp-0.3.0"
       (sources."globby-9.2.0" // {
@@ -57868,7 +59220,7 @@ in
           sources."kind-of-3.2.2"
         ];
       })
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
       sources."object.getownpropertydescriptors-2.0.3"
@@ -57928,7 +59280,7 @@ in
       sources."qs-6.5.2"
       sources."quick-lru-1.1.0"
       sources."read-1.0.7"
-      sources."read-cmd-shim-1.0.4"
+      sources."read-cmd-shim-1.0.5"
       (sources."read-package-json-2.1.0" // {
         dependencies = [
           sources."slash-1.0.0"
@@ -57993,7 +59345,7 @@ in
       sources."signal-exit-3.0.2"
       sources."slash-2.0.0"
       sources."slide-1.1.6"
-      sources."smart-buffer-4.0.2"
+      sources."smart-buffer-4.1.0"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
           sources."debug-2.6.9"
@@ -58024,7 +59376,7 @@ in
           sources."kind-of-3.2.2"
         ];
       })
-      sources."socks-2.3.2"
+      sources."socks-2.3.3"
       (sources."socks-proxy-agent-4.0.2" // {
         dependencies = [
           sources."agent-base-4.2.1"
@@ -58115,7 +59467,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."type-fest-0.3.1"
       sources."typedarray-0.0.6"
-      (sources."uglify-js-3.6.7" // {
+      (sources."uglify-js-3.6.8" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -59146,68 +60498,70 @@ in
     src = ../interpreters/clojurescript/lumo;
     dependencies = [
       sources."@babel/code-frame-7.5.5"
-      sources."@babel/core-7.6.4"
-      sources."@babel/generator-7.6.4"
-      sources."@babel/helper-annotate-as-pure-7.0.0"
-      sources."@babel/helper-builder-binary-assignment-operator-visitor-7.1.0"
-      sources."@babel/helper-call-delegate-7.4.4"
-      sources."@babel/helper-create-class-features-plugin-7.6.0"
-      sources."@babel/helper-define-map-7.5.5"
-      sources."@babel/helper-explode-assignable-expression-7.1.0"
-      sources."@babel/helper-function-name-7.1.0"
-      sources."@babel/helper-get-function-arity-7.0.0"
-      sources."@babel/helper-hoist-variables-7.4.4"
-      sources."@babel/helper-member-expression-to-functions-7.5.5"
-      sources."@babel/helper-module-imports-7.0.0"
-      sources."@babel/helper-module-transforms-7.5.5"
-      sources."@babel/helper-optimise-call-expression-7.0.0"
+      sources."@babel/core-7.7.2"
+      sources."@babel/generator-7.7.2"
+      sources."@babel/helper-annotate-as-pure-7.7.0"
+      sources."@babel/helper-builder-binary-assignment-operator-visitor-7.7.0"
+      sources."@babel/helper-call-delegate-7.7.0"
+      sources."@babel/helper-create-class-features-plugin-7.7.0"
+      sources."@babel/helper-create-regexp-features-plugin-7.7.2"
+      sources."@babel/helper-define-map-7.7.0"
+      sources."@babel/helper-explode-assignable-expression-7.7.0"
+      sources."@babel/helper-function-name-7.7.0"
+      sources."@babel/helper-get-function-arity-7.7.0"
+      sources."@babel/helper-hoist-variables-7.7.0"
+      sources."@babel/helper-member-expression-to-functions-7.7.0"
+      sources."@babel/helper-module-imports-7.7.0"
+      sources."@babel/helper-module-transforms-7.7.0"
+      sources."@babel/helper-optimise-call-expression-7.7.0"
       sources."@babel/helper-plugin-utils-7.0.0"
       sources."@babel/helper-regex-7.5.5"
-      sources."@babel/helper-remap-async-to-generator-7.1.0"
-      sources."@babel/helper-replace-supers-7.5.5"
-      sources."@babel/helper-simple-access-7.1.0"
-      sources."@babel/helper-split-export-declaration-7.4.4"
-      sources."@babel/helper-wrap-function-7.2.0"
-      sources."@babel/helpers-7.6.2"
+      sources."@babel/helper-remap-async-to-generator-7.7.0"
+      sources."@babel/helper-replace-supers-7.7.0"
+      sources."@babel/helper-simple-access-7.7.0"
+      sources."@babel/helper-split-export-declaration-7.7.0"
+      sources."@babel/helper-wrap-function-7.7.0"
+      sources."@babel/helpers-7.7.0"
       sources."@babel/highlight-7.5.0"
-      sources."@babel/parser-7.6.4"
+      sources."@babel/parser-7.7.3"
       sources."@babel/plugin-external-helpers-7.0.0"
-      sources."@babel/plugin-proposal-async-generator-functions-7.2.0"
-      sources."@babel/plugin-proposal-class-properties-7.5.5"
-      sources."@babel/plugin-proposal-dynamic-import-7.5.0"
+      sources."@babel/plugin-proposal-async-generator-functions-7.7.0"
+      sources."@babel/plugin-proposal-class-properties-7.7.0"
+      sources."@babel/plugin-proposal-dynamic-import-7.7.0"
       sources."@babel/plugin-proposal-json-strings-7.2.0"
       sources."@babel/plugin-proposal-object-rest-spread-7.6.2"
       sources."@babel/plugin-proposal-optional-catch-binding-7.2.0"
-      sources."@babel/plugin-proposal-unicode-property-regex-7.6.2"
+      sources."@babel/plugin-proposal-unicode-property-regex-7.7.0"
       sources."@babel/plugin-syntax-async-generators-7.2.0"
       sources."@babel/plugin-syntax-dynamic-import-7.2.0"
       sources."@babel/plugin-syntax-json-strings-7.2.0"
       sources."@babel/plugin-syntax-object-rest-spread-7.2.0"
       sources."@babel/plugin-syntax-optional-catch-binding-7.2.0"
+      sources."@babel/plugin-syntax-top-level-await-7.7.0"
       sources."@babel/plugin-transform-arrow-functions-7.2.0"
-      sources."@babel/plugin-transform-async-to-generator-7.5.0"
+      sources."@babel/plugin-transform-async-to-generator-7.7.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.2.0"
       sources."@babel/plugin-transform-block-scoping-7.6.3"
-      sources."@babel/plugin-transform-classes-7.5.5"
+      sources."@babel/plugin-transform-classes-7.7.0"
       sources."@babel/plugin-transform-computed-properties-7.2.0"
       sources."@babel/plugin-transform-destructuring-7.6.0"
-      sources."@babel/plugin-transform-dotall-regex-7.6.2"
+      sources."@babel/plugin-transform-dotall-regex-7.7.0"
       sources."@babel/plugin-transform-duplicate-keys-7.5.0"
       sources."@babel/plugin-transform-exponentiation-operator-7.2.0"
       sources."@babel/plugin-transform-for-of-7.4.4"
-      sources."@babel/plugin-transform-function-name-7.4.4"
+      sources."@babel/plugin-transform-function-name-7.7.0"
       sources."@babel/plugin-transform-literals-7.2.0"
       sources."@babel/plugin-transform-member-expression-literals-7.2.0"
       sources."@babel/plugin-transform-modules-amd-7.5.0"
-      sources."@babel/plugin-transform-modules-commonjs-7.6.0"
-      sources."@babel/plugin-transform-modules-systemjs-7.5.0"
-      sources."@babel/plugin-transform-modules-umd-7.2.0"
-      sources."@babel/plugin-transform-named-capturing-groups-regex-7.6.3"
+      sources."@babel/plugin-transform-modules-commonjs-7.7.0"
+      sources."@babel/plugin-transform-modules-systemjs-7.7.0"
+      sources."@babel/plugin-transform-modules-umd-7.7.0"
+      sources."@babel/plugin-transform-named-capturing-groups-regex-7.7.0"
       sources."@babel/plugin-transform-new-target-7.4.4"
       sources."@babel/plugin-transform-object-super-7.5.5"
       sources."@babel/plugin-transform-parameters-7.4.4"
       sources."@babel/plugin-transform-property-literals-7.2.0"
-      sources."@babel/plugin-transform-regenerator-7.4.5"
+      sources."@babel/plugin-transform-regenerator-7.7.0"
       sources."@babel/plugin-transform-reserved-words-7.2.0"
       sources."@babel/plugin-transform-runtime-7.6.2"
       sources."@babel/plugin-transform-shorthand-properties-7.2.0"
@@ -59215,13 +60569,13 @@ in
       sources."@babel/plugin-transform-sticky-regex-7.2.0"
       sources."@babel/plugin-transform-template-literals-7.4.4"
       sources."@babel/plugin-transform-typeof-symbol-7.2.0"
-      sources."@babel/plugin-transform-unicode-regex-7.6.2"
-      sources."@babel/preset-env-7.6.3"
+      sources."@babel/plugin-transform-unicode-regex-7.7.0"
+      sources."@babel/preset-env-7.7.1"
       sources."@babel/preset-stage-2-7.0.0"
-      sources."@babel/runtime-7.6.3"
-      sources."@babel/template-7.6.0"
-      sources."@babel/traverse-7.6.3"
-      sources."@babel/types-7.6.3"
+      sources."@babel/runtime-7.7.2"
+      sources."@babel/template-7.7.0"
+      sources."@babel/traverse-7.7.2"
+      sources."@babel/types-7.7.2"
       sources."@calebboyd/semaphore-1.3.1"
       sources."@comandeer/babel-plugin-banner-4.1.0"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
@@ -59232,7 +60586,7 @@ in
       sources."@types/events-3.0.0"
       sources."@types/glob-7.1.1"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.12.5"
+      sources."@types/node-12.12.7"
       sources."@webassemblyjs/ast-1.8.5"
       sources."@webassemblyjs/floating-point-hex-parser-1.8.5"
       sources."@webassemblyjs/helper-api-error-1.8.5"
@@ -59521,11 +60875,11 @@ in
       sources."console-browserify-1.2.0"
       sources."constants-browserify-1.0.0"
       sources."content-disposition-0.5.3"
-      sources."convert-source-map-1.6.0"
+      sources."convert-source-map-1.7.0"
       sources."copy-concurrently-1.0.5"
       sources."copy-descriptor-0.1.1"
       sources."core-js-2.6.10"
-      (sources."core-js-compat-3.3.6" // {
+      (sources."core-js-compat-3.4.1" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -59605,7 +60959,7 @@ in
       })
       sources."duplexer3-0.1.4"
       sources."duplexify-3.7.1"
-      sources."electron-to-chromium-1.3.302"
+      sources."electron-to-chromium-1.3.306"
       sources."elliptic-6.5.1"
       sources."emoji-regex-7.0.3"
       sources."emojis-list-2.1.0"
@@ -59767,7 +61121,7 @@ in
       sources."get-proxy-2.1.0"
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."glob-base-0.3.0"
       sources."glob-parent-2.0.0"
       sources."glob-to-regexp-0.3.0"
@@ -59975,7 +61329,7 @@ in
       sources."node-fetch-2.6.0"
       (sources."node-libs-browser-2.2.1" // {
         dependencies = [
-          sources."buffer-4.9.1"
+          sources."buffer-4.9.2"
           sources."punycode-1.4.1"
         ];
       })
@@ -60319,7 +61673,7 @@ in
       sources."supports-color-2.0.0"
       sources."tapable-1.1.3"
       sources."tar-stream-1.6.2"
-      (sources."terser-4.3.9" // {
+      (sources."terser-4.4.0" // {
         dependencies = [
           sources."commander-2.20.3"
           sources."source-map-0.6.1"
@@ -60616,7 +61970,7 @@ in
       sha512 = "z4uLbDHNbs/aRuR6zCcnzwFQuMixkHCcWqgVaommfK/3cA1Ahq7OXemn+m8JwTYcBApSHgcrSbPr9sm3sZFL+A==";
     };
     dependencies = [
-      sources."commander-4.0.0"
+      sources."commander-4.0.1"
       sources."esm-3.2.25"
       sources."mathjax-full-git://github.com/mathjax/MathJax-src.git"
       sources."mj-context-menu-0.2.0"
@@ -60697,7 +62051,7 @@ in
       })
       (sources."accord-0.28.0" // {
         dependencies = [
-          sources."glob-7.1.5"
+          sources."glob-7.1.6"
           sources."minimatch-3.0.4"
           sources."semver-5.7.1"
           sources."uglify-js-2.8.29"
@@ -60796,7 +62150,7 @@ in
       sources."commander-2.20.3"
       sources."component-emitter-1.3.0"
       sources."concat-map-0.0.1"
-      sources."convert-source-map-1.6.0"
+      sources."convert-source-map-1.7.0"
       sources."copy-descriptor-0.1.1"
       sources."core-util-is-1.0.2"
       sources."cryptiles-2.0.5"
@@ -60870,7 +62224,7 @@ in
         ];
       })
       sources."expand-tilde-2.0.2"
-      (sources."ext-1.1.2" // {
+      (sources."ext-1.2.0" // {
         dependencies = [
           sources."type-2.0.0"
         ];
@@ -60982,7 +62336,7 @@ in
           sources."clone-2.1.2"
           sources."clone-stats-1.0.0"
           sources."extend-shallow-1.1.4"
-          sources."glob-7.1.5"
+          sources."glob-7.1.6"
           sources."glob-stream-6.1.0"
           sources."graceful-fs-4.2.3"
           sources."kind-of-1.1.0"
@@ -61329,8 +62683,8 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-1.2.0"
-      sources."typescript-3.6.4"
-      (sources."uglify-js-3.6.7" // {
+      sources."typescript-3.7.2"
+      (sources."uglify-js-3.6.8" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -61432,7 +62786,7 @@ in
       sources."diff-3.5.0"
       sources."emoji-regex-7.0.3"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
       sources."find-up-3.0.0"
@@ -61464,7 +62818,7 @@ in
       sources."mkdirp-0.5.1"
       sources."ms-2.1.1"
       sources."node-environment-flags-1.0.5"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object.assign-4.1.0"
       sources."object.getownpropertydescriptors-2.0.3"
@@ -61558,7 +62912,7 @@ in
       sources."path-loader-1.0.10"
       sources."process-nextick-args-2.0.1"
       sources."punycode-2.1.1"
-      sources."qs-6.9.0"
+      sources."qs-6.9.1"
       sources."readable-stream-2.3.6"
       sources."safe-buffer-5.1.2"
       sources."slash-2.0.0"
@@ -61680,7 +63034,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -61805,7 +63159,7 @@ in
       sources."base64-js-0.0.8"
       sources."bcrypt-pbkdf-1.0.2"
       sources."biased-opener-0.2.8"
-      sources."big-integer-1.6.47"
+      sources."big-integer-1.6.48"
       sources."block-stream-0.0.9"
       sources."body-parser-1.19.0"
       sources."boom-2.10.1"
@@ -61928,7 +63282,7 @@ in
       sources."negotiator-0.6.2"
       (sources."node-pre-gyp-0.6.39" // {
         dependencies = [
-          sources."glob-7.1.5"
+          sources."glob-7.1.6"
           sources."rimraf-2.7.1"
           sources."semver-5.7.1"
         ];
@@ -62017,7 +63371,7 @@ in
       sources."tar-2.2.2"
       (sources."tar-pack-3.4.1" // {
         dependencies = [
-          sources."glob-7.1.5"
+          sources."glob-7.1.6"
           sources."rimraf-2.7.1"
         ];
       })
@@ -62103,7 +63457,7 @@ in
       sources."fs-minipass-1.2.7"
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."has-unicode-2.0.1"
       sources."iconv-lite-0.4.24"
       sources."ignore-walk-3.0.3"
@@ -62173,7 +63527,7 @@ in
       sha512 = "QSyPpAGGVFgVlKyumWFd8j2hd420+sh8DSxlvAtatDVaIG3+MaAD3eDLg49HIwRyAhiROVS1XNWkqyq/H1/cBA==";
     };
     dependencies = [
-      sources."@babel/runtime-7.6.3"
+      sources."@babel/runtime-7.7.2"
       sources."@node-red/editor-api-1.0.2"
       sources."@node-red/editor-client-1.0.2"
       (sources."@node-red/nodes-1.0.2" // {
@@ -62327,7 +63681,7 @@ in
           sources."depd-2.0.0"
         ];
       })
-      (sources."ext-1.1.2" // {
+      (sources."ext-1.2.0" // {
         dependencies = [
           sources."type-2.0.0"
         ];
@@ -62347,7 +63701,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."glob-parent-3.1.0"
       (sources."glob-stream-6.1.0" // {
         dependencies = [
@@ -62677,7 +64031,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -63162,10 +64516,10 @@ in
   npm = nodeEnv.buildNodePackage {
     name = "npm";
     packageName = "npm";
-    version = "6.12.1";
+    version = "6.13.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm/-/npm-6.12.1.tgz";
-      sha512 = "+pMvUpgSXVBythrv//64j4i6DaLLJ1O0y8kwjNgjAE7atBNGzX4rcOEWvmsuiei6J+mA38O0nUZ/P35GuCD/jg==";
+      url = "https://registry.npmjs.org/npm/-/npm-6.13.0.tgz";
+      sha512 = "zjSJ8zjk0cDBZXqTWbQ6+qOdm1m2k489YDFP60RQRUhOxT5LOBhl+cDtFlEXEIblcNjofmsZ/qQ/wzmn5frimQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -63180,10 +64534,10 @@ in
   npm-check-updates = nodeEnv.buildNodePackage {
     name = "npm-check-updates";
     packageName = "npm-check-updates";
-    version = "3.2.0";
+    version = "3.2.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.2.0.tgz";
-      sha512 = "Gqxd6Fv+EoGNKg2thclx3LPs9dHa1Tp/R+/59iYAgbliJ5NsDd/D6j6kjhnLtKh+7XMX7co3gTrVzsSqTPNRAg==";
+      url = "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.2.1.tgz";
+      sha512 = "gYXHGc9mAncGrEMjs2uRJgOdWRP5CR9iZ+HyUNf4eqjtdDV6jLvi2e19G5BEpdvc8fU73J+B5m8ALYB49du/EA==";
     };
     dependencies = [
       sources."@sindresorhus/is-0.14.0"
@@ -63270,7 +64624,7 @@ in
       sources."genfun-5.0.0"
       sources."get-stdin-7.0.0"
       sources."get-stream-4.1.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."global-dirs-0.1.1"
       sources."got-9.6.0"
       sources."graceful-fs-4.2.3"
@@ -63397,7 +64751,7 @@ in
       sources."progress-2.0.3"
       sources."promise-inflight-1.0.1"
       sources."promise-retry-1.1.1"
-      sources."prompts-2.2.1"
+      sources."prompts-2.3.0"
       sources."protoduck-5.0.1"
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
@@ -63447,9 +64801,9 @@ in
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
-      sources."sisteransi-1.0.3"
-      sources."smart-buffer-4.0.2"
-      sources."socks-2.3.2"
+      sources."sisteransi-1.0.4"
+      sources."smart-buffer-4.1.0"
+      sources."socks-2.3.3"
       (sources."socks-proxy-agent-4.0.2" // {
         dependencies = [
           sources."agent-base-4.2.1"
@@ -63585,7 +64939,7 @@ in
       })
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-2.0.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -63748,91 +65102,93 @@ in
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
-      (sources."@babel/core-7.6.4" // {
+      (sources."@babel/core-7.7.2" // {
         dependencies = [
           sources."json5-2.1.1"
           sources."source-map-0.5.7"
         ];
       })
-      (sources."@babel/generator-7.6.4" // {
+      (sources."@babel/generator-7.7.2" // {
         dependencies = [
           sources."source-map-0.5.7"
         ];
       })
-      sources."@babel/helper-annotate-as-pure-7.0.0"
-      sources."@babel/helper-builder-binary-assignment-operator-visitor-7.1.0"
-      sources."@babel/helper-builder-react-jsx-7.3.0"
-      sources."@babel/helper-call-delegate-7.4.4"
-      sources."@babel/helper-define-map-7.5.5"
-      sources."@babel/helper-explode-assignable-expression-7.1.0"
-      sources."@babel/helper-function-name-7.1.0"
-      sources."@babel/helper-get-function-arity-7.0.0"
-      sources."@babel/helper-hoist-variables-7.4.4"
-      sources."@babel/helper-member-expression-to-functions-7.5.5"
-      sources."@babel/helper-module-imports-7.0.0"
-      sources."@babel/helper-module-transforms-7.5.5"
-      sources."@babel/helper-optimise-call-expression-7.0.0"
+      sources."@babel/helper-annotate-as-pure-7.7.0"
+      sources."@babel/helper-builder-binary-assignment-operator-visitor-7.7.0"
+      sources."@babel/helper-builder-react-jsx-7.7.0"
+      sources."@babel/helper-call-delegate-7.7.0"
+      sources."@babel/helper-create-regexp-features-plugin-7.7.2"
+      sources."@babel/helper-define-map-7.7.0"
+      sources."@babel/helper-explode-assignable-expression-7.7.0"
+      sources."@babel/helper-function-name-7.7.0"
+      sources."@babel/helper-get-function-arity-7.7.0"
+      sources."@babel/helper-hoist-variables-7.7.0"
+      sources."@babel/helper-member-expression-to-functions-7.7.0"
+      sources."@babel/helper-module-imports-7.7.0"
+      sources."@babel/helper-module-transforms-7.7.0"
+      sources."@babel/helper-optimise-call-expression-7.7.0"
       sources."@babel/helper-plugin-utils-7.0.0"
       sources."@babel/helper-regex-7.5.5"
-      sources."@babel/helper-remap-async-to-generator-7.1.0"
-      sources."@babel/helper-replace-supers-7.5.5"
-      sources."@babel/helper-simple-access-7.1.0"
-      sources."@babel/helper-split-export-declaration-7.4.4"
-      sources."@babel/helper-wrap-function-7.2.0"
-      sources."@babel/helpers-7.6.2"
+      sources."@babel/helper-remap-async-to-generator-7.7.0"
+      sources."@babel/helper-replace-supers-7.7.0"
+      sources."@babel/helper-simple-access-7.7.0"
+      sources."@babel/helper-split-export-declaration-7.7.0"
+      sources."@babel/helper-wrap-function-7.7.0"
+      sources."@babel/helpers-7.7.0"
       sources."@babel/highlight-7.5.0"
-      sources."@babel/parser-7.6.4"
-      sources."@babel/plugin-proposal-async-generator-functions-7.2.0"
-      sources."@babel/plugin-proposal-dynamic-import-7.5.0"
+      sources."@babel/parser-7.7.3"
+      sources."@babel/plugin-proposal-async-generator-functions-7.7.0"
+      sources."@babel/plugin-proposal-dynamic-import-7.7.0"
       sources."@babel/plugin-proposal-json-strings-7.2.0"
       sources."@babel/plugin-proposal-object-rest-spread-7.6.2"
       sources."@babel/plugin-proposal-optional-catch-binding-7.2.0"
-      sources."@babel/plugin-proposal-unicode-property-regex-7.6.2"
+      sources."@babel/plugin-proposal-unicode-property-regex-7.7.0"
       sources."@babel/plugin-syntax-async-generators-7.2.0"
       sources."@babel/plugin-syntax-dynamic-import-7.2.0"
-      sources."@babel/plugin-syntax-flow-7.2.0"
+      sources."@babel/plugin-syntax-flow-7.7.0"
       sources."@babel/plugin-syntax-json-strings-7.2.0"
       sources."@babel/plugin-syntax-jsx-7.2.0"
       sources."@babel/plugin-syntax-object-rest-spread-7.2.0"
       sources."@babel/plugin-syntax-optional-catch-binding-7.2.0"
+      sources."@babel/plugin-syntax-top-level-await-7.7.0"
       sources."@babel/plugin-transform-arrow-functions-7.2.0"
-      sources."@babel/plugin-transform-async-to-generator-7.5.0"
+      sources."@babel/plugin-transform-async-to-generator-7.7.0"
       sources."@babel/plugin-transform-block-scoped-functions-7.2.0"
       sources."@babel/plugin-transform-block-scoping-7.6.3"
-      sources."@babel/plugin-transform-classes-7.5.5"
+      sources."@babel/plugin-transform-classes-7.7.0"
       sources."@babel/plugin-transform-computed-properties-7.2.0"
       sources."@babel/plugin-transform-destructuring-7.6.0"
-      sources."@babel/plugin-transform-dotall-regex-7.6.2"
+      sources."@babel/plugin-transform-dotall-regex-7.7.0"
       sources."@babel/plugin-transform-duplicate-keys-7.5.0"
       sources."@babel/plugin-transform-exponentiation-operator-7.2.0"
       sources."@babel/plugin-transform-flow-strip-types-7.6.3"
       sources."@babel/plugin-transform-for-of-7.4.4"
-      sources."@babel/plugin-transform-function-name-7.4.4"
+      sources."@babel/plugin-transform-function-name-7.7.0"
       sources."@babel/plugin-transform-literals-7.2.0"
       sources."@babel/plugin-transform-member-expression-literals-7.2.0"
       sources."@babel/plugin-transform-modules-amd-7.5.0"
-      sources."@babel/plugin-transform-modules-commonjs-7.6.0"
-      sources."@babel/plugin-transform-modules-systemjs-7.5.0"
-      sources."@babel/plugin-transform-modules-umd-7.2.0"
-      sources."@babel/plugin-transform-named-capturing-groups-regex-7.6.3"
+      sources."@babel/plugin-transform-modules-commonjs-7.7.0"
+      sources."@babel/plugin-transform-modules-systemjs-7.7.0"
+      sources."@babel/plugin-transform-modules-umd-7.7.0"
+      sources."@babel/plugin-transform-named-capturing-groups-regex-7.7.0"
       sources."@babel/plugin-transform-new-target-7.4.4"
       sources."@babel/plugin-transform-object-super-7.5.5"
       sources."@babel/plugin-transform-parameters-7.4.4"
       sources."@babel/plugin-transform-property-literals-7.2.0"
-      sources."@babel/plugin-transform-react-jsx-7.3.0"
-      sources."@babel/plugin-transform-regenerator-7.4.5"
+      sources."@babel/plugin-transform-react-jsx-7.7.0"
+      sources."@babel/plugin-transform-regenerator-7.7.0"
       sources."@babel/plugin-transform-reserved-words-7.2.0"
       sources."@babel/plugin-transform-shorthand-properties-7.2.0"
       sources."@babel/plugin-transform-spread-7.6.2"
       sources."@babel/plugin-transform-sticky-regex-7.2.0"
       sources."@babel/plugin-transform-template-literals-7.4.4"
       sources."@babel/plugin-transform-typeof-symbol-7.2.0"
-      sources."@babel/plugin-transform-unicode-regex-7.6.2"
-      sources."@babel/preset-env-7.6.3"
-      sources."@babel/runtime-7.6.3"
-      sources."@babel/template-7.6.0"
-      sources."@babel/traverse-7.6.3"
-      sources."@babel/types-7.6.3"
+      sources."@babel/plugin-transform-unicode-regex-7.7.0"
+      sources."@babel/preset-env-7.7.1"
+      sources."@babel/runtime-7.7.2"
+      sources."@babel/template-7.7.0"
+      sources."@babel/traverse-7.7.2"
+      sources."@babel/types-7.7.2"
       sources."@iarna/toml-2.2.3"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
       sources."@nodelib/fs.stat-1.1.3"
@@ -63854,7 +65210,7 @@ in
       sources."alphanum-sort-1.0.2"
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
-      sources."ansi-to-html-0.6.12"
+      sources."ansi-to-html-0.6.13"
       (sources."anymatch-2.0.0" // {
         dependencies = [
           sources."normalize-path-2.1.1"
@@ -63922,7 +65278,7 @@ in
         ];
       })
       sources."browserslist-4.7.2"
-      (sources."buffer-4.9.1" // {
+      (sources."buffer-4.9.2" // {
         dependencies = [
           sources."isarray-1.0.0"
         ];
@@ -63936,6 +65292,7 @@ in
       sources."caller-callsite-2.0.0"
       sources."caller-path-2.0.0"
       sources."callsites-2.0.0"
+      sources."camelcase-5.3.1"
       sources."caniuse-api-3.0.0"
       sources."caniuse-lite-1.0.30001008"
       sources."caseless-0.12.0"
@@ -63945,6 +65302,12 @@ in
       sources."class-utils-0.3.6"
       sources."cli-cursor-2.1.0"
       sources."cli-spinners-1.3.1"
+      (sources."cliui-5.0.0" // {
+        dependencies = [
+          sources."ansi-regex-4.1.0"
+          sources."strip-ansi-5.2.0"
+        ];
+      })
       sources."clone-2.1.2"
       sources."coa-2.0.2"
       sources."collection-visit-1.0.0"
@@ -63960,10 +65323,10 @@ in
       sources."concat-stream-1.6.2"
       sources."console-browserify-1.2.0"
       sources."constants-browserify-1.0.0"
-      sources."convert-source-map-1.6.0"
+      sources."convert-source-map-1.7.0"
       sources."copy-descriptor-0.1.1"
       sources."core-js-2.6.10"
-      (sources."core-js-compat-3.3.6" // {
+      (sources."core-js-compat-3.4.1" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -63993,7 +65356,7 @@ in
           sources."supports-color-3.2.3"
         ];
       })
-      sources."css-select-2.0.2"
+      sources."css-select-2.1.0"
       sources."css-select-base-adapter-0.1.1"
       (sources."css-selector-tokenizer-0.7.1" // {
         dependencies = [
@@ -64005,7 +65368,7 @@ in
       })
       sources."css-tree-1.0.0-alpha.37"
       sources."css-unit-converter-1.1.1"
-      sources."css-what-2.1.3"
+      sources."css-what-3.2.1"
       sources."cssesc-0.1.0"
       sources."cssnano-4.1.10"
       sources."cssnano-preset-default-4.0.7"
@@ -64020,6 +65383,7 @@ in
       sources."data-urls-1.1.0"
       sources."deasync-0.1.15"
       sources."debug-4.1.1"
+      sources."decamelize-1.2.0"
       sources."decode-uri-component-0.2.0"
       sources."deep-is-0.1.3"
       (sources."defaults-1.0.3" // {
@@ -64049,7 +65413,7 @@ in
       sources."des.js-1.0.0"
       sources."destroy-1.0.4"
       sources."diffie-hellman-5.0.3"
-      (sources."dom-serializer-0.2.1" // {
+      (sources."dom-serializer-0.2.2" // {
         dependencies = [
           sources."domelementtype-2.0.1"
           sources."entities-2.0.0"
@@ -64066,18 +65430,19 @@ in
       sources."duplexer2-0.1.4"
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
-      sources."electron-to-chromium-1.3.302"
+      sources."electron-to-chromium-1.3.306"
       sources."elliptic-6.5.1"
+      sources."emoji-regex-7.0.3"
       sources."encodeurl-1.0.2"
       sources."entities-1.1.2"
       sources."envinfo-7.4.0"
       sources."error-ex-1.3.2"
       (sources."es-abstract-1.16.0" // {
         dependencies = [
-          sources."object-inspect-1.6.0"
+          sources."object-inspect-1.7.0"
         ];
       })
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."escodegen-1.9.1"
@@ -64109,6 +65474,7 @@ in
       sources."fastparse-1.1.2"
       sources."filesize-3.6.1"
       sources."fill-range-4.0.0"
+      sources."find-up-3.0.0"
       sources."for-in-1.0.2"
       sources."foreach-2.0.5"
       sources."forever-agent-0.6.1"
@@ -64118,10 +65484,11 @@ in
       sources."fs.realpath-1.0.0"
       sources."fsevents-1.2.9"
       sources."function-bind-1.1.1"
+      sources."get-caller-file-2.0.5"
       sources."get-port-3.2.0"
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -64156,9 +65523,10 @@ in
       sources."html-comment-regex-1.1.2"
       sources."html-encoding-sniffer-1.0.2"
       sources."html-tags-1.2.0"
-      (sources."htmlnano-0.2.4" // {
+      (sources."htmlnano-0.2.5" // {
         dependencies = [
-          sources."terser-4.3.9"
+          sources."posthtml-0.12.0"
+          sources."terser-4.4.0"
         ];
       })
       (sources."htmlparser2-3.10.1" // {
@@ -64202,6 +65570,7 @@ in
       sources."is-directory-0.3.1"
       sources."is-extendable-0.1.1"
       sources."is-extglob-2.1.1"
+      sources."is-fullwidth-code-point-2.0.0"
       sources."is-glob-4.0.1"
       sources."is-html-1.1.0"
       sources."is-number-3.0.0"
@@ -64243,6 +65612,7 @@ in
       sources."jsprim-1.4.1"
       sources."kind-of-3.2.2"
       sources."levn-0.3.0"
+      sources."locate-path-3.0.0"
       sources."lodash-4.17.15"
       sources."lodash.clone-4.5.0"
       sources."lodash.memoize-4.1.2"
@@ -64330,9 +65700,12 @@ in
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."opn-5.5.0"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."ora-2.1.0"
       sources."os-browserify-0.3.0"
+      sources."p-limit-2.2.1"
+      sources."p-locate-3.0.0"
+      sources."p-try-2.2.0"
       sources."pako-0.2.9"
       sources."parse-asn1-5.1.5"
       sources."parse-json-4.0.0"
@@ -64341,6 +65714,7 @@ in
       sources."pascalcase-0.1.1"
       sources."path-browserify-0.0.1"
       sources."path-dirname-1.0.2"
+      sources."path-exists-3.0.0"
       sources."path-is-absolute-1.0.1"
       sources."path-key-2.0.1"
       sources."path-parse-1.0.6"
@@ -64416,7 +65790,7 @@ in
       sources."postcss-unique-selectors-4.0.1"
       sources."postcss-value-parser-3.3.1"
       sources."posthtml-0.11.6"
-      sources."posthtml-parser-0.4.1"
+      sources."posthtml-parser-0.4.2"
       sources."posthtml-render-1.1.5"
       sources."prelude-ls-1.1.2"
       sources."private-0.1.8"
@@ -64425,6 +65799,12 @@ in
       sources."psl-1.4.0"
       sources."public-encrypt-4.0.3"
       sources."punycode-2.1.1"
+      (sources."purgecss-1.4.1" // {
+        dependencies = [
+          sources."cssesc-3.0.0"
+          sources."postcss-selector-parser-6.0.2"
+        ];
+      })
       sources."q-1.5.1"
       sources."qs-6.5.2"
       sources."querystring-0.2.0"
@@ -64467,6 +65847,8 @@ in
       })
       sources."request-promise-core-1.1.3"
       sources."request-promise-native-1.0.8"
+      sources."require-directory-2.1.1"
+      sources."require-main-filename-2.0.0"
       sources."resolve-1.12.0"
       sources."resolve-from-3.0.0"
       sources."resolve-url-0.2.1"
@@ -64494,6 +65876,7 @@ in
       })
       sources."serialize-to-js-3.0.0"
       sources."serve-static-1.14.1"
+      sources."set-blocking-2.0.0"
       sources."set-value-2.0.1"
       sources."setimmediate-1.0.5"
       sources."setprototypeof-1.1.1"
@@ -64540,6 +65923,12 @@ in
       sources."stealthy-require-1.1.1"
       sources."stream-browserify-2.0.2"
       sources."stream-http-2.8.3"
+      (sources."string-width-3.1.0" // {
+        dependencies = [
+          sources."ansi-regex-4.1.0"
+          sources."strip-ansi-5.2.0"
+        ];
+      })
       sources."string.prototype.trimleft-2.1.0"
       sources."string.prototype.trimright-2.1.0"
       sources."string_decoder-1.1.1"
@@ -64633,12 +66022,22 @@ in
       sources."whatwg-mimetype-2.3.0"
       sources."whatwg-url-7.1.0"
       sources."which-1.3.1"
-      sources."wordwrap-1.0.0"
+      sources."which-module-2.0.0"
+      sources."word-wrap-1.2.3"
+      (sources."wrap-ansi-5.1.0" // {
+        dependencies = [
+          sources."ansi-regex-4.1.0"
+          sources."strip-ansi-5.2.0"
+        ];
+      })
       sources."wrappy-1.0.2"
       sources."ws-5.2.2"
       sources."xml-name-validator-3.0.0"
       sources."xmlchars-2.2.0"
       sources."xtend-4.0.2"
+      sources."y18n-4.0.0"
+      sources."yargs-14.2.1"
+      sources."yargs-parser-15.0.0"
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -64675,7 +66074,7 @@ in
       sources."balanced-match-1.0.0"
       sources."base64-js-0.0.8"
       sources."bencode-2.0.1"
-      sources."big-integer-1.6.47"
+      sources."big-integer-1.6.48"
       sources."bitfield-0.1.0"
       (sources."bittorrent-dht-6.4.2" // {
         dependencies = [
@@ -64749,7 +66148,7 @@ in
       sources."function-bind-1.1.1"
       sources."get-browser-rtc-1.0.2"
       sources."get-stdin-4.0.1"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
@@ -65100,7 +66499,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."get-browser-rtc-1.0.2"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -65337,10 +66736,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "4.1.7";
+    version = "4.2.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-4.1.7.tgz";
-      sha512 = "0JfrmMLsy5x5nwUULUnXmKz6IbRXLc1r04STPDje6SIwcnyDwiRC5gR4LkC+AgVe2HuIhOSQm/MM1ypC63JDnQ==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-4.2.2.tgz";
+      sha512 = "cgIti3UV6PlZnuLd1Il78vxjbAo+UfeTvdDxdneZphjGwmJqFbmWxw5jQK/JiiNTLn2Tnj3Oy3+/hRxhVHFQug==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -65355,10 +66754,10 @@ in
   prettier = nodeEnv.buildNodePackage {
     name = "prettier";
     packageName = "prettier";
-    version = "1.18.2";
+    version = "1.19.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz";
-      sha512 = "OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==";
+      url = "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz";
+      sha512 = "s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -65464,7 +66863,7 @@ in
       sources."function-bind-1.1.1"
       sources."gaze-1.1.3"
       sources."get-assigned-identifiers-1.2.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."globule-1.2.1"
       sources."graceful-fs-4.2.3"
       sources."has-1.0.3"
@@ -65639,7 +67038,7 @@ in
       sources."eyes-0.1.8"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
       sources."i-0.3.6"
@@ -66025,10 +67424,10 @@ in
   serverless = nodeEnv.buildNodePackage {
     name = "serverless";
     packageName = "serverless";
-    version = "1.56.1";
+    version = "1.57.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/serverless/-/serverless-1.56.1.tgz";
-      sha512 = "yLEQbyHdrgM8MG64J7o1jrjaaCaGOoNThRl9PGzBGZmibtDBDzRBlclVcjcWIWDItw35t6OtMRlwQrXYPtgoqw==";
+      url = "https://registry.npmjs.org/serverless/-/serverless-1.57.0.tgz";
+      sha512 = "pb+6Jo3/oRdo4BNYTz8wbnqhetC0epFfezzEbUsOCHGPUoHgxnZmo22rceBXL9P7Npd4JA8qwtTu7GYmrTZSSA==";
     };
     dependencies = [
       sources."@serverless/cli-1.4.0"
@@ -66043,7 +67442,7 @@ in
           sources."semver-6.3.0"
         ];
       })
-      (sources."@serverless/enterprise-plugin-3.2.1" // {
+      (sources."@serverless/enterprise-plugin-3.2.3" // {
         dependencies = [
           sources."fs-extra-7.0.1"
           sources."node-fetch-2.6.0"
@@ -66051,7 +67450,7 @@ in
         ];
       })
       sources."@serverless/event-mocks-1.1.1"
-      (sources."@serverless/platform-sdk-2.2.0" // {
+      (sources."@serverless/platform-sdk-2.2.1" // {
         dependencies = [
           sources."ramda-0.25.0"
           sources."uuid-3.3.3"
@@ -66060,7 +67459,7 @@ in
       sources."@serverless/template-1.1.3"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
-      sources."@types/lodash-4.14.144"
+      sources."@types/lodash-4.14.146"
       sources."agent-base-4.3.0"
       sources."ansi-align-2.0.0"
       sources."ansi-escapes-4.2.1"
@@ -66088,10 +67487,10 @@ in
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
       sources."atob-2.1.2"
-      (sources."aws-sdk-2.563.0" // {
+      (sources."aws-sdk-2.569.0" // {
         dependencies = [
-          sources."buffer-4.9.1"
-          sources."uuid-3.3.2"
+          sources."buffer-4.9.2"
+          sources."uuid-3.3.3"
         ];
       })
       sources."balanced-match-1.0.0"
@@ -66200,6 +67599,7 @@ in
       sources."deep-extend-0.6.0"
       sources."defer-to-connect-1.1.0"
       sources."deferred-0.7.11"
+      sources."define-properties-1.1.3"
       sources."define-property-2.0.2"
       sources."delayed-stream-1.0.0"
       sources."dot-prop-4.2.0"
@@ -66215,6 +67615,8 @@ in
       sources."duplexer3-0.1.4"
       sources."encoding-0.1.12"
       sources."end-of-stream-1.4.4"
+      sources."es-abstract-1.16.0"
+      sources."es-to-primitive-1.2.1"
       sources."es5-ext-0.10.52"
       sources."es6-iterator-2.0.3"
       sources."es6-promise-4.2.8"
@@ -66236,7 +67638,7 @@ in
           sources."get-stream-3.0.0"
         ];
       })
-      sources."ext-1.1.2"
+      sources."ext-1.2.0"
       sources."extend-3.0.2"
       sources."extend-shallow-3.0.2"
       sources."external-editor-3.1.0"
@@ -66261,17 +67663,18 @@ in
         ];
       })
       sources."fs.realpath-1.0.0"
-      (sources."fs2-0.3.6" // {
+      (sources."fs2-0.3.7" // {
         dependencies = [
           sources."type-1.2.0"
         ];
       })
-      sources."fsevents-2.1.1"
+      sources."fsevents-2.1.2"
+      sources."function-bind-1.1.1"
       sources."get-proxy-2.1.0"
       sources."get-stdin-5.0.1"
       sources."get-stream-4.1.0"
       sources."get-value-2.0.6"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."glob-parent-5.1.0"
       sources."global-dirs-0.1.1"
       sources."globby-6.1.0"
@@ -66279,8 +67682,10 @@ in
       sources."graceful-fs-4.2.1"
       sources."graceful-readlink-1.0.1"
       sources."graphlib-2.1.7"
+      sources."has-1.0.3"
       sources."has-flag-3.0.0"
       sources."has-symbol-support-x-1.4.2"
+      sources."has-symbols-1.0.0"
       sources."has-to-string-tag-x-1.4.1"
       sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
@@ -66318,8 +67723,10 @@ in
       sources."is-accessor-descriptor-1.0.0"
       sources."is-binary-path-2.1.0"
       sources."is-buffer-2.0.4"
+      sources."is-callable-1.1.4"
       sources."is-ci-1.2.1"
       sources."is-data-descriptor-1.0.0"
+      sources."is-date-object-1.0.1"
       sources."is-descriptor-1.0.2"
       sources."is-docker-1.1.0"
       sources."is-extendable-1.0.1"
@@ -66336,8 +67743,10 @@ in
       sources."is-plain-object-2.0.4"
       sources."is-promise-2.1.0"
       sources."is-redirect-1.0.0"
+      sources."is-regex-1.0.4"
       sources."is-retry-allowed-1.2.0"
       sources."is-stream-1.1.0"
+      sources."is-symbol-1.0.2"
       sources."is-windows-1.0.2"
       sources."is-wsl-2.1.1"
       sources."isarray-1.0.0"
@@ -66433,7 +67842,10 @@ in
         ];
       })
       sources."object-hash-1.3.1"
+      sources."object-inspect-1.7.0"
+      sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
+      sources."object.getownpropertydescriptors-2.0.3"
       sources."object.pick-1.3.0"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
@@ -66459,7 +67871,7 @@ in
       sources."path-key-2.0.1"
       sources."path-loader-1.0.10"
       sources."pend-1.2.0"
-      sources."picomatch-2.1.0"
+      sources."picomatch-2.1.1"
       sources."pify-2.3.0"
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
@@ -66471,7 +67883,7 @@ in
       sources."pseudomap-1.0.2"
       sources."pump-3.0.0"
       sources."punycode-1.3.2"
-      sources."qs-6.9.0"
+      sources."qs-6.9.1"
       sources."querystring-0.2.0"
       sources."ramda-0.26.1"
       (sources."raven-1.2.1" // {
@@ -66502,7 +67914,7 @@ in
       sources."safe-buffer-5.2.0"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
-      sources."sax-1.2.1"
+      sources."sax-1.2.4"
       (sources."seek-bzip-1.0.5" // {
         dependencies = [
           sources."commander-2.8.1"
@@ -66578,6 +67990,8 @@ in
           sources."strip-ansi-4.0.0"
         ];
       })
+      sources."string.prototype.trimleft-2.1.0"
+      sources."string.prototype.trimright-2.1.0"
       (sources."string_decoder-1.1.1" // {
         dependencies = [
           sources."safe-buffer-5.1.2"
@@ -66653,6 +68067,7 @@ in
       sources."url-to-options-1.0.1"
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
+      sources."util.promisify-1.0.0"
       sources."uuid-2.0.3"
       sources."walkdir-0.0.11"
       sources."whatwg-fetch-3.0.0"
@@ -66662,8 +68077,8 @@ in
       sources."write-file-atomic-2.4.3"
       sources."ws-6.2.1"
       sources."xdg-basedir-3.0.0"
-      sources."xml2js-0.4.19"
-      sources."xmlbuilder-9.0.7"
+      sources."xml2js-0.4.22"
+      sources."xmlbuilder-11.0.1"
       sources."xtend-4.0.2"
       sources."yallist-2.1.2"
       sources."yaml-ast-parser-0.0.43"
@@ -67171,6 +68586,7 @@ in
       sources."assert-plus-0.1.5"
       sources."backoff-2.5.0"
       sources."balanced-match-1.0.0"
+      sources."bcrypt-pbkdf-1.0.2"
       sources."brace-expansion-1.1.11"
       sources."bunyan-1.5.1"
       sources."clone-0.1.6"
@@ -67184,10 +68600,15 @@ in
       sources."ctype-0.5.3"
       sources."dashdash-1.7.3"
       sources."dtrace-provider-0.6.0"
-      sources."ecc-jsbn-0.2.0"
+      sources."ecc-jsbn-0.1.2"
       sources."escape-regexp-component-1.0.2"
       sources."extsprintf-1.2.0"
       sources."formidable-1.2.1"
+      (sources."getpass-0.1.7" // {
+        dependencies = [
+          sources."assert-plus-1.0.0"
+        ];
+      })
       sources."glob-6.0.4"
       sources."http-signature-0.11.0"
       sources."inflight-1.0.6"
@@ -67237,13 +68658,16 @@ in
       sources."semver-4.3.6"
       (sources."smartdc-auth-2.3.1" // {
         dependencies = [
+          sources."asn1-0.2.4"
           sources."assert-plus-0.1.2"
           sources."clone-0.1.5"
           sources."dashdash-1.10.1"
           sources."extsprintf-1.0.0"
-          (sources."http-signature-1.2.0" // {
+          (sources."http-signature-1.3.1" // {
             dependencies = [
               sources."assert-plus-1.0.0"
+              sources."dashdash-1.14.1"
+              sources."sshpk-1.16.1"
             ];
           })
           sources."json-schema-0.2.2"
@@ -67303,22 +68727,21 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.242.0";
+    version = "1.244.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.242.0.tgz";
-      sha512 = "/FYu3vnv0XWA3bu6yVWpAXDYRVaC3xFf09KfekyYYXXZKPwBeYD7eu3iT+aXYua+DNuIfMJ6mWUbxjLp7LCi3Q==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.244.0.tgz";
+      sha512 = "w94dZS2w23XKunecST979nBaYAMFp/YjIPjS0aDK1vL4tEVu1l0qDBlwJGsd5Ijv5cyuO0m2/U0JMPUA1FqKlQ==";
     };
     dependencies = [
       sources."@snyk/cli-interface-2.2.0"
-      sources."@snyk/cocoapods-lockfile-parser-2.0.4"
-      sources."@snyk/composer-lockfile-parser-1.0.3"
+      sources."@snyk/cocoapods-lockfile-parser-3.0.0"
+      sources."@snyk/composer-lockfile-parser-1.2.0"
       sources."@snyk/dep-graph-1.13.1"
       sources."@snyk/gemfile-1.2.0"
       sources."@snyk/ruby-semver-2.0.4"
-      (sources."@snyk/snyk-cocoapods-plugin-1.0.3" // {
+      (sources."@snyk/snyk-cocoapods-plugin-2.0.1" // {
         dependencies = [
           sources."@snyk/cli-interface-1.5.0"
-          sources."@snyk/dep-graph-1.13.0"
         ];
       })
       sources."@types/agent-base-4.2.0"
@@ -67326,7 +68749,7 @@ in
       sources."@types/debug-4.1.5"
       sources."@types/events-3.0.0"
       sources."@types/js-yaml-3.12.1"
-      sources."@types/node-12.12.5"
+      sources."@types/node-12.12.7"
       sources."@types/restify-4.3.6"
       sources."@types/semver-5.5.0"
       sources."@types/xml2js-0.4.3"
@@ -67384,7 +68807,7 @@ in
       sources."color-name-1.1.3"
       sources."concat-map-0.0.1"
       sources."configstore-3.1.2"
-      sources."core-js-3.3.6"
+      sources."core-js-3.4.1"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       (sources."cross-spawn-6.0.5" // {
@@ -67418,7 +68841,7 @@ in
       sources."emoji-regex-7.0.3"
       sources."end-of-stream-1.4.4"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
@@ -67455,7 +68878,7 @@ in
       })
       sources."git-up-4.0.1"
       sources."git-url-parse-11.1.2"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."global-dirs-0.1.1"
       (sources."got-6.7.1" // {
         dependencies = [
@@ -67546,13 +68969,13 @@ in
       sources."npm-run-path-2.0.2"
       sources."number-is-nan-1.0.1"
       sources."object-hash-1.3.1"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object.getownpropertydescriptors-2.0.3"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."opn-5.5.0"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."os-locale-1.4.0"
       sources."os-name-3.1.0"
       sources."os-tmpdir-1.0.2"
@@ -67622,7 +69045,7 @@ in
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."signal-exit-3.0.2"
-      sources."smart-buffer-4.0.2"
+      sources."smart-buffer-4.1.0"
       sources."snyk-config-2.2.3"
       (sources."snyk-docker-plugin-1.33.1" // {
         dependencies = [
@@ -67649,7 +69072,7 @@ in
       sources."snyk-nodejs-lockfile-parser-1.16.1"
       sources."snyk-nuget-plugin-1.13.1"
       sources."snyk-paket-parser-1.5.0"
-      (sources."snyk-php-plugin-1.6.4" // {
+      (sources."snyk-php-plugin-1.7.0" // {
         dependencies = [
           sources."tslib-1.9.3"
         ];
@@ -67677,7 +69100,7 @@ in
           sources."yallist-2.1.2"
         ];
       })
-      sources."socks-2.3.2"
+      sources."socks-2.3.3"
       (sources."socks-proxy-agent-4.0.2" // {
         dependencies = [
           sources."agent-base-4.2.1"
@@ -67744,7 +69167,7 @@ in
       sources."widest-line-2.0.1"
       sources."window-size-0.1.4"
       sources."windows-release-3.2.0"
-      sources."wordwrap-1.0.0"
+      sources."word-wrap-1.2.3"
       (sources."wrap-ansi-5.1.0" // {
         dependencies = [
           sources."string-width-3.1.0"
@@ -67898,7 +69321,7 @@ in
       sources."duplexer3-0.1.4"
       sources."error-ex-1.3.2"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."es6-promise-4.2.8"
       sources."es6-promisify-5.0.0"
       sources."escape-string-regexp-1.0.5"
@@ -67953,7 +69376,7 @@ in
       sources."ms-2.0.0"
       sources."normalize-package-data-2.5.0"
       sources."npm-run-path-2.0.2"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object.getownpropertydescriptors-2.0.3"
       sources."onetime-2.0.1"
@@ -68186,7 +69609,7 @@ in
       sources."epidemic-broadcast-trees-7.0.0"
       sources."errno-0.1.7"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."exit-hook-1.1.1"
       sources."expand-brackets-0.1.5"
@@ -68628,7 +70051,7 @@ in
       sources."right-pad-1.0.1"
       (sources."rimraf-2.7.1" // {
         dependencies = [
-          sources."glob-7.1.5"
+          sources."glob-7.1.6"
         ];
       })
       sources."rng-0.2.2"
@@ -68648,7 +70071,7 @@ in
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
       sources."shellsubstitute-1.2.0"
-      sources."smart-buffer-4.0.2"
+      sources."smart-buffer-4.1.0"
       (sources."snapdragon-0.8.2" // {
         dependencies = [
           sources."debug-2.6.9"
@@ -68676,7 +70099,7 @@ in
         ];
       })
       sources."snapdragon-util-3.0.1"
-      sources."socks-2.3.2"
+      sources."socks-2.3.3"
       sources."sodium-browserify-1.3.0"
       (sources."sodium-browserify-tweetnacl-0.2.6" // {
         dependencies = [
@@ -68762,7 +70185,7 @@ in
       (sources."tape-4.11.0" // {
         dependencies = [
           sources."deep-equal-1.0.1"
-          sources."glob-7.1.5"
+          sources."glob-7.1.6"
         ];
       })
       sources."text-table-0.2.0"
@@ -68922,11 +70345,7 @@ in
       sources."async-1.5.2"
       sources."async-limiter-1.0.1"
       sources."asynckit-0.4.0"
-      (sources."aws-sdk-2.563.0" // {
-        dependencies = [
-          sources."uuid-3.3.2"
-        ];
-      })
+      sources."aws-sdk-2.569.0"
       sources."aws-sign2-0.6.0"
       sources."aws4-1.8.0"
       sources."babel-runtime-6.26.0"
@@ -68957,7 +70376,7 @@ in
       })
       sources."boom-2.10.1"
       sources."brace-expansion-1.1.11"
-      sources."buffer-4.9.1"
+      sources."buffer-4.9.2"
       sources."buffer-crc32-0.2.13"
       sources."buffer-equal-constant-time-1.0.1"
       sources."buffer-from-1.1.1"
@@ -69028,6 +70447,7 @@ in
       sources."debug-2.6.9"
       sources."decamelize-1.2.0"
       sources."deep-extend-0.4.2"
+      sources."define-properties-1.1.3"
       sources."delayed-stream-1.0.0"
       sources."depd-1.1.2"
       sources."deref-0.6.4"
@@ -69062,6 +70482,8 @@ in
       })
       sources."engine.io-parser-2.2.0"
       sources."error-ex-1.3.2"
+      sources."es-abstract-1.16.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-2.0.0"
@@ -69137,6 +70559,7 @@ in
         ];
       })
       sources."has-cors-1.1.0"
+      sources."has-symbols-1.0.0"
       sources."hawk-3.1.3"
       sources."highlight.js-8.2.0"
       (sources."hipchatter-0.3.2" // {
@@ -69168,6 +70591,8 @@ in
       sources."ipaddr.js-1.9.0"
       sources."is-arrayish-0.2.1"
       sources."is-buffer-1.1.6"
+      sources."is-callable-1.1.4"
+      sources."is-date-object-1.0.1"
       (sources."is-expression-3.0.0" // {
         dependencies = [
           sources."acorn-4.0.13"
@@ -69180,6 +70605,7 @@ in
       sources."is-property-1.0.2"
       sources."is-regex-1.0.4"
       sources."is-stream-1.1.0"
+      sources."is-symbol-1.0.2"
       sources."is-typedarray-1.0.0"
       sources."is-utf8-0.2.1"
       sources."isarray-1.0.0"
@@ -69305,6 +70731,9 @@ in
       sources."object-assign-4.1.1"
       sources."object-component-0.0.3"
       sources."object-hash-0.3.0"
+      sources."object-inspect-1.7.0"
+      sources."object-keys-1.1.1"
+      sources."object.getownpropertydescriptors-2.0.3"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -69426,7 +70855,7 @@ in
       sources."safe-buffer-5.1.2"
       sources."safe-json-stringify-1.2.0"
       sources."safer-buffer-2.1.2"
-      sources."sax-1.2.1"
+      sources."sax-1.2.4"
       sources."semver-5.7.1"
       (sources."send-0.17.1" // {
         dependencies = [
@@ -69506,6 +70935,8 @@ in
           sources."strip-ansi-4.0.0"
         ];
       })
+      sources."string.prototype.trimleft-2.1.0"
+      sources."string.prototype.trimright-2.1.0"
       sources."string_decoder-0.10.31"
       sources."stringstream-0.0.6"
       sources."strip-ansi-3.0.1"
@@ -69516,7 +70947,7 @@ in
           sources."debug-3.2.6"
           sources."form-data-2.5.1"
           sources."ms-2.1.2"
-          sources."qs-6.9.0"
+          sources."qs-6.9.1"
           sources."readable-stream-2.3.6"
           sources."string_decoder-1.1.1"
         ];
@@ -69529,7 +70960,7 @@ in
           sources."esprima-4.0.1"
           sources."js-yaml-3.13.1"
           sources."lodash-3.10.1"
-          sources."qs-6.9.0"
+          sources."qs-6.9.1"
         ];
       })
       sources."swagger-schema-official-2.0.0-bab6bed"
@@ -69538,13 +70969,13 @@ in
           sources."esprima-4.0.1"
           sources."isarray-0.0.1"
           sources."js-yaml-3.13.1"
-          sources."path-to-regexp-1.7.0"
+          sources."path-to-regexp-1.8.0"
         ];
       })
       sources."switchback-2.0.5"
       (sources."temp-0.8.4" // {
         dependencies = [
-          sources."glob-7.1.5"
+          sources."glob-7.1.6"
           sources."rimraf-2.6.3"
         ];
       })
@@ -69592,6 +71023,7 @@ in
       sources."url-join-1.1.0"
       sources."utf-8-validate-1.2.2"
       sources."util-deprecate-1.0.2"
+      sources."util.promisify-1.0.0"
       sources."utils-merge-1.0.1"
       sources."uuid-3.3.3"
       sources."validate-npm-package-license-3.0.4"
@@ -69641,8 +71073,8 @@ in
           sources."node-forge-0.2.24"
         ];
       })
-      sources."xml2js-0.4.19"
-      sources."xmlbuilder-9.0.7"
+      sources."xml2js-0.4.22"
+      sources."xmlbuilder-11.0.1"
       sources."xmldom-0.1.27"
       sources."xmlhttprequest-ssl-1.5.5"
       sources."xpath-0.0.5"
@@ -69708,13 +71140,13 @@ in
       sources."coa-2.0.2"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
-      sources."css-select-2.0.2"
+      sources."css-select-2.1.0"
       sources."css-select-base-adapter-0.1.1"
       sources."css-tree-1.0.0-alpha.37"
-      sources."css-what-2.1.3"
+      sources."css-what-3.2.1"
       sources."csso-4.0.2"
       sources."define-properties-1.1.3"
-      (sources."dom-serializer-0.2.1" // {
+      (sources."dom-serializer-0.2.2" // {
         dependencies = [
           sources."domelementtype-2.0.1"
         ];
@@ -69723,7 +71155,7 @@ in
       sources."domutils-1.7.0"
       sources."entities-2.0.0"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
       sources."function-bind-1.1.1"
@@ -69739,7 +71171,7 @@ in
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       sources."nth-check-1.0.2"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object.getownpropertydescriptors-2.0.3"
       sources."object.values-1.1.0"
@@ -69959,7 +71391,7 @@ in
       sources."fsevents-1.2.9"
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -70157,11 +71589,11 @@ in
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.2"
-          sources."qs-6.9.0"
+          sources."qs-6.9.1"
           sources."superagent-3.8.3"
         ];
       })
-      (sources."path-to-regexp-1.7.0" // {
+      (sources."path-to-regexp-1.8.0" // {
         dependencies = [
           sources."isarray-0.0.1"
         ];
@@ -70334,7 +71766,7 @@ in
       sources."truncate-utf8-bytes-1.0.2"
       sources."type-is-1.6.18"
       sources."typedarray-0.0.6"
-      (sources."uglify-js-3.6.7" // {
+      (sources."uglify-js-3.6.8" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -70405,7 +71837,7 @@ in
       sha256 = "886069ecc5eedf0371b948e8ff66e7f2943c85fe7cfdaa7183e1a3572d55852b";
     };
     dependencies = [
-      sources."@types/node-12.12.5"
+      sources."@types/node-12.12.7"
       sources."ajv-6.10.2"
       sources."ansi-regex-4.1.0"
       sources."ansi-styles-3.2.1"
@@ -70540,7 +71972,7 @@ in
       sources."enhanced-resolve-2.3.0"
       sources."errno-0.1.7"
       sources."fs.realpath-1.0.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -70594,7 +72026,7 @@ in
       sources."@textlint/textlint-plugin-text-4.1.10"
       sources."@textlint/types-1.2.3"
       sources."@textlint/utils-1.0.3"
-      sources."@types/bluebird-3.5.28"
+      sources."@types/bluebird-3.5.29"
       sources."ajv-4.11.8"
       sources."ajv-keywords-1.5.1"
       sources."ansi-regex-2.1.1"
@@ -70625,7 +72057,7 @@ in
       sources."diff-4.0.1"
       sources."error-ex-1.3.2"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
       sources."extend-3.0.2"
@@ -70639,7 +72071,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."get-stdin-5.0.1"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."has-1.0.3"
       sources."has-ansi-2.0.0"
@@ -70688,11 +72120,11 @@ in
       sources."ms-2.1.2"
       sources."normalize-package-data-2.5.0"
       sources."number-is-nan-1.0.1"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-is-1.0.1"
       sources."object-keys-1.1.1"
       sources."once-1.4.0"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."p-limit-1.3.0"
       sources."p-locate-2.0.0"
       sources."p-try-1.0.0"
@@ -70768,16 +72200,16 @@ in
       sources."unified-6.2.0"
       sources."unique-concat-0.2.2"
       sources."unist-util-is-3.0.0"
-      sources."unist-util-remove-position-1.1.3"
+      sources."unist-util-remove-position-1.1.4"
       sources."unist-util-stringify-position-1.1.2"
       sources."unist-util-visit-1.4.1"
       sources."unist-util-visit-parents-2.1.2"
       sources."util-deprecate-1.0.2"
       sources."validate-npm-package-license-3.0.4"
       sources."vfile-2.3.0"
-      sources."vfile-location-2.0.5"
+      sources."vfile-location-2.0.6"
       sources."vfile-message-1.1.1"
-      sources."wordwrap-1.0.0"
+      sources."word-wrap-1.2.3"
       sources."wrappy-1.0.2"
       sources."write-1.0.3"
       sources."x-is-string-0.1.0"
@@ -70920,7 +72352,7 @@ in
       sources."get-stream-3.0.0"
       sources."git-diff-tree-1.0.0"
       sources."git-spawned-stream-0.1.1"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."global-dirs-0.1.1"
       sources."got-6.7.1"
       sources."graceful-fs-4.2.3"
@@ -71033,7 +72465,7 @@ in
       sources."replace-ext-1.0.0"
       sources."resolve-1.12.0"
       sources."resolve-from-5.0.0"
-      sources."retext-english-3.0.3"
+      sources."retext-english-3.0.4"
       sources."retext-equality-3.2.0"
       sources."retext-profanities-4.4.0"
       sources."safe-buffer-5.1.2"
@@ -71104,9 +72536,9 @@ in
       sources."unified-message-control-1.0.4"
       sources."unique-string-1.0.0"
       sources."unist-util-is-3.0.0"
-      sources."unist-util-modify-children-1.1.4"
-      sources."unist-util-position-3.0.3"
-      sources."unist-util-remove-position-1.1.3"
+      sources."unist-util-modify-children-1.1.5"
+      sources."unist-util-position-3.0.4"
+      sources."unist-util-remove-position-1.1.4"
       sources."unist-util-stringify-position-1.1.2"
       sources."unist-util-visit-1.4.1"
       sources."unist-util-visit-children-1.1.3"
@@ -71119,7 +72551,7 @@ in
       sources."validate-npm-package-license-3.0.4"
       sources."vfile-2.3.0"
       sources."vfile-find-up-2.0.2"
-      sources."vfile-location-2.0.5"
+      sources."vfile-location-2.0.6"
       sources."vfile-message-1.1.1"
       (sources."vfile-reporter-4.0.0" // {
         dependencies = [
@@ -71291,7 +72723,7 @@ in
       sources."core-util-is-1.0.2"
       sources."define-properties-1.1.3"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
       sources."has-symbols-1.0.0"
@@ -71302,7 +72734,7 @@ in
       sources."is-symbol-1.0.2"
       sources."isarray-1.0.0"
       sources."object-assign-4.1.1"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object.values-1.1.0"
       sources."process-nextick-args-2.0.1"
@@ -71345,7 +72777,7 @@ in
       sources."emoji-regex-6.5.1"
       sources."end-with-1.0.2"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
       sources."has-symbols-1.0.0"
@@ -71353,7 +72785,7 @@ in
       sources."is-date-object-1.0.1"
       sources."is-regex-1.0.4"
       sources."is-symbol-1.0.2"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."string.prototype.trimleft-2.1.0"
       sources."string.prototype.trimright-2.1.0"
@@ -71440,7 +72872,7 @@ in
       sources."array-includes-3.0.3"
       sources."define-properties-1.1.3"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."function-bind-1.1.1"
       sources."has-1.0.3"
       sources."has-symbols-1.0.0"
@@ -71449,7 +72881,7 @@ in
       sources."is-date-object-1.0.1"
       sources."is-regex-1.0.4"
       sources."is-symbol-1.0.2"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."string.prototype.trimleft-2.1.0"
       sources."string.prototype.trimright-2.1.0"
@@ -71587,7 +73019,7 @@ in
       sources."content-type-1.0.4"
       sources."cookie-0.4.0"
       sources."cookie-signature-1.0.6"
-      sources."core-js-3.3.6"
+      sources."core-js-3.4.1"
       sources."core-util-is-1.0.2"
       sources."css-select-1.2.0"
       sources."css-what-2.1.3"
@@ -71658,7 +73090,7 @@ in
       sources."gauge-2.7.4"
       sources."get-stream-4.1.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."got-9.6.0"
       sources."graceful-fs-4.2.3"
       sources."grapheme-splitter-1.0.4"
@@ -71893,7 +73325,7 @@ in
       sources."verror-1.10.0"
       sources."web-push-3.4.1"
       sources."wide-align-1.1.3"
-      sources."with-open-file-0.1.6"
+      sources."with-open-file-0.1.7"
       sources."wrappy-1.0.2"
       sources."ws-7.2.0"
       sources."xmlhttprequest-ssl-1.5.5"
@@ -71993,7 +73425,7 @@ in
       sources."fs-extra-7.0.1"
       sources."fs.realpath-1.0.0"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -72114,7 +73546,7 @@ in
         ];
       })
       sources."glob-5.0.15"
-      (sources."http-signature-1.2.0" // {
+      (sources."http-signature-1.3.1" // {
         dependencies = [
           sources."assert-plus-1.0.0"
         ];
@@ -72285,7 +73717,7 @@ in
       sources."diff-2.2.3"
       sources."escape-string-regexp-1.0.5"
       sources."fs.realpath-1.0.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."has-ansi-2.0.0"
       sources."inflight-1.0.6"
       sources."inherits-2.0.4"
@@ -72339,10 +73771,10 @@ in
   typescript = nodeEnv.buildNodePackage {
     name = "typescript";
     packageName = "typescript";
-    version = "3.6.4";
+    version = "3.7.2";
     src = fetchurl {
-      url = "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz";
-      sha512 = "unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==";
+      url = "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz";
+      sha512 = "ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -72374,10 +73806,10 @@ in
       sources."tempy-0.2.1"
       sources."unique-string-1.0.0"
       sources."universalify-0.1.2"
-      sources."vscode-jsonrpc-5.0.0-next.2"
+      sources."vscode-jsonrpc-5.0.0-next.4"
       sources."vscode-languageserver-5.3.0-next.10"
-      sources."vscode-languageserver-protocol-3.15.0-next.10"
-      sources."vscode-languageserver-types-3.15.0-next.6"
+      sources."vscode-languageserver-protocol-3.15.0-next.11"
+      sources."vscode-languageserver-types-3.15.0-next.8"
       sources."vscode-textbuffer-1.0.0"
       sources."vscode-uri-1.0.8"
     ];
@@ -72393,10 +73825,10 @@ in
   uglify-js = nodeEnv.buildNodePackage {
     name = "uglify-js";
     packageName = "uglify-js";
-    version = "3.6.7";
+    version = "3.6.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.7.tgz";
-      sha512 = "4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==";
+      url = "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz";
+      sha512 = "XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==";
     };
     dependencies = [
       sources."commander-2.20.3"
@@ -72415,12 +73847,13 @@ in
   ungit = nodeEnv.buildNodePackage {
     name = "ungit";
     packageName = "ungit";
-    version = "1.4.48";
+    version = "1.5.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ungit/-/ungit-1.4.48.tgz";
-      sha512 = "OnChT88XpseexbxagMAL5wqM9dIZxb5oHCwUXaEZ8ERy77GDzhFKko1DZLWZg6uljrOx1yryBGe7ft8eJ5/O9g==";
+      url = "https://registry.npmjs.org/ungit/-/ungit-1.5.0.tgz";
+      sha512 = "/z1T7PRc2c3AlXK1IQCzpZ1ft07MLxi/WmZlBBdqZiVV9pf3tOa7uWILs9bHaHUAlWMxix1F0ZATCNqb38e1dA==";
     };
     dependencies = [
+      sources."@primer/octicons-9.2.0"
       sources."abbrev-1.1.1"
       sources."accepts-1.3.7"
       sources."after-0.8.2"
@@ -72579,7 +74012,7 @@ in
       sources."get-stream-4.1.0"
       sources."getmac-1.4.6"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"
@@ -72623,7 +74056,7 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."just-detect-adblock-1.0.0"
-      sources."knockout-3.5.0"
+      sources."knockout-3.5.1"
       sources."lcid-2.0.0"
       sources."locate-path-3.0.0"
       sources."locks-0.2.2"
@@ -72658,7 +74091,7 @@ in
           sources."semver-5.7.1"
         ];
       })
-      sources."npm-6.9.2"
+      sources."npm-6.12.1"
       (sources."npm-package-arg-6.1.1" // {
         dependencies = [
           sources."semver-5.7.1"
@@ -72676,7 +74109,6 @@ in
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
       sources."object-component-0.0.3"
-      sources."octicons-3.5.0"
       sources."on-finished-2.3.0"
       sources."on-headers-1.0.2"
       sources."once-1.4.0"
@@ -72803,7 +74235,7 @@ in
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."type-is-1.6.18"
-      sources."typechecker-4.7.0"
+      sources."typechecker-4.8.0"
       sources."typedarray-0.0.6"
       sources."uid-safe-2.1.5"
       sources."unpipe-1.0.0"
@@ -73026,7 +74458,7 @@ in
       sources."get-stream-3.0.0"
       sources."getpass-0.1.7"
       sources."git-clone-0.1.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."got-6.7.1"
       sources."graceful-fs-4.2.3"
       sources."graceful-readlink-1.0.1"
@@ -73184,7 +74616,7 @@ in
       sources."tslib-1.10.0"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
-      sources."uglify-js-3.6.7"
+      sources."uglify-js-3.6.8"
       sources."uid-0.0.2"
       sources."unbzip2-stream-1.3.3"
       sources."unyield-0.0.1"
@@ -73240,10 +74672,10 @@ in
       sources."@starptech/rehype-minify-whitespace-0.9.0"
       sources."@starptech/rehype-webparser-0.9.0"
       sources."@starptech/webparser-0.9.0"
-      sources."@types/node-12.12.5"
+      sources."@types/node-12.12.7"
       sources."@types/unist-2.0.3"
       sources."@types/vfile-3.0.2"
-      sources."@types/vfile-message-1.0.1"
+      sources."@types/vfile-message-2.0.0"
       sources."abbrev-1.1.1"
       sources."acorn-6.3.0"
       sources."acorn-jsx-5.1.0"
@@ -73514,7 +74946,7 @@ in
       sources."get-caller-file-1.0.3"
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       (sources."glob-base-0.3.0" // {
         dependencies = [
           sources."glob-parent-2.0.0"
@@ -73552,7 +74984,7 @@ in
       sources."hast-util-has-property-1.0.3"
       sources."hast-util-is-body-ok-link-1.0.2"
       sources."hast-util-is-element-1.0.3"
-      sources."hast-util-parse-selector-2.2.2"
+      sources."hast-util-parse-selector-2.2.3"
       sources."hast-util-to-string-1.0.2"
       sources."hast-util-whitespace-1.0.3"
       sources."hosted-git-info-2.8.5"
@@ -73645,7 +75077,7 @@ in
       sources."lodash.merge-4.6.2"
       sources."lodash.rest-4.0.5"
       sources."lodash.unescape-4.0.1"
-      sources."loglevel-1.6.4"
+      sources."loglevel-1.6.6"
       (sources."loglevel-colored-level-prefix-1.0.0" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
@@ -73726,7 +75158,7 @@ in
       sources."object.pick-1.3.0"
       sources."once-1.4.0"
       sources."onetime-2.0.1"
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."os-homedir-1.0.2"
       (sources."os-locale-3.1.0" // {
         dependencies = [
@@ -73780,7 +75212,7 @@ in
       sources."prelude-ls-1.1.2"
       sources."prepend-http-1.0.4"
       sources."preserve-0.2.0"
-      sources."prettier-1.18.2"
+      sources."prettier-1.19.1"
       (sources."prettier-eslint-8.8.2" // {
         dependencies = [
           sources."acorn-5.7.3"
@@ -74038,11 +75470,11 @@ in
       sources."trim-trailing-lines-1.1.2"
       sources."trough-1.0.4"
       sources."tslib-1.10.0"
-      sources."tslint-5.20.0"
+      sources."tslint-5.20.1"
       sources."tsutils-2.29.0"
       sources."type-check-0.3.2"
       sources."typedarray-0.0.6"
-      sources."typescript-3.6.4"
+      sources."typescript-3.7.2"
       (sources."typescript-eslint-parser-16.0.1" // {
         dependencies = [
           sources."semver-5.5.0"
@@ -74065,8 +75497,8 @@ in
       sources."unist-util-find-1.0.1"
       sources."unist-util-inspect-4.1.4"
       sources."unist-util-is-2.1.3"
-      sources."unist-util-modify-children-1.1.4"
-      sources."unist-util-remove-position-1.1.3"
+      sources."unist-util-modify-children-1.1.5"
+      sources."unist-util-remove-position-1.1.4"
       sources."unist-util-stringify-position-1.1.2"
       sources."unist-util-visit-1.4.1"
       (sources."unist-util-visit-parents-2.1.2" // {
@@ -74094,17 +75526,17 @@ in
       sources."user-home-2.0.0"
       sources."util-deprecate-1.0.2"
       sources."validate-npm-package-license-3.0.4"
-      (sources."vfile-4.0.1" // {
+      (sources."vfile-4.0.2" // {
         dependencies = [
-          sources."unist-util-stringify-position-2.0.1"
-          sources."vfile-message-2.0.1"
+          sources."unist-util-stringify-position-2.0.2"
+          sources."vfile-message-2.0.2"
         ];
       })
-      sources."vfile-location-2.0.5"
+      sources."vfile-location-2.0.6"
       sources."vfile-message-1.1.1"
       (sources."vfile-reporter-5.1.2" // {
         dependencies = [
-          sources."unist-util-stringify-position-2.0.1"
+          sources."unist-util-stringify-position-2.0.2"
         ];
       })
       sources."vfile-sort-2.2.1"
@@ -74115,14 +75547,14 @@ in
           sources."vscode-languageserver-types-3.14.0"
         ];
       })
-      sources."vscode-jsonrpc-5.0.0-next.2"
+      sources."vscode-jsonrpc-5.0.0-next.4"
       sources."vscode-languageserver-5.3.0-next.10"
-      sources."vscode-languageserver-protocol-3.15.0-next.10"
-      sources."vscode-languageserver-types-3.15.0-next.6"
+      sources."vscode-languageserver-protocol-3.15.0-next.11"
+      sources."vscode-languageserver-types-3.15.0-next.8"
       sources."vscode-nls-4.1.1"
       sources."vscode-textbuffer-1.0.0"
       sources."vscode-uri-1.0.8"
-      (sources."vue-eslint-parser-6.0.4" // {
+      (sources."vue-eslint-parser-6.0.5" // {
         dependencies = [
           sources."debug-4.1.1"
         ];
@@ -74133,7 +75565,7 @@ in
       sources."which-module-2.0.0"
       sources."widest-line-2.0.1"
       sources."window-size-0.2.0"
-      sources."wordwrap-1.0.0"
+      sources."word-wrap-1.2.3"
       (sources."wrap-ansi-2.1.0" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
@@ -74171,23 +75603,23 @@ in
   web-ext = nodeEnv.buildNodePackage {
     name = "web-ext";
     packageName = "web-ext";
-    version = "3.2.0";
+    version = "3.2.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/web-ext/-/web-ext-3.2.0.tgz";
-      sha512 = "UM2ucXzEKs6tD+YT6FjmfIeQtLy4t9CwdwyQl8Nthn2BbGgDLht+wBWsU8VYnNXtrObxX24Co8oaF7Id06JbgA==";
+      url = "https://registry.npmjs.org/web-ext/-/web-ext-3.2.1.tgz";
+      sha512 = "WzZbCDIjIUshZRVaiYFbaMp/1/xPjW7qeTQ0F7Xx1MYkamZ4RN5dnhxWFz+Hzg6GzhFdny+zucNDKOwYfAV3LA==";
     };
     dependencies = [
       sources."@babel/code-frame-7.5.5"
       sources."@babel/highlight-7.5.0"
       sources."@babel/polyfill-7.6.0"
       sources."@babel/runtime-7.6.2"
-      sources."@babel/runtime-corejs2-7.6.3"
+      sources."@babel/runtime-corejs2-7.7.2"
       sources."@cliqz-oss/firefox-client-0.3.1"
       sources."@cliqz-oss/node-firefox-connect-1.2.1"
       sources."@sindresorhus/is-0.14.0"
       sources."@szmarczak/http-timer-1.1.2"
       sources."@types/minimatch-3.0.3"
-      sources."@types/node-12.12.5"
+      sources."@types/node-12.12.7"
       sources."JSONSelect-0.2.1"
       sources."acorn-6.3.0"
       sources."acorn-jsx-5.1.0"
@@ -74443,7 +75875,7 @@ in
       sources."entities-1.1.2"
       sources."error-ex-1.3.2"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."es5-ext-0.10.52"
       sources."es6-error-4.1.1"
       sources."es6-iterator-2.0.3"
@@ -74549,7 +75981,7 @@ in
           sources."kind-of-5.1.0"
         ];
       })
-      (sources."ext-1.1.2" // {
+      (sources."ext-1.2.0" // {
         dependencies = [
           sources."type-2.0.0"
         ];
@@ -74852,7 +76284,7 @@ in
           sources."kind-of-3.2.2"
         ];
       })
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-is-1.0.1"
       sources."object-keys-1.1.1"
       sources."object-visit-1.0.1"
@@ -74865,7 +76297,7 @@ in
           sources."is-wsl-1.1.0"
         ];
       })
-      sources."optionator-0.8.2"
+      sources."optionator-0.8.3"
       sources."os-homedir-1.0.2"
       sources."os-locale-4.0.0"
       sources."os-shim-0.1.3"
@@ -75174,7 +76606,7 @@ in
         ];
       })
       sources."winreg-0.0.12"
-      sources."wordwrap-1.0.0"
+      sources."word-wrap-1.2.3"
       (sources."wrap-ansi-5.1.0" // {
         dependencies = [
           sources."ansi-regex-4.1.0"
@@ -75299,7 +76731,7 @@ in
       sources."browserify-rsa-4.0.1"
       sources."browserify-sign-4.0.4"
       sources."browserify-zlib-0.2.0"
-      sources."buffer-4.9.1"
+      sources."buffer-4.9.2"
       sources."buffer-from-1.1.1"
       sources."buffer-xor-1.0.3"
       sources."builtin-status-codes-3.0.0"
@@ -75410,7 +76842,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."fsevents-1.2.9"
       sources."get-value-2.0.6"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
@@ -75627,7 +77059,7 @@ in
       sources."stream-shift-1.0.0"
       sources."string_decoder-1.1.1"
       sources."tapable-1.1.3"
-      (sources."terser-4.3.9" // {
+      (sources."terser-4.4.0" // {
         dependencies = [
           sources."source-map-0.6.1"
         ];
@@ -76050,7 +77482,7 @@ in
       sources."@protobufjs/pool-1.1.0"
       sources."@protobufjs/utf8-1.1.0"
       sources."@types/long-4.0.0"
-      sources."@types/node-10.17.3"
+      sources."@types/node-10.17.5"
       sources."addr-to-ip-port-1.5.1"
       sources."airplay-js-0.3.0"
       sources."async-limiter-1.0.1"
@@ -76136,7 +77568,7 @@ in
       sources."elementtree-0.1.7"
       sources."end-of-stream-1.4.4"
       sources."es-abstract-1.16.0"
-      sources."es-to-primitive-1.2.0"
+      sources."es-to-primitive-1.2.1"
       sources."escape-html-1.0.3"
       sources."executable-4.1.1"
       sources."filestream-5.0.0"
@@ -76150,7 +77582,7 @@ in
       sources."function-bind-1.1.1"
       sources."get-browser-rtc-1.0.2"
       sources."get-stdin-7.0.0"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."has-1.0.3"
       sources."has-symbols-1.0.0"
       sources."he-1.2.0"
@@ -76215,7 +77647,7 @@ in
       sources."node-gyp-build-3.7.0"
       sources."node-ssdp-2.9.1"
       sources."nodebmc-0.0.7"
-      sources."object-inspect-1.6.0"
+      sources."object-inspect-1.7.0"
       sources."object-keys-1.1.1"
       sources."object.getownpropertydescriptors-2.0.3"
       sources."on-finished-2.3.0"
@@ -76268,14 +77700,14 @@ in
       sources."semver-5.1.1"
       sources."simple-concat-1.0.0"
       sources."simple-get-2.8.1"
-      (sources."simple-peer-9.6.0" // {
+      (sources."simple-peer-9.6.1" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
         ];
       })
       sources."simple-sha1-3.0.1"
-      (sources."simple-websocket-8.0.1" // {
+      (sources."simple-websocket-8.1.0" // {
         dependencies = [
           sources."debug-4.1.1"
           sources."ms-2.1.2"
@@ -76525,7 +77957,7 @@ in
       sources."config-chain-1.1.12"
       sources."configstore-3.1.2"
       sources."copy-descriptor-0.1.1"
-      sources."core-js-3.3.6"
+      sources."core-js-3.4.1"
       sources."core-util-is-1.0.2"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-6.0.5"
@@ -76627,14 +78059,14 @@ in
       sources."get-stream-3.0.0"
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       (sources."glob-parent-3.1.0" // {
         dependencies = [
           sources."is-glob-3.1.0"
         ];
       })
       sources."glob-to-regexp-0.3.0"
-      (sources."global-agent-2.1.5" // {
+      (sources."global-agent-2.1.6" // {
         dependencies = [
           sources."semver-6.3.0"
         ];
@@ -76926,7 +78358,7 @@ in
       sources."responselike-1.0.2"
       sources."restore-cursor-2.0.0"
       sources."ret-0.1.15"
-      sources."roarr-2.14.3"
+      sources."roarr-2.14.4"
       sources."root-check-1.0.0"
       sources."run-async-2.3.0"
       sources."rx-4.1.0"

--- a/pkgs/development/node-packages/node-packages-v12.nix
+++ b/pkgs/development/node-packages/node-packages-v12.nix
@@ -697,13 +697,13 @@ let
         sha1 = "5eff8e3e684d569ae4cb2b1282604e8ba62149fa";
       };
     };
-    "glob-7.1.5" = {
+    "glob-7.1.6" = {
       name = "glob";
       packageName = "glob";
-      version = "7.1.5";
+      version = "7.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz";
-        sha512 = "J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==";
+        url = "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz";
+        sha512 = "LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==";
       };
     };
     "global-modules-1.0.0" = {
@@ -2651,7 +2651,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"

--- a/pkgs/development/node-packages/node-packages-v13.nix
+++ b/pkgs/development/node-packages/node-packages-v13.nix
@@ -391,13 +391,13 @@ let
         sha1 = "5eff8e3e684d569ae4cb2b1282604e8ba62149fa";
       };
     };
-    "glob-7.1.5" = {
+    "glob-7.1.6" = {
       name = "glob";
       packageName = "glob";
-      version = "7.1.5";
+      version = "7.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz";
-        sha512 = "J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==";
+        url = "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz";
+        sha512 = "LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==";
       };
     };
     "graceful-fs-4.2.3" = {
@@ -1319,7 +1319,7 @@ in
       sources."fs.realpath-1.0.0"
       sources."gauge-2.7.4"
       sources."getpass-0.1.7"
-      sources."glob-7.1.5"
+      sources."glob-7.1.6"
       sources."graceful-fs-4.2.3"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.3"

--- a/pkgs/development/tools/misc/texlab/citeproc/package.json
+++ b/pkgs/development/tools/misc/texlab/citeproc/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "citeproc",
+  "version": "0.1.0",
+  "description": "Render BibTeX citations",
+  "repository": "https://github.com/latex-lsp/citeproc.git",
+  "author": "Eric Förster <efoerster@users.noreply.github.com>",
+  "license": "MIT",
+  "scripts": {
+    "dist": "webpack",
+    "format": "prettier --write \"src/**/*.{js,json}\" \"*.{js,json,yml,md}\" \".vscode/**/*.{json}\""
+  },
+  "dependencies": {
+    "@babel/core": "^7.5.5",
+    "@babel/preset-env": "^7.5.5",
+    "@citation-js/core": "^0.4.8",
+    "@citation-js/plugin-bibtex": "^0.4.8",
+    "@citation-js/plugin-csl": "^0.4.8",
+    "@types/node": "^11.13.17",
+    "@types/webpack": "^4.4.35",
+    "babel-loader": "^8.0.6",
+    "babel-polyfill": "^6.26.0",
+    "null-loader": "^0.1.1",
+    "prettier": "^1.18.2",
+    "ts-loader": "^5.4.5",
+    "ts-node": "^8.3.0",
+    "tslint": "^5.18.0",
+    "tslint-config-prettier": "^1.15.0",
+    "webpack": "^4.35.3",
+    "webpack-cli": "^3.3.6"
+  }
+}

--- a/pkgs/development/tools/misc/texlab/citeproc/update-package.json.sh
+++ b/pkgs/development/tools/misc/texlab/citeproc/update-package.json.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p jq
+
+set -eu -o pipefail
+
+if [ "$#" -ne 1 ] || [[ "$1" == -* ]]; then
+	echo "Usage: $0 <git release tag>"
+	exit 1
+fi
+
+TEXLAB_WEB_SRC="https://raw.githubusercontent.com/latex-lsp/texlab/$1"
+
+curl --silent "$TEXLAB_WEB_SRC/src/citeproc/js/package.json" | \
+	jq '. + {"dependencies": .devDependencies} | del(.devDependencies)' > package.json

--- a/pkgs/development/tools/misc/texlab/default.nix
+++ b/pkgs/development/tools/misc/texlab/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+, nodejs
+, Security
+, texlab-citeproc-build-deps
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "texlab";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "latex-lsp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "115f63fij0lxcccf7ba9p0lzg1hlfp9i2g7gvvnx0il426h4ynnm";
+  };
+
+  cargoSha256 = "0cp8q3qags01s6v3kbghxyzz1hc5rhq6jf15fzz10d1l8mrmw4cy";
+
+  nativeBuildInputs = [ nodejs ];
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
+
+  preBuild = ''
+    rm build.rs
+    ln -s ${texlab-citeproc-build-deps}/lib/node_modules/citeproc/node_modules src/citeproc/js
+    (cd src/citeproc/js && npm run dist)
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An implementation of the Language Server Protocol for LaTeX";
+    homepage = https://texlab.netlify.com/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar metadark ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10424,6 +10424,11 @@ in
 
   texi2mdoc = callPackage ../tools/misc/texi2mdoc { };
 
+  texlab = callPackage ../development/tools/misc/texlab {
+    inherit (darwin.apple_sdk.frameworks) Security;
+    texlab-citeproc-build-deps = nodePackages."texlab-citeproc-build-deps-../tools/misc/texlab/citeproc";
+  };
+
   tflint = callPackage ../development/tools/analysis/tflint { };
 
   todoist = callPackage ../applications/misc/todoist { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/67934

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
```
[118 built, 1782 copied (4690.2 MiB), 1542.7 MiB DL]
19 package were build:
antora create-cycle-app emojione hueadm image_optim iosevka joplin lumo parity-ui rambox-pro sage sageWithDoc slack slack-dark texlab thelounge triton twemoji-color-font wasm-text-gen
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @doronbehar
