### PR TITLE
pythonPackages.pyglet + alienarena + ati_drivers_x11: fix libGL and libGLU paths

### DIFF
--- a/pkgs/development/python-modules/pyglet/default.nix
+++ b/pkgs/development/python-modules/pyglet/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
             if name == 'GL':
                 path = '${libGL}/lib/libGL${ext}'
             elif name == 'GLU':
-                path = '${libGL}/lib/libGLU${ext}'
+                path = '${libGLU}/lib/libGLU${ext}'
             elif name == 'c':
                 path = '${glibc}/lib/libc${ext}.6'
             elif name == 'X11':

--- a/pkgs/games/alienarena/default.nix
+++ b/pkgs/games/alienarena/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libjpeg, libX11, libXxf86vm, curl, libogg
-, libvorbis, freetype, openal, libGLU, libGL }:
+, libvorbis, freetype, openal, libGL }:
 
 stdenv.mkDerivation {
   name = "alienarena-7.65";
@@ -11,12 +11,12 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libjpeg libX11 curl libogg libvorbis
-                  freetype openal libGLU libGL libXxf86vm ];
+                  freetype openal libGL libXxf86vm ];
 
   patchPhase = ''
     substituteInPlace ./configure \
       --replace libopenal.so.1 ${openal}/lib/libopenal.so.1 \
-      --replace libGL.so.1 ${libGLU libGL}/lib/libGL.so.1
+      --replace libGL.so.1 ${libGL}/lib/libGL.so.1
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/ati-drivers/builder.sh
+++ b/pkgs/os-specific/linux/ati-drivers/builder.sh
@@ -246,9 +246,9 @@ if test -z "$libsOnly"; then
   ( # build and install fgl_glxgears
     cd fgl_glxgears;
     gcc -DGL_ARB_texture_multisample=1 -g \
-    -I$libGLU libGL/include \
+    -I$libGL/include -I$libGLU/include \
     -I$out/include \
-    -L$libGLU libGL/lib -lGL -lGLU -lX11 -lm \
+    -L$libGL/lib -L$libGLU/lib -lGL -lGLU -lX11 -lm \
     -o $out/bin/fgl_glxgears -Wall fgl_glxgears.c
   )
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixup some paths that got messed up during #73261 rewrite.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @adisbladis
