### PR TITLE
rc-effect-playground: init at unstable-28-10-2019

### DIFF
--- a/pkgs/applications/audio/rc-effect-playground/default.nix
+++ b/pkgs/applications/audio/rc-effect-playground/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, boost, cairo, lv2, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "rc-effect-playground";
+  version = "unstable-28-10-2019";
+
+  src = fetchFromGitHub {
+    owner = "jpcima";
+    repo = pname;
+    rev = "7a0306bf0d426318195bccdd4290b7ccd284093d";
+    sha256 = "14nq9p3n4lnmpdvwdr7zhsfqc1v7dyrygnzcf83hvra1z515pwrm";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    patchShebangs ./dpf/utils/generate-ttl.sh
+  '';
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [
+    boost cairo lv2
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jpcima/rc-effect-playground;
+    description = "Juno audio effect based on DISTRHO Plugin Framework";
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+    license = licenses.isc;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5934,6 +5934,8 @@ in
 
   rc = callPackage ../shells/rc { };
 
+  rc-effect-playground = callPackage ../applications/audio/rc-effect-playground { };
+
   rdma-core = callPackage ../os-specific/linux/rdma-core { };
 
   react-native-debugger = callPackage ../development/tools/react-native-debugger { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
