### PR TITLE
multitime: init at 1.4

### DIFF
--- a/pkgs/tools/misc/multitime/default.nix
+++ b/pkgs/tools/misc/multitime/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "multitime";
+  version = "1.4";
+
+  src = fetchFromGitHub {
+    owner = "ltratt";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "1p6m4gyy6dw7nxnpsk32qiijagmiq9vwch0fbc25qvmybwqp8qc0";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = {
+    description = "Time command execution over multiple executions";
+
+    longDescription = ''
+      Unix's `time` utility is a simple and often effective way of measuring
+      how long a command takes to run. Unfortunately, running a command once
+      can give misleading timings: the process may create a cache on its first
+      execution, running faster subsequently; other processes may cause the
+      command to be starved of CPU or IO time; etc. It is common to see people
+      run `time` several times and take whichever values they feel most
+      comfortable with. Inevitably, this causes problems.
+
+      `multitime` is, in essence, a simple extension to time which runs a
+      command multiple times and prints the timing means (with confidence
+      intervals), standard deviations, minimums, medians, and maximums having
+      done so. This can give a much better understanding of the command's
+      performance.
+    '';
+
+    license = stdenv.lib.licenses.mit;
+    homepage = "https://tratt.net/laurie/src/multitime/";
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5035,6 +5035,8 @@ in
 
   mt-st = callPackage ../tools/backup/mt-st {};
 
+  multitime = callPackage ../tools/misc/multitime { };
+
   multitran = recurseIntoAttrs (let callPackage = newScope pkgs.multitran; in {
     multitrandata = callPackage ../tools/text/multitran/data { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers