### PR TITLE
giac-with-xcas: fix build

### DIFF
--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, texlive, bison, flex, liblapack
+{ stdenv, lib, fetchurl, fetchpatch, texlive, bison, flex, liblapack
 , gmp, mpfr, pari, ntl, gsl, blas, mpfi, ecm, glpk, nauty
 , readline, gettext, libpng, libao, gfortran, perl
 , enableGUI ? false, libGL ? null, libGLU ? null, xorg ? null, fltk ? null
@@ -7,8 +7,7 @@
 assert enableGUI -> libGLU != null && libGL != null && xorg != null && fltk != null;
 
 stdenv.mkDerivation rec {
-  name = "${attr}-${version}";
-  attr = if enableGUI then "giac-with-xcas" else "giac";
+  pname = "giac${lib.optionalString enableGUI "-with-xcas"}";
   version = "1.5.0-21"; # TODO try to remove preCheck phase on upgrade
 
   src = fetchurl {
@@ -104,7 +103,7 @@ stdenv.mkDerivation rec {
     description = "A free computer algebra system (CAS)";
     homepage = "https://www-fourier.ujf-grenoble.fr/~parisse/giac.html";
     license = licenses.gpl3Plus;
-    platforms = platforms.unix;
+    platforms = platforms.linux ++ (optionals (!enableGUI) platforms.darwin);
     maintainers = [ maintainers.symphorien ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
remove libGLU_combined package and replace with libGL and libGLU

noticed it was broken while reviewing #73958
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
