### PR TITLE
prometheus-postgres-exporter: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/postgres-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postgres-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "postgres_exporter";
-  version = "0.7.0";
+  version = "0.8.0";
 
   goPackagePath = "github.com/wrouesnel/postgres_exporter";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "wrouesnel";
     repo = "postgres_exporter";
     rev = "v${version}";
-    sha256 = "0xi61090kmkp1cid3hx00csfa4w8nvaw8ky0w004czwqlyids6jg";
+    sha256 = "0mid2kvskab3a32jscygg5jh0741nr7dvxzj4v029yiiqcx55nrc";
   };
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change
New [minor release](https://github.com/wrouesnel/postgres_exporter/releases/tag/v0.8.0).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (x86_64-linux & aarch64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).