### PR TITLE
zenmonitor: init at 1.3

### DIFF
--- a/pkgs/os-specific/linux/zenmonitor/default.nix
+++ b/pkgs/os-specific/linux/zenmonitor/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, pkgconfig, gtk3, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "zenmonitor";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "ocerman";
+    repo = "zenmonitor";
+    rev = "v${version}";
+    sha256 = "16p2njrgik8zfkidm64v4qy53qlsqqxxgr9m3n84pr9l3pk25dwk";
+  };
+
+  buildInputs = [ gtk3 ];
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = with stdenv.lib; {
+    description = "Monitoring software for AMD Zen-based CPUs";
+    homepage = https://github.com/ocerman/zenmonitor;
+    license = licenses.mit;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ alexbakker ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17122,6 +17122,8 @@ in
 
   zd1211fw = callPackage ../os-specific/linux/firmware/zd1211 { };
 
+  zenmonitor = callPackage ../os-specific/linux/zenmonitor { };
+
   inherit (callPackage ../os-specific/linux/zfs {
     configFile = "user";
   }) zfsStable zfsUnstable;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Monitoring software for AMD Zen-based CPUs. See also: #73814.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).