### PR TITLE
Refresh LinPhone ecosystem

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -2,19 +2,18 @@
 , zlib, libxml2, gtk2, libnotify, speex, ffmpeg, libX11, libsoup, udev
 , ortp, mediastreamer, sqlite, belle-sip, libosip, libexosip, bzrtp
 , mediastreamer-openh264, bctoolbox, makeWrapper, fetchFromGitHub, cmake
-, libmatroska, bcunit, doxygen, gdk-pixbuf, glib, cairo, pango, polarssl
-, python, graphviz, belcard
+, libmatroska, bcunit, doxygen, gdk-pixbuf, glib, cairo, pango, mbedtls
+, python, graphviz, belcard, bcg729
 , withGui ? true
 }:
 
 stdenv.mkDerivation rec {
-  baseName = "linphone";
+  pname = "linphone";
   version = "3.12.0";
-  name = "${baseName}-${version}";
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = baseName;
+    repo = pname;
     rev = version;
     sha256 = "0az2ywrpx11sqfb4s4r2v726avcjf4k15bvrqj7xvhz7hdndmh0j";
   };
@@ -27,21 +26,25 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     readline openldap cyrus_sasl libupnp zlib libxml2 gtk2 libnotify speex ffmpeg libX11
-    polarssl libsoup udev ortp mediastreamer sqlite belle-sip libosip libexosip
-    bctoolbox libmatroska bcunit gdk-pixbuf glib cairo pango bzrtp belcard
+    mbedtls libsoup udev ortp mediastreamer sqlite belle-sip libosip libexosip
+    bctoolbox libmatroska gdk-pixbuf glib cairo pango bzrtp belcard bcg729
   ];
 
   nativeBuildInputs = [
-    intltool pkgconfig makeWrapper cmake doxygen graphviz
+    intltool pkgconfig makeWrapper cmake bcunit doxygen graphviz
     (python.withPackages (ps: [ ps.pystache ps.six ]))
   ];
 
-  NIX_CFLAGS_COMPILE = " -Wno-error -I${glib.dev}/include/glib-2.0
-    -I${glib.out}/lib/glib-2.0/include -I${gtk2.dev}/include/gtk-2.0/
-    -I${cairo.dev}/include/cairo -I${pango.dev}/include/pango-1.0
-    -I${gtk2}/lib/gtk-2.0/include
-    -DLIBLINPHONE_GIT_VERSION=\"v${version}\"
-    ";
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error"
+    "-I${glib.dev}/include/glib-2.0"
+    "-I${glib.out}/lib/glib-2.0/include"
+    "-I${gtk2.dev}/include/gtk-2.0/"
+    "-I${cairo.dev}/include/cairo"
+    "-I${pango.dev}/include/pango-1.0"
+    "-I${gtk2}/lib/gtk-2.0/include"
+    "-DLIBLINPHONE_GIT_VERSION=\"v${version}\""
+  ];
 
   postInstall = ''
     for i in $(cd $out/bin && ls); do
@@ -50,8 +53,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.linphone.org/;
-    description = "Open Source video SIP softphone";
+    homepage = https://www.linphone.org/;
+    description = "Open source SIP phone for voice/video calls and instant messaging";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/bcg729/default.nix
+++ b/pkgs/development/libraries/bcg729/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bcg729";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "BelledonneCommunications";
+    repo = pname;
+    rev = version;
+    sha256 = "05s0c5ps3a763y0v34wg5zghj0cdjnq4ch7g81848xxry7q90fwa";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/BelledonneCommunications/bcg729/commit/a5907daf1b111e4ad7aab4f558f57e2af1e37e55.patch";
+      sha256 = "0445syfwj4w4chh8ak80rq77iqcr27924n1ld5snshk3d21nxd64";
+    })
+    (fetchpatch {
+      url = "https://github.com/BelledonneCommunications/bcg729/commit/697bf6653a8c7421f0e821ee8d42471246e6850f.patch";
+      sha256 = "1h3gf5sj2sg5cs5iv1lcav3lkqmd5jf4agvjzz83l89wd5f5hp5l";
+    })
+    (fetchpatch {
+      url = "https://github.com/BelledonneCommunications/bcg729/commit/d63ce04a93711820d9a6985b1d11d8d91ed8e6b6.patch";
+      sha256 = "1piwf63ci2gma6jd6b4adkvxirysvazf0vklb5pc6vx1g93nkgxs";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Opensource implementation of both encoder and decoder of the ITU G729 Annex A/B speech codec";
+    homepage = "https://linphone.org/technical-corner/bcg729";
+    changelog = "https://gitlab.linphone.org/BC/public/bcg729/raw/${version}/NEWS";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ c0bw3b ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/bctoolbox/default.nix
+++ b/pkgs/development/libraries/bctoolbox/default.nix
@@ -1,19 +1,23 @@
-{stdenv, fetchFromGitHub, cmake, mbedtls, bcunit, srtp}:
+{ stdenv, fetchFromGitHub, cmake, bcunit, mbedtls }:
+
 stdenv.mkDerivation rec {
-  name = "${baseName}-${version}";
-  baseName = "bctoolbox";
+  pname = "bctoolbox";
   version = "0.6.0";
-  buildInputs = [cmake mbedtls bcunit srtp];
+
+  nativeBuildInputs = [ cmake bcunit ];
+  buildInputs = [ mbedtls ];
+
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = baseName;
+    repo = pname;
     rev = version;
     sha256 = "1cxx243wyzkd4xnvpyqf97n0rjhfckpvw1vhwnbwshq3q6fra909";
   };
 
   meta = {
     inherit version;
-    description = ''Utilities library for Linphone'';
+    description = "Utilities library for Linphone";
+    homepage = "https://github.com/BelledonneCommunications/bctoolbox";
     license = stdenv.lib.licenses.gpl2Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -1,15 +1,14 @@
-{ stdenv, antlr3_4, libantlr3c, jre, polarssl, fetchFromGitHub
+{ stdenv, antlr3_4, libantlr3c, jre, mbedtls, fetchFromGitHub
   , cmake, zlib, bctoolbox
 }:
 
 stdenv.mkDerivation rec {
-  baseName = "belle-sip";
+  pname = "belle-sip";
   version = "1.6.3";
-  name = "${baseName}-${version}";
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = baseName;
+    repo = pname;
     rev = version;
     sha256 = "0q70db1klvhca1af29bm9paka3gyii5hfbzrj4178gclsg7cj8fk";
   };
@@ -24,18 +23,14 @@ stdenv.mkDerivation rec {
     "-Wno-error=cast-function-type"
   ];
 
-  propagatedBuildInputs = [ antlr3_4 libantlr3c polarssl bctoolbox ];
-
-  configureFlags = [
-    "--with-polarssl=${polarssl}"
-  ];
+  propagatedBuildInputs = [ antlr3_4 libantlr3c mbedtls bctoolbox ];
 
   # Fails to build with lots of parallel jobs
   enableParallelBuilding = false;
 
   meta = with stdenv.lib; {
-    homepage = http://www.linphone.org/index.php/eng;
-    description = "A Voice-over-IP phone";
+    homepage = https://linphone.org/technical-corner/belle-sip;
+    description = "Modern library implementing SIP (RFC 3261) transport, transaction and dialog layers";
     license = licenses.gpl2;
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -1,17 +1,16 @@
 { stdenv, pkgconfig, intltool, alsaLib, libpulseaudio, speex, gsm
 , libopus, ffmpeg, libX11, libXv, libGLU_combined, glew, libtheora, libvpx, SDL, libupnp
 , ortp, libv4l, libpcap, srtp, fetchFromGitHub, cmake, bctoolbox, doxygen
-, python, libXext, libmatroska, openssl, fetchpatch
+, python, libXext, libmatroska, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
-  baseName = "mediastreamer2";
+  pname = "mediastreamer2";
   version = "2.16.1";
-  name = "${baseName}-${version}";
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = baseName;
+    repo = pname;
     rev = version;
     sha256 = "02745bzl2r1jqvdqzyv94fjd4w92zr976la4c4nfvsy52waqah7j";
   };
@@ -31,19 +30,18 @@ stdenv.mkDerivation rec {
     alsaLib libpulseaudio speex gsm libopus
     ffmpeg libX11 libXv libGLU_combined glew libtheora libvpx SDL libupnp
     ortp libv4l libpcap srtp bctoolbox libXext libmatroska
-    openssl
   ];
 
   NIX_CFLAGS_COMPILE = [
-    "-DGIT_VERSION=\"v2.14.0\""
+    "-DGIT_VERSION=\"v${version}\""
     "-Wno-error=deprecated-declarations"
     "-Wno-error=cast-function-type"
   ];
-  NIX_LDFLAGS = "-lXext -lssl";
+  NIX_LDFLAGS = "-lXext";
 
   meta = with stdenv.lib; {
     description = "A powerful and lightweight streaming engine specialized for voice/video telephony applications";
-    homepage = http://www.linphone.org/technical-corner/mediastreamer2/overview;
+    homepage = http://www.linphone.org/technical-corner/mediastreamer2;
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/mediastreamer/msopenh264.nix
+++ b/pkgs/development/libraries/mediastreamer/msopenh264.nix
@@ -1,23 +1,30 @@
 { stdenv, autoreconfHook, pkgconfig, mediastreamer, openh264
-, fetchgit, cmake
+, fetchurl, fetchpatch, cmake
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "mediastreamer-openh264";
-  version = "0.0pre20160801";
+  version = "1.2.1";
 
-  src = fetchgit {
-    url = "git://git.linphone.org/msopenh264.git";
-    rev = "4cb4b134bf0f1538fd0c2c928eee2d5388115abc";
-    sha256 = "001km4xy1ifwbg1c19ncc75h867fzfcxy9pxvl4pxqb64169xc1k";
+  src = fetchurl {
+    url = "https://www.linphone.org/releases/sources/plugins/msopenh264/msopenh264-${version}.tar.gz";
+    sha256 = "0rdxgazm52560g52pp6mp3mwx6j1z3h2zyizzfycp8y8zi92fqm8";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "msopenh264-build-with-openh264-v2.patch";
+      url = "https://git.pld-linux.org/?p=packages/mediastreamer-plugin-msopenh264.git;a=blob_plain;f=mediastreamer-plugin-msopenh264-openh264.patch;hb=344b8af379701a7e58b4ffb3cbac1517eff079fd";
+      sha256 = "10c24b0afchx78q28176pd8iz7i1nlf57f6v6lyqxpz60fm5nrcc";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook cmake pkgconfig ];
   buildInputs = [ mediastreamer openh264 ];
 
   meta = with stdenv.lib; {
     description = "H.264 encoder/decoder plugin for mediastreamer2";
-    homepage = http://www.linphone.org/technical-corner/mediastreamer2/overview;
+    homepage = "https://www.linphone.org/technical-corner/mediastreamer2";
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/ortp/default.nix
+++ b/pkgs/development/libraries/ortp/default.nix
@@ -1,13 +1,12 @@
 { stdenv, cmake, fetchFromGitHub, bctoolbox }:
 
 stdenv.mkDerivation rec {
-  baseName = "ortp";
+  pname = "ortp";
   version = "1.0.2";
-  name = "${baseName}-${version}";
 
   src = fetchFromGitHub {
     owner = "BelledonneCommunications";
-    repo = baseName;
+    repo = pname;
     rev = version;
     sha256 = "12cwv593bsdnxs0zfcp07vwyk7ghlz2wv7vdbs1ksv293w3vj2rv";
   };
@@ -17,8 +16,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A Real-Time Transport Protocol (RFC3550) stack";
-    homepage = http://www.linphone.org/index.php/eng/code_review/ortp;
-    license = licenses.lgpl21;
+    homepage = https://linphone.org/technical-corner/ortp;
+    license = licenses.gpl2Plus;
     platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10697,6 +10697,8 @@ in
 
   bamf = callPackage ../development/libraries/bamf { };
 
+  bcg729 = callPackage ../development/libraries/bcg729 { };
+
   bctoolbox = callPackage ../development/libraries/bctoolbox { };
 
   beecrypt = callPackage ../development/libraries/beecrypt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19760,9 +19760,7 @@ in
 
   links2 = callPackage ../applications/networking/browsers/links2 { };
 
-  linphone = callPackage ../applications/networking/instant-messengers/linphone {
-    polarssl = mbedtls_1_3;
-  };
+  linphone = callPackage ../applications/networking/instant-messengers/linphone { };
 
   linuxsampler = callPackage ../applications/audio/linuxsampler { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10697,9 +10697,7 @@ in
 
   bamf = callPackage ../development/libraries/bamf { };
 
-  bctoolbox = callPackage ../development/libraries/bctoolbox {
-    mbedtls = mbedtls_1_3;
-  };
+  bctoolbox = callPackage ../development/libraries/bctoolbox { };
 
   beecrypt = callPackage ../development/libraries/beecrypt { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Main goal is to cleanup the last dependencies on `mbedtls_1_3` which has been EoL for a while now
\+ `mediastreamer-openh264` update
\+ fix many homepages pointing to non-existing pages under the linphone.org domain
\+ add `bcg729` library

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c 

---

Result of `nix-review` 
<details>
  <summary>12 package were build:</summary>

  - bcg729
  - bctoolbox
  - belcard
  - belle-sip
  - belr
  - bzrtp
  - linphone
  - mediastreamer
  - mediastreamer-openh264
  - msilbc
  - ortp
  - trx
</details>
