### PR TITLE
java classpath hook: allow unbound $CLASSPATH

### DIFF
--- a/pkgs/build-support/setup-hooks/set-java-classpath.sh
+++ b/pkgs/build-support/setup-hooks/set-java-classpath.sh
@@ -6,7 +6,7 @@ export CLASSPATH
 addPkgToClassPath () {
     local jar
     for jar in $1/share/java/*.jar; do
-        export CLASSPATH=''${CLASSPATH}''${CLASSPATH:+:}''${jar}
+        export CLASSPATH=''${CLASSPATH-}''${CLASSPATH:+:}''${jar}
     done
 }
 


### PR DESCRIPTION
###### Motivation for this change

Started getting `CLASSPATH: unbound` from this hook after updating master a couple hours ago, and it seems to be related to #72347.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ericson2314

This seems to cause rebuilds of JVMs, unforunately; but we can't build Java/Graal packages anymore without it.