### PR TITLE
[staging] python3Packages.mock: remove funcsigs dependency

### DIFF
--- a/pkgs/development/python-modules/mock/default.nix
+++ b/pkgs/development/python-modules/mock/default.nix
@@ -1,7 +1,7 @@
-{ stdenv
+{ lib
 , buildPythonPackage
 , fetchPypi
-, unittest2
+, isPy27
 , funcsigs
 , six
 , pbr
@@ -17,8 +17,7 @@ buildPythonPackage rec {
     sha256 = "83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3";
   };
 
-  buildInputs = [ unittest2 ];
-  propagatedBuildInputs = [ funcsigs six pbr ];
+  propagatedBuildInputs = [ six pbr ] ++ lib.optionals isPy27 [ funcsigs ];
 
   # On PyPy for Python 2.7 in particular, Mock's tests have a known failure.
   # Mock upstream has a decoration to disable the failing test and make
@@ -30,10 +29,10 @@ buildPythonPackage rec {
     ${python.interpreter} -m unittest discover
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Mock objects for Python";
     homepage = http://python-mock.sourceforge.net/;
-    license = stdenv.lib.licenses.bsd2;
+    license = licenses.bsd2;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
help with python39 package set.

collections removals made everything that uses unittest2 unable to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
