### PR TITLE
gerbil-unstable: 2019-08-11 -> 2019-11-10

### DIFF
--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,14 +1,15 @@
-{ stdenv, callPackage, fetchFromGitHub, gambit-unstable }:
+{ stdenv, callPackage, fetchFromGitHub, gambit, gambit-unstable }:
 
 callPackage ./build.nix {
-  version = "unstable-2019-08-11";
-  git-version = "0.16-DEV-132-gcb58f9a3";
-  gambit = gambit-unstable;
+  version = "unstable-2019-11-15";
+  git-version = "0.15.1-461-gee22de62";
+  #gambit = gambit-unstable;
+  gambit = gambit;
   src = fetchFromGitHub {
     owner = "vyzo";
     repo = "gerbil";
-    rev = "cb58f9a30630a6f3e85a55f2c1dcc654f517ffed";
-    sha256 = "18jh64v1gi6z3pks9zf19f2wcjpv21cs270dnaq617kgwp53vysh";
+    rev = "ee22de628a656ee59c6c72bc25d7b2e25a4ece2f";
+    sha256 = "1n1j596b91k9xcmv22l72nga6wv20bka2q51ik2jw2vkcw8zkc1c";
   };
   inherit stdenv;
 }


### PR DESCRIPTION
Also, build with gambit rather than gambit-unstable, because of, well,
instability in the current gambit-unstable.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upstream update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c 
