### PR TITLE
nixosTest.gocd-{agent,server}: port to python

### DIFF
--- a/nixos/tests/gocd-agent.nix
+++ b/nixos/tests/gocd-agent.nix
@@ -9,14 +9,14 @@ let
   header = "Accept: application/vnd.go.cd.v2+json";
 in
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "gocd-agent";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ grahamc swarren83 ];
   };
 
   nodes = {
-    gocd_agent =
+    agent =
       { ... }:
       {
         virtualisation.memorySize = 2046;
@@ -30,11 +30,15 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   testScript = ''
-    startAll;
-    $gocd_agent->waitForUnit("gocd-server");
-    $gocd_agent->waitForOpenPort("8153");
-    $gocd_agent->waitForUnit("gocd-agent");
-    $gocd_agent->waitUntilSucceeds("curl ${serverUrl} -H '${header}' | ${pkgs.jq}/bin/jq -e ._embedded.agents[0].uuid");
-    $gocd_agent->succeed("curl ${serverUrl} -H '${header}' | ${pkgs.jq}/bin/jq -e ._embedded.agents[0].agent_state | grep -q Idle");
+    start_all()
+    agent.wait_for_unit("gocd-server")
+    agent.wait_for_open_port("8153")
+    agent.wait_for_unit("gocd-agent")
+    agent.wait_until_succeeds(
+        "curl ${serverUrl} -H '${header}' | ${pkgs.jq}/bin/jq -e ._embedded.agents[0].uuid"
+    )
+    agent.succeed(
+        "curl ${serverUrl} -H '${header}' | ${pkgs.jq}/bin/jq -e ._embedded.agents[0].agent_state | grep -q Idle"
+    )
   '';
 })

--- a/nixos/tests/gocd-agent.nix
+++ b/nixos/tests/gocd-agent.nix
@@ -13,6 +13,10 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   name = "gocd-agent";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ grahamc swarren83 ];
+
+    # gocd agent needs to register with the autoregister key created on first server startup,
+    # but NixOS module doesn't seem to allow to pass during runtime currently
+    broken = true;
   };
 
   nodes = {

--- a/nixos/tests/gocd-server.nix
+++ b/nixos/tests/gocd-server.nix
@@ -2,7 +2,7 @@
 #   1. GoCD server starts
 #   2. GoCD server responds
 
-import ./make-test.nix ({ pkgs, ...} :
+import ./make-test-python.nix ({ pkgs, ...} :
 
 {
   name = "gocd-server";
@@ -10,19 +10,19 @@ import ./make-test.nix ({ pkgs, ...} :
     maintainers = [ swarren83 ];
   };
 
-nodes = {
-  gocd_server =
-    { ... }:
-    {
-      virtualisation.memorySize = 2046;
-      services.gocd-server.enable = true;
-    };
-};
+  nodes = {
+    server =
+      { ... }:
+      {
+        virtualisation.memorySize = 2046;
+        services.gocd-server.enable = true;
+      };
+  };
 
   testScript = ''
-    $gocd_server->start;
-    $gocd_server->waitForUnit("gocd-server");
-    $gocd_server->waitForOpenPort("8153");
-    $gocd_server->waitUntilSucceeds("curl -s -f localhost:8153/go");
+    server.start()
+    server.wait_for_unit("gocd-server")
+    server.wait_for_open_port(8153)
+    server.wait_until_succeeds("curl -s -f localhost:8153/go")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
#72828

These already failed on master, but according to https://github.com/NixOS/nixpkgs/pull/61309, the service seems to behave fine.

The tests might just need a small update.

Looking at the logs it seems like the agent tries to download `agent-launcher.jar` from `https://localhost:8154`, is the https endpoint and not enabled. This might be just a matter of reconfiguring it in there, not sure about the error message in the PR here.

Could you take a look at it? This might also help in unbreaking https://github.com/NixOS/nixpkgs/pull/61309.

cc @cryptix 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
