### PR TITLE
python3Packages.papis: remove restrictive version bounds

### DIFF
--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -3,7 +3,7 @@
 , pyyaml, chardet, beautifulsoup4, colorama, bibtexparser
 , pylibgen, click, python-slugify, habanero, isbnlib
 , prompt_toolkit, pygments, stevedore, tqdm, lxml
-, python-doi, isPy3k
+, python-doi, isPy3k, pythonOlder
 #, optional, dependencies
 , whoosh, pytest
 , stdenv
@@ -12,6 +12,7 @@
 buildPythonPackage rec {
   pname = "papis";
   version = "0.9";
+  disabled = !isPy3k;
 
   # Missing tests on Pypi
   src = fetchFromGitHub {
@@ -32,9 +33,14 @@ buildPythonPackage rec {
     whoosh
   ];
 
-  disabled = !isPy3k;
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "lxml<=4.3.5" "lxml~=4.3" \
+      --replace "python-slugify>=1.2.6,<4" "python-slugify"
+  '';
 
-  doCheck = !stdenv.isDarwin;
+  # pytest seems to hang with python3.8
+  doCheck = !stdenv.isDarwin && pythonOlder "3.8";
 
   checkInputs = ([
     pytest


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken while reviewing #74199

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/74202
2 package were built:
papis python38Packages.papis
```