### PR TITLE
klayout: init at 0.26.2

### DIFF
--- a/pkgs/applications/misc/klayout/default.nix
+++ b/pkgs/applications/misc/klayout/default.nix
@@ -1,0 +1,63 @@
+{ lib, mkDerivation, fetchFromGitHub, fetchpatch
+, python, ruby, qtbase, qtmultimedia, qttools, qtxmlpatterns
+, which, perl, makeWrapper, fixDarwinDylibNames
+}:
+
+mkDerivation rec {
+  pname = "klayout";
+  version = "0.26.2";
+
+  src = fetchFromGitHub {
+    owner = "KLayout";
+    repo = "klayout";
+    rev = "v${version}";
+    sha256 = "0svyqayvr45snqw0dhx6jpnjhg4qb097pz28s8k1crx5i31nnd94";
+  };
+
+  postPatch = ''
+    substituteInPlace src/klayout.pri --replace "-Wno-reserved-user-defined-literal" ""
+    patchShebangs .
+  '';
+
+  nativeBuildInputs = [
+    which
+  ];
+
+  buildInputs = [
+    python
+    ruby
+    qtbase
+    qtmultimedia
+    qttools
+    qtxmlpatterns
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    mkdir -p $out/lib
+    ./build.sh -qt5 -prefix $out/lib -j$NIX_BUILD_CORES
+    runHook postBuild
+  '';
+
+  postBuild = ''
+    mkdir $out/bin
+    mv $out/lib/klayout $out/bin/
+  '';
+
+  NIX_CFLAGS_COMPILE = [ "-Wno-parentheses" ];
+
+  dontInstall = true; # Installation already happens as part of "build.sh"
+
+  # Fix: "gsiDeclQMessageLogger.cc:126:42: error: format not a string literal
+  # and no format arguments [-Werror=format-security]"
+  hardeningDisable = [ "format" ];
+
+  meta = with lib; {
+    description = "High performance layout viewer and editor with support for GDS and OASIS";
+    license = with licenses; [ gpl3 ];
+    homepage = "https://www.klayout.de/";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ knedlsepp ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19601,6 +19601,8 @@ in
 
   kiwix = callPackage ../applications/misc/kiwix { };
 
+  klayout = libsForQt5.callPackage ../applications/misc/klayout { };
+
   kmplayer = libsForQt5.callPackage ../applications/video/kmplayer { };
 
   kmymoney = libsForQt5.callPackage ../applications/office/kmymoney {


### PR DESCRIPTION
###### Motivation for this change
This adds klayout, a viewer and editor for GDS and OASIS files.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

