### PR TITLE
git-subrepo: enable on Darwin

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-subrepo/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-subrepo/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/ingydotnet/git-subrepo;
     description = "Git submodule alternative";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.unix ++ platforms.darwin;
     maintainers = [ maintainers.ryantrinkle ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

`git-subrepo` works fine on Darwin (at least for me).


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).