### PR TITLE
celluloid: 0.17 -> 0.18

### DIFF
--- a/pkgs/applications/video/celluloid/default.nix
+++ b/pkgs/applications/video/celluloid/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "celluloid";
-  version = "0.17";
+  version = "0.18";
 
   src = fetchFromGitHub {
     owner = "celluloid-player";
     repo = "celluloid";
     rev = "v${version}";
-    sha256 = "0pnxjv6n2q6igxdr8wzbahcj7vccw4nfjdk8fjdnaivf2lyrpv2d";
+    sha256 = "1j8z75y98liirr41rlcn89cshvp1xp71cspcclm6wx455i7q2cg1";
   };
 
   nativeBuildInputs = [
@@ -45,7 +45,6 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs meson-post-install.py src/generate-authors.py
-    sed -i '/gtk-update-icon-cache/s/^/#/' meson-post-install.py
   '';
 
   doCheck = true;

--- a/pkgs/applications/video/celluloid/default.nix
+++ b/pkgs/applications/video/celluloid/default.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/celluloid-player/celluloid";
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ worldofpeace ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/celluloid-player/celluloid/releases/tag/v0.18

Been using git master for a bit since mpv 30 was released.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
