### PR TITLE
circus: fix incompatible dependency of python-circus

### DIFF
--- a/pkgs/development/python-modules/circus/default.nix
+++ b/pkgs/development/python-modules/circus/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, iowait, psutil, pyzmq, tornado, mock }:
+, iowait, psutil, pyzmq, tornado_4, mock }:
 
 buildPythonPackage rec {
   pname = "circus";
@@ -13,15 +13,14 @@ buildPythonPackage rec {
   postPatch = ''
     # relax version restrictions to fix build
     substituteInPlace setup.py \
-      --replace "pyzmq>=13.1.0,<17.0" "pyzmq>13.1.0" \
-      --replace "tornado>=3.0,<5.0" "tornado>=3.0"
+      --replace "pyzmq>=13.1.0,<17.0" "pyzmq>13.1.0"
   '';
 
   checkInputs = [ mock ];
 
   doCheck = false; # weird error
 
-  propagatedBuildInputs = [ iowait psutil pyzmq tornado ];
+  propagatedBuildInputs = [ iowait psutil pyzmq tornado_4 ];
 
   meta = with stdenv.lib; {
     description = "A process and socket manager";

--- a/pkgs/tools/networking/circus/default.nix
+++ b/pkgs/tools/networking/circus/default.nix
@@ -1,5 +1,8 @@
-{ stdenv, buildPythonApplication, fetchPypi
-, iowait, psutil, pyzmq, tornado_4, mock }:
+{ stdenv, python3Packages }:
+
+let
+  inherit (python3Packages) buildPythonApplication fetchPypi iowait psutil pyzmq tornado_4 mock;
+in
 
 buildPythonApplication rec {
   pname = "circus";

--- a/pkgs/tools/networking/circus/default.nix
+++ b/pkgs/tools/networking/circus/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonApplication, fetchPypi
 , iowait, psutil, pyzmq, tornado_4, mock }:
 
-buildPythonPackage rec {
+buildPythonApplication rec {
   pname = "circus";
   version = "0.15.0";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2309,7 +2309,7 @@ in
     buildGoModule = buildGo112Module;
   };
 
-  circus = python3Packages.callPackage ../tools/networking/circus { };
+  circus = callPackage ../tools/networking/circus { };
 
   # Cleanup before 20.03:
   citrix_receiver = throw "citrix_receiver has been discontinued by Citrix (https://docs.citrix.com/en-us/citrix-workspace-app.html). Please use citrix_workspace.";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2309,6 +2309,8 @@ in
     buildGoModule = buildGo112Module;
   };
 
+  circus = python3Packages.callPackage ../tools/networking/circus { };
+
   # Cleanup before 20.03:
   citrix_receiver = throw "citrix_receiver has been discontinued by Citrix (https://docs.citrix.com/en-us/citrix-workspace-app.html). Please use citrix_workspace.";
   citrix_receiver_13_10_0 = citrix_receiver;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1643,8 +1643,6 @@ in {
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };
 
-  circus = callPackage ../development/python-modules/circus {};
-
   colorcet = callPackage ../development/python-modules/colorcet { };
 
   coloredlogs = callPackage ../development/python-modules/coloredlogs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix runtime failure

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh @volth @etu @xeji 
