### PR TITLE
python3Packages.arviz: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, emcee
+, matplotlib
+, netcdf4
+, numba
+, numpy
+, pandas
+, pytest
+, scipy
+, setuptools
+, tensorflow-probability
+, xarray
+#, h5py (used by disabled tests)
+#, pymc3 (broken)
+#, pyro-ppl (broken)
+#, pystan (not packaged)
+#, numpyro (not packaged)
+}:
+
+buildPythonPackage rec {
+  pname = "arviz";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "arviz-devs";
+    repo = "arviz";
+    rev = version;
+    sha256 = "0p600cakix24wz2ridnzy6sp3l1p2kr5s60qc7s82wpv7fw0i9ry";
+  };
+
+  propagatedBuildInputs = [
+    # needed to install
+    matplotlib
+    netcdf4
+    pandas
+    xarray
+    # needed to import
+    setuptools
+    # not needed to import, but used by many functions
+    # and is listed as a dependency in the documentation
+    numpy
+    scipy
+  ];
+
+  checkInputs = [
+    emcee
+    numba
+    pytest
+    tensorflow-probability
+    #h5py (used by disabled tests)
+    #pymc3 (broken)
+    #pyro-ppl (broken)
+    #pystan (not packaged)
+    #numpyro (not packaged)
+  ];
+
+  # check requires pymc3 and pyro-ppl, which are currently broken, and pystan
+  # and numpyro, which are not yet packaged, some checks also need to make
+  # directories and do not have permission to do so. So we can only check part
+  # of the package
+  # Additionally, there are some failures with the plots test, which revolve
+  # around attempting to output .mp4 files through an interface that only wants
+  # to output .html files.
+  # The following test have been disabled as a result: data_cmdstanpy,
+  # data_numpyro, data_pyro, data_pystan, and plots.
+  checkPhase = ''
+    cd arviz/tests/
+    HOME=$TMPDIR pytest test_{data_cmdstan,data_emcee,data,data_tfp,\
+    diagnostics,plot_utils,rcparams,stats,stats_utils,utils}.py
+  '';
+
+  meta = with lib; {
+    description = "ArviZ is a Python package for exploratory analysis of Bayesian models.";
+    homepage = https://github.com/arviz-devs/arviz;
+    license = licenses.asl20;
+    maintainers = [ maintainers.omnipotententity ];
+  };
+}

--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -72,8 +72,8 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "ArviZ is a Python package for exploratory analysis of Bayesian models.";
-    homepage = https://github.com/arviz-devs/arviz;
+    description = "ArviZ is a Python package for exploratory analysis of Bayesian models";
+    homepage = "https://arviz-devs.github.io/arviz/";
     license = licenses.asl20;
     maintainers = [ maintainers.omnipotententity ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -180,6 +180,8 @@ in {
   aresponses = callPackage ../development/python-modules/aresponses { };
 
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
+  
+  arviz = callPackage ../development/python-modules/arviz { };
 
   asana = callPackage ../development/python-modules/asana { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Introduce the python package arviz, which is a module for helping visualize Bayesian distributions.  Particularly useful in Bayesian Neural Network analysis.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
