### PR TITLE
pythonPackages.awkward1: init at 0.1.28

### DIFF
--- a/pkgs/development/python-modules/awkward1/default.nix
+++ b/pkgs/development/python-modules/awkward1/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cmake
+, numba
+, numpy
+, pytest
+, rapidjson
+}:
+
+buildPythonPackage rec {
+  pname = "awkward1";
+  version = "0.1.28";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2269aca04c827549435e24f9976d27e904d02b74a30caa9a2a463225a8ba1609";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ rapidjson ];
+  propagatedBuildInputs = [ numpy ];
+
+  dontUseCmakeConfigure = true;
+
+  checkInputs = [ pytest numba ];
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with lib; {
+    description = "Development of awkward 1.0, to replace scikit-hep/awkward-array in 2020";
+    homepage = "https://github.com/scikit-hep/awkward-1.0";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -225,6 +225,7 @@ in {
   automat = callPackage ../development/python-modules/automat { };
 
   awkward = callPackage ../development/python-modules/awkward { };
+  awkward1 = callPackage ../development/python-modules/awkward1 { };
 
   aws-sam-translator = callPackage ../development/python-modules/aws-sam-translator { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Implement package awkward 1.0 development branch
https://github.com/scikit-hep/awkward-1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @costrouc