### PR TITLE
systemd: v243.3 -> v243.4

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -263,6 +263,6 @@ in stdenv.mkDerivation {
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     priority = 10;
-    maintainers = with maintainers; [ eelco andir mic92 ];
+    maintainers = with maintainers; [ andir eelco flokli mic92 ];
   };
 }

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -36,10 +36,10 @@ in stdenv.mkDerivation {
   # When updating, use https://github.com/systemd/systemd-stable tree, not the development one!
   # Also fresh patches should be cherry-picked from that tree to our current one.
   src = fetchFromGitHub {
-    owner = "NixOS";
+    owner = "flokli";
     repo = "systemd";
-    rev = "491a247eff9b7ce1e5877f5f3431517c95f3222f";
-    sha256 = "1xqiahapg480m165glrwqbfmc1fxw5sacdlm933cwyi1q8x4537g";
+    rev = "717698964418d41883eceb056256b8e077165eed";
+    sha256 = "0sffsd52160fnbjfm7h72xl4dixsj3823biv2rmf3xih4l1y383q";
   };
 
   outputs = [ "out" "lib" "man" "dev" ];


### PR DESCRIPTION
This bumps `systemd` to the `v243.4` stable release.

https://github.com/NixOS/nixpkgs/pull/74026 already bumped to `243.3`, but that was not sufficient enough to include the fixes mentioned in https://github.com/NixOS/nixpkgs/issues/73504#issuecomment-557939795.

I'd appreciate some thorough looks, especially given upstream also did some changes in `src/timedate/timedated.c`, which had to be treated manually while merging in the `v243.4` branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).