### PR TITLE
buildStackProject: Set __noChroot to make it fail without sandbox

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -398,7 +398,9 @@ nix:
 For more on how to write a `shell.nix` file see the below section. You'll need
 to express a derivation. Note that Nixpkgs ships with a convenience wrapper
 function around `mkDerivation` called `haskell.lib.buildStackProject` to help you
-create this derivation in exactly the way Stack expects. All of the same inputs
+create this derivation in exactly the way Stack expects. However for this to work
+you need to disable the sandbox, which you can do by using `--option sandbox relaxed`
+or `--option sandbox false` to the Nix command. All of the same inputs
 as `mkDerivation` can be provided. For example, to build a Stack project that
 including packages that link against a version of the R library compiled with
 special options turned on:

--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -20,6 +20,10 @@ let
 
 in stdenv.mkDerivation (args // {
 
+  # Doesn't work in the sandbox. Pass `--option sandbox relaxed` or
+  # `--option sandbox false` to be able to build this
+  __noChroot = true;
+
   buildInputs = buildInputs
     ++ lib.optional (stdenv.hostPlatform.libc == "glibc") glibcLocales;
 


### PR DESCRIPTION
###### Motivation for this change

Currently `buildStackProject` doesn't have any indication that it needs the sandbox to be disabled, leading to a hard-to-decipher error, see https://github.com/NixOS/nixpkgs/issues/32005

With this change, doing a `buildStackProject` will result in

    error: derivation '/nix/store/nk4wms3hk4mp9lc86k30vc8w44fcq0rj-foo.drv' has
      '__noChroot' set, but that's not allowed when 'sandbox' is 'true'

when attempting to build it without `--option sandbox false`

Fixes #32005

###### Things done

- [x] Made sure this error happens without disabling the sandbox