### PR TITLE
nixosTests.nginx*: port to python

### DIFF
--- a/nixos/tests/nginx-sso.nix
+++ b/nixos/tests/nginx-sso.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test-python.nix ({ pkgs, ... }: {
   name = "nginx-sso";
   meta = {
     maintainers = with pkgs.stdenv.lib.maintainers; [ delroth ];
@@ -27,18 +27,20 @@ import ./make-test.nix ({ pkgs, ... }: {
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $machine->waitForUnit("nginx-sso.service");
-    $machine->waitForOpenPort(8080);
+    machine.wait_for_unit("nginx-sso.service")
+    machine.wait_for_open_port(8080)
 
     # No valid user -> 401.
-    $machine->fail("curl -sSf http://localhost:8080/auth");
+    machine.fail("curl -sSf http://localhost:8080/auth")
 
     # Valid user but no matching ACL -> 403.
-    $machine->fail("curl -sSf -H 'Authorization: Token MyToken' http://localhost:8080/auth");
+    machine.fail("curl -sSf -H 'Authorization: Token MyToken' http://localhost:8080/auth")
 
     # Valid user and matching ACL -> 200.
-    $machine->succeed("curl -sSf -H 'Authorization: Token MyToken' -H 'X-Application: MyApp' http://localhost:8080/auth");
+    machine.succeed(
+        "curl -sSf -H 'Authorization: Token MyToken' -H 'X-Application: MyApp' http://localhost:8080/auth"
+    )
   '';
 })

--- a/nixos/tests/nginx-sso.nix
+++ b/nixos/tests/nginx-sso.nix
@@ -32,15 +32,17 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     machine.wait_for_unit("nginx-sso.service")
     machine.wait_for_open_port(8080)
 
-    # No valid user -> 401.
-    machine.fail("curl -sSf http://localhost:8080/auth")
+    with subtest("No valid user -> 401"):
+        machine.fail("curl -sSf http://localhost:8080/auth")
 
-    # Valid user but no matching ACL -> 403.
-    machine.fail("curl -sSf -H 'Authorization: Token MyToken' http://localhost:8080/auth")
+    with subtest("Valid user but no matching ACL -> 403"):
+        machine.fail(
+            "curl -sSf -H 'Authorization: Token MyToken' http://localhost:8080/auth"
+        )
 
-    # Valid user and matching ACL -> 200.
-    machine.succeed(
-        "curl -sSf -H 'Authorization: Token MyToken' -H 'X-Application: MyApp' http://localhost:8080/auth"
-    )
+    with subtest("Valid user and matching ACL -> 200"):
+        machine.succeed(
+            "curl -sSf -H 'Authorization: Token MyToken' -H 'X-Application: MyApp' http://localhost:8080/auth"
+        )
   '';
 })

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -4,7 +4,7 @@
 #   2. whether the ETag header is properly generated whenever we're serving
 #      files in Nix store paths
 #   3. nginx doesn't restart on configuration changes (only reloads)
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test-python.nix ({ pkgs, ... }: {
   name = "nginx";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ mbbx6spp ];
@@ -69,43 +69,46 @@ import ./make-test.nix ({ pkgs, ... }: {
     justReloadSystem = "${nodes.webserver.config.system.build.toplevel}/fine-tune/child-2";
     reloadRestartSystem = "${nodes.webserver.config.system.build.toplevel}/fine-tune/child-3";
   in ''
-    my $url = 'http://localhost/index.html';
+    url = "http://localhost/index.html"
 
-    sub checkEtag {
-      my $etag = $webserver->succeed(
-        'curl -v '.$url.' 2>&1 | sed -n -e "s/^< [Ee][Tt][Aa][Gg]: *//p"'
-      );
-      $etag =~ s/\r?\n$//;
-      my $httpCode = $webserver->succeed(
-        'curl -w "%{http_code}" -X HEAD -H \'If-None-Match: '.$etag.'\' '.$url
-      );
-      chomp $httpCode;
-      die "HTTP code is not 304" unless $httpCode == 304;
-      return $etag;
-    }
 
-    $webserver->waitForUnit("nginx");
-    $webserver->waitForOpenPort("80");
+    def checkEtag():
+        etag = webserver.succeed(
+            f'curl -v {url} 2>&1 | sed -n -e "s/^< [Ee][Tt][Aa][Gg]: *//p"'
+        )
+        httpCode = webserver.succeed(
+            f"curl -w '%{http_code}' -X HEAD -H 'If-None-Match: {etag}' {url}"
+        )
+        assert httpCode == "304"
 
-    subtest "check ETag if serving Nix store paths", sub {
-      my $oldEtag = checkEtag;
-      $webserver->succeed("${etagSystem}/bin/switch-to-configuration test >&2");
-      $webserver->sleep(1); # race condition
-      my $newEtag = checkEtag;
-      die "Old ETag $oldEtag is the same as $newEtag" if $oldEtag eq $newEtag;
-    };
+        return etag
 
-    subtest "config is reloaded on nixos-rebuild switch", sub {
-      $webserver->succeed("${justReloadSystem}/bin/switch-to-configuration test >&2");
-      $webserver->waitForOpenPort("8080");
-      $webserver->fail("journalctl -u nginx | grep -q -i stopped");
-      $webserver->succeed("journalctl -u nginx | grep -q -i reloaded");
-    };
 
-    subtest "restart when nginx package changes", sub {
-      $webserver->succeed("${reloadRestartSystem}/bin/switch-to-configuration test >&2");
-      $webserver->waitForUnit("nginx");
-      $webserver->succeed("journalctl -u nginx | grep -q -i stopped");
-    };
+    webserver.wait_for_unit("nginx")
+    webserver.wait_for_open_port("80")
+
+    with subtest("check ETag if serving Nix store paths"):
+        oldEtag = checkEtag
+        webserver.succeed(
+            "${etagSystem}/bin/switch-to-configuration test >&2"
+        )
+        webserver.sleep(1)  # race condition
+        newEtag = checkEtag
+        assert oldEtag != newEtag
+
+    with subtest("config is reloaded on nixos-rebuild switch"):
+        webserver.succeed(
+            "${justReloadSystem}/bin/switch-to-configuration test >&2"
+        )
+        webserver.wait_for_open_port("8080")
+        webserver.fail("journalctl -u nginx | grep -q -i stopped")
+        webserver.succeed("journalctl -u nginx | grep -q -i reloaded")
+
+    with subtest("restart when nginx package changes"):
+        webserver.succeed(
+            "${reloadRestartSystem}/bin/switch-to-configuration test >&2"
+        )
+        webserver.wait_for_unit("nginx")
+        webserver.succeed("journalctl -u nginx | grep -q -i stopped")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
#72828 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
