### PR TITLE
ocamlPackages.parany: init at 7.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/parany/default.nix
+++ b/pkgs/development/ocaml-modules/parany/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildDunePackage, fetchFromGitHub, ocamlnet, setcore }:
+
+buildDunePackage rec {
+  pname = "parany";
+  version = "7.0.0";
+
+  src = fetchFromGitHub {
+    owner = "UnixJunkie";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "0kylhgi1d4gj68x40ifli7pnrxkdc6ks5mgfvlcsigqg8i8nvc7q";
+  };
+
+  propagatedBuildInputs = [ ocamlnet setcore ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Generalized map/reduce for multicore computing";
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.lgpl2;
+  };
+}

--- a/pkgs/development/ocaml-modules/setcore/default.nix
+++ b/pkgs/development/ocaml-modules/setcore/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildDunePackage, fetchFromGitHub, autoconf }:
+
+buildDunePackage rec {
+  pname = "setcore";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "UnixJunkie";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "1yn660gxk2ccp7lbdq9v6pjz1c3pm08s9dl9k9l5492ld6bx8fxc";
+  };
+
+  preConfigure = ''
+    autoconf
+    autoheader
+  '';
+
+  buildInputs = [ autoconf ];
+
+  hardeningDisable = stdenv.lib.optional stdenv.isDarwin "strictoverflow";
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Generalized map/reduce for multicore computing";
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.lgpl2;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -755,6 +755,8 @@ let
 
     sedlex = callPackage ../development/ocaml-modules/sedlex { };
 
+    setcore = callPackage ../development/ocaml-modules/setcore { };
+
     sodium = callPackage ../development/ocaml-modules/sodium { };
 
     spelll = callPackage ../development/ocaml-modules/spelll { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -688,6 +688,8 @@ let
 
     pa_test = callPackage ../development/ocaml-modules/pa_test { };
 
+    parany = callPackage ../development/ocaml-modules/parany { };
+
     pipebang = callPackage ../development/ocaml-modules/pipebang { };
 
     pprint = callPackage ../development/ocaml-modules/pprint { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
