### PR TITLE
nginx-sso: 0.16.1 -> 0.22.0

### DIFF
--- a/pkgs/servers/nginx-sso/default.nix
+++ b/pkgs/servers/nginx-sso/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "nginx-sso";
-  version = "0.16.1";
+  version = "0.22.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/Luzifer/nginx-sso";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "Luzifer";
     repo = "nginx-sso";
-    sha256 = "100k5dxrwj5xa1yh79qmyv6jampijqjbr4vkn1d9avim352yhnk1";
+    sha256 = "1kcyb7sbqna18yw3myi3c0imhh4hsa0h2k2y0bqfr2pqsnssz54a";
   };
 
   postInstall = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
update nginx-sso

:warning: Note that I only tested that the binary ran (and I accessed it with a browser to see the login page). I don't use nginx-sso yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

❯ nix path-info -S /nix/store/jhl6867ax44dp8ijvzsw5s3gv5qiccjl-nginx-sso-0.16.1-bin
/nix/store/jhl6867ax44dp8ijvzsw5s3gv5qiccjl-nginx-sso-0.16.1-bin	   44707632

❯ nix path-info -S /nix/store/brcbzs0gq0k617q1q40c3ki1nxznccnr-nginx-sso-0.22.0-bin
/nix/store/brcbzs0gq0k617q1q40c3ki1nxznccnr-nginx-sso-0.22.0-bin	   51235376

###### Notify maintainers

cc @delroth
