### PR TITLE
python3Packages.spglib: 1.12.1.post0 -> 1.14.1.post0

### DIFF
--- a/pkgs/development/python-modules/spglib/default.nix
+++ b/pkgs/development/python-modules/spglib/default.nix
@@ -2,21 +2,12 @@
 
 buildPythonPackage rec {
   pname = "spglib";
-  version = "1.12.2.post0";
+  version = "1.14.1.post0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "15b02b74c0f06179bc3650c43a710a5200abbba387c6eda3105bfd9236041443";
+    sha256 = "0kmllcch5p20ylxirqiqzls567jr2808rbld9i8f1kf0205al8qq";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-assertions.patch";
-      url = https://github.com/atztogo/spglib/commit/d57070831585a6f02dec0a31d25b375ba347798c.patch;
-      stripLen = 1;
-      sha256 = "0crmkc498rbrawiy9zbl39qis2nmsbfr4s6kk6k3zhdy8z2ppxw7";
-    })
-  ];
 
   propagatedBuildInputs = [ numpy ];
 


### PR DESCRIPTION
###### Motivation for this change
fix seekpath build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[13 built, 17 copied (171.3 MiB), 70.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/73899
13 package were built:
python27Packages.seekpath python27Packages.spglib python37Packages.boltztrap2 python37Packages.dftfit python37Packages.lammps-cython python37Packages.pymatgen python37Packages.pymatgen-lammps python37Packages.seekpath python37Packages.spglib python37Packages.sumo python38Packages.boltztrap2 python38Packages.seekpath python38Packages.spglib
```