### PR TITLE
hyphen: init at 2.8.8

### DIFF
--- a/pkgs/development/libraries/hyphen/default.nix
+++ b/pkgs/development/libraries/hyphen/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, perl, ... }:
+
+let
+  version = "2.8.8";
+  folder = with builtins;
+    let parts = splitVersion version;
+    in concatStringsSep "." [ (elemAt parts 0) (elemAt parts 1) ];
+in stdenv.mkDerivation rec {
+  pname = "hyphen";
+  inherit version;
+
+  nativeBuildInputs = [ perl ];
+
+  src = fetchurl {
+    url =
+      "https://sourceforge.net/projects/hunspell/files/Hyphen/${folder}/${pname}-${version}.tar.gz";
+    sha256 = "01ap9pr6zzzbp4ky0vy7i1983fwyqy27pl0ld55s30fdxka3ciih";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A text hyphenation library";
+    homepage = "https://sourceforge.net/projects/hunspell/files/Hyphen/";
+    platforms = platforms.all;
+    license = with licenses; [ gpl2 lgpl21 mpl11 ];
+    maintainers = with maintainers; [ filalex77 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3992,6 +3992,8 @@ in
 
   hylafaxplus = callPackage ../servers/hylafaxplus { };
 
+  hyphen = callPackage ../development/libraries/hyphen { };
+
   i2c-tools = callPackage ../os-specific/linux/i2c-tools { };
 
   i2p = callPackage ../tools/networking/i2p {};


### PR DESCRIPTION
###### Motivation for this change

Related to #60005.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/73208)
<!-- Reviewable:end -->
