### PR TITLE
dpdk: build with meson, odp-dpdk: -> 1.22.0.0

### DIFF
--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -1,9 +1,13 @@
-{ stdenv, lib, kernel, fetchurl, pkgconfig, numactl, shared ? false }:
+{ stdenv, lib
+, kernel
+, fetchurl
+, pkgconfig, meson, ninja
+, libbsd, numactl, libbpf, zlib, libelf, jansson, openssl, libpcap
+, doxygen, python3
+, shared ? false }:
 
 let
-
   kver = kernel.modDirVersion or null;
-
   mod = kernel != null;
 
 in stdenv.mkDerivation rec {
@@ -15,40 +19,38 @@ in stdenv.mkDerivation rec {
     sha256 = "141bqqy4w6nzs9z70x7yv94a4gmxjfal46pxry9bwdh3zi1jwnyd";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ numactl ] ++ lib.optional mod kernel.moduleBuildDependencies;
-
-  RTE_KERNELDIR = if mod then "${kernel.dev}/lib/modules/${kver}/build" else "/var/empty";
-  RTE_TARGET = "x86_64-native-linuxapp-gcc";
-
-  # we need sse3 instructions to build
-  NIX_CFLAGS_COMPILE = [ "-msse3" ];
-  hardeningDisable = [ "pic" ];
+  nativeBuildInputs = [
+    doxygen
+    meson
+    ninja
+    pkgconfig
+    python3
+    python3.pkgs.sphinx
+  ];
+  buildInputs = [
+    jansson
+    libbpf
+    libbsd
+    libelf
+    libpcap
+    numactl
+    openssl.dev
+    zlib
+  ] ++ lib.optionals mod kernel.moduleBuildDependencies;
 
   postPatch = ''
-    cat >>config/defconfig_$RTE_TARGET <<EOF
-# Build static or shared libraries.
-CONFIG_RTE_BUILD_SHARED_LIB=${if shared then "y" else "n"}
-EOF
-  '' + lib.optionalString (!mod) ''
-    cat >>config/defconfig_$RTE_TARGET <<EOF
-# Do not build kernel modules.
-CONFIG_RTE_EAL_IGB_UIO=n
-CONFIG_RTE_KNI_KMOD=n
-EOF
+    patchShebangs config/arm
   '';
 
-  configurePhase = ''
-    make T=${RTE_TARGET} config
-  '';
-
-  installTargets = [ "install-runtime" "install-sdk" "install-kmod" ]; # skip install-doc
-
-  installFlags = [
-    "prefix=$(out)"
-  ] ++ lib.optionals mod [
-    "kerneldir=$(kmod)/lib/modules/${kver}"
-  ];
+  mesonFlags = [
+    "-Denable_docs=true"
+    "-Denable_kmods=${if kernel != null then "true" else "false"}"
+  ]
+  ++ lib.optionals (shared == false) [
+    "-Ddefault_library=static"
+  ]
+  ++ lib.optional stdenv.isx86_64 "-Dmachine=nehalem"
+  ++ lib.optional (kernel != null) "-Dkernel_dir=${kernel.dev}/lib/modules/${kernel.modDirVersion}";
 
   outputs = [ "out" ] ++ lib.optional mod "kmod";
 
@@ -58,7 +60,7 @@ EOF
     description = "Set of libraries and drivers for fast packet processing";
     homepage = http://dpdk.org/;
     license = with licenses; [ lgpl21 gpl2 bsd2 ];
-    platforms =  [ "x86_64-linux" ];
+    platforms =  platforms.linux;
     maintainers = with maintainers; [ domenkozar magenbluten orivej ];
   };
 }

--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -1,42 +1,56 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig
-, dpdk, libconfig, libpcap, numactl, openssl
+, dpdk, libconfig, libpcap, numactl, openssl, zlib, libbsd, libelf, jansson
 }: let
-
-  dpdk_17_11 = dpdk.overrideAttrs (old: rec {
-    version = "17.11.9";
+  dpdk_18_11 = dpdk.overrideAttrs (old: rec {
+    version = "18.11.5";
     src = fetchurl {
       url = "https://fast.dpdk.org/rel/dpdk-${version}.tar.xz";
-      sha256 = "0vrcc9mdjs5fk69lh7bigsk9208dfmjsz3jxaddkjlvk2hds1id6";
+      sha256 = "0000000000000000000000000000000000000000000000000000";
     };
   });
 
 in stdenv.mkDerivation rec {
   pname = "odp-dpdk";
-  version = "1.19.0.0_DPDK_17.11";
+  version = "1.22.0.0_DPDK_18.11";
 
   src = fetchurl {
     url = "https://git.linaro.org/lng/odp-dpdk.git/snapshot/${pname}-${version}.tar.gz";
-    sha256 = "05bwjaxl9hqc6fbkp95nniq11g3kvzmlxw0bq55i7p2v35nv38px";
+    sha256 = "1m8xhmfjqlj2gkkigq5ka3yh0xgzrcpfpaxp1pnh8d1g99094vbx";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ dpdk_17_11 libconfig libpcap numactl openssl ];
-
-  RTE_SDK = "${dpdk_17_11}/share/dpdk";
-  RTE_TARGET = "x86_64-native-linuxapp-gcc";
-
-  dontDisableStatic = true;
-
-  configureFlags = [
-    "--disable-shared"
-    "--with-dpdk-path=${dpdk_17_11}"
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
   ];
+  buildInputs = [
+    dpdk_18_11
+    libconfig
+    libpcap
+    numactl
+    openssl
+    zlib
+    libbsd
+    libelf
+    jansson
+  ];
+
+  # for some reason, /build/odp-dpdk-1.22.0.0_DPDK_18.11/lib/.libs ends up in all binaries,
+  # while it should be $out/lib instead.
+  # prepend rpath with the proper location, the /build will get removed during rpath shrinking
+  preFixup = ''
+    for prog in $out/bin/*; do
+      patchelf --set-rpath $out/lib:`patchelf --print-rpath $prog` $prog
+    done
+  '';
+
+  # binaries will segfault otherwise
+  dontStrip = true;
 
   meta = with stdenv.lib; {
     description = "Open Data Plane optimized for DPDK";
     homepage = https://www.opendataplane.org;
     license = licenses.bsd3;
-    platforms =  [ "x86_64-linux" ];
+    platforms =  platforms.linux;
     maintainers = [ maintainers.abuibrahim ];
   };
 }


### PR DESCRIPTION
This converts the dpdk build to meson, and bumps odp-dpdk to the latest version.

Due to some cleanups, we can now build dynamically, and also build on aarch64-linux, which is a very interesting target for dpdk :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).