### PR TITLE
Add checkPhase for pipenv

### DIFF
--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -41,7 +41,7 @@ in buildPythonApplication rec {
 
   doCheck = true;
   checkPhase = ''
-    export HOME=$PWD
+    export HOME=$(mktemp -d)
     $out/bin/pipenv install ${fetchPypi {pname="pyjokes"; version="0.6.0"; sha256="08860eedb78cbfa4618243c8db088f21c39823ece1fdaf0133e52d9c56e981a5";} }
   '';
 

--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -42,7 +42,8 @@ in buildPythonApplication rec {
   doCheck = true;
   checkPhase = ''
     export HOME=$(mktemp -d)
-    $out/bin/pipenv install ${fetchPypi {pname="pyjokes"; version="0.6.0"; sha256="08860eedb78cbfa4618243c8db088f21c39823ece1fdaf0133e52d9c56e981a5";} }
+    cp -r --no-preserve=mode ${wheel.src} $HOME/wheel-src
+    $out/bin/pipenv install $HOME/wheel-src
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -39,7 +39,11 @@ in buildPythonApplication rec {
 
   propagatedBuildInputs = runtimeDeps;
 
-  doCheck = false;
+  doCheck = true;
+  checkPhase = ''
+    export HOME=$PWD
+    $out/bin/pipenv install ${fetchPypi {pname="pyjokes"; version="0.6.0"; sha256="08860eedb78cbfa4618243c8db088f21c39823ece1fdaf0133e52d9c56e981a5";} }
+  '';
 
   meta = with lib; {
     description = "Python Development Workflow for Humans";


### PR DESCRIPTION
###### Motivation for this change

This is to prevent regressions such as https://github.com/NixOS/nixpkgs/issues/73254
by using pipenv to install a simple Python package, thus testing
that pipenv was built correctly.

I tested the patch locally against nixpgs master (pipenv built successfully) and against nixpgs 19.09 (pipenv build failed, as expected, with `ModuleNotFoundError: No module named 'pip._internal.main'`). 

Refs https://github.com/NixOS/nixpkgs/issues/73254

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh

Many thanks to @Infinisil and @domenkozar for hand-holding!

