### PR TITLE
numix-icon-theme-circle: Fix dangling symlinks

### DIFF
--- a/pkgs/data/icons/numix-icon-theme-circle/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-circle/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
+    for panel in $out/share/icons/*/*/panel; do
+      ln -sf $(realpath ${numix-icon-theme}/share/icons/Numix/16/$(readlink $panel)) $panel
+    done
+
     for theme in $out/share/icons/*; do
       gtk-update-icon-cache $theme
     done

--- a/pkgs/data/icons/numix-icon-theme-square/default.nix
+++ b/pkgs/data/icons/numix-icon-theme-square/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
+    for panel in $out/share/icons/*/*/panel; do
+      ln -sf $(realpath ${numix-icon-theme}/share/icons/Numix/16/$(readlink $panel)) $panel
+    done
+
     for theme in $out/share/icons/*; do
       gtk-update-icon-cache $theme
     done


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The panel folders in icon themes, e.g. `share/icons/Numix-Circle-Light/16/panel` are symlinks to the base theme. E.g. to `../../Numix-Light/16/panel`.
The path it should resolve to is `/run/current-system/sw/share/icons/Numix-Light/16/panel`. However, as the real path is `/nix/store/41sz1f24wbfi0xjx5wpzdhb2b6yp3rlb-numix-icon-theme-circle-19.09.20/share/icons/Numix-Circle-Light/16/panel`, it resolves to `/nix/store/41sz1f24wbfi0xjx5wpzdhb2b6yp3rlb-numix-icon-theme-circle-19.09.20/share/icons/Numix-Light/16/panel` instead.
The right path would be `/nix/store/4fjgbp26h1xsqjf54jfhlyi9vir80571-numix-icon-theme-19.09.20/share/icons/Numix-Light/16/panel` from the `numix-icon-theme` package, not `numix-icon-theme-circle`.

###### Things done
Patch symlink paths to point to the absolute path of the `numix-icon-theme` package.
The link will be set to `realpath ${numix-icon-theme}/share/icons/Numix/16/../../Numix-Light/16/panel`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @romildo
