### PR TITLE
pythonPackages.archinfo: init at 8.19.10.30

### DIFF
--- a/pkgs/development/python-modules/archinfo/default.nix
+++ b/pkgs/development/python-modules/archinfo/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, nose
+, pkgs
+}:
+
+buildPythonPackage rec {
+  pname = "archinfo";
+  version = "8.19.10.30";
+
+  src = fetchFromGitHub {
+    owner = "angr";
+    repo = pname;
+    rev = "ddcd3a60256789b0ed3302907cb798bf01b1c5e6"; # versions are only tagged on PyPi
+    sha256 = "1wvqhrxynj652jpzcn1nmrbchxxwwfwqrgfwrhhynyxrw1gal84m";
+  };
+
+  checkInputs = [ nose ];
+  checkPhase = ''
+    nosetests tests/
+  '';
+
+  meta = with pkgs.lib; {
+    description = "A collection of classes that contain architecture-specific information";
+    homepage = "https://github.com/angr/archinfo";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.pamplemousse ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -181,6 +181,8 @@ in {
 
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
 
+  archinfo = disabledIf (!isPy3k) (callPackage ../development/python-modules/archinfo { });
+
   asana = callPackage ../development/python-modules/asana { };
 
   asdf = callPackage ../development/python-modules/asdf { };


### PR DESCRIPTION
###### Motivation for this change

Making progress on #67413 : `archinfo` is one of the component of `angr`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).