### PR TITLE
glib.setupHook: fix make_glib_find_gsettings_schemas

### DIFF
--- a/pkgs/development/libraries/glib/setup-hook.sh
+++ b/pkgs/development/libraries/glib/setup-hook.sh
@@ -1,8 +1,8 @@
 
 make_glib_find_gsettings_schemas() {
     # For packages that need gschemas of other packages (e.g. empathy)
-    for maybe_dir in "$1"/share/gsettings-schemas/*/glib-2.0; do
-        if [[ -d "$maybe_dir/schemas" ]]; then
+    for maybe_dir in "$1"/share/gsettings-schemas/*; do
+        if [[ -d "$maybe_dir/glib-2.0/schemas" ]]; then
             addToSearchPath GSETTINGS_SCHEMAS_PATH "$maybe_dir"
         fi
     done


### PR DESCRIPTION
###### Motivation for this change
`GSETTINGS_SCHEMAS_PATH` needs to contain a list of directories containing `glib-2.0/schemas`. 770a4c7946a1c55bf6295a34a42e1c4b657d1088 broke that by accidentally adding `glib-2.0` to the paths.

This needs to go to master because it is blocking channels via `gnome3` tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace 