### PR TITLE
tribler: 7.1.2 -> 7.4.0-exp1 (python 3)

### DIFF
--- a/pkgs/applications/networking/p2p/tribler/default.nix
+++ b/pkgs/applications/networking/p2p/tribler/default.nix
@@ -1,48 +1,51 @@
-{ stdenv, fetchurl, pythonPackages, makeWrapper, imagemagick
-, enablePlayer ? true, vlc ? null, qt5 }:
+{ stdenv, fetchurl, pkgs, python3Packages, makeWrapper
+, enablePlayer ? true, vlc ? null, qt5, lib }:
 
 stdenv.mkDerivation rec {
   pname = "tribler";
-  version = "7.1.2";
+  version = "7.4.0-exp1";
 
   src = fetchurl {
-    url = "https://github.com/Tribler/tribler/releases/download/v${version}/Tribler-v${version}.tar.gz";
-    sha256 = "1ayzqx4358qlx56hsnsn5s8xl6mzdb6nw4kwsalmp86dw6vmmis8";
+    url = "https://github.com/Tribler/tribler/releases/download/v${version}/Tribler-v${version}.tar.xz";
+    sha256 = "18ziisg0v2gdxnprbhqsryz92yk270waj0la7m2h326k5qql3qkf";
   };
 
-  buildInputs = [
-    pythonPackages.python
-    pythonPackages.wrapPython
+  nativeBuildInputs = [
+    python3Packages.wrapPython
     makeWrapper
-    imagemagick
+  ];
+
+  buildInputs = [
+    python3Packages.python
   ];
 
   pythonPath = [
-    pythonPackages.libtorrentRasterbar
-    pythonPackages.apsw
-    pythonPackages.twisted
-    pythonPackages.netifaces
-    pythonPackages.pycrypto
-    pythonPackages.pyasn1
-    pythonPackages.requests
-    pythonPackages.setuptools
-    pythonPackages.m2crypto
-    pythonPackages.pyqt5
-    pythonPackages.chardet
-    pythonPackages.cherrypy
-    pythonPackages.cryptography
-    pythonPackages.libnacl
-    pythonPackages.configobj
-    pythonPackages.matplotlib
-    pythonPackages.plyvel
-    pythonPackages.decorator
-    pythonPackages.feedparser
-    pythonPackages.service-identity
-    pythonPackages.psutil
-    pythonPackages.meliae
-    pythonPackages.sip
-    pythonPackages.pillow
-    pythonPackages.networkx
+    python3Packages.libtorrentRasterbar
+    python3Packages.twisted
+    python3Packages.netifaces
+    python3Packages.pycrypto
+    python3Packages.pyasn1
+    python3Packages.requests
+    python3Packages.m2crypto
+    python3Packages.pyqt5
+    python3Packages.chardet
+    python3Packages.cherrypy
+    python3Packages.cryptography
+    python3Packages.libnacl
+    python3Packages.configobj
+    python3Packages.decorator
+    python3Packages.feedparser
+    python3Packages.service-identity
+    python3Packages.psutil
+    python3Packages.pillow
+    python3Packages.networkx
+    python3Packages.pony
+    python3Packages.lz4
+    python3Packages.pyqtgraph
+
+    # there is a BTC feature, but it requires some unclear version of
+    # bitcoinlib, so this doesn't work right now.
+    # python3Packages.bitcoinlib
   ];
 
   postPatch = ''
@@ -54,12 +57,11 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    find . -name '*.png' -exec convert -strip {} {} \;
     mkdir -pv $out
     # Nasty hack; call wrapPythonPrograms to set program_PYTHONPATH.
     wrapPythonPrograms
     cp -prvd ./* $out/
-    makeWrapper ${pythonPackages.python}/bin/python $out/bin/tribler \
+    makeWrapper ${python3Packages.python}/bin/python $out/bin/tribler \
         --set QT_QPA_PLATFORM_PLUGIN_PATH ${qt5.qtbase.bin}/lib/qt-*/plugins/platforms \
         --set _TRIBLERPATH $out \
         --set PYTHONPATH $out:$program_PYTHONPATH \


### PR DESCRIPTION
###### Motivation for this change

Updating version for tribler to use python 3.
One most notable change is dropping the optional `pythonPackages.meliae`
as it does not support python 3 and addition pony, lz4 and pyqtgraph.

Depends on: https://github.com/NixOS/nixpkgs/pull/74193
Related: https://github.com/NixOS/nixpkgs/pull/73927

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @xvapx 
