### PR TITLE
nixosTests.google-oslogin: port to python

### DIFF
--- a/nixos/tests/google-oslogin/default.nix
+++ b/nixos/tests/google-oslogin/default.nix
@@ -1,7 +1,14 @@
-import ../make-test.nix ({ pkgs, ... } :
+import ../make-test-python.nix ({ pkgs, ... } :
 let
   inherit (import ./../ssh-keys.nix pkgs)
     snakeOilPrivateKey snakeOilPublicKey;
+
+    # don't check host keys or known hosts, use the snakeoil ssh key
+    ssh-config = builtins.toFile "ssh.conf" ''
+      UserKnownHostsFile=/dev/null
+      StrictHostKeyChecking=no
+      IdentityFile=~/.ssh/id_snakeoil
+    '';
 in {
   name = "google-oslogin";
   meta = with pkgs.stdenv.lib.maintainers; {
@@ -15,38 +22,49 @@ in {
     client = { ... }: {};
   };
   testScript =  ''
-    startAll;
+    start_all()
 
-    $server->waitForUnit("mock-google-metadata.service");
-    $server->waitForOpenPort(80);
+    server.wait_for_unit("mock-google-metadata.service")
+    server.wait_for_open_port(80)
 
     # mockserver should return a non-expired ssh key for both mockuser and mockadmin
-    $server->succeed('${pkgs.google-compute-engine-oslogin}/bin/google_authorized_keys mockuser | grep -q "${snakeOilPublicKey}"');
-    $server->succeed('${pkgs.google-compute-engine-oslogin}/bin/google_authorized_keys mockadmin | grep -q "${snakeOilPublicKey}"');
+    server.succeed(
+        '${pkgs.google-compute-engine-oslogin}/bin/google_authorized_keys mockuser | grep -q "${snakeOilPublicKey}"'
+    )
+    server.succeed(
+        '${pkgs.google-compute-engine-oslogin}/bin/google_authorized_keys mockadmin | grep -q "${snakeOilPublicKey}"'
+    )
 
-    # install snakeoil ssh key on the client
-    $client->succeed("mkdir -p ~/.ssh");
-    $client->succeed("cat ${snakeOilPrivateKey} > ~/.ssh/id_snakeoil");
-    $client->succeed("chmod 600 ~/.ssh/id_snakeoil");
+    # install snakeoil ssh key on the client, and provision .ssh/config file
+    client.succeed("mkdir -p ~/.ssh")
+    client.succeed(
+        "cat ${snakeOilPrivateKey} > ~/.ssh/id_snakeoil"
+    )
+    client.succeed("chmod 600 ~/.ssh/id_snakeoil")
+    client.succeed("cp ${ssh-config} ~/.ssh/config")
 
-    $client->waitForUnit("network.target");
-    $server->waitForUnit("sshd.service");
+    client.wait_for_unit("network.target")
+    server.wait_for_unit("sshd.service")
 
     # we should not be able to connect as non-existing user
-    $client->fail("ssh -o User=ghost -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server -i ~/.ssh/id_snakeoil 'true'");
+    client.fail("ssh ghost@server 'true'")
 
     # we should be able to connect as mockuser
-    $client->succeed("ssh -o User=mockuser -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server -i ~/.ssh/id_snakeoil 'true'");
+    client.succeed("ssh mockuser@server 'true'")
     # but we shouldn't be able to sudo
-    $client->fail("ssh -o User=mockuser -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server -i ~/.ssh/id_snakeoil '/run/wrappers/bin/sudo /run/current-system/sw/bin/id' | grep -q 'root'");
+    client.fail(
+        "ssh mockuser@server '/run/wrappers/bin/sudo /run/current-system/sw/bin/id' | grep -q 'root'"
+    )
 
     # we should also be able to log in as mockadmin
-    $client->succeed("ssh -o User=mockadmin -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server -i ~/.ssh/id_snakeoil 'true'");
+    client.succeed("ssh mockadmin@server 'true'")
     # pam_oslogin_admin.so should now have generated a sudoers file
-    $server->succeed("find /run/google-sudoers.d | grep -q '/run/google-sudoers.d/mockadmin'");
+    server.succeed("find /run/google-sudoers.d | grep -q '/run/google-sudoers.d/mockadmin'")
 
     # and we should be able to sudo
-    $client->succeed("ssh -o User=mockadmin -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no server -i ~/.ssh/id_snakeoil '/run/wrappers/bin/sudo /run/current-system/sw/bin/id' | grep -q 'root'");
+    client.succeed(
+        "ssh mockadmin@server '/run/wrappers/bin/sudo /run/current-system/sw/bin/id' | grep -q 'root'"
+    )
   '';
   })
 


### PR DESCRIPTION
also use a .ssh/config instead of passing the same options over and over
again

###### Motivation for this change
#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
