### PR TITLE
nixosTests.glusterfs: port to python

### DIFF
--- a/nixos/tests/glusterfs.nix
+++ b/nixos/tests/glusterfs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... } :
+import ./make-test-python.nix ({pkgs, lib, ...}:
 
 let
   client = { pkgs, ... } : {
@@ -39,27 +39,29 @@ in {
   };
 
   testScript = ''
-    $server1->waitForUnit("glusterd.service");
-    $server2->waitForUnit("glusterd.service");
+    server1.wait_for_unit("glusterd.service")
+    server2.wait_for_unit("glusterd.service")
+
+    server1.wait_until_succeeds("gluster peer status")
+    server2.wait_until_succeeds("gluster peer status")
 
     # establish initial contact
-    $server1->succeed("sleep 2");
-    $server1->succeed("gluster peer probe server2");
-    $server1->succeed("gluster peer probe server1");
+    server1.succeed("gluster peer probe server2")
+    server1.succeed("gluster peer probe server1")
 
-    $server1->succeed("gluster peer status | grep Connected");
+    server1.succeed("gluster peer status | grep Connected")
 
     # create volumes
-    $server1->succeed("mkdir -p /data/vg0");
-    $server2->succeed("mkdir -p /data/vg0");
-    $server1->succeed("gluster volume create gv0 server1:/data/vg0 server2:/data/vg0");
-    $server1->succeed("gluster volume start gv0");
+    server1.succeed("mkdir -p /data/vg0")
+    server2.succeed("mkdir -p /data/vg0")
+    server1.succeed("gluster volume create gv0 server1:/data/vg0 server2:/data/vg0")
+    server1.succeed("gluster volume start gv0")
 
     # test clients
-    $client1->waitForUnit("gluster.mount");
-    $client2->waitForUnit("gluster.mount");
+    client1.wait_for_unit("gluster.mount")
+    client2.wait_for_unit("gluster.mount")
 
-    $client1->succeed("echo test > /gluster/file1");
-    $client2->succeed("grep test /gluster/file1");
+    client1.succeed("echo test > /gluster/file1")
+    client2.succeed("grep test /gluster/file1")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
