### PR TITLE
fcitx-configtool: patch paths to fcitx-remote

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
@@ -19,6 +19,14 @@ stdenv.mkDerivation rec {
   buildInputs = [ makeWrapper fcitx cmake isocodes gtk3
     gnome3.adwaita-icon-theme ];
 
+  # Patch paths to `fcitx-remote`
+  prePatch = ''
+    for f in gtk{3,}/config_widget.c; do
+      substituteInPlace $f \
+        --replace 'EXEC_PREFIX "/bin/fcitx-remote"' '"${fcitx}/bin/fcitx-remote"'
+    done
+  '';
+
   preFixup = ''
     wrapProgram $out/bin/fcitx-config-gtk3 \
       --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix paths to `fcitx-remote`, so it can correctly call `fcitx-remote -r` when settings getting modified.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
