### PR TITLE
yosys-withGui: New wrapper derivation with GUI runtime dependencies

### DIFF
--- a/pkgs/development/compilers/yosys/gui-wrapper.nix
+++ b/pkgs/development/compilers/yosys/gui-wrapper.nix
@@ -1,0 +1,23 @@
+# This derivation provides a drop-in replacement for the "yosys"
+# package with a wrapper to setup the runtime GUI dependencies for the
+# "show" command.
+{ stdenv, yosys, runCommand, makeWrapper,
+  graphviz, psmisc, python3Packages, hicolor-icon-theme, gnome3 }:
+
+# Runtime dependencies for the "show" command.
+let guiPackages = [ graphviz psmisc python3Packages.xdot ]; in
+
+runCommand yosys.pname
+  { inherit yosys;
+    version = yosys.version;
+    meta = yosys.meta;
+    buildInputs = [ makeWrapper ];
+  }
+  ''
+  cp -a $yosys $out
+  chmod +w $out/bin
+  wrapProgram $out/bin/yosys \
+    --prefix PATH ':' ${stdenv.lib.makeBinPath guiPackages} \
+    --prefix XDG_DATA_DIRS ':' \
+      "${hicolor-icon-theme}/share:${gnome3.adwaita-icon-theme}/share"
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8853,6 +8853,8 @@ in
 
   yosys = callPackage ../development/compilers/yosys { };
 
+  yosys-withGui = callPackage ../development/compilers/yosys/gui-wrapper.nix { };
+
   z88dk = callPackage ../development/compilers/z88dk { };
 
   zulip = callPackage ../applications/networking/instant-messengers/zulip { };


### PR DESCRIPTION
This commit adds a new package called 'yosys-withGui' that is
identical to yosys but wraps the bin/yosys script to setup runtime
dependencies needed for the "show" command i.e. to graphically
visualize a design.

I have consciously avoided changing the existing yosys derivation
because it takes a long time to build. The new derivation simply
copies yosys out of the Nix store and then hacks the wrapper in place.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @shell @thoughtpolice @emily
