### PR TITLE
nixos/upower: Allow customization of UPower.conf

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -77,6 +77,12 @@
     be set if the hostname of the node should be non default.
     </para>
    </listitem>
+   <listitem>
+    <para>
+    UPower's configuration is now managed by NixOS and can be customized
+    via <option>services.upower</option>.
+    </para>
+   </listitem>
   </itemizedlist>
 
  </section>

--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -37,6 +37,172 @@ in
         '';
       };
 
+      enableWattsUpPro = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable the Watts Up Pro device.
+
+          The Watts Up Pro contains a generic FTDI USB device without a specific
+          vendor and product ID. When we probe for WUP devices, we can cause
+          the user to get a perplexing "Device or resource busy" error when
+          attempting to use their non-WUP device.
+
+          The generic FTDI device is known to also be used on:
+
+          <itemizedlist>
+            <listitem><para>Sparkfun FT232 breakout board</para></listitem>
+            <listitem><para>Parallax Propeller</para></listitem>
+          </itemizedlist>
+        '';
+      };
+
+      noPollBatteries = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Don't poll the kernel for battery level changes.
+
+          Some hardware will send us battery level changes through
+          events, rather than us having to poll for it. This option
+          allows disabling polling for hardware that sends out events.
+        '';
+      };
+
+      ignoreLid = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Do we ignore the lid state
+
+          Some laptops are broken. The lid state is either inverted, or stuck
+          on or off. We can't do much to fix these problems, but this is a way
+          for users to make the laptop panel vanish, a state that might be used
+          by a couple of user-space daemons. On Linux systems, see also
+          logind.conf(5).
+        '';
+      };
+
+      usePercentageForPolicy = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Policy for warnings and action based on battery levels
+
+          Whether battery percentage based policy should be used. The default
+          is to use the percentage, which
+          should work around broken firmwares. It is also more reliable than
+          the time left (frantically saving all your files is going to use more
+          battery than letting it rest for example).
+        '';
+      };
+
+      percentageLow = mkOption {
+        type = types.ints.unsigned;
+        default = 10;
+        description = ''
+          When <literal>usePercentageForPolicy</literal> is
+          <literal>true</literal>, the levels at which UPower will consider the
+          battery low.
+
+          This will also be used for batteries which don't have time information
+          such as that of peripherals.
+
+          If any value (of <literal>percentageLow</literal>,
+          <literal>percentageCritical</literal> and
+          <literal>percentageAction</literal>) is invalid, or not in descending
+          order, the defaults will be used.
+        '';
+      };
+
+      percentageCritical = mkOption {
+        type = types.ints.unsigned;
+        default = 3;
+        description = ''
+          When <literal>usePercentageForPolicy</literal> is
+          <literal>true</literal>, the levels at which UPower will consider the
+          battery critical.
+
+          This will also be used for batteries which don't have time information
+          such as that of peripherals.
+
+          If any value (of <literal>percentageLow</literal>,
+          <literal>percentageCritical</literal> and
+          <literal>percentageAction</literal>) is invalid, or not in descending
+          order, the defaults will be used.
+        '';
+      };
+
+      percentageAction = mkOption {
+        type = types.ints.unsigned;
+        default = 2;
+        description = ''
+          When <literal>usePercentageForPolicy</literal> is
+          <literal>true</literal>, the levels at which UPower will take action
+          for the critical battery level.
+
+          This will also be used for batteries which don't have time information
+          such as that of peripherals.
+
+          If any value (of <literal>percentageLow</literal>,
+          <literal>percentageCritical</literal> and
+          <literal>percentageAction</literal>) is invalid, or not in descending
+          order, the defaults will be used.
+        '';
+      };
+
+      timeLow = mkOption {
+        type = types.ints.unsigned;
+        default = 1200;
+        description = ''
+          When <literal>usePercentageForPolicy</literal> is
+          <literal>false</literal>, the time remaining at which UPower will
+          consider the battery low.
+
+          If any value (of <literal>timeLow</literal>,
+          <literal>timeCritical</literal> and <literal>timeAction</literal>) is
+          invalid, or not in descending order, the defaults will be used.
+        '';
+      };
+
+      timeCritical = mkOption {
+        type = types.ints.unsigned;
+        default = 300;
+        description = ''
+          When <literal>usePercentageForPolicy</literal> is
+          <literal>false</literal>, the time remaining at which UPower will
+          consider the battery critical.
+
+          If any value (of <literal>timeLow</literal>,
+          <literal>timeCritical</literal> and <literal>timeAction</literal>) is
+          invalid, or not in descending order, the defaults will be used.
+        '';
+      };
+
+      timeAction = mkOption {
+        type = types.ints.unsigned;
+        default = 120;
+        description = ''
+          When <literal>usePercentageForPolicy</literal> is
+          <literal>false</literal>, the time remaining at which UPower will
+          take action for the critical battery level.
+
+          If any value (of <literal>timeLow</literal>,
+          <literal>timeCritical</literal> and <literal>timeAction</literal>) is
+          invalid, or not in descending order, the defaults will be used.
+        '';
+      };
+
+      criticalPowerAction = mkOption {
+        type = types.enum [ "PowerOff" "Hibernate" "HybridSleep" ];
+        default = "HybridSleep";
+        description = ''
+          The action to take when <literal>timeAction</literal> or
+          <literal>percentageAction</literal> has been reached for the batteries
+          (UPS or laptop batteries) supplying the computer
+        '';
+      };
+
     };
 
   };
@@ -54,6 +220,24 @@ in
 
     systemd.packages = [ cfg.package ];
 
+    systemd.services.upower.environment.UPOWER_CONF_FILE_NAME = pkgs.writeTextFile {
+      name = "UPower.conf";
+      text = generators.toINI {} {
+        UPower = {
+          EnableWattsUpPro = cfg.enableWattsUpPro;
+          NoPollBatteries = cfg.noPollBatteries;
+          IgnoreLid = cfg.ignoreLid;
+          UsePercentageForPolicy = cfg.usePercentageForPolicy;
+          PercentageLow = cfg.percentageLow;
+          PercentageCritical = cfg.percentageCritical;
+          PercentageAction = cfg.percentageAction;
+          TimeLow = cfg.timeLow;
+          TimeCritical = cfg.timeCritical;
+          TimeAction = cfg.timeAction;
+          CriticalPowerAction = cfg.criticalPowerAction;
+        };
+      };
+    };
   };
 
 }

--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -220,22 +220,19 @@ in
 
     systemd.packages = [ cfg.package ];
 
-    systemd.services.upower.environment.UPOWER_CONF_FILE_NAME = pkgs.writeTextFile {
-      name = "UPower.conf";
-      text = generators.toINI {} {
-        UPower = {
-          EnableWattsUpPro = cfg.enableWattsUpPro;
-          NoPollBatteries = cfg.noPollBatteries;
-          IgnoreLid = cfg.ignoreLid;
-          UsePercentageForPolicy = cfg.usePercentageForPolicy;
-          PercentageLow = cfg.percentageLow;
-          PercentageCritical = cfg.percentageCritical;
-          PercentageAction = cfg.percentageAction;
-          TimeLow = cfg.timeLow;
-          TimeCritical = cfg.timeCritical;
-          TimeAction = cfg.timeAction;
-          CriticalPowerAction = cfg.criticalPowerAction;
-        };
+    environment.etc."UPower/UPower.conf".text = generators.toINI {} {
+      UPower = {
+        EnableWattsUpPro = cfg.enableWattsUpPro;
+        NoPollBatteries = cfg.noPollBatteries;
+        IgnoreLid = cfg.ignoreLid;
+        UsePercentageForPolicy = cfg.usePercentageForPolicy;
+        PercentageLow = cfg.percentageLow;
+        PercentageCritical = cfg.percentageCritical;
+        PercentageAction = cfg.percentageAction;
+        TimeLow = cfg.timeLow;
+        TimeCritical = cfg.timeCritical;
+        TimeAction = cfg.timeAction;
+        CriticalPowerAction = cfg.criticalPowerAction;
       };
     };
   };

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -52,12 +52,14 @@ stdenv.mkDerivation {
     "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
     "--with-systemdutildir=${placeholder "out"}/lib/systemd"
     "--with-udevrulesdir=${placeholder "out"}/lib/udev/rules.d"
+    "--sysconfdir=/etc"
   ];
 
   doCheck = false; # fails with "env: './linux/integration-test': No such file or directory"
 
   installFlags = [
     "historydir=$(TMPDIR)/foo"
+    "sysconfdir=${placeholder "out"}/etc"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Documentation of options and default values taken from the upstream
UPower.conf. The documentation was modified slightly to make more sense
when displayed on https://nixos.org/nixos/options.html.

A copy of upstream UPower.conf can be found here:
https://cgit.freedesktop.org/upower/tree/etc/UPower.conf?id=28bd86c181e2510ef6a1dc7cfa26f97803698a79

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

On my laptop, the battery jumps from 20% straight down to 0%, not giving it enough time to hibernate under the default settings.

#25815

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested this on my laptop running NixOS 19.09 by cherry-picking the commit onto the release branch and adding this to my config:

```
  services.upower.percentageLow = 35;
  services.upower.percentageCritical = 30;
  services.upower.percentageAction = 25;
```

###### Notify maintainers

cc @mmahut @worldofpeace
