### PR TITLE
ocamlPackages.facile: 1.1.3 → 1.1.4

### DIFF
--- a/pkgs/development/ocaml-modules/facile/default.nix
+++ b/pkgs/development/ocaml-modules/facile/default.nix
@@ -1,38 +1,19 @@
-{ stdenv, fetchurl, ocaml, findlib }:
+{ lib, fetchurl, buildDunePackage }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-facile-${version}";
-
-  version = "1.1.3";
+buildDunePackage rec {
+  pname = "facile";
+  version = "1.1.4";
 
   src = fetchurl {
-    url = "http://opti.recherche.enac.fr/facile/distrib/facile-${version}.tar.gz";
-    sha256 = "1v4apqcw4gm36ph5xwf1wxaaza0ggvihvgsdslnf33fa1pdkvdjw";
+    url = "https://github.com/Emmanuel-PLF/facile/releases/download/${version}/facile-${version}.tbz";
+    sha256 = "0jqrwmn6fr2vj2rrbllwxq4cmxykv7zh0y4vnngx29f5084a04jp";
   };
 
-  dontAddPrefix = 1;
-
-  buildInputs = [ ocaml findlib ];
-
-  createFindlibDestdir = true;
-
-  installFlags = [ "FACILEDIR=$(OCAMLFIND_DESTDIR)/facile" ];
-
-  postInstall = ''
-    cat > $OCAMLFIND_DESTDIR/facile/META <<EOF
-    version = "${version}"
-    name = "facile"
-    description = "A Functional Constraint Library"
-    requires = ""
-    archive(byte) = "facile.cma"
-    archive(native) = "facile.cmxa"
-    EOF
-  '';
+  doCheck = true;
 
   meta = {
     homepage = "http://opti.recherche.enac.fr/facile/";
-    license = stdenv.lib.licenses.lgpl21Plus;
+    license = lib.licenses.lgpl21Plus;
     description = "A Functional Constraint Library";
-    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Current package fails to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
