### PR TITLE
pythonPackages.m3u8: init at 0.5.2

### DIFF
--- a/pkgs/development/python-modules/m3u8/default.nix
+++ b/pkgs/development/python-modules/m3u8/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, python, fetchFromGitHub, requests, iso8601, bottle, pytest, pytestcov }:
+
+buildPythonPackage rec {
+  pname = "m3u8";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "globocom";
+    repo = pname;
+    rev = version;
+    sha256 = "0p6wmwv1nfa5pyakq5d55w9v142z5ja3db3s3qr44kx895d9lhng";
+  };
+
+  checkInputs = [ bottle pytest pytestcov ];
+
+  checkPhase = ''
+    pytest tests/test_{parser,model,variant_m3u8}.py
+  '';
+
+  propagatedBuildInputs = [ requests iso8601 ];
+
+  meta = with lib; {
+    homepage = "https://github.com/globocom/m3u8";
+    description = "Python m3u8 parser";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Scriptkiddi ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3851,6 +3851,8 @@ in {
 
   python_magic = callPackage ../development/python-modules/python-magic { };
 
+  m3u8 = callPackage ../development/python-modules/m3u8 { };
+
   magic = callPackage ../development/python-modules/magic { };
 
   m2crypto = callPackage ../development/python-modules/m2crypto { };
@@ -4489,7 +4491,7 @@ in {
 
   praw = if isPy3k then callPackage ../development/python-modules/praw { }
     else callPackage ../development/python-modules/praw/6.3.nix { };
-  
+
   prance = callPackage ../development/python-modules/prance { };
 
   prawcore = callPackage ../development/python-modules/prawcore { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
