### PR TITLE
ghcjs-ng: The GHC source should be configured with native build inputs

### DIFF
--- a/pkgs/development/compilers/ghcjs-ng/configured-ghcjs-src.nix
+++ b/pkgs/development/compilers/ghcjs-ng/configured-ghcjs-src.nix
@@ -16,7 +16,7 @@
 }:
 
 runCommand "configured-ghcjs-src" {
-  buildInputs = [
+  nativeBuildInputs = [
     perl
     autoconf
     automake


### PR DESCRIPTION
###### Motivation for this change

Backport of #74087.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
