### PR TITLE
treewide: Purge most parseDrvName preserving compat for 19.09

### DIFF
--- a/doc/configuration.xml
+++ b/doc/configuration.xml
@@ -179,11 +179,10 @@
      allows unfree packages named flash player and visual studio code:
 <programlisting>
 {
-  allowUnfreePredicate = (pkg: builtins.elem
-    (builtins.parseDrvName pkg.name).name [
-      "flashplayer"
-      "vscode"
-    ]);
+  allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+    "flashplayer"
+    "vscode"
+  ];
 }
 </programlisting>
     </para>
@@ -273,7 +272,7 @@
      very short names:
 <programlisting>
 {
-  allowInsecurePredicate = (pkg: (builtins.stringLength (builtins.parseDrvName pkg.name).name) &lt;= 5);
+  allowInsecurePredicate = (pkg: (builtins.stringLength (lib.getName pkg) &lt;= 5);
 }
 </programlisting>
     </para>

--- a/doc/configuration.xml
+++ b/doc/configuration.xml
@@ -272,7 +272,7 @@
      very short names:
 <programlisting>
 {
-  allowInsecurePredicate = (pkg: (builtins.stringLength (lib.getName pkg) &lt;= 5);
+  allowInsecurePredicate = pkg: builtins.stringLength (lib.getName pkg) &lt;= 5;
 }
 </programlisting>
     </para>

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -84,7 +84,8 @@ let
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape
       escapeShellArg escapeShellArgs replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
-      removePrefix removeSuffix versionOlder versionAtLeast getVersion
+      removePrefix removeSuffix versionOlder versionAtLeast
+      getName getVersion
       nameFromURL enableFeature enableFeatureAs withFeature
       withFeatureAs fixedWidthString fixedWidthNumber isStorePath
       toInt readPathsFromFile fileContents;

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -473,6 +473,23 @@ rec {
   versionAtLeast = v1: v2: !versionOlder v1 v2;
 
   /* This function takes an argument that's either a derivation or a
+     derivation's "name" attribute and extracts the name part from that
+     argument.
+
+     Example:
+       getName "youtube-dl-2016.01.01"
+       => "youtube-dl"
+       getName pkgs.youtube-dl
+       => "youtube-dl"
+  */
+  getName = x:
+   let
+     parse = drv: (builtins.parseDrvName drv).name;
+   in if isString x
+      then parse x
+      else x.pname or (parse x.name);
+
+  /* This function takes an argument that's either a derivation or a
      derivation's "name" attribute and extracts the version part from that
      argument.
 

--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -126,7 +126,7 @@ let
 
   packageData = package: {
     name = package.name;
-    pname = (builtins.parseDrvName package.name).name;
+    pname = lib.getName package;
     updateScript = map builtins.toString (pkgs.lib.toList package.updateScript);
   };
 

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -8,15 +8,11 @@ let
 
   mysql = cfg.package;
 
-  isMariaDB =
-    let
-      pName = _p: (builtins.parseDrvName (_p.name)).name;
-    in pName mysql == pName pkgs.mariadb;
+  isMariaDB = lib.getName mysql == lib.getName pkgs.mariadb;
+
   isMysqlAtLeast57 =
-    let
-      pName = _p: (builtins.parseDrvName (_p.name)).name;
-    in (pName mysql == pName pkgs.mysql57)
-       && ((builtins.compareVersions mysql.version "5.7") >= 0);
+    (lib.getName mysql == lib.getName pkgs.mysql57)
+     && (builtins.compareVersions mysql.version "5.7" >= 0);
 
   mysqldOptions =
     "--user=${cfg.user} --datadir=${cfg.dataDir} --basedir=${mysql}";

--- a/nixos/modules/services/networking/znc/default.nix
+++ b/nixos/modules/services/networking/znc/default.nix
@@ -239,7 +239,7 @@ in
     services.znc = {
       configFile = mkDefault (pkgs.writeText "znc-generated.conf" semanticString);
       config = {
-        Version = (builtins.parseDrvName pkgs.znc.name).version;
+        Version = lib.getVersion pkgs.znc;
         Listener.l.Port = mkDefault 5000;
         Listener.l.SSL = mkDefault true;
       };

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -47,8 +47,8 @@ let
       grub = f grub;
       grubTarget = f (grub.grubTarget or "");
       shell = "${pkgs.runtimeShell}";
-      fullName = (builtins.parseDrvName realGrub.name).name;
-      fullVersion = (builtins.parseDrvName realGrub.name).version;
+      fullName = lib.getName realGrub;
+      fullVersion = lib.getVersion realGrub;
       grubEfi = f grubEfi;
       grubTargetEfi = if cfg.efiSupport && (cfg.version == 2) then f (grubEfi.grubTarget or "") else "";
       bootPath = args.path;

--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -36,7 +36,7 @@ mkDerivation rec {
   # https://cgit.kde.org/kdevelop.git/commit/?id=716372ae2e8dff9c51e94d33443536786e4bd85b
   # required as nixos seems to be unable to find CLANG_BUILTIN_DIR
   cmakeFlags = [
-    "-DCLANG_BUILTIN_DIR=${llvmPackages.clang-unwrapped}/lib/clang/${(builtins.parseDrvName llvmPackages.clang.name).version}/include"
+    "-DCLANG_BUILTIN_DIR=${llvmPackages.clang-unwrapped}/lib/clang/${lib.getVersion llvmPackages.clang}/include"
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -3,8 +3,6 @@
 
 let
 
-  getDesktopFileName = drvName: (builtins.parseDrvName drvName).name;
-
   # TODO: Should we move this to `lib`? Seems like its would be useful in many cases.
   extensionOf = filePath:
     lib.concatStringsSep "." (lib.tail (lib.splitString "." (builtins.baseNameOf filePath)));
@@ -15,15 +13,15 @@ let
   '') icons);
 
   mkSweetHome3D =
-  { name, module, version, src, license, description, desktopName, icons }:
+  { pname, module, version, src, license, description, desktopName, icons }:
 
   stdenv.mkDerivation rec {
-    inherit name version src description;
+    inherit pname version src description;
     exec = stdenv.lib.toLower module;
     sweethome3dItem = makeDesktopItem {
       inherit exec desktopName;
-      name = getDesktopFileName name;
-      icon = getDesktopFileName name;
+      name = pname;
+      icon = pname;
       comment =  description;
       genericName = "Computer Aided (Interior) Design";
       categories = "Application;Graphics;2DGraphics;3DGraphics;";
@@ -49,7 +47,7 @@ let
       mkdir -p $out/bin
       cp install/${module}-${version}.jar $out/share/java/.
 
-      ${installIcons (getDesktopFileName name) icons}
+      ${installIcons pname icons}
 
       cp "${sweethome3dItem}/share/applications/"* $out/share/applications
 
@@ -74,9 +72,9 @@ let
 in {
 
   application = mkSweetHome3D rec {
+    pname = stdenv.lib.toLower module + "-application";
     version = "6.2";
     module = "SweetHome3D";
-    name = stdenv.lib.toLower module + "-application-" + version;
     description = "Design and visualize your future home";
     license = stdenv.lib.licenses.gpl2Plus;
     src = fetchsvn {

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -7,20 +7,17 @@ let
     m: "sweethome3d-"
     + removeSuffix "libraryeditor" (toLower m)
     + "-editor";
-  sweetName = m: v: sweetExec m + "-" + v;
-
-  getDesktopFileName = drvName: (builtins.parseDrvName drvName).name;
 
   mkEditorProject =
-  { name, module, version, src, license, description, desktopName }:
+  { pname, module, version, src, license, description, desktopName }:
 
   stdenv.mkDerivation rec {
     application = sweethome3dApp;
-    inherit name module version src description;
+    inherit pname module version src description;
     exec = sweetExec module;
     editorItem = makeDesktopItem {
       inherit exec desktopName;
-      name = getDesktopFileName name;
+      name = pname;
       comment =  description;
       genericName = "Computer Aided (Interior) Design";
       categories = "Application;Graphics;2DGraphics;3DGraphics;";
@@ -66,7 +63,7 @@ in {
   textures-editor = mkEditorProject rec {
     version = "1.5";
     module = "TexturesLibraryEditor";
-    name = sweetName module version;
+    pname = module;
     description = "Easily create SH3T files and edit the properties of the texture images it contain";
     license = stdenv.lib.licenses.gpl2Plus;
     src = fetchcvs {
@@ -81,7 +78,7 @@ in {
   furniture-editor = mkEditorProject rec {
     version = "1.19";
     module = "FurnitureLibraryEditor";
-    name = sweetName module version;
+    pname = module;
     description = "Quickly create SH3F files and edit the properties of the 3D models it contain";
     license = stdenv.lib.licenses.gpl2;
     src = fetchcvs {

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -18,8 +18,10 @@ browser:
 
 let
   wrapper =
-    { browserName ? browser.browserName or (builtins.parseDrvName browser.name).name
-    , name ? (browserName + "-" + (builtins.parseDrvName browser.name).version)
+    { browserName ? browser.browserName or (lib.getName browser)
+    , name ? browserName + "-" + lib.getVersion browser # TODO delete, it's just for compat
+    , pname ? lib.getName name
+    , version ? lib.getVersion name
     , desktopName ? # browserName with first letter capitalized
       (lib.toUpper (lib.substring 0 1 browserName) + lib.substring 1 (-1) browserName)
     , nameSuffix ? ""
@@ -83,7 +85,7 @@ let
       gtk_modules = [ libcanberra-gtk2 ];
 
     in stdenv.mkDerivation {
-      inherit name;
+      inherit pname version;
 
       desktopItem = makeDesktopItem {
         name = browserName;

--- a/pkgs/applications/networking/instant-messengers/slack/update.sh
+++ b/pkgs/applications/networking/instant-messengers/slack/update.sh
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-oldVersion="$(nix-instantiate --eval -E "with import ./. {}; slack-theme-black.version or (builtins.parseDrvName slack-theme-black.name).version" | tr -d '"')"
+oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion slack-theme-black" | tr -d '"')"
 latestSha="$(curl -L -s https://api.github.com/repos/laCour/slack-night-mode/commits\?sha\=master\&since\=${oldVersion} | jq -r '.[0].sha')"
 
 if [ ! "null" = "${latestSha}" ]; then

--- a/pkgs/applications/networking/instant-messengers/zoom-us/update.sh
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/update.sh
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-oldVersion=$(nix-instantiate --eval -E "with import ./. {}; zoom-us.version or (builtins.parseDrvName zoom-us.name).version" | tr -d '"')
+oldVersion=$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion zoom-us" | tr -d '"')
 version="$(curl -sI https://zoom.us/client/latest/zoom_x86_64.tar.xz | grep -Fi 'Location:' | pcregrep -o1 '/(([0-9]\.?)+)/')"
 
 if [ ! "${oldVersion}" = "${version}" ]; then

--- a/pkgs/applications/version-management/git-and-tools/git/update.sh
+++ b/pkgs/applications/version-management/git-and-tools/git/update.sh
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-oldVersion="$(nix-instantiate --eval -E "with import ./. {}; git.version or (builtins.parseDrvName git.name).version" | tr -d '"')"
+oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion git" | tr -d '"')"
 latestTag="$(git ls-remote --tags --sort="v:refname" git://github.com/git/git.git | grep -v '\{\}' | grep -v '\-rc' | tail -1 | sed 's|^.*/v\(.*\)|\1|')"
 
 if [ ! "${oldVersion}" = "${latestTag}" ]; then

--- a/pkgs/applications/version-management/monotone/default.nix
+++ b/pkgs/applications/version-management/monotone/default.nix
@@ -5,7 +5,7 @@
 
 let
   version = "1.1";
-  perlVersion = (builtins.parseDrvName perl.name).version;
+  perlVersion = stdenv.lib.getVersion perl;
 in
 
 assert perlVersion != "";

--- a/pkgs/applications/video/vdr/wrapper.nix
+++ b/pkgs/applications/video/vdr/wrapper.nix
@@ -8,7 +8,7 @@
 
 in symlinkJoin {
 
-  name = "vdr-with-plugins-${(builtins.parseDrvName vdr.name).version}";
+  name = "vdr-with-plugins-${lib.getVersion vdr}";
 
   paths = [ vdr ] ++ plugins;
 

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -16,7 +16,7 @@ let
   else
     throw "Unsupported architecture";
 
-  version = (builtins.parseDrvName edk2.name).version;
+  version = lib.getVersion edk2;
 in
 
 edk2.mkDerivation projectDscPath {

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -34,8 +34,8 @@ let
   targetPrefix = stdenv.lib.optionalString (targetPlatform != hostPlatform)
                                         (targetPlatform.config + "-");
 
-  bintoolsVersion = (builtins.parseDrvName bintools.name).version;
-  bintoolsName = (builtins.parseDrvName bintools.name).name;
+  bintoolsVersion = stdenv.lib.getVersion version;
+  bintoolsName = stdenv.lib.removePrefix targetPrefix (stdenv.lib.getName bintools);
 
   libc_bin = if libc == null then null else getBin libc;
   libc_dev = if libc == null then null else getDev libc;
@@ -74,7 +74,7 @@ in
 
 stdenv.mkDerivation {
   name = targetPrefix
-    + (if name != "" then name else stdenv.lib.removePrefix targetPrefix "${bintoolsName}-wrapper")
+    + (if name != "" then name else "${bintoolsName}-wrapper")
     + (stdenv.lib.optionalString (bintools != null && bintoolsVersion != "") "-${bintoolsVersion}");
 
   preferLocalBuild = true;

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -34,7 +34,7 @@ let
   targetPrefix = stdenv.lib.optionalString (targetPlatform != hostPlatform)
                                         (targetPlatform.config + "-");
 
-  bintoolsVersion = stdenv.lib.getVersion version;
+  bintoolsVersion = stdenv.lib.getVersion bintools;
   bintoolsName = stdenv.lib.removePrefix targetPrefix (stdenv.lib.getName bintools);
 
   libc_bin = if libc == null then null else getBin libc;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -35,8 +35,8 @@ let
   targetPrefix = stdenv.lib.optionalString (targetPlatform != hostPlatform)
                                            (targetPlatform.config + "-");
 
-  ccVersion = (builtins.parseDrvName cc.name).version;
-  ccName = (builtins.parseDrvName cc.name).name;
+  ccVersion = stdenv.lib.getVersion cc;
+  ccName = stdenv.lib.removePrefix targetPrefix (stdenv.lib.getName cc);
 
   libc_bin = if libc == null then null else getBin libc;
   libc_dev = if libc == null then null else getDev libc;
@@ -94,7 +94,7 @@ assert nativePrefix == bintools.nativePrefix;
 
 stdenv.mkDerivation {
   name = targetPrefix
-    + (if name != "" then name else stdenv.lib.removePrefix targetPrefix "${ccName}-wrapper")
+    + (if name != "" then name else "${ccName}-wrapper")
     + (stdenv.lib.optionalString (cc != null && ccVersion != "") "-${ccVersion}");
 
   preferLocalBuild = true;

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -92,8 +92,8 @@ if [ -z "$oldUrl" ]; then
     die "Couldn't evaluate source url from '$attr.src'!"
 fi
 
-drvName=$(nix-instantiate $systemArg --eval -E "with import ./. {}; (builtins.parseDrvName $attr.name).name" | tr -d '"')
-oldVersion=$(nix-instantiate $systemArg --eval -E "with import ./. {}; $attr.${versionKey} or (builtins.parseDrvName $attr.name).version" | tr -d '"')
+drvName=$(nix-instantiate $systemArg --eval -E "with import ./. {}; lib.getName $attr" | tr -d '"')
+oldVersion=$(nix-instantiate $systemArg --eval -E "with import ./. {}; $attr.${versionKey} or lib.getVersion $attr" | tr -d '"')
 
 if [ -z "$drvName" -o -z "$oldVersion" ]; then
     die "Couldn't evaluate name and version from '$attr.name'!"

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -14,10 +14,9 @@ lib.makeScope pkgs.newScope (self: with self; {
   */
   removePackagesByName = packages: packagesToRemove:
     let
-      pkgName = drv: (builtins.parseDrvName drv.name).name;
-      namesToRemove = map pkgName packagesToRemove;
+      namesToRemove = map lib.getName packagesToRemove;
     in
-      lib.filter (x: !(builtins.elem (pkgName x) namesToRemove)) packages;
+      lib.filter (x: !(builtins.elem (lib.getName x) namesToRemove)) packages;
 
   maintainers = with pkgs.lib.maintainers; [ lethalman jtojnar hedning worldofpeace ];
 

--- a/pkgs/development/compilers/chicken/4/eggDerivation.nix
+++ b/pkgs/development/compilers/chicken/4/eggDerivation.nix
@@ -8,7 +8,7 @@
 let
   libPath = "${chicken}/var/lib/chicken/${toString chicken.binaryVersion}/";
   overrides = import ./overrides.nix;
-  baseName = (builtins.parseDrvName name).name;
+  baseName = lib.getName name;
   override = if builtins.hasAttr baseName overrides
    then
      builtins.getAttr baseName overrides

--- a/pkgs/development/em-modules/generic/default.nix
+++ b/pkgs/development/em-modules/generic/default.nix
@@ -10,8 +10,8 @@ pkgs.stdenv.mkDerivation (
   args //
   {
 
-  pname = "emscripten-${args.pname or (builtins.parseDrvName args.name).name}";
-  version = args.version or (builtins.parseDrvName args.name).version;
+  pname = "emscripten-${lib.getName args}";
+  version = lib.getVersion args;
   buildInputs = [ emscripten python ] ++ buildInputs;
   nativeBuildInputs = [ emscripten python ] ++ nativeBuildInputs;
 

--- a/pkgs/development/interpreters/lua-5/build-lua-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-lua-package.nix
@@ -161,7 +161,7 @@ builtins.removeAttrs attrs ["disabled" "checkInputs" "externalDeps"] // {
 
   # enabled only for src.rock
   setSourceRoot= let
-    name_only=(builtins.parseDrvName name).name;
+    name_only= lib.getName name;
   in
     lib.optionalString (knownRockspec == null) ''
     # format is rockspec_basename/source_basename

--- a/pkgs/development/libraries/science/math/caffe2/default.nix
+++ b/pkgs/development/libraries/science/math/caffe2/default.nix
@@ -57,7 +57,7 @@ let
     dst = "pybind11";
   };
 
-  ccVersion = (builtins.parseDrvName stdenv.cc.name).version;
+  ccVersion = lib.getVersion stdenv.cc;
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/lisp-modules/openssl-lib-marked.nix
+++ b/pkgs/development/lisp-modules/openssl-lib-marked.nix
@@ -2,7 +2,7 @@ with import ../../../default.nix {};
 runCommand "openssl-lib-marked" {} ''
   mkdir -p "$out/lib"
   for lib in ssl crypto; do
-    version="${(builtins.parseDrvName openssl.name).version}"
+    version="${lib.getVersion openssl}"
     ln -s "${lib.getLib openssl}/lib/lib$lib.so" "$out/lib/lib$lib.so.$version"
     version="$(echo "$version" | sed -re 's/[a-z]+$//')"
     while test -n "$version"; do

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -34,15 +34,15 @@ toPerlModule(stdenv.mkDerivation (
     # https://metacpan.org/pod/release/XSAWYERX/perl-5.26.0/pod/perldelta.pod#Removal-of-the-current-directory-%28%22.%22%29-from-@INC
     PERL_USE_UNSAFE_INC = "1";
 
-    meta.homepage = "https://metacpan.org/release/${attrs.pname or (builtins.parseDrvName attrs.name).name}"; # TODO: phase-out `attrs.name`
+    meta.homepage = "https://metacpan.org/release/${lib.getName attrs}"; # TODO: phase-out `attrs.name`
     meta.platforms = perl.meta.platforms;
   }
   attrs
   )
   //
   {
-    pname = "perl${perl.version}-${attrs.pname or (builtins.parseDrvName attrs.name).name}"; # TODO: phase-out `attrs.name`
-    version = attrs.version or (builtins.parseDrvName attrs.name).version;                   # TODO: phase-out `attrs.name`
+    pname = "perl${perl.version}-${lib.getName attrs}"; # TODO: phase-out `attrs.name`
+    version = lib.getVersion attrs;                     # TODO: phase-out `attrs.name`
     builder = ./builder.sh;
     buildInputs = buildInputs ++ [ perl ];
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];

--- a/pkgs/development/tools/analysis/radare2/update.py
+++ b/pkgs/development/tools/analysis/radare2/update.py
@@ -38,7 +38,7 @@ def get_radare2_rev() -> str:
 
 def get_cutter_version() -> str:
     version_expr = """
-(with import <nixpkgs> {}; (builtins.parseDrvName (qt5.callPackage <radare2/cutter.nix> {}).name).version)
+(with import <nixpkgs> {}; lib.getVersion (qt5.callPackage <radare2/cutter.nix> {}))
 """
     return sh("nix", "eval", "--raw", version_expr.strip(), "-I", "radare2={0}".format(SCRIPT_DIR))
 

--- a/pkgs/development/tools/continuous-integration/jenkins/update.sh
+++ b/pkgs/development/tools/continuous-integration/jenkins/update.sh
@@ -4,7 +4,7 @@
 set -eu -o pipefail
 
 core_json="$(curl -s --fail --location https://updates.jenkins.io/stable/update-center.actual.json | jq .core)"
-oldVersion=$(nix-instantiate --eval -E "with import ./. {}; jenkins.version or (builtins.parseDrvName jenkins.name).version" | tr -d '"')
+oldVersion=$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion jenkins" | tr -d '"')
 
 version="$(jq -r .version <<<$core_json)"
 sha256="$(jq -r .sha256 <<<$core_json)"

--- a/pkgs/development/tools/documentation/antora/default.nix
+++ b/pkgs/development/tools/documentation/antora/default.nix
@@ -1,16 +1,15 @@
 { stdenv, nodePackages_10_x }:
 
 let
-  drvName = drv: (builtins.parseDrvName drv).name;
   linkNodeDeps = ({ pkg, deps, name ? "" }:
     let
-      targetModule = if name != "" then name else drvName pkg;
+      targetModule = if name != "" then name else stdenv.lib.getName pkg;
     in nodePackages_10_x.${pkg}.override (oldAttrs: {
       postInstall = ''
         mkdir -p $out/lib/node_modules/${targetModule}/node_modules
         ${stdenv.lib.concatStringsSep "\n" (map (dep: ''
-          ln -s ${nodePackages_10_x.${dep}}/lib/node_modules/${drvName dep} \
-            $out/lib/node_modules/${targetModule}/node_modules/${drvName dep}
+          ln -s ${nodePackages_10_x.${dep}}/lib/node_modules/${stdenv.lib.getName dep} \
+            $out/lib/node_modules/${targetModule}/node_modules/${stdenv.lib.getName dep}
         '') deps
         )}
       '';

--- a/pkgs/misc/emulators/retroarch/wrapper.nix
+++ b/pkgs/misc/emulators/retroarch/wrapper.nix
@@ -1,14 +1,8 @@
 { stdenv, lib, makeWrapper, retroarch, cores }:
 
-let
-
-  p = builtins.parseDrvName retroarch.name;
-
-in
-
 stdenv.mkDerivation {
-  name = "retroarch-" + p.version;
-  version = p.version;
+  pname = "retroarch";
+  version = lib.getVersion retroarch;
 
   buildInputs = [ makeWrapper ];
 

--- a/pkgs/misc/emulators/wine/staging.nix
+++ b/pkgs/misc/emulators/wine/staging.nix
@@ -5,7 +5,7 @@ with callPackage ./util.nix {};
 let patch = (callPackage ./sources.nix {}).staging;
     build-inputs = pkgNames: extra:
       (mkBuildInputs wineUnstable.pkgArches pkgNames) ++ extra;
-in assert (builtins.parseDrvName wineUnstable.name).version == patch.version;
+in assert stdenv.lib.getVersion wineUnstable == patch.version;
 
 stdenv.lib.overrideDerivation wineUnstable (self: {
   buildInputs = build-inputs [ "perl" "utillinux" "autoconf" libtxc_dxtn_Name ] self.buildInputs;

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -25,7 +25,7 @@ let
     addonInfo ? null,
     preInstall ? "",
     postInstall ? "",
-    path ? (builtins.parseDrvName pluginName).name,
+    path ? lib.getName pluginName,
     dependencies ? [],
     ...
   }:

--- a/pkgs/misc/vim-plugins/build-vim-plugin.nix
+++ b/pkgs/misc/vim-plugins/build-vim-plugin.nix
@@ -18,7 +18,7 @@ rec {
     buildPhase ? "",
     preInstall ? "",
     postInstall ? "",
-    path ? (builtins.parseDrvName name).name,
+    path ? stdenv.lib.getName name,
     addonInfo ? null,
     ...
   }:

--- a/pkgs/os-specific/linux/prl-tools/default.nix
+++ b/pkgs/os-specific/linux/prl-tools/default.nix
@@ -8,7 +8,7 @@ assert (!libsOnly) -> kernel != null;
 # Disable for kernels 4.15 and above due to compatibility issues
 assert kernel != null -> stdenv.lib.versionOlder kernel.version "4.15";
 
-let xorgFullVer = (builtins.parseDrvName xorg.xorgserver.name).version;
+let xorgFullVer = lib.getVersion xorg.xorgserver;
     xorgVer = lib.concatStringsSep "." (lib.take 2 (lib.splitString "." xorgFullVer));
     x64 = if stdenv.hostPlatform.system == "x86_64-linux" then true
           else if stdenv.hostPlatform.system == "i686-linux" then false
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     ( cd $sourceRoot/tools; tar -xaf prltools${if x64 then ".x64" else ""}.tar.gz )
   '';
 
-  kernelVersion = if libsOnly then "" else (builtins.parseDrvName kernel.name).version;
+  kernelVersion = if libsOnly then "" else lib.getName kernel.name;
   kernelDir = if libsOnly then "" else "${kernel.dev}/lib/modules/${kernelVersion}";
   scriptPath = lib.concatStringsSep ":" (lib.optionals (!libsOnly) [ "${utillinux}/bin" "${gawk}/bin" ]);
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -520,7 +520,7 @@ self: super:
   xorgserver = with self; super.xorgserver.overrideAttrs (attrs_passed:
     # exchange attrs if abiCompat is set
     let
-      version = (builtins.parseDrvName attrs_passed.name).version;
+      version = lib.getVersion attrs_passed;
       attrs =
         if (abiCompat == null || lib.hasPrefix abiCompat version) then
           attrs_passed // {
@@ -555,7 +555,7 @@ self: super:
 
     in attrs //
     (let
-      version = (builtins.parseDrvName attrs.name).version;
+      version = lib.getVersion attrs;
       commonBuildInputs = attrs.buildInputs ++ [ xtrans ];
       commonPropagatedBuildInputs = [
         zlib libGL libGLU dbus

--- a/pkgs/shells/zsh/oh-my-zsh/update.sh
+++ b/pkgs/shells/zsh/oh-my-zsh/update.sh
@@ -3,7 +3,7 @@
 
 set -eu -o pipefail
 
-oldVersion="$(nix-instantiate --eval -E "with import ./. {}; oh-my-zsh.version or (builtins.parseDrvName oh-my-zsh.name).version" | tr -d '"')"
+oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion oh-my-zsh" | tr -d '"')"
 latestSha="$(curl -L -s https://api.github.com/repos/robbyrussell/oh-my-zsh/commits\?sha\=master\&since\=${oldVersion} | jq -r '.[0].sha')"
 url="$(nix-instantiate --eval -E "with import ./. {}; oh-my-zsh.src.url" | tr -d '"')"
 

--- a/pkgs/tools/audio/acoustid-fingerprinter/default.nix
+++ b/pkgs/tools/audio/acoustid-fingerprinter/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cmake qt4 taglib chromaprint ffmpeg ];
 
-  cmakeFlags = [ "-DTAGLIB_MIN_VERSION=${(builtins.parseDrvName taglib.name).version}" ];
+  cmakeFlags = [ "-DTAGLIB_MIN_VERSION=${stdenv.lib.getVersion taglib}" ];
 
   patches = [
     (fetchpatch {

--- a/pkgs/tools/inputmethods/ibus/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus/wrapper.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  name = "ibus-with-plugins-" + (builtins.parseDrvName ibus.name).version;
+  name = "ibus-with-plugins-" + stdenv.lib.getVersion ibus;
   env = {
     buildInputs = [ ibus ] ++ plugins;
     nativeBuildInputs = [ lndir makeWrapper ];

--- a/pkgs/tools/security/afl/libdislocator.nix
+++ b/pkgs/tools/security/afl/libdislocator.nix
@@ -1,7 +1,7 @@
 { stdenv, afl}:
 
 stdenv.mkDerivation {
-  version = (builtins.parseDrvName afl.name).version;
+  version = stdenv.lib.getVersion afl;
   pname = "libdislocator";
 
   src = afl.src;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18327,8 +18327,8 @@ in
 
   firefox-bin = wrapFirefox firefox-bin-unwrapped {
     browserName = "firefox";
-    name = "firefox-bin-" +
-      (builtins.parseDrvName firefox-bin-unwrapped.name).version;
+    pname = "firefox-bin";
+    version = lib.getVersion firefox-bin-unwrapped;
     desktopName = "Firefox";
   };
 
@@ -18341,8 +18341,8 @@ in
 
   firefox-beta-bin = res.wrapFirefox firefox-beta-bin-unwrapped {
     browserName = "firefox";
-    name = "firefox-beta-bin-" +
-      (builtins.parseDrvName firefox-beta-bin-unwrapped.name).version;
+    pname = "firefox-beta-bin";
+    version = lib.getVersion firefox-beta-bin-unwrapped;
     desktopName = "Firefox Beta";
   };
 
@@ -18356,8 +18356,8 @@ in
   firefox-devedition-bin = res.wrapFirefox firefox-devedition-bin-unwrapped {
     browserName = "firefox";
     nameSuffix = "-devedition";
-    name = "firefox-devedition-bin-" +
-      (builtins.parseDrvName firefox-devedition-bin-unwrapped.name).version;
+    pname = "firefox-devedition-bin";
+    version = lib.getVersion firefox-devedition-bin-unwrapped;
     desktopName = "Firefox DevEdition";
   };
 

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -23,7 +23,7 @@ let
   isLua51 = (lib.versions.majorMinor lua.version) == "5.1";
   isLua52 = (lib.versions.majorMinor lua.version) == "5.2";
   isLua53 = lua.luaversion == "5.3";
-  isLuaJIT = (builtins.parseDrvName lua.name).name == "luajit";
+  isLuaJIT = lib.getName lua == "luajit";
 
   lua-setup-hook = callPackage ../development/interpreters/lua-5/setup-hook.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Backport of #74057 that is careful not to break any interfaces. I want to backport because otherwise I'll get more conflicts backporting other things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
