### PR TITLE
numix-solarized-gtk-theme: 20170810 -> 20180913

### DIFF
--- a/pkgs/misc/themes/numix-solarized/default.nix
+++ b/pkgs/misc/themes/numix-solarized/default.nix
@@ -3,14 +3,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "20170810";
+  version = "20180913";
   pname = "numix-solarized-gtk-theme";
 
   src = fetchFromGitHub {
     owner = "Ferdi265";
     repo = "numix-solarized-gtk-theme";
     rev = version;
-    sha256 = "0l4xvsiyg15kp6xwpvm3jckxyhr1lxd678lkhrcyf40n7rd4xinl";
+    sha256 = "1kda0lyqi3cxh163fbj8yyi6jj6pf0y980k4s0cmyi3hkh4cqyd5";
   };
 
   nativeBuildInputs = [ python3 sass glib gdk-pixbuf libxml2 inkscape optipng ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Missing some of the newer schemes like SolarizedDarkCyan

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
