### PR TITLE
ipscan: init at 3.6.2

### DIFF
--- a/pkgs/tools/security/ipscan/default.nix
+++ b/pkgs/tools/security/ipscan/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, jdk, jre, swt, makeWrapper, xorg }:
+
+let
+  pname = "ipscan";
+  version = "3.6.2";
+
+  jar = fetchurl {
+    url = "https://github.com/angryip/ipscan/releases/download/${version}/ipscan-linux64-${version}.jar";
+    sha256 = "0fmrrxanw46g53jvlb50516jqwqjzky564bf3df9i3ymjffrfnw4";
+  };
+
+  jarName = "${pname}-${version}.jar";
+  jarPath = "$out/share/java/${jarName}";
+in stdenv.mkDerivation rec {
+  inherit pname version;
+
+  dontUnpack = true;
+
+  buildInputs = [ makeWrapper jdk ];
+
+  installPhase = ''
+    mkdir -p $out/share/java
+    ln -s ${jar} ${jarPath}
+    makeWrapper ${jre}/bin/java $out/bin/ipscan \
+      --prefix LD_LIBRARY_PATH : "$out/lib/:${stdenv.lib.makeLibraryPath [ swt xorg.libXtst ]}" \
+      --add-flags "-Xmx256m -Djava.library.path=${swt}/lib -cp ${jar}:${swt}/jars/swt.jar net.azib.ipscan.Main"
+  '';
+
+  passthru.jar = jar;
+
+  meta = with stdenv.lib; {
+    description = "Fast and friendly network scanner";
+    homepage = https://angryip.org;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kylesferrazza ];
+  };
+}

--- a/pkgs/tools/security/ipscan/default.nix
+++ b/pkgs/tools/security/ipscan/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper ${jre}/bin/java $out/bin/ipscan \
       --prefix LD_LIBRARY_PATH : "$out/lib/:${stdenv.lib.makeLibraryPath [ swt xorg.libXtst ]}" \
-      --add-flags "-Xmx256m -Djava.library.path=${swt}/lib -cp $out/share/java/${pname}-${version}.jar:${swt}/jars/swt.jar net.azib.ipscan.Main"
+      --add-flags "-Xmx256m -cp $out/share/java/${pname}-${version}.jar:${swt}/jars/swt.jar net.azib.ipscan.Main"
 
     mkdir -p $out/share/applications
     cp usr/share/applications/ipscan.desktop $out/share/applications/ipscan.desktop

--- a/pkgs/tools/security/ipscan/default.nix
+++ b/pkgs/tools/security/ipscan/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "Fast and friendly network scanner";
     homepage = https://angryip.org;
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kylesferrazza ];
   };
 }

--- a/pkgs/tools/security/ipscan/default.nix
+++ b/pkgs/tools/security/ipscan/default.nix
@@ -15,12 +15,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ makeWrapper jdk ];
 
   installPhase = ''
-    mkdir -p $out/share/java
-    cp usr/lib/ipscan/ipscan-linux64-${version}.jar $out/share/java/${pname}-${version}.jar
+    mkdir -p $out/share
+    cp usr/lib/ipscan/ipscan-linux64-${version}.jar $out/share/${pname}-${version}.jar
 
     makeWrapper ${jre}/bin/java $out/bin/ipscan \
       --prefix LD_LIBRARY_PATH : "$out/lib/:${stdenv.lib.makeLibraryPath [ swt xorg.libXtst ]}" \
-      --add-flags "-Xmx256m -cp $out/share/java/${pname}-${version}.jar:${swt}/jars/swt.jar net.azib.ipscan.Main"
+      --add-flags "-Xmx256m -cp $out/share/${pname}-${version}.jar:${swt}/jars/swt.jar net.azib.ipscan.Main"
 
     mkdir -p $out/share/applications
     cp usr/share/applications/ipscan.desktop $out/share/applications/ipscan.desktop

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4148,6 +4148,8 @@ in
 
   netmask = callPackage ../tools/networking/netmask {};
 
+  ipscan = callPackage ../tools/security/ipscan { };
+
   ipv6calc = callPackage ../tools/networking/ipv6calc {};
 
   ipxe = callPackage ../tools/misc/ipxe { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Wanted to use `ipscan`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
