### PR TITLE
yq: 2.8.1 -> 2.9.2

### DIFF
--- a/pkgs/development/tools/yq/default.nix
+++ b/pkgs/development/tools/yq/default.nix
@@ -1,17 +1,31 @@
-{ lib, buildPythonApplication, fetchPypi, pyyaml, xmltodict, jq }:
+{ lib, buildPythonApplication, fetchPypi
+, pyyaml, xmltodict, jq, argcomplete
+, pytest, coverage, flake8, toml
+}:
 
 buildPythonApplication rec {
   pname = "yq";
-  version = "2.8.1";
+  version = "2.10.1";
 
-  propagatedBuildInputs = [ pyyaml xmltodict jq ];
+  propagatedBuildInputs = [ pyyaml xmltodict jq argcomplete ];
 
-  # ValueError: underlying buffer has been detached
-  doCheck = false;
+  doCheck = true;
+
+  checkInputs = [
+   pytest
+   coverage
+   flake8
+   jq
+   toml
+  ];
+
+  checkPhase = ''
+    pytest ./test/test.py
+  '';
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "042p3s011635rbjax9wvwjdrb1kyzw38a6qn59b0j0k7krz6rlr4";
+    sha256 = "1h6nnkp53mm4spwy8nyxwvh9j6p4lxvf20j4bgjskhnhaw3jl9gn";
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/yq/default.nix
+++ b/pkgs/development/tools/yq/default.nix
@@ -1,6 +1,15 @@
-{ lib, buildPythonApplication, fetchPypi
-, pyyaml, xmltodict, jq, argcomplete
-, pytest, coverage, flake8, toml
+{ lib
+, buildPythonApplication
+, fetchPypi
+, argcomplete
+, pyyaml
+, xmltodict
+# Test inputs
+, coverage
+, flake8
+, jq
+, pytest
+, toml
 }:
 
 buildPythonApplication rec {
@@ -19,9 +28,7 @@ buildPythonApplication rec {
    toml
   ];
 
-  checkPhase = ''
-    pytest ./test/test.py
-  '';
+  checkPhase = "pytest ./test/test.py";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11071,7 +11071,9 @@ in
   yodl = callPackage ../development/tools/misc/yodl { };
 
   yq = callPackage ../development/tools/yq {
-    inherit (python3Packages) buildPythonApplication fetchPypi pyyaml xmltodict;
+    inherit (python3Packages)
+    buildPythonApplication fetchPypi pyyaml xmltodict argcomplete pytest
+    coverage flake8 toml;
   };
 
   yq-go = callPackage ../development/tools/yq-go { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11072,8 +11072,7 @@ in
 
   yq = callPackage ../development/tools/yq {
     inherit (python3Packages)
-    buildPythonApplication fetchPypi pyyaml xmltodict argcomplete pytest
-    coverage flake8 toml;
+    buildPythonApplication fetchPypi argcomplete pyyaml xmltodict pytest coverage flake8 toml;
   };
 
   yq-go = callPackage ../development/tools/yq-go { };


### PR DESCRIPTION
###### Motivation for this change
Lots of new releases in the meantime: https://github.com/kislyuk/yq/releases

###### Things done

Tested with `./result/bin/yq . somefile.yml` and `./result/bin/xq . somefile.xml`.
There's not really much to break by altering the first argument since it just converts the file to JSON and pipes that including the first argument to jq.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @womfoo
