### PR TITLE
bazel: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -22,11 +22,11 @@
 }:
 
 let
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchurl {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    sha256 = "1awm5wa4y4c37zy7d1ass83amwq5992wydkj5v9jx0zp7b4shrjb";
+    sha256 = "0vpfpm3l3zp6749b23ysqqf1la029jzq43ks60q6f5mr3056pd4w";
   };
 
   # Update with `eval $(nix-build -A bazel.updater)`,
@@ -50,7 +50,7 @@ let
        else srcs."java_tools_javac11_linux-v6.1.zip")
       srcs."coverage_output_generator-v2.0.zip"
       srcs.build_bazel_rules_nodejs
-      srcs."android_tools_pkg-0.11.tar.gz"
+      srcs."android_tools_pkg-0.12.tar.gz"
       srcs."0.28.3.tar.gz"
       srcs.rules_pkg
       srcs.rules_cc

--- a/pkgs/development/tools/build-managers/bazel/src-deps.json
+++ b/pkgs/development/tools/build-managers/bazel/src-deps.json
@@ -55,11 +55,11 @@
             "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz"
         ]
     },
-    "android_tools_pkg-0.11.tar.gz": {
-        "name": "android_tools_pkg-0.11.tar.gz",
-        "sha256": "6fc50151063bffdda700038ea7df99c89d54dc066e9377a5baff60d55d482ad2",
+    "android_tools_pkg-0.12.tar.gz": {
+        "name": "android_tools_pkg-0.12.tar.gz",
+        "sha256": "96c4eef4d195dd95e43a4259cf5b82a1e34f67333439e91955bbdc0e1c8e7a31",
         "urls": [
-            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.11.tar.gz"
+            "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.12.tar.gz"
         ]
     },
     "bazel_j2objc": {
@@ -108,11 +108,11 @@
     },
     "com_google_googletest": {
         "name": "com_google_googletest",
-        "sha256": "0fb00ff413f6b9b80ccee44a374ca7a18af7315aea72a43c62f2acd1ca74e9b5",
-        "strip_prefix": "googletest-f13bbe2992d188e834339abe6f715b2b2f840a77",
+        "sha256": "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
+        "strip_prefix": "googletest-release-1.10.0",
         "urls": [
-            "https://mirror.bazel.build/github.com/google/googletest/archive/f13bbe2992d188e834339abe6f715b2b2f840a77.tar.gz",
-            "https://github.com/google/googletest/archive/f13bbe2992d188e834339abe6f715b2b2f840a77.tar.gz"
+            "https://mirror.bazel.build/github.com/google/googletest/archive/release-1.10.0.tar.gz",
+            "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
         ]
     },
     "coverage_output_generator-v2.0.zip": {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/bazelbuild/bazel/releases/tag/1.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Profpatsch @guibou 
