### PR TITLE
freebayes: 2017-08-23 -> 1.3.1 (2019-06-03)

### DIFF
--- a/pkgs/applications/science/biology/freebayes/default.nix
+++ b/pkgs/applications/science/biology/freebayes/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "freebayes";
-  version = "2017-08-23";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     name = "freebayes-${version}-src";
     owner  = "ekg";
     repo   = "freebayes";
-    rev    = "8d2b3a060da473e1f4f89be04edfce5cba63f1d3";
-    sha256 = "0yyrgk2639lz1yvg4jf0ccahnkic31dy77q05pb3i28rjf37v45z";
+    rev    = "v${version}";
+    sha256 = "035nriknjqq8gvil81vvsmvqwi35v80q8h1cw24vd1gdyn1x7bys";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
##### Motivation for this change

Version bump.

A lot of the python scripts in `result/bin` can't be executed (before and after this change) because they don't find the interpreter. Should they be removed or left in place?

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jdagilliland 
