### PR TITLE
gjs: clean up

### DIFF
--- a/pkgs/development/libraries/gjs/default.nix
+++ b/pkgs/development/libraries/gjs/default.nix
@@ -7,12 +7,14 @@
 , gobject-introspection
 , spidermonkey_60
 , pango
+, cairo
 , readline
 , glib
 , libxml2
 , dbus
 , gdk-pixbuf
 , makeWrapper
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -24,24 +26,24 @@ stdenv.mkDerivation rec {
     sha256 = "1xf68rbagkflb9yi3visfw8cbxqlzd717y8jakgw0y6whzm1dpxl";
   };
 
-  outputs = [ "out" "installedTests" ];
+  outputs = [ "out" "dev" "installedTests" ];
 
   nativeBuildInputs = [
     pkgconfig
     makeWrapper
+    libxml2 # for xml-stripblanks
   ];
 
   buildInputs = [
-    libxml2
     gobject-introspection
-    glib
-    pango
+    cairo
     readline
-    dbus
+    spidermonkey_60
+    dbus # for dbus-run-session
   ];
 
   propagatedBuildInputs = [
-    spidermonkey_60
+    glib
   ];
 
   configureFlags = [
@@ -55,8 +57,6 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    sed 's|-lreadline|-L${readline.out}/lib -lreadline|g' -i $out/lib/libgjs.la
-
     moveToOutput "share/installed-tests" "$installedTests"
     moveToOutput "libexec/gjs/installed-tests" "$installedTests"
 
@@ -67,6 +67,10 @@ stdenv.mkDerivation rec {
   separateDebugInfo = stdenv.isLinux;
 
   passthru = {
+    tests = {
+      installed-tests = nixosTests.installed-tests.gjs;
+    };
+
     updateScript = gnome3.updateScript {
       packageName = "gjs";
     };


### PR DESCRIPTION
* Do not propagate spidermonkey, it is only needed gjs to link against.
* Split out dev output, any propagated dependencies should go there.
* Drop unnecessary sed, the readline thing is no longer there.

It is just 2.5 MB closure reduction but every megabyte counts.