### PR TITLE
nixosTests.wordpress: port to python

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4524,6 +4524,12 @@
     githubId = 117842;
     name = "Henri Bourcereau";
   };
+  mmilata = {
+    email = "martin@martinmilata.cz";
+    github = "mmilata";
+    gitHubId = 85857;
+    name = "Martin Milata";
+  };
   mmlb = {
     email = "me.mmlb@mmlb.me";
     github = "mmlb";

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -3,7 +3,11 @@ import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "wordpress";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ grahamc ]; # under duress!
+    maintainers = [
+      flokli
+      grahamc # under duress!
+      mmilata
+    ];
   };
 
   machine =

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
 
 {
   name = "wordpress";
@@ -23,19 +23,31 @@ import ./make-test.nix ({ pkgs, ... }:
     };
 
   testScript = ''
-    startAll;
+    import re
 
-    $machine->waitForUnit("httpd");
-    $machine->waitForUnit("phpfpm-wordpress-site1.local");
-    $machine->waitForUnit("phpfpm-wordpress-site2.local");
+    start_all()
 
-    $machine->succeed("curl -L site1.local | grep 'Welcome to the famous'");
-    $machine->succeed("curl -L site2.local | grep 'Welcome to the famous'");
+    machine.wait_for_unit("httpd")
 
-    $machine->succeed("systemctl --no-pager show wordpress-init-site1.local.service | grep 'ExecStart=.*status=0'");
-    $machine->succeed("systemctl --no-pager show wordpress-init-site2.local.service | grep 'ExecStart=.*status=0'");
-    $machine->succeed("grep -E '^define.*NONCE_SALT.{64,};\$' /var/lib/wordpress/site1.local/secret-keys.php");
-    $machine->succeed("grep -E '^define.*NONCE_SALT.{64,};\$' /var/lib/wordpress/site2.local/secret-keys.php");
+    machine.wait_for_unit("phpfpm-wordpress-site1.local")
+    machine.wait_for_unit("phpfpm-wordpress-site2.local")
+
+    site_names = ["site1.local", "site2.local"]
+
+    with subtest("website returns welcome screen"):
+        for site_name in site_names:
+            assert "Welcome to the famous" in machine.succeed(f"curl -L {site_name}")
+
+    with subtest("wordpress-init went through"):
+        for site_name in site_names:
+            info = machine.get_unit_info(f"wordpress-init-{site_name}")
+            assert info.Result == "success"
+
+    with subtest("secret keys are set"):
+        re.compile(r"^define.*NONCE_SALT.{64,};$")
+        for site_name in site_names:
+            assert r.match(
+                machine.succeed(f"cat /var/lib/wordpress/{site_name}/secret-keys.php")
+            )
   '';
-
 })


### PR DESCRIPTION
###### Motivation for this change
#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
