### PR TITLE
substitute: init at 0

### DIFF
--- a/pkgs/build-support/substitute/substitute.nix
+++ b/pkgs/build-support/substitute/substitute.nix
@@ -1,0 +1,14 @@
+{ stdenvNoCC }:
+
+args:
+
+# This is a wrapper around `substitute` in the stdenv.
+# The `replacements` attribute should be a list of list of arguments
+# to `substitute`, such as `[ "--replace" "sourcetext" "replacementtext" ]`
+stdenvNoCC.mkDerivation ({
+  name = if args ? name then args.name else baseNameOf (toString args.src);
+  builder = ./substitute.sh;
+  inherit (args) src;
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+} // args // { replacements = args.replacements; })

--- a/pkgs/build-support/substitute/substitute.sh
+++ b/pkgs/build-support/substitute/substitute.sh
@@ -1,0 +1,18 @@
+source $stdenv/setup
+
+args=
+
+target=$out
+if test -n "$dir"; then
+    target=$out/$dir/$name
+    mkdir -p $out/$dir
+fi
+
+substitute $src $target $replacements
+
+if test -n "$isExecutable"; then
+    chmod +x $target
+fi
+
+eval "$postInstall"
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -420,6 +420,8 @@ in
 
   srcOnly = args: callPackage ../build-support/src-only args;
 
+  substitute = callPackage ../build-support/substitute/substitute.nix { };
+
   substituteAll = callPackage ../build-support/substitute/substitute-all.nix { };
 
   substituteAllFiles = callPackage ../build-support/substitute-files/substitute-all-files.nix { };


### PR DESCRIPTION
Similar to the colocated `substituteAll` script and derivation, this
PR adds nix-level support for `substitute` directly.  This is useful,
for instance, to be able to easily make tweaks to patch files for an
existing derivation's existing patch files.

###### Motivation for this change
Couldn't easily tweak an existing patchfile in an existing derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace 
