### PR TITLE
cargo-fuzz: 0.5.3 -> 0.5.4

### DIFF
--- a/pkgs/development/tools/rust/cargo-fuzz/default.nix
+++ b/pkgs/development/tools/rust/cargo-fuzz/default.nix
@@ -2,28 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-fuzz";
-  version = "0.5.3"; # Note to self: on 0.5.4, remove the hand-added Cargo.lock
+  version = "0.5.4";
 
-  src =
-    let
-      source = fetchFromGitHub {
-        owner = "rust-fuzz";
-        repo = "cargo-fuzz";
-        rev = version;
-        sha256 = "1l452fnjw7i10nrd4y4rssi5d457vgjp6rhdr9cnq32bjhdkprrs";
-      };
-      cargo-lock = fetchurl {
-        url = "https://gist.githubusercontent.com/Ekleog/7d5b62d13b7207aafa4c37d1bbdf2de7/raw/c6027fc1c531947f4d6836a3c4cba1b3e24df24c/Cargo.lock";
-        sha256 = "0d7b6kxfbfvwksybzrihylamg2zv5fmsk9m6xshryhwipskzzvmd";
-      };
-    in
-    runCommand "cargo-fuzz-src" {} ''
-      cp -R ${source} $out
-      chmod +w $out
-      cp ${cargo-lock} $out/Cargo.lock
-    '';
+  src = fetchFromGitHub {
+    owner = "rust-fuzz";
+    repo = "cargo-fuzz";
+    rev = version;
+    sha256 = "0qy4xb7bxyw2x2ya7zmbkz48wxb69jcnvvj7021f1kyc6wdwcxs7";
+  };
 
-  cargoSha256 = "19kldw2sx0jd89q5q9cwmdcaan148s45fxlb2m0vdxwb69crb7yp";
+  cargoSha256 = "1d42cmpg1yn1ql9isx26kxsxzf5rg6qw6j948skc5p054r0c9n3f";
 
   meta = with stdenv.lib; {
     description = "Command line helpers for fuzzing";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ekleog
