### PR TITLE
python3.pkgs.authlib: init at 0.13

### DIFF
--- a/pkgs/development/python-modules/authlib/default.nix
+++ b/pkgs/development/python-modules/authlib/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, mock
+, cryptography
+, requests
+}:
+
+buildPythonPackage rec {
+  version = "0.13";
+  pname = "authlib";
+
+  src = fetchFromGitHub {
+    owner = "lepture";
+    repo = "authlib";
+    rev = "v${version}";
+    sha256 = "1nv0jbsaqr9qjn7nnl55s42iyx655k7fsj8hs69652lqnfn5y3d5";
+  };
+
+  propagatedBuildInputs = [ cryptography requests ];
+
+  checkInputs = [ mock pytest ];
+
+  checkPhase = ''
+    PYTHONPATH=$PWD:$PYTHONPATH pytest tests/{core,files}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/lepture/authlib;
+    description = "The ultimate Python library in building OAuth and OpenID Connect servers. JWS,JWE,JWK,JWA,JWT included.";
+    maintainers = with maintainers; [ flokli ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -234,6 +234,8 @@ in {
 
   atomman = callPackage ../development/python-modules/atomman { };
 
+  authlib = callPackage ../development/python-modules/authlib { };
+
   # packages defined elsewhere
 
   amazon_kclpy = callPackage ../development/python-modules/amazon_kclpy { };


### PR DESCRIPTION
###### Motivation for this change
This adds `authlib`, a popular OAuth and OpenID Connect library.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).