### PR TITLE
ceph: fixes

### DIFF
--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     "-DWITH_ZLIB=1"
     "-DWITH_ZSTD=1"
     "-DWITH_GFLAGS=0"
+    "-DUSE_RTTI=1"
     (lib.optional
         (stdenv.hostPlatform.system == "i686-linux"
          || stdenv.hostPlatform.system == "x86_64-linux")

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -6,9 +6,10 @@
 , libxml2, zlib, lz4
 , openldap, lttng-ust
 , babeltrace, gperf
+, gtest
 , cunit, snappy
 , rocksdb, makeWrapper
-, leveldb, oathToolkit, removeReferencesTo
+, leveldb, oathToolkit
 
 # Optional Dependencies
 , yasm ? null, fcgi ? null, expat ? null
@@ -108,14 +109,14 @@ in rec {
     nativeBuildInputs = [
       cmake
       pkgconfig which git python3Packages.wrapPython makeWrapper
+      python3Packages.python # for the toPythonPath function
       (ensureNewerSourcesHook { year = "1980"; })
     ];
 
     buildInputs = cryptoLibsMap.${cryptoStr} ++ [
       boost ceph-python-env libxml2 optYasm optLibatomic_ops optLibs3
-      malloc zlib openldap lttng-ust babeltrace gperf cunit
+      malloc zlib openldap lttng-ust babeltrace gperf gtest cunit
       snappy rocksdb lz4 oathToolkit leveldb
-      removeReferencesTo
     ] ++ optionals stdenv.isLinux [
       linuxHeaders utillinux libuuid udev keyutils optLibaio optLibxfs optZfs
       # ceph 14
@@ -124,54 +125,52 @@ in rec {
       optFcgi optExpat optCurl optFuse optLibedit
     ];
 
+    pythonPath = [ ceph-python-env "${placeholder "out"}/${ceph-python-env.sitePackages}" ];
+
     preConfigure =''
       substituteInPlace src/common/module.c --replace "/sbin/modinfo"  "modinfo"
       substituteInPlace src/common/module.c --replace "/sbin/modprobe" "modprobe"
-      # Since Boost 1.67 this seems to have changed
-      substituteInPlace CMakeLists.txt --replace "list(APPEND BOOST_COMPONENTS python)" "list(APPEND BOOST_COMPONENTS python37)"
-      substituteInPlace src/CMakeLists.txt --replace "Boost::python " "Boost::python37 "
 
       # for pybind/rgw to find internal dep
       export LD_LIBRARY_PATH="$PWD/build/lib:$LD_LIBRARY_PATH"
       # install target needs to be in PYTHONPATH for "*.pth support" check to succeed
-      export PYTHONPATH=${ceph-python-env}/lib/python3.7/site-packages:$lib/lib/python3.7/site-packages/:$out/lib/python3.7/site-packages/
 
-      patchShebangs src/spdk
+      patchShebangs src/script src/spdk src/test src/tools
     '';
 
     cmakeFlags = [
       "-DWITH_PYTHON3=ON"
       "-DWITH_SYSTEM_ROCKSDB=OFF"
+      "-DCMAKE_INSTALL_DATADIR=${placeholder "lib"}/lib"
+
 
       "-DWITH_SYSTEM_BOOST=ON"
+      "-DWITH_SYSTEM_ROCKSDB=ON"
+      "-DWITH_SYSTEM_GTEST=ON"
+      "-DMGR_PYTHON_VERSION=${ceph-python-env.python.pythonVersion}"
       "-DWITH_SYSTEMD=OFF"
       "-DWITH_TESTS=OFF"
       # TODO breaks with sandbox, tries to download stuff with npm
       "-DWITH_MGR_DASHBOARD_FRONTEND=OFF"
     ];
 
-    preFixup = ''
-      find $lib -type f -exec remove-references-to -t $out '{}' +
-      mv $out/share/ceph/mgr $lib/lib/ceph/
-    '';
-
     postFixup = ''
-      export PYTHONPATH="${ceph-python-env}/lib/python3.7/site-packages:$lib/lib/ceph/mgr:$out/lib/python3.7/site-packages/"
       wrapPythonPrograms
-      wrapProgram $out/bin/ceph-mgr --prefix PYTHONPATH ":" "${ceph-python-env}/lib/python3.7/site-packages:$lib/lib/ceph/mgr:$out/lib/python3.7/site-packages/"
-      wrapProgram $out/bin/ceph-volume --prefix PYTHONPATH ":" "${ceph-python-env}/lib/python3.7/site-packages:$lib/lib/ceph/mgr:$out/lib/python3.7/site-packages/"
+      wrapProgram $out/bin/ceph-mgr --prefix PYTHONPATH ":" "$(toPythonPath ${placeholder "out"}):$(toPythonPath ${ceph-python-env})"
     '';
 
     enableParallelBuilding = true;
 
     outputs = [ "out" "lib" "dev" "doc" "man" ];
 
+    doCheck = false; # uses pip to install things from the internet
+
     meta = {
       homepage = https://ceph.com/;
       description = "Distributed storage system";
       license = with licenses; [ lgpl21 gpl2 bsd3 mit publicDomain ];
       maintainers = with maintainers; [ adev ak krav johanot ];
-      platforms = platforms.unix;
+      platforms = [ "x86_64-linux" ];
     };
 
     passthru.version = version;
@@ -183,7 +182,7 @@ in rec {
         description = "Tools needed to mount Ceph's RADOS Block Devices";
         license = with licenses; [ lgpl21 gpl2 bsd3 mit publicDomain ];
         maintainers = with maintainers; [ adev ak johanot krav ];
-        platforms = platforms.unix;
+        platforms = [ "x86_64-linux" ];
       };
     } ''
       mkdir -p $out/{bin,etc,lib/python3.7/site-packages}


### PR DESCRIPTION
This cleans up the ceph expression a lot, and starts using the nixpkgs-provided rocksdb and gtest.

```
commit 06b7a9b8f3c7d1b5b51e95ea8cf075195bae3e80 (HEAD -> MMesch-nixpkgs-jupyterlab-extension-kernels, flokli/ceph-fixes)
Author: Florian Klink <flokli@flokli.de>
Date:   Sat Nov 9 23:18:48 2019 +0100

    ceph: use system-provided gtest and rocksdb

commit a0d7d1025680c79675b4974298640628e071e5de
Author: Florian Klink <flokli@flokli.de>
Date:   Sat Nov 9 23:32:56 2019 +0100

    rocksdb: enable USE_RTTI=1
    
    This is required for programs using rocksdb and and typeinfo.
    
    Otherwise, linking them fails with errors like this (that's ceph):
    
    /nix/store/cg0k49h66nkdqx6ccwnqr0i4q0fnfznc-binutils-2.31.1/bin/ld: ../../lib/libos.a(RocksDBStore.cc.o):(.data.rel.ro._ZTIN12RocksDBStore14RocksWBHandlerE[_ZTIN12RocksDBStore14RocksWBHandlerE]+0x10): undefined reference to `typeinfo for rocksdb::WriteBatch::Handler'
    /nix/store/cg0k49h66nkdqx6ccwnqr0i4q0fnfznc-binutils-2.31.1/bin/ld: ../../lib/libos.a(RocksDBStore.cc.o):(.data.rel.ro._ZTIN12RocksDBStore19MergeOperatorRouterE[_ZTIN12RocksDBStore19MergeOperatorRouterE]+0x10): undefined reference to `typeinfo for rocksdb::AssociativeMergeOperator'
    /nix/store/cg0k49h66nkdqx6ccwnqr0i4q0fnfznc-binutils-2.31.1/bin/ld: ../../lib/libos.a(RocksDBStore.cc.o):(.data.rel.ro._ZTIN12RocksDBStore19MergeOperatorLinkerE[_ZTIN12RocksDBStore19MergeOperatorLinkerE]+0x10): undefined reference to `typeinfo for rocksdb::AssociativeMergeOperator'
    /nix/store/cg0k49h66nkdqx6ccwnqr0i4q0fnfznc-binutils-2.31.1/bin/ld: ../../lib/libos.a(RocksDBStore.cc.o):(.data.rel.ro._ZTI17CephRocksdbLogger[_ZTI17CephRocksdbLogger]+0x10): undefined reference to `typeinfo for rocksdb::Logger'
    /nix/store/cg0k49h66nkdqx6ccwnqr0i4q0fnfznc-binutils-2.31.1/bin/ld: ../../lib/libos.a(BlueRocksEnv.cc.o):(.data.rel.ro._ZTI12BlueRocksEnv[_ZTI12BlueRocksEnv]+0x10): undefined reference to `typeinfo for rocksdb::EnvWrapper'
    /nix/store/cg0k49h66nkdqx6ccwnqr0i4q0fnfznc-binutils-2.31.1/bin/ld: ../../lib/libos.a(BlueRocksEnv.cc.o):(.data.rel.ro._ZTI23BlueRocksSequentialFile[_ZTI23BlueRocksSequentialFile]+0x10): undefined reference to `typeinfo for rocksdb::SequentialFile'
    /nix/store/cg0k49h66nkdqx6ccwnqr0i4q0fnfznc-binutils-2.31.1/bin/ld: ../../lib/libos.a(BlueRocksEnv.cc.o):(.data.rel.ro._ZTI25BlueRocksRandomAccessFile[_ZTI25BlueRocksRandomAccessFile]+0x10): undefined reference to `typeinfo for rocksdb::RandomAccessFile'
    /nix/store/cg0k49h66nkdqx6ccwnqr0i4q0fnfznc-binutils-2.31.1/bin/ld: ../../lib/libos.a(BlueRocksEnv.cc.o):(.data.rel.ro._ZTI21BlueRocksWritableFile[_ZTI21BlueRocksWritableFile]+0x10): undefined reference to `typeinfo for rocksdb::WritableFile'
    /nix/store/cg0k49h66nkdqx6ccwnqr0i4q0fnfznc-binutils-2.31.1/bin/ld: ../../lib/libos.a(BlueRocksEnv.cc.o):(.data.rel.ro._ZTI17BlueRocksFileLock[_ZTI17BlueRocksFileLock]+0x10): undefined reference to `typeinfo for rocksdb::FileLock'

commit a47f3242a8044fb9e1c78fb4c74c4def3c006a54
Author: Florian Klink <flokli@flokli.de>
Date:   Sat Nov 9 23:20:15 2019 +0100

    ceph: patch more shebangs

commit c6ba0456743646778c448f2b05d84edd6e45923c
Author: Florian Klink <flokli@flokli.de>
Date:   Sat Nov 9 23:19:46 2019 +0100

    ceph: set doCheck = false explicitly
    
    and describe why.

commit 86db1bf7a9102a265c73957c8578d38f6dd64b4e
Author: Florian Klink <flokli@flokli.de>
Date:   Sat Nov 9 22:04:49 2019 +0100

    ceph: clean up PYTHONPATH wrapping
    
    Set `pythonPath` instead of exporting PYTHONPATH.
    
    Use `toPythonPath` to construct the PYTHONPATH where we need manual
    wrapping. There's no ceph-volume, only ceph-mgr.

commit d58b45ba36864d86e95c4bc36be1864074b6a6a9
Author: Florian Klink <flokli@flokli.de>
Date:   Sat Nov 9 22:03:42 2019 +0100

    ceph: fix outdated Boost::python substitutions
    
    Instead of substituting in CMakeLists.txt files, one now needs to set
    MGR_PYTHON_VERSION.

commit c4461c04a1c40e647c997b9975d9bd79d3c640ae
Author: Florian Klink <flokli@flokli.de>
Date:   Sat Nov 9 16:50:43 2019 +0100

    ceph: fix multiple output
    
    we currently just move $out/share/ceph/mgr to $lib/lib/ceph, and then
    remove all references to $out with a find command.
    
    I checked $out, the only reference to $out is in
    $lib/lib/ceph/libceph-common.so.0, coming from src/common/options.cc:
    https://github.com/ceph/ceph/blob/master/src/common/options.cc#L5050:
    
    >  Option("mgr_module_path", Option::TYPE_STR, Option::LEVEL_ADVANCED)
    >  .set_default(CEPH_DATADIR "/mgr")
    >  .add_service("mgr")
    >  .set_description("Filesystem path to manager modules."),
    
    Just removing the reference might break some behaviour - it should point
    to $lib/ceph/mgr instead.
    
    We can fix this in a much more elegant fashion by just passing a custom
    CMAKE_INSTALL_DATADIR to the build system.

commit 3d700355b4be3e0db3d37a6acea1fce69875acee
Author: Florian Klink <flokli@flokli.de>
Date:   Mon Nov 11 00:24:27 2019 +0100

    ceph: correct platforms
    
    ceph currently doesn't build on aarch64-linux. So let's not lie in
    meta.platforms.

```



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @adevress @magenbluten for rocksdb,
cc @adevress @alexanderkjeldaas @krav @johanot for ceph
