### PR TITLE
glava: fix glava wants to load shaders from /etc/xdg/glava

### DIFF
--- a/pkgs/applications/misc/glava/default.nix
+++ b/pkgs/applications/misc/glava/default.nix
@@ -8,7 +8,7 @@ let
   wrapperScript = writeScript "glava" ''
     #!${runtimeShell}
     case "$1" in
-      --copy-config)
+      --copy-config|-C)
         # The binary would symlink it, which won't work in Nix because the
         # garbage collector will eventually remove the original files after
         # updates
@@ -45,6 +45,14 @@ in
     ];
 
     preConfigure = ''
+      for f in $(find -type f);do
+        substituteInPlace $f \
+          --replace /etc/xdg $out/etc/xdg
+      done
+
+      substituteInPlace Makefile \
+        --replace '$(DESTDIR)$(SHADERDIR)' '$(SHADERDIR)'
+
       substituteInPlace Makefile \
         --replace 'unknown' 'v${version}'
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

fix absolute paths so `glava` can find default shader files correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @eadwu 
