### PR TITLE
gobi_loader: init at 0.7

### DIFF
--- a/pkgs/os-specific/linux/gobi_loader/default.nix
+++ b/pkgs/os-specific/linux/gobi_loader/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     description = "Firmware loader for Qualcomm Gobi USB chipsets";
     homepage = "https://www.codon.org.uk/~mjg59/gobi_loader/";
     license = with licenses; [ gpl2 ];
-    maintainers = with maintainers; [ "0x4A6F" ];
+    maintainers = [ maintainers."0x4A6F" ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/gobi_loader/default.nix
+++ b/pkgs/os-specific/linux/gobi_loader/default.nix
@@ -1,0 +1,23 @@
+{ stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gobi_loader";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "https://www.codon.org.uk/~mjg59/gobi_loader/download/${pname}-${version}.tar.gz";
+    sha256 = "0jkmpqkiddpxrzl2s9s3kh64ha48m00nn53f82m1rphw8maw5gbq";
+  };
+
+  makeFlags = "prefix=${placeholder "out"}";
+
+  meta = with stdenv.lib; {
+    description = "Firmware loader for Qualcomm Gobi USB chipsets";
+    homepage = "https://www.codon.org.uk/~mjg59/gobi_loader/";
+    license = with licenses; [ gpl2 ];
+    maintainers = with maintainers; [ "0x4A6F" ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/gobi_loader/default.nix
+++ b/pkgs/os-specific/linux/gobi_loader/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "0jkmpqkiddpxrzl2s9s3kh64ha48m00nn53f82m1rphw8maw5gbq";
   };
 
+  postPatch = ''
+    substituteInPlace 60-gobi.rules --replace "gobi_loader" "${placeholder "out"}/lib/udev/gobi_loader"
+    substituteInPlace 60-gobi.rules --replace "/lib/firmware" "/run/current-system/firmware"
+  '';
+
   makeFlags = "prefix=${placeholder "out"}";
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15802,6 +15802,8 @@ in
 
   fwts = callPackage ../os-specific/linux/fwts { };
 
+  gobi_loader = callPackage ../os-specific/linux/gobi_loader { };
+
   libossp_uuid = callPackage ../development/libraries/libossp-uuid { };
 
   libuuid = if stdenv.isLinux


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Loading firmware for Qualcomm Gobi USB chipsets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
