### PR TITLE
[r19.03] slurm: add patch addressing CVE-2019-12838

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libtool, curl
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, libtool, curl
 , python, munge, perl, pam, openssl, zlib
 , ncurses, mysql, gtk2, lua, hwloc, numactl
 , readline, freeipmi, libssh2, xorg, lz4
@@ -21,6 +21,21 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" ];
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-12838-prerequisite-1.patch";
+      url = "https://github.com/SchedMD/slurm/commit/e8567e06be57190825bff737e5523c307da51530.patch";
+      sha256 = "1sxllghnc8j5sh4md1lv3hdj3h3xag3ylqv3v00nhxfximgc74d6";
+      excludes = [ "NEWS" ];
+    })
+    (fetchpatch {
+      name = "CVE-2019-12838.patch";
+      url = "https://github.com/SchedMD/slurm/commit/afa7d743f407c60a7c8a4bd98a10be32c82988b5.patch";
+      sha256 = "017zskjr2yyphij61zws391znghmnh7r7zr21kjngqaixpjaark9";
+      excludes = [ "NEWS" ];
+    })
+  ];
 
   prePatch = stdenv.lib.optional enableX11 ''
     substituteInPlace src/common/x11_util.c \


### PR DESCRIPTION
##### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-12838

Including a prerequisite patch to allow the actual fix to apply cleanly.

19.09 and master are unaffected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
