### PR TITLE
flow: 0.111.3 -> 0.112.0

### DIFF
--- a/pkgs/development/tools/analysis/flow/default.nix
+++ b/pkgs/development/tools/analysis/flow/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, fetchFromGitHub, ocamlPackages, CoreServices }:
+{ stdenv, fetchFromGitHub, ocamlPackages, CoreServices, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "flow";
-  version = "0.111.3";
+  version = "0.112.0";
 
   src = fetchFromGitHub {
     owner  = "facebook";
     repo   = "flow";
     rev    = "refs/tags/v${version}";
-    sha256 = "12hfdcm491ylh0a8rhzj76wdbh556r02aj4q6vv86n3lh2120cxm";
+    sha256 = "1l8aahvlj9hk93snvrqm7r0mxj5iw244q72s6wallsqm7j4g967h";
   };
 
   installPhase = ''
@@ -18,6 +18,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = (with ocamlPackages; [ ocaml findlib ocamlbuild dtoa core_kernel sedlex ocaml_lwt lwt_log lwt_ppx ppx_deriving ppx_gen_rec ppx_tools_versioned visitors wtf8 ocaml-migrate-parsetree ])
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ];
+
+  patches = [
+    # Fix List.compare labeled argument. Remove when https://github.com/facebook/flow/pull/8191 is merged
+    (fetchpatch {
+      url = "https://github.com/facebook/flow/commit/1625664ec7290d4128587d96cb878571751f8881.patch";
+      sha256 = "18fan0d2xa6z4ilbr7ha3vhnfqlr2s6mb02sgpv8ala99b0mcgmn";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "A static type checker for JavaScript";


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/facebook/flow/releases/tag/v0.112.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
