### PR TITLE
sycl-info: init at unstable-2019-11-19

### DIFF
--- a/pkgs/development/libraries/doctest/default.nix
+++ b/pkgs/development/libraries/doctest/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, installShellFiles, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "doctest";
+  version = "2.3.5";
+
+  src = fetchFromGitHub {
+    owner = "onqtam";
+    repo = "doctest";
+    rev = version;
+    sha256 = "0rddlzhnv0f5036q0m0p019pismka7sx6x8cnzk65sk77b1dsbhg";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/onqtam/doctest";
+    description = "The fastest feature-rich C++11/14/17/20 single-header testing framework";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ davidtwco ];
+  };
+}

--- a/pkgs/development/libraries/lyra/default.nix
+++ b/pkgs/development/libraries/lyra/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, installShellFiles, meson, ninja }:
+
+stdenv.mkDerivation rec {
+  pname = "lyra";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "bfgroup";
+    repo = "lyra";
+    rev = version;
+    sha256 = "1wcwsmg41bmjir6pjrjxrwccqj25d9068ifi9m6xz6q3fhaq6s81";
+  };
+
+  nativeBuildInputs = [ meson ninja ];
+
+  enableParallelBuilding = true;
+
+  postPatch = "sed -i s#/usr#$out#g meson.build";
+
+  postInstall = ''
+    mkdir -p $out/include
+    cp -R $src/include/* $out/include
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/bfgroup/Lyra";
+    description = "A simple to use, composable, command line parser for C++ 11 and beyond";
+    platforms = platforms.linux;
+    license = licenses.boost;
+    maintainers = with maintainers; [ davidtwco ];
+  };
+}

--- a/pkgs/development/libraries/sycl-info/default.nix
+++ b/pkgs/development/libraries/sycl-info/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, fetchFromGitHub
+, installShellFiles
+, cmake
+, ninja
+, ocl-icd
+, opencl-headers
+, lyra
+, nlohmann_json
+, ronn
+, doctest
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sycl-info";
+  version = "unstable-2019-11-19";
+
+  src = fetchFromGitHub {
+    owner = "codeplaysoftware";
+    repo = "sycl-info";
+    rev = "b47d498ee2d6b77ec21972de5882e8e12efecd6c";
+    sha256 = "0fy0y1rcfb11p3vijd8wym6xkaicav49pv2bv2l18rma929n1m1m";
+  };
+
+  buildInputs = [
+    nlohmann_json
+    ronn
+    opencl-headers
+    ocl-icd
+    doctest
+    lyra
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_TESTING=ON"
+    "-DBUILD_DOCS=ON"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DLYRA_INCLUDE_DIRS=${stdenv.lib.getDev lyra}/include"
+  ];
+
+  # Required for ronn to compile the manpage.
+  RUBYOPT = "-KU -E utf-8:utf-8";
+
+  meta = with stdenv.lib;
+    {
+      homepage = "https://github.com/codeplaysoftware/sycl-info";
+      description = "Tool to show information about available SYCL implementations";
+      platforms = platforms.linux;
+      license = licenses.asl20;
+      maintainers = with maintainers; [ davidtwco ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6708,6 +6708,8 @@ in
 
   svtplay-dl = callPackage ../tools/misc/svtplay-dl { };
 
+  sycl-info = callPackage ../development/libraries/sycl-info { };
+
   symengine = callPackage ../development/libraries/symengine { };
 
   sysbench = callPackage ../development/tools/misc/sysbench {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13311,6 +13311,8 @@ in
     asciidoc = asciidoc-full;
   };
 
+  lyra = callPackage ../development/libraries/lyra { };
+
   lzo = callPackage ../development/libraries/lzo { };
 
   opencl-clang = callPackage ../development/libraries/opencl-clang { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11230,6 +11230,8 @@ in
 
   dlib = callPackage ../development/libraries/dlib { };
 
+  doctest = callPackage ../development/libraries/doctest { };
+
   docopt_cpp = callPackage ../development/libraries/docopt_cpp { };
 
   dotconf = callPackage ../development/libraries/dotconf { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adds a package for [sycl-info](https://github.com/codeplaysoftware/sycl-info).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc me!
