### PR TITLE
nixosTests.wordpress: fix assertions

### DIFF
--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -45,12 +45,12 @@ import ./make-test-python.nix ({ pkgs, ... }:
     with subtest("wordpress-init went through"):
         for site_name in site_names:
             info = machine.get_unit_info(f"wordpress-init-{site_name}")
-            assert info.Result == "success"
+            assert info["Result"] == "success"
 
     with subtest("secret keys are set"):
-        re.compile(r"^define.*NONCE_SALT.{64,};$")
+        pattern = re.compile(r"^define.*NONCE_SALT.{64,};$", re.MULTILINE)
         for site_name in site_names:
-            assert r.match(
+            assert pattern.search(
                 machine.succeed(f"cat /var/lib/wordpress/{site_name}/secret-keys.php")
             )
   '';


### PR DESCRIPTION
Fix for broken test merged in #73993.

Needed [re.MULTILINE flag](https://docs.python.org/3.9/library/re.html#re.MULTILINE) and using `search` instead of `match` to match single line in the input file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli @worldofpeace @tfc 
