### PR TITLE
ssmtp: use services.ssmtp not networking.defaultMailServer

### DIFF
--- a/nixos/modules/programs/ssmtp.nix
+++ b/nixos/modules/programs/ssmtp.nix
@@ -8,18 +8,16 @@
 with lib;
 
 let
-
-  cfg = config.networking.defaultMailServer;
+  cfg = config.services.ssmtp;
 
 in
-
 {
 
   options = {
 
-    networking.defaultMailServer = {
+    services.ssmtp = {
 
-      directDelivery = mkOption {
+      enable = mkOption {
         type = types.bool;
         default = false;
         description = ''
@@ -29,7 +27,7 @@ in
           <command>sendmail</command> or <command>postfix</command> on
           your machine, set this option to <literal>true</literal>, and
           set the option
-          <option>networking.defaultMailServer.hostName</option> to the
+          <option>services.ssmtp.hostName</option> to the
           host name of your preferred mail server.
         '';
       };
@@ -129,9 +127,9 @@ in
   };
 
 
-  config = mkIf cfg.directDelivery {
+  config = mkIf cfg.enable {
 
-    networking.defaultMailServer.authPassFile = mkIf (cfg.authPass != "")
+    services.ssmtp.authPassFile = mkIf (cfg.authPass != "")
       (mkDefault (toString (pkgs.writeTextFile {
         name = "ssmtp-authpass";
         text = cfg.authPass;

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -11,6 +11,8 @@ with lib;
     (mkRenamedOptionModule [ "networking" "enableRTL8192cFirmware" ] [ "hardware" "enableRedistributableFirmware" ])
     (mkRenamedOptionModule [ "networking" "networkmanager" "useDnsmasq" ] [ "networking" "networkmanager" "dns" ])
     (mkRenamedOptionModule [ "networking" "connman" ] [ "services" "connman" ])
+    (mkRenamedOptionModule [ "networking" "defaultMailServer" ] [ "services" "ssmtp" ])
+    (mkRenamedOptionModule [ "services" "ssmtp" "directDelivery" ] [ "services" "ssmtp" "enable" ])
     (mkChangedOptionModule [ "services" "printing" "gutenprint" ] [ "services" "printing" "drivers" ]
       (config:
         let enabled = getAttrFromPath [ "services" "printing" "gutenprint" ] config;

--- a/nixos/tests/mailcatcher.nix
+++ b/nixos/tests/mailcatcher.nix
@@ -9,8 +9,8 @@ import ./make-test.nix ({ lib, ... }:
     {
       services.mailcatcher.enable = true;
 
-      networking.defaultMailServer.directDelivery = true;
-      networking.defaultMailServer.hostName = "localhost:1025";
+      services.ssmtp.enable = true;
+      services.ssmtp.hostName = "localhost:1025";
 
       environment.systemPackages = [ pkgs.mailutils ];
     };


### PR DESCRIPTION
###### Motivation for this change

This PR is part of the networking.* namespace cleanup.

ssmtp used to be configured via `networking.defaultMailServer` which is sort of misleading since it provides options only for ssmtp. Other dumb mail relays like *nullmailer* have always been living under services.

The intent of this PR is to align ssmtp's options with those of similar services. Specifically, two renames have been done:

* Rename `networking.defaultMailHost` to `services.ssmtp`.
* Rename `directDelivery` to `enable` because this is what it basically does.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - mailcatcher
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @basvandijk 