### PR TITLE
pythonPackages.sunpy: 1.0.2 -> 1.0.6

### DIFF
--- a/pkgs/development/python-modules/sunpy/default.nix
+++ b/pkgs/development/python-modules/sunpy/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , buildPythonPackage
 , fetchFromGitHub
 , numpy
@@ -26,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "sunpy";
-  version = "1.0.2";
+  version = "1.0.6";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "sunpy";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0dmfzxxsjjax9wf2ljyl4z07pxbshrj828zi5qnsa9rgk4148q9x";
+    sha256 = "0j2yfhfxgi95rig8cfp9lvszb7694gq90jvs0xrb472hwnzgh2sk";
   };
 
   propagatedBuildInputs = [
@@ -67,8 +68,11 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
+  # darwin has write permission issues
+  doCheck = stdenv.isLinux;
+  # ignore documentation tests
   checkPhase = ''
-    pytest sunpy -k "not test_rotation"
+    pytest sunpy -k 'not rst'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

breaking apart #70684

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/74019
1 package were built:
python37Packages.sunpy
```