### PR TITLE
python3Packages.python-daemon: fix missing dependency

### DIFF
--- a/pkgs/development/python-modules/python-daemon/default.nix
+++ b/pkgs/development/python-modules/python-daemon/default.nix
@@ -1,4 +1,11 @@
-{ lib, buildPythonPackage, fetchPypi, mock, testscenarios, docutils, lockfile }:
+{ lib, buildPythonPackage, fetchPypi
+, docutils
+, lockfile
+, mock
+, pytest
+, testscenarios
+, twine
+}:
 
 buildPythonPackage rec {
   pname = "python-daemon";
@@ -9,11 +16,21 @@ buildPythonPackage rec {
     sha256 = "57c84f50a04d7825515e4dbf3a31c70cc44414394a71608dee6cfde469e81766";
   };
 
-  # A test fail within chroot builds.
-  doCheck = false;
-
-  buildInputs = [ mock testscenarios ];
+  nativeBuildInputs = [ twine ];
   propagatedBuildInputs = [ docutils lockfile ];
+
+  checkInputs = [ pytest mock testscenarios ];
+  checkPhase = ''
+    pytest -k 'not detaches_process_context \
+                and not standard_stream_file_descriptors'
+  '';
+
+  pythonImportsCheck = [
+    "daemon"
+    "daemon.daemon"
+    "daemon.pidfile"
+    "daemon.runner"
+  ];
 
   meta = with lib; {
     description = "Library to implement a well-behaved Unix daemon process";


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken

added tests,
cleaned up arguments a bit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built (1 failed), 6 copied (28.3 MiB), 4.0 MiB DL]
error: build of '/nix/store/awklcgykqpgcfr288235qilypgghxd2r-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/73897
7 package are marked as broken and were skipped:
python27Packages.ansible-kernel python27Packages.ansible-runner python27Packages.coilmq python27Packages.ledger_agent python27Packages.libagent python27Packages.python-daemon python27Packages.salmon-mail

1 package failed to build:
python38Packages.salmon-mail

18 package were built:
apache-airflow evdevremapkeys keepkey_agent ledger_agent luigi python37Packages.ansible-kernel python37Packages.ansible-runner python37Packages.libagent python37Packages.python-daemon python37Packages.salmon-mail trezor_agent python38Packages.ansible-kernel python38Packages.ansible-runner python38Packages.keepkey_agent python38Packages.ledger_agent python38Packages.libagent python38Packages.python-daemon python38Packages.trezor_agent
```