### PR TITLE
pythonPackages.mlflow: init at 1.4.0

### DIFF
--- a/pkgs/development/python-modules/databricks-cli/default.nix
+++ b/pkgs/development/python-modules/databricks-cli/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, click
+, requests
+, tabulate
+, six
+, configparser
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "databricks-cli";
+  version = "0.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ebf123b5567c06b7583688077120ead075ca06938b9995d4acafa97863ed8ff";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = "pytest tests";
+  # tests folder is missing in PyPI
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    click
+    requests
+    tabulate
+    six
+    configparser
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/databricks/databricks-cli";
+    description = "A command line interface for Databricks";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/gorilla/default.nix
+++ b/pkgs/development/python-modules/gorilla/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi}:
+
+buildPythonPackage rec {
+  pname = "gorilla";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "feb2899b923935c25420b94aa8c266ccb5c0315199c685b725303a73195d802c";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/christophercrouzet/gorilla";
+    description = "Convenient approach to monkey patching";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, alembic
+, click
+, cloudpickle
+, requests
+, six
+, flask
+, numpy
+, pandas
+, python-dateutil
+, protobuf
+, GitPython
+, pyyaml
+, querystring_parser
+, simplejson
+, docker
+, databricks-cli
+, entrypoints
+, sqlparse
+, sqlalchemy
+, gorilla
+, gunicorn
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "mlflow";
+  version = "1.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9116d82be380c32fa465049d14b217c4c200ad11614f4c6674e6b524b2935206";
+  };
+
+  # run into https://stackoverflow.com/questions/51203641/attributeerror-module-alembic-context-has-no-attribute-config
+  # also, tests use conda so can't run on NixOS without buildFHSUserEnv
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    alembic
+    click
+    cloudpickle
+    requests
+    six
+    flask
+    numpy
+    pandas
+    python-dateutil
+    protobuf
+    GitPython
+    pyyaml
+    querystring_parser
+    simplejson
+    docker
+    databricks-cli
+    entrypoints
+    sqlparse
+    sqlalchemy
+    gorilla
+    gunicorn
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mlflow/mlflow";
+    description = "Open source platform for the machine learning lifecycle";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, isPy27
 , alembic
 , click
 , cloudpickle
@@ -26,6 +26,7 @@
 buildPythonPackage rec {
   pname = "mlflow";
   version = "1.4.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/querystring-parser/default.nix
+++ b/pkgs/development/python-modules/querystring-parser/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, python, isPy27
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "querystring_parser";
+  version = "1.2.4";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "644fce1cffe0530453b43a83a38094dbe422ccba8c9b2f2a1c00280e14ca8a62";
+  };
+
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkPhase = "${python.interpreter} querystring_parser/tests.py -k 'not test_parse_normalized'";
+  # one test fails due to https://github.com/bernii/querystring-parser/issues/35
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/bernii/querystring-parser";
+    description = "QueryString parser for Python/Django that correctly handles nested dictionaries";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/servers/mlflow-server/default.nix
+++ b/pkgs/servers/mlflow-server/default.nix
@@ -1,0 +1,37 @@
+{lib, python3, writeText}:
+
+let
+  py = python3.pkgs;
+in
+py.toPythonApplication 
+  (py.mlflow.overridePythonAttrs(old: rec {
+    pname = "mlflow-server";
+
+    propagatedBuildInputs = old.propagatedBuildInputs ++ [
+      py.boto3
+      py.mysqlclient
+    ];
+
+    postPatch = ''
+      substituteInPlace mlflow/utils/process.py --replace \
+        "child = subprocess.Popen(cmd, env=cmd_env, cwd=cwd, universal_newlines=True," \
+        "cmd[0]='$out/bin/gunicornMlflow'; child = subprocess.Popen(cmd, env=cmd_env, cwd=cwd, universal_newlines=True,"
+    '';
+
+    gunicornScript = writeText "gunicornMlflow"
+    ''
+        #!/usr/bin/env python
+        import re
+        import sys
+        from gunicorn.app.wsgiapp import run
+        if __name__ == '__main__':
+          sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', ''', sys.argv[0])
+          sys.exit(run())
+      '';
+
+    postInstall = ''
+      gpath=$out/bin/gunicornMlflow
+      cp ${gunicornScript} $gpath
+      chmod 555 $gpath
+    '';
+}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15357,6 +15357,8 @@ in
 
   miniHttpd = callPackage ../servers/http/mini-httpd {};
 
+  mlflow-server = callPackage ../servers/mlflow-server { };
+  
   mlmmj = callPackage ../servers/mail/mlmmj { };
 
   moodle = callPackage ../servers/web-apps/moodle { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -574,6 +574,8 @@ in {
 
   btchip = callPackage ../development/python-modules/btchip { };
 
+  databricks-cli = callPackage ../development/python-modules/databricks-cli { };
+
   datatable = callPackage ../development/python-modules/datatable {
     inherit (pkgs.llvmPackages) openmp libcxx libcxxabi;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3735,6 +3735,8 @@ in {
 
   google_resumable_media = callPackage ../development/python-modules/google_resumable_media { };
 
+  gorilla = callPackage ../development/python-modules/gorilla { };
+
   gpgme = toPythonModule (pkgs.gpgme.override {
     pythonSupport = true;
     inherit python;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5187,6 +5187,8 @@ in {
   # alias for an older package which did not support Python 3
   Quandl = callPackage ../development/python-modules/quandl { };
 
+  querystring_parser = callPackage ../development/python-modules/querystring-parser { };
+
   qscintilla-qt4 = callPackage ../development/python-modules/qscintilla { };
 
   qscintilla-qt5 = pkgs.libsForQt5.callPackage ../development/python-modules/qscintilla-qt5 {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2898,6 +2898,8 @@ in {
 
   mlrose = callPackage ../development/python-modules/mlrose { };
 
+  mlflow = callPackage ../development/python-modules/mlflow { };
+
   mt-940 = callPackage ../development/python-modules/mt-940 { };
 
   mwlib = callPackage ../development/python-modules/mwlib { };


### PR DESCRIPTION
###### Motivation for this change
add mlflow, an Open source platform for the machine learning lifecycle. Note that this package is only partially functional on NixOS, and is not intended to support features requiring conda.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).