### PR TITLE
vulnix: 1.8.2 -> 1.9.1

### DIFF
--- a/pkgs/tools/security/vulnix/default.nix
+++ b/pkgs/tools/security/vulnix/default.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "vulnix";
-  version = "1.8.2";
+  version = "1.9.1";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0zn21j15vd1z7s40s45zr5wri3r770yvazxqmm60fqpzc5sg552y";
+    sha256 = "0pcg90j3g3lxrkbxlnjakrgcx5iwnhka03510zmcf0zcpwkrqakb";
   };
 
   outputs = [ "out" "doc" "man" ];
@@ -24,7 +24,6 @@ python3Packages.buildPythonApplication rec {
   ] ++ (with python3Packages; [
     click
     colorama
-    lxml
     pyyaml
     requests
     setuptools
@@ -47,8 +46,8 @@ python3Packages.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     description = "NixOS vulnerability scanner";
-    homepage = https://github.com/flyingcircusio/vulnix;
+    homepage = "https://github.com/flyingcircusio/vulnix";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ckauhaus plumps ];
+    maintainers = with maintainers; [ ckauhaus ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upstream release. The old version is broken because NIST has discontinued NVD XML feeds. vulnix 1.9.x uses the JSON feeds.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): 280948800 -> 225478136 (reduction!)
- [ ] Ensured that relevant documentation is up to date -> discussion going on in #73342
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

[ckauhaus] I don't want to merge my own PR. Would someone please review this? TIA
