### PR TITLE
gvisor: init at 2019-11-14

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -103,6 +103,7 @@ in
   grafana = handleTest ./grafana.nix {};
   graphite = handleTest ./graphite.nix {};
   graylog = handleTest ./graylog.nix {};
+  gvisor = handleTest ./gvisor.nix {};
   hadoop.hdfs = handleTestOn [ "x86_64-linux" ] ./hadoop/hdfs.nix {};
   hadoop.yarn = handleTestOn [ "x86_64-linux" ] ./hadoop/yarn.nix {};
   handbrake = handleTestOn ["x86_64-linux"] ./handbrake.nix {};

--- a/nixos/tests/gvisor.nix
+++ b/nixos/tests/gvisor.nix
@@ -1,0 +1,49 @@
+# This test runs a container through gvisor and checks if simple container starts
+
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "gvisor";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ andrew-d ];
+  };
+
+  nodes = {
+    gvisor =
+      { pkgs, ... }:
+        {
+          virtualisation.docker = {
+            enable = true;
+            extraOptions = "--add-runtime runsc=${pkgs.gvisor}/bin/runsc";
+          };
+
+          networking = {
+            dhcpcd.enable = false;
+            defaultGateway = "192.168.1.1";
+            interfaces.eth1.ipv4.addresses = pkgs.lib.mkOverride 0 [
+              { address = "192.168.1.2"; prefixLength = 24; }
+            ];
+          };
+        };
+    };
+
+  testScript = ''
+    start_all()
+
+    gvisor.wait_for_unit("network.target")
+    gvisor.wait_for_unit("sockets.target")
+
+    # Start by verifying that gvisor itself works
+    output = gvisor.succeed(
+        "${pkgs.gvisor}/bin/runsc -alsologtostderr do ${pkgs.coreutils}/bin/echo hello world"
+    )
+    assert output.strip() == "hello world"
+
+    # Also test the Docker runtime
+    gvisor.succeed("tar cv --files-from /dev/null | docker import - scratchimg")
+    gvisor.succeed(
+        "docker run -d --name=sleeping --runtime=runsc -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
+    )
+    gvisor.succeed("docker ps | grep sleeping")
+    gvisor.succeed("docker stop sleeping")
+  '';
+})
+

--- a/pkgs/applications/virtualization/gvisor/containerd-shim.nix
+++ b/pkgs/applications/virtualization/gvisor/containerd-shim.nix
@@ -1,0 +1,36 @@
+{ lib, fetchFromGitHub, buildGoModule, go-bindata }:
+
+buildGoModule rec {
+  name = "gvisor-containerd-shim-${version}";
+  version = "2019-10-09";
+
+  src = fetchFromGitHub {
+    owner  = "google";
+    repo   = "gvisor-containerd-shim";
+    rev    = "f299b553afdd8455a0057862004061ea12e660f5";
+    sha256 = "077bhrmjrpcxv1z020yxhx2c4asn66j21gxlpa6hz0av3lfck9lm";
+  };
+
+  modSha256 = "1jdhgbrn59ahnabwnig99i21f6kimmqx9f3dg10ffwfs3dx0gzlg";
+
+  buildPhase = ''
+    make
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    make test
+  '';
+
+  installPhase = ''
+    make install DESTDIR="$out"
+  '';
+
+  meta = with lib; {
+    description = "containerd shim for gVisor";
+    homepage    = https://github.com/google/gvisor-containerd-shim;
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ andrew-d ];
+    platforms   = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/virtualization/gvisor/default.nix
+++ b/pkgs/applications/virtualization/gvisor/default.nix
@@ -1,0 +1,101 @@
+{ stdenv
+, buildBazelPackage
+, fetchFromGitHub
+, cacert
+, git
+, glibcLocales
+, go
+, iproute
+, iptables
+, makeWrapper
+, procps
+, python3
+}:
+
+let
+  preBuild = ''
+    patchShebangs .
+
+    # Tell rules_go to use the Go binary found in the PATH
+    sed -E -i \
+      -e 's|go_version\s*=\s*"[^"]+",|go_version = "host",|g' \
+      WORKSPACE
+
+    # The gazelle Go tooling needs CA certs
+    export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
+
+    # If we don't reset our GOPATH, the rules_go stdlib builder tries to
+    # install something into it. Ideally that wouldn't happen, but for now we
+    # can also get around it by unsetting GOPATH entirely, since rules_go
+    # doesn't need it.
+    export GOPATH=
+  '';
+
+in buildBazelPackage rec {
+  name = "gvisor-${version}";
+  version = "2019-11-14";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo  = "gvisor";
+    rev   = "release-20191114.0";
+    sha256 = "0kyixjjlws9iz2r2srgpdd4rrq94vpxkmh2rmmzxd9mcqy2i9bg1";
+  };
+
+  nativeBuildInputs = [ git glibcLocales go makeWrapper python3 ];
+
+  bazelTarget = "//runsc:runsc";
+
+  # gvisor uses the Starlark implementation of rules_cc, not the built-in one,
+  # so we shouldn't delete it from our dependencies.
+  removeRulesCC = false;
+
+  fetchAttrs = {
+    inherit preBuild;
+
+    preInstall = ''
+      # Remove the go_sdk (it's just a copy of the go derivation) and all
+      # references to it from the marker files. Bazel does not need to download
+      # this sdk because we have patched the WORKSPACE file to point to the one
+      # currently present in PATH. Without removing the go_sdk from the marker
+      # file, the hash of it will change anytime the Go derivation changes and
+      # that would lead to impurities in the marker files which would result in
+      # a different sha256 for the fetch phase.
+      rm -rf $bazelOut/external/{go_sdk,\@go_sdk.marker}
+
+      # Remove the gazelle tools, they contain go binaries that are built
+      # non-deterministically. As long as the gazelle version matches the tools
+      # should be equivalent.
+      rm -rf $bazelOut/external/{bazel_gazelle_go_repository_tools,\@bazel_gazelle_go_repository_tools.marker}
+
+      # Remove the gazelle repository cache
+      chmod -R +w $bazelOut/external/bazel_gazelle_go_repository_cache
+      rm -rf $bazelOut/external/{bazel_gazelle_go_repository_cache,\@bazel_gazelle_go_repository_cache.marker}
+
+      # Remove log file(s)
+      rm -f "$bazelOut"/java.log "$bazelOut"/java.log.*
+    '';
+
+    sha256 = "122qk6iv8hd7g2a84y9aqqhij4r0m47vpxzbqhhh6k5livc73qd6";
+  };
+
+  buildAttrs = {
+    inherit preBuild;
+
+    installPhase = ''
+      install -Dm755 bazel-bin/runsc/*_pure_stripped/runsc $out/bin/runsc
+
+      # Needed for the 'runsc do' subcomand
+      wrapProgram $out/bin/runsc \
+        --prefix PATH : ${stdenv.lib.makeBinPath [ iproute iptables procps ]}
+    '';
+  };
+
+  meta = with stdenv.lib; {
+    description = "Container Runtime Sandbox";
+    homepage = https://github.com/google/gvisor;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ andrew-d ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19223,6 +19223,8 @@ in
 
   gvisor = callPackage ../applications/virtualization/gvisor { };
 
+  gvisor-containerd-shim = callPackage ../applications/virtualization/gvisor/containerd-shim.nix { };
+
   guvcview = callPackage ../os-specific/linux/guvcview { };
 
   gxmessage = callPackage ../applications/misc/gxmessage { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19221,6 +19221,8 @@ in
 
   gv = callPackage ../applications/misc/gv { };
 
+  gvisor = callPackage ../applications/virtualization/gvisor { };
+
   guvcview = callPackage ../os-specific/linux/guvcview { };
 
   gxmessage = callPackage ../applications/misc/gxmessage { };


### PR DESCRIPTION
###### Motivation for this change
This is a revamp of #50218 after enough upstream changes that it's possible to build inside a Nix sandbox. This was requested in #39889, but there were some problems with Bazel at the time. I've managed to get this working with `buildBazelPackage`. At the end of the whole process, gvisor is runnable:

```
$ /nix/store/7k1c1jikms1pjimk8561x18xpj51dm5l-gvisor-2019-11-08/bin/runsc --help
Usage: runsc <flags> <subcommand> <subcommand args>

Subcommands:
	checkpoint       checkpoint current state of container (experimental)
	create           create a secure container
	delete           delete resources held by a container
	do               Simplistic way to execute a command inside the sandbox. It's to be used for testing only.
	events           display container events such as OOM notifications, cpu, memory, and IO usage statistics
```

(I also added the `containerd` shim as well, since it didn't feel worth another PR)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] ~macOS~
   - [ ] other Linux distributions
- [x] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc original reviewers @nlewo, @Profpatsch, and commenters @dtzWill, @benpye and @ghuntley  

Closes #50218
Closes #39889