### PR TITLE
pkgs/development/libraries: add missing descriptions and homepages

### DIFF
--- a/pkgs/development/libraries/clipper/default.nix
+++ b/pkgs/development/libraries/clipper/default.nix
@@ -15,11 +15,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ninja unzip ];
 
   meta = with stdenv.lib; {
+    description = "A polygon and line clipping and offsetting library (C++, C#, Delphi)";
     longDescription = ''
       The Clipper library performs line & polygon clipping - intersection, union, difference & exclusive-or,
       and line & polygon offsetting. The library is based on Vatti's clipping algorithm.
     '';
-    homepage = https://sourceforge.net/projects/polyclipping;
+    homepage = "https://sourceforge.net/projects/polyclipping";
     license = licenses.boost;
     maintainers = with maintainers; [ mpickering ];
     platforms = with platforms; unix;

--- a/pkgs/development/libraries/exempi/default.nix
+++ b/pkgs/development/libraries/exempi/default.nix
@@ -19,7 +19,8 @@ stdenv.mkDerivation rec {
   doCheck = stdenv.isLinux;
 
   meta = with stdenv.lib; {
-    homepage = https://libopenraw.freedesktop.org/wiki/Exempi/;
+    description = "An implementation of XMP (Adobe's Extensible Metadata Platform)";
+    homepage = "https://libopenraw.freedesktop.org/wiki/Exempi/";
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.bsd3;
   };

--- a/pkgs/development/libraries/garmintools/default.nix
+++ b/pkgs/development/libraries/garmintools/default.nix
@@ -7,7 +7,8 @@ stdenv.mkDerivation {
   };
   buildInputs = [ libusb ];
   meta = {
-    homepage = https://code.google.com/archive/p/garmintools/; # community clone at https://github.com/ianmartin/garmintools
+    description = "Provides the ability to communicate with the Garmin Forerunner 305 via the USB interface";
+    homepage = "https://code.google.com/archive/p/garmintools/"; # community clone at https://github.com/ianmartin/garmintools
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ stdenv.lib.maintainers.ocharles ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/ilmbase/default.nix
+++ b/pkgs/development/libraries/ilmbase/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
   doCheck = stdenv.isx86_64;
 
   meta = with stdenv.lib; {
+    description = " A library for 2D/3D vectors and matrices and other mathematical objects, functions and data types for computer graphics";
     homepage = https://www.openexr.com/;
     license = licenses.bsd3;
     platforms = platforms.all;

--- a/pkgs/development/libraries/java/smack/default.nix
+++ b/pkgs/development/libraries/java/smack/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation {
   };
 
   meta = {
+    description = "A XMPP (Jabber) client library for instant messaging and presence";
+    homepage = "http://www.igniterealtime.org/projects/smack/";
     platforms = stdenv.lib.platforms.unix;
     license = stdenv.lib.licenses.asl20;
   };


### PR DESCRIPTION
###### Motivation for this change 
Many packages below pkgs/development/libraries lack a description and sometimes also a homepage in their metadata. This PR adds some.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
