### PR TITLE
netgen-mesher: init at version 6.2.2004

### DIFF
--- a/pkgs/applications/science/geometry/netgen-mesher/default.nix
+++ b/pkgs/applications/science/geometry/netgen-mesher/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, opencascade, fetchFromGitHub, cmake, python3, tcl, tk, libjpeg, zlib, mesa, libGLU, xorg, ffmpeg }:
+
+
+stdenv.mkDerivation rec {
+  pname = "netgen-mesher";
+
+  version = "6.2.2004";
+
+  src = fetchFromGitHub {
+    owner = "NGSolve";
+    repo = "netgen";
+    rev = "v${version}";
+    # pybind11 is a submodule
+    fetchSubmodules = true;
+    sha256 = "05s982z1s3rny20cafwbrr7n1z0ql7czq97zs75hgqwrbldfij5y";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ python3 tcl tk libjpeg ffmpeg zlib mesa libGLU xorg.libXmu opencascade ];
+
+  cmakeFlags = [
+    "-DUSE_JPEG=ON"
+    "-DUSE_MPEG=ON"
+    "-DUSE_OCC=ON"
+    "-DOCC_INCLUDE_DIR=${opencascade}/include/oce"
+  ];
+
+  meta = {
+    description = "An automatic 3d tetrahedral mesh generator";
+    homepage = "https://sourceforge.net/projects/netgen-mesher/";
+    license = stdenv.lib.licenses.lgpl21;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/science/geometry/netgen-mesher/default.nix
+++ b/pkgs/applications/science/geometry/netgen-mesher/default.nix
@@ -1,6 +1,5 @@
 { stdenv, opencascade, fetchFromGitHub, cmake, python3, tcl, tk, libjpeg, zlib, mesa, libGLU, xorg, ffmpeg }:
 
-
 stdenv.mkDerivation rec {
   pname = "netgen-mesher";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24240,6 +24240,8 @@ in
   tetgen = callPackage ../applications/science/geometry/tetgen { }; # AGPL3+
   tetgen_1_4 = callPackage ../applications/science/geometry/tetgen/1.4.nix { }; # MIT
 
+  netgen-mesher = callPackage ../applications/science/geometry/netgen-mesher { };
+
   ### SCIENCE/BENCHMARK
 
   papi = callPackage ../development/libraries/science/benchmark/papi { };


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Wanted to try myself at creating nix packages. Closes #49532

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

`meta.maintainers` is NOT set.
