### PR TITLE
python.pkgs.requests_oauthlib: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/requests-oauthlib/default.nix
+++ b/pkgs/development/python-modules/requests-oauthlib/default.nix
@@ -2,12 +2,12 @@
 , oauthlib, requests }:
 
 buildPythonPackage rec {
-  version = "1.2.0";
+  version = "1.3.0";
   pname = "requests-oauthlib";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bd6533330e8748e94bf0b214775fed487d309b8b8fe823dc45641ebcd9a32f57";
+    sha256 = "0smaxs5ixng4z0k6dsgmm6s972ka3p6a2ykdpnl23mqzlw0ic9ml";
   };
 
   doCheck = false;        # Internet tests fail when building in chroot


### PR DESCRIPTION
###### Motivation for this change
Release notes:

 - Instagram compliance fix
 - Added force_querystring argument to fetch_token() method on OAuth2Session


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).