### PR TITLE
xits-math: fonttools requires python3

### DIFF
--- a/pkgs/data/fonts/xits-math/default.nix
+++ b/pkgs/data/fonts/xits-math/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python2Packages, fontforge }:
+{ stdenv, fetchFromGitHub, python3Packages}:
 
 stdenv.mkDerivation rec {
   pname = "xits-math";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "043g0gnjc7wn1szvrs0rc1vvrq1qmhqh45b0y2kwrlxsgprpv8ll";
   };
 
-  nativeBuildInputs = [ fontforge ] ++ (with python2Packages; [ python fonttools ]);
+  nativeBuildInputs = (with python3Packages; [ python fonttools fontforge ]);
 
   postPatch = ''
     rm *.otf

--- a/pkgs/data/fonts/xits-math/default.nix
+++ b/pkgs/data/fonts/xits-math/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xits-math";
-  version = "1.200";
+  version = "1.301";
 
   src = fetchFromGitHub {
     owner = "alif-type";
     repo = "xits";
     rev = "v${version}";
-    sha256 = "0s1qqqg3zv9k4wqn1vkx0z895fjccg96n58syc1d5f2wba9kyfcm";
+    sha256 = "043g0gnjc7wn1szvrs0rc1vvrq1qmhqh45b0y2kwrlxsgprpv8ll";
   };
 
   nativeBuildInputs = [ fontforge ] ++ (with python2Packages; [ python fonttools ]);

--- a/pkgs/data/fonts/xits-math/default.nix
+++ b/pkgs/data/fonts/xits-math/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/khaledhosny/xits-math;
+    homepage = "https://github.com/alif-type/xits";
     description = "OpenType implementation of STIX fonts with math support";
     license = licenses.ofl;
     platforms = platforms.all;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update xits-math and fix #72164.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar 
