### PR TITLE
jasper: mark as vulnerable

### DIFF
--- a/pkgs/applications/gis/saga/default.nix
+++ b/pkgs/applications/gis/saga/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gdal, wxGTK30, proj, libiodbc, lzma, jasper,
+{ stdenv, fetchurl, gdal, wxGTK30, proj, libiodbc, lzma,
   libharu, opencv, vigra, postgresql, Cocoa,
   unixODBC , poppler, hdf4, hdf5, netcdf, sqlite, qhull, giflib }:
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   # See https://groups.google.com/forum/#!topic/nix-devel/h_vSzEJAPXs
   # for why the have additional buildInputs on darwin
   buildInputs = [ gdal wxGTK30 proj libharu opencv vigra postgresql libiodbc lzma
-                  jasper qhull giflib ]
+                  qhull giflib ]
                 ++ stdenv.lib.optionals stdenv.isDarwin
                   [ Cocoa unixODBC poppler hdf4.out hdf5 netcdf sqlite ];
 

--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -26,7 +26,7 @@
 , exiv2
 , ffmpeg
 , flex
-, jasper
+, jasper ? null, withJpeg2k ? false  # disable JPEG2000 support, jasper has unfixed CVE
 , lcms2
 , lensfun
 , libgphoto2
@@ -70,7 +70,6 @@ mkDerivation rec {
     exiv2
     ffmpeg
     flex
-    jasper
     lcms2
     lensfun
     libgphoto2
@@ -103,7 +102,8 @@ mkDerivation rec {
     marble
     oxygen
     threadweaver
-  ];
+  ]
+  ++ lib.optionals withJpeg2k [ jasper ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/misc/k2pdfopt/default.nix
+++ b/pkgs/applications/misc/k2pdfopt/default.nix
@@ -3,7 +3,7 @@
 , enableGSL ? true, gsl
 , enableGhostScript ? true, ghostscript
 , enableMuPDF ? true, mupdf
-, enableJPEG2K ? true, jasper
+, enableJPEG2K ? false, jasper ? null  # disabled by default, jasper has unfixed CVE
 , enableDJVU ? true, djvulibre
 , enableGOCR ? false, gocr # Disabled by default due to crashes
 , enableTesseract ? true, leptonica, tesseract4

--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -9,7 +9,7 @@
 , libXinerama, libXrandr
 , libXtst, libXfixes, systemd
 , alsaLib, libGLU, libGL, glew, fontconfig, freetype, ftgl
-, libjpeg, jasper, libpng, libtiff
+, libjpeg, libpng, libtiff
 , libmpeg2, libsamplerate, libmad
 , libogg, libvorbis, flac, libxslt
 , lzo, libcdio, libmodplug, libass, libbluray
@@ -157,7 +157,7 @@ in stdenv.mkDerivation {
       libX11 xorgproto libXt libXmu libXext
       libXinerama libXrandr libXtst libXfixes
       alsaLib libGL libGLU glew fontconfig freetype ftgl
-      libjpeg jasper libpng libtiff
+      libjpeg libpng libtiff
       libmpeg2 libsamplerate libmad
       libogg libvorbis flac libxslt systemd
       lzo libcdio libmodplug libass libbluray

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, nixosTests, fixDarwinDylibNames, meson, ninja, pkgconfig, gettext, python3, libxml2, libxslt, docbook_xsl
 , docbook_xml_dtd_43, gtk-doc, glib, libtiff, libjpeg, libpng, libX11, gnome3
-, jasper, gobject-introspection, doCheck ? false, makeWrapper }:
+, gobject-introspection, doCheck ? false, makeWrapper }:
 
 let
   pname = "gdk-pixbuf";
@@ -31,11 +31,10 @@ in stdenv.mkDerivation rec {
   ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
-  propagatedBuildInputs = [ glib libtiff libjpeg libpng jasper ];
+  propagatedBuildInputs = [ glib libtiff libjpeg libpng ];
 
   mesonFlags = [
     "-Ddocs=true"
-    "-Djasper=true"
     "-Dx11=true"
     "-Dgir=${if gobject-introspection != null then "true" else "false"}"
     "-Dgio_sniffing=false"

--- a/pkgs/development/libraries/grib-api/default.nix
+++ b/pkgs/development/libraries/grib-api/default.nix
@@ -1,5 +1,5 @@
-{ fetchurl, stdenv,
-  cmake, netcdf, gfortran, jasper, libpng,
+{ fetchurl, fetchpatch, stdenv,
+  cmake, netcdf, gfortran, libpng, openjpeg,
   enablePython ? false, pythonPackages }:
 
 stdenv.mkDerivation rec{
@@ -11,6 +11,13 @@ stdenv.mkDerivation rec{
     sha256 = "0qbj12ap7yy2rl1pq629chnss2jl73wxdj1lwzv0xp87r6z5qdfl";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://salsa.debian.org/science-team/grib-api/raw/debian/1.28.0-2/debian/patches/openjpeg2.patch";
+      sha256 = "05faxh51vlidiazxq1ssd3k4cjivk1adyn30k94mxqa1xnb2r2pc";
+    })
+  ];
+
   preConfigure = ''
     # Fix "no member named 'inmem_' in 'jas_image_t'"
     substituteInPlace "src/grib_jasper_encoding.c" --replace "image.inmem_    = 1;" ""
@@ -19,8 +26,8 @@ stdenv.mkDerivation rec{
   buildInputs = [ cmake
                   netcdf
                   gfortran
-                  jasper
                   libpng
+                  openjpeg
                 ] ++ stdenv.lib.optionals enablePython [
                   pythonPackages.python
                 ];
@@ -32,6 +39,7 @@ stdenv.mkDerivation rec{
   cmakeFlags = [ "-DENABLE_PYTHON=${if enablePython then "ON" else "OFF"}"
                  "-DENABLE_PNG=ON"
                  "-DENABLE_FORTRAN=ON"
+                 "-DOPENJPEG_INCLUDE_DIR=${openjpeg.dev}/include/${openjpeg.incDir}"
                ];
 
   enableParallelBuilding = true;
@@ -52,13 +60,15 @@ stdenv.mkDerivation rec{
     homepage = https://software.ecmwf.int/wiki/display/GRIB/Home;
     license = licenses.asl20;
     platforms = with platforms; linux ++ darwin;
-    description = "ECMWF Library for the GRIB file format";
+    description = "ECMWF Library for the GRIB file format -- DEPRECATED";
     longDescription = ''
       The ECMWF GRIB API is an application program interface accessible from C,
       FORTRAN and Python programs developed for encoding and decoding WMO FM-92
       GRIB edition 1 and edition 2 messages.
+
+      Please note: GRIB-API support is being discontinued at the end of 2018.
+      After which there will be no further releases. Please upgrade to ecCodes
     '';
     maintainers = with maintainers; [ knedlsepp ];
   };
 }
-

--- a/pkgs/development/libraries/jasper/default.nix
+++ b/pkgs/development/libraries/jasper/default.nix
@@ -42,5 +42,10 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.jasper;
     maintainers = with maintainers; [ pSub ];
+    knownVulnerabilities = [
+      "Numerous CVE unsolved upstream"
+      "See: https://github.com/NixOS/nixpkgs/pull/57681#issuecomment-475857499"
+      "See: https://github.com/mdadams/jasper/issues/208"
+    ];
   };
 }

--- a/pkgs/development/libraries/libicns/default.nix
+++ b/pkgs/development/libraries/libicns/default.nix
@@ -1,14 +1,24 @@
-{ stdenv, fetchurl, libpng, jasper }:
+{ stdenv, fetchurl, fetchpatch, autoreconfHook, libpng, openjpeg }:
 
 stdenv.mkDerivation rec {
-  name = "libicns-0.8.1";
+  pname = "libicns";
+  version = "0.8.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/icns/${name}.tar.gz";
+    url = "mirror://sourceforge/icns/${pname}-${version}.tar.gz";
     sha256 = "1hjm8lwap7bjyyxsyi94fh5817xzqhk4kb5y0b7mb6675xw10prk";
   };
 
-  buildInputs = [ libpng jasper ];
+  patches = [
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/libi/libicns/0.8.1-3.1/debian/patches/support-libopenjp2.patch";
+      sha256 = "0ss298lyzvydxvaxsadi6kbbjpwykd86jw3za76brcsg2dpssgas";
+    })
+  ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ libpng openjpeg ];
+  NIX_CFLAGS_COMPILE = [ "-I${openjpeg.dev}/include/${openjpeg.incDir}" ];
 
   meta = with stdenv.lib; {
     description = "Library for manipulation of the Mac OS icns resource format";

--- a/pkgs/development/libraries/libraw/default.nix
+++ b/pkgs/development/libraries/libraw/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, lcms2, jasper, pkgconfig }:
+{ stdenv, fetchurl, lcms2, pkgconfig
+, jasper ? null, withJpeg2k ? false
+# disable JPEG2000 support by default as jasper has many CVE
+}:
 
 stdenv.mkDerivation rec {
   pname = "libraw";
@@ -11,7 +14,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" "doc" ];
 
-  buildInputs = [ jasper ];
+  buildInputs = stdenv.lib.optionals withJpeg2k [ jasper ];
 
   propagatedBuildInputs = [ lcms2 ];
 

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -9,7 +9,7 @@
 , enableTIFF      ? true, libtiff
 , enableWebP      ? true, libwebp
 , enableEXR ?     !stdenv.isDarwin, openexr, ilmbase
-, enableJPEG2K    ? true, jasper
+, enableJPEG2K    ? false, jasper  # disable jasper by default (many CVE)
 , enableEigen     ? true, eigen
 , enableOpenblas  ? true, openblas
 , enableContrib   ? true

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -9,7 +9,7 @@
 , enableTIFF      ? true, libtiff
 , enableWebP      ? true, libwebp
 , enableEXR ?     !stdenv.isDarwin, openexr, ilmbase
-, enableJPEG2K    ? true, jasper
+, enableJPEG2K    ? false, jasper  # disable jasper by default (many CVE)
 , enableEigen     ? true, eigen
 , enableOpenblas  ? true, openblas
 , enableContrib   ? true

--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -6,7 +6,7 @@
 , enablePNG ? true, libpng
 , enableTIFF ? true, libtiff
 , enableEXR ? (!stdenv.isDarwin), openexr, ilmbase
-, enableJPEG2K ? true, jasper
+, enableJPEG2K ? false, jasper  # disable jasper by default (many CVE)
 , enableFfmpeg ? false, ffmpeg
 , enableGStreamer ? false, gst_all_1
 , enableEigen ? true, eigen

--- a/pkgs/development/libraries/openscenegraph/default.nix
+++ b/pkgs/development/libraries/openscenegraph/default.nix
@@ -2,7 +2,7 @@
   libX11, libXinerama, libXrandr, libGLU, libGL,
   glib, ilmbase, libxml2, pcre, zlib,
   jpegSupport ? true, libjpeg,
-  jasperSupport ? true, jasper,
+  jasperSupport ? false, jasper,  # disable jasper by default (many CVE)
   exrSupport ? false, openexr,
   gifSupport ? true, giflib,
   pngSupport ? true, libpng,

--- a/pkgs/tools/graphics/dcraw/default.nix
+++ b/pkgs/tools/graphics/dcraw/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "dcraw-9.28.0";
 
   src = fetchurl {
-    url = "https://www.cybercom.net/~dcoffin/dcraw/archive/${name}.tar.gz";
+    url = "https://www.dechifro.org/dcraw/archive/${name}.tar.gz";
     sha256 = "1fdl3xa1fbm71xzc3760rsjkvf0x5jdjrvdzyg2l9ka24vdc7418";
   };
 
@@ -23,10 +23,17 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.cybercom.net/~dcoffin/dcraw/;
+    homepage = https://www.dechifro.org/dcraw/;
     description = "Decoder for many camera raw picture formats";
     license = stdenv.lib.licenses.free;
     platforms = stdenv.lib.platforms.unix; # Once had cygwin problems
     maintainers = [ ];
+    knownVulnerabilities = [
+      "CVE-2018-19655"
+      "CVE-2018-19565"
+      "CVE-2018-19566"
+      "CVE-2018-19567"
+      "CVE-2018-19568"
+    ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The JPEG2000 library `jasper` has many unfixed CVEs. See previous discussion in #57681
Vuln roundups: #57148, #55388 and many more before. Also [Debian sec tracker](https://security-tracker.debian.org/tracker/source-package/jasper) for it.
v2.0.16 could have fixed a small subset of known CVEs but many are still open and upstream seems dead. At this point, Debian/Ubuntu, Gentoo and NetBSD removed `jasper` entirely. OpenSuSE should do it too.
An [upstream issue](https://github.com/mdadams/jasper/issues/208) by an OpenSuSE maintainer sums up the situation. On DigiKam bug tracker an interested party also [shared informations](https://bugs.kde.org/show_bug.cgi?id=364231#c4) showing that `jasper` is barely on life support.

So I replaced `jasper` with `openjpeg` whenever possible, otherwise I disabled JPEG2000 support by default.

OpenCV situation is a little bit different because it disables jasper by default (since 3.4.6/4.1.0) and requires a deliberate runtime option to use it. See https://github.com/opencv/opencv/issues/14058
But since `jasper` will fail to eval because of `meta.knownVulnerabilities` it will prevent opencv from building. ~~Will turn it off by default in opencv too tomorrow~~ Done

I don't think we will _need_ to backport this given that open CVEs in jasper are mostly memory mgmt issues (low to medium severity) and that exploitability remains unknown.
But this goes in the direction of deprecating `jasper`. Hopefully by the time we release 20.03 digikam, gdk-pixbuf & co would have switched to using openjpeg instead.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @pSub @andir 
