### PR TITLE
[r19.03] libextractor: add patch for CVE-2019-15531

### DIFF
--- a/pkgs/development/libraries/libextractor/default.nix
+++ b/pkgs/development/libraries/libextractor/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, libtool, gettext, zlib, bzip2, flac, libvorbis
+{ fetchurl, fetchpatch, stdenv, libtool, gettext, zlib, bzip2, flac, libvorbis
 , exiv2, libgsf, rpm, pkgconfig
 , gtkSupport ? true, glib ? null, gtk3 ? null
 , videoSupport ? true, ffmpeg ? null, libmpeg2 ? null}:
@@ -13,6 +13,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/libextractor/${name}.tar.gz";
     sha256 = "1z1cb35griqzvshqdv5ck98dy0sgpsswn7fgiy7lbzi34sma8dg2";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-15531.patch";
+      url = "https://git.gnunet.org/libextractor.git/patch/?id=d2b032452241708bee68d02aa02092cfbfba951a";
+      sha256 = "01xhcjbzv6p53wz7y2ii76kb8m9iwvnm4ip9w4a0bpgaxqz4b9fw";
+      excludes = [ "ChangeLog" ];
+    })
+  ];
 
   preConfigure =
     '' echo "patching installation directory in \`extractor.c'..."


### PR DESCRIPTION
###### Motivation for this change
Backport of #73573

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
