### PR TITLE
async: init at 0.1.1

### DIFF
--- a/pkgs/development/tools/async/default.nix
+++ b/pkgs/development/tools/async/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "async";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "ctbur";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "19ypflbayi5l0mb8yw7w0a4bq9a3w8nl9jsxapp9m3xggzmsvrxx";
+  };
+
+  cargoSha256 = "1qf52xsd15rj8y9w65zyab7akvzry76k1d4gxvxlz7ph3sl7jl3y";
+
+  meta = with stdenv.lib; {
+    description = "A tool to parallelize shell commands";
+    longDescription = ''
+      `async` is a tool to run shell commands in parallel and is designed to be
+      able to quickly parallelize shell scripts with minimal changes. It was
+      inspired by GNU Parallel, with the main difference being that async
+      retains state between commands by running a server in the background.
+      '';
+    homepage = "https://github.com/ctbur/async";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ minijackson ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -666,6 +666,8 @@ in
     gsl = gsl_1;
   };
 
+  async = callPackage ../development/tools/async {};
+
   atheme = callPackage ../servers/irc/atheme { };
 
   atinout = callPackage ../tools/networking/atinout { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A very cool piece of software to parallelize commands in shell scripts.

https://github.com/ctbur/async

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).