### PR TITLE
nixos/timesyncd: add extraConfig option

### DIFF
--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -20,6 +20,18 @@ with lib;
           The set of NTP servers from which to synchronise.
         '';
       };
+      extraConfig = mkOption {
+        default = "";
+        type = types.lines;
+        example = ''
+          PollIntervalMaxSec=180
+        '';
+        description = ''
+          Extra config options for systemd-timesyncd. See
+          <link xlink:href="https://www.freedesktop.org/software/systemd/man/timesyncd.conf.html">
+          timesyncd.conf(5)</link> for available options.
+        '';
+      };
     };
   };
 
@@ -35,6 +47,7 @@ with lib;
     environment.etc."systemd/timesyncd.conf".text = ''
       [Time]
       NTP=${concatStringsSep " " config.services.timesyncd.servers}
+      ${config.services.timesyncd.extraConfig}
     '';
 
     users.users.systemd-timesync.uid = config.ids.uids.systemd-timesync;


### PR DESCRIPTION
This adds an `extraConfig` option to timesyncd for setting additional
options in `/etc/systemd/timesyncd.conf`.

This is similar to things like `services.journald.extraConfig` and
`services.logind.extraConfig`.

To test this, in my local `configuration.nix` I added the following:

```nix
{
  services.timesyncd.extraConfig = ''
    PollIntervalMaxSec=180
  '';
}
```

After running `nixos-rebuild switch`, here is the content of the `/etc/systemd/timesyncd.conf` file:

```
[Time]
NTP=0.nixos.pool.ntp.org 1.nixos.pool.ntp.org 2.nixos.pool.ntp.org 3.nixos.pool.ntp.org
PollIntervalMaxSec=180
```

Here's the output of the two relevant `timedatectl` commands:

```console
$ timedatectl timesync-status
       Server: 198.13.37.28 (0.nixos.pool.ntp.org)
Poll interval: 4min 16s (min: 32s; max 3min)
         Leap: normal
      Version: 4
...
$ timedatectl show-timesync 
SystemNTPServers=0.nixos.pool.ntp.org 1.nixos.pool.ntp.org 2.nixos.pool.ntp.org 3.nixos.pool.ntp.org
FallbackNTPServers=0.nixos.pool.ntp.org 1.nixos.pool.ntp.org 2.nixos.pool.ntp.org 3.nixos.pool.ntp.org
ServerName=0.nixos.pool.ntp.org
ServerAddress=198.13.37.28
RootDistanceMaxUSec=5s
PollIntervalMinUSec=32s
PollIntervalMaxUSec=3min
PollIntervalUSec=4min 16s
...
```

You can see that the max poll interval has been updated.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

Pinging some of the people I recognize in the git history for the timesyncd module: @flokli @andir 