### PR TITLE
prometheus-blackbox-exporter: 0.15.1 -> 0.16.0, disable tests

### DIFF
--- a/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/blackbox-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "blackbox_exporter";
-  version = "0.15.1";
+  version = "0.16.0";
   rev = version;
 
   goPackagePath = "github.com/prometheus/blackbox_exporter";
@@ -11,10 +11,11 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "prometheus";
     repo = "blackbox_exporter";
-    sha256 = "14z4xkkh9jb6ylclzsyj6gyqrb67lxs5cxd7lrs70qli567gzqwc";
+    sha256 = "1zbf3ljasv0r91rrmk3mj5nhimaf7xg3aih1ldz27rh5yww7gyzg";
   };
 
-  doCheck = true;
+  # dns-lookup is performed for the tests
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Blackbox probing of endpoints over HTTP, HTTPS, DNS, TCP and ICMP";


### PR DESCRIPTION
###### Motivation for this change
New release: https://github.com/prometheus/blackbox_exporter/releases/tag/v0.16.0

###### Things done
Disabled tests again, after enabling them recently, because networking would be required for a dns lookup.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).