### PR TITLE
bgpdump: 2017-09-29 -> 1.6.0

### DIFF
--- a/pkgs/tools/networking/bgpdump/default.nix
+++ b/pkgs/tools/networking/bgpdump/default.nix
@@ -1,18 +1,19 @@
-{ stdenv, fetchzip, autoreconfHook, zlib, bzip2 }:
+{ stdenv, fetchurl, autoreconfHook, zlib, bzip2 }:
 
-stdenv.mkDerivation {
-  name = "bgpdump-2017-09-29";
+stdenv.mkDerivation rec {
+  pname = "bgpdump";
+  version = "1.6.0";
 
-  src = fetchzip {
-    url = "https://bitbucket.org/ripencc/bgpdump/get/94a0e724b335.zip";
-    sha256 = "09g9vz2zc4nyzl669w1j7fxw21ifja6dxbp0xbqh6n7w3gpx2g88";
+  src = fetchurl {
+    url = "https://ris.ripe.net/source/bgpdump/libbgpdump-1.6.0.tgz";
+    sha256 = "144369gj35mf63nz4idqwsvgsirw7fybm8kkk07yymrjp8jr3aqk";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ zlib bzip2 ];
 
   meta = {
-    homepage = https://bitbucket.org/ripencc/bgpdump/wiki/Home;
+    homepage = https://bitbucket.org/ripencc/bgpdump/;
     description = ''Analyze dump files produced by Zebra/Quagga or MRT'';
     license = stdenv.lib.licenses.hpnd;
     maintainers = with stdenv.lib.maintainers; [ lewo ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Refresh an old package
\+ it was reported as problematic by Repology because of version mismatch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nlewo 
