### PR TITLE
nixos/lxd: add package options for LXC, LXD and ZFS

### DIFF
--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -7,6 +7,7 @@ with lib;
 let
 
   cfg = config.virtualisation.lxd;
+  zfsCfg = config.boot.zfs;
 
 in
 
@@ -26,11 +27,38 @@ in
           <command>lxc</command> command line tool, among others.
         '';
       };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.lxd;
+        description = ''
+          The LXD package to use.
+        '';
+      };
+
+      lxcPackage = mkOption {
+        type = types.package;
+        default = pkgs.lxc;
+        description = ''
+          The LXC package to use with LXD (required for AppArmor profiles).
+        '';
+      };
+
+      zfsPackage = mkOption {
+        type = types.package;
+        default = with pkgs; if zfsCfg.enableUnstable then zfsUnstable else zfs;
+        defaultText = "pkgs.zfs";
+        description = ''
+          The ZFS package to use with LXD.
+        '';
+      };
+
       zfsSupport = mkOption {
         type = types.bool;
         default = false;
         description = ''
-          enables lxd to use zfs as a storage for containers.
+          Enables lxd to use zfs as a storage for containers.
+
           This option is enabled by default if a zfs pool is configured
           with nixos.
         '';
@@ -54,15 +82,15 @@ in
 
   config = mkIf cfg.enable {
 
-    environment.systemPackages = [ pkgs.lxd ];
+    environment.systemPackages = [ cfg.package ];
 
     security.apparmor = {
       enable = true;
       profiles = [
-        "${pkgs.lxc}/etc/apparmor.d/usr.bin.lxc-start"
-        "${pkgs.lxc}/etc/apparmor.d/lxc-containers"
+        "${cfg.lxcPackage}/etc/apparmor.d/usr.bin.lxc-start"
+        "${cfg.lxcPackage}/etc/apparmor.d/lxc-containers"
       ];
-      packages = [ pkgs.lxc ];
+      packages = [ cfg.lxcPackage ];
     };
 
     systemd.services.lxd = {
@@ -71,14 +99,14 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "systemd-udev-settle.service" ];
 
-      path = lib.optional cfg.zfsSupport pkgs.zfs;
+      path = lib.optional cfg.zfsSupport cfg.zfsPackage;
 
       preStart = ''
         mkdir -m 0755 -p /var/lib/lxc/rootfs
       '';
 
       serviceConfig = {
-        ExecStart = "@${pkgs.lxd.bin}/bin/lxd lxd --group lxd";
+        ExecStart = "@${cfg.package.bin}/bin/lxd lxd --group lxd";
         Type = "simple";
         KillMode = "process"; # when stopping, leave the containers alone
         LimitMEMLOCK = "infinity";

--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -31,6 +31,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.lxd;
+        defaultText = "pkgs.lxd";
         description = ''
           The LXD package to use.
         '';
@@ -39,6 +40,7 @@ in
       lxcPackage = mkOption {
         type = types.package;
         default = pkgs.lxc;
+        defaultText = "pkgs.lxc";
         description = ''
           The LXC package to use with LXD (required for AppArmor profiles).
         '';


### PR DESCRIPTION
Currently, LXD always use pkgs.zfs, even if boot.zfs.enableUnstable is set. This
change provides the option to change the LXC, LXD and ZFS packages, and
determines the default ZFS package based on zfs.enableUnstable.

###### Motivation for this change

I had to change the LXD package (to use LXD from `nixpkgs-unstable`), and noticed it could not be changed in `virtualisation/lxd.nix`. I also noticed that `zfs.enableUnstable` was not taken into account for the ZFS dependency.

###### Things done

Added options for the LXC, LXD and ZFS packages in the LXD configuration.

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
