### PR TITLE
buildpack: init at 0.5.0

### DIFF
--- a/pkgs/development/tools/buildpack/default.nix
+++ b/pkgs/development/tools/buildpack/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "pack";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "buildpack";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0yh62h7lz2i07gixccmfyxk607djp1nrs57rzk7nkxnjcj4jj5sr";
+  };
+
+  goPackagePath = "github.com/buildpack/pack";
+
+  subPackages = [ "cmd/pack" ];
+
+  buildFlagsArray = [ "-ldflags=-s -w -X github.com/buildpack/pack/cmd.Version=${version}" ];
+
+  meta = with lib; {
+    homepage = "https://buildpacks.io/";
+    description = "Local CLI for building apps using Cloud Native Buildpacks";
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1249,6 +1249,8 @@ in
     asciidoc = asciidoc-full;
   };
 
+  buildpack = callPackage ../development/tools/buildpack { };
+
   buildtorrent = callPackage ../tools/misc/buildtorrent { };
 
   bustle = haskellPackages.bustle;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/buildpack/pack

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
