### PR TITLE
retext: properly wrap with wrapQtApp

### DIFF
--- a/pkgs/applications/editors/retext/default.nix
+++ b/pkgs/applications/editors/retext/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, python3, fetchFromGitHub, makeWrapper, buildEnv, aspellDicts
+{ stdenv, python3, fetchFromGitHub, wrapQtAppsHook, buildEnv, aspellDicts
 # Use `lib.collect lib.isDerivation aspellDicts;` to make all dictionaries
 # available.
 , enchantAspellDicts ? with aspellDicts; [ en en-computers en-science ]
@@ -42,12 +42,11 @@ in python.pkgs.buildPythonApplication {
 
   doCheck = false;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ wrapQtAppsHook ];
   propagatedBuildInputs = [ pythonEnv ];
 
   postInstall = ''
-    mv $out/bin/retext $out/bin/.retext
-    makeWrapper "$out/bin/.retext" "$out/bin/retext" \
+    wrapQtApp "$out/bin/retext" \
       --set ASPELL_CONF "dict-dir ${buildEnv {
         name = "aspell-all-dicts";
         paths = map (path: "${path}/lib/aspell") enchantAspellDicts;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5946,7 +5946,7 @@ in
 
   redsocks = callPackage ../tools/networking/redsocks { };
 
-  retext = callPackage ../applications/editors/retext { };
+  retext = libsForQt5.callPackage ../applications/editors/retext { };
 
   richgo = callPackage ../development/tools/richgo {  };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
While fixing the build for retext I noticed that it was not wrapped properly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @klntsky 
