### PR TITLE
Treewide: replace last refs to alioth.debian.org

### DIFF
--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -5,7 +5,7 @@ callPackage ./generic.nix (args // rec {
   src = fetchurl {
     sha256 = "1j9nbqspaj0rlgalafb5z6r606k0i22kz0rcpd744p176yzlfdr9";
     urls = [
-      "https://alioth.debian.org/frs/download.php/latestfile/176/sane-backends-${version}.tar.gz"
+      "https://alioth-archive.debian.org/releases/sane/sane-backends/${version}/sane-backends-${version}.tar.gz"
     ];
   };
 })

--- a/pkgs/applications/graphics/sane/backends/git.nix
+++ b/pkgs/applications/graphics/sane/backends/git.nix
@@ -5,6 +5,6 @@ callPackage ./generic.nix (args // {
   src = fetchgit {
     sha256 = "0qf7d7268kdxnb723c03m6icxhbgx0vw8gqvck2q1w5b948dy9g8";
     rev = "e895ee55bec8a3320a0e972b32c05d35b47fe226";
-    url = "git://alioth.debian.org/git/sane/sane-backends.git";
+    url = "https://gitlab.com/sane-project/backends.git";
   };
 })

--- a/pkgs/applications/graphics/sane/frontends.nix
+++ b/pkgs/applications/graphics/sane/frontends.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.0.14";
 
   src = fetchurl {
-    url = "https://alioth.debian.org/frs/download.php/latestfile/175/${pname}-${version}.tar.gz";
+    url = "https://alioth-archive.debian.org/releases/sane/${pname}/${version}/${pname}-${version}.tar.gz";
     sha256 = "1ad4zr7rcxpda8yzvfkq1rfjgx9nl6lan5a628wvpdbh3fn9v0z7";
   };
 

--- a/pkgs/development/tools/misc/chrpath/default.nix
+++ b/pkgs/development/tools/misc/chrpath/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "chrpath-0.16";
 
   src = fetchurl {
-    url = "https://alioth.debian.org/frs/download.php/file/3979/chrpath-0.16.tar.gz";
+    url = "https://alioth-archive.debian.org/releases/chrpath/chrpath/0.16/chrpath-0.16.tar.gz";
     sha256 = "0yvfq891mcdkf8g18gjjkn2m5rvs8z4z4cl1vwdhx6f2p9a4q3dv";
   };
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
       binary. The rpath, or runpath if it is present, is where the runtime
       linker should look for the libraries needed for a program.
     '';
-    homepage = https://alioth.debian.org/projects/chrpath/;
+    homepage = https://tracker.debian.org/pkg/chrpath;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/tools/networking/surfraw/default.nix
+++ b/pkgs/tools/networking/surfraw/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "surfraw-2.3.0";
 
   src = fetchurl {
-    url = "http://surfraw.alioth.debian.org/dist/surfraw-2.3.0.tar.gz";
+    url = "https://gitlab.com/surfraw/Surfraw/uploads/2de827b2786ef2fe43b6f07913ca7b7f/surfraw-2.3.0.tar.gz";
     sha256 = "099nbif0x5cbcf18snc58nx1a3q7z0v9br9p2jiq9pcc7ic2015d";
   };
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Provides a fast unix command line interface to a variety of popular WWW search engines and other artifacts of power";
-    homepage = http://surfraw.alioth.debian.org;
+    homepage = https://gitlab.com/surfraw/Surfraw;
     maintainers = [];
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.publicDomain;

--- a/pkgs/tools/system/fakeroot/default.nix
+++ b/pkgs/tools/system/fakeroot/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://fakeroot.alioth.debian.org/;
+    homepage = https://salsa.debian.org/clint/fakeroot;
     description = "Give a fake root environment through LD_PRELOAD";
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [viric];

--- a/pkgs/tools/system/logcheck/default.nix
+++ b/pkgs/tools/system/logcheck/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       Logcheck helps spot problems and security violations in your logfiles automatically and will send the results to you by e-mail.
       Logcheck was part of the Abacus Project of security tools, but this version has been rewritten.
     '';
-    homepage = http://logcheck.alioth.debian.org/;
+    homepage = https://salsa.debian.org/debian/logcheck;
     license = licenses.gpl2;
     maintainers = [ maintainers.bluescreen303 ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Alioth is now offline -> https://wiki.debian.org/Salsa/AliothMigration
Sources moved to other forges (Salsa for example)
Some release tarballs are available on alioth-archive.debian.org

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti for sane
