### PR TITLE
graalvm8-ee: 19.2.1 -> 19.3.1, graalvm11-ee: init at 19.3.1

### DIFF
--- a/pkgs/development/compilers/graalvm/enterprise-edition.nix
+++ b/pkgs/development/compilers/graalvm/enterprise-edition.nix
@@ -5,33 +5,33 @@ let
     let
       graalvmXXX-ee = stdenv.mkDerivation rec {
         pname = "graalvm${javaVersion}-ee";
-        version = "19.3.0.2";
+        version = "19.3.1";
         srcs = [
           (requireFile {
              name   = "graalvm-ee-java${javaVersion}-linux-amd64-${version}.tar.gz";
-             sha256 = {  "8" = "0ed34a7336abec6cf854e3b2b08d4c26a492bdf221a3cf73d31b9492a21a4f9c";
-                        "11" = "ebfcf47ed88a26eecf1e85a9d515bfc07d8dbaea5f2ca3139022f60c8193698a";
+             sha256 = {  "8" = "b4833f1996e0e271d8abde1d0af3420e2bc6797624515a3720bdbedfa99b1e82";
+                        "11" = "a965abb093934712f31cd2183f3f0d68ed1410a50365489f665a30e5382908dc";
                       }.${javaVersion};
              url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
           })
           (requireFile {
              name   = "native-image-installable-svm-svmee-java${javaVersion}-linux-amd64-${version}.jar";
-             sha256 = {  "8" = "fa48268c56b47cbb71cd6bbe7ca25800b0d87fb9be7c201ec8587a50d231f071";
-                        "11" = "9e26a0cbd68470989e04749331196d403203dbf62c97154f81a11a9b8cad6969";
+             sha256 = {  "8" = "fe3447dd60fbe3da39c650654594796873cd6bc9995d1430a421363e71d41702";
+                        "11" = "53357b7facb36c7b38857a2369471d0e869c0ff45555aa8baf2ab84de0c4782c";
                       }.${javaVersion};
              url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
           })
           (requireFile {
              name   = "python-installable-svm-svmee-java${javaVersion}-linux-amd64-${version}.jar";
-             sha256 = {  "8" = "c0a6bed780077e1398c43834a27d441ea459effd92d27802ab8229b3f229b76d";
-                        "11" = "218bd9c4050e72be34de3d48bada305691fcb36e367a24871223e89f2c3067be";
+             sha256 = {  "8" = "003e9574e18656a82626aa5d310fac31979abc04955587d68ff977808829a91d";
+                        "11" = "65558e14a25802001f3c79571a09170fa11564de34df6987724163416d3889bf";
                       }.${javaVersion};
              url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
           })
           (requireFile {
              name   = "ruby-installable-svm-svmee-java${javaVersion}-linux-amd64-${version}.jar";
-             sha256 = {  "8" = "76c776b8d2e61232e7d9ad8fcbe9d098908b62fec383288c07b7e37c2d6941c4";
-                        "11" = "f9a92ab69866edc4da6e2d906525a5bdd297f9ae0b01177c6752206343aefded";
+             sha256 = {  "8" = "45abe74d10e09680f1e40101f93def5615e65f29ced328054a40c8517e054290";
+                        "11" = "3d4de372b78b68dbd966b36489d1c6d84a326990e91a0314fb77404eed0741ad";
                       }.${javaVersion};
              url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
           })

--- a/pkgs/development/compilers/graalvm/enterprise-edition.nix
+++ b/pkgs/development/compilers/graalvm/enterprise-edition.nix
@@ -5,33 +5,33 @@ let
     let
       graalvmXXX-ee = stdenv.mkDerivation rec {
         pname = "graalvm${javaVersion}-ee";
-        version = "19.3.0";
+        version = "19.3.0.2";
         srcs = [
           (requireFile {
              name   = "graalvm-ee-java${javaVersion}-linux-amd64-${version}.tar.gz";
-             sha256 = {  "8" = "dae766424457faea3bd2d7179477bab8dc073d92755ad09c51eee55ce5cb8b78";
-                        "11" = "aced0251642e942081aa386a05656bab84984999ced296b4e001ae982ac3842d";
+             sha256 = {  "8" = "0ed34a7336abec6cf854e3b2b08d4c26a492bdf221a3cf73d31b9492a21a4f9c";
+                        "11" = "ebfcf47ed88a26eecf1e85a9d515bfc07d8dbaea5f2ca3139022f60c8193698a";
                       }.${javaVersion};
              url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
           })
           (requireFile {
              name   = "native-image-installable-svm-svmee-java${javaVersion}-linux-amd64-${version}.jar";
-             sha256 = {  "8" = "92fc421c8a07c7794179c96489ddf29d755d0a81ead2056fbf47fa137dbefc69";
-                        "11" = "fe6363ecfe919d3575607276ac6541a4f0d29cd740424b3ea7fadd26c5915106";
+             sha256 = {  "8" = "fa48268c56b47cbb71cd6bbe7ca25800b0d87fb9be7c201ec8587a50d231f071";
+                        "11" = "9e26a0cbd68470989e04749331196d403203dbf62c97154f81a11a9b8cad6969";
                       }.${javaVersion};
              url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
           })
           (requireFile {
              name   = "python-installable-svm-svmee-java${javaVersion}-linux-amd64-${version}.jar";
-             sha256 = {  "8" = "2668c44a6939393983fd941fc1c5573f49a349fc0cf919f6cd0ae98b7e8fac56";
-                        "11" = "f148e1c2b78614b77ffc8c4292f62f21377e67f7359b8505fe6331d41e5a1a75";
+             sha256 = {  "8" = "c0a6bed780077e1398c43834a27d441ea459effd92d27802ab8229b3f229b76d";
+                        "11" = "218bd9c4050e72be34de3d48bada305691fcb36e367a24871223e89f2c3067be";
                       }.${javaVersion};
              url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
           })
           (requireFile {
              name   = "ruby-installable-svm-svmee-java${javaVersion}-linux-amd64-${version}.jar";
-             sha256 = {  "8" = "e5f5938b9f55bde3f8b4e0f48f52cbb79a8668b53bbf96ab89b1da8d85bdfa90";
-                        "11" = "2481b6e2644d302c190a898e58a21cda1aa32e473d12775217a6dd4d919413ea";
+             sha256 = {  "8" = "76c776b8d2e61232e7d9ad8fcbe9d098908b62fec383288c07b7e37c2d6941c4";
+                        "11" = "f9a92ab69866edc4da6e2d906525a5bdd297f9ae0b01177c6752206343aefded";
                       }.${javaVersion};
              url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
           })

--- a/pkgs/development/compilers/graalvm/enterprise-edition.nix
+++ b/pkgs/development/compilers/graalvm/enterprise-edition.nix
@@ -1,133 +1,167 @@
-{ stdenv, requireFile, perl, unzip, glibc, zlib, gdk-pixbuf, xorg, glib, fontconfig, freetype, cairo, pango, gtk3, gtk2, ffmpeg, libGL, atk, alsaLib, libav_0_8, setJavaClassPath }:
+{ stdenv, requireFile, perl, unzip, glibc, zlib, bzip2, gdk-pixbuf, xorg, glib, fontconfig, freetype, cairo, pango, gtk3, gtk2, ffmpeg, libGL, atk, alsaLib, libav_0_8, setJavaClassPath }:
 
 let
-  graalvm8-ee = stdenv.mkDerivation rec {
-    pname = "graalvm8-ee";
-    version = "19.2.0";
-    srcs = [
-      (requireFile {
-         name   = "graalvm-ee-linux-amd64-${version}.tar.gz";
-         sha256 = "1j56lyids48zyjhxk8xl4niy8hk6qzi1aj7c55yfh62id8v6cpbw";
-         url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
-      })
-      (requireFile {
-         name   = "native-image-installable-svm-svmee-linux-amd64-${version}.jar";
-         sha256 = "07c25l27msxccqrbz4bknz0sxsl0z2k8990cdfkbrgxvhxspfnnm";
-         url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
-      })
-      (requireFile {
-         name   = "python-installable-svm-svmee-linux-amd64-${version}.jar";
-         sha256 = "1c7kpz56w9p418li97ymixdwywscr85vhn7jkzxq71bj7ia7pxwz";
-         url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
-      })
-      (requireFile {
-         name   = "ruby-installable-svm-svmee-linux-amd64-${version}.jar";
-         sha256 = "13jfm5qpxqxz7f5n9yyvqrv1vwigifrjwk3hssp23maski2ssys1";
-         url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
-      })
-    ];
-    nativeBuildInputs = [ unzip perl ];
-    unpackPhase = ''
-      unpack_jar() {
-        jar=$1
-        unzip $jar -d $out
-        perl -ne 'use File::Path qw(make_path);
-                  use File::Basename qw(dirname);
-                  if (/^(.+) = (.+)$/) {
-                    make_path dirname("$ENV{out}/$1");
-                    system "ln -s $2 $ENV{out}/$1";
-                  }' $out/META-INF/symlinks
-        perl -ne 'if (/^(.+) = ([r-])([w-])([x-])([r-])([w-])([x-])([r-])([w-])([x-])$/) {
-                    my $mode = ($2 eq 'r' ? 0400 : 0) + ($3 eq 'w' ? 0200 : 0) + ($4  eq 'x' ? 0100 : 0) +
-                               ($5 eq 'r' ? 0040 : 0) + ($6 eq 'w' ? 0020 : 0) + ($7  eq 'x' ? 0010 : 0) +
-                               ($8 eq 'r' ? 0004 : 0) + ($9 eq 'w' ? 0002 : 0) + ($10 eq 'x' ? 0001 : 0);
-                    chmod $mode, "$ENV{out}/$1";
-                  }' $out/META-INF/permissions
-        rm -rf $out/META-INF
-      }
+  common = javaVersion:
+    let
+      graalvmXXX-ee = stdenv.mkDerivation rec {
+        pname = "graalvm${javaVersion}-ee";
+        version = "19.3.0";
+        srcs = [
+          (requireFile {
+             name   = "graalvm-ee-java${javaVersion}-linux-amd64-${version}.tar.gz";
+             sha256 = {  "8" = "dae766424457faea3bd2d7179477bab8dc073d92755ad09c51eee55ce5cb8b78";
+                        "11" = "aced0251642e942081aa386a05656bab84984999ced296b4e001ae982ac3842d";
+                      }.${javaVersion};
+             url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
+          })
+          (requireFile {
+             name   = "native-image-installable-svm-svmee-java${javaVersion}-linux-amd64-${version}.jar";
+             sha256 = {  "8" = "92fc421c8a07c7794179c96489ddf29d755d0a81ead2056fbf47fa137dbefc69";
+                        "11" = "fe6363ecfe919d3575607276ac6541a4f0d29cd740424b3ea7fadd26c5915106";
+                      }.${javaVersion};
+             url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
+          })
+          (requireFile {
+             name   = "python-installable-svm-svmee-java${javaVersion}-linux-amd64-${version}.jar";
+             sha256 = {  "8" = "2668c44a6939393983fd941fc1c5573f49a349fc0cf919f6cd0ae98b7e8fac56";
+                        "11" = "f148e1c2b78614b77ffc8c4292f62f21377e67f7359b8505fe6331d41e5a1a75";
+                      }.${javaVersion};
+             url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
+          })
+          (requireFile {
+             name   = "ruby-installable-svm-svmee-java${javaVersion}-linux-amd64-${version}.jar";
+             sha256 = {  "8" = "e5f5938b9f55bde3f8b4e0f48f52cbb79a8668b53bbf96ab89b1da8d85bdfa90";
+                        "11" = "2481b6e2644d302c190a898e58a21cda1aa32e473d12775217a6dd4d919413ea";
+                      }.${javaVersion};
+             url    = "https://www.oracle.com/technetwork/graalvm/downloads/index.html";
+          })
+        ];
+        nativeBuildInputs = [ unzip perl ];
+        unpackPhase = ''
+          unpack_jar() {
+            jar=$1
+            unzip $jar -d $out
+            perl -ne 'use File::Path qw(make_path);
+                      use File::Basename qw(dirname);
+                      if (/^(.+) = (.+)$/) {
+                        make_path dirname("$ENV{out}/$1");
+                        system "ln -s $2 $ENV{out}/$1";
+                      }' $out/META-INF/symlinks
+            perl -ne 'if (/^(.+) = ([r-])([w-])([x-])([r-])([w-])([x-])([r-])([w-])([x-])$/) {
+                        my $mode = ($2 eq 'r' ? 0400 : 0) + ($3 eq 'w' ? 0200 : 0) + ($4  eq 'x' ? 0100 : 0) +
+                                   ($5 eq 'r' ? 0040 : 0) + ($6 eq 'w' ? 0020 : 0) + ($7  eq 'x' ? 0010 : 0) +
+                                   ($8 eq 'r' ? 0004 : 0) + ($9 eq 'w' ? 0002 : 0) + ($10 eq 'x' ? 0001 : 0);
+                        chmod $mode, "$ENV{out}/$1";
+                      }' $out/META-INF/permissions
+            rm -rf $out/META-INF
+          }
 
-      mkdir -p $out
-      arr=($srcs)
-      tar xf ''${arr[0]} -C $out --strip-components=1
-      unpack_jar ''${arr[1]}
-      unpack_jar ''${arr[2]}
-      unpack_jar ''${arr[3]}
-    '';
+          mkdir -p $out
+          arr=($srcs)
+          tar xf ''${arr[0]} -C $out --strip-components=1
+          unpack_jar ''${arr[1]}
+          unpack_jar ''${arr[2]}
+          unpack_jar ''${arr[3]}
+        '';
 
-    installPhase = ''
-      # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
-      substituteInPlace $out/jre/lib/security/java.security \
-        --replace file:/dev/random    file:/dev/./urandom \
-        --replace NativePRNGBlocking  SHA1PRNG
+        installPhase = {
+          "8" = ''
+            # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
+            substituteInPlace $out/jre/lib/security/java.security \
+              --replace file:/dev/random    file:/dev/./urandom \
+              --replace NativePRNGBlocking  SHA1PRNG
 
-      # provide libraries needed for static compilation
-      for f in ${glibc}/lib/* ${glibc.static}/lib/* ${zlib.static}/lib/*; do
-        ln -s $f $out/jre/lib/svm/clibraries/linux-amd64/$(basename $f)
-      done
-    '';
+            # provide libraries needed for static compilation
+            for f in ${glibc}/lib/* ${glibc.static}/lib/* ${zlib.static}/lib/*; do
+              ln -s $f $out/jre/lib/svm/clibraries/linux-amd64/$(basename $f)
+            done
 
-    dontStrip = true;
+            # allow using external truffle-api.jar and languages not included in the distrubution
+            rm $out/jre/lib/jvmci/parentClassLoader.classpath
+          '';
+          "11" = ''
+            # BUG workaround http://mail.openjdk.java.net/pipermail/graal-dev/2017-December/005141.html
+            substituteInPlace $out/conf/security/java.security \
+              --replace file:/dev/random    file:/dev/./urandom \
+              --replace NativePRNGBlocking  SHA1PRNG
 
-    preFixup = ''
-      # Set JAVA_HOME automatically.
-      mkdir -p $out/nix-support
-      cat <<EOF > $out/nix-support/setup-hook
-      if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
-      EOF
-    '';
+            # provide libraries needed for static compilation
+            for f in ${glibc}/lib/* ${glibc.static}/lib/* ${zlib.static}/lib/*; do
+              ln -s $f $out/lib/svm/clibraries/linux-amd64/$(basename $f)
+            done
+           '';
+        }.${javaVersion};
 
-    postFixup = ''
-      rpath="$out/jre/lib/amd64/jli:$out/jre/lib/amd64/server:$out/jre/lib/amd64:${
-        stdenv.lib.strings.makeLibraryPath [ glibc xorg.libXxf86vm xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXrender
-                                             glib zlib alsaLib fontconfig freetype pango gtk3 gtk2 cairo gdk-pixbuf atk ffmpeg libGL ]}"
+        dontStrip = true;
 
-      for f in $(find $out -type f -perm -0100); do
-        patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$f" || true
-        patchelf --set-rpath   "$rpath"                                    "$f" || true
-      done
+        # copy-paste openjdk's preFixup
+        preFixup = ''
+          # Set JAVA_HOME automatically.
+          mkdir -p $out/nix-support
+          cat <<EOF > $out/nix-support/setup-hook
+            if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+          EOF
+        '';
 
-      for f in $(find $out -type f -perm -0100); do
-        if ldd "$f" | fgrep 'not found'; then echo "in file $f"; fi
-      done
-    '';
+        postFixup = ''
+          rpath="${ {  "8" = "$out/jre/lib/amd64/jli:$out/jre/lib/amd64/server:$out/jre/lib/amd64";
+                      "11" = "$out/lib/jli:$out/lib/server:$out/lib";
+                    }.${javaVersion}
+                 }:${
+            stdenv.lib.strings.makeLibraryPath [ glibc xorg.libXxf86vm xorg.libX11 xorg.libXext xorg.libXtst xorg.libXi xorg.libXrender
+                                                 glib zlib bzip2 alsaLib fontconfig freetype pango gtk3 gtk2 cairo gdk-pixbuf atk ffmpeg libGL ]}"
 
-    propagatedBuildInputs = [ setJavaClassPath zlib ]; # $out/bin/native-image needs zlib to build native executables
-    
-    doInstallCheck = true;
-    installCheckPhase = ''
-      echo ${stdenv.lib.escapeShellArg ''
-               public class HelloWorld {
-                 public static void main(String[] args) {
-                   System.out.println("Hello World");
-                 }
-               }
-             ''} > HelloWorld.java
-      $out/bin/javac HelloWorld.java
+          for f in $(find $out -type f -perm -0100); do
+            patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$f" || true
+            patchelf --set-rpath   "$rpath"                                    "$f" || true
+          done
 
-      # run on JVM with Graal Compiler
-      $out/bin/java -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:+UseJVMCICompiler HelloWorld
-      $out/bin/java -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:+UseJVMCICompiler HelloWorld | fgrep 'Hello World'
+          for f in $(find $out -type f -perm -0100); do
+            if ldd "$f" | fgrep 'not found'; then echo "in file $f"; fi
+          done
+        '';
 
-      # Ahead-Of-Time compilation
-      $out/bin/native-image --no-server HelloWorld
-      ./helloworld
-      ./helloworld | fgrep 'Hello World'
+        propagatedBuildInputs = [ setJavaClassPath zlib ]; # $out/bin/native-image needs zlib to build native executables
 
-      # Ahead-Of-Time compilation with --static
-      $out/bin/native-image --no-server --static HelloWorld
-      ./helloworld
-      ./helloworld | fgrep 'Hello World'
-    '';
+        doInstallCheck = true;
+        installCheckPhase = ''
+          echo ${stdenv.lib.escapeShellArg ''
+                   public class HelloWorld {
+                     public static void main(String[] args) {
+                       System.out.println("Hello World");
+                     }
+                   }
+                 ''} > HelloWorld.java
+          $out/bin/javac HelloWorld.java
 
-    passthru.home = graalvm8-ee;
+          # run on JVM with Graal Compiler
+          $out/bin/java -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:+UseJVMCICompiler HelloWorld
+          $out/bin/java -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:+UseJVMCICompiler HelloWorld | fgrep 'Hello World'
 
-    meta = with stdenv.lib; {
-      homepage = https://www.graalvm.org/;
-      description = "High-Performance Polyglot VM";
-      license = licenses.unfree;
-      maintainers = with maintainers; [ volth hlolli ];
-      platforms = [ "x86_64-linux" ];
-    };
-  };
-in
-  graalvm8-ee
+          # Ahead-Of-Time compilation
+          $out/bin/native-image --no-server HelloWorld
+          ./helloworld
+          ./helloworld | fgrep 'Hello World'
+
+          # Ahead-Of-Time compilation with --static
+          $out/bin/native-image --no-server --static HelloWorld
+          ./helloworld
+          ./helloworld | fgrep 'Hello World'
+        '';
+
+        passthru.home = graalvmXXX-ee;
+
+        meta = with stdenv.lib; {
+          homepage = https://www.graalvm.org/;
+          description = "High-Performance Polyglot VM";
+          license = licenses.unfree;
+          maintainers = with maintainers; [ volth hlolli ];
+          platforms = [ "x86_64-linux" ];
+        };
+      };
+    in
+      graalvmXXX-ee;
+in {
+  graalvm8-ee  = common  "8";
+  graalvm11-ee = common "11";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8295,7 +8295,9 @@ in
 
   inherit (callPackages ../development/compilers/graalvm { }) mx jvmci8 graalvm8;
 
-  graalvm8-ee = callPackage ../development/compilers/graalvm/enterprise-edition.nix { };
+  inherit (callPackages ../development/compilers/graalvm/enterprise-edition.nix { })
+    graalvm8-ee
+    graalvm11-ee;
 
   openshot-qt = libsForQt5.callPackage ../applications/video/openshot-qt { };
 


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @hlolli 
