### PR TITLE
roundcube: 1.3.10 -> 1.4.0

### DIFF
--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -25,6 +25,6 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     roundcube.wait_for_unit("postgresql.service")
     roundcube.wait_for_unit("phpfpm-roundcube.service")
     roundcube.wait_for_unit("nginx.service")
-    roundcube.succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'")
+    roundcube.succeed("curl -sSL http://roundcube/ | grep 'Keep me logged in'")
   '';
 })

--- a/pkgs/servers/roundcube/0001-Don-t-resolve-symlinks-when-trying-to-find-INSTALL_P.patch
+++ b/pkgs/servers/roundcube/0001-Don-t-resolve-symlinks-when-trying-to-find-INSTALL_P.patch
@@ -18,7 +18,7 @@ index 08e3bb5..b2ad498 100755
  */
  
 -define('INSTALL_PATH', realpath(__DIR__ . '/..') . '/' );
-+define('INSTALL_PATH', __DIR__ . '/../' );
++define('INSTALL_PATH', dirname(dirname($argv[0])).'/');
  
  require_once INSTALL_PATH . 'program/include/clisetup.php';
  

--- a/pkgs/servers/roundcube/default.nix
+++ b/pkgs/servers/roundcube/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "roundcube";
-  version = "1.3.10";
+  version = "1.4.0";
 
   src = fetchurl {
     url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz";
-    sha256 = "1gx8dgrr3p6fksv3pm381a080i9r6snwcmfd1q112mqg19ai3zk9";
+    sha256 = "0b7gc342z0smn7q6cnznj9ncal0515ki4kkq1hlmqmyn0nna5lkb";
   };
 
   patches = [ ./0001-Don-t-resolve-symlinks-when-trying-to-find-INSTALL_P.patch ];


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://roundcube.net/news/2019/11/09/roundcube-1.4.0-released

* `curl` cmd in the test can fail as roundcube returns a http/401 if
  unauthorized (and we're explicitly requesting the login form). By
  checking if the `persistent_login` plugin is loaded, the assertion is
  still valid.

* Use `$argv[0]` to determine install path in the installer script. I'm
  not exactly sure why, but it seems as `__DIR__` now resolves symlinks
  which breaks the installer if roundcube is in a `buildEnv` with
  third-party plugins.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

