### PR TITLE
nixos/kubernetes: allow configuring cfssl API server SANs

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -20,6 +20,7 @@ let
         size = 2048;
     };
     CN = top.masterAddress;
+    hosts = cfg.cfsslAPIExtraSANs;
   });
 
   cfsslAPITokenBaseName = "apitoken.secret";
@@ -64,6 +65,15 @@ in
       '';
       default = true;
       type = bool;
+    };
+
+    cfsslAPIExtraSANs = mkOption {
+      description = ''
+        Extra x509 Subject Alternative Names to be added to the cfssl API webserver TLS cert.
+      '';
+      default = [];
+      example = [ "subdomain.example.com" ];
+      type = listOf str;
     };
 
     genCfsslAPIToken = mkOption {


### PR DESCRIPTION
#### Motivation for this change

`services.kubernetes.easyCerts` is really useful to bootstrap a Kubernetes cluster. A common use case in Kubernetes clusters is to have a DNS entry for the master so that nodes can connect to a master that may change address (e.g. in an autoscaling group).

Right now this is not easily possible because the master also runs the cfssl API server but doesn't allow registering Subject Alternative Names in its TLS cert. 

This PR proposes allowing configuring the extra SANs in this certificate similarly to what's available in the API server:
 https://github.com/NixOS/nixpkgs/blob/a3465d9d104149c810ece20bb706395321fa8631/nixos/modules/services/cluster/kubernetes/apiserver.nix#L139-L143

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @johanot @calbrecht (apologies if spammy, this is my first contribution to nixpkgs and you both were listed as the top committers in `pki.nix`)
