### PR TITLE
Fix PPSSPP with wrapQtApps #65399

### DIFF
--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qtbase, qtmultimedia
+{ stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qtbase, qtmultimedia
 , glew, libzip, snappy, zlib, withGamepads ? true, SDL2 }:
 
 assert withGamepads -> (SDL2 != null);
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "ppsspp";
   version = "1.4.2";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
PPSSPP was not starting (`qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""` error).

###### Things done
Use `mkDerivation` from arguments instead of `stdenv.mkDerivation` 
