### PR TITLE
gcc: Clean up cross configure flags and name prefix for 19.09

### DIFF
--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -106,20 +106,7 @@ let version = "4.9.4";
       # Ensure that -print-prog-name is able to find the correct programs.
       [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
         "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossMingw && crossStageStatic then [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--with-gnu-ld"
-        "--disable-shared"
-        "--disable-nls"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--enable-threads=win32"
-        "--disable-win32-registry"
-        "--disable-libmpx" # requires libc
-      ] else if crossStageStatic then [
+      (if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
         "--without-headers"
@@ -130,41 +117,47 @@ let version = "4.9.4";
         "--disable-libatomic" # requires libc
         "--disable-decimal-float" # requires libc
         "--disable-libmpx" # requires libc
+      ] ++ optionals crossMingw [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--disable-win32-registry"
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
         "--enable-__cxa_atexit"
         "--enable-long-long"
-      ] ++
-        (if crossMingw then [
-          "--enable-threads=win32"
-          "--enable-sjlj-exceptions"
-          "--enable-hash-synchronization"
-          "--enable-libssp"
-          "--disable-nls"
-          "--with-dwarf2"
-          # To keep ABI compatibility with upstream mingw-w64
-          "--enable-fully-dynamic-string"
-        ] else
-          optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-            # libsanitizer requires netrom/netrom.h which is not
-            # available in uclibc.
-            "--disable-libsanitizer"
-            # In uclibc cases, libgomp needs an additional '-ldl'
-            # and as I don't know how to pass it, I disable libgomp.
-            "--disable-libgomp"
-          ]
-          ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-          ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-          ++ [
-            "--enable-threads=${if targetPlatform.isUnix then "posix"
-                                else if targetPlatform.isWindows then "win32"
-                                else "single"}"
-            "--enable-nls"
-            "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-        ]));
+        "--enable-threads=${if targetPlatform.isUnix then "posix"
+                            else if targetPlatform.isWindows then "win32"
+                            else "single"}"
+        "--enable-nls"
+        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
+        # libsanitizer requires netrom/netrom.h which is not
+        # available in uclibc.
+        "--disable-libsanitizer"
+        # In uclibc cases, libgomp needs an additional '-ldl'
+        # and as I don't know how to pass it, I disable libgomp.
+        "--disable-libgomp"
+      ] ++ optionals (targetPlatform.libc == "musl") [
+        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
+        "--disable-libmpx"
+      ] ++ optionals crossMingw [
+        "--enable-sjlj-exceptions"
+        "--enable-hash-synchronization"
+        "--enable-libssp"
+        "--disable-nls"
+        "--with-dwarf2"
+        # To keep ABI compatibility with upstream mingw-w64
+        "--enable-fully-dynamic-string"
+      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
+        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
+      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "${targetPlatform.config}${stageNameAddon}-" else "";
+    crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
     bootstrap = targetPlatform == hostPlatform;
 

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -93,20 +93,7 @@ let version = "5.5.0";
       # Ensure that -print-prog-name is able to find the correct programs.
       [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
         "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossMingw && crossStageStatic then [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--with-gnu-ld"
-        "--disable-shared"
-        "--disable-nls"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--enable-threads=win32"
-        "--disable-win32-registry"
-        "--disable-libmpx" # requires libc
-      ] else if crossStageStatic then [
+      (if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
         "--without-headers"
@@ -117,41 +104,47 @@ let version = "5.5.0";
         "--disable-libatomic" # requires libc
         "--disable-decimal-float" # requires libc
         "--disable-libmpx" # requires libc
+      ] ++ optionals crossMingw [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--disable-win32-registry"
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
         "--enable-__cxa_atexit"
         "--enable-long-long"
-      ] ++
-        (if crossMingw then [
-          "--enable-threads=win32"
-          "--enable-sjlj-exceptions"
-          "--enable-hash-synchronization"
-          "--enable-libssp"
-          "--disable-nls"
-          "--with-dwarf2"
-          # To keep ABI compatibility with upstream mingw-w64
-          "--enable-fully-dynamic-string"
-        ] else
-          optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-            # libsanitizer requires netrom/netrom.h which is not
-            # available in uclibc.
-            "--disable-libsanitizer"
-            # In uclibc cases, libgomp needs an additional '-ldl'
-            # and as I don't know how to pass it, I disable libgomp.
-            "--disable-libgomp"
-          ]
-          ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-          ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-          ++ [
-            "--enable-threads=${if targetPlatform.isUnix then "posix"
-                                else if targetPlatform.isWindows then "win32"
-                                else "single"}"
-            "--enable-nls"
-            "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-        ]));
+        "--enable-threads=${if targetPlatform.isUnix then "posix"
+                            else if targetPlatform.isWindows then "win32"
+                            else "single"}"
+        "--enable-nls"
+        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
+        # libsanitizer requires netrom/netrom.h which is not
+        # available in uclibc.
+        "--disable-libsanitizer"
+        # In uclibc cases, libgomp needs an additional '-ldl'
+        # and as I don't know how to pass it, I disable libgomp.
+        "--disable-libgomp"
+      ] ++ optionals (targetPlatform.libc == "musl") [
+        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
+        "--disable-libmpx"
+      ] ++ optionals crossMingw [
+        "--enable-sjlj-exceptions"
+        "--enable-hash-synchronization"
+        "--enable-libssp"
+        "--disable-nls"
+        "--with-dwarf2"
+        # To keep ABI compatibility with upstream mingw-w64
+        "--enable-fully-dynamic-string"
+      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
+        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
+      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "${targetPlatform.config}${stageNameAddon}-" else "";
+    crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
     bootstrap = targetPlatform == hostPlatform;
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -90,20 +90,7 @@ let version = "6.5.0";
       # Ensure that -print-prog-name is able to find the correct programs.
       [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
         "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossMingw && crossStageStatic then [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--with-gnu-ld"
-        "--disable-shared"
-        "--disable-nls"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--enable-threads=win32"
-        "--disable-win32-registry"
-        "--disable-libmpx" # requires libc
-      ] else if crossStageStatic then [
+      (if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
         "--without-headers"
@@ -114,43 +101,47 @@ let version = "6.5.0";
         "--disable-libatomic" # requires libc
         "--disable-decimal-float" # requires libc
         "--disable-libmpx" # requires libc
+      ] ++ optionals crossMingw [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--disable-win32-registry"
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
         "--enable-__cxa_atexit"
         "--enable-long-long"
-      ] ++
-        (if crossMingw then [
-          "--enable-threads=win32"
-          "--enable-sjlj-exceptions"
-          "--enable-hash-synchronization"
-          "--enable-libssp"
-          "--disable-nls"
-          "--with-dwarf2"
-          # To keep ABI compatibility with upstream mingw-w64
-          "--enable-fully-dynamic-string"
-        ] else
-          optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-            # libsanitizer requires netrom/netrom.h which is not
-            # available in uclibc.
-            "--disable-libsanitizer"
-            # In uclibc cases, libgomp needs an additional '-ldl'
-            # and as I don't know how to pass it, I disable libgomp.
-            "--disable-libgomp"
-            # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-            "--disable-libmpx"
-          ]
-          ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-          ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-          ++ [
-            "--enable-threads=${if targetPlatform.isUnix then "posix"
-                                else if targetPlatform.isWindows then "win32"
-                                else "single"}"
-            "--enable-nls"
-            "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-        ]));
+        "--enable-threads=${if targetPlatform.isUnix then "posix"
+                            else if targetPlatform.isWindows then "win32"
+                            else "single"}"
+        "--enable-nls"
+        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
+        # libsanitizer requires netrom/netrom.h which is not
+        # available in uclibc.
+        "--disable-libsanitizer"
+        # In uclibc cases, libgomp needs an additional '-ldl'
+        # and as I don't know how to pass it, I disable libgomp.
+        "--disable-libgomp"
+      ] ++ optionals (targetPlatform.libc == "musl") [
+        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
+        "--disable-libmpx"
+      ] ++ optionals crossMingw [
+        "--enable-sjlj-exceptions"
+        "--enable-hash-synchronization"
+        "--enable-libssp"
+        "--disable-nls"
+        "--with-dwarf2"
+        # To keep ABI compatibility with upstream mingw-w64
+        "--enable-fully-dynamic-string"
+      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
+        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
+      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "${targetPlatform.config}${stageNameAddon}-" else "";
+    crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
     bootstrap = targetPlatform == hostPlatform;
 

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -67,20 +67,7 @@ let version = "7.4.0";
       # Ensure that -print-prog-name is able to find the correct programs.
       [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
         "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossMingw && crossStageStatic then [
-        "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--with-gnu-ld"
-        "--disable-shared"
-        "--disable-nls"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--enable-threads=win32"
-        "--disable-win32-registry"
-        "--disable-libmpx" # requires libc
-      ] else if crossStageStatic then [
+      (if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
         "--without-headers"
@@ -91,44 +78,47 @@ let version = "7.4.0";
         "--disable-libatomic" # requires libc
         "--disable-decimal-float" # requires libc
         "--disable-libmpx" # requires libc
+      ] ++ optionals crossMingw [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--disable-win32-registry"
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
         "--enable-__cxa_atexit"
         "--enable-long-long"
-      ] ++
-        (if crossMingw then [
-          "--enable-threads=win32"
-          "--enable-sjlj-exceptions"
-          "--enable-hash-synchronization"
-          "--enable-libssp"
-          "--disable-nls"
-          "--with-dwarf2"
-          # To keep ABI compatibility with upstream mingw-w64
-          "--enable-fully-dynamic-string"
-        ] else
-          optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-            # libsanitizer requires netrom/netrom.h which is not
-            # available in uclibc.
-            "--disable-libsanitizer"
-            # In uclibc cases, libgomp needs an additional '-ldl'
-            # and as I don't know how to pass it, I disable libgomp.
-            "--disable-libgomp"
-            # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-            "--disable-libmpx"
-          ]
-          ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-          ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-          ++ [
-            "--enable-threads=${if targetPlatform.isUnix then "posix"
-                                else if targetPlatform.isWindows then "win32"
-                                else "single"}"
-            "--enable-nls"
-            # No final libdecnumber (it may work only in 386)
-            "--disable-decimal-float"
-          ]));
+        "--enable-threads=${if targetPlatform.isUnix then "posix"
+                            else if targetPlatform.isWindows then "win32"
+                            else "single"}"
+        "--enable-nls"
+        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
+        # libsanitizer requires netrom/netrom.h which is not
+        # available in uclibc.
+        "--disable-libsanitizer"
+        # In uclibc cases, libgomp needs an additional '-ldl'
+        # and as I don't know how to pass it, I disable libgomp.
+        "--disable-libgomp"
+      ] ++ optionals (targetPlatform.libc == "musl") [
+        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
+        "--disable-libmpx"
+      ] ++ optionals crossMingw [
+        "--enable-sjlj-exceptions"
+        "--enable-hash-synchronization"
+        "--enable-libssp"
+        "--disable-nls"
+        "--with-dwarf2"
+        # To keep ABI compatibility with upstream mingw-w64
+        "--enable-fully-dynamic-string"
+      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
+        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
+      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "${targetPlatform.config}${stageNameAddon}-" else "";
+    crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
     bootstrap = targetPlatform == hostPlatform;
 

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -59,20 +59,7 @@ let version = "8.3.0";
       # Ensure that -print-prog-name is able to find the correct programs.
       [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
         "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossMingw && crossStageStatic then [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--with-gnu-ld"
-        "--disable-shared"
-        "--disable-nls"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--enable-threads=win32"
-        "--disable-win32-registry"
-        "--disable-libmpx" # requires libc
-      ] else if crossStageStatic then [
+      (if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
         "--without-headers"
@@ -83,41 +70,45 @@ let version = "8.3.0";
         "--disable-libatomic" # requires libc
         "--disable-decimal-float" # requires libc
         "--disable-libmpx" # requires libc
+      ] ++ optionals crossMingw [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--disable-win32-registry"
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
         "--enable-__cxa_atexit"
         "--enable-long-long"
-      ] ++
-        (if crossMingw then [
-          "--enable-threads=win32"
-          "--enable-sjlj-exceptions"
-          "--enable-hash-synchronization"
-          "--enable-libssp"
-          "--disable-nls"
-          "--with-dwarf2"
-          # To keep ABI compatibility with upstream mingw-w64
-          "--enable-fully-dynamic-string"
-        ] else
-          optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-            # libsanitizer requires netrom/netrom.h which is not
-            # available in uclibc.
-            "--disable-libsanitizer"
-            # In uclibc cases, libgomp needs an additional '-ldl'
-            # and as I don't know how to pass it, I disable libgomp.
-            "--disable-libgomp"
-            # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-            "--disable-libmpx"
-          ]
-          ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-          ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-          ++ [
-            "--enable-threads=${if targetPlatform.isUnix then "posix"
-                                else if targetPlatform.isWindows then "win32"
-                                else "single"}"
-            "--enable-nls"
-            "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-        ]));
+        "--enable-threads=${if targetPlatform.isUnix then "posix"
+                            else if targetPlatform.isWindows then "win32"
+                            else "single"}"
+        "--enable-nls"
+        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
+        # libsanitizer requires netrom/netrom.h which is not
+        # available in uclibc.
+        "--disable-libsanitizer"
+        # In uclibc cases, libgomp needs an additional '-ldl'
+        # and as I don't know how to pass it, I disable libgomp.
+        "--disable-libgomp"
+      ] ++ optionals (targetPlatform.libc == "musl") [
+        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
+        "--disable-libmpx"
+      ] ++ optionals crossMingw [
+        "--enable-sjlj-exceptions"
+        "--enable-hash-synchronization"
+        "--enable-libssp"
+        "--disable-nls"
+        "--with-dwarf2"
+        # To keep ABI compatibility with upstream mingw-w64
+        "--enable-fully-dynamic-string"
+      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
+        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
+      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
@@ -126,7 +117,7 @@ let version = "8.3.0";
 in
 
 stdenv.mkDerivation ({
-  name = "${name}${if stripped then "" else "-debug"}-${version}" + crossNameAddon;
+  name = crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
 
   builder = ../builder.sh;
 

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -58,20 +58,7 @@ let version = "9.2.0";
       # Ensure that -print-prog-name is able to find the correct programs.
       [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
         "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossMingw && crossStageStatic then [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--with-gnu-ld"
-        "--disable-shared"
-        "--disable-nls"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--enable-threads=win32"
-        "--disable-win32-registry"
-        "--disable-libmpx" # requires libc
-      ] else if crossStageStatic then [
+      (if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
         "--without-headers"
@@ -82,41 +69,45 @@ let version = "9.2.0";
         "--disable-libatomic" # requires libc
         "--disable-decimal-float" # requires libc
         "--disable-libmpx" # requires libc
+      ] ++ optionals crossMingw [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--disable-win32-registry"
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
         "--enable-__cxa_atexit"
         "--enable-long-long"
-      ] ++
-        (if crossMingw then [
-          "--enable-threads=win32"
-          "--enable-sjlj-exceptions"
-          "--enable-hash-synchronization"
-          "--enable-libssp"
-          "--disable-nls"
-          "--with-dwarf2"
-          # To keep ABI compatibility with upstream mingw-w64
-          "--enable-fully-dynamic-string"
-        ] else
-          optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-            # libsanitizer requires netrom/netrom.h which is not
-            # available in uclibc.
-            "--disable-libsanitizer"
-            # In uclibc cases, libgomp needs an additional '-ldl'
-            # and as I don't know how to pass it, I disable libgomp.
-            "--disable-libgomp"
-            # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-            "--disable-libmpx"
-          ]
-          ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-          ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-          ++ [
-            "--enable-threads=${if targetPlatform.isUnix then "posix"
-                                else if targetPlatform.isWindows then "win32"
-                                else "single"}"
-            "--enable-nls"
-            "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-        ]));
+        "--enable-threads=${if targetPlatform.isUnix then "posix"
+                            else if targetPlatform.isWindows then "win32"
+                            else "single"}"
+        "--enable-nls"
+        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
+        # libsanitizer requires netrom/netrom.h which is not
+        # available in uclibc.
+        "--disable-libsanitizer"
+        # In uclibc cases, libgomp needs an additional '-ldl'
+        # and as I don't know how to pass it, I disable libgomp.
+        "--disable-libgomp"
+      ] ++ optionals (targetPlatform.libc == "musl") [
+        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
+        "--disable-libmpx"
+      ] ++ optionals crossMingw [
+        "--enable-sjlj-exceptions"
+        "--enable-hash-synchronization"
+        "--enable-libssp"
+        "--disable-nls"
+        "--with-dwarf2"
+        # To keep ABI compatibility with upstream mingw-w64
+        "--enable-fully-dynamic-string"
+      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
+        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
+      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
@@ -125,7 +116,7 @@ let version = "9.2.0";
 in
 
 stdenv.mkDerivation ({
-  name = "${name}${if stripped then "" else "-debug"}-${version}" + crossNameAddon;
+  name = crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
 
   builder = ../builder.sh;
 

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -55,20 +55,7 @@ let version = "7-20170409";
       # Ensure that -print-prog-name is able to find the correct programs.
       [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
         "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossMingw && crossStageStatic then [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--with-gnu-ld"
-        "--disable-shared"
-        "--disable-nls"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--enable-threads=win32"
-        "--disable-win32-registry"
-        "--disable-libmpx" # requires libc
-      ] else if crossStageStatic then [
+      (if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
         "--without-headers"
@@ -79,39 +66,45 @@ let version = "7-20170409";
         "--disable-libatomic" # requires libc
         "--disable-decimal-float" # requires libc
         "--disable-libmpx" # requires libc
+      ] ++ optionals crossMingw [
+        "--with-headers=${libcCross}/include"
+        "--with-gcc"
+        "--with-gnu-as"
+        "--with-gnu-ld"
+        "--disable-debug"
+        "--enable-sjlj-exceptions"
+        "--disable-win32-registry"
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
-         else                "--with-headers=${getDev libcCross}/include")
+         else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
         "--enable-__cxa_atexit"
         "--enable-long-long"
-      ] ++
-        (if crossMingw then [
-          "--enable-threads=win32"
-          "--enable-sjlj-exceptions"
-          "--enable-hash-synchronization"
-          "--enable-libssp"
-          "--disable-nls"
-          "--with-dwarf2"
-          # To keep ABI compatibility with upstream mingw-w64
-          "--enable-fully-dynamic-string"
-        ] else
-          optionals (targetPlatform.libc == "uclibc") [
-            # libsanitizer requires netrom/netrom.h which is not
-            # available in uclibc.
-            "--disable-libsanitizer"
-            # In uclibc cases, libgomp needs an additional '-ldl'
-            # and as I don't know how to pass it, I disable libgomp.
-            "--disable-libgomp"
-          ]
-          ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-          ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-          ++ [
-            "--enable-threads=${if targetPlatform.isUnix then "posix"
-                                else if targetPlatform.isWindows then "win32"
-                                else "single"}"
-            "--enable-nls"
-            "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-        ]));
+        "--enable-threads=${if targetPlatform.isUnix then "posix"
+                            else if targetPlatform.isWindows then "win32"
+                            else "single"}"
+        "--enable-nls"
+        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
+        # libsanitizer requires netrom/netrom.h which is not
+        # available in uclibc.
+        "--disable-libsanitizer"
+        # In uclibc cases, libgomp needs an additional '-ldl'
+        # and as I don't know how to pass it, I disable libgomp.
+        "--disable-libgomp"
+      ] ++ optionals (targetPlatform.libc == "musl") [
+        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
+        "--disable-libmpx"
+      ] ++ optionals crossMingw [
+        "--enable-sjlj-exceptions"
+        "--enable-hash-synchronization"
+        "--enable-libssp"
+        "--disable-nls"
+        "--with-dwarf2"
+        # To keep ABI compatibility with upstream mingw-w64
+        "--enable-fully-dynamic-string"
+      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
+        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
+      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
 
@@ -120,7 +113,7 @@ let version = "7-20170409";
 in
 
 stdenv.mkDerivation ({
-  name = "${name}${if stripped then "" else "-debug"}-${version}" + crossNameAddon;
+  name = crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
 
   builder = ../builder.sh;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of #73173

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
