### PR TITLE
deployAndroidPackage: prefer local builds

### DIFF
--- a/pkgs/development/mobile/androidenv/deploy-androidpackage.nix
+++ b/pkgs/development/mobile/androidenv/deploy-androidpackage.nix
@@ -8,6 +8,7 @@ stdenv.mkDerivation ({
   name = package.name + "-" + package.revision;
   src = if os != null && builtins.hasAttr os package.archives then package.archives.${os} else package.archives.all;
   buildInputs = [ unzip ] ++ buildInputs;
+  preferLocalBuild = true;
 
   # Most Android Zip packages have a root folder, but some don't. We unpack
   # the zip file in a folder and we try to discover whether it has a single root


### PR DESCRIPTION
###### Motivation for this change

These derivations just unzip something and maybe do a little patching, so there's no benefit to sending the zip file off to a build server and then downloading the unzipped results again.

###### Things done

I've just done minimal testing that `nix-build` still works; I really hope changing `preferLocalBuilds` doesn't affect behavior of the built package or anything that depends on it :sweat_smile:

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
