### PR TITLE
xerox6280: init at 1.0-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6914,6 +6914,12 @@
       fingerprint = "E631 8869 586F 99B4 F6E6  D785 5942 58F0 389D 2802";
     }];
   };
+  twistedjoe = {
+    email = "dupuisj@dupuisj.com";
+    github = "twistedjoe";
+    githubId = 1518299;
+    name = "Joé Dupuis";
+  };
   typetetris = {
     email = "ericwolf42@mail.com";
     github = "typetetris";

--- a/pkgs/misc/cups/drivers/xerox6280/default.nix
+++ b/pkgs/misc/cups/drivers/xerox6280/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, rpm, cpio} :
+stdenv.mkDerivation {
+  pname = "Xerox-Phaser-6280";
+  version = "1.0.0.0";
+
+  buildInputs = [rpm cpio];
+
+  src = fetchTarball {
+    url = "http://download.support.xerox.com/pub/drivers/6280/drivers/linux/en/6280_Linux.tar";
+    sha256 = "1xkawpj697bv82rd1f31nfs5bfq58jsgni5zq1cvqnn7layifv24";
+  };
+
+  postUnpack = ''
+    (
+    cd source
+    rpm2cpio English/Xerox-Phaser-6280-1.0-1.noarch.rpm | cpio -idmv
+    )
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    mv usr/share $out/
+  '';
+
+
+  meta = with stdenv.lib; {
+    homepage = https://www.xerox.com/;
+    description = "Print drivers for Xerox Phaser 6280 (DN/DT/N)";
+    license = licenses.unfreeRedistributable;
+    platforms = platforms.linux;
+    downloadPage = "https://www.support.xerox.com/support/phaser-6280/downloads/enus.html?operatingSystem=linux&fileLanguage=en";
+    maintainers = [ maintainers.twistedjoe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25224,6 +25224,8 @@ in
 
   xcftools = callPackage ../tools/graphics/xcftools { };
 
+  xerox6280 = callPackage ../misc/cups/drivers/xerox6280 { };
+
   xhyve = callPackage ../applications/virtualization/xhyve {
     inherit (darwin.apple_sdk.frameworks) Hypervisor vmnet;
     inherit (darwin.apple_sdk.libs) xpc;


### PR DESCRIPTION
###### Motivation for this change
Add xerox 6280 (DN/DT/N) printers ppd files.
The xerox 6280 Do not print correctly with the generic ones.

###### Things done
It's only ppd files. I only tested it on Nixos, but there is no executable. 
Should work on all linux distribution. 

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions (Should work too, it's only the ppd files, no executable)  
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


