### PR TITLE
pythonPackages.papermill: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/ansiwrap/default.nix
+++ b/pkgs/development/python-modules/ansiwrap/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, tox
+, pytest
+, ansicolors
+, coverage
+, pytestcov
+, textwrap3
+}:
+
+buildPythonPackage rec {
+  pname = "ansiwrap";
+  version = "0.8.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "ca0c740734cde59bf919f8ff2c386f74f9a369818cdc60efe94893d01ea8d9b7";
+  };
+
+  checkInputs = [
+    tox
+    pytest
+    ansicolors
+    coverage
+    pytestcov
+  ];
+
+  propagatedBuildInputs = [
+    textwrap3
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Textwrap, but savvy to ANSI colors and styles";
+    homepage = https://github.com/jonathaneunice/ansiwrap;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/papermill/default.nix
+++ b/pkgs/development/python-modules/papermill/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ansiwrap
+, click
+, future
+, pyyaml
+, nbformat
+, nbconvert
+, six
+, tqdm
+, jupyter_client
+, requests
+, entrypoints
+, tenacity
+, futures
+, backports_tempfile
+, isPy27
+, pytest
+, pytestcov
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "papermill";
+  version = "1.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04dadaabdeb129c7414079f77b9f9a4a08f1322549aa99e20e4a12700ee23509";
+  };
+
+  propagatedBuildInputs = [
+    ansiwrap
+    click
+    future
+    pyyaml
+    nbformat
+    nbconvert
+    six
+    tqdm
+    jupyter_client
+    requests
+    entrypoints
+    tenacity
+  ] ++ lib.optionals isPy27 [
+    futures
+    backports_tempfile
+  ];
+
+  checkInputs = [
+    pytest
+    pytestcov
+    pytest-mock
+  ];
+
+  checkPhase = ''
+    HOME=$(mktemp -d) pytest
+  '';
+
+  # the test suite depends on cloud resources azure/aws
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Parametrize and run Jupyter and nteract Notebooks";
+    homepage = https://github.com/nteract/papermill;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/textwrap3/default.nix
+++ b/pkgs/development/python-modules/textwrap3/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, tox
+, pytest
+, coverage
+, pytestcov
+}:
+
+buildPythonPackage rec {
+  pname = "textwrap3";
+  version = "0.9.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "5008eeebdb236f6303dcd68f18b856d355f6197511d952ba74bc75e40e0c3414";
+  };
+
+  checkInputs = [
+    tox
+    pytest
+    coverage
+    pytestcov
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Textwrap from Python 3.6 backport plus a few tweaks";
+    homepage = https://github.com/jonathaneunice/textwrap3;
+    license = licenses.psfl;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -167,6 +167,8 @@ in {
 
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
+  ansiwrap =  callPackage ../development/python-modules/ansiwrap { };
+
   ansi2html = callPackage ../development/python-modules/ansi2html { };
 
   anytree = callPackage ../development/python-modules/anytree {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -880,6 +880,8 @@ in {
 
   palettable = callPackage ../development/python-modules/palettable { };
 
+  papermill = callPackage ../development/python-modules/papermill { };
+
   parsley = callPackage ../development/python-modules/parsley { };
 
   pastel = callPackage ../development/python-modules/pastel { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5258,7 +5258,9 @@ in {
 
   texttable = callPackage ../development/python-modules/texttable { };
 
-  tiledb = callPackage ../development/python-modules/tiledb { 
+  textwrap3 =  callPackage ../development/python-modules/textwrap3 { };
+
+  tiledb = callPackage ../development/python-modules/tiledb {
     inherit (pkgs) tiledb;
   };
 


### PR DESCRIPTION
###### Motivation for this change

@anirrudh wanted this package :) Would be nice to have more jupyterlab python packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
