### PR TITLE
[19.09] lorri: init at unstable-2019-10-30 (backport)

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -316,6 +316,7 @@
   ./services/development/bloop.nix
   ./services/development/hoogle.nix
   ./services/development/jupyter/default.nix
+  ./services/development/lorri.nix
   ./services/editors/emacs.nix
   ./services/editors/infinoted.nix
   ./services/games/factorio.nix

--- a/nixos/modules/services/development/lorri.nix
+++ b/nixos/modules/services/development/lorri.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.lorri;
+  socketPath = "lorri/daemon.socket";
+in {
+  options = {
+    services.lorri = {
+      enable = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = ''
+          Enables the daemon for `lorri`, a nix-shell replacement for project
+          development. The socket-activated daemon starts on the first request
+          issued by the `lorri` command.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.sockets.lorri = {
+      description = "Socket for Lorri Daemon";
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream = "%t/${socketPath}";
+        RuntimeDirectory = "lorri";
+      };
+    };
+
+    systemd.user.services.lorri = {
+      description = "Lorri Daemon";
+      requires = [ "lorri.socket" ];
+      after = [ "lorri.socket" ];
+      path = with pkgs; [ config.nix.package gnutar gzip ];
+      serviceConfig = {
+        ExecStart = "${pkgs.lorri}/bin/lorri daemon";
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = "read-only";
+        Restart = "on-failure";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -153,6 +153,7 @@ in
   login = handleTest ./login.nix {};
   loki = handleTest ./loki.nix {};
   #logstash = handleTest ./logstash.nix {};
+  lorri = handleTest ./lorri/default.nix {};
   mailcatcher = handleTest ./mailcatcher.nix {};
   mathics = handleTest ./mathics.nix {};
   matrix-synapse = handleTest ./matrix-synapse.nix {};

--- a/nixos/tests/lorri/builder.sh
+++ b/nixos/tests/lorri/builder.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+printf "%s" "${name:?}" > "${out:?}"

--- a/nixos/tests/lorri/default.nix
+++ b/nixos/tests/lorri/default.nix
@@ -1,0 +1,24 @@
+import ../make-test.nix {
+  machine = { pkgs, ... }: {
+    imports = [ ../../modules/profiles/minimal.nix ];
+    environment.systemPackages = [ pkgs.lorri ];
+  };
+
+  testScript = ''
+    # Copy files over
+    $machine->succeed(
+        "cp '${./fake-shell.nix}' shell.nix",
+        "cp '${./builder.sh}' builder.sh"
+    );
+
+    # Start the daemon and wait until it is ready
+    $machine->execute("lorri daemon > lorri.stdout 2> lorri.stderr &");
+    $machine->waitUntilSucceeds("grep --fixed-strings 'lorri: ready' lorri.stdout");
+
+    # Ping the daemon
+    $machine->execute("lorri ping_ \$(readlink -f shell.nix)");
+
+    # Wait for the daemon to finish the build
+    $machine->waitUntilSucceeds("grep --fixed-strings 'OutputPaths' lorri.stdout");
+  '';
+}

--- a/nixos/tests/lorri/fake-shell.nix
+++ b/nixos/tests/lorri/fake-shell.nix
@@ -1,0 +1,5 @@
+derivation {
+  system = builtins.currentSystem;
+  name = "fake-shell";
+  builder = ./builder.sh;
+}

--- a/pkgs/tools/misc/lorri/default.nix
+++ b/pkgs/tools/misc/lorri/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, pkgs
+, fetchFromGitHub
+, rustPlatform
+  # Updater script
+, runtimeShell
+, writeScript
+  # Tests
+, nixosTests
+  # Apple dependencies
+, CoreServices
+, Security
+, cf-private
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lorri";
+  version = "unstable-2019-10-30";
+
+  meta = with stdenv.lib; {
+    description = "Your project's nix-env";
+    homepage = "https://github.com/target/lorri";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ grahamc Profpatsch ];
+  };
+
+  src = fetchFromGitHub {
+    owner = "target";
+    repo = pname;
+    # Run `eval $(nix-build -A lorri.updater)` after updating the revision!
+    rev = "03f10395943449b1fc5026d3386ab8c94c520ee3";
+    sha256 = "0fcl79ndaziwd8d74mk1lsijz34p2inn64b4b4am3wsyk184brzq";
+  };
+
+  cargoSha256 = "1daff4plh7hwclfp21hkx4fiflh9r80y2c7k2sd3zm4lmpy0jpfz";
+  doCheck = false;
+
+  BUILD_REV_COUNT = src.revCount or 1;
+  RUN_TIME_CLOSURE = pkgs.callPackage ./runtime.nix {};
+
+  nativeBuildInputs = with pkgs; [ nix direnv which ];
+  buildInputs =
+    stdenv.lib.optionals stdenv.isDarwin [ CoreServices Security cf-private ];
+
+  passthru = {
+    updater = with builtins; writeScript "copy-runtime-nix.sh" ''
+      #!${runtimeShell}
+      set -euo pipefail
+      cp ${src}/nix/runtime.nix ${toString ./runtime.nix}
+      cp ${src}/nix/runtime-closure.nix.template ${toString ./runtime-closure.nix.template}
+    '';
+    tests = {
+      nixos = nixosTests.lorri;
+    };
+  };
+}

--- a/pkgs/tools/misc/lorri/runtime-closure.nix.template
+++ b/pkgs/tools/misc/lorri/runtime-closure.nix.template
@@ -1,0 +1,37 @@
+# Nix with sandboxing requires every path used at build time be
+# explicitly declared. If we simply passed in the paths, they
+# would be copied in as sources. Using builtins.storePath we're
+# able to tell Nix that, no, in fact, treat these not as sources
+# to copy, but instead of a regular store path.
+#
+# Include the explicit closure, too, otherwise we'll get mysterious
+# "file not found" errors due to the glibc interpreter being
+# missing.
+let
+  # Magic inspired by Nix's config.nix:
+  # https://github.com/NixOS/nix/blob/f9a2ea44867cd1dbb408bca4df0ced806137b7f7/corepkgs/config.nix.in#L23
+  #
+  # If the dependency is in the Nix store we're using, refer to
+  # it as a literal store path. If it isn't, refer to it "normally".
+  #
+  # This makes sandboxing happy when in a nix-build, and the
+  # evaluation happy when in a «cargo build».
+  tools_build_host = @tools_build_host@;
+
+  # Compare the stringified version of the tools_build_host Nix store
+  # path to the evaluator's stringified Nix store path. Otherwise,
+  # Nix will read the sources in to the /nix/store, and, well,
+  # you can only copy the /nix/store in to the /nix/store so many
+  # times before you run out of disk space.
+  dep = if ("${toString (dirOf tools_build_host)}" == "${toString builtins.storeDir}")
+    then (builtins.trace "using storePath"  builtins.storePath)
+    else (builtins.trace "using toString" toString) # assume we have no sandboxing
+    ;
+
+  tools = dep tools_build_host;
+
+in {
+  path = "${tools}/bin";
+  builder = "${tools}/bin/bash";
+  closure = import @runtime_closure_list@ { inherit dep; };
+}

--- a/pkgs/tools/misc/lorri/runtime.nix
+++ b/pkgs/tools/misc/lorri/runtime.nix
@@ -1,0 +1,33 @@
+{
+  # Plumbing tools:
+  closureInfo, runCommand, writeText, buildEnv,
+
+  # Actual dependencies to propagate:
+  bash, coreutils }:
+let
+  tools = buildEnv {
+    name = "lorri-runtime-tools";
+    paths = [ coreutils bash ];
+  };
+
+  runtimeClosureInfo = closureInfo {
+    rootPaths = [ tools ];
+  };
+
+  closureToNix = runCommand "closure.nix" {}
+  ''
+    (
+      echo '{ dep, ... }: ['
+      sed -E 's/^(.*)$/    (dep \1)/' ${runtimeClosureInfo}/store-paths
+      echo ']'
+    ) > $out
+  '';
+
+  runtimeClosureInfoAsNix = runCommand "runtime-closure.nix" {
+    runtime_closure_list = closureToNix;
+    tools_build_host = tools;
+  }
+  ''
+    substituteAll ${./runtime-closure.nix.template} $out
+  '';
+in runtimeClosureInfoAsNix

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8170,7 +8170,10 @@ in
 
   llvmPackages_latest = llvmPackages_8;
 
-  lorri = throw "lorri is not stable yet. Please go to https://github.com/target/lorri and follow the installation instructions there, for the time being.";
+  lorri = callPackage ../tools/misc/lorri {
+    inherit (darwin) cf-private;
+    inherit (darwin.apple_sdk.frameworks) CoreServices Security;
+  };
 
   manticore = callPackage ../development/compilers/manticore { };
 


### PR DESCRIPTION
backport of the lorri release (#72889)

This is strictly an improvement over the error message we threw before for `lorri`.

cc @curiousleo 