### PR TITLE
alex: drop patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -102,11 +102,6 @@ self: super: {
   vault = dontHaddock super.vault;
   monad-par = dontCheck super.monad-par;   # test suite does not compile in monad-par-0.3.4.8
 
-  # TODO dont fetch patch if https://github.com/simonmar/alex/issues/140 is resolved
-  alex = appendPatch super.alex (pkgs.fetchpatch {
-    url = "https://github.com/simonmar/alex/commit/deaae6eddef5186bfd0e42e2c3ced39e26afa4d6.patch";
-    sha256 = "1v40gmnw4lqyk271wngdwz8whpfdhmza58srbkka8icwwwrck3l5";
-  });
   # https://github.com/snapframework/snap-core/issues/288
   snap-core = overrideCabal super.snap-core (drv: { prePatch = "substituteInPlace src/Snap/Internal/Core.hs --replace 'fail   = Fail.fail' ''"; });
   # needs a release


### PR DESCRIPTION
simonmar/alex#140 was merged and the patch has been applied in alex
version 3.2.5 so the build is broken trying to re-apply the patch.

###### Motivation for this change

Build is currently broken:
```
toonn@terra ~/s/nixpkgs> nix-shell -p haskell.packages.ghc881.alex
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
these derivations will be built:
  /nix/store/m1kpjzmnknjj3id1z99vxm6n2vgjaj94-alex-3.2.5.drv
building '/nix/store/m1kpjzmnknjj3id1z99vxm6n2vgjaj94-alex-3.2.5.drv'...
setupCompilerEnvironmentPhase
Build with /nix/store/w80d6hkln8677c0rs8adn69bydmblf24-ghc-8.8.1.
unpacking sources
unpacking source archive /nix/store/x90v6grkvnasfb4k6x529vi993yghv14-alex-3.2.5.tar.gz
source root is alex-3.2.5
setting SOURCE_DATE_EPOCH to timestamp 1000000000 of file alex-3.2.5/tests/unicode.x
patching sources
applying patch /nix/store/zd1s3kb85vkry8wfz21x8yccwx1xmpyr-deaae6eddef5186bfd0e42e2c3ced39e26afa4d6.patch
patching file tests/default_typeclass.x
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file tests/default_typeclass.x.rej
builder for '/nix/store/m1kpjzmnknjj3id1z99vxm6n2vgjaj94-alex-3.2.5.drv' failed with exit code 1
error: build of '/nix/store/m1kpjzmnknjj3id1z99vxm6n2vgjaj94-alex-3.2.5.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @