### PR TITLE
[WIP] nixos/tests/installer: support useEFIBoot

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from xml.sax.saxutils import XMLGenerator
 import _thread
 import atexit
+import base64
 import json
 import os
 import ptpython.repl
@@ -709,6 +710,13 @@ class Machine:
         """Make the machine reachable.
         """
         self.send_monitor_command("set_link virtio-net-pci.1 on")
+
+    def copy_file_from_host(self, from_path, to_path):
+        """Copy a file to the machine.
+        """
+        with open(from_path, "rb") as f:
+            content = base64.b64encode(f.read())
+            self.succeed("echo '{}' | base64 -d > {}".format(content.decode(), to_path))
 
 
 def create_machine(args):

--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -241,20 +241,16 @@ class Machine:
         if "hda" in args:
             hda_path = os.path.abspath(args["hda"])
             if args.get("hdaInterface", "") == "scsi":
-                start_command += (
-                    "-drive id=hda,file="
-                    + hda_path
-                    + ",werror=report,if=none "
-                    + "-device scsi-hd,drive=hda "
-                )
+                hda_device_driver = "scsi-hd"
             else:
-                start_command += (
-                    "-drive file="
-                    + hda_path
-                    + ",if="
-                    + args["hdaInterface"]
-                    + ",werror=report "
-                )
+                hda_device_driver = "virtio-blk-pci"
+
+            start_command += "-drive id=hda,file={},if=none,werror=report ".format(
+                hda_path
+            )
+            start_command += "-device {},drive=hda,bootindex=0 ".format(
+                hda_device_driver
+            )
 
         if "cdrom" in args:
             start_command += "-cdrom " + args["cdrom"] + " "
@@ -267,8 +263,21 @@ class Machine:
                 + ",if=none,readonly "
                 + "-device usb-storage,drive=usbdisk "
             )
+
         if "bios" in args:
             start_command += "-bios " + args["bios"] + " "
+
+        if "efiFirmware" in args:
+            efi_firmware_path = os.path.abspath(args["efiFirmware"])
+            start_command += "-drive if=pflash,format=raw,readonly,file={} ".format(
+                efi_firmware_path
+            )
+
+        if "efiVars" in args:
+            efi_vars_path = os.path.abspath(args["efiVars"])
+            start_command += "-drive if=pflash,format=raw,file={} ".format(
+                efi_vars_path
+            )
 
         start_command += args.get("qemuFlags", "")
 

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -2,8 +2,7 @@
   config ? {},
   pkgs ? import ../.. { inherit system config; }
 }:
-
-with import ../lib/testing.nix { inherit system pkgs; };
+with import ../lib/testing-python.nix { inherit system pkgs; };
 with pkgs.lib;
 
 let
@@ -68,160 +67,180 @@ let
                   , testCloneConfig
                   }:
     let
+
       iface = if grubVersion == 1 then "ide" else "virtio";
       isEfi = bootLoader == "systemd-boot" || (bootLoader == "grub" && grubUseEfi);
 
-      # FIXME don't duplicate the -enable-kvm etc. flags here yet again!
-      qemuFlags =
-        (if system == "x86_64-linux" then "-m 768 " else "-m 512 ") +
-        (optionalString (system == "x86_64-linux") "-cpu kvm64 ") +
-        (optionalString (system == "aarch64-linux") "-enable-kvm -machine virt,gic-version=host -cpu host ");
+      makeMachineConfig = name: pkgs.writeText "machine-config.json" (builtins.toJSON ({
+        inherit name;
+        # FIXME don't duplicate the -enable-kvm etc. flags here yet again!
+        qemuFlags =
+          (if system == "x86_64-linux" then "-m 768 " else "-m 512 ") +
+          (optionalString (system == "x86_64-linux") "-cpu kvm64 ") +
+          (optionalString (system == "aarch64-linux") "-enable-kvm -machine virt,gic-version=host -cpu host ");
 
-      hdFlags = ''hda => "vm-state-machine/machine.qcow2", hdaInterface => "${iface}", ''
-        + optionalString isEfi (if pkgs.stdenv.isAarch64
-            then ''bios => "${pkgs.OVMF.fd}/FV/QEMU_EFI.fd", ''
-            else ''bios => "${pkgs.OVMF.fd}/FV/OVMF.fd", '');
+        hda = "vm-state-machine/machine.qcow2";
+        hdaInterface = iface;
+      } // (optionalAttrs isEfi {
+        bios = if pkgs.stdenv.isAarch64
+          then "${pkgs.OVMF.fd}/FV/QEMU_EFI.fd"
+          else "${pkgs.OVMF.fd}/FV/OVMF.fd";
+      })));
+
     in if !isEfi && !(pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64) then
       throw "Non-EFI boot methods are only supported on i686 / x86_64"
     else ''
+      def create_machine_from_file(machine_config_file):
+          with open(machine_config_file, "r") as f:
+              return create_machine(json.load(f))
 
-      $machine->start;
+
+      machine.start()
 
       # Make sure that we get a login prompt etc.
-      $machine->succeed("echo hello");
-      #$machine->waitForUnit('getty@tty2');
-      #$machine->waitForUnit("rogue");
-      $machine->waitForUnit("nixos-manual");
+      machine.succeed("echo hello")
+      # machine.wait_for_unit("getty@tty2")
+      # machine.wait_for_unit("rogue")
+      machine.wait_for_unit("nixos-manual")
 
       # Wait for hard disks to appear in /dev
-      $machine->succeed("udevadm settle");
+      machine.succeed("udevadm settle")
 
       # Partition the disk.
       ${createPartitions}
 
       # Create the NixOS configuration.
-      $machine->succeed("nixos-generate-config --root /mnt");
+      machine.succeed("nixos-generate-config --root /mnt")
 
-      $machine->succeed("cat /mnt/etc/nixos/hardware-configuration.nix >&2");
+      machine.succeed("cat /mnt/etc/nixos/hardware-configuration.nix >&2")
 
-      $machine->copyFileFromHost(
+      machine.copy_file_from_host(
           "${ makeConfig { inherit bootLoader grubVersion grubDevice grubIdentifier grubUseEfi extraConfig; } }",
-          "/mnt/etc/nixos/configuration.nix");
+          "/mnt/etc/nixos/configuration.nix",
+      )
 
       # Perform the installation.
-      $machine->succeed("nixos-install < /dev/null >&2");
+      machine.succeed("nixos-install < /dev/null >&2")
 
       # Do it again to make sure it's idempotent.
-      $machine->succeed("nixos-install < /dev/null >&2");
+      machine.succeed("nixos-install < /dev/null >&2")
 
-      $machine->succeed("umount /mnt/boot || true");
-      $machine->succeed("umount /mnt");
-      $machine->succeed("sync");
+      machine.succeed("umount /mnt/boot || true")
+      machine.succeed("umount /mnt")
+      machine.succeed("sync")
 
-      $machine->shutdown;
+      machine.shutdown()
 
       # Now see if we can boot the installation.
-      $machine = createMachine({ ${hdFlags} qemuFlags => "${qemuFlags}", name => "boot-after-install" });
+      machine = create_machine_from_file(
+          "${ makeMachineConfig "boot-after-install" }"
+      )
 
       # For example to enter LUKS passphrase.
       ${preBootCommands}
 
       # Did /boot get mounted?
-      $machine->waitForUnit("local-fs.target");
+      machine.wait_for_unit("local-fs.target")
 
       ${if bootLoader == "grub" then
-          ''$machine->succeed("test -e /boot/grub");''
+          ''machine.succeed("test -e /boot/grub")''
         else
-          ''$machine->succeed("test -e /boot/loader/loader.conf");''
+          ''machine.succeed("test -e /boot/loader/loader.conf")''
       }
 
       # Check whether /root has correct permissions.
-      $machine->succeed("stat -c '%a' /root") =~ /700/ or die;
+      machine.succeed("stat -c '%a' /root | grep 700")
 
       # Did the swap device get activated?
       # uncomment once https://bugs.freedesktop.org/show_bug.cgi?id=86930 is resolved
-      $machine->waitForUnit("swap.target");
-      $machine->succeed("cat /proc/swaps | grep -q /dev");
+      machine.wait_for_unit("swap.target")
+      machine.succeed("cat /proc/swaps | grep -q /dev")
 
       # Check that the store is in good shape
-      $machine->succeed("nix-store --verify --check-contents >&2");
+      machine.succeed("nix-store --verify --check-contents >&2")
 
       # Check whether the channel works.
-      $machine->succeed("nix-env -iA nixos.procps >&2");
-      $machine->succeed("type -tP ps | tee /dev/stderr") =~ /.nix-profile/
-          or die "nix-env failed";
+      machine.succeed("nix-env -iA nixos.procps >&2")
+      machine.succeed("type -tP ps | tee /dev/stderr | grep .nix-profile")
 
       # Check that the daemon works, and that non-root users can run builds (this will build a new profile generation through the daemon)
-      $machine->succeed("su alice -l -c 'nix-env -iA nixos.procps' >&2");
+      machine.succeed("su alice -l -c 'nix-env -iA nixos.procps' >&2")
 
       # We need a writable Nix store on next boot.
-      $machine->copyFileFromHost(
+      machine.copy_file_from_host(
           "${ makeConfig { inherit bootLoader grubVersion grubDevice grubIdentifier grubUseEfi extraConfig; forceGrubReinstallCount = 1; } }",
-          "/etc/nixos/configuration.nix");
+          "/etc/nixos/configuration.nix",
+      )
 
       # Check whether nixos-rebuild works.
-      $machine->succeed("nixos-rebuild switch >&2");
+      machine.succeed("nixos-rebuild switch >&2")
 
       # Test nixos-option.
-      $machine->succeed("nixos-option boot.initrd.kernelModules | grep virtio_console");
-      $machine->succeed("nixos-option boot.initrd.kernelModules | grep 'List of modules'");
-      $machine->succeed("nixos-option boot.initrd.kernelModules | grep qemu-guest.nix");
+      machine.succeed("nixos-option boot.initrd.kernelModules | grep virtio_console")
+      machine.succeed("nixos-option boot.initrd.kernelModules | grep 'List of modules'")
+      machine.succeed("nixos-option boot.initrd.kernelModules | grep qemu-guest.nix")
 
-      $machine->shutdown;
+      machine.shutdown()
 
       # Check whether a writable store build works
-      $machine = createMachine({ ${hdFlags} qemuFlags => "${qemuFlags}", name => "rebuild-switch" });
+      machine = create_machine_from_file(
+          "${ makeMachineConfig "rebuild-switch" }"
+      )
       ${preBootCommands}
-      $machine->waitForUnit("multi-user.target");
-      $machine->copyFileFromHost(
+      machine.wait_for_unit("multi-user.target")
+      machine.copy_file_from_host(
           "${ makeConfig { inherit bootLoader grubVersion grubDevice grubIdentifier grubUseEfi extraConfig; forceGrubReinstallCount = 2; } }",
-          "/etc/nixos/configuration.nix");
-      $machine->succeed("nixos-rebuild boot >&2");
-      $machine->shutdown;
+          "/etc/nixos/configuration.nix",
+      )
+      machine.succeed("nixos-rebuild boot >&2")
+      machine.shutdown()
 
       # And just to be sure, check that the machine still boots after
       # "nixos-rebuild switch".
-      $machine = createMachine({ ${hdFlags} qemuFlags => "${qemuFlags}", "boot-after-rebuild-switch" });
+      machine = create_machine_from_file(
+          "${ makeMachineConfig "boot-after-rebuild-switch" }"
+      )
       ${preBootCommands}
-      $machine->waitForUnit("network.target");
-      $machine->shutdown;
-
+      machine.wait_for_unit("network.target")
+      machine.shutdown()
       # Tests for validating clone configuration entries in grub menu
-      ${optionalString testCloneConfig ''
-        # Reboot Machine
-        $machine = createMachine({ ${hdFlags} qemuFlags => "${qemuFlags}", name => "clone-default-config" });
-        ${preBootCommands}
-        $machine->waitForUnit("multi-user.target");
+    '' + optionalString testCloneConfig ''
+      # Reboot Machine
+      machine = create_machine_from_file(
+          "${ makeMachineConfig "clone-default-config" }"
+      )
+      ${preBootCommands}
+      machine.wait_for_unit("multi-user.target")
 
-        # Booted configuration name should be Home
-        # This is not the name that shows in the grub menu.
-        # The default configuration is always shown as "Default"
-        $machine->succeed("cat /run/booted-system/configuration-name >&2");
-        $machine->succeed("cat /run/booted-system/configuration-name | grep Home");
+      # Booted configuration name should be Home
+      # This is not the name that shows in the grub menu.
+      # The default configuration is always shown as "Default"
+      machine.succeed("cat /run/booted-system/configuration-name >&2")
+      machine.succeed("cat /run/booted-system/configuration-name | grep Home")
 
-        # We should find **not** a file named /etc/gitconfig
-        $machine->fail("test -e /etc/gitconfig");
+      # We should find **not** a file named /etc/gitconfig
+      machine.fail("test -e /etc/gitconfig")
 
-        # Set grub to boot the second configuration
-        $machine->succeed("grub-reboot 1");
+      # Set grub to boot the second configuration
+      machine.succeed("grub-reboot 1")
 
-        $machine->shutdown;
+      machine.shutdown()
 
-        # Reboot Machine
-        $machine = createMachine({ ${hdFlags} qemuFlags => "${qemuFlags}", name => "clone-alternate-config" });
-        ${preBootCommands}
+      # Reboot Machine
+      machine = create_machine_from_file(
+          "${ makeMachineConfig "clone-alternate-config" }"
+      )
+      ${preBootCommands}
 
-        $machine->waitForUnit("multi-user.target");
-        # Booted configuration name should be Work
-        $machine->succeed("cat /run/booted-system/configuration-name >&2");
-        $machine->succeed("cat /run/booted-system/configuration-name | grep Work");
+      machine.wait_for_unit("multi-user.target")
+      # Booted configuration name should be Work
+      machine.succeed("cat /run/booted-system/configuration-name >&2")
+      machine.succeed("cat /run/booted-system/configuration-name | grep Work")
 
-        # We should find a file named /etc/gitconfig
-        $machine->succeed("test -e /etc/gitconfig");
+      # We should find a file named /etc/gitconfig
+      machine.succeed("test -e /etc/gitconfig")
 
-        $machine->shutdown;
-      ''}
-
+      machine.shutdown()
     '';
 
 
@@ -312,32 +331,32 @@ let
 
     makeLuksRootTest = name: luksFormatOpts: makeInstallerTest name
       { createPartitions = ''
-          $machine->succeed(
-            "flock /dev/vda parted --script /dev/vda -- mklabel msdos"
-            . " mkpart primary ext2 1M 50MB" # /boot
-            . " mkpart primary linux-swap 50M 1024M"
-            . " mkpart primary 1024M -1s", # LUKS
-            "udevadm settle",
-            "mkswap /dev/vda2 -L swap",
-            "swapon -L swap",
-            "modprobe dm_mod dm_crypt",
-            "echo -n supersecret | cryptsetup luksFormat ${luksFormatOpts} -q /dev/vda3 -",
-            "echo -n supersecret | cryptsetup luksOpen --key-file - /dev/vda3 cryptroot",
-            "mkfs.ext3 -L nixos /dev/mapper/cryptroot",
-            "mount LABEL=nixos /mnt",
-            "mkfs.ext3 -L boot /dev/vda1",
-            "mkdir -p /mnt/boot",
-            "mount LABEL=boot /mnt/boot",
-          );
+          machine.succeed(
+              "flock /dev/vda parted --script /dev/vda -- mklabel msdos"
+              " mkpart primary ext2 1M 50MB"  # /boot
+              " mkpart primary linux-swap 50M 1024M"
+              " mkpart primary 1024M -1s",  # LUKS
+              "udevadm settle",
+              "mkswap /dev/vda2 -L swap",
+              "swapon -L swap",
+              "modprobe dm_mod dm_crypt",
+              "echo -n supersecret | cryptsetup luksFormat ${luksFormatOpts} -q /dev/vda3 -",
+              "echo -n supersecret | cryptsetup luksOpen --key-file - /dev/vda3 cryptroot",
+              "mkfs.ext3 -L nixos /dev/mapper/cryptroot",
+              "mount LABEL=nixos /mnt",
+              "mkfs.ext3 -L boot /dev/vda1",
+              "mkdir -p /mnt/boot",
+              "mount LABEL=boot /mnt/boot",
+          )
         '';
         extraConfig = ''
           boot.kernelParams = lib.mkAfter [ "console=tty0" ];
         '';
         enableOCR = true;
         preBootCommands = ''
-          $machine->start;
-          $machine->waitForText(qr/Passphrase for/);
-          $machine->sendChars("supersecret\n");
+          machine.start()
+          machine.wait_for_text("Passphrase for")
+          machine.send_chars("supersecret\n")
         '';
       };
 
@@ -345,28 +364,28 @@ let
   # one big filesystem partition.
   simple-test-config = { createPartitions =
        ''
-         $machine->succeed(
+         machine.succeed(
              "flock /dev/vda parted --script /dev/vda -- mklabel msdos"
-             . " mkpart primary linux-swap 1M 1024M"
-             . " mkpart primary ext2 1024M -1s",
+             " mkpart primary linux-swap 1M 1024M"
+             " mkpart primary ext2 1024M -1s",
              "udevadm settle",
              "mkswap /dev/vda1 -L swap",
              "swapon -L swap",
              "mkfs.ext3 -L nixos /dev/vda2",
              "mount LABEL=nixos /mnt",
-         );
+         )
        '';
    };
 
   simple-uefi-grub-config =
     { createPartitions =
         ''
-          $machine->succeed(
+          machine.succeed(
               "flock /dev/vda parted --script /dev/vda -- mklabel gpt"
-              . " mkpart ESP fat32 1M 50MiB" # /boot
-              . " set 1 boot on"
-              . " mkpart primary linux-swap 50MiB 1024MiB"
-              . " mkpart primary ext2 1024MiB -1MiB", # /
+              " mkpart ESP fat32 1M 50MiB"  # /boot
+              " set 1 boot on"
+              " mkpart primary linux-swap 50MiB 1024MiB"
+              " mkpart primary ext2 1024MiB -1MiB",  # /
               "udevadm settle",
               "mkswap /dev/vda2 -L swap",
               "swapon -L swap",
@@ -375,7 +394,7 @@ let
               "mkfs.vfat -n BOOT /dev/vda1",
               "mkdir -p /mnt/boot",
               "mount LABEL=BOOT /mnt/boot",
-          );
+          )
         '';
         bootLoader = "grub";
         grubUseEfi = true;
@@ -418,12 +437,12 @@ in {
   simpleUefiSystemdBoot = makeInstallerTest "simpleUefiSystemdBoot"
     { createPartitions =
         ''
-          $machine->succeed(
+          machine.succeed(
               "flock /dev/vda parted --script /dev/vda -- mklabel gpt"
-              . " mkpart ESP fat32 1M 50MiB" # /boot
-              . " set 1 boot on"
-              . " mkpart primary linux-swap 50MiB 1024MiB"
-              . " mkpart primary ext2 1024MiB -1MiB", # /
+              " mkpart ESP fat32 1M 50MiB"  # /boot
+              " set 1 boot on"
+              " mkpart primary linux-swap 50MiB 1024MiB"
+              " mkpart primary ext2 1024MiB -1MiB",  # /
               "udevadm settle",
               "mkswap /dev/vda2 -L swap",
               "swapon -L swap",
@@ -432,7 +451,7 @@ in {
               "mkfs.vfat -n BOOT /dev/vda1",
               "mkdir -p /mnt/boot",
               "mount LABEL=BOOT /mnt/boot",
-          );
+          )
         '';
         bootLoader = "systemd-boot";
     };
@@ -446,11 +465,11 @@ in {
   separateBoot = makeInstallerTest "separateBoot"
     { createPartitions =
         ''
-          $machine->succeed(
+          machine.succeed(
               "flock /dev/vda parted --script /dev/vda -- mklabel msdos"
-              . " mkpart primary ext2 1M 50MB" # /boot
-              . " mkpart primary linux-swap 50MB 1024M"
-              . " mkpart primary ext2 1024M -1s", # /
+              " mkpart primary ext2 1M 50MB"  # /boot
+              " mkpart primary linux-swap 50MB 1024M"
+              " mkpart primary ext2 1024M -1s",  # /
               "udevadm settle",
               "mkswap /dev/vda2 -L swap",
               "swapon -L swap",
@@ -459,7 +478,7 @@ in {
               "mkfs.ext3 -L boot /dev/vda1",
               "mkdir -p /mnt/boot",
               "mount LABEL=boot /mnt/boot",
-          );
+          )
         '';
     };
 
@@ -467,11 +486,11 @@ in {
   separateBootFat = makeInstallerTest "separateBootFat"
     { createPartitions =
         ''
-          $machine->succeed(
+          machine.succeed(
               "flock /dev/vda parted --script /dev/vda -- mklabel msdos"
-              . " mkpart primary ext2 1M 50MB" # /boot
-              . " mkpart primary linux-swap 50MB 1024M"
-              . " mkpart primary ext2 1024M -1s", # /
+              " mkpart primary ext2 1M 50MB"  # /boot
+              " mkpart primary linux-swap 50MB 1024M"
+              " mkpart primary ext2 1024M -1s",  # /
               "udevadm settle",
               "mkswap /dev/vda2 -L swap",
               "swapon -L swap",
@@ -480,7 +499,7 @@ in {
               "mkfs.vfat -n BOOT /dev/vda1",
               "mkdir -p /mnt/boot",
               "mount LABEL=BOOT /mnt/boot",
-          );
+          )
         '';
     };
 
@@ -503,21 +522,18 @@ in {
 
       createPartitions =
         ''
-          $machine->succeed(
+          machine.succeed(
               "flock /dev/vda parted --script /dev/vda -- mklabel msdos"
-              . " mkpart primary linux-swap 1M 1024M"
-              . " mkpart primary 1024M -1s",
+              " mkpart primary linux-swap 1M 1024M"
+              " mkpart primary 1024M -1s",
               "udevadm settle",
-
               "mkswap /dev/vda1 -L swap",
               "swapon -L swap",
-
               "zpool create rpool /dev/vda2",
               "zfs create -o mountpoint=legacy rpool/root",
               "mount -t zfs rpool/root /mnt",
-
-              "udevadm settle"
-          );
+              "udevadm settle",
+          )
         '';
     };
 
@@ -526,12 +542,12 @@ in {
   lvm = makeInstallerTest "lvm"
     { createPartitions =
         ''
-          $machine->succeed(
+          machine.succeed(
               "flock /dev/vda parted --script /dev/vda -- mklabel msdos"
-              . " mkpart primary 1M 2048M" # PV1
-              . " set 1 lvm on"
-              . " mkpart primary 2048M -1s" # PV2
-              . " set 2 lvm on",
+              " mkpart primary 1M 2048M"  # PV1
+              " set 1 lvm on"
+              " mkpart primary 2048M -1s"  # PV2
+              " set 2 lvm on",
               "udevadm settle",
               "pvcreate /dev/vda1 /dev/vda2",
               "vgcreate MyVolGroup /dev/vda1 /dev/vda2",
@@ -541,7 +557,7 @@ in {
               "swapon -L swap",
               "mkfs.xfs -L nixos /dev/MyVolGroup/nixos",
               "mount LABEL=nixos /mnt",
-          );
+          )
         '';
     };
 
@@ -559,28 +575,28 @@ in {
   # keyfile is configured
   encryptedFSWithKeyfile = makeInstallerTest "encryptedFSWithKeyfile"
     { createPartitions = ''
-       $machine->succeed(
-          "flock /dev/vda parted --script /dev/vda -- mklabel msdos"
-          . " mkpart primary ext2 1M 50MB" # /boot
-          . " mkpart primary linux-swap 50M 1024M"
-          . " mkpart primary 1024M 1280M" # LUKS with keyfile
-          . " mkpart primary 1280M -1s",
-          "udevadm settle",
-          "mkswap /dev/vda2 -L swap",
-          "swapon -L swap",
-          "mkfs.ext3 -L nixos /dev/vda4",
-          "mount LABEL=nixos /mnt",
-          "mkfs.ext3 -L boot /dev/vda1",
-          "mkdir -p /mnt/boot",
-          "mount LABEL=boot /mnt/boot",
-          "modprobe dm_mod dm_crypt",
-          "echo -n supersecret > /mnt/keyfile",
-          "cryptsetup luksFormat -q /dev/vda3 --key-file /mnt/keyfile",
-          "cryptsetup luksOpen --key-file /mnt/keyfile /dev/vda3 crypt",
-          "mkfs.ext3 -L test /dev/mapper/crypt",
-          "cryptsetup luksClose crypt",
-          "mkdir -p /mnt/test"
-        );
+        machine.succeed(
+            "flock /dev/vda parted --script /dev/vda -- mklabel msdos"
+            " mkpart primary ext2 1M 50MB"  # /boot
+            " mkpart primary linux-swap 50M 1024M"
+            " mkpart primary 1024M 1280M"  # LUKS with keyfile
+            " mkpart primary 1280M -1s",
+            "udevadm settle",
+            "mkswap /dev/vda2 -L swap",
+            "swapon -L swap",
+            "mkfs.ext3 -L nixos /dev/vda4",
+            "mount LABEL=nixos /mnt",
+            "mkfs.ext3 -L boot /dev/vda1",
+            "mkdir -p /mnt/boot",
+            "mount LABEL=boot /mnt/boot",
+            "modprobe dm_mod dm_crypt",
+            "echo -n supersecret > /mnt/keyfile",
+            "cryptsetup luksFormat -q /dev/vda3 --key-file /mnt/keyfile",
+            "cryptsetup luksOpen --key-file /mnt/keyfile /dev/vda3 crypt",
+            "mkfs.ext3 -L test /dev/mapper/crypt",
+            "cryptsetup luksClose crypt",
+            "mkdir -p /mnt/test",
+        )
       '';
       extraConfig = ''
         fileSystems."/test" =
@@ -598,15 +614,15 @@ in {
   swraid = makeInstallerTest "swraid"
     { createPartitions =
         ''
-          $machine->succeed(
+          machine.succeed(
               "flock /dev/vda parted --script /dev/vda --"
-              . " mklabel msdos"
-              . " mkpart primary ext2 1M 100MB" # /boot
-              . " mkpart extended 100M -1s"
-              . " mkpart logical 102M 2102M" # md0 (root), first device
-              . " mkpart logical 2103M 4103M" # md0 (root), second device
-              . " mkpart logical 4104M 4360M" # md1 (swap), first device
-              . " mkpart logical 4361M 4617M", # md1 (swap), second device
+              " mklabel msdos"
+              " mkpart primary ext2 1M 100MB"  # /boot
+              " mkpart extended 100M -1s"
+              " mkpart logical 102M 2102M"  # md0 (root), first device
+              " mkpart logical 2103M 4103M"  # md0 (root), second device
+              " mkpart logical 4104M 4360M"  # md1 (swap), first device
+              " mkpart logical 4361M 4617M",  # md1 (swap), second device
               "udevadm settle",
               "ls -l /dev/vda* >&2",
               "cat /proc/partitions >&2",
@@ -623,11 +639,11 @@ in {
               "mkdir /mnt/boot",
               "mount LABEL=boot /mnt/boot",
               "udevadm settle",
-          );
+          )
         '';
       preBootCommands = ''
-        $machine->start;
-        $machine->fail("dmesg | grep 'immediate safe mode'");
+        machine.start()
+        machine.fail("dmesg | grep 'immediate safe mode'")
       '';
     };
 
@@ -635,17 +651,17 @@ in {
   grub1 = makeInstallerTest "grub1"
     { createPartitions =
         ''
-          $machine->succeed(
+          machine.succeed(
               "flock /dev/sda parted --script /dev/sda -- mklabel msdos"
-              . " mkpart primary linux-swap 1M 1024M"
-              . " mkpart primary ext2 1024M -1s",
+              " mkpart primary linux-swap 1M 1024M"
+              " mkpart primary ext2 1024M -1s",
               "udevadm settle",
               "mkswap /dev/sda1 -L swap",
               "swapon -L swap",
               "mkfs.ext3 -L nixos /dev/sda2",
               "mount LABEL=nixos /mnt",
               "mkdir -p /mnt/tmp",
-          );
+          )
         '';
       grubVersion = 1;
       grubDevice = "/dev/sda";
@@ -654,14 +670,14 @@ in {
   # Test using labels to identify volumes in grub
   simpleLabels = makeInstallerTest "simpleLabels" {
     createPartitions = ''
-      $machine->succeed(
-        "sgdisk -Z /dev/vda",
-        "sgdisk -n 1:0:+1M -n 2:0:+1G -N 3 -t 1:ef02 -t 2:8200 -t 3:8300 -c 3:root /dev/vda",
-        "mkswap /dev/vda2 -L swap",
-        "swapon -L swap",
-        "mkfs.ext4 -L root /dev/vda3",
-        "mount LABEL=root /mnt",
-      );
+      machine.succeed(
+          "sgdisk -Z /dev/vda",
+          "sgdisk -n 1:0:+1M -n 2:0:+1G -N 3 -t 1:ef02 -t 2:8200 -t 3:8300 -c 3:root /dev/vda",
+          "mkswap /dev/vda2 -L swap",
+          "swapon -L swap",
+          "mkfs.ext4 -L root /dev/vda3",
+          "mount LABEL=root /mnt",
+      )
     '';
     grubIdentifier = "label";
   };
@@ -670,22 +686,22 @@ in {
   # TODO: Fix udev so the symlinks are unneeded in /dev/disks
   simpleProvided = makeInstallerTest "simpleProvided" {
     createPartitions = ''
-      my $UUID = "\$(blkid -s UUID -o value /dev/vda2)";
-      $machine->succeed(
-        "sgdisk -Z /dev/vda",
-        "sgdisk -n 1:0:+1M -n 2:0:+100M -n 3:0:+1G -N 4 -t 1:ef02 -t 2:8300 -t 3:8200 -t 4:8300 -c 2:boot -c 4:root /dev/vda",
-        "mkswap /dev/vda3 -L swap",
-        "swapon -L swap",
-        "mkfs.ext4 -L boot /dev/vda2",
-        "mkfs.ext4 -L root /dev/vda4",
-      );
-      $machine->execute("ln -s ../../vda2 /dev/disk/by-uuid/$UUID");
-      $machine->execute("ln -s ../../vda4 /dev/disk/by-label/root");
-      $machine->succeed(
-        "mount /dev/disk/by-label/root /mnt",
-        "mkdir /mnt/boot",
-        "mount /dev/disk/by-uuid/$UUID /mnt/boot"
-      );
+      uuid = "$(blkid -s UUID -o value /dev/vda2)"
+      machine.succeed(
+          "sgdisk -Z /dev/vda",
+          "sgdisk -n 1:0:+1M -n 2:0:+100M -n 3:0:+1G -N 4 -t 1:ef02 -t 2:8300 -t 3:8200 -t 4:8300 -c 2:boot -c 4:root /dev/vda",
+          "mkswap /dev/vda3 -L swap",
+          "swapon -L swap",
+          "mkfs.ext4 -L boot /dev/vda2",
+          "mkfs.ext4 -L root /dev/vda4",
+      )
+      machine.execute("ln -s ../../vda2 /dev/disk/by-uuid/{}".format(uuid))
+      machine.execute("ln -s ../../vda4 /dev/disk/by-label/root")
+      machine.succeed(
+          "mount /dev/disk/by-label/root /mnt",
+          "mkdir /mnt/boot",
+          "mount /dev/disk/by-uuid/{} /mnt/boot".format(uuid),
+      )
     '';
     grubIdentifier = "provided";
   };
@@ -693,60 +709,60 @@ in {
   # Simple btrfs grub testing
   btrfsSimple = makeInstallerTest "btrfsSimple" {
     createPartitions = ''
-      $machine->succeed(
-        "sgdisk -Z /dev/vda",
-        "sgdisk -n 1:0:+1M -n 2:0:+1G -N 3 -t 1:ef02 -t 2:8200 -t 3:8300 -c 3:root /dev/vda",
-        "mkswap /dev/vda2 -L swap",
-        "swapon -L swap",
-        "mkfs.btrfs -L root /dev/vda3",
-        "mount LABEL=root /mnt",
-      );
+      machine.succeed(
+          "sgdisk -Z /dev/vda",
+          "sgdisk -n 1:0:+1M -n 2:0:+1G -N 3 -t 1:ef02 -t 2:8200 -t 3:8300 -c 3:root /dev/vda",
+          "mkswap /dev/vda2 -L swap",
+          "swapon -L swap",
+          "mkfs.btrfs -L root /dev/vda3",
+          "mount LABEL=root /mnt",
+      )
     '';
   };
 
   # Test to see if we can detect /boot and /nix on subvolumes
   btrfsSubvols = makeInstallerTest "btrfsSubvols" {
     createPartitions = ''
-      $machine->succeed(
-        "sgdisk -Z /dev/vda",
-        "sgdisk -n 1:0:+1M -n 2:0:+1G -N 3 -t 1:ef02 -t 2:8200 -t 3:8300 -c 3:root /dev/vda",
-        "mkswap /dev/vda2 -L swap",
-        "swapon -L swap",
-        "mkfs.btrfs -L root /dev/vda3",
-        "btrfs device scan",
-        "mount LABEL=root /mnt",
-        "btrfs subvol create /mnt/boot",
-        "btrfs subvol create /mnt/nixos",
-        "btrfs subvol create /mnt/nixos/default",
-        "umount /mnt",
-        "mount -o defaults,subvol=nixos/default LABEL=root /mnt",
-        "mkdir /mnt/boot",
-        "mount -o defaults,subvol=boot LABEL=root /mnt/boot",
-      );
+      machine.succeed(
+          "sgdisk -Z /dev/vda",
+          "sgdisk -n 1:0:+1M -n 2:0:+1G -N 3 -t 1:ef02 -t 2:8200 -t 3:8300 -c 3:root /dev/vda",
+          "mkswap /dev/vda2 -L swap",
+          "swapon -L swap",
+          "mkfs.btrfs -L root /dev/vda3",
+          "btrfs device scan",
+          "mount LABEL=root /mnt",
+          "btrfs subvol create /mnt/boot",
+          "btrfs subvol create /mnt/nixos",
+          "btrfs subvol create /mnt/nixos/default",
+          "umount /mnt",
+          "mount -o defaults,subvol=nixos/default LABEL=root /mnt",
+          "mkdir /mnt/boot",
+          "mount -o defaults,subvol=boot LABEL=root /mnt/boot",
+      )
     '';
   };
 
   # Test to see if we can detect default and aux subvolumes correctly
   btrfsSubvolDefault = makeInstallerTest "btrfsSubvolDefault" {
     createPartitions = ''
-      $machine->succeed(
-        "sgdisk -Z /dev/vda",
-        "sgdisk -n 1:0:+1M -n 2:0:+1G -N 3 -t 1:ef02 -t 2:8200 -t 3:8300 -c 3:root /dev/vda",
-        "mkswap /dev/vda2 -L swap",
-        "swapon -L swap",
-        "mkfs.btrfs -L root /dev/vda3",
-        "btrfs device scan",
-        "mount LABEL=root /mnt",
-        "btrfs subvol create /mnt/badpath",
-        "btrfs subvol create /mnt/badpath/boot",
-        "btrfs subvol create /mnt/nixos",
-        "btrfs subvol set-default \$(btrfs subvol list /mnt | grep 'nixos' | awk '{print \$2}') /mnt",
-        "umount /mnt",
-        "mount -o defaults LABEL=root /mnt",
-        "mkdir -p /mnt/badpath/boot", # Help ensure the detection mechanism is actually looking up subvolumes
-        "mkdir /mnt/boot",
-        "mount -o defaults,subvol=badpath/boot LABEL=root /mnt/boot",
-      );
+      machine.succeed(
+          "sgdisk -Z /dev/vda",
+          "sgdisk -n 1:0:+1M -n 2:0:+1G -N 3 -t 1:ef02 -t 2:8200 -t 3:8300 -c 3:root /dev/vda",
+          "mkswap /dev/vda2 -L swap",
+          "swapon -L swap",
+          "mkfs.btrfs -L root /dev/vda3",
+          "btrfs device scan",
+          "mount LABEL=root /mnt",
+          "btrfs subvol create /mnt/badpath",
+          "btrfs subvol create /mnt/badpath/boot",
+          "btrfs subvol create /mnt/nixos",
+          "btrfs subvol set-default \$(btrfs subvol list /mnt | grep 'nixos' | awk '{print \$2}') /mnt",
+          "umount /mnt",
+          "mount -o defaults LABEL=root /mnt",
+          "mkdir -p /mnt/badpath/boot",  # Help ensure the detection mechanism is actually looking up subvolumes
+          "mkdir /mnt/boot",
+          "mount -o defaults,subvol=badpath/boot LABEL=root /mnt/boot",
+      )
     '';
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
As discussed [here](https://github.com/NixOS/nixpkgs/pull/58121#issuecomment-552273518) in #58121 some work was required to allow booting to EFI when starting the VM which is used to run `nixos-install`.
This is in effect required for cases where we want to install an EFI-bootmanager into non-fallback-locations(as opposed to `/EFI/BOOT/...`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @samueldr 
