### PR TITLE
essentia-extractor: init at 2.1_beta2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3944,6 +3944,22 @@
     github = "lovek323";
     name = "Jason O'Conal";
   };
+  lovesegfault = {
+    email = "meurerbernardo@gmail.com";
+    github = "lovesegfault";
+    githubId = 7243783;
+    name = "Bernardo Meurer";
+    keys = [
+      {
+        longkeyid = "rsa2048/0xE421C74191EA186C";
+        fingerprint = "5894 12CE 19DF 582A E10A  3320 E421 C741 91EA 186C";
+      }
+      {
+        longkeyid = "rsa2048/0x4A6D87A0E7475769";
+        fingerprint = "56A8 E164 E834 290C 4AC0  EE3E 4A6D 87A0 E747 5769";
+      }
+    ];
+  };
   lowfatcomputing = {
     email = "andreas.wagner@lowfatcomputing.org";
     github = "lowfatcomputing";

--- a/pkgs/tools/audio/essentia-extractor/default.nix
+++ b/pkgs/tools/audio/essentia-extractor/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl }:
+let
+  arch_table = {
+    "x86_64-linux" = "linux-x86_64";
+    "i686-linux" = "linux-i686";
+  };
+
+  sha_table = {
+    "x86_64-linux" =
+      "d9902aadac4f442992877945da2a6fe8d6ea6b0de314ca8ac0c28dc5f253f7d8";
+    "i686-linux" =
+      "46deb0a053b4910c4e68737a7b6556ff5360260c8f86652f91a0130445f5c949";
+  };
+
+  arch = arch_table.${stdenv.system};
+  sha = sha_table.${stdenv.system};
+in stdenv.mkDerivation rec {
+  pname = "essentia-extractor";
+  version = "2.1_beta2";
+
+  src = fetchurl {
+    url =
+      "ftp://ftp.acousticbrainz.org/pub/acousticbrainz/essentia-extractor-v${version}-${arch}.tar.gz";
+    sha256 = sha;
+  };
+
+  unpackPhase = "unpackFile $src ; export sourceRoot=.";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp streaming_extractor_music $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://acousticbrainz.org/download";
+    description = "AcousticBrainz audio feature extractor";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ lovesegfault ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -855,6 +855,8 @@ in
 
   enpass = callPackage ../tools/security/enpass { };
 
+  essentia-extractor = callPackage ../tools/audio/essentia-extractor { };
+
   esh = callPackage ../tools/text/esh { };
 
   ezstream = callPackage ../tools/audio/ezstream { };


### PR DESCRIPTION
###### Motivation for this change

Beets (`tools/audio/beets`) has a plugin called `absubmit` which relies on a statically linked binary provided by MusicBrainz. This is an example output of the `essentia` project called `streaming_extractor_music`, but called in the MusicBrainz archives as `essentia-extractor`. It reads an audio file and outputs a format the AcousticBrainz database can use.

Normally I'd try to package  `essentia` itself, but it uses waf as its build system and all my attempts to package it have left me depressed, so I think going with the binary provided by MusicBrainz, which they recommend, is a better approach. Citing the MB FAQ:

> Q: Why does AcousticBrainz prefer that people use the provided static extractor builds, rather than letting others build their own versions?

> A: Besides building your own version being a major pain, it is possible for different combinations of libraries and compilers (gcc vs clang, libffmpeg vs libav) to produce slightly different outputs. We're aiming to reduce the variances of output between the extractors in an effort to create the most consistent and stable dataset. We're going to build a test suite in the future that can evaluate the performance of a compiled extractor, but we're not quite there yet. So, for the time being, if it is possible in any way for you to use one of our static builds, we would greatly appreciate that. 

This will be followed by a PR fixing beets' deps.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
