### PR TITLE
pythonPackages.measurement: now python3 only

### DIFF
--- a/pkgs/development/python-modules/measurement/default.nix
+++ b/pkgs/development/python-modules/measurement/default.nix
@@ -1,15 +1,26 @@
-{ lib, fetchPypi, buildPythonPackage, pbr, six, sympy }:
+{ lib, fetchFromGitHub, buildPythonPackage, isPy3k
+, sympy, pytest, pytestrunner, sphinx, setuptools_scm }:
 
 buildPythonPackage rec {
   pname = "measurement";
   version = "3.2.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "352b20f7f0e553236af7c5ed48d091a51cf26061c1a063f46b31706ff7c0d57a";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "coddingtonbear";
+    repo = "python-measurement";
+    rev = version;
+    sha256 = "1mk9qg1q4cnnipr6xa72i17qvwwhz2hd8p4vlsa9gdzrcv4vr8h9";
   };
 
-  propagatedBuildInputs = [ pbr six sympy ];
+  postPatch = ''
+    sed -i 's|use_scm_version=True|version="${version}"|' setup.py
+  '';
+
+  checkInputs = [ pytest pytestrunner ];
+  nativeBuildInputs = [ sphinx setuptools_scm ];
+  propagatedBuildInputs = [ sympy ];
 
   meta = with lib; {
     description = "Use and manipulate unit-aware measurement objects in Python";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
