### PR TITLE
nixos/kubernetes: ensure kubelet cert contains a well-formed user

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -6,6 +6,12 @@ let
   top = config.services.kubernetes;
   cfg = top.kubelet;
 
+  kubeletRbacUser =
+    if top.kubelet.hostname == "" then
+      throw "kubelet.hostname must be set. This is probably caused by networking.hostName being empty."
+    else
+      "system:node:${top.kubelet.hostname}";
+
   cniConfig =
     if cfg.cni.config != [] && cfg.cni.configDir != null then
       throw "Verbatim CNI-config and CNI configDir cannot both be set."
@@ -313,7 +319,7 @@ in
         };
         kubeletClient = mkCert {
           name = "kubelet-client";
-          CN = "system:node:${top.kubelet.hostname}";
+          CN = kubeletRbacUser;
           fields = {
             O = "system:nodes";
           };

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -7,10 +7,10 @@ let
   cfg = top.kubelet;
 
   kubeletRbacUser =
-    if top.kubelet.hostname == "" then
+    if cfg.hostname == "" then
       throw "kubelet.hostname must be set. This is probably caused by networking.hostName being empty."
     else
-      "system:node:${top.kubelet.hostname}";
+      "system:node:${cfg.hostname}";
 
   cniConfig =
     if cfg.cni.config != [] && cfg.cni.configDir != null then


### PR DESCRIPTION
If the hostname is empty, this otherwise gets generated as
`system:node:`, which causes problems during node registration.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
