### PR TITLE
python3Packges.sqlalchemy: disable mem tests on darwin

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonPackage, isPy3k, isPy35
+{ stdenv, lib, fetchPypi, buildPythonPackage, isPy3k, isPy35
 , mock
 , pysqlite
 , fetchpatch
@@ -25,7 +25,9 @@ buildPythonPackage rec {
 
   dontUseSetuptoolsCheck = true;
 
-  disabledTests = lib.optionals isPy35 [ "exception_persistent_flush_py3k "];
+  # disable mem-usage tests on mac, has trouble serializing pickle files
+  disabledTests = lib.optionals isPy35 [ "exception_persistent_flush_py3k "]
+    ++ lib.optionals stdenv.isDarwin [ "MemUsageWBackendTest" "MemUsageTest" ];
 
   patches = [
     # Two patches for sqlite 3.30 compatibility.


### PR DESCRIPTION
These tests fail to pickle a file locally

###### Motivation for this change

Trying to fix the tests, currently blocks 185 other darwin python packages

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
