### PR TITLE
pplatex: init at unstable-2015-09-14

### DIFF
--- a/pkgs/tools/typesetting/tex/pplatex/default.nix
+++ b/pkgs/tools/typesetting/tex/pplatex/default.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkgconfig,
+  pcre,
+} :
+  stdenv.mkDerivation rec {
+    pname = "pplatex";
+    version = "unstable-2015-09-14";
+
+    src = fetchFromGitHub {
+      owner = "stefanhepp";
+      repo = "pplatex";
+      rev = "5cec891ad6aec0115081cdd114ae1cc4f1ed7c06";
+      sha256 = "0wrkkbz6b6x91650nm8gccz7xghlp7b1i31fxwalz9xw3py9xygb";
+    };
+
+    nativeBuildInputs =
+    [
+      cmake
+      pkgconfig
+    ];
+
+    buildInputs =
+    [
+      pcre
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      install -Dm555 src/pplatex "$out"/bin/pplatex
+      runHook postInstall
+    '';
+    
+
+    meta = with stdenv.lib; {
+      description = "A tool to reformat the output of latex and friends into readable messages";
+      homepage = "https://github.com/stefanhepp/pplatex";
+      license = licenses.gpl3Plus;
+      maintainers = [ maintainers.srgom ];
+      platforms = platforms.linux;
+    };
+  }
+

--- a/pkgs/tools/typesetting/tex/pplatex/default.nix
+++ b/pkgs/tools/typesetting/tex/pplatex/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/stefanhepp/pplatex";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.srgom ];
-    platforms = platforms.darwin;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/typesetting/tex/pplatex/default.nix
+++ b/pkgs/tools/typesetting/tex/pplatex/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, pcre }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "pplatex";
   version = "unstable-2015-09-14";
 

--- a/pkgs/tools/typesetting/tex/pplatex/default.nix
+++ b/pkgs/tools/typesetting/tex/pplatex/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, pcre, }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, pcre }:
+
 stdenv.mkDerivation rec {
   pname = "pplatex";
   version = "unstable-2015-09-14";
@@ -26,7 +27,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/stefanhepp/pplatex";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.srgom ];
-    platforms = platforms.linux;
+    platforms = platforms.darwin;
   };
 }
-

--- a/pkgs/tools/typesetting/tex/pplatex/default.nix
+++ b/pkgs/tools/typesetting/tex/pplatex/default.nix
@@ -1,45 +1,32 @@
-{
-  stdenv,
-  fetchFromGitHub,
-  cmake,
-  pkgconfig,
-  pcre,
-} :
-  stdenv.mkDerivation rec {
-    pname = "pplatex";
-    version = "unstable-2015-09-14";
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, pcre, }:
+stdenv.mkDerivation rec {
+  pname = "pplatex";
+  version = "unstable-2015-09-14";
 
-    src = fetchFromGitHub {
-      owner = "stefanhepp";
-      repo = "pplatex";
-      rev = "5cec891ad6aec0115081cdd114ae1cc4f1ed7c06";
-      sha256 = "0wrkkbz6b6x91650nm8gccz7xghlp7b1i31fxwalz9xw3py9xygb";
-    };
+  src = fetchFromGitHub {
+    owner = "stefanhepp";
+    repo = "pplatex";
+    rev = "5cec891ad6aec0115081cdd114ae1cc4f1ed7c06";
+    sha256 = "0wrkkbz6b6x91650nm8gccz7xghlp7b1i31fxwalz9xw3py9xygb";
+  };
 
-    nativeBuildInputs =
-    [
-      cmake
-      pkgconfig
-    ];
+  nativeBuildInputs = [ cmake pkgconfig ];
 
-    buildInputs =
-    [
-      pcre
-    ];
+  buildInputs = [ pcre ];
 
-    installPhase = ''
-      runHook preInstall
-      install -Dm555 src/pplatex "$out"/bin/pplatex
-      runHook postInstall
-    '';
-    
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 src/pplatex "$out"/bin/pplatex
+    runHook postInstall
+  '';
 
-    meta = with stdenv.lib; {
-      description = "A tool to reformat the output of latex and friends into readable messages";
-      homepage = "https://github.com/stefanhepp/pplatex";
-      license = licenses.gpl3Plus;
-      maintainers = [ maintainers.srgom ];
-      platforms = platforms.linux;
-    };
-  }
+  meta = with stdenv.lib; {
+    description =
+      "A tool to reformat the output of latex and friends into readable messages";
+    homepage = "https://github.com/stefanhepp/pplatex";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.srgom ];
+    platforms = platforms.linux;
+  };
+}
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5740,6 +5740,8 @@ in
 
   ppl = callPackage ../development/libraries/ppl { };
 
+  pplatex = callPackage ../tools/typesetting/tex/pplatex { };
+
   ppp = callPackage ../tools/networking/ppp { };
 
   pptp = callPackage ../tools/networking/pptp {};


### PR DESCRIPTION
###### Motivation for this change
Tired of unreadable TeX errors, pplatex pretty prints them and makes them (actually) readable.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x]NixOS
   - [x] macOS
   - [ ]other Linux distributions
 
 
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @SRGOM 
