### PR TITLE
Adds support for infiniband network interfaces

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -613,6 +613,7 @@
   ./services/networking/hylafax/default.nix
   ./services/networking/i2pd.nix
   ./services/networking/i2p.nix
+  ./services/networking/infiniband.nix
   ./services/networking/iodine.nix
   ./services/networking/iperf3.nix
   ./services/networking/ircd-hybrid/default.nix

--- a/nixos/modules/services/networking/infiniband.nix
+++ b/nixos/modules/services/networking/infiniband.nix
@@ -1,0 +1,78 @@
+{lib, pkgs, config, ...}:
+
+let
+  cfg = config.networking.ib-interfaces;
+in {
+
+  imports = [];
+
+  options = {
+    networking.ib-interfaces = {
+      enable = lib.mkEnableOption "ib-interfaces";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.rdma-core ];
+    services.udev.packages =
+      let patchedUdevRules = pkgs.stdenv.mkDerivation {
+        name = "patched-${pkgs.rdma-core.name}-udev-rules";
+        src = "${pkgs.rdma-core}/lib/udev/rules.d";
+        phases = ["unpackPhase" "patchPhase" "installPhase"];
+        patchPhase = ''
+          substituteInPlace 60-srp_daemon.rules \
+            --replace /bin/systemctl ${pkgs.systemd}/bin/systemctl
+        '';
+        installPhase = ''
+          mkdir -p $out/lib/udev/rules.d
+          cp -r . $out/lib/udev/rules.d/
+        '';
+      }; in [ patchedUdevRules ];
+
+    # Units
+    systemd.units = with pkgs; {
+      "ibacm.service".text =
+        builtins.readFile "${rdma-core}/lib/systemd/system/ibacm.service";
+      "ibacm.socket".text =
+        builtins.readFile "${rdma-core}/lib/systemd/system/ibacm.socket";
+      "iwpmd.service".text =
+        builtins.readFile "${rdma-core}/lib/systemd/system/iwpmd.service";
+      "rdma-hw.target".text =
+        builtins.readFile "${rdma-core}/lib/systemd/system/rdma-hw.target";
+      "rdma-load-modules@.service".text = ''
+        [Unit]
+        Description=Load RDMA modules from /nix/store/q38v9b228hiwavpnvfqgds42hfwqv6a3-rdma-core-25.0/etc/rdma/modules/%I.conf
+        Documentation=file:/nix/store/q38v9b228hiwavpnvfqgds42hfwqv6a3-rdma-core-25.0/share/doc/udev.md
+        # Kernel module loading must take place before sysinit.target, similar to
+        # systemd-modules-load.service
+        DefaultDependencies=no
+        Before=sysinit.target
+        # Do not execute concurrently with an ongoing shutdown
+        Conflicts=shutdown.target
+        Before=shutdown.target
+        # Partially support distro network setup scripts that run after
+        # systemd-modules-load.service but before sysinit.target, eg a classic network
+        # setup script. Run them after modules have loaded.
+        Wants=network-pre.target
+        Before=network-pre.target
+        # Orders all kernel module startup before rdma-hw.target can become ready
+        Before=rdma-hw.target
+
+        ConditionCapability=CAP_SYS_MODULE
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=${pkgs.systemd}/lib/systemd/systemd-modules-load /nix/store/q38v9b228hiwavpnvfqgds42hfwqv6a3-rdma-core-25.0/etc/rdma/modules/%I.conf
+        TimeoutSec=90s
+      '';
+      "rdma-ndd.service".text =
+        builtins.readFile "${rdma-core}/lib/systemd/system/rdma-ndd.service";
+      "srp_daemon_port@.service".text =
+        builtins.readFile "${rdma-core}/lib/systemd/system/srp_daemon_port@.service";
+      "srp_daemon.service".text =
+        builtins.readFile "${rdma-core}/lib/systemd/system/srp_daemon.service";
+    };
+  };
+}


### PR DESCRIPTION
Adds a service module for bringing up userspace infiniband devices, including IP over IB

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
