### PR TITLE
nixosTests.prosody*: port to python

### DIFF
--- a/nixos/tests/xmpp/prosody-mysql.nix
+++ b/nixos/tests/xmpp/prosody-mysql.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix {
+import ../make-test-python.nix {
   name = "prosody-mysql";
 
   nodes = {
@@ -57,21 +57,21 @@ import ../make-test.nix {
   };
 
   testScript = { nodes, ... }: ''
-    $mysql->waitForUnit('mysql.service');
-    $server->waitForUnit('prosody.service');
-    $server->succeed('prosodyctl status') =~ /Prosody is running/;
+    mysql.wait_for_unit("mysql.service")
+    server.wait_for_unit("prosody.service")
+    server.succeed('prosodyctl status | grep "Prosody is running"')
 
     # set password to 'nothunter2' (it's asked twice)
-    $server->succeed('yes nothunter2 | prosodyctl adduser cthon98@example.com');
+    server.succeed("yes nothunter2 | prosodyctl adduser cthon98@example.com")
     # set password to 'y'
-    $server->succeed('yes | prosodyctl adduser azurediamond@example.com');
+    server.succeed("yes | prosodyctl adduser azurediamond@example.com")
     # correct password to 'hunter2'
-    $server->succeed('yes hunter2 | prosodyctl passwd azurediamond@example.com');
+    server.succeed("yes hunter2 | prosodyctl passwd azurediamond@example.com")
 
-    $client->succeed("send-message");
+    client.succeed("send-message")
 
-    $server->succeed('prosodyctl deluser cthon98@example.com');
-    $server->succeed('prosodyctl deluser azurediamond@example.com');
+    server.succeed("prosodyctl deluser cthon98@example.com")
+    server.succeed("prosodyctl deluser azurediamond@example.com")
   '';
 }
 

--- a/nixos/tests/xmpp/prosody.nix
+++ b/nixos/tests/xmpp/prosody.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix {
+import ../make-test-python.nix {
   name = "prosody";
 
   nodes = {
@@ -28,19 +28,19 @@ import ../make-test.nix {
   };
 
   testScript = { nodes, ... }: ''
-    $server->waitForUnit('prosody.service');
-    $server->succeed('prosodyctl status') =~ /Prosody is running/;
+    server.wait_for_unit("prosody.service")
+    server.succeed('prosodyctl status | grep "Prosody is running"')
 
     # set password to 'nothunter2' (it's asked twice)
-    $server->succeed('yes nothunter2 | prosodyctl adduser cthon98@example.com');
+    server.succeed("yes nothunter2 | prosodyctl adduser cthon98@example.com")
     # set password to 'y'
-    $server->succeed('yes | prosodyctl adduser azurediamond@example.com');
-    # correct password to 'hunter2'
-    $server->succeed('yes hunter2 | prosodyctl passwd azurediamond@example.com');
+    server.succeed("yes | prosodyctl adduser azurediamond@example.com")
+    # correct password to "hunter2"
+    server.succeed("yes hunter2 | prosodyctl passwd azurediamond@example.com")
 
-    $client->succeed("send-message");
+    client.succeed("send-message")
 
-    $server->succeed('prosodyctl deluser cthon98@example.com');
-    $server->succeed('prosodyctl deluser azurediamond@example.com');
+    server.succeed("prosodyctl deluser cthon98@example.com")
+    server.succeed("prosodyctl deluser azurediamond@example.com")
   '';
 }


### PR DESCRIPTION
###### Motivation for this change
#72828

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
