### PR TITLE
jpegexiforient: init at 2002-02-17

### DIFF
--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, makeWrapper
 , xorg, imlib2, libjpeg, libpng
-, curl, libexif, perlPackages }:
+, curl, libexif, jpegexiforient, perlPackages }:
 
 with stdenv.lib;
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   installTargets = [ "install" ];
   postInstall = ''
-    wrapProgram "$out/bin/feh" --prefix PATH : "${libjpeg.bin}/bin" \
+    wrapProgram "$out/bin/feh" --prefix PATH : "${makeBinPath [ libjpeg jpegexiforient ]}" \
                                --add-flags '--theme=feh'
   '';
 

--- a/pkgs/tools/graphics/jpegexiforient/default.nix
+++ b/pkgs/tools/graphics/jpegexiforient/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchurl }:
+stdenv.mkDerivation {
+  pname = "jpegexiforient";
+  version = "unstable-2002-02-17";
+  src = fetchurl {
+    url = "http://sylvana.net/jpegcrop/jpegexiforient.c";
+    sha256 = "1v0f42cvs0397g9v46p294ldgxwbp285npg6npgnlnvapk6nzh5s";
+  };
+  unpackPhase = ''
+    cp $src jpegexiforient.c
+  '';
+  buildPhase = ''
+    cc -o jpegexiforient jpegexiforient.c
+  '';
+  installPhase = ''
+    install -Dt $out/bin jpegexiforient
+  '';
+  meta = with lib; {
+    description = "Utility program to get and set the Exif Orientation Tag";
+    homepage = "http://sylvana.net/jpegcrop/exif_orientation.html";
+    # Website doesn't mention any license, but I think it's safe to assume this
+    # to be free since it's from IJG, the current maintainers of libjpeg
+    license = licenses.free;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ infinisil ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4226,6 +4226,8 @@ in
 
   jpeg-archive = callPackage ../applications/graphics/jpeg-archive { };
 
+  jpegexiforient = callPackage ../tools/graphics/jpegexiforient { };
+
   jpeginfo = callPackage ../applications/graphics/jpeginfo { };
 
   jpegoptim = callPackage ../applications/graphics/jpegoptim { };


### PR DESCRIPTION
###### Motivation for this change
This allows `feh --edit` to work properly, whereas previously it would give
```
feh WARNING: lossless rotate: Failed to exec jpegexiforient: No such file or directory
feh WARNING: lossless rotate: Failed to update EXIF orientation tag: jpegexiforient returned 1
```

###### Things done

- [x] Built and tested on linux