### PR TITLE
makeFontsCache: Fix cross-compilation, use nativeBuildInputs

### DIFF
--- a/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
+++ b/pkgs/development/libraries/fontconfig/make-fonts-cache.nix
@@ -2,7 +2,7 @@
 
 runCommand "fc-cache"
   {
-    buildInputs = [ fontconfig.bin ];
+    nativeBuildInputs = [ fontconfig.bin ];
     preferLocalBuild = true;
     allowSubstitutes = false;
     passAsFile = [ "fontDirs" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This commit fixes missing `fc-cache` binary from the `make-fonts-cache.nix` build:

```
builder for '/nix/store/az48nr8gdqrw3fliddmi82ghj2ljxrj4-fc-cache.drv' failed with exit code 127; last 1 log lines:
  /nix/store/p3z1lgsi7xymvl7akg531ikwiisqs4x5-stdenv-linux/setup: line 1299: fc-cache: command not found
cannot build derivation '/nix/store/swaxvjsf8h0rsmm9kigp6j3f5q5h4nvg-fc-00-nixos-cache.conf.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/wiaiv0pq7w1xm2i2fqp2ngd1ljb4n6n9-fontconfig-conf.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/4zhiwpiyccs0rs26bs3q0w8fwaxrrgw0-fontconfig-etc.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/xhvljdp9b00fbkapx6cbfs4sjdh49qwv-etc.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/w63q0n0vh7vkdfrjmhb41qy1alx7qa8s-nixos-system-nixos-19.09.git.c814289.drv': 1 dependencies couldn't be built
```

This pull request fixes https://github.com/NixOS/nixpkgs/pull/67916#discussion_r319838459 from pull request #67916.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @symphorien @Mic92 
