### PR TITLE
Remove networking.hostConf option

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -41,19 +41,6 @@ in
       '';
     };
 
-    networking.hostConf = lib.mkOption {
-      type = types.lines;
-      default = "multi on";
-      example = ''
-        multi on
-        reorder on
-        trim lan
-      '';
-      description = ''
-        The contents of <filename>/etc/host.conf</filename>. See also <citerefentry><refentrytitle>host.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
-      '';
-    };
-
     networking.timeServers = mkOption {
       default = [
         "0.nixos.pool.ntp.org"
@@ -186,7 +173,9 @@ in
         '';
 
         # /etc/host.conf: resolver configuration file
-        "host.conf".text = cfg.hostConf;
+        "host.conf".text = ''
+          multi on
+        '';
 
       } // optionalAttrs (pkgs.stdenv.hostPlatform.libc == "glibc") {
         # /etc/rpc: RPC program numbers.

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -239,6 +239,7 @@ with lib;
     (mkRemovedOptionModule [ "systemd" "generator-packages" ] "Use systemd.packages instead.")
     (mkRemovedOptionModule [ "fonts" "enableCoreFonts" ] "Use fonts.fonts = [ pkgs.corefonts ]; instead.")
     (mkRemovedOptionModule [ "networking" "vpnc" ] "Use environment.etc.\"vpnc/service.conf\" instead.")
+    (mkRemovedOptionModule [ "networking" "hostConf" ] "Use environment.etc.\"host.conf\" instead.")
 
     # ZSH
     (mkRenamedOptionModule [ "programs" "zsh" "enableSyntaxHighlighting" ] [ "programs" "zsh" "syntaxHighlighting" "enable" ])

--- a/nixos/tests/resolv.nix
+++ b/nixos/tests/resolv.nix
@@ -1,0 +1,77 @@
+# Test whether DNS resolving returns multiple records and all address families.
+import ./make-test-python.nix ({ pkgs, ... } : {
+  name = "resolv";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ ckauhaus ];
+  };
+
+  nodes.resolv = { ... }: {
+    networking.extraHosts = ''
+      # IPv4 only
+      192.0.2.1 host-ipv4.example.net
+      192.0.2.2 host-ipv4.example.net
+      # IP6 only
+      2001:db8::2:1 host-ipv6.example.net
+      2001:db8::2:2 host-ipv6.example.net
+      # dual stack
+      192.0.2.1 host-dual.example.net
+      192.0.2.2 host-dual.example.net
+      2001:db8::2:1 host-dual.example.net
+      2001:db8::2:2 host-dual.example.net
+    '';
+  };
+
+  testScript = let
+    getaddrinfo_py = pkgs.writeScript "getaddrinfo.py" ''
+      import socket
+      import sys
+
+      result = set()
+      for gai in socket.getaddrinfo(sys.argv[1], 0):
+          result.add(gai[4][0])
+
+      print(' '.join(sorted(list(result))))
+    '';
+
+    getaddrinfo = "${pkgs.python3.interpreter} ${getaddrinfo_py}";
+
+  in
+  ''
+    def compare(test, should, is_):
+        should = should.strip()
+        is_ = is_.strip()
+        resolv.log("{}: expected '{}', actual '{}'".format(test, should, is_))
+        if should == is_:
+            resolv.log("* OK")
+            return True
+        else:
+            resolv.log("* FAILED")
+            return False
+
+
+    start_all()
+    resolv.wait_for_unit("nscd")
+    res = []
+
+    out = resolv.succeed(
+        "${getaddrinfo} host-ipv4.example.net"
+    )
+    res.append(compare("resolve IPv4", "192.0.2.1 192.0.2.2", out))
+
+    out = resolv.succeed(
+        "${getaddrinfo} host-ipv6.example.net"
+    )
+    res.append(compare("resolve IPv6", "2001:db8::2:1 2001:db8::2:2", out))
+
+    out = resolv.succeed(
+        "${getaddrinfo} host-dual.example.net"
+    )
+    res.append(
+        compare(
+            "resolve dual stack", "192.0.2.1 192.0.2.2 2001:db8::2:1 2001:db8::2:2", out
+        )
+    )
+
+    assert all(res) is True
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

This PR is part of the networking.* namespace cleanup. We feel that
networking.hostConf is rarely used and provides little value compared to
using environment.etc."host.conf" directly.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - nixos/tests/network.nix with _networkd=false_
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
  - no appearances outside options.html
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

