### PR TITLE
cataclysm-dda-git: 2019-05-03 -> 2019-11-22

### DIFF
--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -10,15 +10,18 @@ let
 in
 
 stdenv.mkDerivation (common // rec {
-  version = "2019-05-03";
+  version = "2019-11-22";
   name = "cataclysm-dda-git-${version}";
 
   src = fetchFromCleverRaven {
-    rev = "65a05026e7306b5d1228dc6ed885c43447f128b5";
-    sha256 = "18yn0h6b4j9lx67sq1d886la3l6l7bqsnwj6mw2khidssiy18y0n";
+    rev = "a6c8ece992bffeae3788425dd4b3b5871e66a9cd";
+    sha256 = "0ww2q5gykxm802z1kffmnrfahjlx123j1gfszklpsv0b1fccm1ab";
   };
 
-  patches = [ ./patches/fix_locale_dir_git.patch ];
+  patches = [
+    # Locale patch required for Darwin builds, see: https://github.com/NixOS/nixpkgs/pull/74064#issuecomment-560083970
+    ./patches/fix_locale_dir_git.patch
+  ];
 
   makeFlags = common.makeFlags ++ [
     "VERSION=git-${version}-${substring 0 8 src.rev}"

--- a/pkgs/games/cataclysm-dda/patches/fix_locale_dir_git.patch
+++ b/pkgs/games/cataclysm-dda/patches/fix_locale_dir_git.patch
@@ -1,8 +1,8 @@
 diff --git a/src/translations.cpp b/src/translations.cpp
-index 0068a35785..c8034cbeac 100644
+index 067e2cd77d..5660d18b3d 100644
 --- a/src/translations.cpp
 +++ b/src/translations.cpp
-@@ -202,14 +202,12 @@ void set_language()
+@@ -211,14 +211,12 @@ void set_language()
      auto env = getenv( "LANGUAGE" );
      locale_dir = std::string( FILENAMES["base_path"] + "lang/mo/" + ( env ? env : "none" ) +
                                "/LC_MESSAGES/cataclysm-dda.mo" );
@@ -16,5 +16,5 @@ index 0068a35785..c8034cbeac 100644
 -#else
 -    locale_dir = "lang/mo";
  #endif
- 
+
      const char *locale_dir_char = locale_dir.c_str();


### PR DESCRIPTION
###### Motivation for this change

The cataclysm-dda-git package is pinned to a specific version, and the previous version was bumped more than 6 months ago. There has been some substantial work done on the game, so it's good to keep it bumped occasionally.

I built the newest version without the locale patch (since it didn't apply cleanly) and it built/ran fine. I'm not sure if there was a reason why it was needed originally that I missed (didn't find any relevant comments in the old commits), so I removed it for now.

Played the game for a while, seems to work great.

If it is needed, here's a new backported verison of the patch that we can add back in:

```patch
diff --git a/src/translations.cpp b/src/translations.cpp
index 2bd330314e..c786216930 100644
--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -211,14 +211,12 @@ void set_language()
     auto env = getenv( "LANGUAGE" );
     locale_dir = std::string( PATH_INFO::base_path() + "lang/mo/" + ( env ? env : "none" ) +
                               "/LC_MESSAGES/cataclysm-dda.mo" );
-#elif (defined(__linux__) || (defined(MACOSX) && !defined(TILES)))
+#else
     if( !PATH_INFO::base_path().empty() ) {
         locale_dir = PATH_INFO::base_path() + "share/locale";
     } else {
         locale_dir = "lang/mo";
     }
-#else
-    locale_dir = "lang/mo";
 #endif

     const char *locale_dir_char = locale_dir.c_str();
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mnacamura @rardiol
