### PR TITLE
quickjs: init at 2019-10-27

### DIFF
--- a/pkgs/development/interpreters/quickjs/default.nix
+++ b/pkgs/development/interpreters/quickjs/default.nix
@@ -12,6 +12,26 @@ stdenv.mkDerivation rec {
   makeFlags = [ "prefix=${placeholder ''out''}" ];
   enableParallelBuilding = true;
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    PATH="$out/bin:$PATH"
+
+    # Programs exit with code 1 when testing help, so grep for a string
+    set +o pipefail
+    qjs     --help 2>&1 | grep "QuickJS version"
+    qjsbn   --help 2>&1 | grep "QuickJS version"
+    qjscalc --help 2>&1 | grep "QuickJS version"
+    set -o pipefail
+
+    temp=$(mktemp).js
+    echo "console.log('Output from compiled program');" > "$temp"
+    set -o verbose
+    out=$(mktemp) && qjsc         "$temp" -o "$out" && "$out" | grep -q "Output from compiled program"
+    out=$(mktemp) && qjsbnc       "$temp" -o "$out" && "$out" | grep -q "Output from compiled program"
+    out=$(mktemp) && qjsc   -flto "$temp" -o "$out" && "$out" | grep -q "Output from compiled program"
+    out=$(mktemp) && qjsbnc -flto "$temp" -o "$out" && "$out" | grep -q "Output from compiled program"
+  '';
+
   meta = with stdenv.lib; {
     description = "A small and embeddable Javascript engine";
     homepage = "https://bellard.org/quickjs/";

--- a/pkgs/development/interpreters/quickjs/default.nix
+++ b/pkgs/development/interpreters/quickjs/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "quickjs";
+  version = "2019-07-09";
+
+  src = fetchurl {
+    url = "https://bellard.org/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "0r6mgh0m85c11y8ah5iphzpw518br0hi36f92mgdg2iivpciq31m";
+  };
+
+  postPatch = ''
+    sed -e "s/^CONFIG_M32=y/#&/" -i Makefile
+  '';
+
+  makeFlags = [ "prefix=${placeholder ''out''}" ];
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A small and embeddable Javascript engine";
+    homepage = https://bellard.org/quickjs/;
+    maintainers = [ maintainers.stesie ];
+    platforms = platforms.linux;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/interpreters/quickjs/default.nix
+++ b/pkgs/development/interpreters/quickjs/default.nix
@@ -2,24 +2,20 @@
 
 stdenv.mkDerivation rec {
   pname = "quickjs";
-  version = "2019-07-09";
+  version = "2019-10-27";
 
   src = fetchurl {
     url = "https://bellard.org/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "0r6mgh0m85c11y8ah5iphzpw518br0hi36f92mgdg2iivpciq31m";
+    sha256 = "0xm16ja3c0k80jy0xkx0f40r44v2lgx2si4dnaw2w7c5nx7cmkai";
   };
-
-  postPatch = ''
-    sed -e "s/^CONFIG_M32=y/#&/" -i Makefile
-  '';
 
   makeFlags = [ "prefix=${placeholder ''out''}" ];
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "A small and embeddable Javascript engine";
-    homepage = https://bellard.org/quickjs/;
-    maintainers = [ maintainers.stesie ];
+    homepage = "https://bellard.org/quickjs/";
+    maintainers = with maintainers; [ stesie ivan ];
     platforms = platforms.linux;
     license = licenses.mit;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5889,6 +5889,8 @@ in
 
   qtikz = libsForQt5.callPackage ../applications/graphics/ktikz { };
 
+  quickjs = callPackage ../development/interpreters/quickjs { };
+
   quickserve = callPackage ../tools/networking/quickserve { };
 
   quicktun = callPackage ../tools/networking/quicktun { };


### PR DESCRIPTION
###### Motivation for this change

Add [quickjs](https://bellard.org/quickjs/).  This is based on #64668 but bumps the version and adds an `installCheckPhase`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @stesie 
#64668 reviewers @tadeokondrak @worldofpeace 