### PR TITLE
nixos/manual: reword installation section

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -392,11 +392,11 @@
      <filename>hardware-configuration.nix</filename> is included from
      <filename>configuration.nix</filename> and will be overwritten by future
      invocations of <command>nixos-generate-config</command>; thus, you
-     generally should not modify it.) Additionally, you may want to look at 
+     generally should not modify it.) Additionally, you may want to look at
      <link xlink:href="https://github.com/NixOS/nixos-hardware">Hardware
      configuration for known-hardware</link> at this point or after
      installation.
-      
+
     </para>
     <note>
      <para>
@@ -418,11 +418,11 @@
      Do the installation:
 <screen>
 <prompt># </prompt>nixos-install</screen>
-     Cross fingers. If this fails due to a temporary problem (such as a network
-     issue while downloading binaries from the NixOS binary cache), you can
-     just re-run <command>nixos-install</command>. Otherwise, fix your
-     <filename>configuration.nix</filename> and then re-run
-     <command>nixos-install</command>.
+     This will install your system based on the configuration you provided.
+     If anything fails due to a configuration problem or any other issue
+     (such as a network outage while downloading binaries from the NixOS
+     binary cache), you can re-run <command>nixos-install</command> after
+     fixing your <filename>configuration.nix</filename>.
     </para>
     <para>
      As the last step, <command>nixos-install</command> will ask you to set the


### PR DESCRIPTION
###### Motivation for this change

Sounded a bit unprofessional and pessimistic. Was actually called out on twitter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
