### PR TITLE
freeoffice: 971 -> 973

### DIFF
--- a/pkgs/applications/office/softmaker/freeoffice.nix
+++ b/pkgs/applications/office/softmaker/freeoffice.nix
@@ -2,13 +2,13 @@
 
 callPackage ./generic.nix (args // rec {
   pname = "freeoffice";
-  version = "971";
+  version = "973";
   edition = "2018";
   suiteName = "FreeOffice";
 
   src = fetchurl {
     url = "https://www.softmaker.net/down/softmaker-freeoffice-${version}-amd64.tgz";
-    sha256 = "1h36pjbpbiy4cw383cbrwh1jx2kp1ay29734zailmhifz53gj44f";
+    sha256 = "0xac4ynf1lfh8qmni5bhp4ybaamdfngva4bqaq21n1m4pgrx1ba5";
   };
 
   archive = "freeoffice${edition}.tar.lzma";

--- a/pkgs/applications/office/softmaker/generic.nix
+++ b/pkgs/applications/office/softmaker/generic.nix
@@ -96,6 +96,10 @@ in stdenv.mkDerivation rec {
       done
     done
 
+    # freeoffice 973 misses the 96x96 application icons, giving broken symbolic links
+    # remove broken symbolic links
+    find $out -xtype l -ls -exec rm {} \;
+
     # Add desktop items
     ${desktopItems.planmaker.buildCommand}
     ${desktopItems.presentations.buildCommand}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to version [973](https://www.freeoffice.com/en/download/servicepacks)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @danieldk 
