### PR TITLE
[WIP] pynac: switch to python3

### DIFF
--- a/pkgs/applications/science/math/pynac/default.nix
+++ b/pkgs/applications/science/math/pynac/default.nix
@@ -4,7 +4,7 @@
 , pkgconfig
 , flint
 , gmp
-, python2
+, python3
 , singular
 }:
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     gmp
     singular
     singular
-    python2
+    python3
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Getting the sage python3 build ready. Unfortunately switching pynac over to python3 fails:

```
checking for python3.7... (cached) /nix/store/gpnm7i19lpj8p43mjrdw03d0hjalmskl-python3-3.7.5/bin/python
checking for a version of Python >= '2.1.0'... yes
checking for the distutils Python package... yes
checking for Python include path... -I/nix/store/gpnm7i19lpj8p43mjrdw03d0hjalmskl-python3-3.7.5/include/python3.7m
checking for Python library path... -L/nix/store/gpnm7i19lpj8p43mjrdw03d0hjalmskl-python3-3.7.5/lib -lpython3.7m
checking for Python site-packages path... /nix/store/gpnm7i19lpj8p43mjrdw03d0hjalmskl-python3-3.7.5/lib/python3.7/site-packages
checking python extra libraries... -lpthread -ldl -lcrypt -lncurses -lutil -lm
checking python extra linking flags... -Xlinker -export-dynamic
checking consistency of all components of python development environment... no
configure: error: in `/build/source':
configure: error:
  Could not link test program to Python. Maybe the main Python library has been
  installed in some non-standard library path. If so, pass it to configure,
  via the LDFLAGS environment variable.
  Example: ./configure LDFLAGS="-L/usr/non-standard-path/python/lib"
  ============================================================================
   ERROR!
   You probably have to install the development version of the Python package
   for your distribution.  The exact name of this package varies among them.
  ============================================================================

See `config.log' for more details
```

@FRidh is this package-specific weirdness or are there any differences between the python2 and python3 packages that I should be aware of?

Archlinux apparently was able to switch this package over without any changes: [python2](https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/pynac) to [python3](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=pynac-python3). I tried `export PYTHON=python3` without success.

This [issue](https://github.com/pynac/pynac/issues/205) might be relevant, but setting `libdir=${python3}/lib` didn't solve the issue.

[Here](https://github.com/pynac/pynac/blob/340afb52f522f3795d810ec509cfe2a8492b0c88/m4/ax_python_devel.m4#L288) is the relevant m4 file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
