### PR TITLE
noise-repellent: init at unstable-29-12-2018

### DIFF
--- a/pkgs/applications/audio/noise-repellent/default.nix
+++ b/pkgs/applications/audio/noise-repellent/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, fftwFloat, lv2 }:
+
+stdenv.mkDerivation rec {
+  pname = "noise-repellent";
+  version = "unstable-2018-12-29";
+
+  src = fetchFromGitHub {
+    owner = "lucianodato";
+    repo = pname;
+    rev = "9efdd0b41ec184a792087c87cbf5382f455e33ec";
+    sha256 = "0pn9cxapfvb5l62q86bchyfll1290vi0rhrzarb1jpc4ix7kz53c";
+    fetchSubmodules = true;
+  };
+
+  mesonFlags = ("--prefix=${placeholder "out"}/lib/lv2");
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [
+    fftwFloat lv2
+  ];
+
+  meta = with stdenv.lib; {
+    description = "An lv2 plugin for broadband noise reduction";
+    homepage    = https://github.com/lucianodato/noise-repellent;
+    license     = licenses.gpl3;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "i686-darwin"  ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5248,6 +5248,9 @@ in
 
   nnn = callPackage ../applications/misc/nnn { };
 
+
+  noise-repellent = callPackage ../applications/audio/noise-repellent { };
+
   notary = callPackage ../tools/security/notary { };
 
   notify-osd = callPackage ../applications/misc/notify-osd { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
