### PR TITLE
neovim-qt: 0.2.12 -> 0.2.15

### DIFF
--- a/pkgs/applications/editors/neovim/qt.nix
+++ b/pkgs/applications/editors/neovim/qt.nix
@@ -4,13 +4,13 @@
 let
   unwrapped = mkDerivation rec {
     pname = "neovim-qt-unwrapped";
-    version = "0.2.12";
+    version = "0.2.15";
 
     src = fetchFromGitHub {
       owner  = "equalsraf";
       repo   = "neovim-qt";
       rev    = "v${version}";
-      sha256 = "09s3044j0y8nmyi8ykslfii6fx7k9mckmdvb0jn2xmdabpb60i20";
+      sha256 = "097nykglqp4jyvla4yp32sc1f1hph4cqqhp6rm9ww7br8c0j54xl";
     };
 
     cmakeFlags = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

nix-review failed with the following error, but I was able to compile it and run sucessfully on my machine

```
builder for '/nix/store/2327mmims9ypfc5vlzrz6jc0yzy302nw-luajit-2.1.0-beta3-env.drv' failed with exit code 1; last 2 log lines:
  created 16 symlinks in user environment
  /nix/store/wpi89y86krq9rbvwcbx0hc36ibp5d0v7-stdenv-linux/setup: line 320: [@]: bad substitution
cannot build derivation '/nix/store/i9l40vp8mw2vb7w1qi4ba8j808nsz18p-neovim-unwrapped-0.4.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/nyf3avymprn7wm0can324s2nfdxs6yvc-neovim-0.4.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/kl0xsxpmbsdjkdah8il9vag494s9b5cw-neovim-qt-unwrapped-0.2.15.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/034v125nihgnv1282jmdydan1x20gn0f-neovim-qt-0.2.15.drv': 2 dependencies couldn't be built
cannot build derivation '/nix/store/yvcd9rwf77pdzlcqagaqa4z8a0f875p2-env.drv': 1 dependencies couldn't be built
[0 built (1 failed)]
error: build of '/nix/store/yvcd9rwf77pdzlcqagaqa4z8a0f875p2-env.drv' failed
1 package failed to build:
neovim-qt

[0.0 MiB DL]
error: build log of '/nix/store/034v125nihgnv1282jmdydan1x20gn0f-neovim-qt-0.2.15.drv' is not available
$ nix-shell /home/dema/.cache/nix-review/rev-e40adc8788c506ff24a4dec5cf83b8c26dadecfc-1/shell.nix```