### PR TITLE
libredirect: fix argument forwarding in `open*` functions

### DIFF
--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -59,6 +59,11 @@ static const char * rewrite(const char * path, char * buf)
     return path;
 }
 
+static int open_needs_mode(int flags)
+{
+    return (flags & O_CREAT) || (flags & O_TMPFILE) == O_TMPFILE;
+}
+
 /* The following set of Glibc library functions is very incomplete -
    it contains only what we needed for programs in Nixpkgs. Just add
    more functions as needed. */
@@ -67,7 +72,7 @@ int open(const char * path, int flags, ...)
 {
     int (*open_real) (const char *, int, mode_t) = dlsym(RTLD_NEXT, "open");
     mode_t mode = 0;
-    if (flags & O_CREAT) {
+    if (open_needs_mode(flags)) {
         va_list ap;
         va_start(ap, flags);
         mode = va_arg(ap, mode_t);
@@ -81,7 +86,7 @@ int open64(const char * path, int flags, ...)
 {
     int (*open64_real) (const char *, int, mode_t) = dlsym(RTLD_NEXT, "open64");
     mode_t mode = 0;
-    if (flags & O_CREAT) {
+    if (open_needs_mode(flags)) {
         va_list ap;
         va_start(ap, flags);
         mode = va_arg(ap, mode_t);
@@ -95,7 +100,7 @@ int openat(int dirfd, const char * path, int flags, ...)
 {
     int (*openat_real) (int, const char *, int, mode_t) = dlsym(RTLD_NEXT, "openat");
     mode_t mode = 0;
-    if (flags & O_CREAT) {
+    if (open_needs_mode(flags)) {
         va_list ap;
         va_start(ap, flags);
         mode = va_arg(ap, mode_t);

--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -145,9 +145,9 @@ int stat(const char * path, struct stat * st)
     return __stat_real(rewrite(path, buf), st);
 }
 
-int * access(const char * path, int mode)
+int access(const char * path, int mode)
 {
-    int * (*access_real) (const char *, int mode) = dlsym(RTLD_NEXT, "access");
+    int (*access_real) (const char *, int mode) = dlsym(RTLD_NEXT, "access");
     char buf[PATH_MAX];
     return access_real(rewrite(path, buf), mode);
 }


### PR DESCRIPTION
###### Motivation for this change
`libredirect` incorrectly forwards arguments of `open`, `open64` and `openat` functions when `O_TMPFILE` flag is set.

From `man 2 open`:
> The mode argument specifies the file mode bits be applied when a new  file  is  created.   This  argument  must  be supplied when O_CREAT or O_TMPFILE is specified in flags; if  neither  O_CREAT nor O_TMPFILE is specified, then mode is ignored.

This PR solves this issue: https://github.com/NixOS/nixpkgs/issues/73077 .

###### Things done
* Fixed argument forwarding in `open`, `open64`, `openat` functions
* Fixed return type of `access` function

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ma27 
