### PR TITLE
pythonPackages.qrcode: Fix "No module named pkg_resources" error

### DIFF
--- a/pkgs/development/python-modules/qrcode/default.nix
+++ b/pkgs/development/python-modules/qrcode/default.nix
@@ -5,6 +5,7 @@
 , pillow
 , pymaging_png
 , mock
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -16,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "505253854f607f2abf4d16092c61d4e9d511a3b4392e60bff957a68592b04369";
   };
 
-  propagatedBuildInputs = [ six pillow pymaging_png ];
+  propagatedBuildInputs = [ six pillow pymaging_png setuptools ];
   checkInputs = [ mock ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Right now qr will throw:
```
Traceback (most recent call last):
  File "/nix/store/1avr62jc76yjcsm6v0960mffxl7972a4-python2.7-qrcode-6.1/bin/.qr-wrapped", line 11, in <module>
    sys.exit(main())
  File "/nix/store/1avr62jc76yjcsm6v0960mffxl7972a4-python2.7-qrcode-6.1/lib/python2.7/site-packages/qrcode/console_scripts.py", line 36, in main
    from pkg_resources import get_distribution
ImportError: No module named pkg_resources
```
This fixes this by adding the setup-tools dependency.

###### Things done

- [x] Tested build and execution on x86_64_linux
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).