### PR TITLE
darwin.CF: workaround intermittent CFRuntime.c failures

### DIFF
--- a/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
+++ b/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
@@ -63,10 +63,31 @@ stdenv.mkDerivation {
   # I'm guessing at the version here. https://github.com/apple/swift-corelibs-foundation/commit/df3ec55fe6c162d590a7653d89ad669c2b9716b1 imported "high sierra"
   # and this version is a version from there. No idea how accurate it is.
   LDFLAGS = "-current_version 1454.90.0 -compatibility_version 150.0.0 -init ___CFInitialize";
-  configurePhase = "../configure release --sysroot UNUSED";
+
+  configurePhase = ''
+    ../configure release --sysroot UNUSED
+  '';
 
   enableParallelBuilding = true;
-  buildPhase = "ninja -j $NIX_BUILD_CORES";
+
+  # FIXME: Workaround for intermittent build failures of CFRuntime.c.
+  # Based on testing this issue seems to only occur with clang_7, so
+  # please remove this when updating the default llvm versions to 8 or
+  # later.
+  buildPhase = stdenv.lib.optionalString true ''
+    for i in {1..512}; do
+        if ninjaBuildPhase; then
+          break
+        fi
+
+        echo >&2
+        echo "[$i/512] retrying build, workaround for #66811" >&2
+        echo "  With clang_7 the build of CFRuntime.c fails intermittently." >&2
+        echo "  See https://github.com/NixOS/nixpkgs/issues/66811 for more details." >&2
+        echo >&2
+        continue
+    done
+  '';
 
   # TODO: their build system sorta kinda can do this, but it doesn't seem to work right now
   # Also, this includes a bunch of private headers in the framework, which is not what we want


### PR DESCRIPTION
Based on testing this issue seems to only occur with clang_7, so
we should be able to revert this when the default llvm versions are
updated.

Fixes #66811

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NixOS/darwin-maintainers @vcunat @FRidh
