### PR TITLE
python37Packages.blist: fix compatibility for python 3.7

### DIFF
--- a/pkgs/development/python-modules/blist/default.nix
+++ b/pkgs/development/python-modules/blist/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , buildPythonPackage
+, fetchpatch
 , fetchPypi
 , isPyPy
 }:
@@ -13,6 +14,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1hqz9pqbwx0czvq9bjdqjqh5bwfksva1is0anfazig81n18c84is";
   };
+
+
+  patches = [
+    # Fix compatibility for Python 3.7 https://github.com/DanielStutzbach/blist/pull/78
+    (fetchpatch {
+      url = "https://github.com/DanielStutzbach/blist/commit/2dc1ec28ed68611fcec9ac1c68070c782d6b4b4e.patch";
+      sha256 = "0ma0z6ga80w3wzh3sidwd8ckfbgx4j1y7cc29q6j9ddrvxpf276y";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = http://stutzbachenterprises.com/blist/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://hydra.nixos.org/build/106559618 and https://hydra.nixos.org/build/106558784

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).