### PR TITLE
endless-sky: 0.9.8 -> 0.9.10

### DIFF
--- a/pkgs/games/endless-sky/default.nix
+++ b/pkgs/games/endless-sky/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "0.9.8";
+  version = "0.9.10";
 
 in
 stdenv.mkDerivation {
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     owner = "endless-sky";
     repo = "endless-sky";
     rev = "v${version}";
-    sha256 = "0i36lawypikbq8vvzfis1dn7yf6q0d2s1cllshfn7kmjb6pqfi6c";
+    sha256 = "1wax9qhxakydg6bs92d1jy2fki1n9r0wkps1np02y0pvm1fl189i";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/games/endless-sky/fixes.patch
+++ b/pkgs/games/endless-sky/fixes.patch
@@ -2,15 +2,6 @@ diff --git a/SConstruct b/SConstruct
 index 48fd080..419b40d 100644
 --- a/SConstruct
 +++ b/SConstruct
-@@ -1,7 +1,7 @@
- import os
- 
- # Load any environment variables that alter the build.
--env = Environment()
-+env = Environment(ENV = os.environ)
- if 'CCFLAGS' in os.environ:
- 	env.Append(CCFLAGS = os.environ['CCFLAGS'])
- if 'CXXFLAGS' in os.environ:
 @@ -55,7 +55,7 @@ sky = env.Program("endless-sky", Glob("build/" + env["mode"] + "/*.cpp"))
  
  


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
New upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [?] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`

I ran that command inside my working git repo with the updated package definition.  It said it “No diff detected”.  I'm really not sure how that review tool is supposed to be run.  Is that what I'm supposed to do, or is it something completely different?  At any rate, I don't think any other package depends on endless-sky, but I'm not really sure how to verify that.

- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lheckemann 
