### PR TITLE
pythonPackages.gpyopt: init at unstable-2019-09-25

### DIFF
--- a/pkgs/development/python-modules/gpyopt/default.nix
+++ b/pkgs/development/python-modules/gpyopt/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, numpy, scipy, gpy, emcee, nose }:
+
+buildPythonPackage rec {
+  pname = "GPyOpt";
+  version = "unstable-2019-09-25";
+
+  src = fetchFromGitHub {
+    repo   = pname;
+    owner  = "SheffieldML";
+    rev    = "249b8ff29c52c12ed867f145a627d529372022d8";
+    sha256 = "1ywaw1kpdr7dv4s4cr7afmci86sw7w61178gs45b0lq08652zdlb";
+  };
+
+  doCheck = false;  # requires several packages not available in Nix
+
+  checkInputs = [ nose ];
+
+  checkPhase = "nosetests -v GPyOpt/testing";
+
+  propagatedBuildInputs = [ numpy scipy gpy emcee ];
+
+  meta = with stdenv.lib; {
+    description = "Bayesian optimization toolbox in Python";
+    homepage = https://sheffieldml.github.io/GPyOpt;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2433,6 +2433,8 @@ in {
 
   gpy = callPackage ../development/python-modules/gpy { };
 
+  gpyopt = callPackage ../development/python-modules/gpyopt { };
+
   gitdb = callPackage ../development/python-modules/gitdb { };
 
   gitdb2 = callPackage ../development/python-modules/gitdb2 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [NA] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
