### PR TITLE
nftables: update build configuration

### DIFF
--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -1,7 +1,9 @@
-{ stdenv, fetchurl, pkgconfig, bison, flex
+{ stdenv, fetchurl, pkgconfig, bison, file, flex
 , asciidoc, libxslt, findXMLCatalogs, docbook_xml_dtd_45, docbook_xsl
 , libmnl, libnftnl, libpcap
 , gmp, jansson, readline
+, withDebugSymbols ? false
+, withPython ? false , python3
 , withXtables ? false , iptables
 }:
 
@@ -16,19 +18,27 @@ stdenv.mkDerivation rec {
     sha256 = "1x8kalbggjq44j4916i6vyv1rb20dlh1dcsf9xvzqsry2j063djw";
   };
 
-  configureFlags = [
-    "--with-json"
-  ] ++ optional withXtables "--with-xtables";
-
   nativeBuildInputs = [
-    pkgconfig bison flex
-    asciidoc libxslt findXMLCatalogs docbook_xml_dtd_45 docbook_xsl
+    pkgconfig bison file flex
+    asciidoc docbook_xml_dtd_45 docbook_xsl findXMLCatalogs libxslt 
   ];
 
   buildInputs = [
     libmnl libnftnl libpcap
-    gmp readline jansson
-  ] ++ optional withXtables iptables;
+    gmp jansson readline
+  ] ++ optional withXtables iptables
+    ++ optional withPython python3;
+
+  preConfigure = ''
+    substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file
+  '';
+
+  configureFlags = [
+    "--with-json"
+  ] ++ optional (!withDebugSymbols) "--disable-debug"
+    ++ optional (!withPython) "--disable-python"
+    ++ optional withPython "--enable-python"
+    ++ optional withXtables "--with-xtables";
 
   meta = {
     description = "The project that aims to replace the existing {ip,ip6,arp,eb}tables framework";


### PR DESCRIPTION
###### Motivation for this change
Add custom options:
 - `withDebugSymbols `- build with debug symbols
 - `withPython` - build with python package

Fix error:
`./configure: line 7055: /usr/bin/file: No such file or directory`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
