### PR TITLE
apple_sdk: broken link update

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -12,8 +12,8 @@ let
     #  3. ???
     #  4. Profit
     src = fetchurl {
-      url    = "http://swcdn.apple.com/content/downloads/28/09/091-29862/pafhn2u002b9slnrxzy9p86rpedycnjhb5/DevSDK_OSX1012.pkg";
-      sha256 = "1sggc70rypqwcjwr7ciavw8sczwll16cwqxdxrbw7r2qvy3b0nhx";
+      url    = "http://swcdn.apple.com/content/downloads/33/36/041-90419-A_7JJ4H9ZHO2/xs88ob5wjz6riz7g6764twblnvksusg4ps/DevSDK_OSX1012.pkg";
+      sha256 = "13xq34sb7383b37hwy076gnhf96prpk1b4087p87xnwswxbrisih";
     };
 
     buildInputs = [ xar cpio python pbzx ];


### PR DESCRIPTION
###### Motivation for this change

Apple DevSDK for OS X Sierra(10.12) became unavailable recently, so trying to build apple_sdk leads to this:
```
% nix build nixpkgs.darwin.apple_sdk
builder for '/nix/store/k08c0q6vmv8swrkibqap961bkysfg7g8-DevSDK_OSX1012.pkg.drv' failed with exit code 1; last 7 log lines:

  trying http://swcdn.apple.com/content/downloads/28/09/091-29862/pafhn2u002b9slnrxzy9p86rpedycnjhb5/DevSDK_OSX1012.pkg
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  curl: (22) The requested URL returned error: 404 Not Found
  error: cannot download DevSDK_OSX1012.pkg from any mirror
cannot build derivation '/nix/store/s0advspxkj2nmpw9valj66vxx1cfjh1p-MacOS_SDK-10.12.drv': 1 dependencies couldn't be built
[0 built (1 failed)]
error: build of '/nix/store/s0advspxkj2nmpw9valj66vxx1cfjh1p-MacOS_SDK-10.12.drv' failed
```

###### Things done

DevSDK link updated to the one still available. I'm leaving https://github.com/NixOS/nixpkgs/pull/73744 as a discussion for a possible DevSDK update.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NixOS/darwin-maintainers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/73984)
<!-- Reviewable:end -->
