### PR TITLE
pypi2nix: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/development/tools/pypi2nix/default.nix
+++ b/pkgs/development/tools/pypi2nix/default.nix
@@ -4,12 +4,13 @@ with python3;
 
 pkgs.buildPythonApplication rec {
   pname = "pypi2nix";
-  version = "2.0.0";
+  version = "2.0.1";
   src = pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "0w9z07kdnfs96230jag8xgz4wx337bb3q3bvqxn3r31x8fsmz6rr";
+    sha256 = "138fwd3cznkfa6w3a5s4fbflh88q26hk4grlmq73dcbk06ykf84k";
   };
   checkInputs = with pkgs; [ pytest ];
+  buildInputs = with pkgs; [ setuptools_scm ];
   propagatedBuildInputs = with pkgs; [
     attrs
     click


### PR DESCRIPTION
###### Motivation for this change
`pypi2nix` got updated on PyPI.  This change updates it in `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
