### PR TITLE
fix ghc-paths-nix-ghcjs.patch

### DIFF
--- a/pkgs/development/haskell-modules/patches/ghc-paths-nix-ghcjs.patch
+++ b/pkgs/development/haskell-modules/patches/ghc-paths-nix-ghcjs.patch
@@ -43,13 +43,13 @@ index c87565d..88b3db4 100644
 +ghc     = fromMaybe GHC_PATHS_GHC     nixGhc
 +ghc_pkg = fromMaybe GHC_PATHS_GHC_PKG nixGhcPkg
 diff --git a/Setup.hs b/Setup.hs
-index fad5026..1651650 100644
+index f2d1733..ca4792e 100644
 --- a/Setup.hs
 +++ b/Setup.hs
-@@ -27,13 +27,13 @@ main = defaultMainWithHooks simpleUserHooks {
-     defaultPostConf :: Args -> ConfigFlags -> PackageDescription -> LocalBuildInfo -> IO ()
-     defaultPostConf args flags pkgdescr lbi = do
+@@ -39,13 +39,13 @@ main = defaultMainWithHooks simpleUserHooks {
+ #else
        libdir_ <- rawSystemProgramStdoutConf (fromFlag (configVerbosity flags))
+ #endif
 -                     ghcProgram (withPrograms lbi) ["--print-libdir"]
 +                     ghcjsProgram (withPrograms lbi) ["--print-libdir"]
        let libdir = reverse $ dropWhile isSpace $ reverse libdir_


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This patch is used in pkgs/development/haskell-modules/configuration-ghcjs.nix
 to fix the ghc-path package for use with ghcjs.
 The ghc-paths package has been updated in a way that the existing patch can no longer
be applied.
This PR fixes the patch-file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @obadz
