### PR TITLE
doc/contributing: mention the word “backporting” for grep-ability

### DIFF
--- a/doc/contributing/submitting-changes.xml
+++ b/doc/contributing/submitting-changes.xml
@@ -441,7 +441,7 @@ Additional information.
    <itemizedlist>
     <listitem>
      <para>
-      If you're cherry-picking a commit to a stable release branch, always use <command>git cherry-pick -xe</command> and ensure the message contains a clear description about why this needs to be included in the stable branch.
+      If you're cherry-picking a commit to a stable release branch (“backporting”), always use <command>git cherry-pick -xe</command> and ensure the message contains a clear description about why this needs to be included in the stable branch.
      </para>
      <para>
       An example of a cherry-picked commit would look like this:


### PR DESCRIPTION
When a contributor wants to know how to do this ominous “backporting”
everybody is talking about, a grep should be enough to find it.
