### PR TITLE
string-machine: init at unstable-2020-01-20

### DIFF
--- a/pkgs/applications/audio/string-machine/default.nix
+++ b/pkgs/applications/audio/string-machine/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, boost, cairo, lv2, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "string-machine";
+  version = "unstable-2020-01-20";
+
+  src = fetchFromGitHub {
+    owner = "jpcima";
+    repo = pname;
+    rev = "188082dd0beb9a3c341035604841c53675fe66c4";
+    sha256 = "0l9xrzp3f0hk6h320qh250a0n1nbd6qhjmab21sjmrlb4ngy672v";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    patchShebangs ./dpf/utils/generate-ttl.sh
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    boost cairo lv2
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/jpcima/string-machine";
+    description = "Digital model of electronic string ensemble instrument";
+    maintainers = [ maintainers.magnetophon ];
+    platforms = intersectLists platforms.linux platforms.x86;
+    license = licenses.boost;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2016,6 +2016,8 @@ in
 
   step-cli = callPackage ../tools/security/step-cli { };
 
+  string-machine = callPackage ../applications/audio/string-machine { };
+
   bash-supergenpass = callPackage ../tools/security/bash-supergenpass { };
 
   sweep-visualizer = callPackage ../tools/misc/sweep-visualizer { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
