### PR TITLE
php74: init at 7.4.0

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,10 +1,10 @@
 # pcre functionality is tested in nixos/tests/php-pcre.nix
-{ lib, stdenv, fetchurl, autoconf, bison, libtool, pkgconfig, re2c
+{ config, lib, stdenv, fetchurl, autoconf, bison, libtool, pkgconfig, re2c
 , libxml2, readline, zlib, curl, postgresql, gettext
-, openssl, pcre, pcre2, sqlite, config, libjpeg, libpng, freetype
+, openssl, pcre, pcre2, sqlite, libjpeg, libpng, freetype
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, unixODBC
 , uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium, html-tidy, libargon2
-, libzip, valgrind
+, libzip, valgrind, oniguruma
 }:
 
 with lib;
@@ -79,6 +79,7 @@ let
       buildInputs = [ ]
         ++ optional (versionOlder version "7.3") pcre
         ++ optional (versionAtLeast version "7.3") pcre2
+        ++ optional (versionAtLeast version "7.4") oniguruma
         ++ optional withSystemd systemd
         ++ optionals imapSupport [ uwimap openssl pam ]
         ++ optionals curlSupport [ curl openssl ]
@@ -113,7 +114,8 @@ let
         "--with-config-file-scan-dir=/etc/php.d"
       ]
       ++ optional (versionOlder version "7.3") "--with-pcre-regex=${pcre.dev} PCRE_LIBDIR=${pcre}"
-      ++ optional (versionAtLeast version "7.3") "--with-pcre-regex=${pcre2.dev} PCRE_LIBDIR=${pcre2}"
+      ++ optional ((versionAtLeast version "7.3") && (!versionAtLeast version "7.4")) "--with-pcre-regex=${pcre2.dev} PCRE_LIBDIR=${pcre2}"
+      ++ optional (versionAtLeast version "7.4") "--with-external-pcre=${pcre2.dev} PCRE_LIBDIR=${pcre2}"
       ++ optional stdenv.isDarwin "--with-iconv=${libiconv}"
       ++ optional withSystemd "--with-fpm-systemd"
       ++ optionals imapSupport [
@@ -126,16 +128,16 @@ let
         "LDAP_INCDIR=${openldap.dev}/include"
         "LDAP_LIBDIR=${openldap.out}/lib"
       ]
-      ++ optional (ldapSupport && stdenv.isLinux)   "--with-ldap-sasl=${cyrus_sasl.dev}"
+      ++ optional (ldapSupport && stdenv.isLinux) "--with-ldap-sasl=${cyrus_sasl.dev}"
       ++ optional apxs2Support "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
       ++ optional embedSupport "--enable-embed"
       ++ optional mhashSupport "--with-mhash"
       ++ optional curlSupport "--with-curl=${curl.dev}"
       ++ optional zlibSupport "--with-zlib=${zlib.dev}"
-      ++ optional libxml2Support "--with-libxml-dir=${libxml2.dev}"
+      ++ optional (libxml2Support && (versionOlder version "7.4")) "--with-libxml-dir=${libxml2.dev}"
       ++ optional (!libxml2Support) [
         "--disable-dom"
-        "--disable-libxml"
+        ( if (versionOlder version "7.4") then "--disable-libxml" else "--without-libxml" )
         "--disable-simplexml"
         "--disable-xml"
         "--disable-xmlreader"
@@ -154,7 +156,7 @@ let
       ++ optional bcmathSupport "--enable-bcmath"
       # FIXME: Our own gd package doesn't work, see https://bugs.php.net/bug.php?id=60108.
       ++ optionals gdSupport [
-        "--with-gd"
+        ( if (versionOlder version "7.4") then "--with-gd" else "--enable-gd" )
         "--with-freetype-dir=${freetype.dev}"
         "--with-png-dir=${libpng.dev}"
         "--with-jpeg-dir=${libjpeg.dev}"
@@ -170,7 +172,7 @@ let
       ++ optional xslSupport "--with-xsl=${libxslt.dev}"
       ++ optional mcryptSupport "--with-mcrypt=${libmcrypt'}"
       ++ optional bz2Support "--with-bz2=${bzip2.dev}"
-      ++ optional zipSupport "--enable-zip"
+      ++ optional (zipSupport && (versionOlder version "7.4")) "--enable-zip"
       ++ optional ftpSupport "--enable-ftp"
       ++ optional fpmSupport "--enable-fpm"
       ++ optional ztsSupport "--enable-maintainer-zts"
@@ -178,7 +180,7 @@ let
       ++ optional sodiumSupport "--with-sodium=${libsodium.dev}"
       ++ optional tidySupport "--with-tidy=${html-tidy}"
       ++ optional argon2Support "--with-password-argon2=${libargon2}"
-      ++ optional libzipSupport "--with-libzip=${libzip.dev}"
+      ++ optional (libzipSupport && (versionOlder version "7.4")) "--with-libzip=${libzip.dev}"
       ++ optional phpdbgSupport "--enable-phpdbg"
       ++ optional (!phpdbgSupport) "--disable-phpdbg"
       ++ optional (!cgiSupport) "--disable-cgi"
@@ -263,5 +265,10 @@ in {
 
     # https://bugs.php.net/bug.php?id=76826
     extraPatches = optional stdenv.isDarwin ./php73-darwin-isfinite.patch;
+  };
+
+  php74 = generic {
+    version = "7.4.0";
+    sha256 = "1h01bahvcm9kgm5jqhm2j9k9d4q4rpfkkpqk00c47rirdblnn85z";
   };
 }

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -202,9 +202,6 @@ let
 
         export EXTENSION_DIR=$out/lib/php/extensions
 
-        configureFlags+=(--with-config-file-path=$out/etc \
-          --includedir=$dev/include)
-
         ./buildconf --force
       '';
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,5 +1,6 @@
 # pcre functionality is tested in nixos/tests/php-pcre.nix
-{ config, lib, stdenv, fetchurl, autoconf, bison, libtool, pkgconfig, re2c
+{ config, lib, stdenv, fetchurl
+, autoconf, automake, bison, file, flex, libtool, pkgconfig, re2c
 , libxml2, readline, zlib, curl, postgresql, gettext
 , openssl, pcre, pcre2, sqlite
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, unixODBC
@@ -72,11 +73,14 @@ let
 
       inherit version;
 
-      name = "php-${version}";
+      pname = "php";
 
       enableParallelBuilding = true;
 
-      nativeBuildInputs = [ autoconf bison libtool pkgconfig re2c ];
+      nativeBuildInputs = [
+        autoconf automake bison file flex libtool pkgconfig re2c
+      ];
+
       buildInputs = [ ]
         ++ optional (versionOlder version "7.3") pcre
         ++ optional (versionAtLeast version "7.3") pcre2
@@ -219,11 +223,17 @@ let
             --replace '@PHP_LDFLAGS@' ""
         done
 
-        #[[ -z "$libxml2" ]] || addToSearchPath PATH $libxml2/bin
+        substituteInPlace ./build/libtool.m4 --replace /usr/bin/file ${file}/bin/file
 
         export EXTENSION_DIR=$out/lib/php/extensions
 
-        ./buildconf --force
+        ./buildconf --copy --force
+
+        if test -f $src/genfiles; then
+          ./genfiles
+        fi
+      '' + optionalString stdenv.isDarwin ''
+        substituteInPlace configure --replace "-lstdc++" "-lc++"
       '';
 
       postInstall = ''
@@ -235,8 +245,8 @@ let
         mkdir -p $dev/bin $dev/share/man/man1
         mv $out/bin/phpize $out/bin/php-config $dev/bin/
         mv $out/share/man/man1/phpize.1.gz \
-          $out/share/man/man1/php-config.1.gz \
-          $dev/share/man/man1/
+           $out/share/man/man1/php-config.1.gz \
+           $dev/share/man/man1/
       '';
 
       src = fetchurl {
@@ -254,10 +264,6 @@ let
       };
 
       patches = [ ./fix-paths-php7.patch ] ++ extraPatches;
-
-      postPatch = optional stdenv.isDarwin ''
-        substituteInPlace configure --replace "-lstdc++" "-lc++"
-      '';
 
       stripDebugList = "bin sbin lib modules";
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -61,6 +61,7 @@ let
   , xmlrpcSupport ? (config.php.xmlrpc or false) && (libxml2Support)
   , cgotoSupport ? config.php.cgoto or false
   , valgrindSupport ? (config.php.valgrind or true) && (versionAtLeast version "7.2")
+  , ipv6Support ? config.php.ipv6 or true
   }:
 
     let
@@ -184,7 +185,8 @@ let
       ++ optional (!pharSupport) "--disable-phar"
       ++ optional xmlrpcSupport "--with-xmlrpc"
       ++ optional cgotoSupport "--enable-re2c-cgoto"
-      ++ optional valgrindSupport "--with-valgrind=${valgrind.dev}";
+      ++ optional valgrindSupport "--with-valgrind=${valgrind.dev}"
+      ++ optional (!ipv6Support) "--disable-ipv6";
 
       hardeningDisable = [ "bindnow" ];
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,6 +1,6 @@
 # pcre functionality is tested in nixos/tests/php-pcre.nix
 { lib, stdenv, fetchurl, autoconf, bison, libtool, pkgconfig, re2c
-, libmysqlclient, libxml2, readline, zlib, curl, postgresql, gettext
+, libxml2, readline, zlib, curl, postgresql, gettext
 , openssl, pcre, pcre2, sqlite, config, libjpeg, libpng, freetype
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, unixODBC
 , uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium, html-tidy, libargon2
@@ -19,8 +19,8 @@ let
   , ldapSupport ? config.php.ldap or true
   , mhashSupport ? config.php.mhash or false
   , mysqlndSupport ? config.php.mysqlnd or true
-  , mysqliSupport ? config.php.mysqli or true
-  , pdo_mysqlSupport ? config.php.pdo_mysql or true
+  , mysqliSupport ? (config.php.mysqli or true) && (mysqlndSupport)
+  , pdo_mysqlSupport ? (config.php.pdo_mysql or true) && (mysqlndSupport)
   , libxml2Support ? config.php.libxml2 or true
   , apxs2Support ? config.php.apxs2 or (!stdenv.isDarwin)
   , embedSupport ? config.php.embed or false
@@ -64,7 +64,6 @@ let
   }:
 
     let
-      mysqlBuildInputs = optional (!mysqlndSupport) libmysqlclient;
       libmcrypt' = libmcrypt.override { disablePosixThreads = true; };
     in stdenv.mkDerivation {
 
@@ -94,8 +93,6 @@ let
         ++ optional postgresqlSupport postgresql
         ++ optional pdo_odbcSupport unixODBC
         ++ optional pdo_pgsqlSupport postgresql
-        ++ optional pdo_mysqlSupport mysqlBuildInputs
-        ++ optional mysqliSupport mysqlBuildInputs
         ++ optional gmpSupport gmp
         ++ optional gettextSupport gettext
         ++ optional intlSupport icu
@@ -149,11 +146,9 @@ let
       ++ optional postgresqlSupport "--with-pgsql=${postgresql}"
       ++ optional pdo_odbcSupport "--with-pdo-odbc=unixODBC,${unixODBC}"
       ++ optional pdo_pgsqlSupport "--with-pdo-pgsql=${postgresql}"
-      ++ optional pdo_mysqlSupport "--with-pdo-mysql=${if mysqlndSupport then "mysqlnd" else libmysqlclient}"
-      ++ optionals mysqliSupport [
-        "--with-mysqli=${if mysqlndSupport then "mysqlnd" else "${libmysqlclient}/bin/mysql_config"}"
-      ]
-      ++ optional ( pdo_mysqlSupport || mysqliSupport ) "--with-mysql-sock=/run/mysqld/mysqld.sock"
+      ++ optional (pdo_mysqlSupport && mysqlndSupport) "--with-pdo-mysql=mysqlnd"
+      ++ optional (mysqliSupport && mysqlndSupport) "--with-mysqli=mysqlnd"
+      ++ optional (pdo_mysqlSupport || mysqliSupport) "--with-mysql-sock=/run/mysqld/mysqld.sock"
       ++ optional bcmathSupport "--enable-bcmath"
       # FIXME: Our own gd package doesn't work, see https://bugs.php.net/bug.php?id=60108.
       ++ optionals gdSupport [

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -62,6 +62,7 @@ let
   , cgotoSupport ? config.php.cgoto or false
   , valgrindSupport ? (config.php.valgrind or true) && (versionAtLeast version "7.2")
   , ipv6Support ? config.php.ipv6 or true
+  , pearSupport ? (config.php.pear or true) && (libxml2Support)
   }:
 
     let
@@ -186,7 +187,8 @@ let
       ++ optional xmlrpcSupport "--with-xmlrpc"
       ++ optional cgotoSupport "--enable-re2c-cgoto"
       ++ optional valgrindSupport "--with-valgrind=${valgrind.dev}"
-      ++ optional (!ipv6Support) "--disable-ipv6";
+      ++ optional (!ipv6Support) "--disable-ipv6"
+      ++ optional (pearSupport && libxml2Support) "--with-pear=$(out)/lib/php/pear";
 
       hardeningDisable = [ "bindnow" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9085,7 +9085,8 @@ in
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
   })
     php72
-    php73;
+    php73
+    php74;
 
   php-embed = php73-embed;
 
@@ -9095,6 +9096,11 @@ in
   };
 
   php73-embed = php73.override {
+    config.php.embed = true;
+    config.php.apxs2 = false;
+  };
+
+  php74-embed = php74.override {
     config.php.embed = true;
     config.php.apxs2 = false;
   };
@@ -9111,6 +9117,15 @@ in
   };
 
   php73-unit = php73.override {
+    config.php.embed = true;
+    config.php.apxs2 = false;
+    config.php.systemd = false;
+    config.php.phpdbg = false;
+    config.php.cgi = false;
+    config.php.fpm = false;
+  };
+
+  php74-unit = php74.override {
     config.php.embed = true;
     config.php.apxs2 = false;
     config.php.systemd = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9071,6 +9071,10 @@ in
     php = php73;
   });
 
+  php74Packages = recurseIntoAttrs (callPackage ./php-packages.nix {
+    php = php74;
+  });
+
   phpPackages-unit = php72Packages-unit;
 
   php72Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
@@ -9079,6 +9083,10 @@ in
 
   php73Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
     php = php73-unit;
+  });
+
+  php74Packages-unit = recurseIntoAttrs (callPackage ./php-packages.nix {
+    php = php74-unit;
   });
 
   inherit (callPackages ../development/interpreters/php {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -14,6 +14,7 @@ let
     });
 
   isPhp73 = pkgs.lib.versionAtLeast php.version "7.3";
+  isPhp74 = pkgs.lib.versionAtLeast php.version "7.4";
 
   apcu = buildPecl {
     version = "5.1.17";
@@ -101,7 +102,7 @@ let
     };
   };
 
-  couchbase = buildPecl rec {
+  couchbase = assert !isPhp74; buildPecl rec {
     version = "2.6.1";
     pname = "couchbase";
 
@@ -140,6 +141,8 @@ let
              AC_MSG_WARN([Cannot find igbinary.h])
       '')
     ];
+
+    meta.broken = isPhp74;
   };
 
   event = buildPecl {
@@ -254,20 +257,24 @@ let
     buildInputs = [ (if isPhp73 then pkgs.pcre2 else pkgs.pcre) ];
   };
 
-  pcs = buildPecl {
+  pcs = assert !isPhp74; buildPecl {
     version = "1.3.3";
     pname = "pcs";
 
     sha256 = "0d4p1gpl8gkzdiv860qzxfz250ryf0wmjgyc8qcaaqgkdyh5jy5p";
+
+    meta.broken = isPhp74;
   };
 
-  pdo_sqlsrv = buildPecl {
+  pdo_sqlsrv = assert !isPhp74; buildPecl {
     version = "5.6.1";
     pname = "pdo_sqlsrv";
 
     sha256 = "02ill1iqffa5fha9iz4y91823scml24ikfk8pn90jyycfwv07x6a";
 
     buildInputs = [ pkgs.unixODBC ];
+
+     meta.broken = isPhp74;
   };
 
   php-cs-fixer = mkDerivation rec {
@@ -478,7 +485,7 @@ let
     };
   };
 
-  protobuf = buildPecl {
+  protobuf = assert !isPhp74; buildPecl {
     version = "3.9.0";
     pname = "protobuf";
 
@@ -492,6 +499,8 @@ let
       '';
       license = licenses.bsd3;
       homepage = "https://developers.google.com/protocol-buffers/";
+
+      broken = isPhp74;
     };
   };
 
@@ -585,13 +594,15 @@ let
     sha256 = "0b5pw17lzqknhijfymksvf8fm1zilppr97ypb31n599jw3mxf62f";
   };
 
-  sqlsrv = buildPecl {
+  sqlsrv = assert !isPhp74; buildPecl {
     version = "5.6.1";
     pname = "sqlsrv";
 
     sha256 = "0ial621zxn9zvjh7k1h755sm2lc9aafc389yxksqcxcmm7kqmd0a";
 
     buildInputs = [ pkgs.unixODBC ];
+
+    meta.broken = isPhp74;
   };
 
   v8 = buildPecl {


### PR DESCRIPTION
###### Motivation for this change
Issue - https://github.com/NixOS/nixpkgs/issues/72780

To correct build phpPackages need this PR - https://github.com/NixOS/nixpkgs/pull/73908

Changes in this PR:
- Drop support build php wint maraidb connector-c. Php not support version 3.1.
- Remove unused configure flags. The `configureFlags+` option is not applied during build.
- Add option `config.php.pear`
- Add option `config.php.ipv6`
- Add php v7.4 RC6
- Build PHP with an external GD library
- Update `preConfigure` phase. Needed for a correct build from git-source.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
