### PR TITLE
gamecube-tools: fix build

### DIFF
--- a/pkgs/development/tools/gamecube-tools/default.nix
+++ b/pkgs/development/tools/gamecube-tools/default.nix
@@ -1,20 +1,19 @@
-{ stdenv, which, autoconf, automake, fetchFromGitHub,
-  libtool, freeimage, mesa }:
+{ stdenv, fetchFromGitHub, autoreconfHook
+, freeimage, libGL }:
+
 stdenv.mkDerivation rec {
-  version = "v1.0.2";
+  version = "1.0.2";
   pname = "gamecube-tools";
 
-  nativeBuildInputs = [ which autoconf automake libtool ];
-  buildInputs = [ freeimage mesa ];
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ freeimage libGL ];
 
   src = fetchFromGitHub {
     owner = "devkitPro";
     repo  = "gamecube-tools";
-    rev = version;
+    rev = "v${version}";
     sha256 = "0zvpkzqvl8iv4ndzhkjkmrzpampyzgb91spv0h2x2arl8zy4z7ca";
   };
-
-  preConfigure = "./autogen.sh";
 
   meta = with stdenv.lib; {
     description = "Tools for gamecube/wii projects";


### PR DESCRIPTION
###### Motivation for this change
GL/gl.h was removed from mesa package in https://github.com/NixOS/nixpkgs/pull/72999, needs to be
directly imported from libGL now

list of hydra builds possibly broken by the GL/gl.h removal: https://hydra.nixos.org/eval/1555741?filter=x86_64-linux&compare=1555703&full=1#tabs-now-fail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
