### PR TITLE
nixosTests.pantheon: port to python

### DIFF
--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -22,16 +22,18 @@ import ./make-test.nix ({ pkgs, ...} :
   testScript = { nodes, ... }: let
     user = nodes.machine.config.users.users.alice;
   in ''
-    startAll;
-
     # Wait for display manager to start
+    $machine->waitForUnit("display-manager.service");
+
+    # Test we can see username in elementary-greeter
     $machine->waitForText(qr/${user.description}/);
-    $machine->screenshot("lightdm");
+    $machine->screenshot("elementary_greeter_lightdm");
 
     # Log in
     $machine->sendChars("${user.password}\n");
-    $machine->waitForFile("/home/alice/.Xauthority");
-    $machine->succeed("xauth merge ~alice/.Xauthority");
+    $machine->waitForUnit("default.target","alice");
+    $machine->waitForFile("${user.home}/.Xauthority");
+    $machine->succeed("xauth merge ${user.home}/.Xauthority");
 
     # Check if "pantheon-shell" components actually start
     $machine->waitUntilSucceeds("pgrep gala");

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -22,18 +22,19 @@ import ./make-test-python.nix ({ pkgs, ...} :
 
   testScript = { nodes, ... }: let
     user = nodes.machine.config.users.users.alice;
+    bob = nodes.machine.config.users.users.bob;
   in ''
     # Wait for display manager to start
     machine.wait_for_unit("display-manager.service")
 
-    # Test we can see username in elementary-greeter
+    # Test we can see usernames in elementary-greeter
     machine.wait_for_text("${user.description}")
+    machine.wait_for_text("${bob.description}")
     machine.screenshot("elementary_greeter_lightdm")
 
     # Log in with elementary-greeter
     machine.send_chars("${user.password}\n")
-    machine.wait_for_unit("default.target", "${user.name}")
-    machine_wait_for_x()
+    machine.wait_for_x()
     machine.wait_for_file("${user.home}/.Xauthority")
     machine.succeed("xauth merge ${user.home}/.Xauthority")
 

--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -24,36 +24,35 @@ import ./make-test-python.nix ({ pkgs, ...} :
     user = nodes.machine.config.users.users.alice;
     bob = nodes.machine.config.users.users.bob;
   in ''
-    # Wait for display manager to start
     machine.wait_for_unit("display-manager.service")
 
-    # Test we can see usernames in elementary-greeter
-    machine.wait_for_text("${user.description}")
-    machine.wait_for_text("${bob.description}")
-    machine.screenshot("elementary_greeter_lightdm")
+    with subtest("Test we can see usernames in elementary-greeter"):
+        machine.wait_for_text("${user.description}")
+        machine.wait_for_text("${bob.description}")
+        machine.screenshot("elementary_greeter_lightdm")
 
-    # Log in with elementary-greeter
-    machine.send_chars("${user.password}\n")
-    machine.wait_for_x()
-    machine.wait_for_file("${user.home}/.Xauthority")
-    machine.succeed("xauth merge ${user.home}/.Xauthority")
+    with subtest("Login with elementary-greeter"):
+        machine.send_chars("${user.password}\n")
+        machine.wait_for_x()
+        machine.wait_for_file("${user.home}/.Xauthority")
+        machine.succeed("xauth merge ${user.home}/.Xauthority")
 
-    # Check that logging in has given the user ownership of devices
-    machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
+    with subtest("Check that logging in has given the user ownership of devices"):
+        machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
 
-    # TODO: DBus API could eliminate this?
-    # Check if pantheon-shell components actually start
-    machine.wait_until_succeeds("pgrep gala")
-    machine.wait_for_window("gala")
-    machine.wait_until_succeeds("pgrep wingpanel")
-    machine.wait_for_window("wingpanel")
-    machine.wait_until_succeeds("pgrep plank")
-    machine.wait_for_window("plank")
+    # TODO: DBus API could eliminate this? Pantheon uses Bamf.
+    with subtest("Check if pantheon session components actually start"):
+        machine.wait_until_succeeds("pgrep gala")
+        machine.wait_for_window("gala")
+        machine.wait_until_succeeds("pgrep wingpanel")
+        machine.wait_for_window("wingpanel")
+        machine.wait_until_succeeds("pgrep plank")
+        machine.wait_for_window("plank")
 
-    # Open elementary terminal
-    machine.execute("su - ${user.name} -c 'DISPLAY=:0 io.elementary.terminal &'")
-    machine.wait_for_window("io.elementary.terminal")
-    machine.sleep(20)
-    machine.screenshot("screen")
+    with subtest("Open elementary terminal"):
+        machine.execute("su - ${user.name} -c 'DISPLAY=:0 io.elementary.terminal &'")
+        machine.wait_for_window("io.elementary.terminal")
+        machine.sleep(20)
+        machine.screenshot("screen")
   '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
