### PR TITLE
rhodium-libre: init at 1.2.0

### DIFF
--- a/pkgs/data/fonts/rhodium-libre/default.nix
+++ b/pkgs/data/fonts/rhodium-libre/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub }:
+
+let
+  pname = "RhodiumLibre";
+  version = "1.2.0";
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+
+  owner = "DunwichType";
+  repo = pname;
+  rev = version;
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    install -Dm444 -t $out/share/fonts/opentype/ RhodiumLibre-Regular.otf
+    install -Dm444 -t $out/share/fonts/truetype/ RhodiumLibre-Regular.ttf
+  '';
+
+  sha256 = "04ax6bri5vsji465806p8d7zbdf12r5bpvcm9nb8isfqm81ggj0r";
+
+  meta = with lib; {
+    description = "F/OSS/Libre font for Latin and Devanagari";
+    homepage = "https://github.com/DunwichType/RhodiumLibre";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17593,6 +17593,8 @@ in
 
   recursive = callPackage ../data/fonts/recursive { };
 
+  rhodium-libre = callPackage ../data/fonts/rhodium-libre { };
+
   rictydiminished-with-firacode = callPackage ../data/fonts/rictydiminished-with-firacode { };
 
   roboto = callPackage ../data/fonts/roboto { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/DunwichType/RhodiumLibre

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
