### PR TITLE
multibootusb: Fix QT and refactor

### DIFF
--- a/pkgs/applications/misc/multibootusb/default.nix
+++ b/pkgs/applications/misc/multibootusb/default.nix
@@ -1,21 +1,33 @@
-{ stdenv, python36Packages, fetchFromGitHub, libxcb, mtools, p7zip, parted, procps, utillinux, qt5, runtimeShell }:
+{ fetchFromGitHub, libxcb, mtools, p7zip, parted, procps,
+  python36Packages, qt5, runtimeShell, stdenv, utillinux, wrapQtAppsHook }:
+
+# Note: Multibootusb is tricky to maintain. It relies on the
+# $PYTHONPATH variable containing some of their code, so that
+# something like:
+#
+# from scripts import config
+#
+# works. It also relies on the current directory to find some runtime
+# resources thanks to a use of __file__.
+#
+# https://github.com/mbusb/multibootusb/blob/0d34d70c3868f1d7695cfd141141b17c075de967/scripts/osdriver.py#L59
+
 python36Packages.buildPythonApplication rec {
   pname = "multibootusb";
   name = "${pname}-${version}";
   version = "9.2.0";
 
+  nativeBuildInputs = [
+    wrapQtAppsHook
+  ];
+
   buildInputs = [
-    python36Packages.dbus-python
-    python36Packages.pyqt5
-    python36Packages.pytest-shutil
-    python36Packages.python
-    python36Packages.pyudev
-    python36Packages.six
     libxcb
     mtools
     p7zip
     parted
     procps
+    python36Packages.python
     qt5.full
     utillinux
   ];
@@ -28,32 +40,42 @@ python36Packages.buildPythonApplication rec {
     sha256 = "0wlan0cp6c2i0nahixgpmkm0h4n518gj8rc515d579pqqp91p2h3";
   };
 
-  # Skip the fixup stage where stuff is shrinked (can't shrink text files)
-  phases = [ "unpackPhase" "installPhase" ];
+  # Tests can't run inside the NixOS sandbox
+  # "Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory"
+  doCheck = false;
 
-  installPhase = ''
-    share="$out/share/${pname}"
-    mkdir -p "$share"
-    cp -r data "$share/data"
-    cp -r scripts "$share/scripts"
-    cp "${pname}" "$share/${pname}"
+  pythonPath = [
+    python36Packages.dbus-python
+    python36Packages.pyqt5
+    python36Packages.pytest-shutil
+    python36Packages.pyudev
+    python36Packages.six
+  ];
 
-    mkdir "$out/bin"
-    cat > "$out/bin/${pname}" <<EOF
-      #!${runtimeShell}
-      cd "$share"
-      export PYTHONPATH="$PYTHONPATH:$share"
-      export PATH="$PATH:${parted}/bin:${procps}/bin"
+  makeWrapperArgs = [
+    # Firstly, add all necessary QT variables
+    "\${qtWrapperArgs[@]}"
 
-      "${python36Packages.python}/bin/python" "${pname}"
-    EOF
-    chmod +x "$out/bin/${pname}"
+    # Then, add the installed scripts/ directory to the python path
+    "--prefix" "PYTHONPATH" ":" "$out/lib/${python36Packages.python.libPrefix}/site-packages"
+
+    # Finally, move to directory that contains data
+    "--run" "\"cd $out/share/${pname}\""
+  ];
+
+  postInstall = ''
+    # This script doesn't work and it doesn't add much anyway
+    rm $out/bin/multibootusb-pkexec
+
+    # The installed data isn't sufficient for whatever reason, missing gdisk/gdisk.exe
+    mkdir -p "$out/share/${pname}"
+    cp -r data "$out/share/${pname}/data"
   '';
 
   meta = with stdenv.lib; {
     description = "Multiboot USB creator for Linux live disks";
     homepage = http://multibootusb.org/;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ jD91mZM2 ];
+    maintainers = []; # Looking for a maintainer!
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19009,7 +19009,7 @@ in
 
   moe =  callPackage ../applications/editors/moe { };
 
-  multibootusb = callPackage ../applications/misc/multibootusb {};
+  multibootusb = qt5.callPackage ../applications/misc/multibootusb {};
 
   praat = callPackage ../applications/audio/praat { };
 


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Fixes #56921, see #65399.