### PR TITLE
fop: builds on all platforms

### DIFF
--- a/pkgs/tools/typesetting/fop/default.nix
+++ b/pkgs/tools/typesetting/fop/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://xmlgraphics.apache.org/fop/;
     license = licenses.asl20;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = with maintainers; [ bjornfor ndowens ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

asciidoc-full won't install on Mac because `fop` claims it can't install.

fop is pure Java, AFAIK.  I looked but couldn't find a way to enable this
for "all platforms supporting Java", so settled on `platforms.all`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bjornfor @ndowens