### PR TITLE
nixos-containers: allow writable api fs

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -564,6 +564,18 @@ in
               '';
             };
 
+            writableAPIVFS = mkOption {
+              type = types.enum [ true false "network" ];
+              default = false;
+              example = "network";
+              description = ''
+                If <literal>true</literal>, make <literal>/sys</literal> and
+                <literal>/proc/sys</literal> and friends writable in the
+                container. If set to <literal>network</literal>, leave only
+                <literal>/proc/sys/net</literal> writable.
+              '';
+            };
+
             interfaces = mkOption {
               type = types.listOf types.str;
               default = [];
@@ -798,6 +810,12 @@ in
               ${optionalString (cfg.localAddress6 != null) ''
                 LOCAL_ADDRESS6=${cfg.localAddress6}
               ''}
+            ''}
+            ${optionalString (cfg.writableAPIVFS == true) ''
+              SYSTEMD_NSPAWN_API_VFS_WRITABLE=1
+            ''}
+            ${optionalString (cfg.writableAPIVFS == "network") ''
+              SYSTEMD_NSPAWN_API_VFS_WRITABLE="${cfg.writableAPIVFS}"
             ''}
             INTERFACES="${toString cfg.interfaces}"
             MACVLANS="${toString cfg.macvlans}"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -59,6 +59,7 @@ in
   containers-physical_interfaces = handleTest ./containers-physical_interfaces.nix {};
   containers-restart_networking = handleTest ./containers-restart_networking.nix {};
   containers-tmpfs = handleTest ./containers-tmpfs.nix {};
+  containers-writable-apivfs = handleTest ./containers-writeable-apivfs.nix {};
   couchdb = handleTest ./couchdb.nix {};
   deluge = handleTest ./deluge.nix {};
   dhparams = handleTest ./dhparams.nix {};

--- a/nixos/tests/containers-writeable-apivfs.nix
+++ b/nixos/tests/containers-writeable-apivfs.nix
@@ -1,0 +1,72 @@
+let
+  container = { writableAPIVFS }: {
+    inherit writableAPIVFS;
+    autoStart = true;
+    config = {
+      boot.kernel.sysctl = { "net.ipv4.ip_forward" = false; };
+      networking.hostName = "test";
+    };
+  };
+in
+import ./make-test-python.nix (
+  { pkgs, ... }: {
+    name = "containers-writeable-apivfs";
+    meta = with pkgs.stdenv.lib.maintainers; {
+      maintainers = [ xwvvvvwx ];
+    };
+
+    machine = {
+      containers.allWritable = container { writableAPIVFS = true; };
+      containers.netWritable = container { writableAPIVFS = "network"; };
+      containers.notWritable = container { writableAPIVFS = false; };
+    };
+
+    testScript = ''
+      # --- helpers ---
+
+
+      def succeed(container, cmd):
+          return machine.succeed(f"nixos-container run {container} -- sh -c '{cmd}'").strip()
+
+
+      def fail(container, cmd):
+          machine.fail(f"nixos-container run {container} -- sh -c '{cmd}'")
+
+
+      # --- setup ---
+
+
+      machine.wait_for_unit("default.target")
+
+
+      # --- writableAPIVFS = true ---
+
+
+      with subtest("allWritable: /proc/sys/net is writable"):
+          succeed("allWritable", "echo 1 > /proc/sys/net/ipv4/ip_forward")
+
+      with subtest("allWritable: /proc/sys/kernel is writable"):
+          succeed("allWritable", "echo allWritable > /proc/sys/kernel/hostname")
+
+
+      # --- writableAPIVFS = "network" ---
+
+
+      with subtest("netWritable: /proc/sys/net is writable"):
+          succeed("netWritable", "echo 1 > /proc/sys/net/ipv4/ip_forward")
+
+      with subtest("netWritable: /proc/sys/kernel is not writable"):
+          fail("netWritable", "echo netWritable > /proc/sys/kernel/hostname")
+
+
+      # --- writableAPIVFS = false ---
+
+
+      with subtest("notWritable: /proc/sys/net is not writable"):
+          fail("notWritable", "echo 1 > /proc/sys/net/ipv4/ip_forward")
+
+      with subtest("notWritable: /proc/sys/kernel is not writable"):
+          fail("notWritable", "echo notWritable > /proc/sys/kernel/hostname")
+    '';
+  }
+)


### PR DESCRIPTION
###### Motivation for this change

I run `network-manager` and `dhcpcd` in containers as part of a namespace based whole internet wireguard vpn solution. Both of these packages will not work unless they can write to `/proc/sys/net`, so require the `SYSTEMD_NSPAWN_API_VFS_WRITABLE` environment variable (see [here](https://systemd.io/ENVIRONMENT/) for docs) to be set.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
