### PR TITLE
iperf3: correct license to bsd3

### DIFF
--- a/pkgs/tools/networking/iperf/3.nix
+++ b/pkgs/tools/networking/iperf/3.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     homepage = http://software.es.net/iperf/;
     description = "Tool to measure IP bandwidth using UDP or TCP";
     platforms = platforms.unix;
-    license = "as-is";
+    license = licenses.bsd3;
     maintainers = with maintainers; [ fpletz ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Quoth http://software.es.net/iperf:
> [iperf3] is released under a three-clause BSD license.

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).