### PR TITLE
kubernix: v0.2.0

### DIFF
--- a/pkgs/applications/networking/cluster/kubernix/default.nix
+++ b/pkgs/applications/networking/cluster/kubernix/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kubernix";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "saschagrunert";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04dzfdzjwcwwaw9min322g30q0saxpq5kqzld4f22fmk820ki6gp";
+  };
+
+  cargoSha256 = "17agwqx7nhzi124yq1s6zpqb227drrhp9c11r3jbicc08dz88bwg";
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Single dependency Kubernetes clusters for local testing, experimenting and development";
+    homepage = "https://github.com/saschagrunert/kubernix";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ saschagrunert ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20250,6 +20250,8 @@ in
 
   kubeseal = callPackage ../applications/networking/cluster/kubeseal { };
 
+  kubernix = callPackage ../applications/networking/cluster/kubernix { };
+
   kubectl = callPackage ../applications/networking/cluster/kubectl { };
 
   kubeless = callPackage ../applications/networking/cluster/kubeless { };


### PR DESCRIPTION
##### Motivation for this change

Add [kubernix](https://github.com/saschagrunert/kubernix) to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
