### PR TITLE
nix-prefetch-docker: handle overrides correctly

### DIFF
--- a/pkgs/build-support/docker/nix-prefetch-docker
+++ b/pkgs/build-support/docker/nix-prefetch-docker
@@ -38,7 +38,7 @@ get_image_digest(){
         imageTag="latest"
     fi
 
-    skopeo inspect "docker://$imageName:$imageTag" | jq '.Digest' -r
+    skopeo --override-os ${os} --override-arch ${arch} inspect "docker://$imageName:$imageTag" | jq '.Digest' -r
 }
 
 get_name() {


### PR DESCRIPTION
Without this change, the `--os` and `--arch` switches are disregarded
for operations involving `skopeo inspect` invocations. This means that,
for example, one cannot fetch Linux images while on macOS.

###### Motivation for this change

Correct oversight on `nix-prefetch-docker` script.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

@grahamc or @lethalman are you maintainers? Not sure how to correctly identify maintainers of this code. And I have more PRs to submit.