### PR TITLE
canon-cups-ufr2: 2.90 -> 3.70

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3700,6 +3700,18 @@
     githubId = 449813;
     name = "Roman Kuznetsov";
   };
+  kylesferrazza = {
+    name = "Kyle Sferrazza";
+    email = "kyle.sferrazza@gmail.com";
+
+    github = "kylesferrazza";
+    githubId = 6677292;
+
+    keys = [{
+      longkeyid = "rsa4096/81A1540948162372";
+      fingerprint = "5A9A 1C9B 2369 8049 3B48  CF5B 81A1 5409 4816 2372";
+    }];
+  };
   kylewlacy = {
     email = "kylelacy+nix@pm.me";
     github = "kylewlacy";

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -214,9 +214,12 @@ stdenv.mkDerivation {
       --prefix PATH ":" "$out/bin"
     '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "CUPS Linux drivers for Canon printers";
     homepage = http://www.canon.com/;
-    license = stdenv.lib.licenses.unfree;
+    license = licenses.unfree;
+    maintainers = with maintainers; [
+      kylesferrazza
+    ];
   };
 }

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -1,49 +1,55 @@
-{stdenv, fetchurl, unzip, autoreconfHook, libtool, makeWrapper, cups, ghostscript, pkgsi686Linux }:
+{stdenv, fetchurl, unzip, autoreconfHook, libtool, makeWrapper, cups, ghostscript, pkgsi686Linux, zlib }:
 
 let
 
   i686_NIX_GCC = pkgsi686Linux.callPackage ({gcc}: gcc) {};
   i686_libxml2 = pkgsi686Linux.callPackage ({libxml2}: libxml2) {};
 
+  commonVer = "4.10";
+  version = "3.70";
+  dl = "8/0100007658/08";
+
+  versionNoDots = builtins.replaceStrings ["."] [""] version;
   src_canon = fetchurl {
-    url = "https://files.canon-europe.com/files/soft45378/software/o147jen_linuxufrII_0290.zip";
-    sha256 = "1qpdmaaw42gm5fi21rp4lf05skffkq42ka5c8xkw8rckzb13sy9j";
+    url = "http://gdlp01.c-wss.com/gds/${dl}/linux-UFRII-drv-v${versionNoDots}-uken-05.tar.gz";
+    sha256 = "0424lvyrsvsb94qga4p4ldis7f714c5yw5ydv3f84mdl2a7papg0";
   };
 
 in
 
 
 stdenv.mkDerivation {
-  name = "canon-cups-ufr2-2.90";
+  pname = "canon-cups-ufr2";
+  version = version;
   src = src_canon;
 
   phases = [ "unpackPhase" "installPhase" ];
 
   postUnpack = ''
-    (cd $sourceRoot; tar -xzf Sources/cndrvcups-common-2.90-1.tar.gz)
-    (cd $sourceRoot; tar -xzf Sources/cndrvcups-lb-2.90-1.tar.gz)
+    (cd $sourceRoot; tar -xzf Sources/cndrvcups-common-${commonVer}-1.tar.gz)
+    (cd $sourceRoot; tar -xzf Sources/cndrvcups-lb-${version}-1.tar.gz)
   '';
 
   nativeBuildInputs = [ makeWrapper unzip autoreconfHook libtool ];
 
-  buildInputs = [ cups ];
+  buildInputs = [ cups zlib ];
 
   installPhase = ''
     ##
     ## cndrvcups-common buildPhase
     ##
-    ( cd cndrvcups-common-2.90/buftool
+    ( cd cndrvcups-common-${commonVer}/buftool
       autoreconf -fi
       ./autogen.sh --prefix=$out --enable-progpath=$out/bin --libdir=$out/lib --disable-shared --enable-static
       make
     )
 
-    ( cd cndrvcups-common-2.90/backend
+    ( cd cndrvcups-common-${commonVer}/backend
       ./autogen.sh --prefix=$out --libdir=$out/lib
       make
     )
 
-    ( cd cndrvcups-common-2.90/c3plmod_ipc
+    ( cd cndrvcups-common-${commonVer}/c3plmod_ipc
       make
     )
 
@@ -51,19 +57,19 @@ stdenv.mkDerivation {
     ## cndrvcups-common installPhase
     ##
 
-    ( cd cndrvcups-common-2.90/buftool
+    ( cd cndrvcups-common-${commonVer}/buftool
       make install
     )
 
-    ( cd cndrvcups-common-2.90/backend
+    ( cd cndrvcups-common-${commonVer}/backend
       make install
     )
 
-    ( cd cndrvcups-common-2.90/c3plmod_ipc
+    ( cd cndrvcups-common-${commonVer}/c3plmod_ipc
       make install DESTDIR=$out/lib
     )
 
-    ( cd cndrvcups-common-2.90/libs
+    ( cd cndrvcups-common-${commonVer}/libs
       chmod 755 *
       mkdir -p $out/lib32
       mkdir -p $out/bin
@@ -72,15 +78,22 @@ stdenv.mkDerivation {
       cp libc3pl.so.0.0.1 $out/lib32
       cp libcaepcm.so.1.0 $out/lib32
       cp libColorGear.so.0.0.0 $out/lib32
-      cp libColorGearC.so.0.0.0 $out/lib32
+      cp libColorGearC.so.1.0.0 $out/lib32
       cp libcanon_slim.so.1.0.0 $out/lib32
       cp c3pldrv $out/bin
     )
 
-    (cd cndrvcups-common-2.90/data
+    (cd cndrvcups-common-${commonVer}/Rule
+      mkdir -p $out/share/usb
+      chmod 644 *.usb-quirks $out/share/usb
+    )
+
+    (cd cndrvcups-common-${commonVer}/data
       chmod 644 *.ICC
       mkdir -p $out/share/caepcm
       cp *.ICC $out/share/caepcm
+      cp *.icc $out/share/caepcm
+      cp *.PRF $out/share/caepcm
     )
 
     (cd $out/lib32
@@ -96,8 +109,8 @@ stdenv.mkDerivation {
       ln -sf libcanon_slim.so.1.0.0 libcanon_slim.so
       ln -sf libColorGear.so.0.0.0 libColorGear.so.0
       ln -sf libColorGear.so.0.0.0 libColorGear.so
-      ln -sf libColorGearC.so.0.0.0 libColorGearC.so.0
-      ln -sf libColorGearC.so.0.0.0 libColorGearC.so
+      ln -sf libColorGearC.so.1.0.0 libColorGearC.so.1
+      ln -sf libColorGearC.so.1.0.0 libColorGearC.so
     )
 
     (cd $out/lib
@@ -106,7 +119,7 @@ stdenv.mkDerivation {
     )
 
     patchelf --set-rpath "$(cat ${i686_NIX_GCC}/nix-support/orig-cc)/lib" $out/lib32/libColorGear.so.0.0.0
-    patchelf --set-rpath "$(cat ${i686_NIX_GCC}/nix-support/orig-cc)/lib" $out/lib32/libColorGearC.so.0.0.0
+    patchelf --set-rpath "$(cat ${i686_NIX_GCC}/nix-support/orig-cc)/lib" $out/lib32/libColorGearC.so.1.0.0
 
     patchelf --interpreter "$(cat ${i686_NIX_GCC}/nix-support/dynamic-linker)" --set-rpath "$out/lib32" $out/bin/c3pldrv
 
@@ -127,18 +140,13 @@ stdenv.mkDerivation {
     ## cndrvcups-lb buildPhase
     ##
 
-    ( cd cndrvcups-lb-2.90/ppd
-      ./autogen.sh --prefix=$out
+    ( cd cndrvcups-lb-${version}/buftool
+      ./autogen.sh --prefix=$out --libdir=$out/lib --enable-progpath=$out/bin --enable-static
       make
     )
 
-    ( cd cndrvcups-lb-2.90/pstoufr2cpca
-      CPPFLAGS="-I$out/include" LDFLAGS=" -L$out/lib" ./autogen.sh --prefix=$out --enable-progpath=$out/bin
-      make
-    )
-
-    ( cd cndrvcups-lb-2.90/cpca
-      CPPFLAGS="-I$out/include" LDFLAGS=" -L$out/lib" ./autogen.sh --prefix=$out --enable-progpath=$out/bin  --enable-static
+    ( cd cndrvcups-lb-${version}/pstoufr2cpca
+      ./autogen.sh --prefix=$out --libdir=$out/lib
       make
     )
 
@@ -146,19 +154,11 @@ stdenv.mkDerivation {
     ## cndrvcups-lb installPhase
     ##
 
-    ( cd cndrvcups-lb-2.90/ppd
+    ( cd cndrvcups-lb-${version}/pstoufr2cpca
       make install
     )
 
-    ( cd cndrvcups-lb-2.90/pstoufr2cpca
-      make install
-    )
-
-    ( cd cndrvcups-lb-2.90/cpca
-      make install
-    )
-
-    ( cd cndrvcups-lb-2.90/libs
+    ( cd cndrvcups-lb-${version}/libs
       chmod 755 *
       mkdir -p $out/lib32
       mkdir -p $out/bin
@@ -189,7 +189,7 @@ stdenv.mkDerivation {
       ln -sf libcnlbcm.so.1.0 libcnlbcm.so
     )
 
-    ( cd cndrvcups-lb-2.90
+    ( cd cndrvcups-lb-${version}
       chmod 644 data/CnLB*
       chmod 644 libs/cnpkbidi_info*
       chmod 644 libs/ThLB*
@@ -200,6 +200,9 @@ stdenv.mkDerivation {
       cp libs/cnpkbidi_info* $out/share/cnpkbidi
       cp libs/ThLB* $out/share/ufr2filter
     )
+
+    mkdir -p $out/share/cups/model
+    install -c -m 644 cndrvcups-lb-${version}/ppd/CN*.ppd $out/share/cups/model/
 
     patchelf --set-rpath "$out/lib32:${i686_libxml2.out}/lib" $out/lib32/libcanonufr2.so.1.0.0
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
My Canon MF240 was not supported by the current version of the `canon-cups-ufr2` driver.
Closes #55447 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


###### Note
I based this update on changes to the rpm `.spec` file bundled with the source. I'm not super familiar with autotools so this update may not be complete.
The driver works with my Canon MF240, but needs testing with other printers before merging.

@cptMikky if you still have the canon printer for testing this, that would be great

Also 5.00 is now available, but this is a step in the right direction