### PR TITLE
nixosTests.containers*: port to python

### DIFF
--- a/nixos/tests/containers-hosts.nix
+++ b/nixos/tests/containers-hosts.nix
@@ -1,6 +1,6 @@
 # Test for NixOS' container support.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-hosts";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ montag451 ];
@@ -42,11 +42,11 @@ import ./make-test.nix ({ pkgs, ...} : {
     };
 
   testScript = ''
-    startAll;
-    $machine->waitForUnit("default.target");
+    start_all()
+    machine.wait_for_unit("default.target")
 
-    # Ping the containers using the entries added in /etc/hosts
-    $machine->succeed("ping -n -c 1 simple.containers");
-    $machine->succeed("ping -n -c 1 netmask.containers");
+    with subtest("Ping the containers using the entries added in /etc/hosts"):
+        for host in "simple.containers", "netmask.containers":
+            machine.succeed(f"ping -n -c 1 {host}")
   '';
 })

--- a/nixos/tests/containers-reloadable.nix
+++ b/nixos/tests/containers-reloadable.nix
@@ -1,7 +1,7 @@
-import ./make-test.nix ({ pkgs, lib, ...} :
+import ./make-test-python.nix ({ pkgs, lib, ...} :
 let
   client_base = {
-    
+
     containers.test1 = {
       autoStart = true;
       config = {
@@ -48,18 +48,25 @@ in {
     c1System = nodes.client_c1.config.system.build.toplevel;
     c2System = nodes.client_c2.config.system.build.toplevel;
   in ''
-    $client->start();
-    $client->waitForUnit("default.target");
-    $client->succeed("[[ \$(nixos-container run test1 cat /etc/check) == client_base ]] >&2");
+    client.start()
+    client.wait_for_unit("default.target")
 
-    $client->succeed("${c1System}/bin/switch-to-configuration test >&2");
-    $client->succeed("[[ \$(nixos-container run test1 cat /etc/check) == client_c1 ]] >&2");
-    $client->succeed("systemctl status httpd -M test1 >&2");
+    assert "client_base" in client.succeed("nixos-container run test1 cat /etc/check")
 
-    $client->succeed("${c2System}/bin/switch-to-configuration test >&2");
-    $client->succeed("[[ \$(nixos-container run test1 cat /etc/check) == client_c2 ]] >&2");
-    $client->fail("systemctl status httpd -M test1 >&2");
-    $client->succeed("systemctl status nginx -M test1 >&2");
+    with subtest("httpd is available after activating config1"):
+        client.succeed(
+            "${c1System}/bin/switch-to-configuration test >&2",
+            "[[ $(nixos-container run test1 cat /etc/check) == client_c1 ]] >&2",
+            "systemctl status httpd -M test1 >&2",
+        )
+
+    with subtest("httpd is not available any longer after switching to config2"):
+        client.succeed(
+            "${c2System}/bin/switch-to-configuration test >&2",
+            "[[ $(nixos-container run test1 cat /etc/check) == client_c2 ]] >&2",
+            "systemctl status nginx -M test1 >&2",
+        )
+        client.fail("systemctl status httpd -M test1 >&2")
   '';
 
 })

--- a/nixos/tests/containers-tmpfs.nix
+++ b/nixos/tests/containers-tmpfs.nix
@@ -1,6 +1,6 @@
 # Test for NixOS' container support.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-tmpfs";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ kampka ];
@@ -31,49 +31,63 @@ import ./make-test.nix ({ pkgs, ...} : {
       virtualisation.pathsInNixDB = [ pkgs.stdenv ];
     };
 
-  testScript =
-    ''
-      $machine->waitForUnit("default.target");
-      $machine->succeed("nixos-container list") =~ /tmpfs/ or die;
+  testScript = ''
+      machine.wait_for_unit("default.target")
+      assert "tmpfs" in machine.succeed("nixos-container list")
 
-      # Start the tmpfs container.
-      #$machine->succeed("nixos-container status tmpfs") =~ /up/ or die;
-
-      # Verify that /var is mounted as a tmpfs
-      #$machine->succeed("nixos-container run tmpfs -- systemctl status var.mount --no-pager 2>/dev/null") =~ /What: tmpfs/ or die;
-      $machine->succeed("nixos-container run tmpfs -- mountpoint -q /var 2>/dev/null");
-
-      # Verify that /var/log is mounted as a tmpfs
-      $machine->succeed("nixos-container run tmpfs -- systemctl status var-log.mount --no-pager 2>/dev/null") =~ /What: tmpfs/ or die;
-      $machine->succeed("nixos-container run tmpfs -- mountpoint -q /var/log 2>/dev/null");
-
-      # Verify that /some/random/path is mounted as a tmpfs
-      $machine->succeed("nixos-container run tmpfs -- systemctl status some-random-path.mount --no-pager 2>/dev/null") =~ /What: tmpfs/ or die;
-      $machine->succeed("nixos-container run tmpfs -- mountpoint -q /some/random/path 2>/dev/null");
-
-      # Verify that files created in the container in a non-tmpfs directory are visible on the host.
-      # This establishes legitimacy for the following tests
-      $machine->succeed("nixos-container run tmpfs -- touch /root/test.file 2>/dev/null");
-      $machine->succeed("nixos-container run tmpfs -- ls -l  /root | grep -q test.file 2>/dev/null");
-      $machine->succeed("test -e /var/lib/containers/tmpfs/root/test.file");
+      with subtest("tmpfs container is up"):
+          assert "up" in machine.succeed("nixos-container status tmpfs")
 
 
-      # Verify that /some/random/path is writable and that files created there
-      # are not in the hosts container dir but in the tmpfs
-      $machine->succeed("nixos-container run tmpfs -- touch /some/random/path/test.file 2>/dev/null");
-      $machine->succeed("nixos-container run tmpfs -- test -e /some/random/path/test.file 2>/dev/null");
+      def tmpfs_cmd(command):
+          return f"nixos-container run tmpfs -- {command} 2>/dev/null"
 
-      $machine->fail("test -e /var/lib/containers/tmpfs/some/random/path/test.file");
 
-      # Verify that files created in the hosts container dir in a path where a tmpfs file system has been mounted
-      # are not visible to the container as the do not exist in the tmpfs
-      $machine->succeed("touch /var/lib/containers/tmpfs/var/test.file");
+      with subtest("/var is mounted as a tmpfs"):
+          machine.succeed(tmpfs_cmd("mountpoint -q /var"))
 
-      $machine->succeed("test -e /var/lib/containers/tmpfs/var/test.file");
-      $machine->succeed("ls -l /var/lib/containers/tmpfs/var/ | grep -q test.file 2>/dev/null");
+      with subtest("/var/log is mounted as a tmpfs"):
+          assert "What: tmpfs" in machine.succeed(
+              tmpfs_cmd("systemctl status var-log.mount --no-pager")
+          )
+          machine.succeed(tmpfs_cmd("mountpoint -q /var/log"))
 
-      $machine->fail("nixos-container run tmpfs -- ls -l /var | grep -q test.file 2>/dev/null");
+      with subtest("/some/random/path is mounted as a tmpfs"):
+          assert "What: tmpfs" in machine.succeed(
+              tmpfs_cmd("systemctl status some-random-path.mount --no-pager")
+          )
+          machine.succeed(tmpfs_cmd("mountpoint -q /some/random/path"))
 
+      with subtest(
+          "files created in the container in a non-tmpfs directory are visible on the host."
+      ):
+          # This establishes legitimacy for the following tests
+          machine.succeed(
+              tmpfs_cmd("touch /root/test.file"),
+              tmpfs_cmd("ls -l  /root | grep -q test.file"),
+              "test -e /var/lib/containers/tmpfs/root/test.file",
+          )
+
+      with subtest(
+          "/some/random/path is writable and that files created there are not "
+          + "in the hosts container dir but in the tmpfs"
+      ):
+          machine.succeed(
+              tmpfs_cmd("touch /some/random/path/test.file"),
+              tmpfs_cmd("test -e /some/random/path/test.file"),
+          )
+          machine.fail("test -e /var/lib/containers/tmpfs/some/random/path/test.file")
+
+      with subtest(
+          "files created in the hosts container dir in a path where a tmpfs "
+          + "file system has been mounted are not visible to the container as "
+          + "the do not exist in the tmpfs"
+      ):
+          machine.succeed(
+              "touch /var/lib/containers/tmpfs/var/test.file",
+              "test -e /var/lib/containers/tmpfs/var/test.file",
+              "ls -l /var/lib/containers/tmpfs/var/ | grep -q test.file 2>/dev/null",
+          )
+          machine.fail(tmpfs_cmd("ls -l /var | grep -q test.file"))
     '';
-
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace @flokli @Lassulus 
