### PR TITLE
[19.09] processing: update reference archive hash

### DIFF
--- a/pkgs/applications/graphics/processing/default.nix
+++ b/pkgs/applications/graphics/processing/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     ${xmlstarlet}/bin/xmlstarlet ed --inplace -P -d '//get[@src="http://download.processing.org/reference.zip"]' build/build.xml
     install -D -m0444 ${fetchurl {
                           url    = http://download.processing.org/reference.zip;
-                          sha256 = "198bpk8mzns6w5h0zdf50wr6iv7sgdi6v7jznj5rbsnpgyilxz35";
+                          sha256 = "0k454pdr4dzjpfx8nv1h08r9wp28r19390yndqqvrw4bji697hps";
                         }
                        } ./java/reference.zip
 


### PR DESCRIPTION
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/74008

Fixes build failure:

```
hash mismatch in fixed-output derivation '/nix/store/5fg4pzprvm456g5y9v0ivnxigprjr492-reference.zip':
  wanted: sha256:198bpk8mzns6w5h0zdf50wr6iv7sgdi6v7jznj5rbsnpgyilxz35
  got:    sha256:0k454pdr4dzjpfx8nv1h08r9wp28r19390yndqqvrw4bji697hps
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
