### PR TITLE
pbis-open: init at 9.1.0

### DIFF
--- a/pkgs/tools/security/pbis/default.nix
+++ b/pkgs/tools/security/pbis/default.nix
@@ -1,0 +1,70 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, perl, flex, bison, curl,
+  pam, popt, libiconv, libuuid, openssl_1_0_2, cyrus_sasl, sqlite, tdb, libxml2 }:
+
+stdenv.mkDerivation rec {
+  pname = "pbis-open";
+  version = "9.1.0";
+
+  src = fetchFromGitHub {
+    owner = "BeyondTrust";
+    repo = pname;
+    rev = version;
+    sha256 = "081jm34sf488nwz5wzs55d6rxx3sv566x6p4h1yqcjaw36174m8v";
+  };
+
+  nativeBuildInputs = [
+    autoconf automake libtool perl flex bison
+  ];
+
+  # curl must be placed after openssl_1_0_2, because it pulls openssl 1.1 dependency.
+  buildInputs = [
+    pam popt libiconv libuuid openssl_1_0_2 cyrus_sasl
+    curl sqlite popt tdb libxml2 /*libglade2 for gtk*/
+  ];
+
+  postPatch = ''
+    patchShebangs .
+    sed -i -e 's/legacy//g' lwupgrade/MakeKitBuild # disable /opt/ symlinks
+    sed -i -e 's/tdb.h//g' samba-interop/MakeKitBuild #include <tdb.h> fails but it won't affect the build
+  '';
+  preConfigure = ''
+    mkdir release
+    cd release
+    if [ $CC = gcc ]; then
+            NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-error=format-overflow"
+    fi
+    NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${stdenv.lib.getDev libxml2}/include/libxml2 -Wno-error=array-bounds -Wno-error=pointer-sign -Wno-error=deprecated-declarations -Wno-error=unused-variable"
+  '';
+  configureScript = ''../configure'';
+  configureFlags = [
+    "CFLAGS=-O"
+    "--docdir=${placeholder "prefix"}/share/doc"
+    "--mandir=${placeholder "prefix"}/share/doc/man"
+    "--datadir=${placeholder "prefix"}/share"
+    "--lw-initdir=${placeholder "prefix"}/etc/init.d"
+    "--selinux=no" # NixOS does not support SELinux
+    "--build-isas=x86_64" # [lwbase] endianness (host/x86_32): [lwbase] ERROR: could not determine endianness
+    "--fail-on-warn=no"
+    # "--debug=yes"
+  ]; # ^ See https://github.com/BeyondTrust/pbis-open/issues/124
+  configureFlagsArray = [ "--lw-bundled-libs=linenoise-mob tomlc99 opensoap krb5 cyrus-sasl curl openldap ${ if libuuid == null then "libuuid" else "" }" ];
+  # ^ it depends on old krb5 version 1.9 (issue #228)
+  # linenoise-mod, tomlc99, opensoap is not in nixpkgs.
+  # krb5 must be old one, and cyrus-sasl and openldap have dependency to newer libkrb5 that cause runtime error
+  enableParallelBuilding = true;
+  makeFlags = "SHELL=";
+  hardeningDisable = [ "format" ]; # -Werror=format-security
+  installPhase = ''
+    mkdir $sys
+    mv stage/{lib,var} $sys
+    mv stage$out $out
+  '';
+  outputs = [ "out" "sys" ];
+
+  meta = with stdenv.lib; {
+    description = "BeyondTrust AD Bridge Open simplifies the process of joining non-Microsoft hosts to Active Directory domains";
+    homepage = "https://github.com/BeyondTrust/pbis-open";
+    license = with licenses; [ gpl2 lgpl21 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20078,6 +20078,8 @@ in
 
   partio = callPackage ../development/libraries/partio {};
 
+  pbis-open = callPackage ../tools/security/pbis { };
+
   pcmanfm = callPackage ../applications/misc/pcmanfm { };
 
   pcmanfm-qt = lxqt.pcmanfm-qt;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
For Active Directory integration. This PR only contains the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill @abbradar @vcunat @edolstra
(members are chosen from linux-pam committers)