### PR TITLE
unit: 1.12.0 -> 1.13.0

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -111,7 +111,7 @@ let
           cp ${config}/config.sub tool/
         '';
 
-        configureFlags = ["--enable-shared" "--enable-pthread"]
+        configureFlags = ["--enable-shared" "--enable-pthread" "--with-soname=ruby_${tag}"]
           ++ op useRailsExpress "--with-baseruby=${baseruby}/bin/ruby"
           ++ op (!docSupport) "--disable-install-doc"
           ++ ops stdenv.isDarwin [

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -1,11 +1,14 @@
 { stdenv, fetchFromGitHub, which
-, withPython ? true, python
-, withPHP72 ? true, php72
-, withPHP73 ? false, php73
-, withPerl ? true, perl
+, withPython2 ? false, python2
+, withPython3 ? true, python3, ncurses
+, withPHP72 ? false, php72
+, withPHP73 ? true, php73
+, withPerl528 ? false, perl528
+, withPerl530 ? true, perl530
 , withPerldevel ? false, perldevel
 , withRuby_2_4 ? false, ruby_2_4
-, withRuby ? true, ruby
+, withRuby_2_5 ? false, ruby_2_5
+, withRuby_2_6 ? true, ruby_2_6
 , withSSL ? true, openssl ? null
 , withIPv6 ? true
 , withDebug ? false
@@ -27,13 +30,16 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ which ];
 
   buildInputs = [ ]
-    ++ optional withPython python
+    ++ optional withPython2 python2
+    ++ optionals withPython3 [ python3 ncurses ]
     ++ optional withPHP72 php72
     ++ optional withPHP73 php73
-    ++ optional withPerl perl
+    ++ optional withPerl528 perl528
+    ++ optional withPerl530 perl530
     ++ optional withPerldevel perldevel
     ++ optional withRuby_2_4 ruby_2_4
-    ++ optional withRuby ruby
+    ++ optional withRuby_2_5 ruby_2_5
+    ++ optional withRuby_2_6 ruby_2_6
     ++ optional withSSL openssl;
 
   configureFlags = [
@@ -46,13 +52,16 @@ stdenv.mkDerivation rec {
     ++ optional withDebug   [ "--debug" ];
 
   postConfigure = ''
-    ${optionalString withPython     "./configure python  --module=python    --config=${python}/bin/python-config  --lib-path=${python}/lib"}
-    ${optionalString withPHP72      "./configure php     --module=php72     --config=${php72.dev}/bin/php-config  --lib-path=${php72}/lib"}
-    ${optionalString withPHP73      "./configure php     --module=php73     --config=${php73.dev}/bin/php-config  --lib-path=${php73}/lib"}
-    ${optionalString withPerl       "./configure perl    --module=perl      --perl=${perl}/bin/perl"}
-    ${optionalString withPerldevel  "./configure perl    --module=perl529   --perl=${perldevel}/bin/perl"}
-    ${optionalString withRuby_2_4   "./configure ruby    --module=ruby24    --ruby=${ruby_2_4}/bin/ruby"}
-    ${optionalString withRuby       "./configure ruby    --module=ruby      --ruby=${ruby}/bin/ruby"}
+    ${optionalString withPython2    "./configure python --module=python2  --config=${python2}/bin/python2-config  --lib-path=${python2}/lib"}
+    ${optionalString withPython3    "./configure python --module=python3  --config=${python3}/bin/python3-config  --lib-path=${python3}/lib"}
+    ${optionalString withPHP72      "./configure php    --module=php72    --config=${php72.dev}/bin/php-config    --lib-path=${php72}/lib"}
+    ${optionalString withPHP73      "./configure php    --module=php73    --config=${php73.dev}/bin/php-config    --lib-path=${php73}/lib"}
+    ${optionalString withPerl528    "./configure perl   --module=perl528  --perl=${perl528}/bin/perl"}
+    ${optionalString withPerl530    "./configure perl   --module=perl530  --perl=${perl530}/bin/perl"}
+    ${optionalString withPerldevel  "./configure perl   --module=perldev  --perl=${perldevel}/bin/perl"}
+    ${optionalString withRuby_2_4   "./configure ruby   --module=ruby24   --ruby=${ruby_2_4}/bin/ruby"}
+    ${optionalString withRuby_2_5   "./configure ruby   --module=ruby25   --ruby=${ruby_2_5}/bin/ruby"}
+    ${optionalString withRuby_2_6   "./configure ruby   --module=ruby26   --ruby=${ruby_2_6}/bin/ruby"}
   '';
 
   meta = {

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -14,14 +14,14 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.12.0";
+  version = "1.13.0";
   pname = "unit";
 
   src = fetchFromGitHub {
     owner = "nginx";
     repo = "unit";
     rev = version;
-    sha256 = "1ylzfsajjfaxzn7mycjs69ms4x58r4szpk07kqrmbf03dp2cmxkq";
+    sha256 = "1b5il05isq5yvnx2qpnihsrmj0jliacvhrm58i87d48anwpv1k8q";
   };
 
   nativeBuildInputs = [ which ];


### PR DESCRIPTION
###### Motivation for this change
Update nginx unit to version 1.13.0

Changelog:
 - Feature: basic support for HTTP reverse proxying.
 - Feature: compatibility with Python 3.8.
 - Bugfix: memory leak in Python application processes when the close handler was used.
 - Bugfix: threads in Python applications might not work correctly.
 - Bugfix: Ruby on Rails applications might not work on Ruby 2.6.
 - Bugfix: backtraces for uncaught exceptions in Python 3 might be logged with significant delays.
 - Bugfix: explicit setting a namespaces isolation option to false might have enabled it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
