### PR TITLE
oil: 0.7.pre5 -> 0.7.pre6

### DIFF
--- a/pkgs/shells/oil/default.nix
+++ b/pkgs/shells/oil/default.nix
@@ -2,21 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "oil";
-  version = "0.7.pre5";
+  version = "0.7.pre6";
 
   src = fetchurl {
     url = "https://www.oilshell.org/download/oil-${version}.tar.xz";
-    sha256 = "1vpk4my8lp7wik8ywspawimya2a7hb1qjkp5vpm7ypmkya5jqivc";
+    sha256 = "1yhfrxrqd4jbjsf0g2fkxv8zypcndnikv9g15yp9szgp4sh1r9vv";
   };
-
-
-  # TODO remove at next bump
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/oilshell/oil/commit/81551d76ae5a8b53179f2472492d0b44f13f84fd.patch";
-      sha256 = "0v99cx13ajqmf489vvxkqhqi9pjyc8jn0dgc8wp78gsv9js2k7km";
-    })
-  ];
 
   postPatch = ''
     patchShebangs build
@@ -34,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A new unix shell";
-    homepage = https://www.oilshell.org/;
+    homepage = "https://www.oilshell.org/";
 
     license = with lib.licenses; [
       psfl # Includes a portion of the python interpreter and standard library


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lheckemann