### PR TITLE
terraform: 0.12.13 -> 0.12.14

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -1,28 +1,20 @@
-{ stdenv
-, lib
-, buildEnv
-, buildGoPackage
-, fetchFromGitHub
-, makeWrapper
-, runCommand
-, writeText
-, terraform-providers
-}:
+{ stdenv, lib, buildEnv, buildGoPackage, fetchFromGitHub, makeWrapper
+, runCommand, writeText, terraform-providers }:
 
 let
   goPackagePath = "github.com/hashicorp/terraform";
 
   generic = { version, sha256, ... }@attrs:
-    let attrs' = builtins.removeAttrs attrs ["version" "sha256"]; in
-    buildGoPackage ({
+    let attrs' = builtins.removeAttrs attrs [ "version" "sha256" ];
+    in buildGoPackage ({
       name = "terraform-${version}";
 
       inherit goPackagePath;
 
       src = fetchFromGitHub {
-        owner  = "hashicorp";
-        repo   = "terraform";
-        rev    = "v${version}";
+        owner = "hashicorp";
+        repo = "terraform";
+        rev = "v${version}";
         inherit sha256;
       };
 
@@ -40,10 +32,17 @@ let
       '';
 
       meta = with stdenv.lib; {
-        description = "Tool for building, changing, and versioning infrastructure";
-        homepage = https://www.terraform.io/;
+        description =
+          "Tool for building, changing, and versioning infrastructure";
+        homepage = "https://www.terraform.io/";
         license = licenses.mpl20;
-        maintainers = with maintainers; [ zimbatm peterhoeg kalbasit marsam ];
+        maintainers = with maintainers; [
+          zimbatm
+          peterhoeg
+          kalbasit
+          marsam
+          babariviere
+        ];
       };
     } // attrs');
 
@@ -54,38 +53,54 @@ let
           actualPlugins = plugins terraform.plugins;
 
           # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
-          wrapperInputs = lib.unique (lib.flatten (lib.catAttrs "propagatedBuildInputs" (builtins.filter (x: x != null) actualPlugins)));
+          wrapperInputs = lib.unique (lib.flatten
+            (lib.catAttrs "propagatedBuildInputs"
+              (builtins.filter (x: x != null) actualPlugins)));
 
           passthru = {
-            withPlugins = newplugins: withPlugins (x: newplugins x ++ actualPlugins);
+            withPlugins = newplugins:
+              withPlugins (x: newplugins x ++ actualPlugins);
             full = withPlugins lib.attrValues;
 
             # Ouch
-            overrideDerivation = f: (pluggable (terraform.overrideDerivation f)).withPlugins plugins;
-            overrideAttrs = f: (pluggable (terraform.overrideAttrs f)).withPlugins plugins;
-            override = x: (pluggable (terraform.override x)).withPlugins plugins;
+            overrideDerivation = f:
+              (pluggable (terraform.overrideDerivation f)).withPlugins plugins;
+            overrideAttrs = f:
+              (pluggable (terraform.overrideAttrs f)).withPlugins plugins;
+            override = x:
+              (pluggable (terraform.override x)).withPlugins plugins;
           };
-        in
           # Don't bother wrapping unless we actually have plugins, since the wrapper will stop automatic downloading
           # of plugins, which might be counterintuitive if someone just wants a vanilla Terraform.
-          if actualPlugins == []
-            then terraform.overrideAttrs (orig: { passthru = orig.passthru // passthru; })
-            else lib.appendToName "with-plugins"(stdenv.mkDerivation {
-              inherit (terraform) name;
-              buildInputs = [ makeWrapper ];
+        in if actualPlugins == [ ] then
+          terraform.overrideAttrs
+          (orig: { passthru = orig.passthru // passthru; })
+        else
+          lib.appendToName "with-plugins" (stdenv.mkDerivation {
+            inherit (terraform) name;
+            buildInputs = [ makeWrapper ];
 
-              buildCommand = ''
-                mkdir -p $out/bin/
-                makeWrapper "${terraform.bin}/bin/terraform" "$out/bin/terraform" \
-                  --set NIX_TERRAFORM_PLUGIN_DIR "${buildEnv { name = "tf-plugin-env"; paths = actualPlugins; }}/bin" \
-                  --prefix PATH : "${lib.makeBinPath wrapperInputs}"
-              '';
+            buildCommand = ''
+              mkdir -p $out/bin/
+              makeWrapper "${terraform.bin}/bin/terraform" "$out/bin/terraform" \
+                --set NIX_TERRAFORM_PLUGIN_DIR "${
+                  buildEnv {
+                    name = "tf-plugin-env";
+                    paths = actualPlugins;
+                  }
+                }/bin" \
+                --prefix PATH : "${lib.makeBinPath wrapperInputs}"
+            '';
 
-              inherit passthru;
-            });
-    in withPlugins (_: []);
+            inherit passthru;
+          });
+    in withPlugins (_: [ ]);
 
-  plugins = removeAttrs terraform-providers ["override" "overrideDerivation" "recurseForDerivations"];
+  plugins = removeAttrs terraform-providers [
+    "override"
+    "overrideDerivation"
+    "recurseForDerivations"
+  ];
 in rec {
   terraform_0_11 = pluggable (generic {
     version = "0.11.14";
@@ -97,8 +112,8 @@ in rec {
   terraform_0_11-full = terraform_0_11.full;
 
   terraform_0_12 = pluggable (generic {
-    version = "0.12.13";
-    sha256 = "11nbr9avw6jx349jdmxgxiawk8i5mpw3p4rrl89yly0wfhg0fh4a";
+    version = "0.12.14";
+    sha256 = "0pq4sfnnlj91gxyxvyzzrgglnvh8xpan90gnc9jvnnb23iv4q96l";
     patches = [ ./provider-path.patch ];
     passthru = { inherit plugins; };
   });
@@ -112,8 +127,8 @@ in rec {
       resource "random_id" "test" {}
     '';
     terraform = terraform_0_11.withPlugins (p: [ p.random ]);
-    test = runCommand "terraform-plugin-test" { buildInputs = [terraform]; }
-      ''
+    test =
+      runCommand "terraform-plugin-test" { buildInputs = [ terraform ]; } ''
         set -e
         # make it fail outside of sandbox
         export HTTP_PROXY=http://127.0.0.1:0 HTTPS_PROXY=https://127.0.0.1:0


### PR DESCRIPTION
lots of these changes are just nix formatting. I can remove those if you want.

The only real changes are: version, sha256 and maintainers

###### Motivation for this change
update terraform to it's latest version

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @zimbatm @peterhoeg @kalbasit @marsam 
