### PR TITLE
grafana-loki: 0.4.0 -> 1.0.0

### DIFF
--- a/pkgs/servers/monitoring/loki/default.nix
+++ b/pkgs/servers/monitoring/loki/default.nix
@@ -1,7 +1,7 @@
 { stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, systemd }:
 
 buildGoPackage rec {
-  version = "0.4.0";
+  version = "1.0.0";
   pname = "grafana-loki";
   goPackagePath = "github.com/grafana/loki";
 
@@ -11,7 +11,7 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "loki";
-    sha256 = "1anwq5dbh29dma18hnialbb253ciazzxmnqvympbh29ricldcf8p";
+    sha256 = "0qqmxrbiph268i5c8i6wpcihspdcglfxd4hy6ag03bl66rciq8nb";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -23,10 +23,10 @@ buildGoPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Like Prometheus, but for logs.";
+    description = "Like Prometheus, but for logs";
     license = licenses.asl20;
     homepage = "https://grafana.com/loki";
-    maintainers = with maintainers; [ willibutz globin ];
+    maintainers = with maintainers; [ willibutz globin mmahut ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

 0.4.0 -> 1.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
