### PR TITLE
stix-two: 2.0.0 -> 2.0.2

### DIFF
--- a/pkgs/data/fonts/stix-two/default.nix
+++ b/pkgs/data/fonts/stix-two/default.nix
@@ -1,18 +1,22 @@
-{ stdenv, fetchzip }:
+{ stdenv, fetchFromGitHub }:
 
 let
-  version = "2.0.0";
-in fetchzip {
+  version = "2.0.2";
+in fetchFromGitHub {
   name = "stix-two-${version}";
 
-  url = "https://github.com/stipub/stixfonts/archive/${version}.zip";
+  owner = "stipub";
+  repo = "stixfonts";
+  rev = "v${version}";
 
   postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile '*/OTF/*.otf' -d $out/share/fonts/opentype
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/opentype/ OTF/*.otf
+    install -m444 -Dt $out/share/fonts/woff/     WOFF/*.woff
+    install -m444 -Dt $out/share/fonts/woff2/    WOFF2/*.woff2
   '';
 
-  sha256 = "19i30d2xjk52bjj7xva1hnlyh58yd5phas1njcc8ldcz87a1lhql";
+  sha256 = "1ah8s0cb67yv4ll8zfs01mdh9m5i2lbkrfbmkhi1xdid6pxsk32x";
 
   meta = with stdenv.lib; {
     homepage = http://www.stixfonts.org/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
