### PR TITLE
shadowenv: 1.2.1 -> 1.3.1

### DIFF
--- a/pkgs/tools/misc/shadowenv/default.nix
+++ b/pkgs/tools/misc/shadowenv/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "shadowenv";
-  version = "1.2.1";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "Shopify";
     repo = pname;
     rev = version;
-    sha256 = "01hhh45h742z9mjcpmyjpbjf90a5b1m58b6nml2han149xpn5b74";
+    sha256 = "1s59ra99wcyyqz8gzly4qmcq5rh22c50c75cdi2kyajm7ghgryy9";
   };
 
-  cargoSha256 = "0r8s20xgcp5d1ac07g5g4lrrnhrn2qsr1kgj13h2csly22j0ca2a";
+  cargoSha256 = "0s4p4mpz1p5v9hr4flxlzqvc1b3zbqr3nxp1nxjw39ng9g3hplpg";
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
 


### PR DESCRIPTION
Minor upstream changes, pretty much just adds a flag to `shadowenv exec`.