### PR TITLE
git: fix the "perlSupport = false" configuration

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -253,7 +253,10 @@ stdenv.mkDerivation {
   installCheckTarget = "test";
 
   # see also installCheckFlagsArray
-  installCheckFlags = "DEFAULT_TEST_TARGET=prove";
+  installCheckFlags = [
+    "DEFAULT_TEST_TARGET=prove"
+    "PERL_PATH=${buildPackages.perl}/bin/perl"
+  ];
 
   preInstallCheck = ''
     installCheckFlagsArray+=(
@@ -295,6 +298,13 @@ stdenv.mkDerivation {
 
     # Tested to fail: 2.18.0
     disable_test t9902-completion "sourcing the completion script clears cached --options"
+
+    ${stdenv.lib.optionalString (!perlSupport) ''
+      # request-pull is a Bash script that invokes Perl, so it is not available
+      # when NO_PERL=1, and the test should be skipped, but the test suite does
+      # not check for the Perl prerequisite.
+      disable_test t5150-request-pull
+    ''}
 
     # As of 2.19.0, t5562 refers to #!/usr/bin/perl
     patchShebangs t/t5562/invoke-with-content-length.pl


### PR DESCRIPTION
When `perlSupport = false`, we will set `NO_PERL=1`, and build Git without Perl support. This is a build option that Git supports. However, Git's test suite still requires a Perl to be available to run the tests, and we did not provide one. The tests respect `PERL_PATH`, and if it is not set, they default to `/usr/bin/perl`.

Before this commit, if we set `perlSupport = false`, then no Perl would be available to the package, and so the tests would default to `/usr/bin/perl`. When building without a sandbox, that could still work,
even though there is no `perl` on the path, because the tests defaulted to an absolute path.

You can reproduce this issue as follows:

    nix-build -E 'let pkgs = (import ./default.nix) {}; in pkgs.git.override { perlSupport = false; }'

I just ran into this when trying to build `pkgs.git` from an old version of Nixpkgs that I was able to build just fine in the past, and today it would not build any more, complaining when running the tests:

    make -C t/ all
    make[1]: Entering directory '/build/git-2.18.0/t'
    rm -f -r 'test-results'
    /nix/store/czx8vkrb9jdgjyz8qfksh10vrnqa723l-bash-4.4-p23/bin/bash: /usr/bin/perl: No such file or directory

In the past the sandbox was not enabled by default, so then it worked for me. But now that it is enabled, my host's (not NixOS) `/usr/bin/perl` is no longer accessible, and the build fails.

The solution is to explicitly set `PERL_PATH` when running the tests. This *almost* works, except that there appears to be a bug in the test for `git request-pull`. That command is a Bash script that calls Perl at some point, so it requires Perl, and therefore it cannot be supported when `NO_PERL=1`. But that particular test does not check whether Git was compiled with Perl support (other tests do include that check), and that makes the test fail:

    t5150-request-pull.sh ..............................
    not ok 4 - pull request after push
    not ok 5 - request asks HEAD to be pulled
    not ok 6 - pull request format
    not ok 7 - request-pull ignores OPTIONS_KEEPDASHDASH poison
    not ok 9 - pull request with mismatched object
    not ok 10 - pull request with stale object
    Dubious, test returned 1 (wstat 256, 0x100)
    Failed 6/10 subtests

This output makes sense if you look at `t5150-request-pull.sh`. Test 1 and 2 are setup steps. Test 3 does call request-pull, but it expects the command to fail, and it cannot distinguish between the command exiting with a nonzero exit code, or failing to start it at all. So test 3 passes for the wrong reasons. Test 4 through 10 all call request-pull, so they fail.

The quick workaround here is to disable the test. I will look into upstreaming a patch that makes the test skip itself when Perl is disabled.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Without sandbox, setting `perlSupport = false` creates an implicit dependency on the host system. With sandbox, building with `perlSupport = false` fails.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I also verified that this does not introduce a Perl dependency in the closure with `nix-store -qR`.

###### Notify maintainers

cc @peti @the-kenny @wmertens @globin

Also, @bgamari, as the author of `perlSupport`, you might be interested in this.
