### PR TITLE
recursive: init at 1.022

### DIFF
--- a/pkgs/data/fonts/recursive/default.nix
+++ b/pkgs/data/fonts/recursive/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  pname = "recursive";
+  version = "1.022";
+
+  srcs = [
+    (fetchzip {
+      name = "${pname}";
+      url = "https://github.com/arrowtype/recursive/releases/download/v${version}/recursive-beta_1_022.zip";
+      sha256 = "09nr1fli7ksv8z4yb25c4xidwsqq50av18qrybsy4kqy5c22957v";
+      stripRoot = false;
+    })
+
+    (fetchzip {
+      name = "${pname}-static";
+      url = "https://github.com/arrowtype/recursive/releases/download/v${version}/recursive-static_fonts-b020.zip";
+      sha256 = "1wlj113gjm26ra9y2r2b3syis2wx0mjq2m8i8xpwscp1kflma1r6";
+      stripRoot = false;
+    })
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/{opentype,truetype,woff2}
+    find -name "*.otf" -exec cp "{}" $out/share/fonts/opentype \;
+    find -name "*.ttf" -exec cp "{}" $out/share/fonts/truetype \;
+    find -name "*.woff2" -exec cp "{}" $out/share/fonts/woff2 \;
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/arrowtype/recursive;
+    description = "A variable font family for code & UI";
+    license = licenses.ofl;
+    maintainers = [ maintainers.eadwu ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17511,6 +17511,8 @@ in
 
   raleway = callPackage ../data/fonts/raleway { };
 
+  recursive = callPackage ../data/fonts/recursive { };
+
   rictydiminished-with-firacode = callPackage ../data/fonts/rictydiminished-with-firacode { };
 
   roboto = callPackage ../data/fonts/roboto { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
