### PR TITLE
ubootTools: use tools-only_defconfig instead of allnoconfig

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -90,15 +90,12 @@ in {
   inherit buildUBoot;
 
   ubootTools = buildUBoot {
-    defconfig = "allnoconfig";
+    defconfig = "tools-only_defconfig";
     installDir = "$out/bin";
     hardeningDisable = [];
     dontStrip = false;
     extraMeta.platforms = lib.platforms.linux;
     extraMakeFlags = [ "HOST_TOOLS_ALL=y" "CROSS_BUILD_TOOLS=1" "NO_SDL=1" "tools" ];
-    postConfigure = ''
-      sed -i '/CONFIG_SYS_TEXT_BASE/c\CONFIG_SYS_TEXT_BASE=0x00000000' .config
-    '';
     filesToInstall = [
       "tools/dumpimage"
       "tools/fdtgrep"


### PR DESCRIPTION
Includes more features in the tools, like support for Flat Device Tree
files in mkimage.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

My boot loader configuration for my chromebook fails with
```
/nix/store/pxar3ajcsmiv6s1rii4dy5qjwh5jbilc-uboot-allnoconfig-2019.10/bin/mkimage: unsupported type Flat Device Tree
```

This used to work, and I haven't tracked down what changed to remove FDT support from `mkimage`, but I'm assuming it's some internal change within uboot's configuration.

Surveying other implementations for guidance, [arch (community)][arch-pkgbuild] uses plain `defconfig`, while [debian][] uses `tools-only_defconfig`, without FDT signatures due to GPL concerns.

For the config changes that result from this change, see the [full diff][].

[arch-pkgbuild]: https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/uboot-tools&id=7962de3d9067bd9b2eed49475ea7288b814ef325#n20

[debian]: https://salsa.debian.org/debian/u-boot/blob/20c6dea05a890e234df091fd4e17742902cd9bab/debian/rules#L113-117

[full diff]: https://gist.github.com/thefloweringash/a94b0e208b8cb6d3ab51a999474e1b35

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @samueldr @dezgeg 
