### PR TITLE
ldns: 1.7.0 -> 1.7.1

### DIFF
--- a/pkgs/development/libraries/ldns/default.nix
+++ b/pkgs/development/libraries/ldns/default.nix
@@ -1,28 +1,13 @@
-{ stdenv, fetchurl, fetchpatch, openssl, perl, which, dns-root-data }:
+{ stdenv, fetchurl, openssl, perl, which, dns-root-data }:
 
 stdenv.mkDerivation rec {
   pname = "ldns";
-  version = "1.7.0";
+  version = "1.7.1";
 
   src = fetchurl {
     url = "https://www.nlnetlabs.nl/downloads/ldns/${pname}-${version}.tar.gz";
-    sha256 = "1k56jw4hz8njspfxcfw0czf1smg0n48ylia89ziwyx5k9wdmp7y1";
+    sha256 = "0ac242n7996fswq1a3nlh1bbbhrsdwsq4mx7xq8ffq6aplb4rj4a";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2017-1000231.patch";
-      url = "https://git.nlnetlabs.nl/ldns/patch/?id=c8391790";
-      sha256 = "1rprfh0y1c28dqiy3vgwvwdhn7b5rsylfzzblx5xdhwfqgdw8vn0";
-      excludes = [ "Changelog" ];
-    })
-    (fetchpatch {
-      name = "CVE-2017-1000232.patch";
-      url = "https://git.nlnetlabs.nl/ldns/patch/?id=3bdeed02";
-      sha256 = "0bv0s5jjp0sswfg8da47d346iwp9yjhj9w7fa3bxh174br0zj07r";
-      excludes = [ "Changelog" ];
-    })
-  ];
 
   postPatch = ''
     patchShebangs doc/doxyparse.pl
@@ -38,6 +23,7 @@ stdenv.mkDerivation rec {
     "--with-trust-anchor=${dns-root-data}/root.key"
     "--with-drill"
     "--disable-gost"
+    "--with-examples"
   ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
@@ -47,16 +33,11 @@ stdenv.mkDerivation rec {
   doCheck = false; # fails. missing some files
 
   postInstall = ''
+    # Only 'drill' stays in $out
+    # the rest are examples:
+    moveToOutput "bin/ldns*" "$examples"
+    # with exception of ldns-config, which goes to $dev:
     moveToOutput "bin/ldns-config" "$dev"
-
-    pushd examples
-    configureFlagsArray+=( "--bindir=$examples/bin" )
-    configurePhase
-    make
-    make install
-    popd
-
-    sed -i "$out/lib/libldns.la" -e "s,-L${openssl.dev},-L${openssl.out},g"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/ldns/default.nix
+++ b/pkgs/development/libraries/ldns/default.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     homepage = http://www.nlnetlabs.nl/projects/ldns/;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ dtzWill ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://www.nlnetlabs.nl/news/2019/Jul/26/ldns-1.7.1-released/

* examples no longer can be configured separately,
  so build everything we want in a single go
  and sort into the appropriate outputs after.
* libtool file doesn't seem to reference openssl at all
  so nothing to patch up there as we did previously.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).