### PR TITLE
i3blocks: unstable-2019-02-07 -> 1.5

### DIFF
--- a/pkgs/applications/window-managers/i3/blocks.nix
+++ b/pkgs/applications/window-managers/i3/blocks.nix
@@ -1,16 +1,16 @@
-{ fetchFromGitHub, fetchpatch, stdenv, autoreconfHook }:
+{ fetchFromGitHub, fetchpatch, stdenv, autoreconfHook, pkg-config }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation {
   pname = "i3blocks";
-  version = "unstable-2019-02-07";
+  version = "1.5";
 
   src = fetchFromGitHub {
     owner = "vivien";
     repo = "i3blocks";
-    rev = "ec050e79ad8489a6f8deb37d4c20ab10729c25c3";
-    sha256 = "1fx4230lmqa5rpzph68dwnpcjfaaqv5gfkradcr85hd1z8d1qp1b";
+    rev = "3417602a2d8322bc866861297f535e1ef80b8cb0";
+    sha256 = "0v8mwnm8qzpv6xnqvrk43s4b9iyld4naqzbaxk4ldq1qkhai0wsv";
   };
 
   patches = [
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     })
   ];
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   meta = {
     description = "A flexible scheduler for your i3bar blocks";


### PR DESCRIPTION
###### Motivation for this change

Package upgrade.
Note that upstream has two commits tagged with "1.5": https://github.com/vivien/i3blocks/commit/3417602a2d8322bc866861297f535e1ef80b8cb0 and https://github.com/vivien/i3blocks/commit/737994c19d12d85258ff5ecb1cf0f510ecf7c245, but 3417602 seems to be used in releases.

pkg-config is needed for PKG_CHECK_MODULES in configure.ac, see https://github.com/vivien/i3blocks/commit/e1a4007084b1d131016762d9a61c4dd802b7111b.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
