### PR TITLE
emplace: init at 0.2.5

### DIFF
--- a/pkgs/tools/package-management/emplace/default.nix
+++ b/pkgs/tools/package-management/emplace/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "emplace";
-  version = "0.2.5";
+  version = "0.2.7";
 
   src = fetchFromGitHub {
     owner = "tversteeg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0ys61wfga7kakfhq2b7yk2ygp8ffar43w4bfa6g483dq7ysqi5hl";
+    sha256 = "0dkdgb0hbaixc69yh75lq4lamvgd421lk1v7qn802h83fibcmh81";
   };
 
-  cargoSha256 = "07336a5xrc7kwgkasl42g1sqad35v0dmpmv1hxr1w5j1wpggw3bj";
+  cargoSha256 = "10y7lpgj9mxrh3rmc15km4rfzspwdjr8dcdh0747rjn6dcpfhcdq";
 
   meta = with lib; {
     description = "Mirror installed software on multiple machines";

--- a/pkgs/tools/package-management/emplace/default.nix
+++ b/pkgs/tools/package-management/emplace/default.nix
@@ -1,0 +1,23 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "emplace";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "tversteeg";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ys61wfga7kakfhq2b7yk2ygp8ffar43w4bfa6g483dq7ysqi5hl";
+  };
+
+  cargoSha256 = "07336a5xrc7kwgkasl42g1sqad35v0dmpmv1hxr1w5j1wpggw3bj";
+
+  meta = with lib; {
+    description = "Mirror installed software on multiple machines";
+    homepage = "https://github.com/tversteeg/emplace";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ filalex77 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -851,6 +851,8 @@ in
 
   elvish = callPackage ../shells/elvish { };
 
+  emplace = callPackage ../tools/package-management/emplace { };
+
   encryptr = callPackage ../tools/security/encryptr {
     gconf = gnome2.GConf;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Close tversteeg/emplace#3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/74166)
<!-- Reviewable:end -->
