### PR TITLE
spike: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -934,6 +934,12 @@
     githubId = 5718007;
     name = "Bastian Köcher";
   };
+  blitz = {
+    email = "js@alien8.de";
+    github = "blitz";
+    githubId = 37907;
+    name = "Julian Stecklina";
+  };
   bluescreen303 = {
     email = "mathijs@bluescreen303.nl";
     github = "bluescreen303";

--- a/nixos/tests/spike.nix
+++ b/nixos/tests/spike.nix
@@ -1,0 +1,22 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+let
+  riscvPkgs = import ../.. { crossSystem = pkgs.stdenv.lib.systems.examples.riscv64-embedded; };
+in
+{
+  name = "spike";
+  meta = with pkgs.stdenv.lib.maintainers; { maintainers = [ blitz ]; };
+
+  machine = { pkgs, lib, ... }: {
+    environment.systemPackages = [ pkgs.spike riscvPkgs.riscv-pk riscvPkgs.hello ];
+  };
+
+  # Run the RISC-V hello applications using the proxy kernel on the
+  # Spike emulator and see whether we get the expected output.
+  testScript =
+    ''
+      machine.wait_for_unit("multi-user.target")
+      output = machine.succeed("spike -m64 $(which pk) $(which hello)")
+      assert output == "Hello, world!\n"
+    '';
+})

--- a/pkgs/applications/virtualization/spike/default.nix
+++ b/pkgs/applications/virtualization/spike/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchgit, dtc }:
+
+stdenv.mkDerivation rec {
+  pname = "spike";
+  version = "1.0.0";
+
+  src = fetchgit {
+    url = "https://github.com/riscv/riscv-isa-sim.git";
+    rev = "v${version}";
+    sha256 = "1hcl01nj96s3rkz4mrq747s5lkw81lgdjdimb8b1b9h8qnida7ww";
+  };
+
+  nativeBuildInputs = [ dtc ];
+  enableParallelBuilding = true;
+
+  patchPhase = ''
+    patchShebangs scripts/*.sh
+    patchShebangs tests/ebreak.py
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "A RISC-V ISA Simulator";
+    homepage = "https://github.com/riscv/riscv-isa-sim";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ blitz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20942,6 +20942,8 @@ in
 
   spice-vdagent = callPackage ../applications/virtualization/spice-vdagent { };
 
+  spike = callPackage ../applications/virtualization/spike { };
+
   spideroak = callPackage ../applications/networking/spideroak { };
 
   split2flac = callPackage ../applications/audio/split2flac { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Spike is the RISC-V ISA simulator of the RISC-V project. It aids in developing RISC-V software.

###### Open Questions

I've pulled in cross compiled versions of `hello` and the RISC-V proxy kernel in the spike integration test. As far as I can see, this is the first integration test that relies on cross-compilation and I'm not sure that this is ok.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @shlevy 
