### PR TITLE
python3Packages.pydocstyle: 2.1.1 -> 4.0.1

### DIFF
--- a/pkgs/development/python-modules/pydocstyle/2.nix
+++ b/pkgs/development/python-modules/pydocstyle/2.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k, pythonOlder
+, snowballstemmer, six, configparser
+, pytest, pytestpep8, mock, pathlib }:
+
+buildPythonPackage rec {
+  pname = "pydocstyle";
+  version = "2.1.1";
+
+  # no tests on PyPI
+  # https://github.com/PyCQA/pydocstyle/issues/302
+  src = fetchFromGitHub {
+    owner = "PyCQA";
+    repo = pname;
+    rev = version;
+    sha256 = "1h0k8lpx14svc8dini62j0kqiam10pck5sdzvxa4xhsx7y689g5l";
+  };
+
+  propagatedBuildInputs = [ snowballstemmer six ] ++ lib.optional (!isPy3k) configparser;
+
+  checkInputs = [ pytest pytestpep8 mock ] ++ lib.optional (pythonOlder "3.4") pathlib;
+
+  checkPhase = ''
+    # test_integration.py installs packages via pip
+    py.test --pep8 --cache-clear -vv src/tests -k "not test_integration"
+  '';
+
+  meta = with lib; {
+    description = "Python docstring style checker";
+    homepage = https://github.com/PyCQA/pydocstyle/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dzabraev ];
+  };
+}

--- a/pkgs/development/python-modules/pydocstyle/default.nix
+++ b/pkgs/development/python-modules/pydocstyle/default.nix
@@ -1,23 +1,25 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy3k, pythonOlder
-, snowballstemmer, six, configparser
-, pytest, pytestpep8, mock, pathlib }:
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
+, mock
+, pytest
+, pytestpep8
+, snowballstemmer
+}:
 
 buildPythonPackage rec {
   pname = "pydocstyle";
-  version = "2.1.1";
+  version = "4.0.1";
+  disabled = !isPy3k;
 
-  # no tests on PyPI
-  # https://github.com/PyCQA/pydocstyle/issues/302
   src = fetchFromGitHub {
     owner = "PyCQA";
     repo = pname;
     rev = version;
-    sha256 = "1h0k8lpx14svc8dini62j0kqiam10pck5sdzvxa4xhsx7y689g5l";
+    sha256 = "1sr8d2fsfpam4f14v4als6g2v6s3n9h138vxlwhd6slb3ll14y4l";
   };
 
-  propagatedBuildInputs = [ snowballstemmer six ] ++ lib.optional (!isPy3k) configparser;
+  propagatedBuildInputs = [ snowballstemmer ];
 
-  checkInputs = [ pytest pytestpep8 mock ] ++ lib.optional (pythonOlder "3.4") pathlib;
+  checkInputs = [ pytest pytestpep8 mock ];
 
   checkPhase = ''
     # test_integration.py installs packages via pip

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -954,7 +954,11 @@ in {
 
   pydbus = callPackage ../development/python-modules/pydbus { };
 
-  pydocstyle = callPackage ../development/python-modules/pydocstyle { };
+  pydocstyle =
+    if isPy27 then
+      callPackage ../development/python-modules/pydocstyle/2.nix { }
+    else
+      callPackage ../development/python-modules/pydocstyle { };
 
   pydocumentdb = callPackage ../development/python-modules/pydocumentdb { };
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was horribly out of date

froze 2.1.1 for python2, bumped python3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

python3.8 failures are due to python38Packages.rope being broken upstream.
```
[12 built (2 failed), 234 copied (399.1 MiB), 76.3 MiB DL]
error: build of '/nix/store/bbp1jd411v4yyszmk3ydk2k5bqj3v678-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/73889
4 package failed to build:
python38Packages.pyls-black python38Packages.pyls-isort python38Packages.pyls-mypy python38Packages.python-language-server

13 package were built:
esphome esptool python37Packages.flake8-import-order python37Packages.pydocstyle python37Packages.pylama python37Packages.pyls-black python37Packages.pyls-isort python37Packages.pyls-mypy python37Packages.python-language-server python38Packages.flake8-import-order python38Packages.pydocstyle python38Packages.pylama todoman
```