### PR TITLE
ocaml-kafka: init at 0.4

### DIFF
--- a/pkgs/development/ocaml-modules/kafka/default.nix
+++ b/pkgs/development/ocaml-modules/kafka/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, base, cmdliner, ocaml_lwt,
+  rdkafka, zlib }:
+
+buildDunePackage rec {
+  pname = "kafka";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "didier-wenzek";
+    repo = "ocaml-kafka";
+    rev = version;
+    sha256 = "0lb8x0wh7sf8v9mjwhq32azjz54kw49fsjfb7m76z4nhxfkjw5hy";
+  };
+
+  buildInputs = [ base cmdliner ocaml_lwt zlib ];
+
+  propagatedBuildInputs = [ rdkafka zlib ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/didier-wenzek/ocaml-kafka;
+    description = "OCaml bindings for Kafka";
+    license     = licenses.mit;
+    maintainers = [ maintainers.rixed ];
+  };
+}
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -374,6 +374,8 @@ let
 
     jsonm = callPackage ../development/ocaml-modules/jsonm { };
 
+    kafka = callPackage ../development/ocaml-modules/kafka { };
+
     ke = callPackage ../development/ocaml-modules/ke { };
 
     lablgl = callPackage ../development/ocaml-modules/lablgl { };


### PR DESCRIPTION
##### Motivation for this change

Add the kafka bindings to OCaml

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

that's me
