### PR TITLE
nixosTests.systemd-nspawn: convert test to python

### DIFF
--- a/nixos/tests/systemd-nspawn.nix
+++ b/nixos/tests/systemd-nspawn.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({pkgs, lib, ...}:
+import ./make-test-python.nix ({pkgs, lib, ...}:
 let
   gpgKeyring = (pkgs.runCommand "gpg-keyring" { buildInputs = [ pkgs.gnupg ]; } ''
     mkdir -p $out
@@ -32,7 +32,7 @@ let
     gpg --batch --sign --detach-sign --output SHA256SUMS.gpg SHA256SUMS
   '');
 in {
-  name = "opensmtpd";
+  name = "systemd-nspawn";
 
   nodes = {
     server = { pkgs, ... }: {
@@ -48,11 +48,13 @@ in {
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $server->waitForUnit("nginx.service");
-    $client->waitForUnit("network-online.target");
-    $client->succeed("machinectl pull-raw --verify=signature http://server/testimage.raw");
-    $client->succeed("cmp /var/lib/machines/testimage.raw ${nspawnImages}/testimage.raw");
+    server.wait_for_unit("nginx.service")
+    client.wait_for_unit("network-online.target")
+    client.succeed("machinectl pull-raw --verify=signature http://server/testimage.raw")
+    client.succeed(
+        "cmp /var/lib/machines/testimage.raw ${nspawnImages}/testimage.raw"
+    )
   '';
 })


### PR DESCRIPTION
also fix a wrong test name ;-)
###### Motivation for this change
#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc
