### PR TITLE
[r19.09] aspell: add patch for CVE-2019-17544

### DIFF
--- a/pkgs/development/libraries/aspell/default.nix
+++ b/pkgs/development/libraries/aspell/default.nix
@@ -28,6 +28,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/GNUAspell/aspell/commit/8089fa02122fed0a.diff";
       sha256 = "1b3p1zy2lqr2fknddckm58hyk95hw4scf6hzjny1v9iaic2p37ix";
     })
+    (fetchpatch {
+      name = "CVE-2019-17544.patch";
+      url = "https://github.com/GNUAspell/aspell/commit/80fa26c74279fced8d778351cff19d1d8f44fe4e.patch";
+      sha256 = "0k5dnh8gcb7chnyx7jgkksqmz2hm05hmrvcd0znsfib975pvp4rg";
+    })
   ] ++ stdenv.lib.optional searchNixProfiles ./data-dirs-from-nix-profiles.patch;
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-17544

For master, see #71242

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
