### PR TITLE
ocamlPackages.cpuid: 0.1.0 → 0.1.2

### DIFF
--- a/pkgs/development/ocaml-modules/cpuid/default.nix
+++ b/pkgs/development/ocaml-modules/cpuid/default.nix
@@ -1,22 +1,20 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, ocb-stubblr }:
+{ lib, fetchurl, buildDunePackage }:
 
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-cpuid-0.1.0";
+buildDunePackage rec {
+  pname = "cpuid";
+  version = "0.1.2";
+
+  minimumOCamlVersion = "4.03";
 
   src = fetchurl {
-    url = https://github.com/pqwy/cpuid/releases/download/v0.1.0/cpuid-0.1.0.tbz;
-    sha256 = "08k2558a3dnxn8msgpz8c93sfn0y027ganfdi2yvql0fp1ixv97p";
+    url = "https://github.com/pqwy/cpuid/releases/download/v${version}/cpuid-v${version}.tbz";
+    sha256 = "08ng4mva6qblb5ipkrxbr0my7ndkc4qwcbswkqgbgir864s74m93";
   };
-
-  buildInputs = [ ocaml findlib ocamlbuild topkg ocb-stubblr ];
-
-  inherit (topkg) buildPhase installPhase;
 
   meta = {
     homepage = https://github.com/pqwy/cpuid;
     description = "Detect CPU features from OCaml";
-    license = stdenv.lib.licenses.isc;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Minor update: https://github.com/pqwy/cpuid/blob/master/CHANGES.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
