### PR TITLE
linux config: add support for xdp sockets and ebpf jit

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -24,6 +24,13 @@ let
   # configuration items have to be part of a subattrs
   flattenKConf =  nested: mapAttrs (_: head) (zipAttrs (attrValues nested));
 
+  whenPlatformHasEBPFJit =
+    mkIf (stdenv.hostPlatform.isAarch32 ||
+          stdenv.hostPlatform.isAarch64 ||
+          stdenv.hostPlatform.isx86_64 ||
+          (stdenv.hostPlatform.isPowerPC && stdenv.hostPlatform.is64bit) ||
+          (stdenv.hostPlatform.isMips && stdenv.hostPlatform.is64bit));
+
   options = {
 
     debug = {
@@ -106,7 +113,12 @@ let
       IP_DCCP_CCID3      = no; # experimental
       CLS_U32_PERF       = yes;
       CLS_U32_MARK       = yes;
-      BPF_JIT            = mkIf (stdenv.hostPlatform.system == "x86_64-linux") yes;
+      BPF_JIT            = whenPlatformHasEBPFJit yes;
+      BPF_JIT_ALWAYS_ON  = whenPlatformHasEBPFJit yes;
+      HAVE_EBPF_JIT      = whenPlatformHasEBPFJit yes;
+      BPF_STREAM_PARSER  = whenAtLeast "4.19" yes;
+      XDP_SOCKETS        = whenAtLeast "4.19" yes;
+      XDP_SOCKETS_DIAG   = whenAtLeast "4.19" yes;
       WAN                = yes;
       # Required by systemd per-cgroup firewalling
       CGROUP_BPF                  = option yes;


### PR DESCRIPTION
xdp socket support (AF_XDP) is the new way of implementing high
performance networking on linux. on arch linux and debian this is
already enabled (checked via the links from the nixos manual).

moreover, these flags are suggested by the bpf documentation at cilium:

https://cilium.readthedocs.io/en/latest/bpf/#compiling-the-kernel

additionally the flag `BPF_JIT_ALWAYS_ON` on was suggested to help
spectre attack mitigations:

https://github.com/torvalds/linux/commit/290af86629b25ffd1ed6232c4e9107da031705cb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Mic92 @flokli 
