### PR TITLE
git: disable failing test on darwin

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -298,6 +298,10 @@ stdenv.mkDerivation {
 
     # As of 2.19.0, t5562 refers to #!/usr/bin/perl
     patchShebangs t/t5562/invoke-with-content-length.pl
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    # XXX: Some tests added in 2.24.0 fail.
+    # Please try to re-enable on the next release.
+    disable_test t7816-grep-binary-pattern
   '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
     # Test fails (as of 2.17.0, musl 1.1.19)
     disable_test t3900-i18n-commit


### PR DESCRIPTION
The tests for null patterns where changed in 25754125cef278c7e9492fbd6dc4a28319b01f18,
it's possible utf-8 normalisation is causing different behaviour here.

    not ok 54 - LC_ALL='C' git grep -P -f f -i 'Æ<NUL>[Ð]' a
    not ok 57 - LC_ALL='C' git grep -P -f f -i '[Æ]<NUL>Ð' a
    not ok 60 - LC_ALL='C' git grep -P -f f -i '[Æ]<NUL>ð' a
    not ok 63 - LC_ALL='C' git grep -P -f f -i 'Æ<NUL>Ð' a
    Dubious, test returned 1 (wstat 256, 0x100)
    Failed 4/145 subtests
            (less 48 skipped subtests: 93 okay)

Fixes #73806

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
