### PR TITLE
monero: 0.14.1.2 -> 0.15.0.0

### DIFF
--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -1,27 +1,27 @@
-{ mkDerivation, lib, makeDesktopItem, fetchFromGitHub
+{ stdenv, wrapQtAppsHook, makeDesktopItem, fetchFromGitHub
 , qtbase, qmake, qtmultimedia, qttools
 , qtgraphicaleffects, qtdeclarative
 , qtlocation, qtquickcontrols, qtquickcontrols2
 , qtwebchannel, qtwebengine, qtx11extras, qtxmlpatterns
 , monero, unbound, readline, boost, libunwind
 , libsodium, pcsclite, zeromq, cppzmq, pkgconfig
-, hidapi
+, hidapi, randomx
 }:
 
-with lib;
+with stdenv.lib;
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.14.1.2";
+  version = "0.15.0.0";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "1rm043r6y2mzy8pclnzbjjfxgps8pkfa2b92p66k8y8rdmgq6m1k";
+    sha256 = "1shpnly2dym5jhvk8zk10p69mz062dihx979djg74q6hgkhhhqsh";
   };
 
-  nativeBuildInputs = [ qmake pkgconfig ];
+  nativeBuildInputs = [ qmake pkgconfig wrapQtAppsHook ];
 
   buildInputs = [
     qtbase qtmultimedia qtgraphicaleffects
@@ -30,7 +30,7 @@ mkDerivation rec {
     qtwebchannel qtwebengine qtx11extras
     qtxmlpatterns monero unbound readline
     boost libunwind libsodium pcsclite zeromq
-    cppzmq hidapi
+    cppzmq hidapi randomx
   ];
 
   patches = [ ./move-log-file.patch ];

--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchgit
-, cmake, pkgconfig, git
+{ stdenv, fetchFromGitHub
+, cmake, pkgconfig
 , boost, miniupnpc, openssl, unbound, cppzmq
 , zeromq, pcsclite, readline, libsodium, hidapi
 , python3Packages
@@ -8,36 +8,34 @@
 
 assert stdenv.isDarwin -> IOKit != null;
 
-with stdenv.lib;
-
 stdenv.mkDerivation rec {
   pname = "monero";
-  version = "0.14.1.0";
+  version = "0.15.0.0";
 
-  src = fetchgit {
-    url    = "https://github.com/monero-project/monero.git";
-    rev    = "v${version}";
-    sha256 = "1asa197fad81jfv12qgaa7y7pdr1r1pda96m9pvivkh4v30cx0nh";
+  src = fetchFromGitHub {
+    owner = "monero-project";
+    repo = "monero";
+    rev = "v${version}";
+    sha256 = "19y4kcj4agws7swfa3draysb1y18c3xb13r8cg0faxx1dlm0zbnr";
+    fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake pkgconfig git ];
+  nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
     boost miniupnpc openssl unbound
     cppzmq zeromq pcsclite readline
     libsodium hidapi
     python3Packages.protobuf
-  ] ++ optionals stdenv.isDarwin [ IOKit CoreData PCSC ];
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit CoreData PCSC ];
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
     "-DBUILD_GUI_DEPS=ON"
     "-DReadline_ROOT_DIR=${readline.dev}"
-  ] ++ optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF";
+  ] ++ stdenv.lib.optional stdenv.isDarwin "-DBoost_USE_MULTITHREADED=OFF";
 
-  hardeningDisable = [ "fortify" ];
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "Private, secure, untraceable currency";
     homepage    = https://getmonero.org/;
     license     = licenses.bsd3;

--- a/pkgs/applications/blockchains/monero/default.nix
+++ b/pkgs/applications/blockchains/monero/default.nix
@@ -2,7 +2,7 @@
 , cmake, pkgconfig
 , boost, miniupnpc, openssl, unbound, cppzmq
 , zeromq, pcsclite, readline, libsodium, hidapi
-, python3Packages
+, python3Packages, randomx, rapidjson
 , CoreData, IOKit, PCSC
 }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost miniupnpc openssl unbound
     cppzmq zeromq pcsclite readline
-    libsodium hidapi
+    libsodium hidapi randomx rapidjson
     python3Packages.protobuf
   ] ++ stdenv.lib.optionals stdenv.isDarwin [ IOKit CoreData PCSC ];
 

--- a/pkgs/development/libraries/randomx/default.nix
+++ b/pkgs/development/libraries/randomx/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "randomX";
+  version = "1.1.6";
+
+  nativeBuildInputs = [ cmake ];
+
+  src = fetchFromGitHub {
+    owner = "tevador";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1qd0rbzgxdy87wwy0n6ca29bcq25j5ndnfgmx8iyf225m4rcwngf";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Proof of work algorithm based on random code execution";
+    homepage = https://github.com/tevador/RandomX;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ rnhmjoj ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13761,6 +13761,8 @@ in
 
   qgnomeplatform =  libsForQt5.callPackage ../development/libraries/qgnomeplatform { };
 
+  randomx = callPackage ../development/libraries/randomx { };
+
   resolv_wrapper = callPackage ../development/libraries/resolv_wrapper { };
 
   rhino = callPackage ../development/libraries/java/rhino {


### PR DESCRIPTION
###### Motivation for this change

Continuing the update in #73124. This PR takes care of monero-gui.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ehmry
