### PR TITLE
zplugin:init at 2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5128,6 +5128,11 @@
     githubId = 131844;
     name = "Igor Pashev";
   };
+  pasqui23 = {
+    email = "p3dimaria@hotmail.it";
+    github = "pasqui23";
+    githubId = 6931743;
+  };
   patternspandemic = {
     email = "patternspandemic@live.com";
     github = "patternspandemic";

--- a/pkgs/shells/zsh/zplugin/default.nix
+++ b/pkgs/shells/zsh/zplugin/default.nix
@@ -1,0 +1,40 @@
+{ stdenvNoCC, lib, fetchFromGitHub, installShellFiles }:
+stdenvNoCC.mkDerivation rec {
+  pname = "zplugin";
+  version = "2.3";
+  src = fetchFromGitHub {
+    owner = "zdharma";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0qqv5p19s8jb06d6h55dm4acji9x2rpxb2ni3h7fb0q43iz6y85w";
+  };
+  # adapted from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zsh-zplugin-git
+  dontBuild = true;
+  nativeBuildInputs = [ installShellFiles ];
+  installPhase = ''
+    outdir="$out/share/$pname"
+
+    cd "$src"
+
+    # Zplugin's source files
+    install -dm0755 "$outdir"
+    install -m0644 zplugin{,-side,-install,-autoload}.zsh "$outdir"
+    install -m0755 git-process-output.zsh "$outdir"
+
+    # Zplugin autocompletion
+    installShellCompletion --zsh _zplugin
+
+    #TODO:Zplugin-module files
+    # find zmodules/ -type d -exec install -dm 755 "{}" "$outdir/{}" \;
+    # find zmodules/ -type f -exec install -m 744 "{}" "$outdir/{}" \;
+
+  '';
+  #TODO:doc output
+
+  meta = with lib; {
+    homepage = "https://github.com/zdharma/zplugin";
+    description = "Flexible zsh plugin manager";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pasqui23 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7461,6 +7461,8 @@ in
   zpaq = callPackage ../tools/archivers/zpaq { };
   zpaqd = callPackage ../tools/archivers/zpaq/zpaqd.nix { };
 
+  zplugin = callPackage ../shells/zsh/zplugin { };
+
   zsh-autoenv = callPackage ../tools/misc/zsh-autoenv { };
 
   zsh-git-prompt = callPackage ../shells/zsh/zsh-git-prompt { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

Building fails with 
```
nix-env -f ./. -iA zplugin
installing 'zplugin-2.3'
these derivations will be built:
  /nix/store/sanj1x0ishjzrqbpkwhpmwr41hl2j6vn-zplugin-2.3.drv
building '/nix/store/sanj1x0ishjzrqbpkwhpmwr41hl2j6vn-zplugin-2.3.drv'...
unpacking sources
unpacking source archive /nix/store/wl0pvhglyvkyvny2hgjvgyn0bi89ilnr-source
source root is source
patching sources
configuring
no configure script, doing nothing
installing
/nix/store/npsin1jlnzs5sqxpsv2mk5gbnm4hk4kr-stdenv-linux/setup: eval: line 1337: unexpected EOF while looking for matching `"'
builder for '/nix/store/sanj1x0ishjzrqbpkwhpmwr41hl2j6vn-zplugin-2.3.drv' failed with exit code 2
error: build of '/nix/store/sanj1x0ishjzrqbpkwhpmwr41hl2j6vn-zplugin-2.3.drv' failed
```

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
