### PR TITLE
Improvements to the NixOS Hardened Profile

### DIFF
--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -14,6 +14,9 @@ with lib;
 
   nix.allowedUsers = mkDefault [ "@users" ];
 
+  environment.memoryAllocator.provider = mkDefault "scudo";
+  environment.variables.SCUDO_OPTIONS = mkDefault "ZeroContents=1";
+
   security.hideProcessInformation = mkDefault true;
 
   security.lockKernelModules = mkDefault true;

--- a/nixos/modules/profiles/hardened.nix
+++ b/nixos/modules/profiles/hardened.nix
@@ -20,6 +20,8 @@ with lib;
 
   security.allowUserNamespaces = mkDefault false;
 
+  nix.useSandbox = mkDefault false;
+
   security.protectKernelImage = mkDefault true;
 
   security.allowSimultaneousMultithreading = mkDefault false;


### PR DESCRIPTION
###### Motivation for this change
Use scudo allocator for the hardened profile by default. Includes changes to compiler-rt to make it more compatible by default with things like man see #65000 for some details. Turning these two options off by default will prevent issues in programs from crashing the malloc, which is critical if we are replacing it as the system malloc. These options are all able to be overridden by simple environment variables even when compiled in so this should be a very safe change. I enabled the allocator zeroing by default in the hardened profile only. The buildSandbox option is currently incompatible with the hardened profile so it should be defaulted to off unless you manually re-enable both it and user namespaces. 

I tested in a VM using the master branch. I used the hardened profile for the guest. I used both standard llvmPackages.compiler_rt and llvmPackages_9.compiler_rt for testing and both work. I mostly tested these options affects on programs by using man but I've also noticed needing these options as an environment variable for qemu to function well.

I feel like this should be backported to 19.09 so that the hardened profile can take advantage of it as was intended in #65000 for 19.09 (albeit with the graphene_malloc allocator). I feel the clang allocator has a much more stable history and should be the mkDefault here. I was unsure if and how to make the environment variable depend on the scudo allocator being the default but I do feel like it's safe to set in to profile anyway since it can be overridden easily.

I wasn't sure if maintainers wanted me to apply the compatibility all the way back to 4 which does still have scudo. I included 8 because I'm not sure what is going to land as the default for 20.03

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @joachifm @lovek323 @dtzWill @7c6f434c 
