### PR TITLE
lua wrapper: Fix bash error

### DIFF
--- a/pkgs/development/interpreters/lua-5/wrapper.nix
+++ b/pkgs/development/interpreters/lua-5/wrapper.nix
@@ -11,7 +11,7 @@
 let
   env = let
     paths =  requiredLuaModules (extraLibs ++ [ lua ] );
-  in buildEnv {
+  in (buildEnv {
     name = "${lua.name}-env";
 
     inherit paths;
@@ -20,12 +20,6 @@ let
 
     # we create wrapper for the binaries in the different packages
     postBuild = ''
-
-      . "${makeWrapper}/nix-support/setup-hook"
-
-      # get access to lua functions
-      . ${lua}/nix-support/setup-hook
-
       if [ -L "$out/bin" ]; then
           unlink "$out/bin"
       fi
@@ -68,5 +62,8 @@ let
         '';
     };
     };
-  };
+  }).overrideAttrs (_: {
+    # Add extra deps needed for postBuild hook.
+    nativeBuildInputs = [ makeWrapper lua ];
+  });
 in env


### PR DESCRIPTION
###### Motivation for this change

Recently, we made it harder for external code to use some stdenv-only bash
variables by unsetting them in https://github.com/NixOS/nixpkgs/blob/9d3911f806034197bb7ace586cc3696ffce7f447/pkgs/stdenv/generic/setup.sh#L574-L578 But Lua's `withPackages` was sourcing some
setup hooks in https://github.com/NixOS/nixpkgs/blob/9d3911f806034197bb7ace586cc3696ffce7f447/pkgs/development/interpreters/lua-5/wrapper.nix#L23-L27, which required those bash variables.

I say great! We caught something bad: Lua should use normal dependencies, even
though that is harder with `buildEnv`. Now it works that way, and everything is
fine.

CC @matthewbauer

Fixes #73887

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
