### PR TITLE
lua-5.3: add patch for CVE-2019-6706

### DIFF
--- a/pkgs/development/interpreters/lua-5/CVE-2019-6706.patch
+++ b/pkgs/development/interpreters/lua-5/CVE-2019-6706.patch
@@ -1,0 +1,22 @@
+--- a/src/lapi.c
++++ b/src/lapi.c
+@@ -1285,14 +1285,14 @@ LUA_API void *lua_upvalueid (lua_State *
+ 
+ LUA_API void lua_upvaluejoin (lua_State *L, int fidx1, int n1,
+                                             int fidx2, int n2) {
+-  LClosure *f1;
+-  UpVal **up1 = getupvalref(L, fidx1, n1, &f1);
++  UpVal **up1 = getupvalref(L, fidx1, n1, NULL); /* the last parameter not needed */
+   UpVal **up2 = getupvalref(L, fidx2, n2, NULL);
++  if (*up1 == *up2) return; /* Already joined */
++  (*up2)->refcount++;
++  if (upisopen(*up2)) (*up2)->u.open.touched = 1;
++  luaC_upvalbarrier(L, *up2);
+   luaC_upvdeccount(L, *up1);
+   *up1 = *up2;
+-  (*up1)->refcount++;
+-  if (upisopen(*up1)) (*up1)->u.open.touched = 1;
+-  luaC_upvalbarrier(L, *up1);
+ }
+ 
+ 

--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -1,5 +1,5 @@
 # similar to interpreters/python/default.nix
-{ stdenv, lib, callPackage, fetchurl }:
+{ stdenv, lib, callPackage, fetchurl, fetchpatch }:
 let
   dsoPatch51 = fetchurl {
     url = "https://projects.archlinux.org/svntogit/packages.git/plain/trunk/lua-arch.patch?h=packages/lua51";
@@ -18,7 +18,10 @@ in rec {
   lua5_3 = callPackage ./interpreter.nix {
     sourceVersion = { major = "5"; minor = "3"; patch = "5"; };
     hash = "0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac";
-    patches = lib.optionals stdenv.isDarwin [ ./5.2.darwin.patch ] ;
+    patches =
+      lib.optionals stdenv.isDarwin [ ./5.2.darwin.patch ] ++ [
+        ./CVE-2019-6706.patch
+      ];
     postConfigure = lib.optionalString (!stdenv.isDarwin) ''
       cat ${./lua-5.3-dso.make} >> src/Makefile
       sed -e 's/ALL_T *= */& $(LUA_SO)/' -i src/Makefile


### PR DESCRIPTION
###### Motivation for this change

Security patch taken from http://launchpadlibrarian.net/417853567/lua5.3_5.3.3-1_5.3.3-1ubuntu0.18.10.1.diff.gz and adapted to our needs.

Re #54799

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) -> nixos/tests/rspamd.nix calls lua
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) -> minimal
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

-> Has lua a maintainer?
