### PR TITLE
libinput-gestures: Add coreutils to $PATH

### DIFF
--- a/pkgs/tools/inputmethods/libinput-gestures/default.nix
+++ b/pkgs/tools/inputmethods/libinput-gestures/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper,
   libinput, wmctrl, python3,
-  xdotool ? null,
+  coreutils, xdotool ? null,
   extraUtilsPath ? lib.optional (xdotool != null) xdotool
 }:
 stdenv.mkDerivation rec {
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       rm "$out/bin/libinput-gestures-setup"
       substituteInPlace "$out/share/applications/libinput-gestures.desktop" --replace "/usr" "$out"
       chmod +x "$out/share/applications/libinput-gestures.desktop"
-      wrapProgram "$out/bin/libinput-gestures" --prefix PATH : "${lib.makeBinPath extraUtilsPath}"
+      wrapProgram "$out/bin/libinput-gestures" --prefix PATH : "${lib.makeBinPath ([coreutils] ++ extraUtilsPath)}"
     '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

The script can't find `stdbuf` when run as a systemd service.

###### Things done

Add `coreutils` to the `$PATH`.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
