### PR TITLE
qt5{9,11,12}: better pulseaudio 13 fix, unbreak qt59

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -72,9 +72,12 @@ let
       # https://gitlab.freedesktop.org/pulseaudio/pulseaudio/issues/707
       # https://bugreports.qt.io/browse/QTBUG-77037
       (fetchpatch {
-        name = "fix-build-with-pulseaudio-13.0.patch";
-        url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/qtbug-77037-workaround.patch?h=packages/qt5-webengine&id=fc77d6b3d5ec74e421b58f199efceb2593cbf951";
-        sha256 = "1gv733qfdn9746nbqqxzyjx4ijjqkkb7zb71nxax49nna5bri3am";
+         # qtwebengine 5.11 is actually based on 65, but this does the job.
+        name = "fix-build-with-pulseaudio-13.0-for-61.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtwebengine-chromium.git;a=patch;h=3b5c9c313c5ecc93289d764200e1f222310c6f73";
+        sha256 = "0ackv7hxf733dmr7sd9ljhz43wqi1s0raz5f5ng6y9xdzk804zjd";
+        extraPrefix = "src/3rdparty/";
+        stripLen = 1;
       })
     ];
     qtwebkit = [ ./qtwebkit.patch ];

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -75,9 +75,11 @@ let
       # https://gitlab.freedesktop.org/pulseaudio/pulseaudio/issues/707
       # https://bugreports.qt.io/browse/QTBUG-77037
       (fetchpatch {
-        name = "fix-build-with-pulseaudio-13.0.patch";
-        url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/qtbug-77037-workaround.patch?h=packages/qt5-webengine&id=fc77d6b3d5ec74e421b58f199efceb2593cbf951";
-        sha256 = "1gv733qfdn9746nbqqxzyjx4ijjqkkb7zb71nxax49nna5bri3am";
+        name = "fix-build-with-pulseaudio-13.0-for-73-based.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtwebengine-chromium.git;a=patch;h=b84e8682b312fb16b16ffb9591415067ceae69f8";
+        sha256 = "0lmvf0v7y55k9q0qgzm5mhggp752ayyb7kxhdxjfxx9yqd3din90";
+        extraPrefix = "src/3rdparty/";
+        stripLen = 1;
       })
       # patch for CVE-2019-13720, can be removed when it is included in the next upstream release
       # https://bugreports.qt.io/browse/QTBUG-1019226

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -58,9 +58,11 @@ let
       # https://gitlab.freedesktop.org/pulseaudio/pulseaudio/issues/707
       # https://bugreports.qt.io/browse/QTBUG-77037
       (fetchpatch {
-        name = "fix-build-with-pulseaudio-13.0.patch";
-        url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/qtbug-77037-workaround.patch?h=packages/qt5-webengine&id=fc77d6b3d5ec74e421b58f199efceb2593cbf951";
-        sha256 = "1gv733qfdn9746nbqqxzyjx4ijjqkkb7zb71nxax49nna5bri3am";
+        name = "fix-build-with-pulseaudio-13.0-for-56-based.patch";
+        url = "https://codereview.qt-project.org/gitweb?p=qt/qtwebengine-chromium.git;a=patch;h=f6daf509b2ac3317b56dd257cd3cd88887ec62bd";
+        sha256 = "0ackv7hxf733dmr7sd9ljhz43wqi1s0raz5f5ng6y9xdzk804zjd";
+        extraPrefix = "src/3rdparty/";
+        stripLen = 1;
       })
     ] ++ optional stdenv.cc.isClang ./qtwebengine-clang-fix.patch
       ++ optional stdenv.isDarwin ./qtwebengine-darwin-no-platform-check.patch;


### PR DESCRIPTION
###### Motivation for this change

Besides unbreaking qt59.qtwebengine,
"better" since this uses official upstream fix for the issue.

May have implications about pulseaudio linked vs loaded,
in the direction of allowing stub usage (I think).
This restores behavior changed in the pulseaudio13 fix
that this commit replaces.

Fixes #72384.

---

On staging it appears we've dropped qt59 and qt511,
and actually qt511.qtwebengine.src 404's for me
(but I was able to test using cached copy).

Not sure what that means for these fixes or how/where
they should be sent..

Hence sending to master where the fix is needed.

Have not build-tested all of these, mostly ensured the patches applied
since the fix patch is different (but not functionally) depending
on what version the vendored chromium is 'based on'.
Luckily it looks like 511 can use a patch for a different 'base'
which is good since its base didn't receive this fix.

Anyway, hopefully this has all the pieces needed to address
the build breakage issue, however we choose to proceed.

Also, very sorry for not seeing this fixed sooner!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).