### PR TITLE
prometheus-varnish-exporter: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/servers/monitoring/prometheus/varnish-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/varnish-exporter.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "prometheus_varnish_exporter";
-  version = "1.5.1";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner = "jonnenauha";
     repo = "prometheus_varnish_exporter";
     rev = version;
-    sha256 = "1lvs44936n3s9z6c5169jbvx390n5g0qk4pcrmnkndg796ixjshd";
+    sha256 = "0rpabw6a6paavv62f0gzhax9brzcgkly27rhkf0ihw8736gkw8ar";
   };
 
   modSha256 = "0w1zg9jc2466srx9pdckw7rzn7ma4pbd0617b1h98v364wjzgj72";


### PR DESCRIPTION
###### Motivation for this change
New [patch release](https://github.com/jonnenauha/prometheus_varnish_exporter/releases/tag/1.5.2).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (x86_64-linux & aarch64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).