### PR TITLE
word2vec: fix build

### DIFF
--- a/pkgs/development/python-modules/word2vec/default.nix
+++ b/pkgs/development/python-modules/word2vec/default.nix
@@ -3,19 +3,23 @@
 , fetchPypi
 , cython
 , numpy
+, scikitlearn
+, six
 , python
+, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "word2vec";
   version = "0.10.2";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "40f6f30a5f113ffbfc24c5ad5de23bfac897f4c1210fb93685b7fca5c4dee7db";
   };
 
-  propagatedBuildInputs = [ cython numpy ];
+  propagatedBuildInputs = [ cython numpy scikitlearn six ];
 
   checkPhase = ''
    cd word2vec/tests;
@@ -27,7 +31,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/danielfrg/word2vec";
     license     = licenses.asl20;
     maintainers = with maintainers; [ NikolaMandic ];
-    broken = true;
   };
 
 }


### PR DESCRIPTION

###### Motivation for this change
The package was marked broken, it turned out it was just lacking two dependencies.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NikolaMandic
