### PR TITLE
quadrafuzz: init at 0.1.1

### DIFF
--- a/pkgs/applications/audio/quadrafuzz/default.nix
+++ b/pkgs/applications/audio/quadrafuzz/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, fetchFromGitHub, boost, cairo, lv2, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "quadrafuzz";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "jpcima";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1kjsf7il9krihwlrq08gk2xvil4b4q5zd87nnm103hby2w7ws7z1";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    patchShebangs ./dpf/utils/generate-ttl.sh
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    boost cairo lv2
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/lv2
+    cp -r bin/quadrafuzz.lv2/ $out/lib/lv2
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/jpcima/quadrafuzz";
+    description = "Multi-band fuzz distortion plugin";
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8033,6 +8033,8 @@ in
 
   qtikz = libsForQt5.callPackage ../applications/graphics/ktikz { };
 
+  quadrafuzz = callPackage ../applications/audio/quadrafuzz { };
+
   quickfix = callPackage ../development/libraries/quickfix { };
 
   quickjs = callPackage ../development/interpreters/quickjs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
