### PR TITLE
mlpack: init at 3.2.1

### DIFF
--- a/pkgs/development/libraries/ensmallen/default.nix
+++ b/pkgs/development/libraries/ensmallen/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, armadillo, cmake, fetchFromGitHub, openmp ? null, enableOpenMP ? false }:
+assert enableOpenMP -> openmp != null;
+
+stdenv.mkDerivation rec {
+  pname = "ensmallen";
+  version = "2.10.3";
+
+  src = fetchFromGitHub {
+    owner = "mlpack";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-pLpBPnFfkqd6M1wbmuxxTb+/XwE1PtcZyLgm7ozwDVk=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ armadillo ] ++ (lib.optional enableOpenMP openmp);
+
+  cmakeFlags = [ "-DUSE_OPENMP=${if enableOpenMP then "ON" else "OFF"}" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A header-only C++ library for mathematical optimization";
+    homepage = "https://ensmallen.org/";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ aminechikhaoui ];
+  };
+}

--- a/pkgs/development/libraries/mlpack/default.nix
+++ b/pkgs/development/libraries/mlpack/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, armadillo, boost, cmake, fetchFromGitHub, ensmallen
+, enableOpenMP ? false }:
+
+stdenv.mkDerivation rec {
+  pname = "mlpack";
+  version = "3.2.1";
+
+  src = fetchFromGitHub {
+    owner = "mlpack";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-/UN/Pmt7m3s9pq4I3XTt0AbHEj3nbbdWeLLcs1TE+9w=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ armadillo boost ensmallen ];
+
+  cmakeFlags = [ "-DUSE_OPENMP=${if enableOpenMP then "ON" else "OFF"}" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A scalable C++ machine learning library";
+    homepage = "https://www.mlpack.org/";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ aminechikhaoui ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -857,6 +857,13 @@ in
 
   enpass = callPackage ../tools/security/enpass { };
 
+  ensmallen = callPackage ../development/libraries/ensmallen { };
+
+  ensmallenOpenMP = callPackage ../development/libraries/ensmallen {
+    openmp = llvmPackages.openmp;
+    enableOpenMP = true;
+  };
+
   essentia-extractor = callPackage ../tools/audio/essentia-extractor { };
 
   esh = callPackage ../tools/text/esh { };
@@ -1903,6 +1910,13 @@ in
   mkspiffs-presets = recurseIntoAttrs (callPackages ../tools/filesystems/mkspiffs/presets.nix { });
 
   mlarchive2maildir = callPackage ../applications/networking/mailreaders/mlarchive2maildir { };
+
+  mlpack = callPackage ../development/libraries/mlpack {};
+
+  mlpackOpenMP = callPackage ../development/libraries/mlpack {
+    ensmallen = ensmallenOpenMP;
+    enableOpenMP = true;
+  };
 
   monetdb = callPackage ../servers/sql/monetdb { };
 


### PR DESCRIPTION
* ensmallen: init at 2.10.3

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
