### PR TITLE
consul-alerts: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/servers/monitoring/consul-alerts/default.nix
+++ b/pkgs/servers/monitoring/consul-alerts/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "consul-alerts";
-  version = "0.5.0";
+  version = "0.6.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/AcalephStorage/consul-alerts";
@@ -13,7 +13,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "AcalephStorage";
     repo = "consul-alerts";
-    sha256 = "0dff2cpk3lkgjsh97rvlrpacpka0kwm29691diyvj7lb9ydzlx3r";
+    sha256 = "0836zicv76sd6ljhbbii1mrzh65pch10w3gfa128iynaviksbgn5";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Changelog: https://github.com/AcalephStorage/consul-alerts/releases/tag/v0.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

myself
