### PR TITLE
dont use nogroup for networkd, resolved and timesyncd

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -924,6 +924,8 @@ in
 
   config = mkIf config.systemd.network.enable {
 
+    users.users.systemd-network.group = "systemd-network";
+
     systemd.additionalUpstreamSystemUnits = [
       "systemd-networkd.service" "systemd-networkd-wait-online.service"
     ];

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -136,6 +136,8 @@ in
       }
     ];
 
+    users.users.resolved.group = "systemd-resolve";
+
     systemd.additionalUpstreamSystemUnits = [
       "systemd-resolved.service"
     ];

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -50,7 +50,10 @@ with lib;
       ${config.services.timesyncd.extraConfig}
     '';
 
-    users.users.systemd-timesync.uid = config.ids.uids.systemd-timesync;
+    users.users.systemd-timesync = {
+      uid = config.ids.uids.systemd-timesync;
+      group = "systemd-timesync";
+    };
     users.groups.systemd-timesync.gid = config.ids.gids.systemd-timesync;
 
     system.activationScripts.systemd-timesyncd-migration = mkIf (versionOlder config.system.stateVersion "19.09") ''

--- a/nixos/tests/systemd-networkd-wireguard.nix
+++ b/nixos/tests/systemd-networkd-wireguard.nix
@@ -1,4 +1,4 @@
-let generateNodeConf = { lib, pkgs, config, privkpath, pubk, peerId, nodeId, ...}: {
+let generateNodeConf = { lib, pkgs, config, privk, pubk, peerId, nodeId, ...}: {
       imports = [ common/user-account.nix ];
       systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
       networking.useNetworkd = true;
@@ -7,13 +7,16 @@ let generateNodeConf = { lib, pkgs, config, privkpath, pubk, peerId, nodeId, ...
       virtualisation.vlans = [ 1 ];
       environment.systemPackages = with pkgs; [ wireguard-tools ];
       boot.extraModulePackages = [ config.boot.kernelPackages.wireguard ];
+      systemd.tmpfiles.rules = [
+        "f /run/wg_priv 0640 root systemd-network - ${privk}"
+      ];
       systemd.network = {
         enable = true;
         netdevs = {
           "90-wg0" = {
             netdevConfig = { Kind = "wireguard"; Name = "wg0"; };
             wireguardConfig = {
-              PrivateKeyFile = privkpath ;
+              PrivateKeyFile = "/run/wg_priv";
               ListenPort = 51820;
               FwMark = 42;
             };
@@ -53,7 +56,7 @@ in import ./make-test-python.nix ({pkgs, ... }: {
   nodes = {
     node1 = { pkgs, ... }@attrs:
     let localConf = {
-        privkpath = pkgs.writeText "priv.key" "GDiXWlMQKb379XthwX0haAbK6hTdjblllpjGX0heP00=";
+        privk = "GDiXWlMQKb379XthwX0haAbK6hTdjblllpjGX0heP00=";
         pubk = "iRxpqj42nnY0Qz8MAQbSm7bXxXP5hkPqWYIULmvW+EE=";
         nodeId = "1";
         peerId = "2";
@@ -62,7 +65,7 @@ in import ./make-test-python.nix ({pkgs, ... }: {
 
     node2 = { pkgs, ... }@attrs:
     let localConf = {
-        privkpath = pkgs.writeText "priv.key" "eHxSI2jwX/P4AOI0r8YppPw0+4NZnjOxfbS5mt06K2k=";
+        privk = "eHxSI2jwX/P4AOI0r8YppPw0+4NZnjOxfbS5mt06K2k=";
         pubk = "27s0OvaBBdHoJYkH9osZpjpgSOVNw+RaKfboT/Sfq0g=";
         nodeId = "2";
         peerId = "1";


### PR DESCRIPTION
###### Motivation for this change
At the networkd sprint, I switched from scripted networking to networkd and stumbled over some things, one of them being that currently `systemd-networkd.service` runs as `systemd-network:nogroup`.
The upstream service file only specifies the `User` option and we didn't manually add the `systemd-network` user to the group with the same name, even though it is already defined in nixpkgs.

I noticed this when I added a wireguard interface to my configuration and wanted to pass the private key for an interface as a file, to avoid adding it to the nix store.
The following is taken from the `[Wireguard]` section of `systemd.netdev(5)`:
```
PrivateKeyFile=
           Takes an absolute path to a file which contains the Base64 encoded private key for the interface. When this option is specified, then PrivateKey= is ignored. Note that the file must be readable by the user "systemd-network", so it should be, e.g., owned by
           "root:systemd-network" with a "0640" file mode.
```

Looking at `/run/systemd/`, I noticed that this also happened for `resolved` and `timesyncd`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc #55370