### PR TITLE
emacspeak: init at 51.0

### DIFF
--- a/pkgs/applications/editors/emacs-modes/emacspeak/default.nix
+++ b/pkgs/applications/editors/emacs-modes/emacspeak/default.nix
@@ -18,11 +18,11 @@ stdenv.mkDerivation rec {
   '';
 
   postBuild = ''
-    make -C servers/native-espeak "TCL_INCLUDE=${tcl}/include" "LIBPARENTDIR=/"
+    make -C servers/native-espeak PREFIX=$out "TCL_INCLUDE=${tcl}/include"
   '';
 
   postInstall = ''
-    make -C servers/native-espeak DESTDIR=${placeholder "out"} install
+    make -C servers/native-espeak PREFIX=$out install
     local d=$out/share/emacs/site-lisp/emacspeak/
     install -d -- "$d"
     cp -a .  "$d"

--- a/pkgs/applications/editors/emacs-modes/emacspeak/default.nix
+++ b/pkgs/applications/editors/emacs-modes/emacspeak/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, makeWrapper, emacs, tcl, tclx, espeak-ng }:
+
+stdenv.mkDerivation rec {
+  pname = "emacspeak";
+  version = "51.0";
+
+
+  src = fetchurl {
+    url = "https://github.com/tvraman/emacspeak/releases/download/${version}/${pname}-${version}.tar.bz2";
+    sha256 = "09a0ywxlqa8jmc0wmvhaf7bdydnkyhy9nqfsdqcpbsgdzj6qpg90";
+  };
+
+  nativeBuildInputs = [ makeWrapper emacs ];
+  buildInputs = [ tcl tclx espeak-ng ];
+
+  preConfigure = ''
+    make config
+  '';
+
+  postBuild = ''
+    make -C servers/native-espeak "TCL_INCLUDE=${tcl}/include" "LIBPARENTDIR=/"
+  '';
+
+  postInstall = ''
+    make -C servers/native-espeak DESTDIR=${placeholder "out"} install
+    local d=$out/share/emacs/site-lisp/emacspeak/
+    install -d -- "$d"
+    cp -a .  "$d"
+    find "$d" \( -type d -or \( -type f -executable \) \) -execdir chmod 755 {} +
+    find "$d" -type f -not -executable -execdir chmod 644 {} +
+    makeWrapper ${emacs}/bin/emacs $out/bin/emacspeak \
+        --set DTK_PROGRAM "${espeak-ng}/bin/espeak" \
+        --add-flags '-l "${placeholder "out"}/share/emacs/site-lisp/emacspeak/lisp/emacspeak-setup.elc"'
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/tvraman/emacspeak/;
+    description = "Emacs extension that provides spoken output";
+    license = licenses.gpl2;
+    maintainers = [ dema ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -65,6 +65,8 @@
     };
   };
 
+  emacspeak = callPackage ./emacspeak {};
+
   ess-R-object-popup =
     callPackage ./ess-R-object-popup { };
 


### PR DESCRIPTION
Closes #70261

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Needs to be tested by users of emacspeak. There're a lot of irrelevant files in the sources like blog posts, speeches, radio playlists and so on. I copied what I think is needed to run it. But I don't know how to use emacspeak, so we need some real user to test if it works. 

###### Notify maintainers

I didn't set `meta.maintainers` field
