### PR TITLE
python3Packages.portalocker: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/development/python-modules/portalocker/default.nix
+++ b/pkgs/development/python-modules/portalocker/default.nix
@@ -10,12 +10,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.5.1";
+  version = "1.5.2";
   pname = "portalocker";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "08d8vm373fbx90wrql2i7025d4ir54sq8ahx6g1pw9h793zqrn0y";
+    sha256 = "17rfgmgwyxyng8q7bvn369cncadqws2wgkg45q6v8337wm9jxins";
   };
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change
https://github.com/WoLpH/portalocker/pull/47 was merged which fixes builds using dev versions of setuptools

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

azure-cli-core is broken on master
```
[8 built (3 failed), 175 copied (179.8 MiB), 27.1 MiB DL]
error: build of '/nix/store/bmfbmrmyyfa647hds0pxpfdcv2dvq2ha-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/73893
3 package failed to build:
python27Packages.azure-cli-core python37Packages.azure-cli-core python38Packages.azure-cli-core

9 package were built:
python27Packages.applicationinsights python27Packages.azure-cli-telemetry python27Packages.portalocker python37Packages.applicationinsights python37Packages.azure-cli-telemetry python37Packages.portalocker python38Packages.applicationinsights python38Packages.azure-cli-telemetry python38Packages.portalocker
```