### PR TITLE
spaCy 2.2.3 and required dependency updates

### DIFF
--- a/pkgs/development/python-modules/catalogue/default.nix
+++ b/pkgs/development/python-modules/catalogue/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, importlib-metadata
+}:
+
+buildPythonPackage rec {
+  pname = "catalogue";
+  version = "0.0.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0m7xp85fg57wi1l1vdsq2k0b8dv5bnfccds33lb04z9vrds4l3jv";
+  };
+
+  propagatedBuildInputs = [ importlib-metadata ];
+
+  meta = with stdenv.lib; {
+    description = "Tiny library for adding function or object registries";
+    homepage = "https://github.com/explosion/catalogue";
+    license = licenses.mit;
+    maintainers = with maintainers; [ danieldk ];
+    };
+}

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -21,16 +21,17 @@
 , blis
 , wasabi
 , srsly
+, catalogue
 , setuptools
 }:
 
 buildPythonPackage rec {
   pname = "spacy";
-  version = "2.2.2";
+  version = "2.2.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "193r7rrqxfj4jqzk4aqgbycficzmc606vkc4ffc46zs3myhlf6sa";
+    sha256 = "0shfjk6nhm6gzp5p88pz5k7bkg5dr3x9yvandkayqb2vsvkwj50x";
   };
 
   propagatedBuildInputs = [
@@ -51,6 +52,7 @@ buildPythonPackage rec {
    blis
    wasabi
    srsly
+   catalogue
    setuptools
   ] ++ lib.optional (pythonOlder "3.4") pathlib;
 

--- a/pkgs/development/python-modules/wasabi/default.nix
+++ b/pkgs/development/python-modules/wasabi/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "wasabi";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0f18x27qrr29rgxyiy1k9b469i37n80h0x9vd9i22pyg8wxx67q5";
+    sha256 = "0w2jkgrf0x58v8x90v4nifbwcb87pp613vp3sld1fk2avn80imnw";
   };
 
   checkInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -469,6 +469,8 @@ in {
 
   cachy = callPackage ../development/python-modules/cachy { };
 
+  catalogue = callPackage ../development/python-modules/catalogue { };
+
   cdecimal = callPackage ../development/python-modules/cdecimal { };
 
   cfn-flip = callPackage ../development/python-modules/cfn-flip { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changelog:

https://github.com/explosion/spaCy/releases/tag/v2.2.3

This update also requires a new derivation, `catalogue`, and a version bump to the `wasabi` derivation. These changes are bundled in this PR.

Tested using the small English model.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
