### PR TITLE
xmobar: tzdata patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -636,4 +636,8 @@ self: super: builtins.intersectAttrs super {
   # need it during the build itself, too.
   cairo = addBuildTool super.cairo self.buildHaskellPackages.gtk2hs-buildtools;
   pango = disableHardening (addBuildTool super.pango self.buildHaskellPackages.gtk2hs-buildtools) ["fortify"];
+
+  # The DateZone xmobar plugin has the hardcoded path /usr/share/zoneinfo
+  # Essentially, this backports upstream PR https://github.com/jaor/xmobar/pull/411
+  xmobar = appendPatch super.xmobar ./patches/xmobar-tzdir.patch;
 }

--- a/pkgs/development/haskell-modules/patches/xmobar-tzdir.patch
+++ b/pkgs/development/haskell-modules/patches/xmobar-tzdir.patch
@@ -1,0 +1,43 @@
+commit d3b962ff8ea0a26bffba69ec27beed11d82b4908
+Author: Emmanuel Rosa <emmanuelrosa@protonmail.com>
+Date:   Sun Nov 17 12:05:41 2019 +0700
+
+    DateZone: get timezone series from TZDIR
+    
+    The DateZone plugin calls `getTimeZoneSeriesFromOlsonFile` using the
+    hard-coded path /usr/share/zoneinfo. While that may work just fine on
+    most Linux distros, it does not work on NixOS since that directory is
+    always locates somewhere under /nix/store.
+    
+    Based on mild research, it seems the environment variable TZDIR is
+    commonly set to the absolute path to `zoneinfo` (but without a trailing
+    slash).
+    
+    This change modifies the DateZone plugin to first try getting
+    the zoneinfo path from the TZDIR environment variable, falling back
+    to the hard-coded path /usr/share/zoneinfo
+
+diff --git a/src/Xmobar/Plugins/DateZone.hs b/src/Xmobar/Plugins/DateZone.hs
+index 22be6c2..35767a8 100644
+--- a/src/Xmobar/Plugins/DateZone.hs
++++ b/src/Xmobar/Plugins/DateZone.hs
+@@ -28,6 +28,9 @@ import Xmobar.Run.Exec
+ import Control.Concurrent.STM
+ 
+ import System.IO.Unsafe
++import System.Environment (lookupEnv)
++
++import Data.Maybe (fromMaybe)
+ 
+ import Data.Time.Format
+ import Data.Time.LocalTime
+@@ -63,7 +66,8 @@ instance Exec DateZone where
+       locale <- getTimeLocale
+       atomically $ putTMVar localeLock lock
+       if z /= "" then do
+-        timeZone <- getTimeZoneSeriesFromOlsonFile ("/usr/share/zoneinfo/" ++ z)
++        tzdir <- lookupEnv "TZDIR"
++        timeZone <- getTimeZoneSeriesFromOlsonFile ((fromMaybe "/usr/share/zoneinfo" tzdir) ++ "/" ++ z)
+         go (dateZone f locale timeZone)
+        else
+         go (date f locale)


### PR DESCRIPTION
The DateZone xmobar plugin uses the hard-coded path /usr/share/zoneinfo
for timezone information. This change patches DateZone.hs to replace the
path with ${pkgs.tzdata}/share/zoneinfo, thus the correct path is set
at compile-time.

Closes #73152

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
