### PR TITLE
WIP: nixos: update system.stateVersion disclaimer

### DIFF
--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -162,7 +162,7 @@ in
         # This value determines the NixOS release with which your system is to be
         # compatible, in order to avoid breaking some software such as database
         # servers. You should change this only after NixOS release notes say you
-        # should.
+        # should. You should never need to change this.
         system.stateVersion = "${config.system.nixos.release}"; # Did you read the comment?
 
       }


### PR DESCRIPTION
##### Motivation for this change
A year ago I asked on discourse if I should ever want to change my system.stateVersion (https://discourse.nixos.org/t/when-should-i-change-system-stateversion/1433). I got my answer, but I thought the comment on the default configuration.nix is a bit misleading. It's meant to tell the user that the user doesn't need to change this value ever, but instead left me to wonder if it should regularly be changed.

Many new users seem to have this exact confusion. By a quick search I found at least 4 threads on discourse where someone asks the same question. I also periodically get hearts on discourse to my last message in the thread, where I state that I understand now that I should never change system.stateVersion. The thread also has more than 1 200 views, which is way more than a simple question should get. I think this is an indication that many users search for an answer to this same question.

I propose that the message to be reworded, but am unsure about the best wording. My current change is just an example, which I intend to replace with a better text. Any ideas about a better message?
