### PR TITLE
boost170: Fix cmake files

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -71,6 +71,8 @@ let
     "link=${link}"
     "-sEXPAT_INCLUDE=${expat.dev}/include"
     "-sEXPAT_LIBPATH=${expat.out}/lib"
+  ] ++ optionals (versionAtLeast version "1.70") [
+    "--cmakedir=$dev/lib/cmake"
 
     # TODO: make this unconditional
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [


### PR DESCRIPTION
###### Motivation for this change
Fixes: #63104
The *-config.cmake files before this commit incorrectly assumed that
their location will be in $out/lib, thus leading to incorrect relative
paths.
I used the following derivation to test that the change really makes a difference. Before this commit this doesn't build. (Interestingly enough it already worked with boost171.)
```nix
{ stdenv, cmake, boost170, writeTextDir}:

stdenv.mkDerivation rec {
  pname = "boost-cmake-example";
  version = "0.0.1";
  src = writeTextDir "CMakeLists.txt" ''
    cmake_minimum_required(VERSION 3.15)
    project(example)
    find_package(Boost REQUIRED COMPONENTS filesystem system program_options thread date_time)
  '';
  nativeBuildInputs = [
    cmake
  ];
  installPhase = ''
    mkdir $out
    echo test >> $out/test
  '';
  buildInputs = [
    boost170
  ];
}
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
