### PR TITLE
slic3r: patch to fix compile error if Boost > 1.55

### DIFF
--- a/pkgs/applications/misc/slic3r/boost-compile-error.patch
+++ b/pkgs/applications/misc/slic3r/boost-compile-error.patch
@@ -1,0 +1,12 @@
+diff --git a/xs/src/libslic3r/GCodeSender.hpp b/xs/src/libslic3r/GCodeSender.hpp
+index cc0b2983..0f39f5a3 100644
+--- a/xs/src/libslic3r/GCodeSender.hpp
++++ b/xs/src/libslic3r/GCodeSender.hpp
+@@ -9,6 +9,7 @@
+ #include <boost/asio.hpp>
+ #include <boost/bind.hpp>
+ #include <boost/thread.hpp>
++#include <boost/core/noncopyable.hpp>
+ 
+ namespace Slic3r {
+ 

--- a/pkgs/applications/misc/slic3r/default.nix
+++ b/pkgs/applications/misc/slic3r/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchgit, perl, makeWrapper, makeDesktopItem
-, which, perlPackages, boost
+{ lib, stdenv, fetchgit, perl, makeWrapper
+, makeDesktopItem, which, perlPackages, boost
 }:
 
 stdenv.mkDerivation rec {
@@ -39,6 +39,11 @@ stdenv.mkDerivation rec {
     # one in the kernel, we use that one instead.
     sed -i 's|"/usr/include/asm-generic/ioctls.h"|<asm-generic/ioctls.h>|g' xs/src/libslic3r/GCodeSender.cpp
   '';
+
+  # note the boost-compile-error is fixed in
+  # https://github.com/slic3r/Slic3r/commit/90f108ae8e7a4315f82e317f2141733418d86a68
+  # this patch can be probably be removed in the next version after 1.3.0
+  patches = lib.optional (lib.versionAtLeast boost.version "1.56.0") ./boost-compile-error.patch;
 
   buildPhase = ''
     export SLIC3R_NO_AUTO=true


### PR DESCRIPTION
###### Motivation for this change

Compile error in Slic3r https://github.com/NixOS/nixpkgs/issues/74250

~~Patch is currently commented out (ie. this PR is currently equivalent to master), because I want to see it fail on the bot's build.~~

~~@GrahamcOfBorg build slic3r~~

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review rev HEAD"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bjornfor @the-kenny
