### PR TITLE
nixos/codimd: port test to python test-driver

### DIFF
--- a/nixos/tests/codimd.nix
+++ b/nixos/tests/codimd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test-python.nix ({ pkgs, lib, ... }:
 {
   name = "codimd";
 
@@ -35,20 +35,18 @@ import ./make-test.nix ({ pkgs, lib, ... }:
   };
 
   testScript = ''
-    startAll();
+    start_all()
 
-    subtest "CodiMD sqlite", sub {
-      $codimdSqlite->waitForUnit("codimd.service");
-      $codimdSqlite->waitForOpenPort(3000);
-      $codimdSqlite->waitUntilSucceeds("curl -sSf http://localhost:3000/new");
-    };
+    with subtest("CodiMD sqlite"):
+        codimdSqlite.wait_for_unit("codimd.service")
+        codimdSqlite.wait_for_open_port(3000)
+        codimdSqlite.wait_until_succeeds("curl -sSf http://localhost:3000/new")
 
-    subtest "CodiMD postgres", sub {
-      $codimdPostgres->waitForUnit("postgresql.service");
-      $codimdPostgres->waitForUnit("codimd.service");
-      $codimdPostgres->waitForOpenPort(5432);
-      $codimdPostgres->waitForOpenPort(3000);
-      $codimdPostgres->waitUntilSucceeds("curl -sSf http://localhost:3000/new");
-    };
+    with subtest("CodiMD postgres"):
+        codimdPostgres.wait_for_unit("postgresql.service")
+        codimdPostgres.wait_for_unit("codimd.service")
+        codimdPostgres.wait_for_open_port(5432)
+        codimdPostgres.wait_for_open_port(3000)
+        codimdPostgres.wait_until_succeeds("curl -sSf http://localhost:3000/new")
   '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#72828 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
