### PR TITLE
c14: change homepage

### DIFF
--- a/pkgs/applications/networking/c14/default.nix
+++ b/pkgs/applications/networking/c14/default.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     description = "C14 is designed for data archiving & long-term backups.";
-    homepage = https://www.online.net/en/c14;
+    homepage = https://www.online.net/en/storage/c14-cold-storage;
     license = licenses.mit;
     maintainers = with maintainers; [ apeyroux ];
   };


### PR DESCRIPTION
###### Motivation for this change

Homepage link "https://www.online.net/en/c14" is dead (HTTP error 404) for more than a month.