### PR TITLE
python3Packages.tensorflow-tensorboard: add wheel as runtime dep

### DIFF
--- a/pkgs/development/python-modules/tensorflow-tensorboard/default.nix
+++ b/pkgs/development/python-modules/tensorflow-tensorboard/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, lib, fetchPypi, buildPythonPackage, isPy3k
+{ lib, fetchPypi, buildPythonPackage, isPy3k
 , numpy
+, wheel
 , werkzeug
 , protobuf
 , grpcio
@@ -34,10 +35,29 @@ buildPythonPackage rec {
     werkzeug
     protobuf
     markdown
-    grpcio absl-py
+    grpcio
+    absl-py
+    # not declared in install_requires, but used at runtime
+    # https://github.com/NixOS/nixpkgs/issues/73840
+    wheel
   ] ++ lib.optional (!isPy3k) futures;
 
-  meta = with stdenv.lib; {
+  # in the absence of a real test suite, run cli and imports
+  checkPhase = ''
+    $out/bin/tensorboard --help > /dev/null
+  '';
+
+  pythonImportsCheck = [
+    "tensorboard"
+    "tensorboard.backend"
+    "tensorboard.compat"
+    "tensorboard.data"
+    "tensorboard.plugins"
+    "tensorboard.summary"
+    "tensorboard.util"
+  ];
+
+  meta = with lib; {
     description = "TensorFlow's Visualization Toolkit";
     homepage = http://tensorflow.org;
     license = licenses.asl20;


### PR DESCRIPTION
The cli requires the wheel package to determine
entry points for execution.

(cherry picked from commit 7d091ce5ad4eb0ee1294f2d7bd2d2a60bca5b43e)
Signed-off-by: Jonathan Ringer <jonringer117@gmail.com>

###### Motivation for this change

backport of #73842

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
