### PR TITLE
argp-standalone: Find ar when cross compiling

### DIFF
--- a/pkgs/development/libraries/argp-standalone/default.nix
+++ b/pkgs/development/libraries/argp-standalone/default.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation {
 
   doCheck = true;
 
+  makeFlags = [ "AR:=$(AR)" ];
+
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
I was trying to build `rng-tools` with musl. To do that, its dependencies also have to be built with musl.

cc @c0bw3b

###### Things done

Built it with `nix-build -A pkgsCross.musl64.argp-standalone`, which failed before.
Didn't test it because `rng-tools` still doesn't build because of other dependencies but this should cause any runtime changes.
The output of `nix-build -A argp-standalone` hashes to the same values as before.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @amar1729
