### PR TITLE
gofumpt: 2019-07-29 -> 2019-11-11

### DIFF
--- a/pkgs/development/tools/gofumpt/default.nix
+++ b/pkgs/development/tools/gofumpt/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "gofumpt";
-  version = "2019-07-29";
+  version = "2019-11-11";
 
   src = fetchFromGitHub {
     owner = "mvdan";
     repo = pname;
-    rev = "96300e3d49fbb3b7bc9c6dc74f8a5cc0ef46f84b";
-    sha256 = "169hwggbhlr6ga045d6sa7xsan3mnj19qbh63i3h4rynqlppzvpf";
+    rev = "eb442649d62000da5d11671f3beb1afa1b746fd7";
+    sha256 = "1cw9mmavxz8gxzzwsllvf5lwb2wwi19jbc7hcwxsi4ywp7a84gh0";
   };
 
-  modSha256 = "1g7dkl60zwlk4q2gwx2780xys8rf2c4kqyy8gr99s5y342wsbx2g";
+  modSha256 = "1ladpxhr90awnms2qmlm2lz91wyh92fl3rqbfr54qngrkpkpbhr2";
 
   meta = with lib; {
     description = "A stricter gofmt";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @kalbasit 