### PR TITLE
davmail: 5.2.0 -> 5.4.0

### DIFF
--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   pname = "davmail";
-  version = "5.2.0";
+  version = "5.4.0";
   src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${version}/${pname}-${version}-2961.zip";
-    sha256 = "0jw6sjg7k7zg8ab0srz6cjjj5hnw5ppxx1w35sw055dlg54fh2m5";
+    url = "mirror://sourceforge/${pname}/${version}/${pname}-${version}-3135.zip";
+    sha256 = "05n2j5canh046744arvni6yfdsandvjkld93w3p7rg116jrh19gq";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A *lot* of things changed between 5.2.0 and 5.4.0 including security fixes (should it be backported?)

```
##DavMail 5.4.0 2019-11-11
Main new feature is experimental support for stored Oauth tokens with davmail.oauth.persistToken=true,
tokens are stored encrypted with client provided password.
Also improved SPECIAL-USE IMAP support and fixed a few regressions related to ExchangeSessionFactory refactoring
and a lot of bug fixed from user feedback.

###Enhancements:
- Add sonar target to ant build
- Sonar configuration
- Add sonarqube-ant-task to lib
- Throw NoSuchElementException in message iterator for iteration beyond the end of the collection
- InterruptedException should not be ignored
- currentVersion is never null
- Make AbstractConnection abstract
- Update default user agent to latest version of Edge on Windows
- Add .gitignore file
- Update StringEncryptor to Java 8
- Update Maven and Ant build to Java 1.8
- Drop Java 7 in travis config
- Add {AES} prefix to encrypted strings
- Improve StringEncryptor compatibility with older jdks
- Ignore stream errors on disconnect, messages cleanup
- Testcase for password based string encryptor
- Implement password based string encryptor
- Refactor settings save to preserve comments
- Force Trusty in Travis config

###Appveyor:
- Appveyor: Update to ant 1.10.7
- Appveyor: test JDK 12 and 13 build

###Security:
- Security: secure XML transformer
- Security: Untrusted XML should be parsed without resolving external data

###SWT:
- SWT: Refactor the synchronisation mechanism to not use a Thread instance as a monitor

###LDAP:
- LDAP: Add a note to Thunderbird directory config on uid=username syntax

###IMAP:
- IMAP: implement RETURN (SPECIAL-USE) in IMAP list command, return special folders only, fix for https://sourceforge.net/p/davmail/bugs/721
- IMAP: allow recursive search on public folders

###Carddav:
- Carddav: iOS does not support VCard 4, detect its old Carddav client and send VCard 3 content, exclude unsupported distribution list items

###Caldav:
- Caldav: do not try to send cancel notifications on shared and public calendars

###EWS:
- EWS: allow O365Manual in headless mode
- EWS: implement command line mode for O365ManualAuthenticator, as suggested in https://github.com/mguessan/davmail/issues/48
- EWS: exchangecookie is not a good check of successful authentication
- EWS: detect direct EWS even if mode is different
- EWS: experimental, store Oauth refresh tokens in davmail.properties when davmail.oauth.persistToken=true
- EWS: fix /public and /archive folders access over EWS
- EWS: improve O365Authenticator error detection 
- EWS: fix access to /public folder
- EWS: Try to improve O365 authentication with ADFS tenants

###Documentation:
- Doc: fix trusterbird link on home page

###Linux:
- Linux: switch spec file to java-1.8.0
- Linux: prepare rhel8 support

###SMTP:
- SMTP: fix #720 Davmail returns 503 instead of 530 when trying to send mail before authentication

## DavMail 5.3.1 2019-08-12
Bugfix release to fix NTLM authentication for some Exchange on premise instances.
Also includes a new OSX handlers implementation required to support recent OSX JDKs.

###Enhancements:
- Reprocess credentials in addNTLM
- Use github download link instead of direct sourceforge link in About dialog
- Improve ExchangeFormAuthenticator logging

###EWS:
- EWS: fix possible bug with username with authenticatorClass
- EWS: add an Open button to O365ManualAuthenticatorDialog in case links are not working
- EWS: fix regression in OWA authentication mode, enable NTLM if required by EWS endpoint

###OSX:
- OSX: comment zulufx jre embed
- OSX: prepare zulufx jre embed
- OSX: drop old OSXAdapter
- OSX: cleanup unused methods
- OSX: no need to register QuitHandler, default is fine
- OSX: implement new Desktop handlers on Java 9 and later, keep compatibility with com.apple.eawt.Application

## DavMail 5.3.0 2019-08-06
Major update with a focus on O365 and MFA support, this release includes a new davmail.userWhiteList
setting to filter users by email or domain. We now have a more modern responsive site thanks to new Maven skin.
Migration to HttpClient 4 is in progress but not finished yet.

###Enhancements:
- Cleanup from audit
- Update Maven POM
- Implement a new davmail.userWhiteList setting to only allow limited users and/or domains, see https://github.com/mguessan/davmail/issues/47
value is a comma separated list of emails or domains (user@company.com or @company.com)
- Cleanup: remove duplicate code

###IMAP:
- IMAP: additional folder test case
- IMAP: Fix #714 StringIndexOutOfBoundsException with NOT UID condition
- IMAP: fix https://github.com/mguessan/davmail/issues/35, Result of of a mailbox search is different between search and uid_search
- IMAP: try to encode invalid character ( and ) in keywords
- IMAP: fix #708 issue, more generic patch when folder name starts with a special folder name
- IMAP: fix #708 issue with folder name that starts with Inbox
- IMAP: encode greater than character in folder name

###HTTP:
- Fix logger and remove old httpClient dependency in HttpClientAdapter
- HTTP: Full Http Client 4 form authentication module
- HTTP: experimental Http Client 4 authenticator
- HTTP: Implement execute with custom local context and manage cookies
- HTTP: cleanup from audit
- HTTP: remove form authentication code from ExchangeSession
- HTTP: Switch to new ExchangeFormAuthenticator
- HTTP: adjust RestRequest for HttpClient 4 Exchange DAV requests
- HTTP: implement HttpClient 4 Exchange DAV requests
- HTTP: prepare major refactoring, extract form authentication from ExchangeSession
- HTTP: migrate O365Token to HttpClient4
- HTTP: remove last dependencies to HttpClient3 in URIUtil
- HTTP: set logging levels for HttpClient 4
- HTTP: improve request implementation
- HTTP: move requests to new package
- HTTP: improve REST request
- HTTP: Accept String urls in GetRequest and PostRequest
- HTTP: switch to GetRequest in getReleasedVersion
- HTTP: Http Client 4 GET and POST request wrappers
- HTTP: a few more test cases
- HTTP: improve HttpClientAdapter interface
- HTTP: switch check released version to HttpClient 4
- HTTP: implement Get and Rest requests with HttpClient 4
- HTTP: reenable basic proxy authentication on Java >= 1.8.111 in HttpClientAdapter
- HTTP: reimplement URIUtil to prepare HttpClient 4 migration
- HTTP: Cleanup from audit
- HTTP: reenable basic proxy authentication on Java >= 1.8.111: jdk.http.auth.tunneling.disabledSchemes=""
- HTTP: Implement JCIFS NTLM authentication with HttpClient 4

###GUI:
- GUI: translate disableTrayActivitySwitch messages
- GUI: merge Add davmail.disableTrayActivitySwitch to disable tray icon activity, see https://github.com/mguessan/davmail/pull/28

###EWS:
- EWS: O365Manual add mode in Settings
- EWS: O365Manual enable in ExchangeSessionFactory
- EWS: O365Manual missing label
- EWS: add davmail.oauth.tenantId setting to GUI and documentation
- EWS: create a new davmail.oauth.tenantId setting to set actual company tenant
- EWS: additional cases for Microsoft account authentication
- EWS: refactor O365 interactive to always use an HttpURLConnectionWrapper
- EWS: Fix error handling in manual authentication failover
- EWS: fix NPE in manual authenticator
- EWS: do not force user agent in O365 interactive authenticator, breaks Microsoft login form browser detection
- EWS: improve Okta support in O365 interactive authenticator
- EWS: prepare tenant independent authenticator: do not hard code /common/
- EWS: always enable interactive authenticator in settings now that we have a failover without JavaFX
- EWS: i18n manual authentication messages
- EWS: Prepare a failover manual authenticator when OpenJFX is not available
- EWS: merge https://github.com/mguessan/davmail/pull/26, Added input names for form authentication
- EWS: do not call addNTLM in ExchangeSessionFactory to avoid kerberos configuration conflict
- EWS: fix regression to correctly detect network down
- EWS: fix regression, do not force user-agent in 0365 interactive authenticator
- EWS: cleanup from audit
- EWS: O36 authenticators cleanup from audit
- EWS: use ConvertId to retrieve current mailbox primary SMTP address, more reliable than ResolveNames
- EWS: migrate O365Authenticator to HttpClient 4
- EWS: remove duplicate code in O365 interactive authenticator
- EWS: improve interactive authenticator, adjust integrity workaround for Okta
- EWS: improve interactive authenticator, adjust integrity workaround and catch javascript errors
- EWS: Apply integrity disable workaround to Okta form second step
- EWS: use URIBuilder instead of URIUtil to build URI
- EWS: fix support for new Okta authentication form, need to disable integrity check
- EWS: drop old Autodiscover failover, need to implement before authentication instead
- EWS: log connection errors in O365InteractiveAuthenticator
- EWS: new AutoDiscoverMethod implementation
- EWS: improve O365 token logging

###Linux:
- Linux: adjust AWT tray icon for Linux Mint Cinnamon
- Linux: Merge patch, add JFX_CLASSPATH when SWT3 is available
- Linux: Fix spec file for copr

###Unix:
- Unix: failover to xdg-open on both Linux and Freebsd

###Documentation:
- Doc: fix title in page
- Doc: improved site skin with collapsible sidebar
- Doc: upgrade Maven Javadoc plugin
- Doc: Switch to modern responsive Maven fluido skin
- Doc: Switch to modern responsive Maven reflow skin

###DAV:
- DAV: cleanup from audit
- DAV: remove dependency to old URIException

###Caldav:
- Caldav: cleanup from audit
- Caldav: send 404 not found instead of 400 for unknown requests
- Caldav: Do not try to update event is X-MOZ-FAKED-MASTER is set
- Caldav: fix test case

###OSX:
- OSX: merge patch #54 Set NSSupportsAutomaticGraphicsSwitching to Yes to prevent macOS GPU access

###SWT:
- SWT: merge duplicate code
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @larkery 
