### PR TITLE
qscintilla: Fix qt4 build [release-19.09]

### DIFF
--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -73,6 +73,5 @@ in stdenv.mkDerivation rec {
     license = with licenses; [ gpl2 gpl3 ]; # and commercial
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;
-    broken = !withQt5;
   };
 }

--- a/pkgs/development/libraries/qscintilla/fix-qt4-build.patch
+++ b/pkgs/development/libraries/qscintilla/fix-qt4-build.patch
@@ -1,6 +1,6 @@
-diff -ur QScintilla_gpl-2.9.4/Qt4Qt5/Qsci/qsciscintillabase.h QScintilla_gpl-2.9.4-fix/Qt4Qt5/Qsci/qsciscintillabase.h
---- QScintilla_gpl-2.9.4/Qt4Qt5/Qsci/qsciscintillabase.h	2016-12-25 23:01:54.000000000 +0100
-+++ QScintilla_gpl-2.9.4-fix/Qt4Qt5/Qsci/qsciscintillabase.h	2019-10-22 09:07:55.429260135 +0200
+diff -ur Qt4Qt5/Qsci/qsciscintillabase.h Qt4Qt5/Qsci/qsciscintillabase.h
+--- Qt4Qt5/Qsci/qsciscintillabase.h	2016-12-25 23:01:54.000000000 +0100
++++ Qt4Qt5/Qsci/qsciscintillabase.h	2019-10-22 09:07:55.429260135 +0200
 @@ -31,6 +31,7 @@
  #include <QByteArray>
  #include <QPoint>


### PR DESCRIPTION
(cherry picked from commit eb1cd0d27d42f5a3d969a5a87330d1322812b09c)

Fixes https://github.com/NixOS/nixpkgs/issues/73148

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/73148

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I have built and testes octaveFull with this backport. Everything works fine (gui + editor).

###### Notify maintainers

cc @
