### PR TITLE
valgrind: Add perl as a native build input

### DIFF
--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation rec {
   # Perl is needed for `callgrind_{annotate,control}'.
   buildInputs = [ gdb perl ]  ++ stdenv.lib.optionals (stdenv.isDarwin) [ bootstrap_cmds xnu ];
 
+  # Perl is also a native build input.
+  nativeBuildInputs = [ perl ];
+
   enableParallelBuilding = true;
   separateDebugInfo = stdenv.isLinux;
 


### PR DESCRIPTION
The changes in #67548 broke cross-compilation not for valgrind, but for
software relying on valgrind at build-time.

###### Motivation for this change

Building `libdrm` through cross-compilation fails.

```
../coregrind/link_tool_exe_linux: line 58: use: command not found
../coregrind/link_tool_exe_linux: line 59: use: command not found
../coregrind/link_tool_exe_linux: line 62: die: command not found
../coregrind/link_tool_exe_linux: line 70: syntax error near unexpected token `$ala'
../coregrind/link_tool_exe_linux: line 70: `    if (length($ala) < 3 || index($ala, "0x") != 0);'
```

This is perl being interpreted by the shell (bash).

Bisecting points to d22b4859a16a3f3e01cf3e6dfaeefc4424ac00cb being the breaking change.

I am not 100% sure that adding perl to both kind of buildInputs is the solution, are there any drawbacks, or dangers to doing so?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - ✔️ NixOS
   - 🔲 macOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- 🔲 Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- 🔲 Tested execution of all binary files (usually in `./result/bin/`)
- 🔲 Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Ensured that relevant documentation is up to date
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

* * *

cc @FRidh (who commented on the PR)
cc @Ericson2314 @matthewbauer (usual cross-compiling peeps)