### PR TITLE
groff: Fix cross-compilation

### DIFF
--- a/pkgs/tools/text/groff/0001-Fix-cross-compilation-by-looking-for-ar.patch
+++ b/pkgs/tools/text/groff/0001-Fix-cross-compilation-by-looking-for-ar.patch
@@ -1,0 +1,46 @@
+From 1454525f70b43a6957b7c9e1870e997368787da3 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Fri, 8 Nov 2019 21:59:21 -0500
+Subject: [PATCH] Fix cross-compilation by looking for `ar`.
+
+---
+ Makefile.am  | 2 +-
+ configure.ac | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index d18c49b8..b1b53338 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -494,7 +494,7 @@ CCC=@CXX@
+ # INSTALL_INFO
+ # LN_S
+ 
+-AR=ar
++AR=@AR@
+ ETAGS=etags
+ ETAGSFLAGS=
+ # Flag that tells etags to assume C++.
+diff --git a/configure.ac b/configure.ac
+index 28e75f17..2449b9f5 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -37,6 +37,7 @@ AC_CONFIG_AUX_DIR([build-aux])
+ 
+ AC_CONFIG_HEADERS([src/include/config.h:src/include/config.hin])
+ AC_CONFIG_SRCDIR([src/roff/groff/groff.cpp])
++AC_CONFIG_MACRO_DIR([m4])
+ 
+ AC_USE_SYSTEM_EXTENSIONS
+ 
+@@ -72,6 +73,7 @@ GROFF_DOC_CHECK
+ GROFF_MAKEINFO
+ GROFF_TEXI2DVI
+ AC_PROG_RANLIB
++AC_CHECK_TOOL([AR], [ar], [ar])
+ GROFF_INSTALL_SH
+ GROFF_INSTALL_INFO
+ AC_PROG_INSTALL
+-- 
+2.23.0
+

--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = false;
 
+  patches = [
+    ./0001-Fix-cross-compilation-by-looking-for-ar.patch
+  ];
+
   postPatch = stdenv.lib.optionalString (psutils != null) ''
     substituteInPlace src/preproc/html/pre-html.cpp \
       --replace "psselect" "${psutils}/bin/psselect"


### PR DESCRIPTION
Fixup the patch from 4f3c8178b8e5eef920c31b030cd89591deb2417d so it
applies to the current groff.

The patch was removed, but cross-compilation not validated, in #70500.

###### Motivation for this change

Quite obviously, to fix cross-compilation of groff!

```
/nix/store/zavn4np1jvm79f0rafkv0p1mrag09qkz-bash-4.4-p23/bin/bash: ar: command not found
make[1]: *** [Makefile:5896: libdriver.a] Error 127
make[1]: Leaving directory '/build/groff-1.22.4'
make: *** [Makefile:5600: all] Error 2
builder for '/nix/store/0mjqs0y4af5fnhy1cb4bnh1b1spxnvk8-groff-1.22.4-aarch64-unknown-linux-gnu.drv' failed with exit code 2
error: build of '/nix/store/0mjqs0y4af5fnhy1cb4bnh1b1spxnvk8-groff-1.22.4-aarch64-unknown-linux-gnu.drv' on 'ssh://samuel@duffman' failed: builder for '/nix/store/0mjqs0y4af5fnhy1cb4bnh1b1spxnvk8-groff-1.22.4-aarch64-unknown-linux-gnu.drv' failed with exit code 2
builder for '/nix/store/0mjqs0y4af5fnhy1cb4bnh1b1spxnvk8-groff-1.22.4-aarch64-unknown-linux-gnu.drv' failed with exit code 1
error: build of '/nix/store/0mjqs0y4af5fnhy1cb4bnh1b1spxnvk8-groff-1.22.4-aarch64-unknown-linux-gnu.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - ✔️ NixOS
   - ❌ macOS
   - ❌ other Linux distributions
- ❌ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ❌ Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- ❌ Tested execution of all binary files (usually in `./result/bin/`)
- ❌ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Ensured that relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tilpner 


