### PR TITLE
codec2: 0.8.0 -> 0.9.2

### DIFF
--- a/pkgs/development/libraries/codec2/default.nix
+++ b/pkgs/development/libraries/codec2/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchsvn, cmake } :
+{ stdenv, fetchFromGitHub, cmake } :
 
 let
-  version = "0.8";
+  version = "0.9.2";
 
 in stdenv.mkDerivation {
   pname = "codec2";
   inherit version;
 
-  src = fetchsvn {
-    url = "https://svn.code.sf.net/p/freetel/code/codec2/branches/${version}";
-    sha256 = "0qbyaqdn37253s30n6m2ric8nfdsxhkslb9h572kdx18j2yjccki";
+  src = fetchFromGitHub {
+    owner = "drowe67";
+    repo = "codec2";
+    rev = "v${version}";
+    sha256 = "1jpvr7bra8srz8jvnlbmhf8andbaavq5v01qjnp2f61za93rzwba";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
update and pull sources from GitHub instead of SVN.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers


