### PR TITLE
bs-platform: init at 6.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2518,6 +2518,12 @@
     githubId = 7047019;
     name = "Florent Becker";
   };
+  gamb = {
+    email = "adam.gamble@pm.me";
+    github = "gamb";
+    githubId = 293586;
+    name = "Adam Gamble";
+  };
   garbas = {
     email = "rok@garbas.si";
     github = "garbas";

--- a/pkgs/development/compilers/bs-platform/bs-platform-62.nix
+++ b/pkgs/development/compilers/bs-platform/bs-platform-62.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchFromGitHub, ninja, nodejs, python3 }:
+let
+  version = "6.2.1";
+  ocaml-version = "4.06.1";
+  src = fetchFromGitHub {
+    owner = "BuckleScript";
+    repo = "bucklescript";
+    rev = "${version}";
+    sha256 = "0zx9nq7cik0c60n3rndqfqy3vdbj5lcrx6zcqcz2d60jjxi1z32y";
+    fetchSubmodules = true;
+  };
+  ocaml =  import ./ocaml.nix {
+    bs-version = version;
+    version = ocaml-version;
+    inherit stdenv;
+    src = "${src}/ocaml";
+  };
+in
+stdenv.mkDerivation {
+  inherit src version;
+  pname = "bs-platform";
+  BS_RELEASE_BUILD = "true";
+  buildInputs = [ nodejs python3 ];
+
+  patchPhase = ''
+    sed -i 's:./configure.py --bootstrap:python3 ./configure.py --bootstrap:' ./scripts/install.js
+
+    mkdir -p ./native/${ocaml-version}/bin
+    ln -sf ${ocaml}/bin/* ./native/${ocaml-version}/bin
+
+    rm -f vendor/ninja/snapshot/ninja.linux
+    cp ${ninja}/bin/ninja vendor/ninja/snapshot/ninja.linux
+  '';
+
+  configurePhase = ''
+    node scripts/ninja.js config
+  '';
+
+  buildPhase = ''
+    node scripts/ninja.js build
+  '';
+
+  installPhase = ''
+    node scripts/install.js
+
+    mkdir -p $out/bin
+
+    cp -rf jscomp lib vendor odoc_gen native $out
+    cp bsconfig.json package.json $out
+
+    ln -s $out/lib/bsb $out/bin/bsb
+    ln -s $out/lib/bsc $out/bin/bsc
+    ln -s $out/lib/bsrefmt $out/bin/bsrefmt
+  '';
+}

--- a/pkgs/development/compilers/bs-platform/default.nix
+++ b/pkgs/development/compilers/bs-platform/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchFromGitHub, ninja, nodejs, python3, ... }:
+let
+  meta = with stdenv.lib; {
+    description = "A JavaScript backend for OCaml focused on smooth integration and clean generated code.";
+    homepage = https://bucklescript.github.io;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ turbomack gamb ];
+    platforms = platforms.all;
+  };
+in
+{
+  bs-platform-621 = import ./bs-platform-62.nix {
+    inherit stdenv fetchFromGitHub ninja nodejs python3;
+  } // { inherit meta; };
+}

--- a/pkgs/development/compilers/bs-platform/ocaml.nix
+++ b/pkgs/development/compilers/bs-platform/ocaml.nix
@@ -1,0 +1,16 @@
+{ stdenv, src, version, bs-version }:
+stdenv.mkDerivation rec {
+  inherit src version;
+  name = "ocaml-${version}+bs-${bs-version}";
+  configurePhase = ''
+    ./configure -prefix $out
+  '';
+  buildPhase = ''
+    make -j9 world.opt
+  '';
+
+  meta = with stdenv.lib; {
+    branch = "4.06";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1287,6 +1287,8 @@ in
 
   burpsuite = callPackage ../tools/networking/burpsuite {};
 
+  bs-platform = (callPackage ../development/compilers/bs-platform {}).bs-platform-621;
+
   c3d = callPackage ../applications/graphics/c3d {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };


### PR DESCRIPTION
###### Motivation for this change
`bs-platform` is a [BuckleScript](https://bucklescript.github.io/) compiler with set of additional tools. It is a OCaml/ReasonML compiler with javascript backend popular for building web and mobile apps. Official distribution is done via npm which doesn't work on NixOS (fails on build of native dependencies). This is an attempt to improve [current status quo around bs-platform on NixOS full of workarounds](https://discourse.nixos.org/t/bs-platform-install/1520).

There was some [previous attempt](https://github.com/NixOS/nixpkgs/pull/66914) using `node2nix` which was closed. This PR avoids usage of NPM alltogether.

In a meantime you can install bs-platform using [this repository](https://github.com/turboMaCk/bs-platform.nix)

###### Things done

bs-platform added to nixpkgs.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @volth (who is maitainer listed as maintainer of ReasonML)

###### Credits

This is based on @hiroqn's project https://github.com/hiroqn/nix-bucklescript
