### PR TITLE
minetime: 1.5.1 -> 1.7.3, patch scheduling service util

### DIFF
--- a/pkgs/applications/office/minetime/default.nix
+++ b/pkgs/applications/office/minetime/default.nix
@@ -3,10 +3,10 @@
 let
   name = "${pname}-${version}";
   pname = "minetime";
-  version = "1.7.1";
+  version = "1.7.2";
   appimage = fetchurl {
     url = "https://github.com/marcoancona/MineTime/releases/download/v${version}/${name}.AppImage";
-    sha256 = "0jbb8am3rwnjhaxf52rhsgq0cppw3x64h4130brhawri6g4gz44l";
+    sha256 = "15gjh4cywg2c4bzxslidk80z4bcsdwjr1mbvf2a5madx3vygfaw1";
   };
   extracted = appimageTools.extractType2 {
     inherit name;

--- a/pkgs/applications/office/minetime/default.nix
+++ b/pkgs/applications/office/minetime/default.nix
@@ -3,10 +3,10 @@
 let
   name = "${pname}-${version}";
   pname = "minetime";
-  version = "1.7.2";
+  version = "1.7.3";
   appimage = fetchurl {
     url = "https://github.com/marcoancona/MineTime/releases/download/v${version}/${name}.AppImage";
-    sha256 = "15gjh4cywg2c4bzxslidk80z4bcsdwjr1mbvf2a5madx3vygfaw1";
+    sha256 = "0zz6p3mwxg9gm1sqzs582pq2nkb10lv0c3r542b9llqyzk9qv5aa";
   };
   extracted = appimageTools.extractType2 {
     inherit name;

--- a/pkgs/applications/office/minetime/default.nix
+++ b/pkgs/applications/office/minetime/default.nix
@@ -1,15 +1,32 @@
-{ appimageTools, fetchurl, lib, gsettings-desktop-schemas, gtk3 }:
+{ appimageTools, fetchurl, lib, runCommandNoCC, stdenv, gsettings-desktop-schemas, gtk3, zlib }:
 
 let
-  pname = "minetime";
-  version = "1.5.1";
-in
-appimageTools.wrapType2 rec {
   name = "${pname}-${version}";
-  src = fetchurl {
-    url = "https://github.com/marcoancona/MineTime/releases/download/v${version}/${name}-x86_64.AppImage";
-    sha256 = "0099cq4p7j01bzs7q79y9xi7g6ji17v9g7cykfjggwsgqfmvd0hz";
+  pname = "minetime";
+  version = "1.7.1";
+  appimage = fetchurl {
+    url = "https://github.com/marcoancona/MineTime/releases/download/v${version}/${name}.AppImage";
+    sha256 = "0jbb8am3rwnjhaxf52rhsgq0cppw3x64h4130brhawri6g4gz44l";
   };
+  extracted = appimageTools.extractType2 {
+    inherit name;
+    src = appimage;
+  };
+  patched = runCommandNoCC "minetime-patchelf" {} ''
+    cp -av ${extracted} $out
+
+    x=$out/resources/app.asar.unpacked/services/scheduling/dist/MinetimeSchedulingService
+    chmod +w $x
+
+    patchelf \
+      --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+      --replace-needed libz.so.1 ${zlib}/lib/libz.so.1 \
+      $x
+  '';
+in
+appimageTools.wrapAppImage rec {
+  inherit name;
+  src = patched;
 
   profile = ''
     export LC_ALL=C.UTF-8
@@ -17,7 +34,9 @@ appimageTools.wrapType2 rec {
   '';
 
   multiPkgs = null; # no 32bit needed
-  extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
+  extraPkgs = ps:
+    appimageTools.defaultFhsEnvArgs.multiPkgs ps
+    ++ (with ps; [ at-spi2-core at-spi2-atk libsecret libnotify ]);
   extraInstallCommands = "mv $out/bin/{${name},${pname}}";
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).