### PR TITLE
rl-2003: Fix typo

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -188,7 +188,7 @@
    </listitem>
    <listitem>
     <para>
-      Going forward, <literal>~/bin/<literal> in the users home directory will no longer be in <literal>PATH</literal> by default.
+      Going forward, <literal>~/bin</literal> in the users home directory will no longer be in <literal>PATH</literal> by default.
       If you depend on this you should set the option <literal>environment.homeBinInPath</literal> to <literal>true</literal>.
       The aforementioned option was added this release.
     </para>


### PR DESCRIPTION
###### Motivation for this change
Fix a typo introduced in a06529b7adb which prevents the manual from building.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andir @worldofpeace @adisbladis @etu
