### PR TITLE
nixosTests.uwsgi: port to python

### DIFF
--- a/nixos/tests/uwsgi.nix
+++ b/nixos/tests/uwsgi.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "uwsgi";
   meta = with pkgs.stdenv.lib.maintainers; {
@@ -30,9 +30,9 @@ import ./make-test.nix ({ pkgs, ... }:
 
   testScript =
     ''
-      $machine->waitForUnit('multi-user.target');
-      $machine->waitForUnit('uwsgi.service');
-      $machine->waitForOpenPort(8000);
-      $machine->succeed('curl -v 127.0.0.1:8000 | grep "Hello World!"');
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_for_unit("uwsgi.service")
+      machine.wait_for_open_port(8000)
+      assert "Hello World" in machine.succeed("curl -v 127.0.0.1:8000")
     '';
 })


### PR DESCRIPTION
###### Motivation for this change
#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
