### PR TITLE
ocamlPackages.biocaml: init at 0.10.0

### DIFF
--- a/pkgs/development/ocaml-modules/biocaml/default.nix
+++ b/pkgs/development/ocaml-modules/biocaml/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildDunePackage, fetchFromGitHub
+, ounit, async, base64, camlzip, cfstream
+, core, ppx_jane, ppx_sexp_conv, rresult, uri, xmlm }:
+
+buildDunePackage rec {
+  pname = "biocaml";
+  version = "0.10.0";
+
+  owner = "biocaml";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "0dghqx6jbzihmga8jjwwavs0wqksgcns4z1nmwj0ds9ik3mcra30";
+  };
+
+  buildInputs = [ ppx_jane ppx_sexp_conv ];
+  checkInputs = [ ounit ];
+  propagatedBuildInputs = [ async base64 camlzip cfstream core rresult uri xmlm ];
+
+  meta = with stdenv.lib; {
+    description = "Bioinformatics library for Ocaml";
+    homepage = "http://${owner}.github.io/${pname}";
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/development/ocaml-modules/cfstream/default.nix
+++ b/pkgs/development/ocaml-modules/cfstream/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildDunePackage, fetchFromGitHub, m4, core_kernel, ounit }:
+
+buildDunePackage rec {
+  pname = "cfstream";
+  version = "1.3.0";
+
+  owner = "biocaml";
+
+  minimumSupportedOcamlVersion = "4.04.1";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo   = pname;
+    rev    = version;
+    sha256 = "1bpzpci0cx6r3sdk183mm603wgzvvj46nlx0lpx44108anxcxbak";
+  };
+
+  patches = [ ./git_commit.patch ];
+
+  buildInputs = [ m4 ];
+  checkInputs = [ ounit ];
+  propagatedBuildInputs = [ core_kernel ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Simple Core-inspired wrapper for standard library Stream module";
+    homepage = "http://github.com/${owner}/${pname}";
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/development/ocaml-modules/cfstream/git_commit.patch
+++ b/pkgs/development/ocaml-modules/cfstream/git_commit.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/jbuild b/lib/jbuild
+index fcc5a39..d72d50c 100644
+--- a/lib/jbuild
++++ b/lib/jbuild
+@@ -10,7 +10,7 @@
+ (rule (
+   (targets (GIT_COMMIT))
+   (deps (../bin/git_commit.sh))
+-  (action (with-stdout-to ${@} (run ${<})))
++  (action (with-stdout-to ${@} (run echo "None")))
+ ))
+ 
+ (rule (

--- a/pkgs/development/ocaml-modules/gnuplot-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/gnuplot-ocaml/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildDunePackage, fetchFromBitbucket, gnuplot, core }:
+
+buildDunePackage rec {
+  pname = "gnuplot-ocaml";
+  version = "0.5.3";
+
+  src = fetchFromBitbucket {
+    owner  = "ogu";
+    repo   = pname;
+    rev    = "release-${version}";
+    sha256 = "00sn9g46pj8pfh7faiyxg3pfhq7w9knafyabjr464bh6qz5kiin3";
+  };
+
+  propagatedBuildInputs = [ core gnuplot ];
+
+  buildPhase = ''
+    runHook preBuild
+    dune build -p gnuplot
+    runHook postBuild
+  '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Ocaml bindings to Gnuplot";
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/development/ocaml-modules/owl-base/default.nix
+++ b/pkgs/development/ocaml-modules/owl-base/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildDunePackage, fetchFromGitHub, integers, stdlib-shims }:
+{ stdenv, buildDunePackage, fetchFromGitHub, stdlib-shims }:
 
 buildDunePackage rec {
   pname = "owl-base";

--- a/pkgs/development/ocaml-modules/owl/default.nix
+++ b/pkgs/development/ocaml-modules/owl/default.nix
@@ -7,9 +7,8 @@ buildDunePackage rec {
 
   inherit (owl-base) version src meta;
 
-  buildInputs = [ eigen ];
   checkInputs = [ alcotest ];
-  propagatedBuildInputs = [ stdio stdlib-shims openblasCompat owl-base ];
+  propagatedBuildInputs = [ eigen stdio stdlib-shims openblasCompat owl-base ];
 
   # tests not enabled for now due to owlbarn/owl/issues/460
 }

--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildDunePackage, fetchFromGitHub, ppx_deriving
+, alcotest, biocaml, gnuplot-ocaml, lacaml, menhir, owl }:
+
+buildDunePackage rec {
+  pname = "phylogenetics";
+  version = "unstable-2019-11-15";
+
+  src = fetchFromGitHub {
+    owner  = "biocaml";
+    repo   = pname;
+    rev    = "91c03834db065cf4a86f33affbb9cfd216defc9f";
+    sha256 = "0i9m0633a6a724as35ix8z3p1gj267cl0hmqrpw4qfq39zxmgnxb";
+  };
+
+  minimumOCamlVersion = "4.08";  # e.g., uses Float.min
+
+  checkInputs = [ alcotest ];
+  buildInputs = [ ppx_deriving ];
+  propagatedBuildInputs = [ biocaml gnuplot-ocaml lacaml menhir owl ];
+
+  doCheck = false;  # many tests require bppsuite
+
+  meta = with stdenv.lib; {
+    inherit (std.meta) homepage;
+    description = "Bioinformatics library for Ocaml";
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.cecill-b;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -73,6 +73,8 @@ let
 
     bigstringaf = callPackage ../development/ocaml-modules/bigstringaf { };
 
+    biocaml = callPackage ../development/ocaml-modules/biocaml { };
+
     bistro = callPackage ../development/ocaml-modules/bistro { };
 
     bitstring = callPackage ../development/ocaml-modules/bitstring { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -617,6 +617,8 @@ let
 
     ounit = callPackage ../development/ocaml-modules/ounit { };
 
+    phylogenetics = callPackage ../development/ocaml-modules/phylogenetics { };
+
     pgsolver = callPackage ../development/ocaml-modules/pgsolver { };
 
     piqi = callPackage ../development/ocaml-modules/piqi {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -295,6 +295,8 @@ let
 
     gmap = callPackage ../development/ocaml-modules/gmap { };
 
+    gnuplot-ocaml = callPackage ../development/ocaml-modules/gnuplot-ocaml { };
+
     herelib = callPackage ../development/ocaml-modules/herelib { };
 
     higlo = callPackage ../development/ocaml-modules/higlo { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -138,6 +138,8 @@ let
 
     cairo2 = callPackage ../development/ocaml-modules/cairo2 { };
 
+    cfstream = callPackage ../development/ocaml-modules/cfstream { };
+
     charInfo_width = callPackage ../development/ocaml-modules/charInfo_width { };
 
     checkseum = callPackage ../development/ocaml-modules/checkseum { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
