### PR TITLE
pkgs/development/libraries: Add missing descriptions and homepages

### DIFF
--- a/pkgs/development/libraries/libcdaudio/default.nix
+++ b/pkgs/development/libraries/libcdaudio/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation {
   };
 
   meta = {
+    description = "A portable library for controlling audio CDs";
+    homepage = "http://libcdaudio.sourceforge.net";
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.lgpl2;
   };

--- a/pkgs/development/libraries/libgudev/default.nix
+++ b/pkgs/development/libraries/libgudev/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
+    description = "A library that provides GObject bindings for libudev";
     homepage = https://wiki.gnome.org/Projects/libgudev;
     maintainers = [ maintainers.eelco ] ++ gnome3.maintainers;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libowfat/default.nix
+++ b/pkgs/development/libraries/libowfat/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
+    description = "A GPL reimplementation of libdjb";
     homepage = https://www.fefe.de/libowfat/;
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libre/default.nix
+++ b/pkgs/development/libraries/libre/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optional (stdenv.cc.libc != null) "SYSROOT=${stdenv.lib.getDev stdenv.cc.libc}"
   ;
   meta = {
-    homepage = http://www.creytiv.com/re.html;
+    description = "A library for real-time communications with async IO support and a complete SIP stack";
+    homepage = "http://www.creytiv.com/re.html";
     platforms = with stdenv.lib.platforms; linux;
     maintainers = with stdenv.lib.maintainers; [raskin];
     license = stdenv.lib.licenses.bsd3;

--- a/pkgs/development/libraries/librem/default.nix
+++ b/pkgs/development/libraries/librem/default.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optional (stdenv.cc.libc != null) "SYSROOT=${stdenv.lib.getDev stdenv.cc.libc}"
   ;
   meta = {
-    homepage = http://www.creytiv.com/rem.html;
+    description = " A library for real-time audio and video processing";
+    homepage = "http://www.creytiv.com/rem.html";
     platforms = with stdenv.lib.platforms; linux;
     maintainers = with stdenv.lib.maintainers; [raskin];
     license = stdenv.lib.licenses.bsd3;

--- a/pkgs/development/libraries/libvorbis/default.nix
+++ b/pkgs/development/libraries/libvorbis/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with stdenv.lib; {
+    description = "Vorbis audio compression reference implementation";
     homepage = https://xiph.org/vorbis/;
     license = licenses.bsd3;
     maintainers = [ maintainers.ehmry ];

--- a/pkgs/development/libraries/minizip/default.nix
+++ b/pkgs/development/libraries/minizip/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation {
   sourceRoot = "zlib-${zlib.version}/contrib/minizip";
 
   meta = {
+    description = "Compression library implementing the deflate compression method found in gzip and PKZIP";
     inherit (zlib.meta) license homepage;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/netcdf/default.nix
+++ b/pkgs/development/libraries/netcdf/default.nix
@@ -41,6 +41,7 @@ in stdenv.mkDerivation rec {
   ++ (stdenv.lib.optionals mpiSupport [ "--enable-parallel-tests" "CC=${mpi}/bin/mpicc" ]);
 
   meta = {
+      description = "Libraries for the Unidata network Common Data Format";
       platforms = stdenv.lib.platforms.unix;
       homepage = https://www.unidata.ucar.edu/software/netcdf/;
       license = {

--- a/pkgs/development/libraries/openbabel/default.nix
+++ b/pkgs/development/libraries/openbabel/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   meta = {
+    description = "A toolbox designed to speak the many languages of chemical data";
+    homepage = "http://openbabel.org";
     platforms = stdenv.lib.platforms.all;
     maintainers = [ ];
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/development/libraries/openbsm/default.nix
+++ b/pkgs/development/libraries/openbsm/default.nix
@@ -16,7 +16,8 @@ stdenv.mkDerivation rec {
   configureFlags = [ "ac_cv_file__usr_include_mach_audit_triggers_defs=no" ];
 
   meta = {
-    homepage = http://www.openbsm.org/;
+    description = "An implementation of Sun's Basic Security Module (BSM) security audit API and file format";
+    homepage = "http://www.openbsm.org/";
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ matthewbauer ];
     license = lib.licenses.bsd2;

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -55,7 +55,8 @@ stdenv.mkDerivation rec {
   doCheck = false; # fails 1 of 1 tests
 
   meta = with stdenv.lib; {
-    homepage = https://www.openexr.com/;
+    description = "A high dynamic-range (HDR) image file format";
+    homepage = "https://www.openexr.com/";
     license = licenses.bsd3;
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/schroedinger/default.nix
+++ b/pkgs/development/libraries/schroedinger/default.nix
@@ -4,10 +4,7 @@ stdenv.mkDerivation {
   name = "schroedinger-1.0.11";
 
   src = fetchurl {
-    urls = [
-      http://diracvideo.org/download/schroedinger/schroedinger-1.0.11.tar.gz
-      https://download.videolan.org/contrib/schroedinger-1.0.11.tar.gz
-    ];
+    url = https://download.videolan.org/contrib/schroedinger-1.0.11.tar.gz;
     sha256 = "04prr667l4sn4zx256v1z36a0nnkxfdqyln48rbwlamr6l3jlmqy";
   };
 
@@ -27,7 +24,8 @@ stdenv.mkDerivation {
   ];
 
   meta = with stdenv.lib; {
-    homepage = http://diracvideo.org/;
+    description = "An implementation of the Dirac video codec in ANSI C";
+    homepage = "https://sourceforge.net/projects/schrodinger/";
     maintainers = [ maintainers.spwhitt ];
     license = [ licenses.mpl11 licenses.lgpl2 licenses.mit ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/spandsp/default.nix
+++ b/pkgs/development/libraries/spandsp/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [audiofile libtiff];
   meta = {
+    description = "A portable and modular SIP User-Agent with audio and video support";
     homepage = http://www.creytiv.com/baresip.html;
     platforms = with stdenv.lib.platforms; linux;
     maintainers = with stdenv.lib.maintainers; [raskin];

--- a/pkgs/development/libraries/tre/default.nix
+++ b/pkgs/development/libraries/tre/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
+    description = "Lightweight and robust POSIX compliant regexp matching library";
+    homepage = "https://laurikari.net/tre/";
     platforms = stdenv.lib.platforms.unix;
     license = stdenv.lib.licenses.bsd2;
   };


### PR DESCRIPTION
###### Motivation for this change 
Many packages are still lacking descriptions and homepages.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
