### PR TITLE
hyperspace: init at 1.1.4

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -618,6 +618,12 @@ in mkLicense lset) ({
     fullName  = "University of Illinois/NCSA Open Source License";
   };
 
+  npl4 = {
+    url = "https://git.pixie.town/thufie/NPL";
+    fullName = "Non-Violent Public License v4";
+    free = false;
+  };
+
   nposl3 = {
     spdxId = "NPOSL-3.0";
     fullName = "Non-Profit Open Software License 3.0";

--- a/pkgs/applications/misc/hyperspace/default.nix
+++ b/pkgs/applications/misc/hyperspace/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchurl, lib
+, autoPatchelfHook, dpkg
+, libX11, libXext, libXi, libXau, libXrender, libXft, libXmu, libSM, libXcomposite, libXfixes, libXpm
+, libXinerama, libXdamage, libICE, libXtst, libXaw, fontconfig, pango, cairo, glib, libxml2, atk, gtk3
+, gdk-pixbuf, nss, nspr, libXScrnSaver, alsa-lib, udev, libdrm, libGL, mesa
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hyperspace";
+  version = "1.1.4";
+
+  src = fetchurl {
+    url = "https://github.com/hyperspacedev/${pname}/releases/download/v${version}/${pname}_${version}_amd64.deb";
+    sha256 = "TCkMe4uxgWWSzemJfsbxKYHB2vUavhI1248t5CcsD+8=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  unpackPhase = ''
+    dpkg-deb -vx $src .
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+
+    mv ./usr/* $out/
+
+    mv ./opt/Hyperspace\ Desktop $out/share/hyperspace
+
+    mkdir -p $out/bin
+    ln -s $out/share/hyperspace/hyperspace $out/bin/hyperspace
+
+    rm -vrf $out/share/hyperspace/{libGLESv2.so,libEGL.so,swiftshader}
+
+    substituteInPlace $out/share/applications/hyperspace.desktop \
+     --replace 'Exec="/opt/Hyperspace Desktop/hyperspace"' \
+               'Exec="$out/bin/hyperspace"'
+  '';
+
+  buildInputs = [
+    stdenv.cc.cc libX11 libXext libXi libXau libXrender libXft libXmu libSM libXcomposite libXfixes libXpm
+    libXinerama libXdamage libICE libXtst libXaw fontconfig pango cairo glib libxml2 atk gtk3
+    gdk-pixbuf nss nspr libXScrnSaver alsa-lib libdrm mesa
+  ];
+
+  runtimeDependencies = [ libGL udev ];
+
+  dontBuild = true;
+  dontStrip = true;
+  dontPatchELF = true;
+
+  meta = with lib; {
+    description = "A beautiful, fluffy client for the fediverse";
+    homepage = "https://hyperspace.marquiskurt.net";
+    license = licenses.npl4;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25747,6 +25747,8 @@ with pkgs;
 
   hyperledger-fabric = callPackage ../tools/misc/hyperledger-fabric { };
 
+  hyperspace = callPackage ../applications/misc/hyperspace { };
+
   jackline = callPackage ../applications/networking/instant-messengers/jackline {
     ocamlPackages = ocaml-ng.ocamlPackages_4_08;
   };


### PR DESCRIPTION
###### Motivation for this change

Mastodon client :).
(electron-based)

FWIW, the license is new to us and not widely used.

Added it to the list, but am unsure how it should be handled.
Hopefully it's alright to include software under this license,
but I mention it because I would appreciate a second opinion O:).

Fixes #57357.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).