### PR TITLE
tests/systemd-networkd-wireguard: migrate to python test runner

### DIFF
--- a/nixos/tests/systemd-networkd-wireguard.nix
+++ b/nixos/tests/systemd-networkd-wireguard.nix
@@ -45,7 +45,7 @@ let generateNodeConf = { lib, pkgs, config, privkpath, pubk, peerId, nodeId, ...
         };
       };
     };
-in import ./make-test.nix ({pkgs, ... }: {
+in import ./make-test-python.nix ({pkgs, ... }: {
   name = "networkd-wireguard";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ ninjatrappeur ];
@@ -70,12 +70,12 @@ in import ./make-test.nix ({pkgs, ... }: {
     in generateNodeConf (attrs // localConf);
   };
 testScript = ''
-    startAll;
-    $node1->waitForUnit('systemd-networkd-wait-online.service');
-    $node2->waitForUnit('systemd-networkd-wait-online.service');
-    $node1->succeed('ping -c 5 10.0.0.2');
-    $node2->succeed('ping -c 5 10.0.0.1');
+    start_all()
+    node1.wait_for_unit("systemd-networkd-wait-online.service")
+    node2.wait_for_unit("systemd-networkd-wait-online.service")
+    node1.succeed("ping -c 5 10.0.0.2")
+    node2.succeed("ping -c 5 10.0.0.1")
     # Is the fwmark set?
-    $node2->succeed('wg | grep -q 42');
+    node2.succeed("wg | grep -q 42")
 '';
 })


### PR DESCRIPTION
Updating `systemd-networkd-wireguard` to use the python test runner.

This change was purely syntactic. This migration did not require any
semantic change.

###### Motivation for this change

Part of #72828

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc 
