### PR TITLE
tightvnc: add patches for CVE-2019-8287, CVE-2019-15678, CVE-2019-15679 & CVE-2019-15680

### DIFF
--- a/pkgs/tools/admin/tightvnc/1.3.10-CVE-2019-15678.patch
+++ b/pkgs/tools/admin/tightvnc/1.3.10-CVE-2019-15678.patch
@@ -1,0 +1,18 @@
+Adapted from https://github.com/LibVNC/libvncserver/commit/c5ba3fee85a7ecbbca1df5ffd46d32b92757bc2a
+diff --git a/vncviewer/rfbproto.c b/vncviewer/rfbproto.c
+index 04b0230..47a6863 100644
+--- a/vncviewer/rfbproto.c
++++ b/vncviewer/rfbproto.c
+@@ -1217,6 +1217,12 @@ HandleRFBServerMessage()
+     if (serverCutText)
+       free(serverCutText);
+ 
++    if (msg.sct.length > 1<<20) {
++      fprintf(stderr,"Ignoring too big cut text length sent by server: %u B > 1 MB\n",
++              (unsigned int)msg.sct.length);
++      return False;
++    }
++
+     serverCutText = malloc(msg.sct.length+1);
+ 
+     if (!ReadFromRFBServer(serverCutText, msg.sct.length))

--- a/pkgs/tools/admin/tightvnc/1.3.10-CVE-2019-15679.patch
+++ b/pkgs/tools/admin/tightvnc/1.3.10-CVE-2019-15679.patch
@@ -1,0 +1,19 @@
+Adapted from https://github.com/LibVNC/libvncserver/commit/c2c4b81e6cb3b485fb1ec7ba9e7defeb889f6ba7
+diff --git a/vncviewer/rfbproto.c b/vncviewer/rfbproto.c
+index 04b0230..bd11b54 100644
+--- a/vncviewer/rfbproto.c
++++ b/vncviewer/rfbproto.c
+@@ -303,7 +303,12 @@ InitialiseRFBConnection(void)
+   si.format.blueMax = Swap16IfLE(si.format.blueMax);
+   si.nameLength = Swap32IfLE(si.nameLength);
+ 
+-  /* FIXME: Check arguments to malloc() calls. */
++  if (si.nameLength > 1<<20) {
++    fprintf(stderr, "Too big desktop name length sent by server: %lu B > 1 MB\n",
++            (unsigned long)si.nameLength);
++    return False;
++  }
++
+   desktopName = malloc(si.nameLength + 1);
+   if (!desktopName) {
+     fprintf(stderr, "Error allocating memory for desktop name, %lu bytes\n",

--- a/pkgs/tools/admin/tightvnc/1.3.10-CVE-2019-15680.patch
+++ b/pkgs/tools/admin/tightvnc/1.3.10-CVE-2019-15680.patch
@@ -1,0 +1,16 @@
+diff --git a/vncviewer/zlib.c b/vncviewer/zlib.c
+index 80c4eee..76998d8 100644
+--- a/vncviewer/zlib.c
++++ b/vncviewer/zlib.c
+@@ -55,6 +55,11 @@ HandleZlibBPP (int rx, int ry, int rw, int rh)
+     raw_buffer_size = (( rw * rh ) * ( BPP / 8 ));
+     raw_buffer = (char*) malloc( raw_buffer_size );
+ 
++    if ( raw_buffer == NULL ) {
++      fprintf(stderr,
++              "couldn't allocate raw_buffer in HandleZlibBPP");
++      return False;
++    }
+   }
+ 
+   if (!ReadFromRFBServer((char *)&hdr, sz_rfbZlibHeader))

--- a/pkgs/tools/admin/tightvnc/1.3.10-CVE-2019-8287.patch
+++ b/pkgs/tools/admin/tightvnc/1.3.10-CVE-2019-8287.patch
@@ -1,0 +1,14 @@
+Adapted from https://github.com/LibVNC/libvncserver/commit/7b1ef0ffc4815cab9a96c7278394152bdc89dc4d
+diff --git a/vncviewer/corre.c b/vncviewer/corre.c
+index c846a10..a4c272d 100644
+--- a/vncviewer/corre.c
++++ b/vncviewer/corre.c
+@@ -56,7 +56,7 @@ HandleCoRREBPP (int rx, int ry, int rw, int rh)
+     XChangeGC(dpy, gc, GCForeground, &gcv);
+     XFillRectangle(dpy, desktopWin, gc, rx, ry, rw, rh);
+ 
+-    if (!ReadFromRFBServer(buffer, hdr.nSubrects * (4 + (BPP / 8))))
++    if (hdr.nSubrects > BUFFER_SIZE / (4 + (BPP / 8)) || !ReadFromRFBServer(buffer, hdr.nSubrects * (4 + (BPP / 8))))
+ 	return False;
+ 
+     ptr = (CARD8 *)buffer;

--- a/pkgs/tools/admin/tightvnc/default.nix
+++ b/pkgs/tools/admin/tightvnc/default.nix
@@ -9,6 +9,13 @@ stdenv.mkDerivation {
     sha256 = "f48c70fea08d03744ae18df6b1499976362f16934eda3275cead87baad585c0d";
   };
 
+  patches = [
+    ./1.3.10-CVE-2019-15678.patch
+    ./1.3.10-CVE-2019-15679.patch
+    ./1.3.10-CVE-2019-15680.patch
+    ./1.3.10-CVE-2019-8287.patch
+  ];
+
   # for the builder script
   inherit fontDirectories;
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-8287
https://nvd.nist.gov/vuln/detail/CVE-2019-15678
https://nvd.nist.gov/vuln/detail/CVE-2019-15679
https://nvd.nist.gov/vuln/detail/CVE-2019-15680

These had to be adapted from patches fixing similar issues in the actively maintained libvnc @ https://github.com/LibVNC/libvncserver
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
