### PR TITLE
zola: fix build on macOS

### DIFF
--- a/pkgs/applications/misc/zola/cargo-lock.patch
+++ b/pkgs/applications/misc/zola/cargo-lock.patch
@@ -1,0 +1,28 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index df5fef3..80f071a 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2158,12 +2158,12 @@ version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+- "sass-sys 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
++ "sass-sys 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "sass-sys"
+-version = "0.4.13"
++version = "0.4.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -3410,7 +3410,7 @@ dependencies = [
+ "checksum safemem 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b08423011dae9a5ca23f07cf57dac3857f5c885d352b76f6d95f4aea9434d0"
+ "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
+ "checksum sass-rs 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cabcf7c6e55053f359911187ac401409aad2dc14338cae972dec266fee486abd"
+-"checksum sass-sys 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6e16ac97c2335bc367e2d675f54c1823558f1b19a6c67671d48b70e30ae22972"
++"checksum sass-sys 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "304b6f9501d1da13f17404aeee85486d7383d06074906669b3ea032f81e83d22"
+ "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
+ "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
+ "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"

--- a/pkgs/applications/misc/zola/default.nix
+++ b/pkgs/applications/misc/zola/default.nix
@@ -8,10 +8,11 @@ rustPlatform.buildRustPackage rec {
     owner = "getzola";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0dbj2rkn4k5glnwdazsvjhah5pj9cbdb8hwlvm5q4njsmrgpyaw5";
+    sha256 = "13kbgxh7r6124d1fjdf0x599j1kpgixp1y9d299zb5vrd6rf5wy5";
   };
+  cargoPatches = [ ./cargo-lock.patch ];
 
-  cargoSha256 = "0i0xqbpbv3md42d2853cfzkhfwlkvxahhz5dldla5x96rm1i2hr8";
+  cargoSha256 = "03rwf5l1l3ap03qi0xqcxsbyvpg3cqmr50j8ql6c5v55xl0ki9w8";
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ openssl ]


### PR DESCRIPTION
###### Motivation for this change
Patches lockfile to update sass-sys to a version which includes
compass-rs/sass-rs#60

Fixes #72972

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dywedir
