### PR TITLE
libreoffice: add dev output with headers

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -65,6 +65,8 @@ in stdenv.mkDerivation rec {
 
   inherit (primary-src) src;
 
+  outputs = [ "out" "dev" ];
+
   # For some reason librdf_redland sometimes refers to rasqal.h instead
   # of rasqal/rasqal.h
   NIX_CFLAGS_COMPILE = [ "-I${librdf_rasqal}/include/rasqal" ] ++ lib.optional stdenv.isx86_64 "-mno-fma";
@@ -276,6 +278,9 @@ in stdenv.mkDerivation rec {
 
     cp -r sysui/desktop/icons  "$out/share"
     sed -re 's@Icon=libreoffice(dev)?[0-9.]*-?@Icon=@' -i "$out/share/applications/"*.desktop
+
+    mkdir -p $dev
+    cp -r include $dev
   '';
 
   configureFlags = [

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -65,6 +65,8 @@ in stdenv.mkDerivation rec {
 
   inherit (primary-src) src;
 
+  outputs = [ "out" "dev" ];
+
   # For some reason librdf_redland sometimes refers to rasqal.h instead
   # of rasqal/rasqal.h
   NIX_CFLAGS_COMPILE = [ "-I${librdf_rasqal}/include/rasqal" ];
@@ -276,6 +278,9 @@ in stdenv.mkDerivation rec {
 
     cp -r sysui/desktop/icons  "$out/share"
     sed -re 's@Icon=libreoffice(dev)?[0-9.]*-?@Icon=@' -i "$out/share/applications/"*.desktop
+
+    mkdir -p $dev
+    cp -r include $dev
   '';
 
   configureFlags = [


### PR DESCRIPTION
Simple change which adds `dev` output, where header files are copied during build.

###### Motivation for this change

I'm working on getting [LibreOffice Online](https://www.libreoffice.org/download/libreoffice-online/) into NixOS and it needs LibreOffice's `include/LibreOfficeKit` directory available during build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c @peterhoeg 
