### PR TITLE
slack: 4.0.2 -> 4.1.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -1,16 +1,17 @@
 { theme ? null, stdenv, fetchurl, dpkg, makeWrapper , alsaLib, atk, cairo,
 cups, curl, dbus, expat, fontconfig, freetype, glib , gnome2, gtk3, gdk-pixbuf,
 libappindicator-gtk3, libnotify, libxcb, nspr, nss, pango , systemd, xorg,
-at-spi2-atk, libuuid, nodePackages
+at-spi2-atk, at-spi2-core, libuuid, nodePackages, libpulseaudio
 }:
 
 let
 
-  version = "4.0.2";
+  version = "4.1.2";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
     at-spi2-atk
+    at-spi2-core
     atk
     cairo
     cups
@@ -32,6 +33,7 @@ let
     stdenv.cc.cc
     systemd
     libuuid
+    libpulseaudio
 
     xorg.libxkbfile
     xorg.libX11
@@ -51,7 +53,7 @@ let
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://downloads.slack-edge.com/linux_releases/slack-desktop-${version}-amd64.deb";
-        sha256 = "053j5py16ilpwy868rhh5l2g93xj1fq4fwxrsi2bkfsnmq261hkm";
+        sha256 = "0a1b2k81hm1lfrdb47gmd07jqb7hva9sxsiph7b3iwzpzw8pjrkh";
       }
     else
       throw "Slack is not supported on ${stdenv.hostPlatform.system}";
@@ -63,18 +65,22 @@ in stdenv.mkDerivation {
   inherit src;
 
   buildInputs = [
-    dpkg
     gtk3  # needed for GSETTINGS_SCHEMAS_PATH
   ];
 
-  nativeBuildInputs = [ makeWrapper nodePackages.asar ];
+  nativeBuildInputs = [ dpkg makeWrapper nodePackages.asar ];
 
   dontUnpack = true;
-  buildCommand = ''
+  dontBuild = true;
+  dontPatchELF = true;
+
+  installPhase = ''
+    # The deb file contains a setuid binary, so 'dpkg -x' doesn't work here
+    dpkg --fsys-tarfile $src | tar --extract
+    rm -rf usr/share/lintian
+
     mkdir -p $out
-    dpkg -x $src $out
-    cp -av $out/usr/* $out
-    rm -rf $out/etc $out/usr $out/share/lintian
+    mv usr/* $out
 
     # Otherwise it looks "suspicious"
     chmod -R g-w $out


### PR DESCRIPTION
###### Motivation for this change
- Update Slack
- Add missing dependency on libpulseaudio
- Extract the deb in the build folder and move only the files we're
  interested in to $out
- Use the regular builder, but turn off the patchELF hook
- Move dpkg from buildInputs to nativeBuildInputs, since it's only
  used at build time

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Tested running `slack` and `slack-dark` locally without issues

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (~570 KiB smaller)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mmahut 
