### PR TITLE
pythonPackages.m2crypto: conditional `typing` dep

### DIFF
--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -1,7 +1,9 @@
 { stdenv
+, lib
 , fetchpatch
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , swig2
 , openssl
 , typing
@@ -28,7 +30,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ swig2 ];
   buildInputs = [ swig2 openssl ];
 
-  propagatedBuildInputs = [ typing ];
+  propagatedBuildInputs = lib.optional (pythonOlder "3.5") typing;
 
   preConfigure = ''
     substituteInPlace setup.py --replace "self.openssl = '/usr'" "self.openssl = '${openssl.dev}'"


### PR DESCRIPTION
###### Motivation for this change

Since python 3.5 typing is included in the stdlib and as such
this library should not be included and propagated for >=3.5.

This is loosely related to https://github.com/NixOS/nixpkgs/pull/73927 - specifically to upgrading
tribler to a python 3 supporting version (separate pending PR).

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andrew-d
