### PR TITLE
python3Packages.portalocker: fix build

### DIFF
--- a/pkgs/development/python-modules/portalocker/default.nix
+++ b/pkgs/development/python-modules/portalocker/default.nix
@@ -28,13 +28,6 @@ buildPythonPackage rec {
     pytestpep8
   ];
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/WoLpH/portalocker/commit/7741925738c7e66ae9c4a0944a04b6a3088037d5.patch";
-      sha256 = "1g95rnfbnagkkk9qfzzd5346dl3clbgjnzr2wk09m0wphds7zd8z";
-    })
-  ];
-
   meta = with lib; {
     description = "A library to provide an easy API to file locking";
     homepage = https://github.com/WoLpH/portalocker;


### PR DESCRIPTION
###### Motivation for this change
forgot I upstreamed the patch, and bumped the version which included the patch, this now fails due to the patch failing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

azure-cli-core fails expectedly, as it requires an old version of azure-mgmt-resource
```
[9 built (3 failed), 139 copied (70.7 MiB), 13.4 MiB DL]
error: build of '/nix/store/73xrbkbrrhay90ghz5lp05iz3y4p3pqg-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/74011
3 package failed to build:
python27Packages.azure-cli-core python37Packages.azure-cli-core python38Packages.azure-cli-core

10 package were built:
azure-cli python27Packages.applicationinsights python27Packages.azure-cli-telemetry python27Packages.portalocker python37Packages.applicationinsights python37Packages.azure-cli-telemetry python37Packages.portalocker python38Packages.applicationinsights python38Packages.azure-cli-telemetry python38Packages.portalocker
```