### PR TITLE
ocamlPackages.lwt4: 4.2.1 → 4.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/lwt/4.x.nix
+++ b/pkgs/development/ocaml-modules/lwt/4.x.nix
@@ -1,5 +1,5 @@
 { lib, fetchzip, pkgconfig, ncurses, libev, buildDunePackage, ocaml
-, cppo, ocaml-migrate-parsetree, ppx_tools_versioned, result
+, cppo, ocaml-migrate-parsetree, ocplib-endian, result
 , mmap, seq
 }:
 
@@ -7,22 +7,17 @@ let inherit (lib) optional versionAtLeast; in
 
 buildDunePackage rec {
   pname = "lwt";
-  version = "4.2.1";
+  version = "4.4.0";
 
   src = fetchzip {
     url = "https://github.com/ocsigen/${pname}/archive/${version}.tar.gz";
-    sha256 = "1hz24fyhpm7d6603v399pgxvdl236srwagqja41ljvjx83y10ysr";
+    sha256 = "1l97zdcql7y13fhaq0m9n9xvxf712jg0w70r72fvv6j49xm4nlhi";
   };
 
-  postPatch = ''
-    substituteInPlace lwt.opam \
-    --replace 'version: "dev"' 'version: "${version}"'
-  '';
-
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cppo ocaml-migrate-parsetree ppx_tools_versioned ]
+  buildInputs = [ cppo ocaml-migrate-parsetree ]
    ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
-  propagatedBuildInputs = [ libev mmap seq result ];
+  propagatedBuildInputs = [ libev mmap ocplib-endian seq result ];
 
   meta = {
     homepage = "https://ocsigen.org/lwt/";


### PR DESCRIPTION
###### Motivation for this change

Bug fixes and co.: https://github.com/ocsigen/lwt/blob/51a7deb8709ab7afa5848b0444b460a8eca91a67/CHANGES

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

