### PR TITLE
nixos/ksm: Enhancements and new ksmtuned package.

### DIFF
--- a/nixos/modules/hardware/ksm.nix
+++ b/nixos/modules/hardware/ksm.nix
@@ -20,6 +20,17 @@ in {
         Setting it to <literal>null</literal> uses the kernel's default time.
       '';
     };
+    zero_pages = mkOption {
+      default = null;
+      type = types.nullOr (types.ints.between 0 1);
+      description = ''
+        ksm will merge kernel zero pages with ksm zero pages if this is set to <literal>1</literal>.
+	Only ksm zero pages are merged by default. Kernel zero pages are merged if this is enabled.
+	The default is <literal>0</literal>. This option is defined <literal>null</literal>.
+	Care should be taken enabling this setting as it can degrade performance in many scenarios.
+	Performance can be increased on architectures with colored zero pages.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -31,6 +42,8 @@ in {
       script = ''
         echo 1 > /sys/kernel/mm/ksm/run
         ${optionalString (cfg.sleep != null) ''echo ${toString cfg.sleep} > /sys/kernel/mm/ksm/sleep_millisecs''}
+        ${optionalString (cfg.zero_pages != null)
+	''echo ${toString cfg.zero_pages} > /sys/kernel/mm/ksm/use_zero_pages''}
       '';
     };
   };

--- a/nixos/modules/hardware/ksm.nix
+++ b/nixos/modules/hardware/ksm.nix
@@ -11,7 +11,7 @@ in {
   ];
 
   options.hardware.ksm = {
-    enable = mkEnableOption "Kernel Same-Page Merging";
+    enable = mkEnableOption "Kernel Samepage Merging";
     sleep = mkOption {
       type = types.nullOr types.int;
       default = null;
@@ -23,15 +23,14 @@ in {
   };
 
   config = mkIf cfg.enable {
-    systemd.services.enable-ksm = {
-      description = "Enable Kernel Same-Page Merging";
+    systemd.services.ksm = {
+      description = "Kernel Samepage Merging";
       wantedBy = [ "multi-user.target" ];
-      after = [ "systemd-udev-settle.service" ];
+      unitConfig.ConditionPathExists = "/sys/kernel/mm/ksm";
+      unitConfig.ConditionVirtualization = "no";
       script = ''
-        if [ -e /sys/kernel/mm/ksm ]; then
-          echo 1 > /sys/kernel/mm/ksm/run
-          ${optionalString (cfg.sleep != null) ''echo ${toString cfg.sleep} > /sys/kernel/mm/ksm/sleep_millisecs''}
-        fi
+        echo 1 > /sys/kernel/mm/ksm/run
+        ${optionalString (cfg.sleep != null) ''echo ${toString cfg.sleep} > /sys/kernel/mm/ksm/sleep_millisecs''}
       '';
     };
   };

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -346,6 +346,7 @@
   ./services/hardware/illum.nix
   ./services/hardware/interception-tools.nix
   ./services/hardware/irqbalance.nix
+  ./services/hardware/ksmtuned.nix
   ./services/hardware/lcd.nix
   ./services/hardware/lirc.nix
   ./services/hardware/nvidia-optimus.nix

--- a/nixos/modules/services/hardware/ksmtuned.nix
+++ b/nixos/modules/services/hardware/ksmtuned.nix
@@ -1,0 +1,34 @@
+#
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.ksmtuned;
+
+in
+{
+  options.services.ksmtuned.enable = mkEnableOption "ksmtuned daemon";
+
+  config = mkIf cfg.enable {
+
+    systemd.services = {
+      ksmtuned = {
+        description = "Kernel Samepage Merging (KSM) Tuning Daemon";
+        path = [ pkgs.ksmtuned ];
+	unitConfig.ConditionVirtualization = "no";
+	after = [ "ksm.service" ];
+	requires = [ "ksm.service" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.ksmtuned}/bin/ksmtuned";
+        };
+        wantedBy = [ "multi-user.target" ];
+      };
+    };
+
+    environment.systemPackages = [ pkgs.ksmtuned ];
+
+  };
+
+}

--- a/pkgs/applications/virtualization/ksmtuned/default.nix
+++ b/pkgs/applications/virtualization/ksmtuned/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, patch, meson, ninja, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "ksmtuned";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ksmtuned";
+    repo = "ksmtuned";
+    rev = "v${version}";
+    sha256 = "188j4i14ldqs8bvbzl9mqhxdz5wxxic73i7rdffpsvr2sy0hncwv";
+  };
+
+  patches = [ ./ksmtuned.patch ];
+
+  nativeBuildInputs = [ meson ninja ];
+
+  meta = with stdenv.lib; {
+    description = "ksmtuned daemon for KSM merge tuning.";
+    homepage = "https://github.com/ksmtuned/ksmtuned";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ kmcopper ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/virtualization/ksmtuned/ksmtuned.patch
+++ b/pkgs/applications/virtualization/ksmtuned/ksmtuned.patch
@@ -1,0 +1,105 @@
+diff --git a/meson.build b/meson.build
+index 7e86649..b8bead1 100644
+--- a/meson.build
++++ b/meson.build
+@@ -5,49 +5,12 @@ project(
+ )
+ 
+ conf_data = configuration_data()
+-conf_data.set('LIBEXECDIR',
+-              join_paths(get_option('prefix'), get_option('libexecdir')))
+-conf_data.set('SBINDIR',
+-              join_paths(get_option('prefix'), get_option('sbindir')))
+-conf_data.set('SYSCONFDIR',
+-              join_paths(get_option('prefix'), get_option('sysconfdir')))
+-
+-executable(
+-    'ksmctl',
+-    sources: 'src/ksmctl.c',
+-    install_dir: conf_data.get('LIBEXECDIR'),
+-    install: true,
+-)
+-
+-if get_option('redhat-sysconfig')
+-  install_data(
+-      'data/sysconfig/ksm',
+-      install_dir: join_paths(conf_data.get('SYSCONFDIR'), 'sysconfig'),
+-  )
+-endif
+-
+-install_data(
+-    'data/ksmtuned.conf',
+-    install_dir: conf_data.get('SYSCONFDIR'),
+-)
++conf_data.set('BINDIR',
++              join_paths(get_option('prefix'), get_option('bindir')))
+ 
+ configure_file(
+-    input: 'src/ksmtuned.sh.in',
++    input: 'src/ksmtuned.sh',
+     output: 'ksmtuned',
+     configuration: conf_data,
+-    install_dir: conf_data.get('SBINDIR'),
+-)
+-
+-configure_file(
+-    input: 'data/ksmtuned.service.in',
+-    output: 'ksmtuned.service',
+-    configuration: conf_data,
+-    install_dir: '/usr/lib/systemd/system/',
+-)
+-
+-configure_file(
+-    input: 'data/ksm.service.in',
+-    output: 'ksm.service',
+-    configuration: conf_data,
+-    install_dir: '/usr/lib/systemd/system/',
++    install_dir: conf_data.get('BINDIR'),
+ )
+diff --git a/src/ksmtuned.sh.in b/src/ksmtuned.sh
+similarity index 91%
+rename from src/ksmtuned.sh.in
+rename to src/ksmtuned.sh
+index 08a4ca7..30854c8 100755
+--- a/src/ksmtuned.sh.in
++++ b/src/ksmtuned.sh
+@@ -18,10 +18,6 @@
+ #
+ # needs testing and ironing. contact danken@redhat.com if something breaks.
+ 
+-if [ -f @SYSCONFDIR@/ksmtuned.conf ]; then
+-    . @SYSCONFDIR@/ksmtuned.conf
+-fi
+-
+ debug() {
+     if [ -n "$DEBUG" ]; then
+         s="`/bin/date`: $*"
+@@ -123,18 +119,15 @@ function nothing () {
+     :
+ }
+ 
+-loop () {
+-    trap nothing SIGUSR1
+-    while true
+-    do
+-        sleep $KSM_MONITOR_INTERVAL &
+-        wait $!
+-        adjust
+-    done
++function cleanup () {
++     KSMCTL stop
++     exit
+ }
+ 
+-PIDFILE=${PIDFILE-/var/run/ksmtune.pid}
+-if touch "$PIDFILE"; then
+-  loop &
+-  echo $! > "$PIDFILE"
+-fi
++trap cleanup SIGHUP
++trap nothing SIGUSR1
++while true; do
++      sleep $KSM_MONITOR_INTERVAL &
++      wait $!
++      adjust
++done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17090,6 +17090,8 @@ in
 
   kmod-debian-aliases = callPackage ../os-specific/linux/kmod-debian-aliases { };
 
+  ksmtuned = callPackages ../applications/virtualization/ksmtuned { };
+
   libcap = callPackage ../os-specific/linux/libcap { };
 
   libcap_ng = callPackage ../os-specific/linux/libcap-ng {


### PR DESCRIPTION
###### Motivation for this change
#73095 partially gave me the idea to work on this patch set to help unload udev-settle. I worked some additional enhancements to the ksm configuration while I was at it.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
There aren't really any of these for ksm but I would appreciate anybodies input on this
