### PR TITLE
blugon: init at 1.11.4

### DIFF
--- a/pkgs/applications/misc/blugon/default.nix
+++ b/pkgs/applications/misc/blugon/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, python3, libX11, libXrandr, gcc, bash }:
+
+stdenv.mkDerivation rec {
+  pname = "blugon";
+  version = "1.11.4";
+
+  src = fetchFromGitHub {
+    owner = "jumper149";
+    repo = "blugon";
+    rev = "c53b47eac7f9b23adeb62f8df10f38ffbc0dd156";
+    sha256 = "0x320w2h5nlcgha4345i8ns15akb4kmrdgkh710s4r1n1by4x11r";
+  };
+
+  buildInputs = [ python3 libX11 libXrandr gcc bash ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Simple and configurable Blue Light Filter for X";
+    longDescription = ''
+      blugon is a simple and fast Blue Light Filter, that is highly configurable and provides a command line interface.
+      The program can be run just once or as a daemon (manually or via systemd).
+      There are several different backends available.
+      blugon calculates the screen color from your local time and configuration.
+    '';
+    license = licenses.asl20;
+    homepage = https://github.com/jumper149/blugon;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17996,6 +17996,8 @@ in
                         libXi libXext libXfixes libXcomposite;
   };
 
+  blugon = callPackage ../applications/misc/blugon { };
+
   bombono = callPackage ../applications/video/bombono {};
 
   bomi = libsForQt5.callPackage ../applications/video/bomi {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Was not in nixpkgs before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).