### PR TITLE
buildRustCrate: add lib output

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -193,6 +193,12 @@
       The aforementioned option was added this release.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      The <literal>buildRustCrate</literal> infrastructure now produces <literal>lib</literal> outputs in addition to the <literal>out</literal> output.
+      This has led to drastically reduced closed sizes for some rust crates since development dependencies are now in the <literal>lib</literal> output.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -91,18 +91,18 @@
 
     echo "$EXTRA_LINK_SEARCH" | while read i; do
        if [[ ! -z "$i" ]]; then
-         for lib in $i; do
-           echo "-L $lib" >> target/link
-           L=$(echo $lib | sed -e "s#$(pwd)/target/build#$out/lib#")
+         for library in $i; do
+           echo "-L $library" >> target/link
+           L=$(echo $library | sed -e "s#$(pwd)/target/build#$lib/lib#")
            echo "-L $L" >> target/link.final
          done
        fi
     done
     echo "$EXTRA_LINK" | while read i; do
        if [[ ! -z "$i" ]]; then
-         for lib in $i; do
-           echo "-l $lib" >> target/link
-           echo "-l $lib" >> target/link.final
+         for library in $i; do
+           echo "-l $library" >> target/link
+           echo "-l $library" >> target/link.final
          done
        fi
     done

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -22,9 +22,9 @@ let
           else
             extern;
         in (if lib.lists.any (x: x == "lib") dep.crateType then
-           " --extern ${name}=${dep.out}/lib/lib${extern}-${dep.metadata}.rlib"
+           " --extern ${name}=${dep.lib}/lib/lib${extern}-${dep.metadata}.rlib"
          else
-           " --extern ${name}=${dep.out}/lib/lib${extern}-${dep.metadata}${stdenv.hostPlatform.extensions.sharedLibrary}")
+           " --extern ${name}=${dep.lib}/lib/lib${extern}-${dep.metadata}${stdenv.hostPlatform.extensions.sharedLibrary}")
       ) dependencies);
 
     echo_build_heading = colors: ''
@@ -96,12 +96,12 @@ stdenv.mkDerivation (rec {
     buildInputs = (crate.buildInputs or []) ++ buildInputs_;
     dependencies =
       builtins.map
-        (dep: dep.override { rust = rust; release = release; verbose = verbose; crateOverrides = crateOverrides; })
+        (dep: lib.getLib (dep.override { rust = rust; release = release; verbose = verbose; crateOverrides = crateOverrides; }))
         dependencies_;
 
     buildDependencies =
       builtins.map
-        (dep: dep.override { rust = rust; release = release; verbose = verbose; crateOverrides = crateOverrides; })
+        (dep: lib.getLib (dep.override { rust = rust; release = release; verbose = verbose; crateOverrides = crateOverrides; }))
         buildDependencies_;
 
     completeDeps = lib.lists.unique (dependencies ++ lib.lists.concatMap (dep: dep.completeDeps) dependencies);
@@ -159,6 +159,9 @@ stdenv.mkDerivation (rec {
               extraRustcOpts;
     };
     installPhase = installCrate crateName metadata;
+
+    outputs = [ "out" "lib" ];
+    outputDev = [ "lib" ];
 
 } // extraDerivationAttrs
 )) {

--- a/pkgs/build-support/rust/build-rust-crate/install-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/install-crate.nix
@@ -1,24 +1,26 @@
 crateName: metadata:
 ''
   runHook preInstall
-  mkdir -p $out
+  # always create $out even if we do not have binaries. We are detecting binary targets during compilation, if those are missing there is no way to only have $lib
+  mkdir $out
   if [[ -s target/env ]]; then
-    cp target/env $out/env
+    mkdir -p $lib
+    cp target/env $lib/env
   fi
   if [[ -s target/link.final ]]; then
-    mkdir -p $out/lib
-    cp target/link.final $out/lib/link
+    mkdir -p $lib/lib
+    cp target/link.final $lib/lib/link
   fi
   if [[ "$(ls -A target/lib)" ]]; then
-    mkdir -p $out/lib
-    cp target/lib/* $out/lib #*/
-    for lib in $out/lib/*.so $out/lib/*.dylib; do #*/
-      ln -s $lib $(echo $lib | sed -e "s/-${metadata}//")
+    mkdir -p $lib/lib
+    cp target/lib/* $lib/lib #*/
+    for library in $lib/lib/*.so $lib/lib/*.dylib; do #*/
+      ln -s $library $(echo $library | sed -e "s/-${metadata}//")
     done
   fi
   if [[ "$(ls -A target/build)" ]]; then # */
-    mkdir -p $out/lib
-    cp -r target/build/* $out/lib # */
+    mkdir -p $lib/lib
+    cp -r target/build/* $lib/lib # */
   fi
   if [[ -d target/bin ]]; then
     if [[ "$(ls -A target/bin)" ]]; then


### PR DESCRIPTION
###### Motivation for this change

This cuts down the dependency tree on some rust builds where a crate not
just exposes a binary but also a library. `$out/lib` contained a bunch
of extra support files that among other information carry linker flags
(including the full path to link-time dependencies). Worst case this led
to some binary outputs depending on the full build closure of rust
crates.

Moving all the `$out/lib` files to `$lib/lib` solves this nicely.

`lib` might be a bit weird here as they are most of the time just rlib
files (rust libraries). Those are essential only required during
compilation but they can also be shared objects (like with traditional
C-style packages). Which is why I went with `lib` for the new output.

One of the caveats we are running into here is that we do not (always)
know ahead of time of a crate produces just a library or just a binary.
Cargo allows for some ambiguity regarding whether or not a crate
provides one, two, … binaries and libraries as it's outputs. Ideally we
would be able to rely on the `crateType` entirely but so far that isn't
the case. More work on that area might show how difficult that actually
is.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mic92
