### PR TITLE
Mosquitto test python

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -749,7 +749,7 @@ def run_tests() -> None:
     if tests is not None:
         with log.nested("running the VM test script"):
             try:
-                exec(tests)
+                exec(tests, globals())
             except Exception as e:
                 eprint("error: {}".format(str(e)))
                 sys.exit(1)

--- a/nixos/tests/mosquitto.nix
+++ b/nixos/tests/mosquitto.nix
@@ -5,17 +5,6 @@ let
   username = "mqtt";
   password = "VERY_secret";
   topic = "test/foo";
-
-  cmd = bin: pkgs.lib.concatStringsSep " " [
-    "${pkgs.mosquitto}/bin/mosquitto_${bin}"
-    "-V mqttv311"
-    "-h server"
-    "-p ${toString port}"
-    "-u ${username}"
-    "-P '${password}'"
-    "-t ${topic}"
-  ];
-
 in {
   name = "mosquitto";
   meta = with pkgs.stdenv.lib; {
@@ -49,9 +38,27 @@ in {
 
   testScript = let
     file = "/tmp/msg";
-    sub = args:
-      "(${cmd "sub"} -C 1 ${args} | tee ${file} &)";
   in ''
+    def mosquitto_cmd(binary):
+        return (
+            "${pkgs.mosquitto}/bin/mosquitto_{} "
+            "-V mqttv311 "
+            "-h server "
+            "-p ${toString port} "
+            "-u ${username} "
+            "-P '${password}' "
+            "-t ${topic}"
+        ).format(binary)
+
+
+    def publish(args):
+        return "{} {}".format(mosquitto_cmd("pub"), args)
+
+
+    def subscribe(args):
+        return "({} -C 1 {} | tee ${file} &)".format(mosquitto_cmd("sub"), args)
+
+
     start_all()
     server.wait_for_unit("mosquitto.service")
 
@@ -59,37 +66,25 @@ in {
         machine.fail("test -f ${file}")
 
     # QoS = 0, so only one subscribers should get it
-    server.execute(
-        "${sub "-q 0"}"
-    )
+    server.execute(subscribe("-q 0"))
 
     # we need to give the subscribers some time to connect
     client2.execute("sleep 5")
-    client2.succeed(
-        "${cmd "pub"} -m FOO -q 0"
-    )
+    client2.succeed(publish("-m FOO -q 0"))
 
     server.wait_until_succeeds("grep -q FOO ${file}")
     server.execute("rm ${file}")
 
     # QoS = 1, so both subscribers should get it
-    server.execute(
-        "${sub "-q 1"}"
-    )
-    client1.execute(
-        "${sub "-q 1"}"
-    )
+    server.execute(subscribe("-q 1"))
+    client1.execute(subscribe("-q 1"))
 
     # we need to give the subscribers some time to connect
     client2.execute("sleep 5")
-    client2.succeed(
-        "${cmd "pub"} -m BAR -q 1"
-    )
+    client2.succeed(publish("-m BAR -q 1"))
 
-    server.wait_until_succeeds("grep -q BAR ${file}")
-    server.execute("rm ${file}")
-
-    client1.wait_until_succeeds("grep -q BAR ${file}")
-    client1.execute("rm ${file}")
+    for machine in server, client1:
+        machine.wait_until_succeeds("grep -q BAR ${file}")
+        machine.execute("rm ${file}")
   '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Port mosquitto test to python test framework #72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @adisbladis @flokli @domenkozar @jonringer 
