### PR TITLE
fastjet-contrib: init at 1.042

### DIFF
--- a/pkgs/development/libraries/physics/fastjet-contrib/default.nix
+++ b/pkgs/development/libraries/physics/fastjet-contrib/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, fastjet }:
+
+stdenv.mkDerivation rec {
+  pname = "fastjet-contrib";
+  version = "1.042";
+
+  src = fetchurl {
+    url = "http://fastjet.hepforge.org/contrib/downloads/fjcontrib-${version}.tar.gz";
+    sha256 = "0cc8dn6g7adj2pgs8hvczg68i3xhlk6978m4gxamgibilf9jw1av";
+  };
+
+  buildInputs = [ fastjet ];
+
+  postPatch = ''
+    for f in Makefile.in */Makefile; do
+      substituteInPlace "$f" --replace "CXX=g++" ""
+    done
+    patchShebangs ./configure ./utils/check.sh ./utils/install-sh
+  '';
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  postBuild = ''
+    make fragile-shared
+  '';
+
+  postInstall = ''
+    make fragile-shared-install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Third party extensions for FastJet";
+    homepage = "http://fastjet.fr/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ veprbl ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24256,6 +24256,8 @@ in
 
   fastjet = callPackage ../development/libraries/physics/fastjet { };
 
+  fastjet-contrib = callPackage ../development/libraries/physics/fastjet-contrib { };
+
   fastnlo = callPackage ../development/libraries/physics/fastnlo { };
 
   geant4 = libsForQt5.callPackage ../development/libraries/physics/geant4 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Upcoming bump for `rivet` to version 3.0.2 requires fastjet-contrib as a new dependency.

The "fragile-shared" targets use used to enable build of a shared library. Additional "make" call were added in `postBuild` and `postInstall` because standard stdenv's features like `installTarget` would not work with these makefiles because "fragile-shared" targets are available in the main makefile, but not in submakefiles, so we can't build those when recursion is taking place.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
