### PR TITLE
pythonPackage.ovirt-engine-sdk: init at 4.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1411,6 +1411,12 @@
     githubId = 411324;
     name = "Carles Pagès";
   };
+  cptMikky = {
+    email = "jakub@ufiseru.cz";
+    github = "cptMikky";
+    githubid = 10010448;
+    name = "Jakub Fišer";
+  };
   craigem = {
     email = "craige@mcwhirter.io";
     github = "craigem";

--- a/pkgs/development/python-modules/ovirt-engine-sdk/default.nix
+++ b/pkgs/development/python-modules/ovirt-engine-sdk/default.nix
@@ -1,0 +1,37 @@
+{ 
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pycurl,
+  six,
+  libxml2Python
+}:
+
+buildPythonPackage rec {
+  pname = "ovirt-engine-sdk-python";
+  version = "4.3.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hz7rcz7l391n8ixcwvqw3iq5bx26fk9l5c6xxymv036zm3r9pnh";
+  };
+
+  doCheck = true;
+
+  propagatedBuildInputs = [ 
+    pycurl 
+    six 
+    libxml2Python
+  ];
+
+  prePatch = ''
+    substituteInPlace setup.py --replace "/usr/include/libxml2" "${lib.getDev libxml2Python}/include/libxml2"
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/oVirt/ovirt-engine-sdk/;
+    description = "The oVirt Python-SDK is a software development kit for the oVirt engine API";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cptMikky ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -834,6 +834,10 @@ in {
 
   outcome = callPackage ../development/python-modules/outcome {};
 
+  ovirt-engine-sdk = callPackage ../development/python-modules/ovirt-engine-sdk {
+    inherit (pkgs) libxml2Python;
+  };
+
   ovito = toPythonModule (pkgs.libsForQt5.callPackage ../development/python-modules/ovito {
       pythonPackages = self;
     });


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Ansible ovirt_* modules require this lib

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
