### PR TITLE
[r19.03] gdal: add patch for CVE-2019-17545

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -16,6 +16,15 @@ stdenv.mkDerivation rec {
     sha256 = "09qgy36z0jc9w05373m4n0vm4j54almdzql6z9p9zr9pdp61syf3";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-17545.patch";
+      url = "https://github.com/OSGeo/gdal/commit/8cd2d2eb6327cf782a74dae263ffa6f89f46c93d.patch";
+      stripLen = 1;
+      sha256 = "06h88a659jcqf6ps1m91qy78s6s9krbkwnz28f5qh7032vlp6qpw";
+    })
+  ];
+
   buildInputs = [ unzip libjpeg libtiff libpng proj openssl sqlite
     libspatialite poppler hdf4 qhull giflib expat libxml2 ]
   ++ (with pythonPackages; [ python numpy wrapPython ])


### PR DESCRIPTION
###### Motivation for this change
Backport of #72054

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
