### PR TITLE
pijul: fix build

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -1,6 +1,17 @@
 { stdenv, fetchurl, rustPlatform, darwin, openssl, libsodium, nettle, clang, libclang, pkgconfig }:
 
-rustPlatform.buildRustPackage rec {
+let
+  # nettle-sys=1.0.1 requires the des-compat.h header, but it was removed in
+  # nettle 3.5.  See https://nest.pijul.com/pijul_org/pijul/discussions/416
+  # Remove with the next release
+  nettle_34 = nettle.overrideAttrs (_oldAttrs: rec {
+    version = "3.4.1";
+    src = fetchurl {
+      url = "mirror://gnu/nettle/nettle-${version}.tar.gz";
+      sha256 = "1bcji95n1iz9p9vsgdgr26v6s7zhpsxfbjjwpqcihpfd6lawyhgr";
+    };
+  });
+in rustPlatform.buildRustPackage rec {
   pname = "pijul";
   version = "0.12.0";
 
@@ -20,7 +31,7 @@ rustPlatform.buildRustPackage rec {
 
   LIBCLANG_PATH = libclang + "/lib";
 
-  buildInputs = [ openssl libsodium nettle libclang ] ++ stdenv.lib.optionals stdenv.isDarwin
+  buildInputs = [ openssl libsodium nettle_34 libclang ] ++ stdenv.lib.optionals stdenv.isDarwin
     (with darwin.apple_sdk.frameworks; [ CoreServices Security ]);
 
   doCheck = false;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
nettle-sys=1.0.1 requires the des-compat.h header, but it was [removed in nettle 3.5](https://github.com/gnutls/nettle/blob/nettle_3.5.1_release_20190627/NEWS#L75-L79).  
Upstream issue https://nest.pijul.com/pijul_org/pijul/discussions/416
FIxes https://github.com/NixOS/nixpkgs/issues/73757
cc: @loewenheim
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FlorentBecker
