### PR TITLE
git-machete: init at 2.12.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -103,6 +103,8 @@ let
 
   git-imerge = callPackage ./git-imerge { };
 
+  git-machete = python3Packages.callPackage ./git-machete { };
+
   git-octopus = callPackage ./git-octopus { };
 
   git-open = callPackage ./git-open { };

--- a/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonApplication, fetchPypi
+, installShellFiles, pbr
+, flake8, mock, pycodestyle, pylint, tox }:
+
+buildPythonApplication rec {
+  pname = "git-machete";
+  version = "2.12.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "114kq396zq45jlibn1lp0nk4lmanj4w1bcn48gi7xzdm0y1nkzfq";
+  };
+
+  nativeBuildInputs = [ installShellFiles pbr ];
+
+  # TODO: Add missing check inputs (2019-11-22):
+  # - stestr
+  doCheck = false;
+  checkInputs = [ flake8 mock pycodestyle pylint tox ];
+
+  postInstall = ''
+      installShellCompletion --bash --name git-machete completion/git-machete.completion.bash
+      installShellCompletion --zsh --name _git-machete completion/git-machete.completion.zsh
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/VirtusLab/git-machete;
+    description = "Git repository organizer and rebase workflow automation tool";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.blitz ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Git machete is a tool for automating rebase-based workflows. See https://github.com/VirtusLab/git-machete for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc @jtraue 
