### PR TITLE
aerc: 0.2.1 -> 0.3.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -1,21 +1,22 @@
 { stdenv, buildGoModule, fetchurl
-, go, ncurses, scdoc
+, go, ncurses, notmuch, scdoc
 , python3, perl, w3m, dante
 }:
 
 buildGoModule rec {
   pname = "aerc";
-  version = "0.2.1";
+  version = "0.3.0";
 
   src = fetchurl {
     url = "https://git.sr.ht/~sircmpwn/aerc/archive/${version}.tar.gz";
-    sha256 = "1ky1nl5b54lf5jnac2kb5404fplwnwypjplas8imdlsf517fw32n";
+    sha256 = "188jln8hmgiqn5il5m54bns0wk4grj09di8y6mmid58ibw6spma4";
   };
 
   nativeBuildInputs = [
     go
     scdoc
     python3.pkgs.wrapPython
+    notmuch
   ];
 
   patches = [
@@ -27,6 +28,8 @@ buildGoModule rec {
   ];
 
   buildInputs = [ python3 perl ];
+
+  GOFLAGS="-tags=notmuch";
 
   buildPhase = "
     runHook preBuild
@@ -43,12 +46,12 @@ buildGoModule rec {
 
   postFixup = ''
     wrapProgram $out/bin/aerc --prefix PATH ":" \
-      "$out/share/aerc/filters:${stdenv.lib.makeBinPath [ ncurses.dev ]}"
+      "$out/share/aerc/filters:${stdenv.lib.makeBinPath [ ncurses ]}"
     wrapProgram $out/share/aerc/filters/html --prefix PATH ":" \
       ${stdenv.lib.makeBinPath [ w3m dante ]}
   '';
 
-  modSha256 = "0fc9m1qb8innypc8cxzbqyrfkawawyaqq3gqy7lqwmyh32f300jh";
+  modSha256 = "0pxbv4zfhii0g41cy0ycfpkkxw6nnd4ibavic6zqw30j476jnm2x";
 
   meta = with stdenv.lib; {
     description = "aerc is an email client for your terminal";

--- a/pkgs/applications/networking/mailreaders/aerc/runtime-sharedir.patch
+++ b/pkgs/applications/networking/mailreaders/aerc/runtime-sharedir.patch
@@ -1,18 +1,19 @@
-From 7ea68a2eef026723903d72f54ca54b629881ec06 Mon Sep 17 00:00:00 2001
+From 6cf3c2e42d219b9665a43ca65f321c653b0aa102 Mon Sep 17 00:00:00 2001
 From: Tadeo Kondrak <me@tadeo.ca>
 Date: Mon, 28 Oct 2019 08:36:36 -0600
 Subject: [PATCH] Fix aerc breaking every time the package is rebuilt.
 
 On NixOS, the SHAREDIR changes on every rebuild to the package, but aerc
-fills it in as part of the default config. Fix this by not substituting
-@SHAREDIR@ in the default config until runtime.
+fills it in as part of the default config and then installs that config
+to the users home folder. Fix this by not substituting @SHAREDIR@ in the
+default config until runtime.
 ---
  Makefile         | 2 +-
- config/config.go | 3 +++
- 2 files changed, 4 insertions(+), 1 deletion(-)
+ config/config.go | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index d3072d3..17ca0be 100644
+index d1c755d..1185a96 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -24,7 +24,7 @@ aerc: $(GOSRC)
@@ -25,10 +26,22 @@ index d3072d3..17ca0be 100644
  DOCS := \
  	aerc.1 \
 diff --git a/config/config.go b/config/config.go
-index bfcbecf..2f4e703 100644
+index 32d07fc..8ffd3e8 100644
 --- a/config/config.go
 +++ b/config/config.go
-@@ -377,6 +377,9 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
+@@ -355,6 +355,11 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
+ 			return nil, err
+ 		}
+ 	}
++	if sec, err := file.GetSection("templates"); err == nil {
++		if key, err := sec.GetKey("template-dirs"); err == nil {
++			sec.NewKey("template-dirs", strings.ReplaceAll(key.String(), "@SHAREDIR@", sharedir))
++		}
++	}
+ 	file.NameMapper = mapName
+ 	config := &AercConfig{
+ 		Bindings: BindingConfig{
+@@ -423,6 +428,9 @@ func LoadConfigFromFile(root *string, sharedir string) (*AercConfig, error) {
  	if err = config.LoadConfig(file); err != nil {
  		return nil, err
  	}


### PR DESCRIPTION
###### Motivation for this change

version bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tadeokondrak
