### PR TITLE
public-sans: 1.006 -> 1.007

### DIFF
--- a/pkgs/data/fonts/public-sans/default.nix
+++ b/pkgs/data/fonts/public-sans/default.nix
@@ -1,18 +1,22 @@
 { lib, fetchzip }:
 
 let
-  version = "1.006";
+  version = "1.007";
 in fetchzip {
   name = "public-sans-${version}";
 
   url = "https://github.com/uswds/public-sans/releases/download/v${version}/public-sans-v${version}.zip";
 
   postFetch = ''
-    mkdir -p $out/share
-    unzip $downloadedFile fonts/{otf,variable}/\*.\[ot\]tf -d $out/share/
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile binaries/otf/\*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile binaries/variable/\*.ttf -d $out/share/fonts/truetype
+    unzip -j $downloadedFile binaries/webfonts/\*.ttf -d $out/share/fonts/truetype
+    unzip -j $downloadedFile binaries/webfonts/\*.woff -d $out/share/fonts/woff
+    unzip -j $downloadedFile binaries/webfonts/\*.woff2 -d $out/share/fonts/woff2
   '';
 
-  sha256 = "1x04mpynfhcgiwx68w5sawgn69xld7k65mbq7n5vcgbfzh2sjwhq";
+  sha256 = "1yzraw08qm1ig7ks850b329xp6zv2znjwl610dppax34kwhqghsm";
 
   meta = with lib; {
     description = "A strong, neutral, principles-driven, open source typeface for text or display";


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/uswds/public-sans/releases/tag/v1.007

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill
