### PR TITLE
graphite2: 1.3.6 -> 1.3.13

### DIFF
--- a/pkgs/development/libraries/silgraphite/graphite2.nix
+++ b/pkgs/development/libraries/silgraphite/graphite2.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, pkgconfig, freetype, cmake, python }:
 
 stdenv.mkDerivation rec {
-  version = "1.3.6";
+  version = "1.3.13";
   pname = "graphite2";
 
   src = fetchurl {
     url = "https://github.com/silnrsi/graphite/releases/download/"
-      + "${version}/graphite-${version}.tgz";
-    sha256 = "0xdg6bc02bl8yz39l5i2skczfg17q4lif0qqan0dhvk0mibpcpj7";
+      + "${version}/graphite2-${version}.tgz";
+    sha256 = "01jzhwnj1c3d68dmw15jdxly0hwkmd8ja4kw755rbkykn1ly2qyx";
   };
 
   nativeBuildInputs = [ pkgconfig cmake ];


### PR DESCRIPTION
Fixes various security bugs with CVEs since 2017.

Fixes #73645.

Note that for 1.3.6 *ONLY*, the file was called `graphite-*.tgz`
and not `graphite2-*.tgz`, that's why the URL changes as well.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c