### PR TITLE
rspamd: Specify correct type for fuzzy worker

### DIFF
--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -60,7 +60,7 @@ let
       };
       type = mkOption {
         type = types.nullOr (types.enum [
-          "normal" "controller" "fuzzy_storage" "rspamd_proxy" "lua" "proxy"
+          "normal" "controller" "fuzzy" "rspamd_proxy" "lua" "proxy"
         ]);
         description = ''
           The type of this worker. The type <literal>proxy</literal> is


### PR DESCRIPTION
The rspamd module has an incorrect type declaration The types require the fuzzy worker to be specified as `fuzzy_storage` but rspamd only accepts `fuzzy` as the worker type.

Perhaps the author just falsely assumed https://rspamd.com/doc/workers/ to be an authoritative list of worker types. That documentation of rspamd is wrong.

If `fuzzy_storage` is specified rspamd will emit a warning that this worker type does not exist, and `fuzzy` is not amissable.


###### Notify maintainers

cc @griff 
