### PR TITLE
inkcut: init at 2.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5453,6 +5453,11 @@
       fingerprint = "7573 56D7 79BB B888 773E  415E 736C CDF9 EF51 BD97";
     }];
   };
+  raboof = {
+    email = "arnout@bzzt.net";
+    github = "raboof";
+    name = "Arnout Engelen";
+  };
   rafaelgg = {
     email = "rafael.garcia.gallego@gmail.com";
     github = "rafaelgg";

--- a/pkgs/applications/misc/inkcut/default.nix
+++ b/pkgs/applications/misc/inkcut/default.nix
@@ -1,0 +1,44 @@
+{ lib, python3Packages, fetchFromGitHub, wrapQtAppsHook }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "inkcut";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0g2vix80rvk3xh90vh7r5mw4nyja2z9fy8x0g72mgjbk6l6afs5x";
+  };
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
+  propagatedBuildInputs = [
+    enamlx
+    twisted
+    lxml
+    qt-reactor
+    jsonpickle
+    pyserial
+    pycups
+    qtconsole
+    pyqt5
+  ];
+
+  # QtApplication.instance() does not work during tests?
+  doCheck = false;
+
+  postFixup = ''
+    wrapQtApp $out/bin/inkcut
+  '';
+
+
+  meta = with lib; {
+    homepage = https://www.codelv.com/projects/inkcut/;
+    description = "Control 2D plotters, cutters, engravers, and CNC machines";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/development/python-modules/enaml/default.nix
+++ b/pkgs/development/python-modules/enaml/default.nix
@@ -1,0 +1,32 @@
+{ 
+  lib, buildPythonPackage, fetchFromGitHub,
+  atom, ply, kiwisolver, qtpy, sip
+}:
+
+buildPythonPackage rec {
+  pname = "enaml";
+  version = "0.10.4";
+
+  src = fetchFromGitHub {
+    owner = "nucleic";
+    repo = pname;
+    rev = version;
+    sha256 = "0xvzllkfgcqrq6c01lc1kjxc14457kim5iqv429qhk7ycvffnq0b";
+  };
+
+  # Of course it would be better to run the tests,
+  # but it runs into a syntax error in byteplay2.py
+  # (even though testing on python3...)
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    atom ply kiwisolver qtpy sip
+  ];
+
+  meta = with lib; {
+    homepage = https://github.com/frmdstryr/enaml;
+    description = "Declarative User Interfaces for Python";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/development/python-modules/enamlx/default.nix
+++ b/pkgs/development/python-modules/enamlx/default.nix
@@ -1,0 +1,34 @@
+{
+  lib, buildPythonPackage, fetchFromGitHub,
+  enaml, pyqtgraph, pythonocc-core
+}:
+
+buildPythonPackage rec {
+  pname = "enamlx";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "frmdstryr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0yh7bw9ibk758bym5w2wk7sifghf1hkxa8sd719q8nsz279cpfc0";
+  };
+
+  propagatedBuildInputs = [
+    enaml
+    # Until https://github.com/inkcut/inkcut/issues/105 perhaps
+    pyqtgraph
+    pythonocc-core
+  ];
+
+  # qt_occ_viewer test requires enaml.qt.QtOpenGL which got dropped somewhere
+  # between enaml 0.9.0 and 0.10.0
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/frmdstryr/enamlx;
+    description = "Additional Qt Widgets for Enaml";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/development/python-modules/qt-reactor/default.nix
+++ b/pkgs/development/python-modules/qt-reactor/default.nix
@@ -1,0 +1,31 @@
+{
+  lib, buildPythonPackage, fetchFromGitHub,
+  twisted, qtpy, pyqt5
+}:
+
+buildPythonPackage rec {
+  pname = "qt-reactor";
+  version = "364b3f561fb0d4d3938404d869baa4db7a982bf0";
+
+  src = fetchFromGitHub {
+    owner = "frmdstryr";
+    repo = pname;
+    rev = version;
+    sha256 = "1nb5iwg0nfz86shw28a2kj5pyhd4jvvxhf73fhnfbl8scgnvjv9h";
+  };
+
+  propagatedBuildInputs = [
+    twisted qtpy
+  ];
+
+  checkInputs = [
+    pyqt5
+  ];
+
+  meta = with lib; {
+    homepage = https://github.com/frmdstryr/qt-reactor;
+    description = "Twisted and PyQt5 eventloop integration";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raboof ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19400,6 +19400,8 @@ in
 
   inherit (nodePackages) imapnotify;
 
+  inkcut = libsForQt5.callPackage ../applications/misc/inkcut { };
+
   img2pdf = callPackage ../applications/misc/img2pdf { };
 
   imgcat = callPackage ../applications/graphics/imgcat { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1962,6 +1962,10 @@ in {
 
   envs = callPackage ../development/python-modules/envs { };
 
+  enaml = callPackage ../development/python-modules/enaml { };
+
+  enamlx = callPackage ../development/python-modules/enamlx { };
+
   eth-hash = callPackage ../development/python-modules/eth-hash { };
 
   eth-typing = callPackage ../development/python-modules/eth-typing { };
@@ -4847,6 +4851,8 @@ in {
   qtconsole = callPackage ../development/python-modules/qtconsole { };
 
   qtpy = callPackage ../development/python-modules/qtpy { };
+
+  qt-reactor = callPackage ../development/python-modules/qt-reactor { };
 
   quantities = callPackage ../development/python-modules/quantities { };
 


### PR DESCRIPTION
###### Motivation for this change

Wanting to use inkcut

Draft PR for early feedback if anyone is interested, not tested in depth yet

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
