### PR TITLE
retext: fix chardet override

### DIFF
--- a/pkgs/applications/editors/retext/default.nix
+++ b/pkgs/applications/editors/retext/default.nix
@@ -9,7 +9,7 @@ let
   python = let
     packageOverrides = self: super: {
       markdown = super.markdown.overridePythonAttrs(old: {
-        src =  super.fetchPypi {
+        src = super.fetchPypi {
           version = "3.0.1";
           pname = "Markdown";
           sha256 = "d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c";
@@ -17,11 +17,12 @@ let
       });
 
       chardet = super.chardet.overridePythonAttrs(old: {
-        src =  super.fetchPypi {
+        src = super.fetchPypi {
           version = "2.3.0";
           pname = "chardet";
           sha256 = "e53e38b3a4afe6d1132de62b7400a4ac363452dc5dfcf8d88e8e0cce663c68aa";
         };
+        patches = [];
       });
     };
     in python3.override { inherit packageOverrides; };


### PR DESCRIPTION
###### Motivation for this change
Fixes https://hydra.nixos.org/build/106817661 which was broken by #63169 b7923da30b68b6ea960e3c69647111a06cbf7460
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @klntsky 
