### PR TITLE
chatterino2: unstable-2019-05-11 -> unstable-2019-11-02 (with qt fix)

### DIFF
--- a/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, pkgconfig, fetchFromGitHub, qtbase, qtsvg, qtmultimedia, qmake, boost, openssl }:
+{ stdenv, mkDerivation, pkgconfig, fetchFromGitHub, qtbase, qtsvg, qtmultimedia, qmake, boost, openssl }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "chatterino2";
-  version = "unstable-2019-05-11";
+  version = "unstable-2019-11-02";
   src = fetchFromGitHub {
-    owner = "fourtf";
+    owner = "Chatterino";
     repo = pname;
-    rev = "8c46cbf571dc8fd77287bf3186445ff52b1d1aaf";
-    sha256 = "0i2385hamhd9i7jdy906cfrd81cybw524j92l87c8pzrkxphignk";
+    rev = "556c2ae";
+    sha256 = "09lasf1y4rdzhb638pw6m0iw0kdn9b9pz495z15msgqidfzspv5x";
     fetchSubmodules = true;
   };
   nativeBuildInputs = [ qmake pkgconfig ];
@@ -17,10 +17,9 @@ stdenv.mkDerivation rec {
     longDescription = ''
       Chatterino is a chat client for Twitch chat. It aims to be an
       improved/extended version of the Twitch web chat. Chatterino 2 is
-      the second installment of the Twitch chat client series
-      "Chatterino".
-  '';
-    homepage = "https://github.com/fourtf/chatterino2";
+      the second installment of the Twitch chat client series "Chatterino".
+    '';
+    homepage = "https://github.com/Chatterino/chatterino2";
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ rexim ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

* fix `Could not find the Qt platform plugin "xcb" ` error. See https://github.com/NixOS/nixpkgs/issues/65399
* update to the latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rexim 
