### PR TITLE
par: use pname

### DIFF
--- a/pkgs/tools/text/par/default.nix
+++ b/pkgs/tools/text/par/default.nix
@@ -1,7 +1,8 @@
 {stdenv, fetchurl, fetchpatch}:
 
 stdenv.mkDerivation {
-  name = "par-1.52";
+  pname = "par";
+  version = "1.52";
 
   src = fetchurl {
     url = http://www.nicemice.net/par/Par152.tar.gz;


### PR DESCRIPTION
###### Motivation for this change
Just general improvement for consistency.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @volth