### PR TITLE
zcash: 1.0.13 -> 2.1.0-1

### DIFF
--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -1,37 +1,29 @@
-{ stdenv, libsodium, fetchFromGitHub, wget, pkgconfig, autoreconfHook, openssl, db62, boost
-, zlib, gtest, gmock, callPackage, gmp, qt4, utillinux, protobuf, qrencode, libevent
-, libsnark, withGui }:
+{ stdenv, libsodium, fetchFromGitHub, wget, pkgconfig, autoreconfHook, openssl, db62, boost17x
+, zlib, gtest, gmock, callPackage, gmp, qt4, utillinux, protobuf, qrencode, libevent }:
 
 let librustzcash = callPackage ./librustzcash {};
 in
 with stdenv.lib;
 stdenv.mkDerivation rec {
 
-  name = "zcash" + (toString (optional (!withGui) "d")) + "-" + version;
-  version = "1.0.13";
+  pname = "zcash";
+  version = "2.1.0-1";
 
   src = fetchFromGitHub {
     owner = "zcash";
     repo  = "zcash";
     rev = "v${version}";
-    sha256 = "05y7wxs66anxr5akbf05r36mmjfzqpwawn6vyh3jhpva51hzzzyz";
+    sha256 = "05bnn4lxrrcv1ha3jdfrgwg4ar576161n3j9d4gpc14ww3zgf9vz";
   };
 
-  # Dependencies are underspecified: "make -C src gtest/zcash_gtest-test_merkletree.o"
-  # fails with "fatal error: test/data/merkle_roots.json.h: No such file or directory"
-  enableParallelBuilding = false;
-
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ gtest gmock gmp openssl wget db62 boost zlib
-                  protobuf libevent libsodium librustzcash libsnark ]
-                  ++ optionals stdenv.isLinux [ utillinux ]
-                  ++ optionals withGui [ qt4 qrencode ];
+  buildInputs = [ gtest gmock gmp openssl wget db62 boost17x zlib
+                  protobuf libevent libsodium librustzcash ]
+                  ++ optionals stdenv.isLinux [ utillinux ];
 
-  configureFlags = [ "--with-boost-libdir=${boost.out}/lib"
-                   ] ++ optionals withGui [ "--with-gui=qt4" ];
+  configureFlags = [ "--with-boost-libdir=${boost17x.out}/lib" ];
 
   patchPhase = ''
-    sed -i"" 's,-lboost_system-mt,-lboost_system,' configure.ac
     sed -i"" 's,-fvisibility=hidden,,g'            src/Makefile.am
   '';
 
@@ -42,7 +34,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Peer-to-peer, anonymous electronic cash system";
     homepage = https://z.cash/;
-    maintainers = with maintainers; [ rht ];
+    maintainers = with maintainers; [ rht tkerber ];
     license = licenses.mit;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/blockchains/zcash/librustzcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/librustzcash/default.nix
@@ -2,28 +2,30 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "librustzcash-unstable";
-  version = "2017-03-17";
+  version = "2018-10-27";
 
   src = fetchFromGitHub {
     owner = "zcash";
     repo = "librustzcash";
-    rev = "91348647a86201a9482ad4ad68398152dc3d635e";
-    sha256 = "02l1f46frpvw1r6k1wfh77mrsnmsdvifqx0vnscxz4xgb9ia9d1c";
+    rev = "06da3b9ac8f278e5d4ae13088cf0a4c03d2c13f5";
+    sha256 = "0md0pp3k97iv7kfjpfkg14pjanhrql4vafa8ggbxpkajv1j4xldv";
   };
 
-  cargoSha256 = "1xlq8vkzfyr5q8gxvzkwi8r1kxg4rg8l1ckdwfdxlkhnw0yscbra";
+  cargoSha256 = "166v8cxlpfslbs5gljbh7wp0lxqakayw47ikxm9r9a39n7j36mq1";
 
   installPhase = ''
     mkdir -p $out/lib
     cp target/release/librustzcash.a $out/lib/
     mkdir -p $out/include
-    cp include/librustzcash.h $out/include/
+    cp librustzcash/include/librustzcash.h $out/include/
   '';
+
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Rust-language assets for Zcash";
     homepage = https://github.com/zcash/librustzcash;
-    maintainers = with maintainers; [ rht ];
+    maintainers = with maintainers; [ rht tkerber ];
     license = with licenses; [ mit asl20 ];
     platforms = platforms.unix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22360,9 +22360,7 @@ in
 
   wownero = callPackage ../applications/blockchains/wownero.nix {};
 
-  zcash = callPackage ../applications/blockchains/zcash {
-    withGui = false;
-  };
+  zcash = callPackage ../applications/blockchains/zcash { };
 
   parity = callPackage ../applications/blockchains/parity { };
   parity-beta = callPackage ../applications/blockchains/parity/beta.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Zcash is severely outdated, and is incompatible with the live network.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Ensured that relevant documentation is up to date
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rht