### PR TITLE
clang-tools: teach about nix's include path [19.09]

### DIFF
--- a/pkgs/development/tools/clang-tools/default.nix
+++ b/pkgs/development/tools/clang-tools/default.nix
@@ -13,15 +13,20 @@ in stdenv.mkDerivation {
     runHook preInstall
 
     mkdir -p $out/bin
+    export libc_includes="${stdenv.lib.getDev stdenv.cc.libc}/include"
+    export libcpp_includes="${llvmPackages.libcxx}/include/c++/v1"
+
+    export clang=${clang}
+    substituteAll ${./wrapper} $out/bin/clangd
+    chmod +x $out/bin/clangd
     for tool in \
       clang-apply-replacements \
       clang-check \
       clang-format \
       clang-rename \
-      clang-tidy \
-      clangd
+      clang-tidy
     do
-      ln -s ${clang}/bin/$tool $out/bin/$tool
+      ln -s $out/bin/clangd $out/bin/$tool
     done
 
     runHook postInstall

--- a/pkgs/development/tools/clang-tools/wrapper
+++ b/pkgs/development/tools/clang-tools/wrapper
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+buildcpath() {
+  local path
+  while (( $# )); do
+    case $1 in
+        -isystem)
+            shift
+            path=$path${path':'}$1
+    esac
+    shift
+  done
+  echo $path
+}
+
+export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE})
+export CPATH=${CPATH}${CPATH:+':'}@libc_includes@
+export CPLUS_INCLUDE_PATH=${CPATH}${CPATH:+':'}@libcpp_includes@
+
+exec -a "$0" @clang@/bin/$(basename $0) "$@"


### PR DESCRIPTION
By translating NIX_CFLAGS_COMPILE to CPATH,
all tools will now find c headers properly,
when run in a nix-shell.

(cherry picked from commit a10ef1aa4fe62aa97859d24921f501183861b7b6)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
