### PR TITLE
nixosTests.syncthing*: port to python

### DIFF
--- a/nixos/tests/syncthing-init.nix
+++ b/nixos/tests/syncthing-init.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, pkgs, ... }: let
+import ./make-test-python.nix ({ lib, pkgs, ... }: let
 
   testId = "7CFNTQM-IMTJBHJ-3UWRDIU-ZGQJFR6-VCXZ3NB-XUH3KZO-N52ITXR-LAIYUAU";
 
@@ -22,13 +22,11 @@ in {
   };
 
   testScript = ''
-    my $config;
-
-    $machine->waitForUnit("syncthing-init.service");
-    $config = $machine->succeed("cat /var/lib/syncthing/.config/syncthing/config.xml");
+    machine.wait_for_unit("syncthing-init.service")
+    config = machine.succeed("cat /var/lib/syncthing/.config/syncthing/config.xml")
    
-    $config =~ /${testId}/ or die;
-    $config =~ /testFolder/ or die;
+    assert "testFolder" in config
+    assert "${testId}" in config
   '';
 })
 

--- a/nixos/tests/syncthing-relay.nix
+++ b/nixos/tests/syncthing-relay.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, pkgs, ... }: {
+import ./make-test-python.nix ({ lib, pkgs, ... }: {
   name = "syncthing-relay";
   meta.maintainers = with pkgs.stdenv.lib.maintainers; [ delroth ];
 
@@ -14,9 +14,13 @@ import ./make-test.nix ({ lib, pkgs, ... }: {
   };
 
   testScript = ''
-    $machine->waitForUnit("syncthing-relay.service");
-    $machine->waitForOpenPort(12345);
-    $machine->waitForOpenPort(12346);
-    $machine->succeed("curl http://localhost:12346/status | jq -r '.options.\"provided-by\"'") =~ /nixos-test/ or die;
+    machine.wait_for_unit("syncthing-relay.service")
+    machine.wait_for_open_port(12345)
+    machine.wait_for_open_port(12346)
+
+    out = machine.succeed(
+        "curl -sS http://localhost:12346/status | jq -r '.options.\"provided-by\"'"
+    )
+    assert "nixos-test" in out
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

#72828 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli @tfc 