### PR TITLE
nixos/prometheus: 'configText' -> 'configFile' and final config in /etc

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -57,6 +57,7 @@ with lib;
       please use 'services.prometheus2.alertmanagers' instead.
     '')
     (mkRenamedOptionModule [ "services" "prometheus2" ] [ "services" "prometheus" ])
+    (mkRemovedOptionModule [ "services" "prometheus" "configText" ] "Use services.prometheus.configFile in combination with pkgs.writeText instead.")
     (mkRenamedOptionModule [ "services" "tor" "relay" "portSpec" ] [ "services" "tor" "relay" "port" ])
     (mkRenamedOptionModule [ "services" "vmwareGuest" ] [ "virtualisation" "vmware" "guest" ])
     (mkRenamedOptionModule [ "jobs" ] [ "systemd" "services" ])


### PR DESCRIPTION

###### Motivation for this change
This allows for configuration of a custom path to the main Prometheus config file. At the same time `configText` becomes obsolete, as `configFile` is easily combined with `pkgs.writeText` for users of the module.

Most importantly though, this PR symlinks `/etc/prometheus/prometheus.yaml` to the promtool checked configuration. Which, is desirable for optional user application of `reloadIfChanged = true` on the Prometheus systemd service. By referencing a store path only, it is currently not possible to SIGHUP Prometheus when the configuration changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @WilliButz @globin 
