### PR TITLE
OCaml: fix configure flags for (optional) flambda and AFL support

### DIFF
--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -12,16 +12,18 @@ in
 
 { stdenv, fetchurl, ncurses, buildEnv
 , libX11, xorgproto, useX11 ? safeX11 stdenv
+, aflSupport ? false
 , flambdaSupport ? false
 }:
 
 assert useX11 -> !stdenv.isAarch32 && !stdenv.isMips;
+assert aflSupport -> stdenv.lib.versionAtLeast version "4.05";
 assert flambdaSupport -> stdenv.lib.versionAtLeast version "4.03";
 
 let
    useNativeCompilers = !stdenv.isMips;
    inherit (stdenv.lib) optional optionals optionalString;
-   name = "ocaml${optionalString flambdaSupport "+flambda"}-${version}";
+   name = "ocaml${optionalString aflSupport "+afl"}${optionalString flambdaSupport "+flambda"}-${version}";
 in
 
 let
@@ -49,6 +51,7 @@ stdenv.mkDerivation (args // {
     optionals useX11 (flags
       [ "--x-libraries=${x11lib}" "--x-includes=${x11inc}"]
       [ "-x11lib" x11lib "-x11include" x11inc ])
+  ++ optional aflSupport (flags "--with-afl" "-afl-instrument")
   ++ optional flambdaSupport (flags "--enable-flambda" "-flambda")
   ;
 

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -41,11 +41,15 @@ stdenv.mkDerivation (args // {
   };
 
   prefixKey = "-prefix ";
-  configureFlags = optionals useX11 (
-    if stdenv.lib.versionAtLeast version "4.08"
-    then [ "--x-libraries=${x11lib}" "--x-includes=${x11inc}"]
-    else [ "-x11lib" x11lib "-x11include" x11inc ])
-  ++ optional flambdaSupport "-flambda"
+  configureFlags =
+    let flags = new: old:
+      if stdenv.lib.versionAtLeast version "4.08"
+      then new else old
+    ; in
+    optionals useX11 (flags
+      [ "--x-libraries=${x11lib}" "--x-includes=${x11inc}"]
+      [ "-x11lib" x11lib "-x11include" x11inc ])
+  ++ optional flambdaSupport (flags "--enable-flambda" "-flambda")
   ;
 
   buildFlags = "world" + optionalString useNativeCompilers " bootstrap world.opt";


### PR DESCRIPTION
###### Motivation for this change

Current `flambdaSupport` option does not work with recent versions of OCaml.

It is also convenient to have an option to enable AFL support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

