### PR TITLE
python3Packages.google_cloud_translate: 1.7.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/google_cloud_translate/default.nix
+++ b/pkgs/development/python-modules/google_cloud_translate/default.nix
@@ -3,24 +3,27 @@
 , fetchPypi
 , google_api_core
 , google_cloud_core
+, grpcio
 , pytest
 , mock
 }:
 
 buildPythonPackage rec {
   pname = "google-cloud-translate";
-  version = "1.7.0";
+  version = "2.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "55b6563121883acce5d80afbf61a59e50d52c429e6ebbfe81a1c8f2734b75e8c";
+    sha256 = "0nfc628nr2k6kd3q9qpgwz7c12l0191rv5x4pvca8q82jl96gip5";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ google_api_core google_cloud_core ];
+  # google_cloud_core[grpc] -> grpcio
+  propagatedBuildInputs = [ google_api_core google_cloud_core grpcio ];
 
+  checkInputs = [ pytest mock ];
   checkPhase = ''
-    pytest tests/unit
+    cd tests # prevent local google/__init__.py from getting loaded
+    pytest unit
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
package was bumped to a broken state, this bumps and fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[3 built, 7 copied (2.6 MiB), 0.4 MiB DL]
https://github.com/NixOS/nixpkgs/pull/73894
2 package were built:
python37Packages.google_cloud_translate python38Packages.google_cloud_translate
```