### PR TITLE
Add configuration for GitHub stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,32 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 180
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: false
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - 1.severity: security
+# Label to use when marking an issue as stale
+staleLabel: 2.status: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  Thank you for your contributions.
+
+  This has been automatically marked as stale because it has had no
+  activity for 180 days.
+
+  If this is still important to you, we ask that you leave a
+  comment below. Your comment can be as simple as "still important
+  to me". This lets people see that at least one person still cares
+  about this. Someone will have to do this at most twice a year if
+  there is no other activity.
+
+  Here are suggestions that might help resolve this more quickly:
+
+  1. Search for maintainers and people that previously touched the
+     related code and @ mention them in a comment.
+  2. Ask on the [NixOS Discourse](https://discourse.nixos.org/).
+  3. Ask on the [#nixos channel](irc://irc.freenode.net/#nixos) on
+     [irc.freenode.net](https://freenode.net).
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Now that RFC 0051 has been accepted, I'm working on implementing it.

The configuration added is taken from RFC 0051, and is the first step
toward implementing it. Next, we will have to enable the stale bot by
installing the GitHub application.

https://github.com/NixOS/rfcs/blob/master/rfcs/0051-mark-stale-issues.md