### PR TITLE
nixosTests.etcd*: port to python

### DIFF
--- a/nixos/tests/etcd-cluster.nix
+++ b/nixos/tests/etcd-cluster.nix
@@ -1,6 +1,6 @@
 # This test runs simple etcd cluster
 
-import ./make-test.nix ({ pkgs, ... } : let
+import ./make-test-python.nix ({ pkgs, ... } : let
 
   runWithOpenSSL = file: cmd: pkgs.runCommand file {
     buildInputs = [ pkgs.openssl ];
@@ -129,29 +129,26 @@ in {
   };
 
   testScript = ''
-    subtest "should start etcd cluster", sub {
-      $node1->start();
-      $node2->start();
-      $node1->waitForUnit("etcd.service");
-      $node2->waitForUnit("etcd.service");
-      $node2->waitUntilSucceeds("etcdctl cluster-health");
-      $node1->succeed("etcdctl set /foo/bar 'Hello world'");
-      $node2->succeed("etcdctl get /foo/bar | grep 'Hello world'");
-    };
+    with subtest("should start etcd cluster"):
+        node1.start()
+        node2.start()
+        node1.wait_for_unit("etcd.service")
+        node2.wait_for_unit("etcd.service")
+        node2.wait_until_succeeds("etcdctl cluster-health")
+        node1.succeed("etcdctl set /foo/bar 'Hello world'")
+        node2.succeed("etcdctl get /foo/bar | grep 'Hello world'")
 
-    subtest "should add another member", sub {
-      $node1->waitUntilSucceeds("etcdctl member add node3 https://node3:2380");
-      $node3->start();
-      $node3->waitForUnit("etcd.service");
-      $node3->waitUntilSucceeds("etcdctl member list | grep 'node3'");
-      $node3->succeed("etcdctl cluster-health");
-    };
+    with subtest("should add another member"):
+        node1.wait_until_succeeds("etcdctl member add node3 https://node3:2380")
+        node3.start()
+        node3.wait_for_unit("etcd.service")
+        node3.wait_until_succeeds("etcdctl member list | grep 'node3'")
+        node3.succeed("etcdctl cluster-health")
 
-    subtest "should survive member crash", sub {
-      $node3->crash;
-      $node1->succeed("etcdctl cluster-health");
-      $node1->succeed("etcdctl set /foo/bar 'Hello degraded world'");
-      $node1->succeed("etcdctl get /foo/bar | grep 'Hello degraded world'");
-    };
+    with subtest("should survive member crash"):
+        node3.crash()
+        node1.succeed("etcdctl cluster-health")
+        node1.succeed("etcdctl set /foo/bar 'Hello degraded world'")
+        node1.succeed("etcdctl get /foo/bar | grep 'Hello degraded world'")
   '';
 })

--- a/nixos/tests/etcd.nix
+++ b/nixos/tests/etcd.nix
@@ -1,6 +1,6 @@
 # This test runs simple etcd node
 
-import ./make-test.nix ({ pkgs, ... } : {
+import ./make-test-python.nix ({ pkgs, ... } : {
   name = "etcd";
 
   meta = with pkgs.stdenv.lib.maintainers; {
@@ -14,14 +14,12 @@ import ./make-test.nix ({ pkgs, ... } : {
   };
 
   testScript = ''
-    subtest "should start etcd node", sub {
-      $node->start();
-      $node->waitForUnit("etcd.service");
-    };
+    with subtest("should start etcd node"):
+        node.start()
+        node.wait_for_unit("etcd.service")
 
-    subtest "should write and read some values to etcd", sub {
-      $node->succeed("etcdctl set /foo/bar 'Hello world'");
-      $node->succeed("etcdctl get /foo/bar | grep 'Hello world'");
-    }
+    with subtest("should write and read some values to etcd"):
+        node.succeed("etcdctl set /foo/bar 'Hello world'")
+        node.succeed("etcdctl get /foo/bar | grep 'Hello world'")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
