### PR TITLE
pythonPackages.cartopy: fix tests 19.09 backport

### DIFF
--- a/pkgs/development/python-modules/cartopy/default.nix
+++ b/pkgs/development/python-modules/cartopy/default.nix
@@ -1,5 +1,5 @@
 { buildPythonPackage, lib, fetchPypi
-, pytest, filelock, mock, pep8
+, pytest_4, filelock, mock, pep8
 , cython, isPy27
 , six, pyshp, shapely, geos, numpy
 , gdal, pillow, matplotlib, pyepsg, pykdtree, scipy, owslib, fiona
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     sha256 = "0q9ckfi37cxj7jwnqnzij62vwcf4krccx576vv5lhvpgvplxjjs2";
   };
 
-  checkInputs = [ filelock mock pytest pep8 ];
+  checkInputs = [ filelock mock pytest_4 pep8 ];
 
   # several tests require network connectivity: we disable them.
   # also py2.7's tk is over-eager in trying to open an x display,

--- a/pkgs/development/python-modules/fiona/default.nix
+++ b/pkgs/development/python-modules/fiona/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k, pythonOlder
+{ stdenv, lib, buildPythonPackage, fetchPypi, isPy3k, pythonOlder
 , attrs, click, cligj, click-plugins, six, munch, enum34
-, pytest, boto3, mock
+, pytest, boto3, mock, giflib
 , gdal_2 # can't bump to 3 yet, https://github.com/Toblerity/Fiona/issues/745
 }:
 
@@ -13,7 +13,7 @@ buildPythonPackage rec {
     sha256 = "0gpvdrayam4qvpqvz0911nlyvf7ib3slsyml52qx172vhpldycgs";
   };
 
-  CXXFLAGS = stdenv.lib.optionalString stdenv.cc.isClang "-std=c++11";
+  CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
 
   nativeBuildInputs = [
     gdal_2 # for gdal-config
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     gdal_2
-  ];
+  ] ++ lib.optionals stdenv.cc.isClang [ giflib ];
 
   propagatedBuildInputs = [
     attrs
@@ -30,12 +30,12 @@ buildPythonPackage rec {
     click-plugins
     six
     munch
-  ] ++ stdenv.lib.optional (!isPy3k) enum34;
+  ] ++ lib.optional (!isPy3k) enum34;
 
   checkInputs = [
     pytest
     boto3
-  ] ++ stdenv.lib.optional (pythonOlder "3.4") mock;
+  ] ++ lib.optional (pythonOlder "3.4") mock;
 
   checkPhase = ''
     rm -r fiona # prevent importing local fiona
@@ -45,7 +45,7 @@ buildPythonPackage rec {
            and not test_*_wheel"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "OGR's neat, nimble, no-nonsense API for Python";
     homepage = http://toblerity.org/fiona/;
     license = licenses.bsd3;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Backported #70671 to fix https://hydra.nixos.org/build/106235075

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mredaelli 
