### PR TITLE
pythonPackages.qrcode: Fix "No module named pkg_resources" error

### DIFF
--- a/pkgs/development/python-modules/qrcode/default.nix
+++ b/pkgs/development/python-modules/qrcode/default.nix
@@ -5,6 +5,7 @@
 , pillow
 , pymaging_png
 , mock
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -16,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "505253854f607f2abf4d16092c61d4e9d511a3b4392e60bff957a68592b04369";
   };
 
-  propagatedBuildInputs = [ six pillow pymaging_png ];
+  propagatedBuildInputs = [ six pillow pymaging_png setuptools ];
   checkInputs = [ mock ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Backport of #73159.