### PR TITLE
birdtray: init at 1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2295,6 +2295,16 @@
     githubId = 415760;
     name = "Jonas Höglund";
   };
+  Flakebi = {
+    email = "flakebi@t-online.de";
+    github = "Flakebi";
+    githubId = "Flakebi";
+    name = "Sebastian Neubauer";
+    keys = [{
+      longkeyid = "rsa4096/0xECC755EE583C1672";
+      fingerprint = "2F93 661D AC17 EA98 A104  F780 ECC7 55EE 583C 1672";
+    }];
+  };
   flexw = {
     email = "felix.weilbach@t-online.de";
     github = "FlexW";

--- a/pkgs/applications/misc/birdtray/default.nix
+++ b/pkgs/applications/misc/birdtray/default.nix
@@ -1,0 +1,40 @@
+{ mkDerivation
+  , lib
+  , fetchFromGitHub
+
+  , cmake
+  , pkgconfig
+  , qtbase
+  , qttools
+  , qtx11extras
+  , sqlite
+}:
+
+mkDerivation rec {
+  pname = "birdtray";
+  version = "1.6";
+
+  src = fetchFromGitHub {
+    owner = "gyunaev";
+    repo = pname;
+    rev = "RELEASE_${version}";
+    sha256 = "0n6qr224ir59ncid4xbdilk5642z0kcaylzbil1bdcv3h32ysjym";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [
+    qtbase qtx11extras sqlite
+  ];
+
+  installPhase = ''
+    install -Dm755 birdtray $out/bin/birdtray
+  '';
+
+  meta = with lib; {
+    description = "Mail system tray notification icon for Thunderbird";
+    homepage = https://github.com/gyunaev/birdtray;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ Flakebi ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1133,6 +1133,8 @@ in
 
   bindfs = callPackage ../tools/filesystems/bindfs { };
 
+  birdtray = libsForQt5.callPackage ../applications/misc/birdtray { };
+
   bitbucket-cli = python2Packages.bitbucket-cli;
 
   blink = libsForQt5.callPackage ../applications/networking/instant-messengers/blink { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done
Add birdtray package, a mail system tray notification icon for Thunderbird.
It allows minimizing Thunderbird to the tray.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc
