### PR TITLE
dragon-drop: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/tools/X11/dragon-drop/default.nix
+++ b/pkgs/tools/X11/dragon-drop/default.nix
@@ -2,21 +2,20 @@
 
 stdenv.mkDerivation rec {
   pname = "dragon-drop";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "mwh";
     repo = "dragon";
     rev = "v${version}";
-    sha256 = "0iwlrcqvbjshpwvg0gsqdqcjv48q1ary59pm74zzjnr8v9470smr";
+    sha256 = "0fgzz39007fdjwq72scp0qygp2v3zc5f1xkm0sxaa8zxm25g1bra";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gtk ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv dragon $out/bin
+    install -D dragon -t $out/bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
https://github.com/mwh/dragon/releases/tag/v1.1.1

Fixes segfault which would make the program unusable: https://github.com/mwh/dragon/commit/3e43b3cca309a504eba059f4c8d44cf3547d48f3

###### Things done

Executed the binary in a few different ways and dragged a few things a few different places :smile: 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jb55 @markus1189