### PR TITLE
[r19.03] pythonPackages.cherrypy: fix build

### DIFF
--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -43,8 +43,10 @@ in buildPythonPackage rec {
     # 3 out of 5 SignalHandlingTests need network access
     # test_2_File_Concurrency also fails upstream: https://github.com/cherrypy/cherrypy/issues/1306
     # ...and skipping it makes 2 other tests fail
+    # also skip test_null_bytes due to incompatibilities with lates pythons:
+    # https://github.com/cherrypy/cherrypy/issues/1781
     LANG=en_US.UTF-8 pytest -k "not SignalHandlingTests and not test_4_Autoreload \
-                            and not test_2_File_Concurrency and not test_3_Redirect and not test_4_File_deletion"
+                            and not test_2_File_Concurrency and not test_3_Redirect and not test_4_File_deletion and not test_null_bytes"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
I realize 19.03 is long in the tooth, but the recent minor bump to its python releases broke `cherrypy` and all its depending packages. Let's not leave it broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
