### PR TITLE
firefox-wrapper: rename gdkWayland->forceWayland; always use libglvnd

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -27,6 +27,7 @@ let
     , icon ? browserName
     , extraNativeMessagingHosts ? []
     , forceWayland ? false
+    , useGlvnd ? true
     , cfg ? config.${browserName} or {}
     }:
 
@@ -68,7 +69,7 @@ let
       libs =   lib.optionals stdenv.isLinux [ udev libva ]
             ++ lib.optional ffmpegSupport ffmpeg
             ++ lib.optional gssSupport kerberos
-            ++ lib.optional gdkWayland libglvnd
+            ++ lib.optional useGlvnd libglvnd
             ++ lib.optionals (cfg.enableQuakeLive or false)
             (with xorg; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsaLib zlib ])
             ++ lib.optional (enableAdobeFlash && (cfg.enableAdobeFlashDRM or false)) hal-flash

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -26,11 +26,11 @@ let
     , nameSuffix ? ""
     , icon ? browserName
     , extraNativeMessagingHosts ? []
-    , gdkWayland ? false
+    , forceWayland ? false
     , cfg ? config.${browserName} or {}
     }:
 
-    assert gdkWayland -> (browser ? gtk3); # Can only use the wayland backend if gtk3 is being used
+    assert forceWayland -> (browser ? gtk3); # Can only use the wayland backend if gtk3 is being used
 
     let
       enableAdobeFlash = cfg.enableAdobeFlash or false;
@@ -83,7 +83,7 @@ let
         exec = "${browserName}${nameSuffix} %U";
         inherit icon;
         comment = "";
-        desktopName = "${desktopName}${nameSuffix}${lib.optionalString gdkWayland " (Wayland)"}";
+        desktopName = "${desktopName}${nameSuffix}${lib.optionalString forceWayland " (Wayland)"}";
         genericName = "Web Browser";
         categories = "Network;WebBrowser;";
         mimeType = stdenv.lib.concatStringsSep ";" [
@@ -124,8 +124,8 @@ let
             --set SNAP_NAME "firefox" \
             --set MOZ_LEGACY_PROFILES 1 \
             --set MOZ_ALLOW_DOWNGRADE 1 \
-            ${lib.optionalString gdkWayland ''
-              --set GDK_BACKEND "wayland" \
+            ${lib.optionalString forceWayland ''
+              --set MOZ_ENABLE_WAYLAND "1" \
             ''}${lib.optionalString (browser ? gtk3)
                 ''--prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
                   --suffix XDG_DATA_DIRS : '${gnome3.adwaita-icon-theme}/share'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19889,7 +19889,7 @@ in
   firefox-unwrapped = firefoxPackages.firefox;
   firefox-esr-68-unwrapped = firefoxPackages.firefox-esr-68;
   firefox = wrapFirefox firefox-unwrapped { };
-  firefox-wayland = wrapFirefox firefox-unwrapped { gdkWayland = true; };
+  firefox-wayland = wrapFirefox firefox-unwrapped { forceWayland = true; };
   firefox-esr-68 = wrapFirefox firefox-esr-68-unwrapped { };
   firefox-esr = firefox-esr-68;
 


### PR DESCRIPTION
###### Motivation for this change
Without this change, when starting Firefox with WebRender enabled, the default standard out/err is filled with errors.

Further, this cleans up some old remnants of what looks like early Firefox Wayland support that is no longer needed. I'm not even sure `libglvnd` needs to be optional.

Note: I'm not sure if I need to do this differently, or make more changes, for backward compat purposes?

A somewhat clipped log when starting Firefox (with WebRender enabled) without my change:

```
Attempting load of libEGL.so
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) [GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) [GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) [GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) [GFX1-]: Failed to get shared GL context
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) |[4][GFX1-]: Failed to load EGL library 3! (t=0.577919) [GFX1-]: Failed to load EGL library 3!
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) |[4][GFX1-]: Failed to load EGL library 3! (t=0.577919) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=0.577936) [GFX1-]: Failed GL context creation for WebRender: 0
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) |[4][GFX1-]: Failed to load EGL library 3! (t=0.577919) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=0.577936) |[6][GFX1-]: Failed to connect WebRenderBridgeChild. (t=0.578027) [GFX1-]: Failed to connect WebRenderBridgeChild.
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) |[4][GFX1-]: Failed to load EGL library 3! (t=0.577919) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=0.577936) |[6][GFX1-]: Failed to connect WebRenderBridgeChild. (t=0.578027) |[7][GFX1-]: Failed to load EGL library 3! (t=0.578314) [GFX1-]: Failed to load EGL library 3!
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) |[4][GFX1-]: Failed to load EGL library 3! (t=0.577919) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=0.577936) |[6][GFX1-]: Failed to connect WebRenderBridgeChild. (t=0.578027) |[7][GFX1-]: Failed to load EGL library 3! (t=0.578314) |[8][GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT (t=0.578345) [GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT

(firefox:15570): dbind-WARNING **: 14:11:12.546: AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) |[4][GFX1-]: Failed to load EGL library 3! (t=0.577919) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=0.577936) |[6][GFX1-]: Failed to connect WebRenderBridgeChild. (t=0.578027) |[7][GFX1-]: Failed to load EGL library 3! (t=0.578314) |[8][GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT (t=0.578345) |[9][GFX1-]: Failed to load EGL library 3! (t=0.718512) [GFX1-]: Failed to load EGL library 3!
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) |[4][GFX1-]: Failed to load EGL library 3! (t=0.577919) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=0.577936) |[6][GFX1-]: Failed to connect WebRenderBridgeChild. (t=0.578027) |[7][GFX1-]: Failed to load EGL library 3! (t=0.578314) |[8][GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT (t=0.578345) |[9][GFX1-]: Failed to load EGL library 3! (t=0.718512) |[10][GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT (t=0.718559) [GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) |[4][GFX1-]: Failed to load EGL library 3! (t=0.577919) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=0.577936) |[6][GFX1-]: Failed to connect WebRenderBridgeChild. (t=0.578027) |[7][GFX1-]: Failed to load EGL library 3! (t=0.578314) |[8][GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT (t=0.578345) |[9][GFX1-]: Failed to load EGL library 3! (t=0.718512) |[10][GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT (t=0.718559) |[11][GFX1-]: Failed to load EGL library 3! (t=1.32254) [GFX1-]: Failed to load EGL library 3!
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) |[4][GFX1-]: Failed to load EGL library 3! (t=0.577919) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=0.577936) |[6][GFX1-]: Failed to connect WebRenderBridgeChild. (t=0.578027) |[7][GFX1-]: Failed to load EGL library 3! (t=0.578314) |[8][GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT (t=0.578345) |[9][GFX1-]: Failed to load EGL library 3! (t=0.718512) |[10][GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT (t=0.718559) |[11][GFX1-]: Failed to load EGL library 3! (t=1.32254) |[12][GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT (t=1.32258) [GFX1-]: [OPENGL] Failed to init compositor with reason: FEATURE_FAILURE_OPENGL_CREATE_CONTEXT
JavaScript error: , line 0: uncaught exception: Object
JavaScript error: , line 0: uncaught exception: Object
JavaScript error: moz-extension://8a7dccdd-9a4d-4fda-a8bf-79a1c0e60b17/common/sidebar-connection.js, line 89: Error: Attempt to postMessage on disconnected port
JavaScript error: moz-extension://8a7dccdd-9a4d-4fda-a8bf-79a1c0e60b17/common/sidebar-connection.js, line 89: Error: Attempt to postMessage on disconnected port
JavaScript warning: https://open.scdn.co/static/vendor.38438abe.js, line 0: Successfully compiled asm.js code (total compilation time 1ms)
JavaScript error: resource://gre/modules/WebNavigationContent.js, line 271: NS_NOINTERFACE: Component returned failure code: 0x80004002 (NS_NOINTERFACE) [nsIWebProgress.DOMWindow]
Extension error: [Exception... "Component returned failure code: 0x80004005 (NS_ERROR_FAILURE) [nsIDOMWindowUtils.removeSheet]"  nsresult: "0x80004005 (NS_ERROR_FAILURE)"  location: "JS frame :: resource://gre/modules/ExtensionCommon.jsm :: runSafeSyncWithoutClone :: line 75"  data: no] undefined 75
[[Exception stack
runSafeSyncWithoutClone@resource://gre/modules/ExtensionCommon.jsm:75:12
cleanup/<@resource://gre/modules/ExtensionContent.jsm:413:36
Current stack
runSafeSyncWithoutClone@resource://gre/modules/ExtensionCommon.jsm:81:9
cleanup/<@resource://gre/modules/ExtensionContent.jsm:413:36
]]
Exiting due to channel error.
Crash Annotation GraphicsCriticalError: |[C0][GFX1-]: Receive IPC close with reason=AbnormalShutdown (t=9.81542) Exiting due to channel error.
Exiting due to channel error.
Exiting due to channel error.
Exiting due to channel error.
[Child 15820, Chrome_ChildThread] WARNING: pipe error: Broken pipe: file /build/firefox-70.0.1/ipc/chromium/src/chrome/common/ipc_channel_posix.cc, line 728
[clipped]
[Child 15820, Chrome_ChildThread] WARNING: pipe error (3): Connection reset by peer: file /build/firefox-70.0.1/ipc/chromium/src/chrome/common/ipc_channel_posix.cc, line 358
Exiting due to channel error.
Exiting due to channel error.
Crash Annotation GraphicsCriticalError: |[C0][GFX1-]: Receive IPC close with reason=AbnormalShutdown (t=13.6711) 
```

Note this one: `Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226486) |[1][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.226627) |[2][GFX1-]: Failed to load EGL library: FEATURE_FAILURE_EGL_LOAD_3 (t=0.577772) |[3][GFX1-]: Failed to get shared GL context (t=0.577814) |[4][GFX1-]: Failed to load EGL library 3! (t=0.577919) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=0.577936) |[6][GFX1-]: Failed to connect WebRenderBridgeChild. (t=0.578027) |[7][GFX1-]: Failed to load EGL library 3! (t=0.578314)`.

Afterward, the complete, non-clipped log is:

```
Attempting load of libEGL.so

(firefox:16916): dbind-WARNING **: 14:13:40.153: AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files
1573683220602	addons.webextension.treestyletab@piro.sakura.ne.jp	WARN	Loading extension 'treestyletab@piro.sakura.ne.jp': Reading manifest: Error processing variable_color_icons: An unexpected property was found in the WebExtension manifest.
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: We don't have EGLSurface to draw into. Called too early? (t=3.02578) [GFX1-]: We don't have EGLSurface to draw into. Called too early?
JavaScript error: , line 0: uncaught exception: Object
JavaScript error: , line 0: uncaught exception: Object
JavaScript error: , line 0: uncaught exception: Object
JavaScript error: , line 0: uncaught exception: Object
JavaScript error: moz-extension://8a7dccdd-9a4d-4fda-a8bf-79a1c0e60b17/common/sidebar-connection.js, line 89: Error: Attempt to postMessage on disconnected port
JavaScript warning: https://open.scdn.co/static/vendor.38438abe.js, line 0: Successfully compiled asm.js code (total compilation time 2ms)
JavaScript error: resource://gre/modules/WebNavigationContent.js, line 271: NS_NOINTERFACE: Component returned failure code: 0x80004002 (NS_NOINTERFACE) [nsIWebProgress.DOMWindow]
Extension error: [Exception... "Component returned failure code: 0x80004005 (NS_ERROR_FAILURE) [nsIDOMWindowUtils.removeSheet]"  nsresult: "0x80004005 (NS_ERROR_FAILURE)"  location: "JS frame :: resource://gre/modules/ExtensionCommon.jsm :: runSafeSyncWithoutClone :: line 75"  data: no] undefined 75
[[Exception stack
runSafeSyncWithoutClone@resource://gre/modules/ExtensionCommon.jsm:75:12
cleanup/<@resource://gre/modules/ExtensionContent.jsm:413:36
Current stack
runSafeSyncWithoutClone@resource://gre/modules/ExtensionCommon.jsm:81:9
cleanup/<@resource://gre/modules/ExtensionContent.jsm:413:36
]]
Exiting due to channel error.
[Child 17213, Chrome_ChildThread] WARNING: pipe error (3): Connection reset by peer: file /build/firefox-70.0.1/ipc/chromium/src/chrome/common/ipc_channel_posix.cc, line 358
Exiting due to channel error.
Exiting due to channel error.
Exiting due to channel error.
Exiting due to channel error.
Crash Annotation GraphicsCriticalError: |[C0][GFX1-]: Receive IPC close with reason=AbnormalShutdown (t=11.6343) [Child 17091, Chrome_ChildThread] WARNING: pipe error (44): Connection reset by peer: file /build/firefox-70.0.1/ipc/chromium/src/chrome/common/ipc_channel_posix.cc, line 358
[Child 17091, Chrome_ChildThread] WARNING: pipe error (54): Connection reset by peer: file /build/firefox-70.0.1/ipc/chromium/src/chrome/common/ipc_channel_posix.cc, line 358
[Child 17091, Chrome_ChildThread] WARNING: pipe error (3): Connection reset by peer: file /build/firefox-70.0.1/ipc/chromium/src/chrome/common/ipc_channel_posix.cc, line 358
Exiting due to channel error.
Exiting due to channel error.

```

More verification that this is doing something good is still a wip.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
