### PR TITLE
parity: 2.5.9 -> 2.5.10, parity-beta: 2.6.4 -> 2.6.5

### DIFF
--- a/pkgs/applications/blockchains/parity/beta.nix
+++ b/pkgs/applications/blockchains/parity/beta.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.6.4";
-  sha256      = "11l93w97961zig4gqf345j9l20g0mjp7fayl1mdwdp14hhd5zk5g";
-  cargoSha256 = "1q6cbms7j1h726bvq38npxkjkmz14b5ir9c4z7pb0jcy7gkplyxx";
+  version     = "2.6.5";
+  sha256      = "1ykrsphqil68051wwp9b0259gsmfrj9xmx0pfhh2yvmmjzv7k4fv";
+  cargoSha256 = "1xqmnirx2r91q5gy1skxl0f79xvaqzimq3l0cj4xvfms7mpdfbg1";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }

--- a/pkgs/applications/blockchains/parity/default.nix
+++ b/pkgs/applications/blockchains/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "2.5.9";
-  sha256      = "06gmfw5l8n5i35dimsmj6dn0fxhbp53zjrdvbkff63r5kfqnwnx2";
-  cargoSha256 = "1kdy0bnmyqx4rhpq0a8gliy6mws68n035kfkxrfa6cxr2cn53dyb";
+  version     = "2.5.10";
+  sha256      = "0s8llcb1xdzs2zb6rnbsa9hck7dj4m8mamzkkvr0xjmgvigskf64";
+  cargoSha256 = "16nf6y0hyffwdhxn1w4ms4zycs5lkzir8sj6c2lgsabig057hb6z";
 in
   import ./parity.nix { inherit version sha256 cargoSha256; }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update `parity` and `partiy-beta` to the latest releases.
- https://github.com/paritytech/parity-ethereum/releases/tag/v2.5.10
- https://github.com/paritytech/parity-ethereum/releases/tag/v2.6.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @akru 
