### PR TITLE
[19.09] nixos/libinput: apply options to all device types

### DIFF
--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -209,12 +209,12 @@ in {
 
     services.xserver.config =
       ''
-        # Automatically enable the libinput driver for all touchpads.
+        # General libinput configuration.
+        # See CONFIGURATION DETAILS section of man:libinput(4).
         Section "InputClass"
           Identifier "libinputConfiguration"
-          MatchIsTouchpad "on"
+          MatchDriver "libinput"
           ${optionalString (cfg.dev != null) ''MatchDevicePath "${cfg.dev}"''}
-          Driver "libinput"
           Option "AccelProfile" "${cfg.accelProfile}"
           ${optionalString (cfg.accelSpeed != null) ''Option "AccelSpeed" "${cfg.accelSpeed}"''}
           ${optionalString (cfg.buttonMapping != null) ''Option "ButtonMapping" "${cfg.buttonMapping}"''}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Without this change any special config used for libinput like `accelSpeed` won't apply to mice because it isn't a touchpad. 

This could possibly change the user experience for someone, like if they came to rely on the bug.
An example situation would be:
* have `services.xserver.libinput.accelSpeed` in config
* not notice it doesn't apply to your device that isn't a touchpad (mouse)
* update on 19.09 and suddenly the acceleration of your mouse is different.

It's generally not good to make a change like that, but it would be nice to be able to actually configure your mouse with libinput...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
@NixOS/backports (and myself apparently)