### PR TITLE
nixos/prometheus: Port prometheus test to python

### DIFF
--- a/nixos/tests/prometheus.nix
+++ b/nixos/tests/prometheus.nix
@@ -31,7 +31,7 @@ let
     };
   };
 
-in import ./make-test.nix {
+in import ./make-test-python.nix {
   name = "prometheus";
 
   nodes = {
@@ -173,67 +173,73 @@ in import ./make-test.nix {
   testScript = { nodes, ... } : ''
     # Before starting the other machines we first make sure that our S3 service is online
     # and has a bucket added for thanos:
-    $s3->start;
-    $s3->waitForUnit("minio.service");
-    $s3->waitForOpenPort(${toString minioPort});
-    $s3->succeed(
-      "mc config host add minio " .
-      "http://localhost:${toString minioPort} ${s3.accessKey} ${s3.secretKey} S3v4");
-    $s3->succeed("mc mb minio/thanos-bucket");
+    s3.start()
+    s3.wait_for_unit("minio.service")
+    s3.wait_for_open_port(${toString minioPort})
+    s3.succeed(
+        "mc config host add minio "
+        + "http://localhost:${toString minioPort} "
+        + "${s3.accessKey} ${s3.secretKey} S3v4",
+        "mc mb minio/thanos-bucket",
+    )
 
     # Now that s3 has started we can start the other machines:
-    $prometheus->start;
-    $query->start;
-    $store->start;
+    for machine in prometheus, query, store:
+        machine.start()
 
     # Check if prometheus responds to requests:
-    $prometheus->waitForUnit("prometheus.service");
-    $prometheus->waitForOpenPort(${toString queryPort});
-    $prometheus->succeed("curl -s http://127.0.0.1:${toString queryPort}/metrics");
+    prometheus.wait_for_unit("prometheus.service")
+    prometheus.wait_for_open_port(${toString queryPort})
+    prometheus.succeed("curl -s http://127.0.0.1:${toString queryPort}/metrics")
 
     # Let's test if pushing a metric to the pushgateway succeeds:
-    $prometheus->waitForUnit("pushgateway.service");
-    $prometheus->succeed(
-      "echo 'some_metric 3.14' | " .
-      "curl --data-binary \@- http://127.0.0.1:${toString pushgwPort}/metrics/job/some_job");
+    prometheus.wait_for_unit("pushgateway.service")
+    prometheus.succeed(
+        "echo 'some_metric 3.14' | "
+        + "curl --data-binary \@- "
+        + "http://127.0.0.1:${toString pushgwPort}/metrics/job/some_job"
+    )
 
     # Now check whether that metric gets ingested by prometheus.
     # Since we'll check for the metric several times on different machines
     # we abstract the test using the following function:
 
     # Function to check if the metric "some_metric" has been received and returns the correct value.
-    local *Machine::waitForMetric = sub {
-      my ($self) = @_;
-      $self->waitUntilSucceeds(
-        "curl -sf 'http://127.0.0.1:${toString queryPort}/api/v1/query?query=some_metric' " .
-        "| jq '.data.result[0].value[1]' | grep '\"3.14\"'");
-    };
+    def wait_for_metric(machine):
+        return machine.wait_until_succeeds(
+            "curl -sf 'http://127.0.0.1:${toString queryPort}/api/v1/query?query=some_metric' | "
+            + "jq '.data.result[0].value[1]' | grep '\"3.14\"'"
+        )
 
-    $prometheus->waitForMetric;
+
+    wait_for_metric(prometheus)
 
     # Let's test if the pushgateway persists metrics to the configured location.
-    $prometheus->waitUntilSucceeds("test -e /var/lib/prometheus-pushgateway/metrics");
+    prometheus.wait_until_succeeds("test -e /var/lib/prometheus-pushgateway/metrics")
 
     # Test thanos
-    $prometheus->waitForUnit("thanos-sidecar.service");
+    prometheus.wait_for_unit("thanos-sidecar.service")
 
     # Test if the Thanos query service can correctly retrieve the metric that was send above.
-    $query->waitForUnit("thanos-query.service");
-    $query->waitForMetric;
+    query.wait_for_unit("thanos-query.service")
+    wait_for_metric(query)
 
     # Test if the Thanos sidecar has correctly uploaded its TSDB to S3, if the
     # Thanos storage service has correctly downloaded it from S3 and if the Thanos
     # query service running on $store can correctly retrieve the metric:
-    $store->waitForUnit("thanos-store.service");
-    $store->waitForMetric;
+    store.wait_for_unit("thanos-store.service")
+    wait_for_metric(store)
 
-    $store->waitForUnit("thanos-compact.service");
+    store.wait_for_unit("thanos-compact.service")
 
     # Test if the Thanos bucket command is able to retrieve blocks from the S3 bucket
     # and check if the blocks have the correct labels:
-    $store->succeed(
-      "thanos bucket ls" .
-      " --objstore.config-file=${nodes.store.config.services.thanos.store.objstore.config-file}" .
-      " --output=json | jq .thanos.labels.some_label | grep 'required by thanos'");
+    store.succeed(
+        "thanos bucket ls "
+        + "--objstore.config-file=${nodes.store.config.services.thanos.store.objstore.config-file} "
+        + "--output=json | "
+        + "jq .thanos.labels.some_label | "
+        + "grep 'required by thanos'"
+    )
   '';
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli @worldofpeace 
