### PR TITLE
nixosTests.mysql*: port to python

### DIFF
--- a/nixos/tests/mysql-backup.nix
+++ b/nixos/tests/mysql-backup.nix
@@ -1,5 +1,5 @@
 # Test whether mysqlBackup option works
-import ./make-test.nix ({ pkgs, ... } : {
+import ./make-test-python.nix ({ pkgs, ... } : {
   name = "mysql-backup";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ rvl ];
@@ -20,31 +20,37 @@ import ./make-test.nix ({ pkgs, ... } : {
     };
   };
 
-  testScript =
-    '' startAll;
+  testScript = ''
+    start_all()
 
-       # Delete backup file that may be left over from a previous test run.
-       # This is not needed on Hydra but useful for repeated local test runs.
-       $master->execute("rm -f /var/backup/mysql/testdb.gz");
+    # Delete backup file that may be left over from a previous test run.
+    # This is not needed on Hydra but useful for repeated local test runs.
+    master.execute("rm -f /var/backup/mysql/testdb.gz")
 
-       # Need to have mysql started so that it can be populated with data.
-       $master->waitForUnit("mysql.service");
+    # Need to have mysql started so that it can be populated with data.
+    master.wait_for_unit("mysql.service")
 
-       # Wait for testdb to be fully populated (5 rows).
-       $master->waitUntilSucceeds("mysql -u root -D testdb -N -B -e 'select count(id) from tests' | grep -q 5");
+    # Wait for testdb to be fully populated (5 rows).
+    master.wait_until_succeeds(
+        "mysql -u root -D testdb -N -B -e 'select count(id) from tests' | grep -q 5"
+    )
 
-       # Do a backup and wait for it to start
-       $master->startJob("mysql-backup.service");
-       $master->waitForJob("mysql-backup.service");
+    # Do a backup and wait for it to start
+    master.start_job("mysql-backup.service")
+    master.wait_for_unit("mysql-backup.service")
 
-       # wait for backup to fail, because of database 'doesnotexist'
-       $master->waitUntilFails("systemctl is-active -q mysql-backup.service");
+    # wait for backup to fail, because of database 'doesnotexist'
+    master.wait_until_fails("systemctl is-active -q mysql-backup.service")
 
-       # wait for backup file and check that data appears in backup
-       $master->waitForFile("/var/backup/mysql/testdb.gz");
-       $master->succeed("${pkgs.gzip}/bin/zcat /var/backup/mysql/testdb.gz | grep hello");
+    # wait for backup file and check that data appears in backup
+    master.wait_for_file("/var/backup/mysql/testdb.gz")
+    master.succeed(
+        "${pkgs.gzip}/bin/zcat /var/backup/mysql/testdb.gz | grep hello"
+    )
 
-       # Check that a failed backup is logged
-       $master->succeed("journalctl -u mysql-backup.service | grep 'fail.*doesnotexist' > /dev/null");
-    '';
+    # Check that a failed backup is logged
+    master.succeed(
+        "journalctl -u mysql-backup.service | grep 'fail.*doesnotexist' > /dev/null"
+    )
+  '';
 })

--- a/nixos/tests/mysql.nix
+++ b/nixos/tests/mysql.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "mysql";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco shlevy ];
@@ -47,17 +47,23 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   testScript = ''
-    startAll;
+    start_all
 
-    $mysql->waitForUnit("mysql");
-    $mysql->succeed("echo 'use empty_testdb;' | mysql -u root");
-    $mysql->succeed("echo 'use testdb; select * from tests;' | mysql -u root -N | grep 4");
+    mysql.wait_for_unit("mysql")
+    mysql.succeed("echo 'use empty_testdb;' | mysql -u root")
+    mysql.succeed("echo 'use testdb; select * from tests;' | mysql -u root -N | grep 4")
     # ';' acts as no-op, just check whether login succeeds with the user created from the initialScript
-    $mysql->succeed("echo ';' | mysql -u passworduser --password=password123");
+    mysql.succeed("echo ';' | mysql -u passworduser --password=password123")
 
-    $mariadb->waitForUnit("mysql");
-    $mariadb->succeed("echo 'use testdb; create table tests (test_id INT, PRIMARY KEY (test_id));' | sudo -u testuser mysql -u testuser");
-    $mariadb->succeed("echo 'use testdb; insert into tests values (42);' | sudo -u testuser mysql -u testuser");
-    $mariadb->succeed("echo 'use testdb; select test_id from tests;' | sudo -u testuser mysql -u testuser -N | grep 42");
+    mariadb.wait_for_unit("mysql")
+    mariadb.succeed(
+        "echo 'use testdb; create table tests (test_id INT, PRIMARY KEY (test_id));' | sudo -u testuser mysql -u testuser"
+    )
+    mariadb.succeed(
+        "echo 'use testdb; insert into tests values (42);' | sudo -u testuser mysql -u testuser"
+    )
+    mariadb.succeed(
+        "echo 'use testdb; select test_id from tests;' | sudo -u testuser mysql -u testuser -N | grep 42"
+    )
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
