### PR TITLE
ocaml-sodium: init at 0.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/sodium/default.nix
+++ b/pkgs/development/ocaml-modules/sodium/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, ctypes, libsodium }:
+
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-sodium";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner  = "dsheets";
+    repo   = "ocaml-sodium";
+    rev    = version;
+    sha256 = "124gpi1jhac46x05gp5viykyrafnlp03v1cmkl13c6pgcs8w04pv";
+  };
+
+  buildInputs = [ ocaml findlib ocamlbuild ];
+  propagatedBuildInputs = [ ctypes libsodium ];
+
+  createFindlibDestdir = true;
+
+  hardeningDisable = stdenv.lib.optional stdenv.isDarwin "strictoverflow";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dsheets/ocaml-sodium;
+    description = "Binding to libsodium 1.0.9+";
+    platforms = ocaml.meta.platforms or [];
+    maintainers = [ maintainers.rixed ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -755,6 +755,8 @@ let
 
     sedlex = callPackage ../development/ocaml-modules/sedlex { };
 
+    sodium = callPackage ../development/ocaml-modules/sodium { };
+
     spelll = callPackage ../development/ocaml-modules/spelll { };
 
     sqlite3EZ = callPackage ../development/ocaml-modules/sqlite3EZ { };


### PR DESCRIPTION
##### Motivation for this change

Trivial packaging of the libsodium bindings for OCaml, that I need for a less trivial one.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
