### PR TITLE
mariadb-connector-c: 3.1.4 -> 3.1.5

### DIFF
--- a/pkgs/servers/sql/mariadb/connector-c/3_1.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/3_1.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./. (args // {
-  version = "3.1.4";
-  sha256 = "05jkaq151a45rqpyh0vrn6xcpawayfxyzhwn1w32hk0fw3z746ks";
+  version = "3.1.5";
+  sha256 = "1mfrm595kfnpjladaq6m184npa3rxff9pr1vwa35r057s7nmzpm9";
 })

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, fetchpatch
+{ stdenv, fetchurl, cmake
 , curl, openssl, zlib
 , libiconv
 , version, sha256, ...
@@ -17,13 +17,6 @@ stdenv.mkDerivation {
     ];
     inherit sha256;
   };
-
-  patches = stdenv.lib.optionals stdenv.isDarwin [
-    (fetchpatch {
-      url = "https://github.com/MariaDB/mariadb-connector-c/commit/ee91b2c98a63acb787114dee4f2694e154630928.patch";
-      sha256 = "05mlyv20kzn9bax4byv2ph1cf42541fcl1zcqzbfwqmynnisvdah";
-    })
-  ];
 
   cmakeFlags = [
     "-DMARIADB_UNIX_ADDR=/run/mysqld/mysqld.sock"


### PR DESCRIPTION
###### Motivation for this change
Update package to version 3.1.5
Changelog - https://mariadb.com/kb/en/library/mariadb-connector-c-315-changelog/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
