### PR TITLE
chez-matchable: init at 1.0

### DIFF
--- a/pkgs/development/chez-modules/chez-matchable/default.nix
+++ b/pkgs/development/chez-modules/chez-matchable/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchgit, chez }:
+{ stdenv, fetchFromGitHub, chez }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "chez-matchable";
-  version = "1.0";
+  version = "20160306";
 
-  src = fetchgit {
-    url = "https://github.com/fedeinthemix/chez-matchable.git";
-    rev = "73e46432ae70ec72eba6ef116bd84ad9ee38b2f2";
-    sha256 = "0rvb177m3vfq625nj7dawgm323jvx3in3nq6xdw8z4psn3bn1ag9";
+  src = fetchFromGitHub {
+    owner = "fedeinthemix";
+    repo = "chez-matchable";
+    rev = "v${version}";
+    sha256 = "02qn7x348p23z1x5lwhkyj7i8z6mgwpzpnwr8dyina0yzsdkr71s";
   };
 
   buildInputs = [ chez ];

--- a/pkgs/development/chez-modules/chez-matchable/default.nix
+++ b/pkgs/development/chez-modules/chez-matchable/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit, chez }:
+
+stdenv.mkDerivation {
+  pname = "chez-matchable";
+  version = "1.0";
+
+  src = fetchgit {
+    url = "https://github.com/fedeinthemix/chez-matchable.git";
+    rev = "73e46432ae70ec72eba6ef116bd84ad9ee38b2f2";
+    sha256 = "0rvb177m3vfq625nj7dawgm323jvx3in3nq6xdw8z4psn3bn1ag9";
+  };
+
+  buildInputs = [ chez ];
+
+  buildPhase = ''
+    make PREFIX=$out CHEZ=${chez}/bin/scheme
+  '';
+
+  installPhase = ''
+    make install PREFIX=$out CHEZ=${chez}/bin/scheme
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "This is a Library for ChezScheme providing the protable hygenic pattern matcher by Alex Shinn";
+    homepage = https://github.com/fedeinthemix/chez-matchable/;
+    maintainers = [ stdenv.lib.maintainers.jitwit ];
+    license = stdenv.lib.licenses.publicDomain;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7637,6 +7637,8 @@ in
 
   chez-scmutils = callPackage ../development/chez-modules/chez-scmutils { };
 
+  chez-matchable = callPackage ../development/chez-modules/chez-matchable { };
+
   clang = llvmPackages.clang;
   clang-manpages = llvmPackages.clang-manpages;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adding a package definition for the hygenic pattern matching library developed by Alex Shinn.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
