### PR TITLE
git-series: use nixpkgs libssh2

### DIFF
--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchpatch, rustPlatform
-, openssl, cmake, perl, pkgconfig, zlib, curl, libgit2
+, openssl, cmake, perl, pkgconfig, zlib, curl, libgit2, libssh2
 }:
 
 with rustPlatform;
@@ -30,8 +30,9 @@ buildRustPackage rec {
   ];
 
   LIBGIT2_SYS_USE_PKG_CONFIG = true;
+  LIBSSH2_SYS_USE_PKG_CONFIG = true;
   nativeBuildInputs = [ cmake pkgconfig perl ];
-  buildInputs = [ openssl zlib curl libgit2 ];
+  buildInputs = [ openssl zlib curl libgit2 libssh2 ];
 
   postBuild = ''
     install -D "$src/git-series.1" "$out/man/man1/git-series.1"

--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, fetchpatch, rustPlatform, openssl, cmake, perl, pkgconfig, zlib, curl, libgit2 }:
+{ stdenv, fetchFromGitHub, fetchpatch, rustPlatform
+, openssl, cmake, perl, pkgconfig, zlib, curl, libgit2
+}:
 
 with rustPlatform;
 


### PR DESCRIPTION
###### Motivation for this change

This replaces the vendored copy from libssh2-sys.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).