### PR TITLE
ocamlPackages.lwt_ppx: fix dependency propagation

### DIFF
--- a/pkgs/development/ocaml-modules/lwt/ppx.nix
+++ b/pkgs/development/ocaml-modules/lwt/ppx.nix
@@ -5,8 +5,7 @@ buildDunePackage {
 
   inherit (lwt) src version;
 
-  buildInputs = [ ppx_tools_versioned ];
-  propagatedBuildInputs = [ lwt ];
+  propagatedBuildInputs = [ lwt ppx_tools_versioned ];
 
   meta = {
     description = "Ppx syntax extension for Lwt";


### PR DESCRIPTION
###### Motivation for this change
dune was showing this error when using `lwt_ppx`:
```
File "/nix/store/sz4cg32ph84lapgs50xv73s3a0baqq2s-ocaml4.08.1-lwt_ppx-4.2.1/lib/ocaml/4.08.1/site-lib/lwt_ppx/dune-package", line 11, characters 56-75:
11 |  (requires compiler-libs.common ocaml-migrate-parsetree ppx_tools_versioned)
                                                             ^^^^^^^^^^^^^^^^^^^
Error: Library "ppx_tools_versioned" not found.
-> required by library "lwt_ppx" in
   /nix/store/sz4cg32ph84lapgs50xv73s3a0baqq2s-ocaml4.08.1-lwt_ppx-4.2.1/lib/ocaml/4.08.1/site-lib/lwt_ppx
-> required by executable wizytests in dune:6
Hint: try: dune external-lib-deps --missing @@default
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vbgl 
