### PR TITLE
ocamlPackages.parmap: init at 1.0-rc11

### DIFF
--- a/pkgs/development/ocaml-modules/parmap/default.nix
+++ b/pkgs/development/ocaml-modules/parmap/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, ocaml_oasis }:
+
+stdenv.mkDerivation rec {
+  pname = "parmap";
+  version = "1.0-rc11";
+
+  owner = "rdicosmo";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo   = pname;
+    rev    = version;
+    sha256 = "149i1sz9xr59707sfa75b94pjahk3v8ky7rfmdhzmj2myjwy1vy8";
+  };
+
+  buildInputs = [ ocaml findlib ocamlbuild ocaml_oasis ];
+
+  meta = with stdenv.lib; {
+    description = "Library for multicore parallel programming";
+    homepage = "http://${owner}.github.io/${pname}";
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -486,6 +486,8 @@ let
       then callPackage ../development/ocaml-modules/num {}
       else null;
 
+    parmap = callPackage ../development/ocaml-modules/parmap { };
+
     comparelib = callPackage ../development/ocaml-modules/comparelib { };
 
     core_extended_p4 = callPackage ../development/ocaml-modules/core_extended { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
