### PR TITLE
python3Packages.xmlschema: 1.0.15 -> 1.0.16

### DIFF
--- a/pkgs/development/python-modules/xmlschema/default.nix
+++ b/pkgs/development/python-modules/xmlschema/default.nix
@@ -4,14 +4,14 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.0.15";
+  version = "1.0.16";
   pname = "xmlschema";
 
   src = fetchFromGitHub {
     owner = "sissaschool";
     repo = "xmlschema";
     rev = "v${version}";
-    sha256 = "1s8ggvy2s7513cxcal3r37rn1bhpkxhq3hs5m9pgvmrysxjdz8lb";
+    sha256 = "0mxvpafkaxib3qiz3zl7fbsgjaq9hbx4kb0w646azwhg7n7nxghj";
   };
 
   propagatedBuildInputs = [ elementpath ];


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[7 built, 6 copied (3.1 MiB), 0.4 MiB DL]
https://github.com/NixOS/nixpkgs/pull/74230
7 package were built:
python27Packages.xmlschema python37Packages.fints python37Packages.sepaxml python37Packages.xmlschema python38Packages.fints python38Packages.sepaxml python38Packages.xmlschema
```