### PR TITLE
nixosTests.jenkins: port to python

### DIFF
--- a/nixos/tests/jenkins.nix
+++ b/nixos/tests/jenkins.nix
@@ -3,7 +3,7 @@
 #   2. jenkins user can be extended on both master and slave
 #   3. jenkins service not started on slave node
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "jenkins";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ bjornfor coconnor domenkozar eelco ];
@@ -33,18 +33,17 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $master->waitForUnit("jenkins");
+    master.wait_for_unit("jenkins")
 
-    $master->mustSucceed("curl http://localhost:8080 | grep 'Authentication required'");
+    assert "Authentication required" in master.succeed("curl http://localhost:8080")
 
-    print $master->execute("sudo -u jenkins groups");
-    $master->mustSucceed("sudo -u jenkins groups | grep jenkins | grep users");
+    for host in master, slave:
+        groups = host.succeed("sudo -u jenkins groups")
+        assert "jenkins" in groups
+        assert "users" in groups
 
-    print $slave->execute("sudo -u jenkins groups");
-    $slave->mustSucceed("sudo -u jenkins groups | grep jenkins | grep users");
-
-    $slave->mustFail("systemctl is-enabled jenkins.service");
+    slave.fail("systemctl is-enabled jenkins.service")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
#72828 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
