### PR TITLE
khard: 0.14.0 -> 0.15.1

### DIFF
--- a/pkgs/applications/misc/khard/default.nix
+++ b/pkgs/applications/misc/khard/default.nix
@@ -1,36 +1,15 @@
-{ stdenv, fetchurl, glibcLocales, python3 }:
+{ stdenv, glibcLocales, python3 }:
 
-let
-  python = python3.override {
-    packageOverrides = self: super: {
-
-      # https://github.com/pimutils/khal/issues/780
-      python-dateutil = super.python-dateutil.overridePythonAttrs (oldAttrs: rec {
-        version = "2.6.1";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca";
-        };
-      });
-
-    };
-  };
-
-in with python.pkgs; buildPythonApplication rec {
-  version = "0.14.0";
+python3.pkgs.buildPythonApplication rec {
+  version = "0.15.1";
   pname = "khard";
-  namePrefix = "";
 
-  src = fetchurl {
-    url = "https://github.com/scheibler/khard/archive/v${version}.tar.gz";
-    sha256 = "0m1pc67jz663yfc0xzfpknymn8jj2bpfxaph3pl0mjd3h1zjfyaq";
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "18ba2xgfq8sw0bg6xmlfjpizid1hkzgswcfcc54gl21y2dwfda2w";
   };
 
-  # setup.py reads the UTF-8 encoded readme.
-  LC_ALL = "en_US.UTF-8";
-  buildInputs = [ glibcLocales ];
-
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python3.pkgs; [
     atomicwrites
     configobj
     vobject
@@ -42,9 +21,6 @@ in with python.pkgs; buildPythonApplication rec {
   postInstall = ''
     install -D misc/zsh/_khard $out/share/zsh/site-functions/_khard
   '';
-
-  # Fails; but there are no tests anyway.
-  doCheck = false;
 
   meta = {
     homepage = https://github.com/scheibler/khard;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update + remove old workarounds for upstream issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matthiasbeyer
