### PR TITLE
update contributors documentation for nix-review

### DIFF
--- a/doc/contributing/submitting-changes.xml
+++ b/doc/contributing/submitting-changes.xml
@@ -305,6 +305,11 @@ Additional information.
     review uncommitted changes:
 <screen>nix-shell -p nix-review --run "nix-review wip"</screen>
    </para>
+
+   <para>
+    review changes from last commit:
+<screen>nix-shell -p nix-review --run "nix-review ref HEAD"</screen>
+   </para>
   </section>
 
   <section xml:id="submitting-changes-tested-execution">

--- a/doc/contributing/submitting-changes.xml
+++ b/doc/contributing/submitting-changes.xml
@@ -308,7 +308,7 @@ Additional information.
 
    <para>
     review changes from last commit:
-<screen>nix-shell -p nix-review --run "nix-review ref HEAD"</screen>
+<screen>nix-shell -p nix-review --run "nix-review rev HEAD"</screen>
    </para>
   </section>
 

--- a/doc/contributing/submitting-changes.xml
+++ b/doc/contributing/submitting-changes.xml
@@ -298,19 +298,17 @@ Additional information.
 
    <para>
     review changes from pull request number 12345:
-<screen>nix-shell -p nix-review --run "nix-review pr 12345"</screen>
+<screen>nix run nixpkgs.nix-review -c nix-review pr 12345</screen>
    </para>
 
    <para>
     review uncommitted changes:
-<screen>nix-shell -p nix-review --run "nix-review wip"</screen>
+<screen>nix run nixpkgs.nix-review -c nix-review wip</screen>
    </para>
 
    <para>
     review changes from last commit:
-<screen>nix-shell -p nix-review --run "nix-review rev HEAD"</screen>
-   </para>
-  </section>
+<screen>nix run nixpkgs.nix-review -c nix-review rev HEAD</screen>
 
   <section xml:id="submitting-changes-tested-execution">
    <title>Tested execution of all binary files (usually in <filename>./result/bin/</filename>)</title>


### PR DESCRIPTION
Useful for newcomers who want to do their review after committing and then stumbling across the PR checklist.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
