### PR TITLE
ocamlPackages.owl: init at 0.7.1

### DIFF
--- a/pkgs/development/ocaml-modules/eigen/default.nix
+++ b/pkgs/development/ocaml-modules/eigen/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildDunePackage, fetchFromGitHub, ctypes }:
+
+buildDunePackage rec {
+  pname = "eigen";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "owlbarn";
+    repo   = pname;
+    rev    = version;
+    sha256 = "0pbqd87i9h7qpx84hr8k4iw0rhmjgma4s3wihxh992jjvsrgdyfi";
+  };
+
+  minimumOCamlVersion = "4.04";
+
+  propagatedBuildInputs = [ ctypes ];
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Minimal/incomplete Ocaml interface to Eigen3, mostly for Owl";
+    platforms = platforms.x86_64;
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/ocaml-modules/owl-base/default.nix
+++ b/pkgs/development/ocaml-modules/owl-base/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildDunePackage, fetchFromGitHub, integers, stdlib-shims }:
+
+buildDunePackage rec {
+  pname = "owl-base";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner  = "owlbarn";
+    repo   = "owl";
+    rev    = version;
+    sha256 = "1v4jfn3w18zq188f9gskx9ffja3xx59j2mgrw6azp8lsbqixg5xk";
+  };
+
+  propagatedBuildInputs = [ stdlib-shims ];
+
+  minimumOCamlVersion = "4.06";
+
+  meta = with stdenv.lib; {
+    description = "Numerical computing library for Ocaml";
+    homepage = "https://ocaml.xyz";
+    platforms = platforms.x86_64;
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/ocaml-modules/owl/default.nix
+++ b/pkgs/development/ocaml-modules/owl/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, buildDunePackage, fetchFromGitHub, alcotest
+, eigen, stdio, stdlib-shims, openblasCompat, owl-base
+}:
+
+buildDunePackage rec {
+  pname = "owl";
+
+  inherit (owl-base) version src meta;
+
+  buildInputs = [ eigen ];
+  checkInputs = [ alcotest ];
+  propagatedBuildInputs = [ stdio stdlib-shims openblasCompat owl-base ];
+
+  # tests not enabled for now due to owlbarn/owl/issues/460
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -235,6 +235,8 @@ let
 
     easy-format = callPackage ../development/ocaml-modules/easy-format { };
 
+    eigen = callPackage ../development/ocaml-modules/eigen { };
+
     elina = callPackage ../development/ocaml-modules/elina { };
 
     eliom = callPackage ../development/ocaml-modules/eliom { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -603,6 +603,10 @@ let
 
     owee = callPackage ../development/ocaml-modules/owee { };
 
+    owl-base = callPackage ../development/ocaml-modules/owl-base { };
+
+    owl = callPackage ../development/ocaml-modules/owl { };
+
     ounit = callPackage ../development/ocaml-modules/ounit { };
 
     pgsolver = callPackage ../development/ocaml-modules/pgsolver { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a package and its dependencies (eigen, owl-base).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
