### PR TITLE
mkl: add scalapack libraries to output

### DIFF
--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -46,6 +46,7 @@ in stdenvNoCC.mkDerivation {
       tar xzvf $f
     done
   '' else ''
+    rpmextract rpm/intel-mkl-cluster-rt-${rpm-ver}.x86_64.rpm
     rpmextract rpm/intel-mkl-common-c-${rpm-ver}.noarch.rpm
     rpmextract rpm/intel-mkl-core-${rpm-ver}.x86_64.rpm
     rpmextract rpm/intel-mkl-core-rt-${rpm-ver}.x86_64.rpm


### PR DESCRIPTION
###### Motivation for this change
Add the scalapack extensions to the output.

###### Things done
Tested compilation with an external program (bagel quantum chemistry). Seems to work fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bhipple 
