### PR TITLE
nixosTests.mongodb: port to python

### DIFF
--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -1,6 +1,6 @@
 # This test start mongodb, runs a query using mongo shell
 
-import ./make-test.nix ({ pkgs, ...} : let
+import ./make-test-python.nix ({ pkgs, ...} : let
   testQuery = pkgs.writeScript "nixtest.js" ''
     db.greetings.insert({ "greeting": "hello" });
     print(db.greetings.findOne().greeting);
@@ -33,8 +33,10 @@ in {
     };
 
   testScript = ''
-    startAll;
-    $one->waitForUnit("mongodb.service");
-    $one->succeed("mongo -u nixtest -p nixtest nixtest ${testQuery}") =~ /hello/ or die;
+    start_all()
+    one.wait_for_unit("mongodb.service")
+    one.succeed(
+        "mongo -u nixtest -p nixtest nixtest ${testQuery} | grep -q hello"
+    )
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc
