### PR TITLE
python37Packages.PyLD: fix behavior to terminate generators

### DIFF
--- a/pkgs/development/python-modules/PyLD/default.nix
+++ b/pkgs/development/python-modules/PyLD/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, python, gnugrep }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch, python, gnugrep }:
 
 let
 
@@ -28,6 +28,14 @@ buildPythonPackage {
     rev = "652473f828e9a396d4c1db9addbd294fb7db1797";
     sha256 = "1bmpz4s6j7by6l45wwxy7dn7hmrhxc26kbx2hbfy41x29vbjg6j9";
   };
+
+  patches = [
+    # Fix tests on Python 3. Remove with the next release
+    (fetchpatch {
+      url = "https://github.com/digitalbazaar/pyld/commit/ec4bd907b7fbd566e1f6c76d09676e4900e3dcd0.patch";
+      sha256 = "0i5phs5qnq4bjsb72if1sbfg751qc14qbdskqn0xhlzx0r75l7za";
+    })
+  ];
 
   # Unfortunately PyLD does not pass all testcases in the JSON-LD corpus. We
   # check for at least a minimum amount of successful tests so we know it's not


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://hydra.nixos.org/build/106233545

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @apeschar 
