### PR TITLE
brotab: init at 0.0.5

### DIFF
--- a/pkgs/tools/misc/brotab/default.nix
+++ b/pkgs/tools/misc/brotab/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchFromGitHub, glibcLocales, python }:
+
+python.pkgs.buildPythonApplication rec {
+  version = "1.1.0";
+  pname = "brotab";
+
+  src = fetchFromGitHub {
+    owner = "balta2ar";
+    repo = pname;
+    rev = version;
+    sha256 = "17yj5i8p28a7zmixdfa1i4gfc7c2fmdkxlymazasar58dz8m68mw";
+  };
+
+  propagatedBuildInputs = with python.pkgs; [
+    requests
+    flask
+    requests
+    pytest
+    psutil
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/balta2ar/brotab";
+    description = "Control your browser's tabs from the command line";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}
+

--- a/pkgs/tools/misc/brotab/default.nix
+++ b/pkgs/tools/misc/brotab/default.nix
@@ -19,6 +19,11 @@ python.pkgs.buildPythonApplication rec {
     psutil
   ];
 
+  # test_integration.py requires Chrome browser session
+  checkPhase = ''
+    ${python.interpreter} -m unittest brotab/tests/test_{brotab,utils}.py
+  '';
+  
   meta = with lib; {
     homepage = "https://github.com/balta2ar/brotab";
     description = "Control your browser's tabs from the command line";
@@ -26,4 +31,3 @@ python.pkgs.buildPythonApplication rec {
     maintainers = with maintainers; [ doronbehar ];
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18324,6 +18324,10 @@ in
 
   browsh = callPackage ../applications/networking/browsers/browsh { };
 
+  brotab = callPackage ../tools/misc/brotab {
+    python = python3;
+  };
+
   bookworm = callPackage ../applications/office/bookworm { };
 
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Browser tab controller - https://github.com/balta2ar/brotab

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
