### PR TITLE
systemd: v243 -> v243.3

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -30,7 +30,7 @@ let gnupg-minimal = gnupg.override {
   bzip2 = null;
 };
 in stdenv.mkDerivation {
-  version = "243";
+  version = "243.3";
   pname = "systemd";
 
   # When updating, use https://github.com/systemd/systemd-stable tree, not the development one!
@@ -38,8 +38,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "systemd";
-    rev = "d25cf413c6bff1b5a9d216a8830e3a90c9cad1de";
-    sha256 = "0ilvrnh3m7g0yflxl16fk52gkb1z0fwwk9ba5gs4005nzpl0c7i0";
+    rev = "491a247eff9b7ce1e5877f5f3431517c95f3222f";
+    sha256 = "1xqiahapg480m165glrwqbfmc1fxw5sacdlm933cwyi1q8x4537g";
   };
 
   outputs = [ "out" "lib" "man" "dev" ];


### PR DESCRIPTION
###### Motivation for this change
This bumps our systemd version to the latest stable point release of system v243. There are a bunch of bugfixes that all look good and none that seem overly intrusive.

Once this has dripped through staging into master I'd also backport it to 19.09 (cc RMs @samueldr @disassembler).

Here is the list of  non-merge changes:

```
test: Pass personality test even when i686 userland runs on x86_64 kernel
docs: fix inadvertent change in uid range
cgroup: fix typo in BPF firewall support warning message
fix build with compilers with default stack-protector enabled
nspawn: surrender controlling terminal to PID2 when using the PID1 stub
pid1: fix DefaultTasksMax initialization
src/core/automount: use DirectoryMode when calling mkdir -p
udevadm trigger: do not propagate EACCES and ENODEV
hwdb: Correct WWWW Pattern In Documentation Comment
nspawn: consistenly fail if parsing the environment fails
nspawn: default to unified hierarchy if --as-pid2 is used
cgroup: Mark memory protections as explicitly set in transient units
cgroup: Respect DefaultMemoryMin when setting memory.min
cgroup: Check ancestor memory min for unified memory config
cgroup: docs: memory.high doc fixups
cgroup: docs: Mention unbounded protection for memory.{low,min}
Consider smb3 as remote filesystem
Handle d_type == DT_UNKNOWN correctly
util-lib: Don't propagate EACCES from find_binary PATH lookup to caller
network: drop noisy log message
Updated log message when the timesync happens for the first time (#13624)
units: make systemd-binfmt.service easier to work with no autofs
Corect man page reference in systemd-nologin.conf comments
man: Add a missing space in machinectl(1)
log: Add missing "%" in "%m" log format strings
pid1: do not warn if /run/systemd/relabel-extra.d/ doesn't exist
man: fix typo
dhcp6: use unaligned_read_be32()
dhcp6: add missing option length check
ndisc: make first solicit delayed randomly
dhcp6: read OPTION_INFORMATION_REFRESH_TIME option
l10n: update Czech Translation
sd-radv: if lifetime < SD_RADV_DEFAULT_MAX_TIMEOUT_USEC, adjust timeout (#13491)
polkit: fix typo
sd-netlink: fix invalid assertion
network: do not enter failed state if device's sysfs entry does not exist yet
network: add missing link->network checks
path: stop watching path specs once we triggered the target unit
hwdb: add Medion Akoya E2292 (#13498)
po: update Brazilian Portuguese translation
po: update Polish translation
polkit: change "revert settings" to "reset settings"
man: fix description of ARPIntervalSec= units
hwdb: axis override for Dell 9360 touchpad
test: drop the missed || exit 1 expression
udevadm: use usec_add()
udevadm: missing initialization of descriptor
networkd: unbreak routing_policy_rule_compare_func()
core: coldplug possible nop_job
tty-ask-pwd-agent: fix message forwarded to wall(1)
core: Fix setting StatusUnitFormat from config files
network DHCP4: Dont mislead the logs.
Update m4 for selective utmp support. 	modified:   tmpfiles.d/systemd.conf.m4
core: restore initialization of u->source_mtime
mount-setup: relabel items mentioned directly in relabel-extra.d
Call getgroups() to know size of supplementary groups array to allocate
test: add test cases for empty string match
udev: fix multi match
man: move TimeoutCleanSec= entry from .service to .exec
zsh: udpate bootctl completions
resolved: fix abort when recv() returns 0
man: remove repeated words
hwdb: Also mark lis3lv02d sensors in "HP" laptops as being in the base
udev: also logs file permission
udev: add missing flag for OPTIONS=static_node
network: do not abort execution when a config file cannot be loaded
fileio: update warning message
pstore: fix use after free
journal: Make the output of --update-catalog deterministic
travis: protect the systemd organization on Fuzzit from forks
hwdb: Mark lis3lv02d sensors in HP laptops as being in the base
po: update Japanese translation
docs: fix push recipe in RELEASE.md
man/systemctl.xml: fix missing "not"
docs: fix typo in boot loader doc
pstore: fix typo in error message - directoy -> directory
Fix typo in comment: overide -> override
po: update Polish translation
```
(https://github.com/NixOS/systemd/compare/nixos-v243...nixos-v243.3)

###### Things done

I did build the nixos-small and the nixos release tests and no new obvious issues appeared.
Running this systemd version on-top of nixos-unstable on my notebook didn't show any obvious problems, as well.

###### Notify maintainers

cc @flokli @fpletz @mic92
