### PR TITLE
nixosTests.rxe: port to python

### DIFF
--- a/nixos/tests/rxe.nix
+++ b/nixos/tests/rxe.nix
@@ -32,18 +32,12 @@ in {
 
     client.wait_for_unit("default.target")
 
-    # ping pong test
-    server.succeed("screen -dmS rc_pingpong ibv_rc_pingpong -p 4800 -g0")
-    client.succeed("sleep 2; ibv_rc_pingpong -p 4800 -g0 server")
-
-    server.succeed("screen -dmS uc_pingpong ibv_uc_pingpong -p 4800 -g0")
-    client.succeed("sleep 2; ibv_uc_pingpong -p 4800 -g0 server")
-
-    server.succeed("screen -dmS ud_pingpong ibv_ud_pingpong -p 4800 -s 1024 -g0")
-    client.succeed("sleep 2; ibv_ud_pingpong -p 4800 -s 1024 -g0 server")
-
-    server.succeed("screen -dmS srq_pingpong ibv_srq_pingpong -p 4800 -g0")
-    client.succeed("sleep 2; ibv_srq_pingpong -p 4800 -g0 server")
+    # ping pong tests
+    for proto in "rc", "uc", "ud", "srq":
+        server.succeed(
+            "screen -dmS {0}_pingpong ibv_{0}_pingpong -p 4800 -s 1024 -g0".format(proto)
+        )
+        client.succeed("sleep 2; ibv_{}_pingpong -p 4800 -s 1024 -g0 server".format(proto))
 
     server.succeed("screen -dmS rping rping -s -a server -C 10")
     client.succeed("sleep 2; rping -c -a server -C 10")

--- a/nixos/tests/rxe.nix
+++ b/nixos/tests/rxe.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... } :
+import ./make-test-python.nix ({ ... } :
 
 let
   node = { pkgs, ... } : {
@@ -26,27 +26,27 @@ in {
 
   testScript = ''
     # Test if rxe interface comes up
-    $server->waitForUnit("default.target");
-    $server->succeed("systemctl status rxe.service");
-    $server->succeed("ibv_devices | grep rxe0");
+    server.wait_for_unit("default.target")
+    server.succeed("systemctl status rxe.service")
+    server.succeed("ibv_devices | grep rxe0")
 
-    $client->waitForUnit("default.target");
+    client.wait_for_unit("default.target")
 
     # ping pong test
-    $server->succeed("screen -dmS rc_pingpong ibv_rc_pingpong -p 4800 -g0");
-    $client->succeed("sleep 2; ibv_rc_pingpong -p 4800 -g0 server");
+    server.succeed("screen -dmS rc_pingpong ibv_rc_pingpong -p 4800 -g0")
+    client.succeed("sleep 2; ibv_rc_pingpong -p 4800 -g0 server")
 
-    $server->succeed("screen -dmS uc_pingpong ibv_uc_pingpong -p 4800 -g0");
-    $client->succeed("sleep 2; ibv_uc_pingpong -p 4800 -g0 server");
+    server.succeed("screen -dmS uc_pingpong ibv_uc_pingpong -p 4800 -g0")
+    client.succeed("sleep 2; ibv_uc_pingpong -p 4800 -g0 server")
 
-    $server->succeed("screen -dmS ud_pingpong ibv_ud_pingpong -p 4800 -s 1024 -g0");
-    $client->succeed("sleep 2; ibv_ud_pingpong -p 4800 -s 1024 -g0 server");
+    server.succeed("screen -dmS ud_pingpong ibv_ud_pingpong -p 4800 -s 1024 -g0")
+    client.succeed("sleep 2; ibv_ud_pingpong -p 4800 -s 1024 -g0 server")
 
-    $server->succeed("screen -dmS srq_pingpong ibv_srq_pingpong -p 4800 -g0");
-    $client->succeed("sleep 2; ibv_srq_pingpong -p 4800 -g0 server");
+    server.succeed("screen -dmS srq_pingpong ibv_srq_pingpong -p 4800 -g0")
+    client.succeed("sleep 2; ibv_srq_pingpong -p 4800 -g0 server")
 
-    $server->succeed("screen -dmS rping rping -s -a server -C 10");
-    $client->succeed("sleep 2; rping -c -a server -C 10");
+    server.succeed("screen -dmS rping rping -s -a server -C 10")
+    client.succeed("sleep 2; rping -c -a server -C 10")
   '';
 })
 


### PR DESCRIPTION
###### Motivation for this change
Port RXE test to python test framework https://github.com/NixOS/nixpkgs/issues/72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

