### PR TITLE
treewide: https://cache.nixos.org/ -> https://cache.nixos.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ system, [Hydra](https://hydra.nixos.org/).
 * [Tests for the NixOS 19.09 release](https://hydra.nixos.org/job/nixos/release-19.09/tested#tabs-constituents)
 
 Artifacts successfully built with Hydra are published to cache at
-https://cache.nixos.org/. When successful build and test criteria are
+<https://cache.nixos.org>. When successful build and test criteria are
 met, the Nixpkgs expressions are distributed via [Nix
 channels](https://nixos.org/nix/manual/#sec-channels).
 

--- a/nixos/doc/manual/administration/network-problems.xml
+++ b/nixos/doc/manual/administration/network-problems.xml
@@ -11,7 +11,7 @@
   whenever a command like <command>nixos-rebuild</command> needs a path in the
   Nix store, Nix will try to download that path from the Internet rather than
   build it from source. The default binary cache is
-  <uri>https://cache.nixos.org/</uri>. If this cache is unreachable, Nix
+  <uri>https://cache.nixos.org</uri>. If this cache is unreachable, Nix
   operations may take a long time due to HTTP connection timeouts. You can
   disable the use of the binary cache by adding <option>--option
   use-binary-caches false</option>, e.g.

--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -303,7 +303,7 @@ if [ -n "$buildNix" ]; then
                 nixStorePath="$(prebuiltNix "$(uname -m)")"
             fi
             if ! nix-store -r $nixStorePath --add-root $tmpDir/nix --indirect \
-                --option extra-binary-caches https://cache.nixos.org/; then
+                --option extra-binary-caches https://cache.nixos.org; then
                 echo "warning: don't know how to get latest Nix" >&2
             fi
             # Older version of nix-store -r don't support --add-root.
@@ -312,7 +312,7 @@ if [ -n "$buildNix" ]; then
                 remoteNixStorePath="$(prebuiltNix "$(buildHostCmd uname -m)")"
                 remoteNix="$remoteNixStorePath/bin"
                 if ! buildHostCmd nix-store -r $remoteNixStorePath \
-                  --option extra-binary-caches https://cache.nixos.org/ >/dev/null; then
+                  --option extra-binary-caches https://cache.nixos.org >/dev/null; then
                     remoteNix=
                     echo "warning: don't know how to get latest Nix" >&2
                 fi

--- a/nixos/modules/programs/captive-browser.nix
+++ b/nixos/modules/programs/captive-browser.nix
@@ -34,7 +34,7 @@ in
                                          ''--no-first-run''
                                          ''--new-window''
                                          ''--incognito''
-                                         ''http://cache.nixos.org/''
+                                         ''http://cache.nixos.org''
                                        ];
         description = ''
           The shell (/bin/sh) command executed once the proxy starts.

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -268,7 +268,7 @@ in
           List of binary cache URLs used to obtain pre-built binaries
           of Nix packages.
 
-          By default https://cache.nixos.org/ is added,
+          By default https://cache.nixos.org is added,
           to override it use <literal>lib.mkForce []</literal>.
         '';
       };
@@ -380,7 +380,7 @@ in
   config = {
 
     nix.binaryCachePublicKeys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" ];
-    nix.binaryCaches = [ "https://cache.nixos.org/" ];
+    nix.binaryCaches = [ "https://cache.nixos.org" ];
 
     environment.etc."nix/nix.conf".source = nixConf;
 


### PR DESCRIPTION
###### Motivation for this change

The latter seems to be marginally nicer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @domenkozar 