### PR TITLE
gcc: Deduplicate `preConfigure` and `configureFlags`

### DIFF
--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -228,12 +228,10 @@ stdenv.mkDerivation ({
     ++ (optional hostPlatform.isDarwin gnused)
     ;
 
-  preConfigure = stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
-    export NIX_LDFLAGS=`echo $NIX_LDFLAGS | sed -e s~$prefix/lib~$prefix/lib/amd64~g`
-    export LDFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $LDFLAGS_FOR_TARGET"
-    export CXXFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CXXFLAGS_FOR_TARGET"
-    export CFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CFLAGS_FOR_TARGET"
-  '';
+  preConfigure = import ../common/pre-configure.nix {
+    inherit (stdenv) lib;
+    inherit version hostPlatform langJava langGo;
+  };
 
   dontDisableStatic = true;
 

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -234,16 +234,10 @@ stdenv.mkDerivation ({
     ++ (optional hostPlatform.isDarwin gnused)
     ;
 
-  preConfigure = stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
-    sed -i -e "s/-lrt//g" libstdc++-v3/configure
-    export NIX_LDFLAGS=`echo $NIX_LDFLAGS | sed -e s~$prefix/lib~$prefix/lib/amd64~g`
-    export LDFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $LDFLAGS_FOR_TARGET"
-    export CXXFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CXXFLAGS_FOR_TARGET"
-    export CFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CFLAGS_FOR_TARGET"
-  ''
-  + stdenv.lib.optionalString (langJava || langGo) ''
-    export lib=$out;
-  '';
+  preConfigure = import ../common/pre-configure.nix {
+    inherit (stdenv) lib;
+    inherit version hostPlatform langJava langGo;
+  };
 
   dontDisableStatic = true;
 

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -101,65 +101,8 @@ let version = "4.9.4";
 
     /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
-    crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags =
-      # Ensure that -print-prog-name is able to find the correct programs.
-      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossStageStatic then [
-        "--disable-libssp"
-        "--disable-nls"
-        "--without-headers"
-        "--disable-threads"
-        "--disable-libgomp"
-        "--disable-libquadmath"
-        "--disable-shared"
-        "--disable-libatomic" # requires libc
-        "--disable-decimal-float" # requires libc
-        "--disable-libmpx" # requires libc
-      ] ++ optionals crossMingw [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--disable-win32-registry"
-      ] else [
-        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
-         else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
-        "--enable-__cxa_atexit"
-        "--enable-long-long"
-        "--enable-threads=${if targetPlatform.isUnix then "posix"
-                            else if targetPlatform.isWindows then "win32"
-                            else "single"}"
-        "--enable-nls"
-        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-        # libsanitizer requires netrom/netrom.h which is not
-        # available in uclibc.
-        "--disable-libsanitizer"
-        # In uclibc cases, libgomp needs an additional '-ldl'
-        # and as I don't know how to pass it, I disable libgomp.
-        "--disable-libgomp"
-      ] ++ optionals (targetPlatform.libc == "musl") [
-        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-        "--disable-libmpx"
-      ] ++ optionals crossMingw [
-        "--enable-sjlj-exceptions"
-        "--enable-hash-synchronization"
-        "--enable-libssp"
-        "--disable-nls"
-        "--with-dwarf2"
-        # To keep ABI compatibility with upstream mingw-w64
-        "--enable-fully-dynamic-string"
-      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
-
-    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -244,86 +187,34 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags =
-    # Basic dependencies
-    [
-      "--with-gmp-include=${gmp.dev}/include"
-      "--with-gmp-lib=${gmp.out}/lib"
-      "--with-mpfr-include=${mpfr.dev}/include"
-      "--with-mpfr-lib=${mpfr.out}/lib"
-      "--with-mpc=${libmpc}"
-    ] ++
-    optional (libelf != null) "--with-libelf=${libelf}" ++
-    optional (!(crossMingw && crossStageStatic))
-      "--with-native-system-header-dir=${getDev stdenv.cc.libc}/include" ++
+  configureFlags = import ../common/configure-flags.nix {
+    inherit
+      stdenv
+      targetPackages
+      crossStageStatic libcCross
+      version
 
-    # Basic configuration
-    [
-      "--enable-lto"
-      "--disable-libstdcxx-pch"
-      "--without-included-gettext"
-      "--with-system-zlib"
-      "--enable-static"
-      "--enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langJava     "java"
-          ++ optional langGo       "go"
-          ++ optional langObjC     "objc"
-          ++ optional langObjCpp   "obj-c++"
-          ++ optionals crossDarwin [ "objc" "obj-c++" ]
-          )
-        )
-      }"
-    ] ++
+      gmp mpfr libmpc libelf isl
+      cloog
 
-    (if (enableMultilib || targetPlatform.isAvr)
-      then ["--enable-multilib" "--disable-libquadmath"]
-      else ["--disable-multilib"]) ++
-    optional (!enableShared) "--disable-shared" ++
-    (if enablePlugin
-      then ["--enable-plugin"]
-      else ["--disable-plugin"]) ++
+      enablePlugin
+      enableMultilib
+      enableShared
 
-    # Optional features
-    optional (isl != null) "--with-isl=${isl}" ++
-    optionals (cloog != null) [
-      "--with-cloog=${cloog}"
-      "--disable-cloog-version-check"
-      "--enable-cloog-backend=isl"
-    ] ++
-
-    # Java options
-    optionals langJava [
-      "--with-ecj-jar=${javaEcj}"
-
-      # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
-      # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
-      "--enable-java-home"
-      "--with-java-home=\${prefix}/lib/jvm/jre"
-    ] ++
-    optional javaAwtGtk "--enable-java-awt=gtk" ++
-    optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
-
-    (import ../common/platform-flags.nix { inherit (stdenv) lib targetPlatform; }) ++
-    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
-    optional (!bootstrap) "--disable-bootstrap" ++
-
-    # Platform-specific flags
-    optional (targetPlatform == hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}" ++
-    optionals hostPlatform.isSunOS [
-      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
-      # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as" "--without-gnu-ld"
-    ]
-  ;
+      langC
+      langCC
+      langFortran
+      langJava javaAwtGtk javaAntlr javaEcj
+      langGo
+      langObjC
+      langObjCpp
+      ;
+  };
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
   buildFlags = optional
-    (bootstrap && hostPlatform == buildPlatform)
+    (hostPlatform == buildPlatform)
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   dontStrip = !stripped;

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -242,12 +242,10 @@ stdenv.mkDerivation ({
 
   NIX_LDFLAGS = stdenv.lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
 
-  preConfigure = stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
-    export NIX_LDFLAGS=`echo $NIX_LDFLAGS | sed -e s~$prefix/lib~$prefix/lib/amd64~g`
-    export LDFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $LDFLAGS_FOR_TARGET"
-    export CXXFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CXXFLAGS_FOR_TARGET"
-    export CFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CFLAGS_FOR_TARGET"
-  '';
+  preConfigure = import ../common/pre-configure.nix {
+    inherit (stdenv) lib;
+    inherit version hostPlatform langJava langGo;
+  };
 
   dontDisableStatic = true;
 

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -88,65 +88,8 @@ let version = "5.5.0";
 
     /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
-    crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags =
-      # Ensure that -print-prog-name is able to find the correct programs.
-      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossStageStatic then [
-        "--disable-libssp"
-        "--disable-nls"
-        "--without-headers"
-        "--disable-threads"
-        "--disable-libgomp"
-        "--disable-libquadmath"
-        "--disable-shared"
-        "--disable-libatomic" # requires libc
-        "--disable-decimal-float" # requires libc
-        "--disable-libmpx" # requires libc
-      ] ++ optionals crossMingw [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--disable-win32-registry"
-      ] else [
-        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
-         else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
-        "--enable-__cxa_atexit"
-        "--enable-long-long"
-        "--enable-threads=${if targetPlatform.isUnix then "posix"
-                            else if targetPlatform.isWindows then "win32"
-                            else "single"}"
-        "--enable-nls"
-        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-        # libsanitizer requires netrom/netrom.h which is not
-        # available in uclibc.
-        "--disable-libsanitizer"
-        # In uclibc cases, libgomp needs an additional '-ldl'
-        # and as I don't know how to pass it, I disable libgomp.
-        "--disable-libgomp"
-      ] ++ optionals (targetPlatform.libc == "musl") [
-        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-        "--disable-libmpx"
-      ] ++ optionals crossMingw [
-        "--enable-sjlj-exceptions"
-        "--enable-hash-synchronization"
-        "--enable-libssp"
-        "--disable-nls"
-        "--with-dwarf2"
-        # To keep ABI compatibility with upstream mingw-w64
-        "--enable-fully-dynamic-string"
-      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
-
-    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -252,87 +195,33 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags =
-    # Basic dependencies
-    [
-      "--with-gmp-include=${gmp.dev}/include"
-      "--with-gmp-lib=${gmp.out}/lib"
-      "--with-mpfr-include=${mpfr.dev}/include"
-      "--with-mpfr-lib=${mpfr.out}/lib"
-      "--with-mpc=${libmpc}"
-    ] ++
-    optional (libelf != null) "--with-libelf=${libelf}" ++
-    optional (!(crossMingw && crossStageStatic))
-      "--with-native-system-header-dir=${getDev stdenv.cc.libc}/include" ++
+  configureFlags = import ../common/configure-flags.nix {
+    inherit
+      stdenv
+      targetPackages
+      crossStageStatic libcCross
+      version
 
-    # Basic configuration
-    [
-      "--enable-lto"
-      "--disable-libstdcxx-pch"
-      "--without-included-gettext"
-      "--with-system-zlib"
-      "--enable-static"
-      "--enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langJava     "java"
-          ++ optional langGo       "go"
-          ++ optional langObjC     "objc"
-          ++ optional langObjCpp   "obj-c++"
-          ++ optionals crossDarwin [ "objc" "obj-c++" ]
-          )
-        )
-      }"
-    ] ++
+      gmp mpfr libmpc libelf isl
 
-    (if (enableMultilib || targetPlatform.isAvr)
-      then ["--enable-multilib" "--disable-libquadmath"]
-      else ["--disable-multilib"]) ++
-    optional (!enableShared) "--disable-shared" ++
-    (if enablePlugin
-      then ["--enable-plugin"]
-      else ["--disable-plugin"]) ++
+      enablePlugin
+      enableMultilib
+      enableShared
 
-    # Optional features
-    optional (isl != null) "--with-isl=${isl}" ++
-
-    # Java options
-    optionals langJava [
-      "--with-ecj-jar=${javaEcj}"
-
-      # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
-      # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
-      "--enable-java-home"
-      "--with-java-home=\${prefix}/lib/jvm/jre"
-    ] ++
-    optional javaAwtGtk "--enable-java-awt=gtk" ++
-    optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
-
-    (import ../common/platform-flags.nix { inherit (stdenv) lib targetPlatform; }) ++
-    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
-    optional (!bootstrap) "--disable-bootstrap" ++
-
-    # Platform-specific flags
-    optional (targetPlatform == hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}" ++
-    optionals hostPlatform.isSunOS [
-      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
-      # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as" "--without-gnu-ld"
-    ]
-    ++ optionals (targetPlatform == hostPlatform && targetPlatform.libc == "musl") [
-      "--disable-libsanitizer"
-      "--disable-symvers"
-      "libat_cv_have_ifunc=no"
-      "--disable-gnu-indirect-function"
-    ]
-  ;
+      langC
+      langCC
+      langFortran
+      langJava javaAwtGtk javaAntlr javaEcj
+      langGo
+      langObjC
+      langObjCpp
+      ;
+  };
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
   buildFlags = optional
-    (bootstrap && hostPlatform == buildPlatform)
+    (hostPlatform == buildPlatform)
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   dontStrip = !stripped;

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -244,15 +244,10 @@ stdenv.mkDerivation ({
 
   NIX_LDFLAGS = stdenv.lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
 
-  preConfigure = stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
-    export NIX_LDFLAGS=`echo $NIX_LDFLAGS | sed -e s~$prefix/lib~$prefix/lib/amd64~g`
-    export LDFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $LDFLAGS_FOR_TARGET"
-    export CXXFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CXXFLAGS_FOR_TARGET"
-    export CFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CFLAGS_FOR_TARGET"
-  ''
-  + stdenv.lib.optionalString (langJava || langGo) ''
-    export lib=$out;
-  '';
+  preConfigure = import ../common/pre-configure.nix {
+    inherit (stdenv) lib;
+    inherit version hostPlatform langJava langGo;
+  };
 
   dontDisableStatic = true;
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -85,65 +85,8 @@ let version = "6.5.0";
 
     /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
-    crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags =
-      # Ensure that -print-prog-name is able to find the correct programs.
-      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossStageStatic then [
-        "--disable-libssp"
-        "--disable-nls"
-        "--without-headers"
-        "--disable-threads"
-        "--disable-libgomp"
-        "--disable-libquadmath"
-        "--disable-shared"
-        "--disable-libatomic" # requires libc
-        "--disable-decimal-float" # requires libc
-        "--disable-libmpx" # requires libc
-      ] ++ optionals crossMingw [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--disable-win32-registry"
-      ] else [
-        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
-         else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
-        "--enable-__cxa_atexit"
-        "--enable-long-long"
-        "--enable-threads=${if targetPlatform.isUnix then "posix"
-                            else if targetPlatform.isWindows then "win32"
-                            else "single"}"
-        "--enable-nls"
-        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-        # libsanitizer requires netrom/netrom.h which is not
-        # available in uclibc.
-        "--disable-libsanitizer"
-        # In uclibc cases, libgomp needs an additional '-ldl'
-        # and as I don't know how to pass it, I disable libgomp.
-        "--disable-libgomp"
-      ] ++ optionals (targetPlatform.libc == "musl") [
-        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-        "--disable-libmpx"
-      ] ++ optionals crossMingw [
-        "--enable-sjlj-exceptions"
-        "--enable-hash-synchronization"
-        "--enable-libssp"
-        "--disable-nls"
-        "--with-dwarf2"
-        # To keep ABI compatibility with upstream mingw-w64
-        "--enable-fully-dynamic-string"
-      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
-
-    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -254,87 +197,33 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags =
-    # Basic dependencies
-    [
-      "--with-gmp-include=${gmp.dev}/include"
-      "--with-gmp-lib=${gmp.out}/lib"
-      "--with-mpfr-include=${mpfr.dev}/include"
-      "--with-mpfr-lib=${mpfr.out}/lib"
-      "--with-mpc=${libmpc}"
-    ] ++
-    optional (libelf != null) "--with-libelf=${libelf}" ++
-    optional (!(crossMingw && crossStageStatic))
-      "--with-native-system-header-dir=${getDev stdenv.cc.libc}/include" ++
+  configureFlags = import ../common/configure-flags.nix {
+    inherit
+      stdenv
+      targetPackages
+      crossStageStatic libcCross
+      version
 
-    # Basic configuration
-    [
-      "--enable-lto"
-      "--disable-libstdcxx-pch"
-      "--without-included-gettext"
-      "--with-system-zlib"
-      "--enable-static"
-      "--enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langJava     "java"
-          ++ optional langGo       "go"
-          ++ optional langObjC     "objc"
-          ++ optional langObjCpp   "obj-c++"
-          ++ optionals crossDarwin [ "objc" "obj-c++" ]
-          )
-        )
-      }"
-    ] ++
+      gmp mpfr libmpc libelf isl
 
-    (if (enableMultilib || targetPlatform.isAvr)
-      then ["--enable-multilib" "--disable-libquadmath"]
-      else ["--disable-multilib"]) ++
-    optional (!enableShared) "--disable-shared" ++
-    (if enablePlugin
-      then ["--enable-plugin"]
-      else ["--disable-plugin"]) ++
+      enablePlugin
+      enableMultilib
+      enableShared
 
-    # Optional features
-    optional (isl != null) "--with-isl=${isl}" ++
-
-    # Java options
-    optionals langJava [
-      "--with-ecj-jar=${javaEcj}"
-
-      # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
-      # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
-      "--enable-java-home"
-      "--with-java-home=\${prefix}/lib/jvm/jre"
-    ] ++
-    optional javaAwtGtk "--enable-java-awt=gtk" ++
-    optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}" ++
-
-    (import ../common/platform-flags.nix { inherit (stdenv) lib targetPlatform; }) ++
-    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
-    optional (!bootstrap) "--disable-bootstrap" ++
-
-    # Platform-specific flags
-    optional (targetPlatform == hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}" ++
-    optionals hostPlatform.isSunOS [
-      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
-      # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as" "--without-gnu-ld"
-    ]
-    ++ optionals (targetPlatform == hostPlatform && targetPlatform.libc == "musl") [
-      "--disable-libsanitizer"
-      "--disable-symvers"
-      "libat_cv_have_ifunc=no"
-      "--disable-gnu-indirect-function"
-    ]
-  ;
+      langC
+      langCC
+      langFortran
+      langJava javaAwtGtk javaAntlr javaEcj
+      langGo
+      langObjC
+      langObjCpp
+      ;
+  };
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
   buildFlags = optional
-    (bootstrap && hostPlatform == buildPlatform)
+    (hostPlatform == buildPlatform)
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   dontStrip = !stripped;

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -220,12 +220,10 @@ stdenv.mkDerivation ({
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString (stdenv.cc.isClang && langFortran) "-Wno-unused-command-line-argument";
   NIX_LDFLAGS = stdenv.lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
 
-  preConfigure = stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
-    export NIX_LDFLAGS=`echo $NIX_LDFLAGS | sed -e s~$prefix/lib~$prefix/lib/amd64~g`
-    export LDFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $LDFLAGS_FOR_TARGET"
-    export CXXFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CXXFLAGS_FOR_TARGET"
-    export CFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CFLAGS_FOR_TARGET"
-  '';
+  preConfigure = import ../common/pre-configure.nix {
+    inherit (stdenv) lib;
+    inherit version hostPlatform langGo;
+  };
 
   dontDisableStatic = true;
 

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -62,65 +62,8 @@ let version = "7.4.0";
 
     /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
-    crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags =
-      # Ensure that -print-prog-name is able to find the correct programs.
-      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossStageStatic then [
-        "--disable-libssp"
-        "--disable-nls"
-        "--without-headers"
-        "--disable-threads"
-        "--disable-libgomp"
-        "--disable-libquadmath"
-        "--disable-shared"
-        "--disable-libatomic" # requires libc
-        "--disable-decimal-float" # requires libc
-        "--disable-libmpx" # requires libc
-      ] ++ optionals crossMingw [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--disable-win32-registry"
-      ] else [
-        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
-         else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
-        "--enable-__cxa_atexit"
-        "--enable-long-long"
-        "--enable-threads=${if targetPlatform.isUnix then "posix"
-                            else if targetPlatform.isWindows then "win32"
-                            else "single"}"
-        "--enable-nls"
-        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-        # libsanitizer requires netrom/netrom.h which is not
-        # available in uclibc.
-        "--disable-libsanitizer"
-        # In uclibc cases, libgomp needs an additional '-ldl'
-        # and as I don't know how to pass it, I disable libgomp.
-        "--disable-libgomp"
-      ] ++ optionals (targetPlatform.libc == "musl") [
-        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-        "--disable-libmpx"
-      ] ++ optionals crossMingw [
-        "--enable-sjlj-exceptions"
-        "--enable-hash-synchronization"
-        "--enable-libssp"
-        "--disable-nls"
-        "--with-dwarf2"
-        # To keep ABI compatibility with upstream mingw-w64
-        "--enable-fully-dynamic-string"
-      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
-
-    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -230,76 +173,34 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags =
-    # Basic dependencies
-    [
-      "--with-gmp-include=${gmp.dev}/include"
-      "--with-gmp-lib=${gmp.out}/lib"
-      "--with-mpfr-include=${mpfr.dev}/include"
-      "--with-mpfr-lib=${mpfr.out}/lib"
-      "--with-mpc=${libmpc}"
-    ] ++
-    optional (libelf != null) "--with-libelf=${libelf}" ++
-    optional (!(crossMingw && crossStageStatic))
-      "--with-native-system-header-dir=${getDev stdenv.cc.libc}/include" ++
+  configureFlags = import ../common/configure-flags.nix {
+    inherit
+      stdenv
+      targetPackages
+      crossStageStatic libcCross
+      version
 
-    # Basic configuration
-    [
-      "--enable-lto"
-      "--disable-libstdcxx-pch"
-      "--without-included-gettext"
-      "--with-system-zlib"
-      "--enable-static"
-      "--enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langGo       "go"
-          ++ optional langObjC     "objc"
-          ++ optional langObjCpp   "obj-c++"
-          ++ optionals crossDarwin [ "objc" "obj-c++" ]
-          )
-        )
-      }"
-    ] ++
+      gmp mpfr libmpc libelf isl
 
-    (if (enableMultilib || targetPlatform.isAvr)
-      then ["--enable-multilib" "--disable-libquadmath"]
-      else ["--disable-multilib"]) ++
-    optional (!enableShared) "--disable-shared" ++
-    (if enablePlugin
-      then ["--enable-plugin"]
-      else ["--disable-plugin"]) ++
+      enablePlugin
+      enableMultilib
+      enableShared
 
-    # Optional features
-    optional (isl != null) "--with-isl=${isl}" ++
-
-    (import ../common/platform-flags.nix { inherit (stdenv) lib targetPlatform; }) ++
-    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
-    optional (!bootstrap) "--disable-bootstrap" ++
-
-    # Platform-specific flags
-    optional (targetPlatform == hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}" ++
-    optionals hostPlatform.isSunOS [
-      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
-      # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as" "--without-gnu-ld"
-    ]
-    ++ optionals (targetPlatform == hostPlatform && targetPlatform.libc == "musl") [
-      "--disable-libsanitizer"
-      "--disable-symvers"
-      "libat_cv_have_ifunc=no"
-      "--disable-gnu-indirect-function"
-    ]
-    ++ optional (targetPlatform.isAarch64) "--enable-fix-cortex-a53-843419"
+      langC
+      langCC
+      langFortran
+      langGo
+      langObjC
+      langObjCpp
+      ;
+  } ++ optional (targetPlatform.isAarch64) "--enable-fix-cortex-a53-843419"
     ++ optional targetPlatform.isNetBSD "--disable-libcilkrts"
   ;
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
   buildFlags = optional
-    (bootstrap && hostPlatform == buildPlatform)
+    (hostPlatform == buildPlatform)
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   dontStrip = !stripped;

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -54,65 +54,8 @@ let version = "8.3.0";
 
     /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
-    crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags =
-      # Ensure that -print-prog-name is able to find the correct programs.
-      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossStageStatic then [
-        "--disable-libssp"
-        "--disable-nls"
-        "--without-headers"
-        "--disable-threads"
-        "--disable-libgomp"
-        "--disable-libquadmath"
-        "--disable-shared"
-        "--disable-libatomic" # requires libc
-        "--disable-decimal-float" # requires libc
-        "--disable-libmpx" # requires libc
-      ] ++ optionals crossMingw [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--disable-win32-registry"
-      ] else [
-        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
-         else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
-        "--enable-__cxa_atexit"
-        "--enable-long-long"
-        "--enable-threads=${if targetPlatform.isUnix then "posix"
-                            else if targetPlatform.isWindows then "win32"
-                            else "single"}"
-        "--enable-nls"
-        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-        # libsanitizer requires netrom/netrom.h which is not
-        # available in uclibc.
-        "--disable-libsanitizer"
-        # In uclibc cases, libgomp needs an additional '-ldl'
-        # and as I don't know how to pass it, I disable libgomp.
-        "--disable-libgomp"
-      ] ++ optionals (targetPlatform.libc == "musl") [
-        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-        "--disable-libmpx"
-      ] ++ optionals crossMingw [
-        "--enable-sjlj-exceptions"
-        "--enable-hash-synchronization"
-        "--enable-libssp"
-        "--disable-nls"
-        "--with-dwarf2"
-        # To keep ABI compatibility with upstream mingw-w64
-        "--enable-fully-dynamic-string"
-      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
-
-    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -216,74 +159,32 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags =
-    # Basic dependencies
-    [
-      "--with-gmp-include=${gmp.dev}/include"
-      "--with-gmp-lib=${gmp.out}/lib"
-      "--with-mpfr-include=${mpfr.dev}/include"
-      "--with-mpfr-lib=${mpfr.out}/lib"
-      "--with-mpc=${libmpc}"
-    ] ++
-    optional (libelf != null) "--with-libelf=${libelf}" ++
-    optional (!(crossMingw && crossStageStatic))
-      "--with-native-system-header-dir=${getDev stdenv.cc.libc}/include" ++
+  configureFlags = import ../common/configure-flags.nix {
+    inherit
+      stdenv
+      targetPackages
+      crossStageStatic libcCross
+      version
 
-    # Basic configuration
-    [
-      "--enable-lto"
-      "--disable-libstdcxx-pch"
-      "--without-included-gettext"
-      "--with-system-zlib"
-      "--enable-static"
-      "--enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langGo       "go"
-          ++ optional langObjC     "objc"
-          ++ optional langObjCpp   "obj-c++"
-          ++ optionals crossDarwin [ "objc" "obj-c++" ]
-          )
-        )
-      }"
-    ] ++
+      gmp mpfr libmpc libelf isl
 
-    (if (enableMultilib || targetPlatform.isAvr)
-      then ["--enable-multilib" "--disable-libquadmath"]
-      else ["--disable-multilib"]) ++
-    optional (!enableShared) "--disable-shared" ++
-    (if enablePlugin
-      then ["--enable-plugin"]
-      else ["--disable-plugin"]) ++
+      enablePlugin
+      enableMultilib
+      enableShared
 
-    # Optional features
-    optional (isl != null) "--with-isl=${isl}" ++
-
-    (import ../common/platform-flags.nix { inherit (stdenv) lib targetPlatform; }) ++
-    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
-    optional (!bootstrap) "--disable-bootstrap" ++
-
-    # Platform-specific flags
-    optional (targetPlatform == hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}" ++
-    optionals hostPlatform.isSunOS [
-      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
-      # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as" "--without-gnu-ld"
-    ]
-    ++ optionals (targetPlatform == hostPlatform && targetPlatform.libc == "musl") [
-      "--disable-libsanitizer"
-      "--disable-symvers"
-      "libat_cv_have_ifunc=no"
-      "--disable-gnu-indirect-function"
-    ]
-  ;
+      langC
+      langCC
+      langFortran
+      langGo
+      langObjC
+      langObjCpp
+      ;
+  };
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
   buildFlags = optional
-    (bootstrap && hostPlatform == buildPlatform)
+    (hostPlatform == buildPlatform)
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   dontStrip = !stripped;

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -206,12 +206,10 @@ stdenv.mkDerivation ({
 
   NIX_LDFLAGS = stdenv.lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
 
-  preConfigure = stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
-    export NIX_LDFLAGS=`echo $NIX_LDFLAGS | sed -e s~$prefix/lib~$prefix/lib/amd64~g`
-    export LDFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $LDFLAGS_FOR_TARGET"
-    export CXXFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CXXFLAGS_FOR_TARGET"
-    export CFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CFLAGS_FOR_TARGET"
-  '';
+  preConfigure = import ../common/pre-configure.nix {
+    inherit (stdenv) lib;
+    inherit version hostPlatform langGo;
+  };
 
   dontDisableStatic = true;
 

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -205,12 +205,10 @@ stdenv.mkDerivation ({
 
   NIX_LDFLAGS = stdenv.lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
 
-  preConfigure = stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
-    export NIX_LDFLAGS=`echo $NIX_LDFLAGS | sed -e s~$prefix/lib~$prefix/lib/amd64~g`
-    export LDFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $LDFLAGS_FOR_TARGET"
-    export CXXFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CXXFLAGS_FOR_TARGET"
-    export CFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CFLAGS_FOR_TARGET"
-  '';
+  preConfigure = import ../common/pre-configure.nix {
+    inherit (stdenv) lib;
+    inherit version hostPlatform langGo;
+  };
 
   dontDisableStatic = true;
 

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -53,65 +53,8 @@ let version = "9.2.0";
 
     /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
-    crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags =
-      # Ensure that -print-prog-name is able to find the correct programs.
-      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossStageStatic then [
-        "--disable-libssp"
-        "--disable-nls"
-        "--without-headers"
-        "--disable-threads"
-        "--disable-libgomp"
-        "--disable-libquadmath"
-        "--disable-shared"
-        "--disable-libatomic" # requires libc
-        "--disable-decimal-float" # requires libc
-        "--disable-libmpx" # requires libc
-      ] ++ optionals crossMingw [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--disable-win32-registry"
-      ] else [
-        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
-         else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
-        "--enable-__cxa_atexit"
-        "--enable-long-long"
-        "--enable-threads=${if targetPlatform.isUnix then "posix"
-                            else if targetPlatform.isWindows then "win32"
-                            else "single"}"
-        "--enable-nls"
-        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-        # libsanitizer requires netrom/netrom.h which is not
-        # available in uclibc.
-        "--disable-libsanitizer"
-        # In uclibc cases, libgomp needs an additional '-ldl'
-        # and as I don't know how to pass it, I disable libgomp.
-        "--disable-libgomp"
-      ] ++ optionals (targetPlatform.libc == "musl") [
-        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-        "--disable-libmpx"
-      ] ++ optionals crossMingw [
-        "--enable-sjlj-exceptions"
-        "--enable-hash-synchronization"
-        "--enable-libssp"
-        "--disable-nls"
-        "--with-dwarf2"
-        # To keep ABI compatibility with upstream mingw-w64
-        "--enable-fully-dynamic-string"
-      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
-
-    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -215,74 +158,32 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags =
-    # Basic dependencies
-    [
-      "--with-gmp-include=${gmp.dev}/include"
-      "--with-gmp-lib=${gmp.out}/lib"
-      "--with-mpfr-include=${mpfr.dev}/include"
-      "--with-mpfr-lib=${mpfr.out}/lib"
-      "--with-mpc=${libmpc}"
-    ] ++
-    optional (libelf != null) "--with-libelf=${libelf}" ++
-    optional (!(crossMingw && crossStageStatic))
-      "--with-native-system-header-dir=${getDev stdenv.cc.libc}/include" ++
+  configureFlags = import ../common/configure-flags.nix {
+    inherit
+      stdenv
+      targetPackages
+      crossStageStatic libcCross
+      version
 
-    # Basic configuration
-    [
-      "--enable-lto"
-      "--disable-libstdcxx-pch"
-      "--without-included-gettext"
-      "--with-system-zlib"
-      "--enable-static"
-      "--enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langGo       "go"
-          ++ optional langObjC     "objc"
-          ++ optional langObjCpp   "obj-c++"
-          ++ optionals crossDarwin [ "objc" "obj-c++" ]
-          )
-        )
-      }"
-    ] ++
+      gmp mpfr libmpc libelf isl
 
-    (if (enableMultilib || targetPlatform.isAvr)
-      then ["--enable-multilib" "--disable-libquadmath"]
-      else ["--disable-multilib"]) ++
-    optional (!enableShared) "--disable-shared" ++
-    (if enablePlugin
-      then ["--enable-plugin"]
-      else ["--disable-plugin"]) ++
+      enablePlugin
+      enableMultilib
+      enableShared
 
-    # Optional features
-    optional (isl != null) "--with-isl=${isl}" ++
-
-    (import ../common/platform-flags.nix { inherit (stdenv) lib targetPlatform; }) ++
-    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
-    optional (!bootstrap) "--disable-bootstrap" ++
-
-    # Platform-specific flags
-    optional (targetPlatform == hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}" ++
-    optionals hostPlatform.isSunOS [
-      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
-      # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as" "--without-gnu-ld"
-    ]
-    ++ optionals (targetPlatform == hostPlatform && targetPlatform.libc == "musl") [
-      "--disable-libsanitizer"
-      "--disable-symvers"
-      "libat_cv_have_ifunc=no"
-      "--disable-gnu-indirect-function"
-    ]
-  ;
+      langC
+      langCC
+      langFortran
+      langGo
+      langObjC
+      langObjCpp
+      ;
+  };
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
   buildFlags = optional
-    (bootstrap && hostPlatform == buildPlatform)
+    (hostPlatform == buildPlatform)
     (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   dontStrip = !stripped;

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -1,0 +1,173 @@
+{ stdenv
+, targetPackages
+
+, crossStageStatic, libcCross
+, version
+
+, gmp, mpfr, libmpc, libelf, isl
+, cloog ? null
+
+, enablePlugin
+, enableMultilib
+, enableShared
+
+, langC
+, langCC
+, langFortran
+, langJava ? false, javaAwtGtk ? false, javaAntlr ? null, javaEcj ? null
+, langGo
+, langObjC
+, langObjCpp
+}:
+
+assert cloog != null -> stdenv.lib.versionOlder version "5";
+assert langJava -> stdenv.lib.versionOlder version "6";
+
+let
+  inherit (stdenv)
+    buildPlatform hostPlatform targetPlatform
+    lib;
+
+  crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
+  crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
+
+  crossConfigureFlags =
+    # Ensure that -print-prog-name is able to find the correct programs.
+    [
+      "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+      "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld"
+    ]
+    ++ (if crossStageStatic then [
+      "--disable-libssp"
+      "--disable-nls"
+      "--without-headers"
+      "--disable-threads"
+      "--disable-libgomp"
+      "--disable-libquadmath"
+      "--disable-shared"
+      "--disable-libatomic" # requires libc
+      "--disable-decimal-float" # requires libc
+      "--disable-libmpx" # requires libc
+    ] ++ lib.optionals crossMingw [
+      "--with-headers=${libcCross}/include"
+      "--with-gcc"
+      "--with-gnu-as"
+      "--with-gnu-ld"
+      "--disable-debug"
+      "--enable-sjlj-exceptions"
+      "--disable-win32-registry"
+    ] else [
+      (if crossDarwin then "--with-sysroot=${lib.getLib libcCross}/share/sysroot"
+       else                "--with-headers=${lib.getDev libcCross}${libcCross.incdir or "/include"}")
+      "--enable-__cxa_atexit"
+      "--enable-long-long"
+      "--enable-threads=${if targetPlatform.isUnix then "posix"
+                          else if targetPlatform.isWindows then "win32"
+                          else "single"}"
+      "--enable-nls"
+      "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
+    ] ++ lib.optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
+      # libsanitizer requires netrom/netrom.h which is not
+      # available in uclibc.
+      "--disable-libsanitizer"
+      # In uclibc cases, libgomp needs an additional '-ldl'
+      # and as I don't know how to pass it, I disable libgomp.
+      "--disable-libgomp"
+    ] ++ lib.optionals (targetPlatform.libc == "musl") [
+      # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
+      "--disable-libmpx"
+    ] ++ lib.optionals crossMingw [
+      "--enable-sjlj-exceptions"
+      "--enable-hash-synchronization"
+      "--enable-libssp"
+      "--disable-nls"
+      "--with-dwarf2"
+      # To keep ABI compatibility with upstream mingw-w64
+      "--enable-fully-dynamic-string"
+    ] ++ lib.optional (targetPlatform.libc == "newlib") "--with-newlib"
+      ++ lib.optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
+    );
+
+  configureFlags =
+    # Basic dependencies
+    [
+      "--with-gmp-include=${gmp.dev}/include"
+      "--with-gmp-lib=${gmp.out}/lib"
+      "--with-mpfr-include=${mpfr.dev}/include"
+      "--with-mpfr-lib=${mpfr.out}/lib"
+      "--with-mpc=${libmpc}"
+    ]
+    ++ lib.optional (libelf != null) "--with-libelf=${libelf}"
+    ++ lib.optional (!(crossMingw && crossStageStatic))
+      "--with-native-system-header-dir=${lib.getDev stdenv.cc.libc}/include"
+
+    # Basic configuration
+    ++ [
+      "--enable-lto"
+      "--disable-libstdcxx-pch"
+      "--without-included-gettext"
+      "--with-system-zlib"
+      "--enable-static"
+      "--enable-languages=${
+        lib.concatStrings (lib.intersperse ","
+          (  lib.optional langC        "c"
+          ++ lib.optional langCC       "c++"
+          ++ lib.optional langFortran  "fortran"
+          ++ lib.optional langJava     "java"
+          ++ lib.optional langGo       "go"
+          ++ lib.optional langObjC     "objc"
+          ++ lib.optional langObjCpp   "obj-c++"
+          ++ lib.optionals crossDarwin [ "objc" "obj-c++" ]
+          )
+        )
+      }"
+    ]
+
+    ++ (if (enableMultilib || targetPlatform.isAvr)
+      then ["--enable-multilib" "--disable-libquadmath"]
+      else ["--disable-multilib"])
+    ++ lib.optional (!enableShared) "--disable-shared"
+    ++ [
+      (lib.enableFeature enablePlugin "plugin")
+    ]
+
+    # Optional features
+    ++ lib.optional (isl != null) "--with-isl=${isl}"
+    ++ lib.optionals (cloog != null) [
+      "--with-cloog=${cloog}"
+      "--disable-cloog-version-check"
+      "--enable-cloog-backend=isl"
+    ]
+
+    # Java options
+    ++ lib.optionals langJava [
+      "--with-ecj-jar=${javaEcj}"
+
+      # Follow Sun's layout for the convenience of IcedTea/OpenJDK.  See
+      # <http://mail.openjdk.java.net/pipermail/distro-pkg-dev/2010-April/008888.html>.
+      "--enable-java-home"
+      "--with-java-home=\${prefix}/lib/jvm/jre"
+    ]
+    ++ lib.optional javaAwtGtk "--enable-java-awt=gtk"
+    ++ lib.optional (langJava && javaAntlr != null) "--with-antlr-jar=${javaAntlr}"
+
+    ++ (import ../common/platform-flags.nix { inherit (stdenv) lib targetPlatform; })
+    ++ lib.optional (targetPlatform != hostPlatform) crossConfigureFlags
+    ++ lib.optional (targetPlatform != hostPlatform) "--disable-bootstrap"
+
+    # Platform-specific flags
+    ++ lib.optional (targetPlatform == hostPlatform && targetPlatform.isx86_32) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
+    ++ lib.optionals hostPlatform.isSunOS [
+      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
+      # On Illumos/Solaris GNU as is preferred
+      "--with-gnu-as" "--without-gnu-ld"
+    ]
+    ++ lib.optionals (targetPlatform == hostPlatform && targetPlatform.libc == "musl") [
+      "--disable-libsanitizer"
+      "--disable-symvers"
+      "libat_cv_have_ifunc=no"
+      "--disable-gnu-indirect-function"
+    ]
+  ;
+
+in configureFlags

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -1,0 +1,12 @@
+{ lib, version, hostPlatform, langJava ? false, langGo }:
+
+assert langJava -> lib.versionOlder version "7";
+
+lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
+  export NIX_LDFLAGS=`echo $NIX_LDFLAGS | sed -e s~$prefix/lib~$prefix/lib/amd64~g`
+  export LDFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $LDFLAGS_FOR_TARGET"
+  export CXXFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CXXFLAGS_FOR_TARGET"
+  export CFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CFLAGS_FOR_TARGET"
+'' + lib.optionalString (lib.versionOlder version "7" && (langJava || langGo)) ''
+  export lib=$out;
+''

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -50,65 +50,8 @@ let version = "7-20170409";
 
     /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";
-    crossDarwin = targetPlatform != hostPlatform && targetPlatform.libc == "libSystem";
-    crossConfigureFlags =
-      # Ensure that -print-prog-name is able to find the correct programs.
-      [ "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
-        "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld" ] ++
-      (if crossStageStatic then [
-        "--disable-libssp"
-        "--disable-nls"
-        "--without-headers"
-        "--disable-threads"
-        "--disable-libgomp"
-        "--disable-libquadmath"
-        "--disable-shared"
-        "--disable-libatomic" # requires libc
-        "--disable-decimal-float" # requires libc
-        "--disable-libmpx" # requires libc
-      ] ++ optionals crossMingw [
-        "--with-headers=${libcCross}/include"
-        "--with-gcc"
-        "--with-gnu-as"
-        "--with-gnu-ld"
-        "--disable-debug"
-        "--enable-sjlj-exceptions"
-        "--disable-win32-registry"
-      ] else [
-        (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
-         else                "--with-headers=${getDev libcCross}${libcCross.incdir or "/include"}")
-        "--enable-__cxa_atexit"
-        "--enable-long-long"
-        "--enable-threads=${if targetPlatform.isUnix then "posix"
-                            else if targetPlatform.isWindows then "win32"
-                            else "single"}"
-        "--enable-nls"
-        "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
-      ] ++ optionals (targetPlatform.libc == "uclibc" || targetPlatform.libc == "musl") [
-        # libsanitizer requires netrom/netrom.h which is not
-        # available in uclibc.
-        "--disable-libsanitizer"
-        # In uclibc cases, libgomp needs an additional '-ldl'
-        # and as I don't know how to pass it, I disable libgomp.
-        "--disable-libgomp"
-      ] ++ optionals (targetPlatform.libc == "musl") [
-        # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
-        "--disable-libmpx"
-      ] ++ optionals crossMingw [
-        "--enable-sjlj-exceptions"
-        "--enable-hash-synchronization"
-        "--enable-libssp"
-        "--disable-nls"
-        "--with-dwarf2"
-        # To keep ABI compatibility with upstream mingw-w64
-        "--enable-fully-dynamic-string"
-      ] ++ optional (targetPlatform.libc == "newlib") "--with-newlib"
-        ++ optional (targetPlatform.libc == "avrlibc") "--with-avrlibc"
-      );
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
     crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
-
-    bootstrap = targetPlatform == hostPlatform;
 
 in
 
@@ -187,70 +130,33 @@ stdenv.mkDerivation ({
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
 
-  configureFlags =
-    # Basic dependencies
-    [
-      "--with-gmp-include=${gmp.dev}/include"
-      "--with-gmp-lib=${gmp.out}/lib"
-      "--with-mpfr-include=${mpfr.dev}/include"
-      "--with-mpfr-lib=${mpfr.out}/lib"
-      "--with-mpc=${libmpc}"
-    ] ++
-    optional (libelf != null) "--with-libelf=${libelf}" ++
-    optional (!(crossMingw && crossStageStatic))
-      "--with-native-system-header-dir=${getDev stdenv.cc.libc}/include" ++
+  configureFlags = import ../common/configure-flags.nix {
+    inherit
+      stdenv
+      targetPackages
+      crossStageStatic libcCross
+      version
 
-    # Basic configuration
-    [
-      "--enable-lto"
-      "--disable-libstdcxx-pch"
-      "--without-included-gettext"
-      "--with-system-zlib"
-      "--enable-static"
-      "--enable-languages=${
-        concatStrings (intersperse ","
-          (  optional langC        "c"
-          ++ optional langCC       "c++"
-          ++ optional langFortran  "fortran"
-          ++ optional langGo       "go"
-          ++ optional langObjC     "objc"
-          ++ optional langObjCpp   "obj-c++"
-          ++ optionals crossDarwin [ "objc" "obj-c++" ]
-          )
-        )
-      }"
-    ] ++
+      gmp mpfr libmpc libelf isl
 
-    (if enableMultilib
-      then ["--enable-multilib" "--disable-libquadmath"]
-      else ["--disable-multilib"]) ++
-    optional (!enableShared) "--disable-shared" ++
-    (if enablePlugin
-      then ["--enable-plugin"]
-      else ["--disable-plugin"]) ++
+      enablePlugin
+      enableMultilib
+      enableShared
 
-    # Optional features
-    optional (isl != null) "--with-isl=${isl}" ++
-
-
-    (import ../common/platform-flags.nix { inherit (stdenv) lib targetPlatform; }) ++
-    optional (targetPlatform != hostPlatform) crossConfigureFlags ++
-    optional (!bootstrap) "--disable-bootstrap" ++
-
-    # Platform-specific flags
-    optional (targetPlatform == hostPlatform && targetPlatform.isi686) "--with-arch=i686" ++
-    optionals hostPlatform.isSunOS [
-      "--enable-long-long" "--enable-libssp" "--enable-threads=posix" "--disable-nls" "--enable-__cxa_atexit"
-      # On Illumos/Solaris GNU as is preferred
-      "--with-gnu-as" "--without-gnu-ld"
-    ]
-  ;
+      langC
+      langCC
+      langFortran
+      langGo
+      langObjC
+      langObjCpp
+      ;
+  };
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
-  buildFlags = if bootstrap then
-    (if profiledCompiler then "profiledbootstrap" else "bootstrap")
-    else "";
+  buildFlags = optional
+    (hostPlatform == buildPlatform)
+    (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
   dontStrip = !stripped;
   NIX_STRIP_DEBUG = !stripped;

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -177,12 +177,10 @@ stdenv.mkDerivation ({
 
   NIX_LDFLAGS = stdenv.lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
 
-  preConfigure = stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
-    export NIX_LDFLAGS=`echo $NIX_LDFLAGS | sed -e s~$prefix/lib~$prefix/lib/amd64~g`
-    export LDFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $LDFLAGS_FOR_TARGET"
-    export CXXFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CXXFLAGS_FOR_TARGET"
-    export CFLAGS_FOR_TARGET="-Wl,-rpath,$prefix/lib/amd64 $CFLAGS_FOR_TARGET"
-  '';
+  preConfigure = import ../common/pre-configure.nix {
+    inherit (stdenv) lib;
+    inherit version hostPlatform langGo;
+  };
 
   dontDisableStatic = true;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of #73180

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
