### PR TITLE
zulip: init at 4.0.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zulip/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zulip/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchurl
+, appimageTools
+}:
+
+let
+  pname = "zulip";
+  version = "4.0.0";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/zulip/zulip-desktop/releases/download/v${version}/Zulip-${version}-x86_64.AppImage";
+    sha256 = "1pni02mb5bvwx3k45vd6ga269ghdl633gjklyslai24rrhp16h9z";
+    name="${pname}-${version}.AppImage";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit name src;
+  };
+
+in appimageTools.wrapType2 {
+  inherit name src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${name} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/zulip.desktop $out/share/applications/zulip.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/zulip.png \
+      $out/share/icons/hicolor/512x512/apps/zulip.png
+    substituteInPlace $out/share/applications/zulip.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with lib; {
+    description = "Desktop client for Zulip Chat";
+    homepage = https://zulipchat.com;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jonafato ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8780,6 +8780,8 @@ in
 
   z88dk = callPackage ../development/compilers/z88dk { };
 
+  zulip = callPackage ../applications/networking/instant-messengers/zulip { };
+
   zulu8 = callPackage ../development/compilers/zulu/8.nix { };
   zulu = callPackage ../development/compilers/zulu { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add the Zulip chat client to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

New package.
