### PR TITLE
rust: add support for armv6l-linux and armv7l-linux

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, echo_build_heading, noisily, makeDeps }:
+{ lib, stdenv, echo_build_heading, noisily, makeDeps, rust }:
 { crateName,
   dependencies,
   crateFeatures, crateRenames, libName, release, libPath,
@@ -13,17 +13,6 @@
         (if release then "-C opt-level=3" else "-C debuginfo=2")
         (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOpts);
     rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";
-
-    # Some platforms have different names for rustc.
-    rustPlatform =
-      with stdenv.hostPlatform.parsed;
-      let cpu_ = if cpu.name == "armv7a" then "armv7"
-                 else cpu.name;
-          vendor_ = vendor.name;
-          kernel_ = kernel.name;
-          abi_ = abi.name;
-      in
-      "${cpu_}-${vendor_}-${kernel_}-${abi_}";
   in ''
     runHook preBuild
     norm=""
@@ -67,7 +56,7 @@
         ${crateFeatures} --out-dir target/bin --emit=dep-info,link -L dependency=target/deps \
         $LINK ${deps}$EXTRA_LIB --cap-lints allow \
         $BUILD_OUT_DIR $EXTRA_BUILD $EXTRA_FEATURES --color ${colors} \
-        ${if stdenv.hostPlatform != stdenv.buildPlatform then "--target ${rustPlatform} -C linker=${stdenv.hostPlatform.config}-gcc" else ""}
+        ${if stdenv.hostPlatform != stdenv.buildPlatform then "--target ${rust.toRustTarget stdenv.hostPlatform} -C linker=${stdenv.hostPlatform.config}-gcc" else ""}
       if [ "$crate_name_" != "$crate_name" ]; then
         mv target/bin/$crate_name_ target/bin/$crate_name
       fi

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -4,7 +4,7 @@
 # This can be useful for deploying packages with NixOps, and to share
 # binary dependencies between projects.
 
-{ lib, stdenv, defaultCrateOverrides, fetchCrate, rustc }:
+{ lib, stdenv, defaultCrateOverrides, fetchCrate, rustc, rust }:
 
 let
     # This doesn't appear to be officially documented anywhere yet.
@@ -59,7 +59,7 @@ let
     '';
 
     configureCrate = import ./configure-crate.nix { inherit lib stdenv echo_build_heading noisily makeDeps; };
-    buildCrate = import ./build-crate.nix { inherit lib stdenv echo_build_heading noisily makeDeps; };
+    buildCrate = import ./build-crate.nix { inherit lib stdenv echo_build_heading noisily makeDeps rust; };
     installCrate = import ./install-crate.nix;
 
     in

--- a/pkgs/development/compilers/rust/1_38_0.nix
+++ b/pkgs/development/compilers/rust/1_38_0.nix
@@ -10,6 +10,7 @@ import ./default.nix {
   bootstrapHashes = {
     i686-unknown-linux-gnu = "74510e0e52a55e65a9f716673c2cda4d2bd427e2453541c6993c77c3ec04acf9";
     x86_64-unknown-linux-gnu = "cb573229bfd32928177c3835fdeb62d52da64806b844bc1095c6225b0665a1cb";
+    arm-unknown-linux-gnueabihf = "272739fbb23cf6c2040c1813af9c8c7f386cac37d9de638f22a1816eb96bc0ae";
     armv7-unknown-linux-gnueabihf = "5b87b877f0ed20c6a09ce26e7a15d8c61b26b62484b97e78a51099d0efefec98";
     aarch64-unknown-linux-gnu = "263ef98fa3a6b2911b56f89c06615cdebf6ef676eb9b2493ad1539602f79b6ba";
     i686-apple-darwin = "e45d0c4d882fc6c404ffa6fe790294f4ea96384a2b48804adbf723f3635477a8";

--- a/pkgs/development/compilers/rust/1_39_0.nix
+++ b/pkgs/development/compilers/rust/1_39_0.nix
@@ -10,6 +10,7 @@ import ./default.nix {
   bootstrapHashes = {
     i686-unknown-linux-gnu = "41aed8a350e24a0cac1444ed99b3dd24a90bc581dd88cb420c6e547d6b5f57af";
     x86_64-unknown-linux-gnu = "adda26b3f0609dbfbdc2019da4a20101879b9db2134fae322a4e863a069ec221";
+    arm-unknown-linux-gnueabihf = "0603a3d3d16ae8f3b3b117eb699e8f3ef7532a6f6d3c29d13e7d4614fc3c9e7a";
     armv7-unknown-linux-gnueabihf = "8b1bf1680a61a643d6b5c7a3b1a1ce88448652756395e20ba5846739cbd085c4";
     aarch64-unknown-linux-gnu = "06afd6d525326cea95c3aa658aaa8542eab26f44235565bb16913ac9d12b7bda";
     i686-apple-darwin = "cdbf2807774bed350a3af6f41d7f7dd7ceff28777cde310c3ba90033188eb2f8";

--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -1,24 +1,11 @@
-{ stdenv, fetchurl, callPackage, version, hashes }:
+{ stdenv, fetchurl, rust, callPackage, version, hashes }:
 
 let
-  platform =
-    if stdenv.hostPlatform.system == "i686-linux"
-    then "i686-unknown-linux-gnu"
-    else if stdenv.hostPlatform.system == "x86_64-linux"
-    then "x86_64-unknown-linux-gnu"
-    else if stdenv.hostPlatform.system == "armv7l-linux"
-    then "armv7-unknown-linux-gnueabihf"
-    else if stdenv.hostPlatform.system == "aarch64-linux"
-    then "aarch64-unknown-linux-gnu"
-    else if stdenv.hostPlatform.system == "i686-darwin"
-    then "i686-apple-darwin"
-    else if stdenv.hostPlatform.system == "x86_64-darwin"
-    then "x86_64-apple-darwin"
-    else throw "missing bootstrap url for platform ${stdenv.hostPlatform.system}";
+  platform = rust.toRustTarget stdenv.hostPlatform;
 
   src = fetchurl {
      url = "https://static.rust-lang.org/dist/rust-${version}-${platform}.tar.gz";
-     sha256 = hashes.${platform};
+     sha256 = hashes.${platform} or (throw "missing bootstrap url for platform ${platform}");
   };
 
 in callPackage ./binary.nix

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -11,6 +11,14 @@
 , llvmPackages_5
 , pkgsBuildTarget, pkgsBuildBuild
 }: rec {
+  toRustTarget = platform: with platform.parsed; let
+    cpu_ = {
+      "armv7a" = "armv7";
+      "armv7l" = "armv7";
+      "armv6l" = "arm";
+    }.${cpu.name} or cpu.name;
+  in "${cpu_}-${vendor.name}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
+
   makeRustPlatform = { rustc, cargo, ... }: {
     rust = {
       inherit rustc cargo;

--- a/pkgs/development/compilers/rust/print-hashes.sh
+++ b/pkgs/development/compilers/rust/print-hashes.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 PLATFORMS=(
   i686-unknown-linux-gnu
   x86_64-unknown-linux-gnu
+  arm-unknown-linux-gnueabihf
   armv7-unknown-linux-gnueabihf
   aarch64-unknown-linux-gnu
   i686-apple-darwin

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,6 +1,6 @@
 { stdenv, removeReferencesTo, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget
 , fetchurl, file, python2
-, llvm_9, darwin, git, cmake, rustPlatform
+, llvm_9, darwin, git, cmake, rust, rustPlatform
 , pkgconfig, openssl
 , which, libffi
 , withBundledLLVM ? false
@@ -53,9 +53,9 @@ in stdenv.mkDerivation rec {
   # We need rust to build rust. If we don't provide it, configure will try to download it.
   # Reference: https://github.com/rust-lang/rust/blob/master/src/bootstrap/configure.py
   configureFlags = let
-    setBuild  = "--set=target.${stdenv.buildPlatform.config}";
-    setHost   = "--set=target.${stdenv.hostPlatform.config}";
-    setTarget = "--set=target.${stdenv.targetPlatform.config}";
+    setBuild  = "--set=target.${rust.toRustTarget stdenv.buildPlatform}";
+    setHost   = "--set=target.${rust.toRustTarget stdenv.hostPlatform}";
+    setTarget = "--set=target.${rust.toRustTarget stdenv.targetPlatform}";
     ccForBuild  = "${pkgsBuildBuild.targetPackages.stdenv.cc}/bin/${pkgsBuildBuild.targetPackages.stdenv.cc.targetPrefix}cc";
     cxxForBuild = "${pkgsBuildBuild.targetPackages.stdenv.cc}/bin/${pkgsBuildBuild.targetPackages.stdenv.cc.targetPrefix}c++";
     ccForHost  = "${pkgsBuildHost.targetPackages.stdenv.cc}/bin/${pkgsBuildHost.targetPackages.stdenv.cc.targetPrefix}cc";
@@ -68,9 +68,9 @@ in stdenv.mkDerivation rec {
     "--set=build.cargo=${rustPlatform.rust.cargo}/bin/cargo"
     "--enable-rpath"
     "--enable-vendor"
-    "--build=${stdenv.buildPlatform.config}"
-    "--host=${stdenv.hostPlatform.config}"
-    "--target=${stdenv.targetPlatform.config}"
+    "--build=${rust.toRustTarget stdenv.buildPlatform}"
+    "--host=${rust.toRustTarget stdenv.hostPlatform}"
+    "--target=${rust.toRustTarget stdenv.targetPlatform}"
 
     "${setBuild}.cc=${ccForBuild}"
     "${setHost}.cc=${ccForHost}"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Extremely similar to #72480, except with a different mapping function name and location, bootstrap tarball hashes for armv6l, and another platform string fixup in `.cargo/config`.

Note that the rust does not build on armv6l right now because bootstrap `rustc` segfaults while building libc since the upgrade (of the bootstrap compiler) to 1.38.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
