### PR TITLE
qutebrowser: 1.8.1 -> 1.8.2

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -10,23 +10,23 @@ assert withMediaPlayback -> gst_all_1 != null;
 
 let
   pdfjs = let
-    version = "2.2.228";
+    version = "2.3.200";
   in
   fetchzip rec {
     name = "pdfjs-${version}";
     url = "https://github.com/mozilla/pdf.js/releases/download/v${version}/${name}-dist.zip";
-    sha256 = "0yik4vfnz46j844jfw1gq5cshgzry42kpy2d5rr7fbn9fjf98bw6";
+    sha256 = "1fpxsw0hzahccyng08acvc7g0gk29j2x701p6w6fg1718mvcrm1q";
     stripRoot = false;
   };
 
 in mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "qutebrowser";
-  version = "1.8.1";
+  version = "1.8.2";
 
   # the release tarballs are different from the git checkout!
   src = fetchurl {
     url = "https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "0ckffbw2zlg0afz4rgyywzdprnqs74va5qj0xqlaqc14ziiypxnw";
+    sha256 = "0walddppjb61k3dyq22cngkaw6alzn75k5npvnawla2l153irw5s";
   };
 
   # Needs tox


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
 
This change is a version bump for qutebrowser (and pdfjs). The following are the [release notes](https://github.com/qutebrowser/qutebrowser/releases/tag/v1.8.2):

**Changed:**

Windows/macOS releases now ship with Qt 5.12.6. This includes security fixes
up to Chromium 77.0.3865.120 plus a security fix for CVE-2019-13720 from
Chromium 78.

**Fixed:**

- Unbinding keys via config.bind(key, None) accidentally worked in v1.7.0 but raises an exception in v1.8.0. It now works again, but is deprecated and shows an error. Note that :config-py-write did write such invalid lines before v1.8.0, so existing config files might need adjustments.
- The readability-js userscript now handles encodings correctly (which it didn't before for some websites).
- can now be used to paste text starting with a hyphen.
- Following hints via the number keypad now works properly again.
- Errors while reading the state file are now displayed instead of causing a crash.
- Crash when using :debug-log-level without a console attached.
- Downloads are now hidden properly when the browser is in fullscreen mode.
- Crash when setting colors.webpage.bg to an empty value with QtWebKit.
- Crash when the history database file is not a proper sqlite database.
- Workaround for missing/broken error pages on Debian.
- A deprecation warning (caused by pywin32) about the imp module on Windows is now hidden.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
