### PR TITLE
tensorman: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6658,6 +6658,12 @@
     githubId = 42933;
     name = "Andrew Childs";
   };
+  thefenriswolf = {
+    email = "stefan.rohrbacher97@gmail.com";
+    github = "thefenriswolf";
+    githubId = "8547242";
+    name = "Stefan Rohrbacher";
+  };
   thesola10 = {
     email = "thesola10@bobile.fr";
     github = "thesola10";

--- a/pkgs/tools/misc/tensorman/default.nix
+++ b/pkgs/tools/misc/tensorman/default.nix
@@ -1,4 +1,4 @@
-{ pkgconfig, stdenv, rustPlatform, rustc, cargo, docker, openssl, fetchFromGithub }:
+{ pkgconfig, stdenv, rustPlatform, rustc, cargo, docker, openssl, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
   pname = "tensorman-${version}";

--- a/pkgs/tools/misc/tensorman/default.nix
+++ b/pkgs/tools/misc/tensorman/default.nix
@@ -1,7 +1,7 @@
 #{ pkgconfig, stdenv, rustPlatform, rustc, cargo, docker, openssl, fetchzip }:
 
 rustPlatform.buildRustPackage rec {
-  name = "tensorman-${version}";
+  pname = "tensorman-${version}";
   version = "0.1.0";
 
  src = fetchzip{
@@ -18,9 +18,9 @@ cargoSha256 = "1gh5w6zzrvjk60bqaf355fagijy723rvmqjh4laksd96pmzdfwn9";
 
   meta = with stdenv.lib; {
     description = "Utility for easy management of Tensorflow containers";
-    homepage = https://github.com/pop-os/tensorman/;
+    homepage = "https://github.com/pop-os/tensorman/";
     license = stdenv.lib.licenses.gpl3;
     platforms =  [ "x86_64-linux" ];
-    maintainers = [  ];
+    maintainers = [ "thefenriswolf" ];
   };
 }

--- a/pkgs/tools/misc/tensorman/default.nix
+++ b/pkgs/tools/misc/tensorman/default.nix
@@ -1,19 +1,16 @@
-#{ pkgconfig, stdenv, rustPlatform, rustc, cargo, docker, openssl, fetchzip }:
+{ pkgconfig, stdenv, rustPlatform, rustc, cargo, docker, openssl, fetchFromGithub }:
 
 rustPlatform.buildRustPackage rec {
   pname = "tensorman-${version}";
   version = "0.1.0";
 
- src = fetchzip{
-    url = "https://github.com/pop-os/tensorman/archive/master_eoan.zip";
-    sha256 = "10srpa3m6bdx0hx9w0p4n699j3c6hw8xx7l2p6r0g2d2d8nakwyf";
-  };
-
- #  src = fetchFromGitHub { # revert this to fetch from Github when upstream has github releases
- #   owner = "pop-os";
- #   repo = "tensorman";
- #   rev = version;
- 
+ src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "tensorman";
+    rev = version;
+    sha256 = "0ywb53snvymmwh10hm6whckz7dwmpqa4rxiggd24y178jdfrm2ns";
+};
+buildInputs = [ pkgconfig openssl ];
 cargoSha256 = "1gh5w6zzrvjk60bqaf355fagijy723rvmqjh4laksd96pmzdfwn9";
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/tensorman/default.nix
+++ b/pkgs/tools/misc/tensorman/default.nix
@@ -1,0 +1,26 @@
+#{ pkgconfig, stdenv, rustPlatform, rustc, cargo, docker, openssl, fetchzip }:
+
+rustPlatform.buildRustPackage rec {
+  name = "tensorman-${version}";
+  version = "0.1.0";
+
+ src = fetchzip{
+    url = "https://github.com/pop-os/tensorman/archive/master_eoan.zip";
+    sha256 = "10srpa3m6bdx0hx9w0p4n699j3c6hw8xx7l2p6r0g2d2d8nakwyf";
+  };
+
+ #  src = fetchFromGitHub { # revert this to fetch from Github when upstream has github releases
+ #   owner = "pop-os";
+ #   repo = "tensorman";
+ #   rev = version;
+ 
+cargoSha256 = "1gh5w6zzrvjk60bqaf355fagijy723rvmqjh4laksd96pmzdfwn9";
+
+  meta = with stdenv.lib; {
+    description = "Utility for easy management of Tensorflow containers";
+    homepage = https://github.com/pop-os/tensorman/;
+    license = stdenv.lib.licenses.gpl3;
+    platforms =  [ "x86_64-linux" ];
+    maintainers = [  ];
+  };
+}

--- a/pkgs/tools/misc/tensorman/default.nix
+++ b/pkgs/tools/misc/tensorman/default.nix
@@ -4,12 +4,13 @@ rustPlatform.buildRustPackage rec {
   pname = "tensorman-${version}";
   version = "0.1.0";
 
- src = fetchFromGitHub {
-    owner = "pop-os";
-    repo = "tensorman";
-    rev = version;
-    sha256 = "0ywb53snvymmwh10hm6whckz7dwmpqa4rxiggd24y178jdfrm2ns";
+src = fetchFromGitHub {
+  owner = "pop-os";
+  repo = "tensorman";
+  rev = version;
+  sha256 = "0ywb53snvymmwh10hm6whckz7dwmpqa4rxiggd24y178jdfrm2ns";
 };
+
 buildInputs = [ pkgconfig openssl ];
 cargoSha256 = "1gh5w6zzrvjk60bqaf355fagijy723rvmqjh4laksd96pmzdfwn9";
 
@@ -18,6 +19,6 @@ cargoSha256 = "1gh5w6zzrvjk60bqaf355fagijy723rvmqjh4laksd96pmzdfwn9";
     homepage = "https://github.com/pop-os/tensorman/";
     license = stdenv.lib.licenses.gpl3;
     platforms =  [ "x86_64-linux" ];
-    maintainers = [ "thefenriswolf" ];
+    maintainers = with maintainers; [ thefenriswolf ];
   };
 }

--- a/pkgs/tools/misc/tensorman/default.nix
+++ b/pkgs/tools/misc/tensorman/default.nix
@@ -4,15 +4,15 @@ rustPlatform.buildRustPackage rec {
   pname = "tensorman-${version}";
   version = "0.1.0";
 
-src = fetchFromGitHub {
-  owner = "pop-os";
-  repo = "tensorman";
-  rev = version;
-  sha256 = "0ywb53snvymmwh10hm6whckz7dwmpqa4rxiggd24y178jdfrm2ns";
-};
+ src = fetchFromGitHub {
+   owner = "pop-os";
+   repo = "tensorman";
+   rev = version;
+   sha256 = "0ywb53snvymmwh10hm6whckz7dwmpqa4rxiggd24y178jdfrm2ns";
+ };
 
-buildInputs = [ pkgconfig openssl ];
-cargoSha256 = "1gh5w6zzrvjk60bqaf355fagijy723rvmqjh4laksd96pmzdfwn9";
+ buildInputs = [ pkgconfig openssl ];
+ cargoSha256 = "1gh5w6zzrvjk60bqaf355fagijy723rvmqjh4laksd96pmzdfwn9";
 
   meta = with stdenv.lib; {
     description = "Utility for easy management of Tensorflow containers";

--- a/pkgs/tools/misc/tensorman/default.nix
+++ b/pkgs/tools/misc/tensorman/default.nix
@@ -1,7 +1,7 @@
 { pkgconfig, stdenv, rustPlatform, rustc, cargo, docker, openssl, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "tensorman-${version}";
+  pname = "tensorman";
   version = "0.1.0";
 
  src = fetchFromGitHub {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21003,7 +21003,7 @@ in
 
   spice-vdagent = callPackage ../applications/virtualization/spice-vdagent { };
   
-   tensorman = callPackage ../tools/misc/tensorman { };
+  tensorman = callPackage ../tools/misc/tensorman { };
 
   spideroak = callPackage ../applications/networking/spideroak { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21002,6 +21002,8 @@ in
   sound-juicer = callPackage ../applications/audio/sound-juicer { };
 
   spice-vdagent = callPackage ../applications/virtualization/spice-vdagent { };
+  
+   tensorman = callPackage ../tools/misc/tensorman { };
 
   spideroak = callPackage ../applications/networking/spideroak { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Easy management of Tensorflow containers with Docker as the backend.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
