### PR TITLE
gitAndTools.git-subtrac: init at 0.01

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -129,6 +129,8 @@ let
 
   git-subrepo = callPackage ./git-subrepo { };
 
+  git-subtrac = callPackage ./git-subtrac { };
+
   git-sync = callPackage ./git-sync { };
 
   git-test = callPackage ./git-test { };

--- a/pkgs/applications/version-management/git-and-tools/git-subtrac/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-subtrac/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "git-subtrac";
+  version = "0.01";
+
+  src = fetchFromGitHub {
+    owner = "apenwarr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1w6gd0x1902lzpqr74gsdrnxq36f6v14bv8h0vhlrfhbwbsih7n6";
+  };
+
+  modSha256 = "147vzllp1gydk2156hif313vwykagrj35vaiqy1swqczxs7p9hhs";
+
+  meta = with lib; {
+    description = "Keep the content for your git submodules all in one place: the parent repo";
+    homepage = "https://github.com/apenwarr/git-subtrac";
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/apenwarr/git-subtrac

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
