### PR TITLE
plasma5: Fix setup hook some more

### DIFF
--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -43,11 +43,11 @@ let
       propagate = out:
         let setupHook = { writeScript }:
               writeScript "setup-hook" ''
-                if [ "''${hookName:-}" != postHook ]; then
+                if [[ "''${hookName-}" != postHook ]]; then
                     postHooks+=("source @dev@/nix-support/setup-hook")
                 else
                     # Propagate $${out} output
-                    propagatedUserEnvPkgs="$propagatedUserEnvPkgs @${out}@"
+                    propagatedUserEnvPkgs+=" @${out}@"
 
                     if [ -z "$outputDev" ]; then
                         echo "error: \$outputDev is unset!" >&2
@@ -57,7 +57,7 @@ let
                     # Propagate $dev so that this setup hook is propagated
                     # But only if there is a separate $dev output
                     if [ "$outputDev" != out ]; then
-                        propagatedBuildInputs="$propagatedBuildInputs @dev@"
+                        propagatedBuildInputs+=" @dev@"
                     fi
                 fi
               '';


### PR DESCRIPTION
###### Motivation for this change

1. `[[...]]` is more robust wrt empty expansions than `[..]`

2. `${foo-}` is simpler and won't accidentally be a url compared to
`${foo:-}`

3. `+=` works even when the variable is undefined.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
