### PR TITLE
yara: 3.10.0 -> 3.11.0, fix build

### DIFF
--- a/pkgs/tools/security/yara/default.nix
+++ b/pkgs/tools/security/yara/default.nix
@@ -1,21 +1,30 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pcre
+{ stdenv, fetchFromGitHub, fetchpatch, autoconf, automake, libtool, pcre
 , withCrypto ? true, openssl
 , enableMagic ? true, file
 , enableCuckoo ? true, jansson
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.10.0";
+  version = "3.11.0";
   pname = "yara";
 
   src = fetchFromGitHub {
     owner = "VirusTotal";
     repo = "yara";
     rev = "v${version}";
-    sha256 = "1qxqk324cyvi4n09s79786ciig1gdyhs9dnsm07hf95a3kh6w5z2";
+    sha256 = "0mx3xm2a70fx8vlynkavq8gfd9w5yjcix5rx85444i2s1h6kcd0j";
   };
 
-  buildInputs = [ autoconf automake libtool pcre]
+  # See: https://github.com/VirusTotal/yara/issues/1036
+  # TODO: This patch should not be necessary in the next release
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/VirusTotal/yara/commit/04df811fa61fa54390b274bfcf56d7403c184404.patch";
+      sha256 = "0hsbc2k7nmk2kskll971draz0an4rmcs5v0iql47mz596vqvkzmb";
+    })
+  ];
+
+  buildInputs = [ autoconf automake libtool pcre ]
     ++ stdenv.lib.optionals withCrypto [ openssl ]
     ++ stdenv.lib.optionals enableMagic [ file ]
     ++ stdenv.lib.optionals enableCuckoo [ jansson ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update YARA 3.10.0 -> 3.11.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
