### PR TITLE
nixos/slurm: fix test and X11 options

### DIFF
--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -18,7 +18,7 @@ let
       ${optionalString (cfg.controlAddr != null) ''controlAddr=${cfg.controlAddr}''}
       ${toString (map (x: "NodeName=${x}\n") cfg.nodeName)}
       ${toString (map (x: "PartitionName=${x}\n") cfg.partitionName)}
-      PlugStackConfig=${plugStackConfig}
+      PlugStackConfig=${plugStackConfig}/plugstack.conf
       ProctrackType=${cfg.procTrackType}
       ${cfg.extraConfig}
     '';
@@ -48,7 +48,6 @@ let
     name = "etc-slurm";
     paths = [ configFile cgroupConfig plugStackConfig ] ++ cfg.extraConfigPaths;
   };
-
 in
 
 {
@@ -112,7 +111,7 @@ in
 
       package = mkOption {
         type = types.package;
-        default = pkgs.slurm;
+        default = pkgs.slurm.override { enableX11 = ! cfg.enableSrunX11; };
         defaultText = "pkgs.slurm";
         example = literalExample "pkgs.slurm-full";
         description = ''
@@ -178,9 +177,14 @@ in
           If enabled srun will accept the option "--x11" to allow for X11 forwarding
           from within an interactive session or a batch job. This activates the
           slurm-spank-x11 module. Note that this option also enables
-          'services.openssh.forwardX11' on the client.
+          <option>services.openssh.forwardX11</option> on the client.
 
           This option requires slurm to be compiled without native X11 support.
+          The default behavior is to re-compile the slurm package with native X11
+          support disabled if this option is set to true.
+
+          To use the native X11 support add <literal>PrologFlags=X11</literal> in <option>extraConfig</option>.
+          Note that this method will only work RSA SSH host keys.
         '';
       };
 

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test-python.nix ({ lib, ... }:
 let
     mungekey = "mungeverryweakkeybuteasytointegratoinatest";
 
@@ -85,63 +85,57 @@ in {
 
   testScript =
   ''
-  startAll;
+  start_all()
 
   # Set up authentification across the cluster
-  foreach my $node (($submit,$control,$dbd,$node1,$node2,$node3))
-  {
-    $node->waitForUnit("default.target");
+  for node in [submit, control, dbd, node1, node2, node3]:
 
-    $node->succeed("mkdir /etc/munge");
-    $node->succeed("echo '${mungekey}' > /etc/munge/munge.key");
-    $node->succeed("chmod 0400 /etc/munge/munge.key");
-    $node->succeed("chown munge:munge /etc/munge/munge.key");
-    $node->succeed("systemctl restart munged");
+      node.wait_for_unit("default.target")
 
-    $node->waitForUnit("munged");
-  };
+      node.succeed("mkdir /etc/munge")
+      node.succeed(
+          "echo '${mungekey}' > /etc/munge/munge.key"
+      )
+      node.succeed("chmod 0400 /etc/munge/munge.key")
+      node.succeed("chown munge:munge /etc/munge/munge.key")
+      node.succeed("systemctl restart munged")
+
+      node.wait_for_unit("munged")
+
 
   # Restart the services since they have probably failed due to the munge init
   # failure
-  subtest "can_start_slurmdbd", sub {
-    $dbd->succeed("systemctl restart slurmdbd");
-    $dbd->waitForUnit("slurmdbd.service");
-    $dbd->waitForOpenPort(6819);
-  };
+  with subtest("can_start_slurmdbd"):
+      dbd.succeed("systemctl restart slurmdbd")
+      dbd.wait_for_unit("slurmdbd.service")
+      dbd.wait_for_open_port(6819)
 
   # there needs to be an entry for the current
   # cluster in the database before slurmctld is restarted
-  subtest "add_account", sub {
-    $control->succeed("sacctmgr -i add cluster default");
-    # check for cluster entry
-    $control->succeed("sacctmgr list cluster | awk '{ print \$1 }' | grep default");
-  };
+  with subtest("add_account"):
+      control.succeed("sacctmgr -i add cluster default")
+      # check for cluster entry
+      control.succeed("sacctmgr list cluster | awk '{ print $1 }' | grep default")
 
-  subtest "can_start_slurmctld", sub {
-    $control->succeed("systemctl restart slurmctld");
-    $control->waitForUnit("slurmctld.service");
-  };
+  with subtest("can_start_slurmctld"):
+      control.succeed("systemctl restart slurmctld")
+      control.waitForUnit("slurmctld.service")
 
-  subtest "can_start_slurmd", sub {
-    foreach my $node (($node1,$node2,$node3))
-    {
-      $node->succeed("systemctl restart slurmd.service");
-      $node->waitForUnit("slurmd");
-    }
-  };
+  with subtest("can_start_slurmd"):
+      for node in [node1, node2, node3]:
+          node.succeed("systemctl restart slurmd.service")
+          node.wait_for_unit("slurmd")
 
   # Test that the cluster works and can distribute jobs;
 
-  subtest "run_distributed_command", sub {
-    # Run `hostname` on 3 nodes of the partition (so on all the 3 nodes).
-    # The output must contain the 3 different names
-    $submit->succeed("srun -N 3 hostname | sort | uniq | wc -l | xargs test 3 -eq");
-  };
+  with subtest("run_distributed_command"):
+      # Run `hostname` on 3 nodes of the partition (so on all the 3 nodes).
+      # The output must contain the 3 different names
+      submit.succeed("srun -N 3 hostname | sort | uniq | wc -l | xargs test 3 -eq")
 
-  subtest "check_slurm_dbd", sub {
-    # find the srun job from above in the database
-    sleep 5;
-    $control->succeed("sacct | grep hostname");
-  };
+      with subtest("check_slurm_dbd"):
+          # find the srun job from above in the database
+          control.succeed("sleep 5")
+          control.succeed("sacct | grep hostname")
   '';
 })

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -54,10 +54,15 @@ in {
         networking.firewall.enable = false;
         services.slurm.dbdserver = {
           enable = true;
+          storagePass = "password123";
         };
         services.mysql = {
           enable = true;
-          package = pkgs.mysql;
+          package = pkgs.mariadb;
+          initialScript = pkgs.writeText "mysql-init.sql" ''
+            CREATE USER 'slurm'@'localhost' IDENTIFIED BY 'password123';
+            GRANT ALL PRIVILEGES ON slurm_acct_db.* TO 'slurm'@'localhost';
+          '';
           ensureDatabases = [ "slurm_acct_db" ];
           ensureUsers = [{
             ensurePermissions = { "slurm_acct_db.*" = "ALL PRIVILEGES"; };

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -48,7 +48,8 @@ stdenv.mkDerivation rec {
       "--with-zlib=${zlib}"
       "--sysconfdir=/etc/slurm"
     ] ++ (optional (gtk2 == null)  "--disable-gtktest")
-      ++ (optional enableX11 "--with-libssh2=${libssh2.dev}");
+      ++ (optional enableX11 "--with-libssh2=${libssh2.dev}")
+      ++ (optional (!enableX11) "--disable-x11");
 
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
This PR fixes two bugs:
* The support for X11 via the spank module was broken.
* The test broke with https://github.com/NixOS/nixpkgs/pull/71977

###### Things done
* Fix path to `plugstack.conf` in module.
* Properly disable internal X11 support in the derivation (required for spank-x11 to work).
* Add options `configFile`, `storageUser`, and `storagePass` to `services.slurm.dbdserver`.
* Fix test
* Convert test to python https://github.com/NixOS/nixpkgs/issues/72828

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

