### PR TITLE
netplan: init at 0.98+git20191004

### DIFF
--- a/pkgs/tools/networking/netplan/default.nix
+++ b/pkgs/tools/networking/netplan/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, fetchFromGitHub
+, glib
+, libuuid
+, libyaml
+, pandoc
+, pkgconfig
+, python3
+, systemd
+, makeWrapper
+}:
+stdenv.mkDerivation rec {
+  pname = "netplan";
+  version = "0.98+git20191004";
+
+  src = fetchFromGitHub {
+    owner = "CanonicalLtd";
+    repo = "netplan";
+    rev = "a5397e60df489dcbbb476e610b08e01ed6aaecbf";
+    sha256 = "0hi1n6zxcm02a5zn47kk02km4p892fb9q5ycsgfhcvf32i6p3jji";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    pandoc
+    pkgconfig
+  ];
+  buildInputs = [
+    glib
+    libuuid
+    libyaml
+    systemd
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "ROOTPREFIX=${placeholder "out"}"
+    "SYSTEMD_GENERATOR_DIR=${placeholder "out"}/lib/systemd/system-generators/"
+    "SYSTEMD_UNIT_DIR=${placeholder "out"}/lib/systemd/units/"
+    "BASH_COMPLETIONS_DIR=${placeholder "out"}/share/bash-completion/completions"
+  ];
+
+  postPatch = ''
+    sed -e 's,SYSTEMD_GENERATOR_DIR=,SYSTEMD_GENERATOR_DIR ?= ,' \
+        -e 's,SYSTEMD_UNIT_DIR=,SYSTEMD_UNIT_DIR ?= ,' \
+        -e 's,BASH_COMPLETIONS_DIR=,BASH_COMPLETIONS_DIR ?= ,' \
+        -i Makefile
+  '';
+
+  postFixup = let
+    pythonEnv = python3.withPackages (p: with p; [ pyyaml netifaces ]);
+  in ''
+    wrapProgram $out/bin/netplan \
+      --set PYTHONPATH "${pythonEnv}/${python3.sitePackages}"
+  '';
+
+  meta = with stdenv.lib; {
+    license = licenses.gpl3;
+    homepage = "http://netplan.io";
+    description = "Backend-agnostic network configuration in YAML";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4152,6 +4152,8 @@ in
 
   netmask = callPackage ../tools/networking/netmask {};
 
+  netplan = callPackage ../tools/networking/netplan {};
+
   ipv6calc = callPackage ../tools/networking/ipv6calc {};
 
   ipxe = callPackage ../tools/misc/ipxe { };


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

During the NixOS network hackathon we looked a bit at netplan and how they structure the configuration of (complex) network setups. This is a very simple attempt to package netplan. It might not work during runtime but it is good enough for experimenting with the generators.

In order for this to be use able we have to fix a bunch of hardcoded paths and/or set more environment variables for the wrapper.

The latest stable release didn't build due to errors in their Makefile.
Going for the at this time current master branch instead. The packages
needs a bunch of cleaning up in order to be portable. Currently that is
done during the postPatch phase but I intend to file upstream PRs to fix
those.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli @fpletz
