### PR TITLE
nixosTests.plasma5: port to python

### DIFF
--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -26,27 +26,34 @@ import ./make-test-python.nix ({ pkgs, ...} :
     user = nodes.machine.config.users.users.alice;
     xdo = "${pkgs.xdotool}/bin/xdotool";
   in ''
-    startAll;
-    # wait for log in
-    $machine->waitForFile("/home/alice/.Xauthority");
-    $machine->succeed("xauth merge ~alice/.Xauthority");
+    with subtest("Wait for login"):
+        start_all()
+        machine.wait_for_file("${user.home}/.Xauthority")
+        machine.succeed("xauth merge ${user.home}/.Xauthority")
 
-    $machine->waitUntilSucceeds("pgrep plasmashell");
-    $machine->waitForWindow("^Desktop ");
+    with subtest("Check plasmashell started"):
+        machine.wait_until_succeeds("pgrep plasmashell")
+        machine.wait_for_window("^Desktop ")
 
-    # Check that logging in has given the user ownership of devices.
-    $machine->succeed("getfacl -p /dev/snd/timer | grep -q alice");
+    with subtest("Check that logging in has given the user ownership of devices"):
+        machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
-    $machine->execute("su - alice -c 'DISPLAY=:0.0 dolphin &'");
-    $machine->waitForWindow(" Dolphin");
+    with subtest("Run Dolphin"):
+        machine.execute("su - ${user.name} -c 'DISPLAY=:0.0 dolphin &'")
+        machine.wait_for_window(" Dolphin")
 
-    $machine->execute("su - alice -c 'DISPLAY=:0.0 konsole &'");
-    $machine->waitForWindow("Konsole");
+    with subtest("Run Konsole"):
+        machine.execute("su - ${user.name} -c 'DISPLAY=:0.0 konsole &'")
+        machine.wait_for_window("Konsole")
 
-    $machine->execute("su - alice -c 'DISPLAY=:0.0 systemsettings5 &'");
-    $machine->waitForWindow("Settings");
+    with subtest("Run systemsettings"):
+        machine.execute("su - ${user.name} -c 'DISPLAY=:0.0 systemsettings5 &'")
+        machine.wait_for_window("Settings")
 
-    $machine->execute("${xdo} key Alt+F1 sleep 10");
-    $machine->screenshot("screen");
+    with subtest("Wait to get a screenshot"):
+        machine.execute(
+            "${xdo} key Alt+F1 sleep 10"
+        )
+        machine.screenshot("screen")
   '';
 })

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} :
+import ./make-test-python.nix ({ pkgs, ...} :
 
 {
   name = "plasma5";
@@ -7,23 +7,11 @@ import ./make-test.nix ({ pkgs, ...} :
   };
 
   machine = { ... }:
-  let
-    sddm_theme = pkgs.stdenv.mkDerivation {
-      name = "breeze-ocr-theme";
-      phases = "buildPhase";
-      buildCommand = ''
-        mkdir -p $out/share/sddm/themes/
-        cp -r ${pkgs.plasma-workspace}/share/sddm/themes/breeze $out/share/sddm/themes/breeze-ocr-theme
-        chmod -R +w $out/share/sddm/themes/breeze-ocr-theme
-        printf "[General]\ntype=color\ncolor=#1d99f3\nbackground=\n" > $out/share/sddm/themes/breeze-ocr-theme/theme.conf
-      '';
-    };
-  in
+
   {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
     services.xserver.displayManager.sddm.enable = true;
-    services.xserver.displayManager.sddm.theme = "breeze-ocr-theme";
     services.xserver.desktopManager.plasma5.enable = true;
     services.xserver.desktopManager.default = "plasma5";
     services.xserver.displayManager.sddm.autoLogin = {
@@ -32,7 +20,6 @@ import ./make-test.nix ({ pkgs, ...} :
     };
     hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
     virtualisation.memorySize = 1024;
-    environment.systemPackages = [ sddm_theme ];
   };
 
   testScript = { nodes, ... }: let


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/72828

Note, a known issue with this test is the desktop doesn't actually get drawn or the panel before it exits.
This is problematic, and wait_for_window actually doesn't check if it's visible or not, so the desktop being broken visually isn't part of the tests coverage. Not sure if there's an API with plasma to check if everything is initialized and stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
