### PR TITLE
krohnkite: init at 0.5

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/scripts/krohnkite.nix
+++ b/pkgs/desktops/plasma-5/kwin/scripts/krohnkite.nix
@@ -1,0 +1,39 @@
+{ lib, mkDerivation, fetchFromGitHub
+, kcoreaddons, kwindowsystem, plasma-framework, systemsettings }:
+
+mkDerivation rec {
+  pname = "krohnkite";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "esjeon";
+    repo = "krohnkite";
+    rev = "v${version}";
+    sha256 = "0i0xr5aj565dzr72zjg7wmyca2gwg9izhnri63pab5y5gp5zjqn2";
+  };
+
+  buildInputs = [
+    kcoreaddons kwindowsystem plasma-framework systemsettings
+  ];
+
+  dontBuild = true;
+
+  # 1. --global still installs to $HOME/.local/share so we use --packageroot
+  # 2. plasmapkg2 doesn't copy metadata.desktop into place, so we do that manually
+  installPhase = ''
+    runHook preInstall
+
+    plasmapkg2 --type kwinscript --install ${src}/res/ --packageroot $out/share/kwin/scripts
+    install -Dm644 ${src}/res/metadata.desktop $out/share/kservices5/krohnkite.desktop
+
+    runHook postInstalll
+  '';
+
+  meta = with lib; {
+    description = "A dynamic tiling extension for KWin";
+    license = licenses.mit;
+    maintainers = with maintainers; [ seqizz ];
+    inherit (src.meta) homepage;
+    inherit (kwindowsystem.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23456,6 +23456,8 @@ in
 
   kwin-tiling = libsForQt5.callPackage ../desktops/plasma-5/kwin/scripts/tiling.nix { };
 
+  krohnkite = libsForQt5.callPackage ../desktops/plasma-5/kwin/scripts/krohnkite.nix { };
+
   ### SCIENCE
 
   ### SCIENCE/CHEMISTY


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

krohnkite is a kwin script which supplies dwm-style tiling

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
