### PR TITLE
nixosTests.yggdrasil: port to python

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2487,6 +2487,7 @@
   gazally = {
     email = "gazally@runbox.com";
     github = "gazally";
+    githubId = 16470252;
     name = "Gemini Lasswell";
   };
   gebner = {

--- a/nixos/tests/yggdrasil.nix
+++ b/nixos/tests/yggdrasil.nix
@@ -19,7 +19,7 @@ let
     SigningPrivateKey = "2a6c21550f3fca0331df50668ffab66b6dce8237bcd5728e571e8033b363e247de111da0ec781e45bf6c63ecb45a78c24d7d4655abfaeea83b26c36eb5c0fd5b";
   };
 
-in import ./make-test.nix ({ pkgs, ...} : {
+in import ./make-test-python.nix ({ pkgs, ...} : {
   name = "yggdrasil";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ gazally ];
@@ -91,33 +91,35 @@ in import ./make-test.nix ({ pkgs, ...} : {
 
   testScript =
     ''
+      import re
+
       # Give Alice a head start so she is ready when Bob calls.
-      $alice->start;
-      $alice->waitForUnit("yggdrasil.service");
+      alice.start()
+      alice.wait_for_unit("yggdrasil.service")
 
-      $bob->start;
-      $carol->start;
-      $bob->waitForUnit("yggdrasil.service");
-      $carol->waitForUnit("yggdrasil.service");
+      bob.start()
+      carol.start()
+      bob.wait_for_unit("yggdrasil.service")
+      carol.wait_for_unit("yggdrasil.service")
 
-      $carol->waitUntilSucceeds("[ `ip -o -6 addr show dev ygg0 scope global | grep -v tentative | wc -l` -ge 1 ]");
-      my $carolIp6 = (split /[ \/]+/, $carol->succeed("ip -o -6 addr show dev ygg0 scope global"))[3];
+      ip_addr_show = "ip -o -6 addr show dev ygg0 scope global"
+      carol.wait_until_succeeds(f"[ `{ip_addr_show} | grep -v tentative | wc -l` -ge 1 ]")
+      carol_ip6 = re.split(" +|/", carol.succeed(ip_addr_show))[3]
 
       # If Alice can talk to Carol, then Bob's outbound peering and Carol's
       # local peering have succeeded and everybody is connected.
-      $alice->waitUntilSucceeds("ping -c 1 $carolIp6");
-      $alice->succeed("ping -c 1 ${bobIp6}");
+      alice.wait_until_succeeds(f"ping -c 1 {carol_ip6}")
+      alice.succeed(f"ping -c 1 ${bobIp6}")
 
-      $bob->succeed("ping -c 1 ${aliceIp6}");
-      $bob->succeed("ping -c 1 $carolIp6");
+      bob.succeed("ping -c 1 ${aliceIp6}")
+      bob.succeed(f"ping -c 1 {carol_ip6}")
 
-      $carol->succeed("ping -c 1 ${aliceIp6}");
-      $carol->succeed("ping -c 1 ${bobIp6}");
+      carol.succeed("ping -c 1 ${aliceIp6}")
+      carol.succeed("ping -c 1 ${bobIp6}")
 
-      $carol->fail("journalctl -u dhcpcd | grep ygg0");
+      carol.fail("journalctl -u dhcpcd | grep ygg0")
 
-      $alice->waitForUnit("httpd.service");
-      $carol->succeed("curl --fail -g http://[${aliceIp6}]");
-
+      alice.wait_for_unit("httpd.service")
+      carol.succeed("curl --fail -g http://[${aliceIp6}]")
     '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

