### PR TITLE
facedetect: switch to opencv4

### DIFF
--- a/pkgs/tools/graphics/facedetect/default.nix
+++ b/pkgs/tools/graphics/facedetect/default.nix
@@ -12,13 +12,13 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ python2Packages.python python2Packages.wrapPython ];
-  pythonPath = [ python2Packages.numpy python2Packages.opencv ];
+  pythonPath = [ python2Packages.numpy python2Packages.opencv4 ];
 
   phases = [ "unpackPhase" "patchPhase" "installPhase" ];
 
   patchPhase = ''
     substituteInPlace facedetect \
-      --replace /usr/share/opencv "${python2Packages.opencv}/share/OpenCV"
+      --replace /usr/share/opencv "${python2Packages.opencv4}/share/opencv4"
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
opencv2 is essentially EOL and has security concerns

No formal tests, so tested this on some images myself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rycee 
