### PR TITLE
pythonPackages.pony: init at 0.7.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1484,6 +1484,16 @@
       }
     ];
   };
+  d-goldin = {
+    email = "dgoldin+github@protonmail.ch";
+    github = "d-goldin";
+    githubId = 43349662;
+    name = "Dima";
+    keys = [{
+      longkeyid = "rsa4096/BAB1D15FB7B4D4CE";
+      fingerprint = "1C4E F4FE 7F8E D8B7 1E88 CCDF BAB1 D15F B7B4 D4CE";
+    }];
+  };
   dadada = {
     name = "dadada";
     email = "dadada@dadada.li";

--- a/pkgs/development/python-modules/pony/default.nix
+++ b/pkgs/development/python-modules/pony/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, python, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pony";
+  version = "0.7.11";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05vyvsbcb99vjjs7qpbwy8j4m854w74z8di6zqsv8p9wbm38s06i";
+  };
+
+  doCheck = true;
+
+  # stripping the tests
+  postInstall = ''
+    rm -rf $out/${python.sitePackages}/pony/orm/tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pony is a Python ORM with beautiful query syntax";
+    homepage = "https://ponyorm.org/";
+    maintainers = with maintainers; [ d-goldin ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6568,6 +6568,8 @@ in {
 
   managesieve = callPackage ../development/python-modules/managesieve { };
 
+  pony = callPackage ../development/python-modules/pony { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

pony is an ORM library.

The main motivation for adding this package is to allow migrating trible
to a newer version that supports python3.

Also adding myself to maintainers to not leave this one without, even
though I dont use it myself much, if anybody else feels like it fits their
interests, feel free to add yourselves.

Related: https://github.com/NixOS/nixpkgs/pull/73927

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
