### PR TITLE
bazel: fix strict action env

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -19,6 +19,7 @@
 , enableNixHacks ? false
 , gcc-unwrapped
 , autoPatchelfHook
+, file
 , substituteAll
 }:
 
@@ -92,7 +93,7 @@ let
     #        ],
     #     )
     #
-    [ bash coreutils findutils gawk gnugrep gnutar gnused gzip which unzip ];
+    [ bash coreutils findutils gawk gnugrep gnutar gnused gzip which unzip file zip ];
 
   # Java toolchain used for the build and tests
   javaToolchain = "@bazel_tools//tools/jdk:toolchain_host${buildJdkName}";

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -19,6 +19,7 @@
 , enableNixHacks ? false
 , gcc-unwrapped
 , autoPatchelfHook
+, substituteAll
 }:
 
 let
@@ -145,6 +146,17 @@ stdenv.mkDerivation rec {
     # This is breaking the build of any C target. This patch removes the last
     # argument if it's found to be an empty string.
     ./trim-last-argument-to-gcc-if-empty.patch
+
+    # --experimental_strict_action_env (which may one day become the default
+    # see bazelbuild/bazel#2574) hardcodes the default
+    # action environment to a non hermetic value (e.g. "/usr/local/bin").
+    # This is non hermetic on non-nixos systems. On NixOS, bazel cannot find the required binaries.
+    # So we are replacing this bazel paths by defaultShellPath,
+    # improving hermeticity and making it work in nixos.
+    (substituteAll {
+      src = ./strict_action_env.patch;
+      strictActionEnvPatch = defaultShellPath;
+    })
   ] ++ lib.optional enableNixHacks ./nix-hacks.patch;
 
 
@@ -389,14 +401,6 @@ stdenv.mkDerivation rec {
           -e "/\$command \\\\$/a --host_javabase='@local_jdk//:jdk' \\\\" \
           -e "/\$command \\\\$/a --host_java_toolchain='${javaToolchain}' \\\\" \
           -i scripts/bootstrap/compile.sh
-
-      # --experimental_strict_action_env (which will soon become the
-      # default, see bazelbuild/bazel#2574) hardcodes the default
-      # action environment to a value that on NixOS at least is bogus.
-      # So we hardcode it to something useful.
-      substituteInPlace \
-        src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java \
-        --replace /bin:/usr/bin ${defaultShellPath}
 
       # This is necessary to avoid:
       # "error: no visible @interface for 'NSDictionary' declares the selector

--- a/pkgs/development/tools/build-managers/bazel/strict_action_env.patch
+++ b/pkgs/development/tools/build-managers/bazel/strict_action_env.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+index a70b5559bc..10bdffe961 100644
+--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
++++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
+@@ -466,7 +466,7 @@ public class BazelRuleClassProvider {
+       // Note that --action_env does not propagate to the host config, so it is not a viable
+       // workaround when a genrule is itself built in the host config (e.g. nested genrules). See
+       // #8536.
+-      return "/bin:/usr/bin:/usr/local/bin";
++      return "@strictActionEnvPatch@";
+     }
+
+     String newPath = "";


### PR DESCRIPTION
##### Motivation for this change

This fix three bugs:

- ~~it restores the usage of `/etc/bazel.bazelrc` if users want to override bazel setting on a system-wide fashion.~~
- it removes `/usr/local/bin` from the path searched by bazel in "strict action env" mode. This increases reproducibility in this context.
- it adds `diff` and `zip` in the bazel test runner context. They are needed on some cases of test and where failing if bazel was used with `strict action env`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli @Profpatsch 
