### PR TITLE
Update deepin packages

### DIFF
--- a/pkgs/desktops/deepin/dde-api/default.nix
+++ b/pkgs/desktops/deepin/dde-api/default.nix
@@ -24,7 +24,7 @@
 
 buildGoPackage rec {
   pname = "dde-api";
-  version = "3.18.4.1";
+  version = "5.0.0";
 
   goPackagePath = "pkg.deepin.io/dde/api";
 
@@ -32,7 +32,7 @@ buildGoPackage rec {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0bcjp5ijwa4wmx6p43lik6vjlb7d5rk7nf8xl495i3yk9x70wyfa";
+    sha256 = "0iv4krj6dqdknwvmax7aj40k1h96259kqcfnljadrwpl7cvsvp5p";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/desktops/deepin/dde-api/deps.nix
+++ b/pkgs/desktops/deepin/dde-api/deps.nix
@@ -5,8 +5,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/alecthomas/template";
-      rev = "a0175ee3bccc567396460bf5acd36800cb10c49c";
-      sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
+      rev = "fb15b899a75114aa79cc930e33c46b577cc664b1";
+      sha256 = "1vlasv4dgycydh5wx6jdcvz40zdv90zz1h7836z7lhsi2ymvii26";
     };
   }
   {
@@ -14,8 +14,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/alecthomas/units";
-      rev = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a";
-      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+      rev = "f65c72e2690dc4b403c8bd637baf4611cd4c069b";
+      sha256 = "04jyqm7m3m01ppfy1f9xk4qvrwvs78q9zml6llyf2b3v5k6b2bbc";
     };
   }
   {
@@ -32,8 +32,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/disintegration/imaging";
-      rev = "465faf0892b5c7b3325643b0e47282e1331672e7";
-      sha256 = "1z9rkphmqgyphznl53pp1gmf0dfrfrmr95bx46p422ldml26c5a0";
+      rev = "9aab30e6aa535fe3337b489b76759ef97dfaf362";
+      sha256 = "015amm3x989hl3r4gxnixj602fl9j8z53n0lrq804cbfbk7a31fw";
     };
   }
   {
@@ -41,8 +41,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/fogleman/gg";
-      rev = "f194ddec6f45226fc9e1b4a61b7237f186edd543";
-      sha256 = "095g5hpqvpy5w9l4kb65cif013snsvlbw6sgln0kwdix0z099j3i";
+      rev = "4dc34561c649343936bb2d29e23959bd6d98ab12";
+      sha256 = "1x1finzdrr80dd3r7wvf7zb184yjf4dawz7s581p2dr64dcialww";
     };
   }
   {
@@ -77,8 +77,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/image";
-      rev = "7e034cad644213bc79b336b52fce73624259aeca";
-      sha256 = "04n4yi0p2yjv8sr9dmnzwc2k6hvzzvl6jdq2xd043kvjwzk583va";
+      rev = "e7c1f5e7dbb87d8921928a6d9fc52fb31ce73b24";
+      sha256 = "0czp897aicqw1dgybj0hc2zzwb20rhqkdqm7siqci3yk7yk9cymf";
     };
   }
   {
@@ -86,8 +86,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev = "3b0461eec859c4b73bb64fdc8285971fd33e3938";
-      sha256 = "0l00c8l0a8xnv6qdpwfzxxsr58jggacgzdrwiprrfx2xqm37b6d5";
+      rev = "daa7c04131f568e31c51927b359a2d197a357058";
+      sha256 = "17gbfvb5iqyayzw0zd6q218zsbf7x74rflvn18wkxvsw95n1y54h";
     };
   }
   {

--- a/pkgs/desktops/deepin/dde-calendar/default.nix
+++ b/pkgs/desktops/deepin/dde-calendar/default.nix
@@ -4,13 +4,13 @@
 
 mkDerivation rec {
   pname = "dde-calendar";
-  version = "1.2.10";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "00aqx24jccf88vvkpb9svyjz8knrqyjgd0152psf9dxc9q13f61h";
+    sha256 = "1zzr3crkz4l5l135y0m53vqhv7fkrbvbspk8295swz9gsm3f7ah9";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dde-control-center/default.nix
+++ b/pkgs/desktops/deepin/dde-control-center/default.nix
@@ -8,13 +8,13 @@
 
 mkDerivation rec {
   pname = "dde-control-center";
-  version = "4.10.11";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1ip8wjwf0n9q8xnqymzh8lz0j5gcnns976n291np6k5kdh2wqhr5";
+    sha256 = "10bx8bpvi3ib32a3l4nyb1j0iq3bch8jm9wfm6d5v0ym1zb92x3b";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dde-daemon/default.nix
+++ b/pkgs/desktops/deepin/dde-daemon/default.nix
@@ -8,7 +8,7 @@
 
 buildGoPackage rec {
   pname = "dde-daemon";
-  version = "3.27.2.6";
+  version = "5.0.0";
 
   goPackagePath = "pkg.deepin.io/dde/daemon";
 
@@ -16,7 +16,7 @@ buildGoPackage rec {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "14g138h23f1lh1y98pdrfhnph1m7pw8lq8ypiwv9qf3fmdyn35d4";
+    sha256 = "08jri31bvzbaxaq78rpp46ndv0li2dij63hakvd9b9gs786srql1";
   };
 
   patches = [

--- a/pkgs/desktops/deepin/dde-daemon/deps.nix
+++ b/pkgs/desktops/deepin/dde-daemon/deps.nix
@@ -5,8 +5,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/alecthomas/template";
-      rev = "a0175ee3bccc567396460bf5acd36800cb10c49c";
-      sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
+      rev = "fb15b899a75114aa79cc930e33c46b577cc664b1";
+      sha256 = "1vlasv4dgycydh5wx6jdcvz40zdv90zz1h7836z7lhsi2ymvii26";
     };
   }
   {
@@ -14,8 +14,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/alecthomas/units";
-      rev = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a";
-      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+      rev = "f65c72e2690dc4b403c8bd637baf4611cd4c069b";
+      sha256 = "04jyqm7m3m01ppfy1f9xk4qvrwvs78q9zml6llyf2b3v5k6b2bbc";
     };
   }
   {
@@ -77,8 +77,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/image";
-      rev = "7e034cad644213bc79b336b52fce73624259aeca";
-      sha256 = "04n4yi0p2yjv8sr9dmnzwc2k6hvzzvl6jdq2xd043kvjwzk583va";
+      rev = "e7c1f5e7dbb87d8921928a6d9fc52fb31ce73b24";
+      sha256 = "0czp897aicqw1dgybj0hc2zzwb20rhqkdqm7siqci3yk7yk9cymf";
     };
   }
   {
@@ -86,8 +86,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev = "3b0461eec859c4b73bb64fdc8285971fd33e3938";
-      sha256 = "0l00c8l0a8xnv6qdpwfzxxsr58jggacgzdrwiprrfx2xqm37b6d5";
+      rev = "daa7c04131f568e31c51927b359a2d197a357058";
+      sha256 = "17gbfvb5iqyayzw0zd6q218zsbf7x74rflvn18wkxvsw95n1y54h";
     };
   }
   {
@@ -95,8 +95,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/text";
-      rev = "342b2e1fbaa52c93f31447ad2c6abc048c63e475";
-      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+      rev = "4b67af870c6ffd08258ef1202f371aebccaf7b68";
+      sha256 = "01mhy1xs2dh18kp6wdk1xnb34lbzv2qkvdwj7w5ha2qgm5rrm4ik";
     };
   }
   {

--- a/pkgs/desktops/deepin/dde-dock/default.nix
+++ b/pkgs/desktops/deepin/dde-dock/default.nix
@@ -7,13 +7,13 @@
 let
 unwrapped = mkDerivation rec {
   pname = "dde-dock";
-  version = "4.10.3";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "17iy78r0frpv42g521igfdcgdklbifzig1wzxq2nl14fq0bgxg4v";
+    sha256 = "12dshsqhzajnxm7r53qg0c84b6xlj313qnssnx2m25z4jdp5i7pr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dde-file-manager/default.nix
+++ b/pkgs/desktops/deepin/dde-file-manager/default.nix
@@ -1,22 +1,23 @@
-{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, avfs, dde-daemon, dde-dock,
-  dde-polkit-agent, dde-qt-dbus-factory, deepin, deepin-anything,
-  deepin-desktop-schemas, deepin-gettext-tools, deepin-movie-reborn,
-  deepin-shortcut-viewer, deepin-terminal, dtkcore, dtkwidget,
-  ffmpegthumbnailer, file, glib, gnugrep, gsettings-qt, gvfs,
-  jemalloc, kcodecs, libX11, libsecret, polkit, polkit-qt, poppler,
-  procps, qmake, qt5integration, qtmultimedia, qtsvg, qttools,
-  qtx11extras, runtimeShell, samba, shadow, taglib, udisks2-qt5,
-  xdg-user-dirs, xorg, zlib, wrapGAppsHook }:
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, avfs, dde-daemon,
+  dde-dock, dde-polkit-agent, dde-qt-dbus-factory, deepin,
+  deepin-anything, deepin-desktop-schemas, deepin-gettext-tools,
+  deepin-movie-reborn, deepin-shortcut-viewer, deepin-terminal,
+  disomaster, dtkcore, dtkwidget, ffmpegthumbnailer, file, glib,
+  gnugrep, gsettings-qt, gvfs, jemalloc, kcodecs, libX11, libsecret,
+  polkit, polkit-qt, poppler, procps, qmake, qt5integration,
+  qtmultimedia, qtsvg, qttools, qtx11extras, runtimeShell, samba,
+  shadow, taglib, udisks2-qt5, xdg-user-dirs, xorg, zlib,
+  wrapGAppsHook }:
 
 mkDerivation rec {
   pname = "dde-file-manager";
-  version = "4.8.6.4";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1m0ykw5a91rm5xcah8bzk21xsambqvncj8104ihdhf9h0z9kdmm2";
+    sha256 = "0n2nl09anqdq0n5yn688n385rn81lcpybs0sa8m311k3k9ndkkyr";
   };
 
   nativeBuildInputs = [
@@ -39,6 +40,7 @@ mkDerivation rec {
     deepin-movie-reborn.dev
     deepin-shortcut-viewer
     deepin-terminal
+    disomaster
     dtkcore
     dtkwidget
     ffmpegthumbnailer

--- a/pkgs/desktops/deepin/dde-launcher/default.nix
+++ b/pkgs/desktops/deepin/dde-launcher/default.nix
@@ -5,13 +5,13 @@
 
 mkDerivation rec {
   pname = "dde-launcher";
-  version = "4.6.13";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1lwwn2qjbd4i7wx18mi8n7hzdh832i3kdadrivr10sbafdank7ky";
+    sha256 = "0zh6bb0r3pgjrnw9rba46ghdzza1ka1mv7r1znf8gw24wsjgjcpn";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dde-network-utils/default.nix
+++ b/pkgs/desktops/deepin/dde-network-utils/default.nix
@@ -3,13 +3,13 @@
 
 mkDerivation rec {
   pname = "dde-network-utils";
-  version = "0.1.4";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0nj9lf455lf2hyqv6xwhm4vrr825ldbl83azzrrzqs6p781x65i1";
+    sha256 = "0670kfnkplf7skkd1ql6y9x15kmrcbdv1005qwkg4vn8hic6s0z3";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dde-polkit-agent/default.nix
+++ b/pkgs/desktops/deepin/dde-polkit-agent/default.nix
@@ -3,13 +3,13 @@
 
 mkDerivation rec {
   pname = "dde-polkit-agent";
-  version = "0.2.10";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0syg121slpd6d9xpifgcf85lg9ca0k96cl1g3rjvsmczs2d2ffgf";
+    sha256 = "00p8syx6rfwhq7wdsk37hm9mvwd0kwj9h0s39hii892h1psd84q9";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dde-qt-dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/dde-qt-dbus-factory/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dde-qt-dbus-factory";
-  version = "1.1.5";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1jzfblsmnfpgym95mmbd8mjkk8wqqfb0kz6n6fy742hmqlzrpsj7";
+    sha256 = "1wbh4jgvy3c09ivy0vvfk0azkg4d2sv37y23c9rq49jb3sakcjgm";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dde-session-ui/default.nix
+++ b/pkgs/desktops/deepin/dde-session-ui/default.nix
@@ -7,13 +7,13 @@
 
 mkDerivation rec {
   pname = "dde-session-ui";
-  version = "4.9.12";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "00i45xv87wx9cww1d445lg6zjbhda5kki8nhsaav8gf2d4cmwzf4";
+    sha256 = "1gy9nlpkr9ayrs1z2dvd7h0dqlw6fq2m66d9cs48qyfkr6c8l9jj";
   };
 
   nativeBuildInputs = [
@@ -89,8 +89,8 @@ mkDerivation rec {
     substituteInPlace lightdm-deepin-greeter/scripts/lightdm-deepin-greeter --replace "/usr/bin/lightdm-deepin-greeter" "$out/bin/lightdm-deepin-greeter"
     substituteInPlace session-ui-guardien/guardien.cpp --replace "dde-lock" "$out/bin/dde-lock"
     substituteInPlace session-ui-guardien/guardien.cpp --replace "dde-shutdown" "$out/bin/dde-shutdown"
-    substituteInPlace session-widgets/lockworker.cpp --replace "dde-switchtogreeter" "$out/bin/dde-switchtogreeter"
-    substituteInPlace session-widgets/lockworker.cpp --replace "which" "${which}/bin/which"
+    substituteInPlace dde-lock/lockworker.cpp --replace "dde-switchtogreeter" "$out/bin/dde-switchtogreeter"
+    substituteInPlace dde-lock/lockworker.cpp --replace "which" "${which}/bin/which"
     substituteInPlace session-widgets/userinfo.cpp --replace "/usr/share/wallpapers/deepin" "${deepin-wallpapers}/share/wallpapers/deepin"
     substituteInPlace widgets/fullscreenbackground.cpp --replace "/usr/share/wallpapers/deepin" "${deepin-wallpapers}/share/wallpapers/deepin"
     substituteInPlace widgets/kblayoutwidget.cpp --replace "setxkbmap" "${setxkbmap}/bin/setxkbmap"

--- a/pkgs/desktops/deepin/deepin-anything/default.nix
+++ b/pkgs/desktops/deepin/deepin-anything/default.nix
@@ -3,7 +3,7 @@
 
 mkDerivation rec {
   pname = "deepin-anything";
-  version = "0.1.0";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";

--- a/pkgs/desktops/deepin/deepin-calculator/default.nix
+++ b/pkgs/desktops/deepin/deepin-calculator/default.nix
@@ -3,13 +3,13 @@
 
 mkDerivation rec {
   pname = "deepin-calculator";
-  version = "1.0.11";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "10bfq0h8v0a8i46gcbsy79l194g8sc0ysg289ndrra209fhwlidq";
+    sha256 = "0f26y7b3giybybhvlzbnwcw8kidzvhq66h0c15n9ww81gnlqf7v5";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/deepin-desktop-base/default.nix
+++ b/pkgs/desktops/deepin/deepin-desktop-base/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "deepin-desktop-base";
-  version = "2019.06.19";
+  version = "2019.07.10";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1r158x4z4qalv4q1ni3aln05krdzblvr7y6wyciwl7cr5ag1i1jy";
+    sha256 = "0rs7bjy35k5gc5nbba1cijhdz16zny30lgmcf2ckx1pkdszk2vra";
   };
 
   nativeBuildInputs = [ deepin.setupHook ];

--- a/pkgs/desktops/deepin/deepin-desktop-schemas/default.nix
+++ b/pkgs/desktops/deepin/deepin-desktop-schemas/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "deepin-desktop-schemas";
-  version = "3.13.6";
+  version = "3.13.9";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "03jqb47kjyb9b43m2yincfjn2i43ma1pn1hddyicrrpg937caa81";
+    sha256 = "1c69j6s7561zb1hrd1j3ihji1nvpgfzfgnp6svsv8jd8dg8vs8l1";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/deepin-image-viewer/default.nix
+++ b/pkgs/desktops/deepin/deepin-image-viewer/default.nix
@@ -5,13 +5,13 @@
 
 mkDerivation rec {
   pname = "deepin-image-viewer";
-  version = "1.3.17";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0hz4f1kqcycyvggwfzpkblhhha87rqd427hq0mf31jfh5x17ymnh";
+    sha256 = "01524hfdy3wvdf07n9b3qb8jdpxzg2hwjpl4gxvr68qws5nbnb3c";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/deepin-movie-reborn/default.nix
+++ b/pkgs/desktops/deepin/deepin-movie-reborn/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qttools, qtx11extras,
+{ stdenv, mkDerivation, fetchFromGitHub, fetchpatch, cmake, pkgconfig, qttools, qtx11extras,
   dtkcore, dtkwidget, ffmpeg, ffmpegthumbnailer, mpv, pulseaudio,
   libdvdnav, libdvdread, xorg, deepin }:
 
 mkDerivation rec {
   pname = "deepin-movie-reborn";
-  version = "3.2.24";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "16mxym7dm6qk90q2w7xqm62047rq0lirrjmnnpaxshzaww9gngkh";
+    sha256 = "0cly8q0514a58s3h3wsvx9yxar7flz6i2q8xkrkfjias22b3z7b0";
   };
 
   outputs = [ "out" "dev" ];
@@ -19,6 +19,7 @@ mkDerivation rec {
     cmake
     pkgconfig
     qttools
+    deepin.setupHook
   ];
 
   buildInputs = [
@@ -37,11 +38,24 @@ mkDerivation rec {
     xorg.xcbproto
   ];
 
+  patches = [
+    # fix: build failed if cannot find dtk-settings tool
+    (fetchpatch {
+      url = "https://github.com/linuxdeepin/deepin-movie-reborn/commit/fbb307b.patch";
+      sha256 = "0915za0khki0729rvcfpxkh6vxhqwc47cgcmjc90kfq1004221vx";
+    })
+  ];
+
   NIX_LDFLAGS = "-ldvdnav";
 
+
   postPatch = ''
-    sed -i src/CMakeLists.txt -e "s,/usr/lib/dtk2,${dtkcore}/lib/dtk2,"
+    searchHardCodedPaths  # debugging
+
     sed -i src/libdmr/libdmr.pc.in -e "s,/usr,$out," -e 's,libdir=''${prefix}/,libdir=,'
+
+    substituteInPlace src/deepin-movie.desktop \
+      --replace "Exec=deepin-movie" "Exec=$out/bin/deepin-movie"
   '';
 
   passthru.updateScript = deepin.updateScript { inherit ;name = "${pname}-${version}"; };

--- a/pkgs/desktops/deepin/deepin-screenshot/default.nix
+++ b/pkgs/desktops/deepin/deepin-screenshot/default.nix
@@ -4,13 +4,13 @@
 
 mkDerivation rec {
   pname = "deepin-screenshot";
-  version = "4.2.1";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "16wy1ywp4lm7fg488laqxgxpir745rbpj9z410r6x7krpgjds189";
+    sha256 = "0h1kcf9i8q6rz4jhym3yf84zr6svzff0hh9sl7b24sflzkxx6zwk";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/deepin-shortcut-viewer/default.nix
+++ b/pkgs/desktops/deepin/deepin-shortcut-viewer/default.nix
@@ -3,7 +3,7 @@
 
 mkDerivation rec {
   pname = "deepin-shortcut-viewer";
-  version = "1.3.5";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";

--- a/pkgs/desktops/deepin/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/deepin-terminal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, ninja, vala_0_44,
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, ninja, vala_0_40,
   gettext, at-spi2-core, dbus, epoxy, expect, gtk3, json-glib,
   libXdmcp, libgee, libpthreadstubs, librsvg, libsecret, libtasn1,
   libxcb, libxkbcommon, p11-kit, pcre, vte, wnck, libselinux, gnutls, pcre2,
@@ -6,20 +6,20 @@
 
 stdenv.mkDerivation rec {
   pname = "deepin-terminal";
-  version = "3.2.6";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = "deepin-terminal";
     rev = version;
-    sha256 = "09s5gvzfxfb353kb61x1b6z3h2aqgln3s3mah3f3zkf5y8hrp2pj";
+    sha256 = "1929saj828b438d07caw3cjhqq60v6gni7mi3fqrg9wdjz81xwv7";
   };
 
   nativeBuildInputs = [
     pkgconfig
     cmake
     ninja
-    vala_0_44 # xcb.vapi:411.3-411.48: error: missing return statement at end of subroutine body
+    vala_0_40 # xcb.vapi:411.3-411.48: error: missing return statement at end of subroutine body
     gettext
     libselinux libsepol utillinux # required by gio
     deepin.setupHook

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -37,6 +37,7 @@ let
     };
     deepin-turbo = callPackage ./deepin-turbo { };
     deepin-wallpapers = callPackage ./deepin-wallpapers { };
+    disomaster = callPackage ./disomaster { };
     dpa-ext-gnomekeyring = callPackage ./dpa-ext-gnomekeyring { };
     dtkcore = callPackage ./dtkcore { };
     dtkwidget = callPackage ./dtkwidget { };

--- a/pkgs/desktops/deepin/disomaster/default.nix
+++ b/pkgs/desktops/deepin/disomaster/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, qtbase, libisoburn, deepin }:
+
+mkDerivation rec {
+  pname = "disomaster";
+  version = "5.0.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "13144gq0mpbpclzxc79fb1kirh0vvi50jvjnbpla9s8lvh59xl62";
+  };
+
+  nativeBuildInputs = [
+    deepin.setupHook
+    pkgconfig
+    qmake
+  ];
+
+  buildInputs = [
+    libisoburn
+    qtbase
+  ];
+
+  postPatch = ''
+    searchHardCodedPaths  # debugging
+
+    sed -i '/^QMAKE_PKGCONFIG_DESTDIR/i QMAKE_PKGCONFIG_PREFIX = $$PREFIX' \
+       libdisomaster/libdisomaster.pro
+  '';
+
+  passthru.updateScript = deepin.updateScript { inherit ;name = "${pname}-${version}"; };
+
+  meta = with stdenv.lib; {
+    description = "A libisoburn wrapper for Qt";
+    homepage = https://github.com/linuxdeepin/disomaster;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo worldofpeace ];
+  };
+}

--- a/pkgs/desktops/deepin/dpa-ext-gnomekeyring/default.nix
+++ b/pkgs/desktops/deepin/dpa-ext-gnomekeyring/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   pname = "dpa-ext-gnomekeyring";
-  version = "0.1.0";
+  version = "5.0.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";

--- a/pkgs/desktops/deepin/dtkcore/default.nix
+++ b/pkgs/desktops/deepin/dtkcore/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "dtkcore";
-  version = "2.0.14";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "0yc6zx8rhzg9mj2brggcsr1jy1pzfvgqy1h305y2dwnx5haazd04";
+    sha256 = "0xdh6mmrv8yr6mjmlwj0fv037parkkwfwlaibcbrskwxqp9iri1y";
   };
 
   nativeBuildInputs = [
@@ -31,12 +31,13 @@ mkDerivation rec {
 
   qmakeFlags = [
     "DTK_VERSION=${version}"
+    "LIB_INSTALL_DIR=${placeholder "out"}/lib"
     "MKSPECS_INSTALL_DIR=${placeholder "out"}/mkspecs"
   ];
 
   postFixup = ''
-    chmod +x $out/lib/dtk2/*.py
-    wrapPythonProgramsIn "$out/lib/dtk2" "$out $pythonPath"
+    chmod +x $out/lib/libdtk-${version}/DCore/bin/*.py
+    wrapPythonProgramsIn "$out/lib/libdtk-${version}/DCore/bin" "$out $pythonPath"
     searchHardCodedPaths $out  # debugging
   '';
 
@@ -45,7 +46,7 @@ mkDerivation rec {
   passthru.updateScript = deepin.updateScript { inherit ;name = "${pname}-${version}"; };
 
   meta = with stdenv.lib; {
-    description = "Deepin tool kit core modules";
+    description = "Deepin tool kit core library";
     homepage = https://github.com/linuxdeepin/dtkcore;
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/desktops/deepin/dtkwidget/default.nix
+++ b/pkgs/desktops/deepin/dtkwidget/default.nix
@@ -4,13 +4,13 @@
 
 mkDerivation rec {
   pname = "dtkwidget";
-  version = "2.0.14";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "11ws0rl7rhlgwbqd4nqpqxhngf4lcyfrrdq33wzxwdlk33d69i1h";
+    sha256 = "0yqrm1p0k1843ldvcd79dxl26ybyl5kljl6vwhzc58sx7pw4qmvh";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/deepin/dtkwm/default.nix
+++ b/pkgs/desktops/deepin/dtkwm/default.nix
@@ -1,15 +1,14 @@
-{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, qtx11extras, dtkcore,
-  deepin }:
+{ stdenv, mkDerivation, fetchFromGitHub, fetchpatch, pkgconfig, qmake, qtx11extras, dtkcore, deepin }:
 
 mkDerivation rec {
   pname = "dtkwm";
-  version = "2.0.11";
+  version = "2.0.12";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "10l89i84vsh5knq9wg2php7vfg5rj5c9hrrl9rjlcidn1rz8yx6f";
+    sha256 = "0rdzzqsggqarldwb4yp5s4sf5czicgxbdmibjn0pw32129r2d1g3";
   };
 
   nativeBuildInputs = [
@@ -20,6 +19,14 @@ mkDerivation rec {
   buildInputs = [
     dtkcore
     qtx11extras
+  ];
+
+  patches = [
+    # Set DTK_MODULE_NAME
+    (fetchpatch {
+      url = "https://github.com/linuxdeepin/dtkwm/commit/2490891a.patch";
+      sha256 = "0krydxjpnaihkgs1n49b6mcf3rd3lkispcnkb1j5vpfs9hp9f48j";
+    })
   ];
 
   outRef = placeholder "out";

--- a/pkgs/desktops/deepin/go-dbus-generator/default.nix
+++ b/pkgs/desktops/deepin/go-dbus-generator/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "go-dbus-generator";
-  version = "0.6.6";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";

--- a/pkgs/desktops/deepin/go-lib/default.nix
+++ b/pkgs/desktops/deepin/go-lib/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "go-lib";
-  version = "1.10.2";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "05z7ayl23cm8mbn4vkn3isy5kgwxljc26ifmzrhmnqm5yibd6lsf";
+    sha256 = "0j1ik5hfrysqgync8cyv815cwyjn67k8n69x6llxdp39jli1k8q0";
   };
 
   buildInputs = [

--- a/pkgs/desktops/deepin/qcef/default.nix
+++ b/pkgs/desktops/deepin/qcef/default.nix
@@ -40,7 +40,7 @@ in
 
 mkDerivation rec {
   pname = "qcef";
-  version = "1.1.6";
+  version = "1.1.7";
 
   srcs = [
     (fetchFromGitHub {
@@ -53,8 +53,8 @@ mkDerivation rec {
     (fetchFromGitHub {
       owner = "linuxdeepin";
       repo = "cef-binary";
-      rev = "059a0c9cef4e289a50dc7a2f4c91fe69db95035e";
-      sha256 = "1h7cq63n94y2a6fprq4g63admh49rcci7avl5z9kdimkhqb2jb84";
+      rev = "fecf00339545d2819224333cc506d5aa22ae8008";
+      sha256 = "06i1zc7ciy7d0qhndiwpjrsii0x5i5hg9j6ddi4w5yf1nzgsrj4n";
       name = "cef-binary";
     })
   ];

--- a/pkgs/desktops/deepin/qt5integration/default.nix
+++ b/pkgs/desktops/deepin/qt5integration/default.nix
@@ -4,7 +4,7 @@
 
 mkDerivation rec {
   pname = "qt5integration";
-  version = "0.3.12";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";

--- a/pkgs/desktops/deepin/udisks2-qt5/default.nix
+++ b/pkgs/desktops/deepin/udisks2-qt5/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "udisks2-qt5";
-  version = "0.0.1";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "1gk4jmq7mrzk181r6man2rz1iyzkfasz7053a30h4nn24mq8ikig";
+    sha256 = "0mqxm6ixzpbg0rr6ly2kvnkpag8gjza67ya7jv4i4rihbq1d0wzi";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update the Deepin Desktop Environment packages to the latest versions.

- deepin.[disomaster](https://github.com/linuxdeepin/disomaster): init at [5.0.0](https://github.com/linuxdeepin/disomaster)
- deepin.dde-api: 3.18.4.1 -> [5.0.0](https://github.com/linuxdeepin/dde-api/releases)
- deepin.dde-calendar: 1.2.10 -> [5.0.1](https://github.com/linuxdeepin/dde-calendar/releases)
- deepin.dde-control-center: 4.10.11 -> [5.0.0](https://github.com/linuxdeepin/dde-control-center/releases)
- deepin.dde-daemon: 3.27.2.6 -> [5.0.0](https://github.com/linuxdeepin/dde-daemon/releases)
- deepin.dde-dock: 4.10.3 -> [5.0.0](https://github.com/linuxdeepin/dde-dock/releases)
- deepin.dde-file-manager: 4.8.6.4 -> [5.0.0](https://github.com/linuxdeepin/dde-file-manager/releases)
- deepin.dde-launcher: 4.6.13 -> [5.0.0](https://github.com/linuxdeepin/dde-launcher/releases)
- deepin.dde-network-utils: 0.1.4 -> [5.0.1](https://github.com/linuxdeepin/dde-network-utils/releases)
- deepin.dde-polkit-agent: 0.2.10 -> [5.0.0](https://github.com/linuxdeepin/dde-polkit-agent/releases)
- deepin.dde-qt-dbus-factory: 1.1.5 -> [5.0.1](https://github.com/linuxdeepin/dde-qt-dbus-factory/releases)
- deepin.dde-session-ui: 4.9.12 -> [5.0.0](https://github.com/linuxdeepin/dde-session-ui/releases)
- deepin.deepin-anything: 0.1.0 -> [5.0.1](https://github.com/linuxdeepin/deepin-anything/releases)
- deepin.deepin-calculator: 1.0.11 -> [5.0.1](https://github.com/linuxdeepin/deepin-calculator/releases)
- deepin.deepin-desktop-base: 2019.06.19 -> [2019.07.10](https://github.com/linuxdeepin/deepin-desktop-base/releases)
- deepin.deepin-desktop-schemas: 3.13.6 -> [3.13.9](https://github.com/linuxdeepin/deepin-desktop-schemas/releases)
- deepin.deepin-image-viewer: 1.3.17 -> [5.0.0](https://github.com/linuxdeepin/deepin-image-viewer/releases)
- deepin.deepin-movie-reborn: 3.2.24 -> [5.0.0](https://github.com/linuxdeepin/deepin-movie-reborn/releases)
- deepin.deepin-screenshot: 4.2.1 -> [5.0.0](https://github.com/linuxdeepin/deepin-screenshot/releases)
- deepin.deepin-shortcut-viewer: 1.3.5 -> [5.0.0](https://github.com/linuxdeepin/deepin-shortcut-viewer/releases)
- deepin.deepin-terminal: 3.2.6 -> [5.0.0](https://github.com/linuxdeepin/deepin-terminal/releases)
- deepin.dpa-ext-gnomekeyring: 0.1.0 -> [5.0.1](https://github.com/linuxdeepin/dpa-ext-gnomekeyring/releases)
- deepin.dtkcore: 2.0.14 -> [2.1.1](https://github.com/linuxdeepin/dtkcore/releases)
- deepin.dtkwidget: 2.0.14 -> [2.1.1](https://github.com/linuxdeepin/dtkwidget/releases)
- deepin.dtkwm: 2.0.11 -> [2.0.12](https://github.com/linuxdeepin/dtkwm/releases)
- deepin.go-dbus-generator: 0.6.6 -> [5.0.0](https://github.com/linuxdeepin/go-dbus-generator/releases)
- deepin.go-lib: 1.10.2 -> [5.0.0](https://github.com/linuxdeepin/go-lib/releases)
- deepin.qcef: 1.1.6 -> [1.1.7](https://github.com/linuxdeepin/qcef/releases)
- deepin.qt5integration: 0.3.12 -> [5.0.0](https://github.com/linuxdeepin/qt5integration/releases)
- deepin.udisks2-qt5: 0.0.1 -> [5.0.0](https://github.com/linuxdeepin/udisks2-qt5/releases)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).