### PR TITLE
datovka: init at 4.14.0

### DIFF
--- a/pkgs/applications/networking/datovka/default.nix
+++ b/pkgs/applications/networking/datovka/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, mkDerivation
+, fetchurl
+, libxml2
+, libisds
+, qmake
+, qtbase
+, qtsvg
+, pkg-config
+}:
+
+mkDerivation rec {
+  pname = "datovka";
+  version = "4.14.0";
+
+  src = fetchurl {
+    url = "https://secure.nic.cz/files/datove_schranky/${version}/${pname}-${version}.tar.xz";
+    sha256 = "0q7zlq522wdgwxgd3jxmxvr3awclcy0mbw3qaymwzn2b8d35168r";
+  };
+
+  buildInputs = [ libisds qmake qtbase qtsvg libxml2 ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  meta = with stdenv.lib; {
+    description = "Client application for operating Czech government-provided Databox infomation system";
+    homepage = "https://www.datovka.cz/";
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libisds/default.nix
+++ b/pkgs/development/libraries/libisds/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchurl
+, expat
+, gpgme
+, libgcrypt
+, libxml2
+, libxslt
+, curl
+, docbook_xsl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libisds";
+  version = "0.11";
+
+  src = fetchurl {
+    url = "http://xpisar.wz.cz/${pname}/dist/${pname}-${version}.tar.xz";
+    sha256 = "1cy161l7rl25xji2xpb9vjpvg02bc7mwd4fpp2sx9zhpifn5dfbr";
+  };
+
+  configureFlags = [
+    "--with-docbook-xsl-stylesheets=${docbook_xsl}/xml/xsl/docbook"
+  ];
+
+  buildInputs = [ expat gpgme libgcrypt libxml2 libxslt curl docbook_xsl ];
+
+  meta = with stdenv.lib; {
+    description = "Client library for accessing SOAP services of Czech government-provided Databox infomation system";
+    homepage = "http://xpisar.wz.cz/libisds/";
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4657,6 +4657,8 @@ in
 
   libircclient = callPackage ../development/libraries/libircclient { };
 
+  libisds = callPackage ../development/libraries/libisds { };
+
   libite = callPackage ../development/libraries/libite { };
 
   liblangtag = callPackage ../development/libraries/liblangtag {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1500,6 +1500,8 @@ in
 
   dateutils = callPackage ../tools/misc/dateutils { };
 
+  datovka = libsForQt5.callPackage ../applications/networking/datovka { };
+
   ddar = callPackage ../tools/backup/ddar { };
 
   ddate = callPackage ../tools/misc/ddate { };


### PR DESCRIPTION
###### Motivation for this change

    datovka: init at 4.14.0
    libisds: init at 0.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).