### PR TITLE
[WIP] darwin: update bootstrap-tools to use llvm_9

### DIFF
--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -3,7 +3,7 @@
 with import pkgspath { inherit system; };
 
 let
-  llvmPackages = llvmPackages_7;
+  llvmPackages = llvmPackages_9;
 in rec {
   coreutils_ = coreutils.override (args: {
     # We want coreutils without ACL support.
@@ -82,6 +82,7 @@ in rec {
 
       cp -rL ${llvmPackages.clang-unwrapped}/lib/clang $out/lib
 
+      cp -d ${llvmPackages.libclang}/lib/libclang-cpp.dylib $out/lib
       cp -d ${llvmPackages.libcxx}/lib/libc++*.dylib $out/lib
       cp -d ${llvmPackages.libcxxabi}/lib/libc++abi*.dylib $out/lib
       cp -d ${llvmPackages.llvm.lib}/lib/libLLVM.dylib $out/lib


### PR DESCRIPTION
This is in preparation for a llvm 7 -> 9 update, bootstrapping fails with our current bootstrap-tools. But this means our bootstrap tarball test won't match the default version until this is complete. @copumpkin is this the most appropriate order of steps to get a tarball built by hydra that we can put in the tarballs bucket?

###### Things done

Used the tarball to bootstrap an llvm 9 based stdenv and a bunch of base packages like python, etc.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NixOS/darwin-maintainers 