### PR TITLE
retroarch: 1.7.8.4 -> 1.8.1

### DIFF
--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -2,12 +2,14 @@
 , ffmpeg, libGLU_combined, freetype, libxml2, python3
 , libobjc, AppKit, Foundation
 , alsaLib ? null
+, libdrm ? null
 , libpulseaudio ? null
 , libv4l ? null
 , libX11 ? null
 , libXdmcp ? null
 , libXext ? null
 , libXxf86vm ? null
+, mesa ? null
 , SDL2 ? null
 , udev ? null
 , enableNvidiaCgToolkit ? false, nvidia_cg_toolkit ? null
@@ -27,12 +29,12 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "retroarch-bare";
-  version = "1.7.8.4";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "RetroArch";
-    sha256 = "1i3i23xwvmck8k2fpalr49np7xjzfg507243mybqrljawlnbxvph";
+    sha256 = "0y7rcpz7psf8k3agsrq277jdm651vbnn9xpqvmj2in1a786idya7";
     rev = "v${version}";
   };
 
@@ -43,10 +45,12 @@ in stdenv.mkDerivation rec {
                 ++ optional enableNvidiaCgToolkit nvidia_cg_toolkit
                 ++ optional withVulkan [ vulkan-loader ]
                 ++ optionals stdenv.isDarwin [ libobjc AppKit Foundation ]
-                ++ optionals stdenv.isLinux [ alsaLib libpulseaudio libv4l libX11
-                                              libXdmcp libXext libXxf86vm udev ];
+                ++ optionals stdenv.isLinux [ alsaLib libdrm libpulseaudio libv4l libX11
+                                              libXdmcp libXext libXxf86vm mesa udev ];
 
   enableParallelBuilding = true;
+
+  configureFlags = if stdenv.isLinux then [ "--enable-kms" ] else "";
 
   postInstall = optionalString withVulkan ''
     wrapProgram $out/bin/retroarch --prefix LD_LIBRARY_PATH ':' ${vulkan-loader}/lib


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update version to latest and build with "--enable-kms" on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @MP2E @edwtjo @matthewbauer 
