### PR TITLE
saga: switch to opencv3

### DIFF
--- a/pkgs/applications/gis/saga/default.nix
+++ b/pkgs/applications/gis/saga/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, gdal, wxGTK30, proj, libiodbc, lzma, jasper,
-  libharu, opencv, vigra, postgresql, Cocoa,
+  libharu, opencv3, vigra, postgresql, Cocoa,
   unixODBC , poppler, hdf4, hdf5, netcdf, sqlite, qhull, giflib }:
 
 stdenv.mkDerivation {
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
 
   # See https://groups.google.com/forum/#!topic/nix-devel/h_vSzEJAPXs
   # for why the have additional buildInputs on darwin
-  buildInputs = [ gdal wxGTK30 proj libharu opencv vigra postgresql libiodbc lzma
+  buildInputs = [ gdal wxGTK30 proj libharu opencv3 vigra postgresql libiodbc lzma
                   jasper qhull giflib ]
                 ++ stdenv.lib.optionals stdenv.isDarwin
                   [ Cocoa unixODBC poppler hdf4.out hdf5 netcdf sqlite ];


### PR DESCRIPTION
###### Motivation for this change
opencv2 is essentially EOL and has security concerns

This is a bit of a funny PR, in that the result I'm proposing compiles but doesn't actually work _for me_. But neither did the existing package. While the module compiles fine, in both cases if you observe the startup log it fails to load `lib/saga/libimagery_opencv.so`. Perhaps I'm testing it wrong, so I'm appealing to maintainers @michelk and @mpickering to ask if you _ever_ had the opencv features working for `saga`.


