### PR TITLE
nixos/switch-to-configuration: restart changed socket units

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -214,7 +214,17 @@ while (my ($unit, $state) = each %{$activePrev}) {
                 # Reload the changed mount unit to force a remount.
                 $unitsToReload{$unit} = 1;
                 recordUnit($reloadListFile, $unit);
-            } elsif ($unit =~ /\.socket$/ || $unit =~ /\.path$/ || $unit =~ /\.slice$/) {
+            } elsif ($unit =~ /\.socket$/) {
+                my $unitInfo = parseUnit($newUnitFile);
+                # If a socket unit has been changed, the corresponding
+                # service unit has to be stopped before the socket can
+                # be restarted. The service will be started again on demand.
+                my $serviceUnit = $unitInfo->{'Unit'} // "$baseName.service";
+                $unitsToStop{$serviceUnit} = 1;
+                $unitsToStop{$unit} = 1;
+                $unitsToStart{$unit} = 1;
+                recordUnit($startListFile, $unit);
+            } elsif ($unit =~ /\.path$/ || $unit =~ /\.slice$/) {
                 # FIXME: do something?
             } else {
                 my $unitInfo = parseUnit($newUnitFile);


### PR DESCRIPTION
###### Motivation for this change
The bugfix part of #50340

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested via nixos/tests/mpd.nix
- [x] Tested via nixos/tests/systemd-confinement.nix
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc author @fpletz