### PR TITLE
qtpass: 1.3.2 cherry-pick to 19.09

### DIFF
--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -5,13 +5,13 @@
 
 mkDerivation rec {
   pname = "qtpass";
-  version = "1.3.1";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner  = "IJHack";
     repo   = "QtPass";
     rev    = "v${version}";
-    sha256 = "025sdk4fq71jgfs54zj7ssgvlci8vvjkqdckgbwz0nqrynlljy08";
+    sha256 = "0748hjvhjrybi33ci3c8hcr74k9pdrf5jv8npf9hrsrmdyy1kr9x";
   };
 
   buildInputs = [ git gnupg pass qtbase qtsvg ];

--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, mkDerivation, fetchFromGitHub
+{ lib, mkDerivation, fetchFromGitHub
 , git, gnupg, pass, qtbase, qtsvg, qttools, qmake
 }:
 
@@ -13,11 +13,16 @@ mkDerivation rec {
     sha256 = "025sdk4fq71jgfs54zj7ssgvlci8vvjkqdckgbwz0nqrynlljy08";
   };
 
-  buildInputs = [ git gnupg pass qtbase qtsvg qttools ];
+  buildInputs = [ git gnupg pass qtbase qtsvg ];
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ qmake qttools ];
 
   enableParallelBuilding = true;
+
+  qmakeFlags = [
+    # setup hook only sets QMAKE_LRELEASE, set QMAKE_LUPDATE too:
+    "QMAKE_LUPDATE=${qttools.dev}/bin/lupdate"
+  ];
 
   qtWrapperArgs = [
     "--suffix PATH : ${lib.makeBinPath [ git gnupg pass ]}"
@@ -28,7 +33,7 @@ mkDerivation rec {
     install -D artwork/icon.svg $out/share/icons/hicolor/scalable/apps/qtpass-icon.svg
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A multi-platform GUI for pass, the standard unix password manager";
     homepage = https://qtpass.org;
     license = licenses.gpl3;

--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -1,5 +1,6 @@
 { lib, mkDerivation, fetchFromGitHub
-, git, gnupg, pass, qtbase, qtsvg, qttools, qmake
+, git, gnupg, pass, pwgen
+, qtbase, qtsvg, qttools, qmake
 }:
 
 mkDerivation rec {
@@ -25,7 +26,7 @@ mkDerivation rec {
   ];
 
   qtWrapperArgs = [
-    "--suffix PATH : ${lib.makeBinPath [ git gnupg pass ]}"
+    "--suffix PATH : ${lib.makeBinPath [ git gnupg pass pwgen ]}"
   ];
 
   postInstall = ''

--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -29,8 +29,9 @@ mkDerivation rec {
   ];
 
   postInstall = ''
-    install -D qtpass.desktop $out/share/applications/qtpass.desktop
+    install -D qtpass.desktop -t $out/share/applications
     install -D artwork/icon.svg $out/share/icons/hicolor/scalable/apps/qtpass-icon.svg
+    install -D qtpass.1 -t $out/share/man/man1
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -1,30 +1,21 @@
-{ stdenv, lib, mkDerivation, fetchFromGitHub, fetchpatch
+{ stdenv, lib, mkDerivation, fetchFromGitHub
 , git, gnupg, pass, qtbase, qtsvg, qttools, qmake
 }:
 
 mkDerivation rec {
   pname = "qtpass";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner  = "IJHack";
     repo   = "QtPass";
     rev    = "v${version}";
-    sha256 = "0v3ca4fdjk6l24vc9wlc0i7r6fdj85kjmnb7jvicd3f8xi9mvhnv";
+    sha256 = "025sdk4fq71jgfs54zj7ssgvlci8vvjkqdckgbwz0nqrynlljy08";
   };
 
   buildInputs = [ git gnupg pass qtbase qtsvg qttools ];
 
   nativeBuildInputs = [ qmake ];
-
-  # Fix missing app icon on Wayland. Has been upstreamed and should be safe to
-  # remove in versions > 1.3.0
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/IJHack/QtPass/commit/aba8c4180f0ab3d66c44f88b21f137b19d17bde8.patch";
-      sha256 = "009bcq0d75khmaligzd7736xdzy6a8s1m9dgqybn70h801h92fcr";
-    })
-  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Cherry-pick recent `master` changes for `qtpass` on 19.09.

Without these (the upgrade to 1.3.2), `qtpass` segfaults at startup if no pass database exists, making it unusable for new installs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @hrdinka

FYI @dtzWill 
