### PR TITLE
nixos/postfix: add missing setgid wrapper

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -631,6 +631,14 @@ in
         setgid = true;
       };
 
+      security.wrappers.mailq = {
+        program = "mailq";
+        source = "${pkgs.postfix}/bin/mailq";
+        group = setgidGroup;
+        setuid = false;
+        setgid = true;
+      };
+
       security.wrappers.postqueue = {
         program = "postqueue";
         source = "${pkgs.postfix}/bin/postqueue";


### PR DESCRIPTION
This is basically an alias for a special case of postqueue, which already has a setgid wrapper.  Would be silly to allow postqueue -p but not mailq.