### PR TITLE
polkit: Don't build elogind on non-Linux.

### DIFF
--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -55,7 +55,8 @@ stdenv.mkDerivation rec {
     ++ [ libxslt docbook_xsl docbook_xml_dtd_412 ]; # man pages
   buildInputs =
     [ expat pam spidermonkey_60 ]
-    ++ (if useSystemd then [systemd] else [elogind])
+    # On Linux, fall back to elogind when systemd support is off.
+    ++ stdenv.lib.optional stdenv.isLinux (if useSystemd then systemd else elogind)
     ++ stdenv.lib.optional withGnome gobject-introspection;
 
   propagatedBuildInputs = [


### PR DESCRIPTION
#### Motivation for this change

In #72057 I added support for elogind when systemd is not supported,
but it occurred to me that it probably doens't make sense to have
either of systemd or elogind on Darwin.

See https://github.com/NixOS/nixpkgs/pull/72057#issuecomment-553713108.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

@worldofpeace