### PR TITLE
jitterentropy: Find strip when crosscompiling

### DIFF
--- a/pkgs/development/libraries/jitterentropy/default.nix
+++ b/pkgs/development/libraries/jitterentropy/default.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation rec {
 
   preInstall = ''
     mkdir -p $out/include
+    substituteInPlace Makefile \
+      --replace "install -m 0755 -s" \
+                'install -m 0755 -s --strip-program $(STRIP)'
   '';
 
   installFlags = [


### PR DESCRIPTION
###### Motivation for this change
I was trying to build `rng-tools` with musl. To do that, its dependencies also have to be built with musl.

cc @c0bw3b @kmcopper

###### Things done

Built it with `nix-build -A pkgsCross.musl64.jitterentropy`.
The outputs of `nix-build -A jitterentropy` hash to the same value as before.
rngd from rng-tools can still initialize the jitterentropy source.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
