### PR TITLE
glui: fix build

### DIFF
--- a/pkgs/development/libraries/glui/default.nix
+++ b/pkgs/development/libraries/glui/default.nix
@@ -1,8 +1,26 @@
-{stdenv, fetchurl, freeglut, libGLU_combined, libXmu, libXext, libX11, libXi}:
-stdenv.mkDerivation {
-  name = "glui-2.35";
-  buildInputs = [freeglut libGLU_combined libXmu libXext libX11 libXi];
+{ stdenv, fetchurl
+, freeglut
+, libGL
+, libGLU
+, libX11
+, libXext
+, libXi
+, libXmu
+}:
+
+stdenv.mkDerivation rec {
+  pname = "glui";
+  version = "2.36";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/glui/Source/${version}/glui-${version}.tgz";
+    sha256 = "11r7f0k5jlbl825ibhm5c6bck0fn1hbliya9x1f253ikry1mxvy1";
+  };
+
+  buildInputs = [ freeglut libGLU libGL libXmu libXext libX11 libXi ];
+
   preConfigure = ''cd src'';
+
   installPhase = ''
     mkdir -p "$out"/{bin,lib,share/glui/doc,include}
     cp -rT bin "$out/bin"
@@ -11,14 +29,11 @@ stdenv.mkDerivation {
     cp -rT doc "$out/share/glui/doc"
     cp LICENSE.txt "$out/share/glui/doc"
   '';
-  src = fetchurl {
-    url = "mirror://sourceforge/project/glui/Source/2.36/glui-2.36.tgz";
-    sha256 = "11r7f0k5jlbl825ibhm5c6bck0fn1hbliya9x1f253ikry1mxvy1";
-  };
-  meta = {
+
+  meta = with stdenv.lib; {
     description = ''A user interface library using OpenGL'';
-    license = stdenv.lib.licenses.zlib ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.zlib ;
+    maintainers = [ maintainers.raskin ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken on hydra

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/73901
1 package were built:
glui
```