### PR TITLE
nixos/kerberos: port tests to python

### DIFF
--- a/nixos/tests/kerberos/heimdal.nix
+++ b/nixos/tests/kerberos/heimdal.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({pkgs, ...}: {
+import ../make-test-python.nix ({pkgs, ...}: {
   name = "kerberos_server-heimdal";
   machine = { config, libs, pkgs, ...}:
   { services.kerberos_server =
@@ -23,31 +23,20 @@ import ../make-test.nix ({pkgs, ...}: {
   };
 
   testScript = ''
-    $machine->start;
+    machine.succeed(
+        "kadmin -l init --realm-max-ticket-life='8 day' --realm-max-renewable-life='10 day' FOO.BAR",
+        "systemctl restart kadmind.service kdc.service",
+    )
 
-    $machine->succeed(
-      "kadmin -l init --realm-max-ticket-life='8 day' \\
-       --realm-max-renewable-life='10 day' FOO.BAR"
-    );
+    for unit in ["kadmind", "kdc", "kpasswdd"]:
+        machine.wait_for_unit(f"{unit}.service")
 
-    $machine->succeed("systemctl restart kadmind.service kdc.service");
-    $machine->waitForUnit("kadmind.service");
-    $machine->waitForUnit("kdc.service");
-    $machine->waitForUnit("kpasswdd.service");
-
-    $machine->succeed(
-      "kadmin -l add --password=admin_pw --use-defaults admin"
-    );
-    $machine->succeed(
-      "kadmin -l ext_keytab --keytab=admin.keytab admin"
-    );
-    $machine->succeed(
-      "kadmin -p admin -K admin.keytab add --password=alice_pw --use-defaults \\
-       alice"
-    );
-    $machine->succeed(
-      "kadmin -l ext_keytab --keytab=alice.keytab alice"
-    );
-    $machine->succeed("kinit -kt alice.keytab alice");
+    machine.succeed(
+        "kadmin -l add --password=admin_pw --use-defaults admin",
+        "kadmin -l ext_keytab --keytab=admin.keytab admin",
+        "kadmin -p admin -K admin.keytab add --password=alice_pw --use-defaults alice",
+        "kadmin -l ext_keytab --keytab=alice.keytab alice",
+        "kinit -kt alice.keytab alice",
+    )
   '';
 })

--- a/nixos/tests/kerberos/mit.nix
+++ b/nixos/tests/kerberos/mit.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({pkgs, ...}: {
+import ../make-test-python.nix ({pkgs, ...}: {
   name = "kerberos_server-mit";
   machine = { config, libs, pkgs, ...}:
   { services.kerberos_server =
@@ -24,22 +24,18 @@ import ../make-test.nix ({pkgs, ...}: {
   };
 
   testScript = ''
-    $machine->start;
+    machine.succeed(
+        "kdb5_util create -s -r FOO.BAR -P master_key",
+        "systemctl restart kadmind.service kdc.service",
+    )
 
-    $machine->succeed(
-      "kdb5_util create -s -r FOO.BAR -P master_key"
-    );
+    for unit in ["kadmind", "kdc"]:
+        machine.wait_for_unit(f"{unit}.service")
 
-    $machine->succeed("systemctl restart kadmind.service kdc.service");
-    $machine->waitForUnit("kadmind.service");
-    $machine->waitForUnit("kdc.service");
-
-    $machine->succeed(
-      "kadmin.local add_principal -pw admin_pw admin"
-    );
-    $machine->succeed(
-      "kadmin -p admin -w admin_pw addprinc -pw alice_pw alice"
-    );
-    $machine->succeed("echo alice_pw | sudo -u alice kinit");
+    machine.succeed(
+        "kadmin.local add_principal -pw admin_pw admin",
+        "kadmin -p admin -w admin_pw addprinc -pw alice_pw alice",
+        "echo alice_pw | sudo -u alice kinit",
+    )
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Port tests for #72828 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc 
