### PR TITLE
gotify-server: 2.0.10 -> 2.0.11

### DIFF
--- a/pkgs/servers/gotify/default.nix
+++ b/pkgs/servers/gotify/default.nix
@@ -10,13 +10,15 @@
 
 buildGoModule rec {
   pname = "gotify-server";
-  version = "2.0.10";
+  # Note that when this is updated, along with the hash, the `ui.nix` file
+  # should include the same changes to the version and the sha256.
+  version = "2.0.11";
 
   src = fetchFromGitHub {
     owner = "gotify";
     repo = "server";
     rev = "v${version}";
-    sha256 = "0f7y6gkxikdfjhdxplkv494ss2b0fqmibd2kl9nifabggfz5gjal";
+    sha256 = "0zrylyaxy1cks1wlzyf0di8in2braj4pfriyqa24vipwrlnhvgs6";
   };
 
   modSha256 = "19mghbs1jasb7vxdw13mmwsbk5sfg3y2vvddr73c82lq0f8g2iha";

--- a/pkgs/servers/gotify/ui.nix
+++ b/pkgs/servers/gotify/ui.nix
@@ -8,13 +8,13 @@ yarn2nix-moretea.mkYarnPackage rec {
   packageJSON = ./package.json;
   yarnNix = ./yarndeps.nix;
 
-  version = "2.0.8";
+  version = "2.0.11";
 
   src_all = fetchFromGitHub {
     owner = "gotify";
     repo = "server";
     rev = "v${version}";
-    sha256 = "17bxs3wcazrxippf3i9w7d2mq8lf0v5m4bn3nl2zb8v8dl3lsc9a";
+    sha256 = "0zrylyaxy1cks1wlzyf0di8in2braj4pfriyqa24vipwrlnhvgs6";
   };
   src = "${src_all}/ui";
 

--- a/pkgs/servers/gotify/yarndeps.nix
+++ b/pkgs/servers/gotify/yarndeps.nix
@@ -706,6 +706,14 @@
       };
     }
     {
+      name = "_babel_runtime___runtime_7.6.3.tgz";
+      path = fetchurl {
+        name = "_babel_runtime___runtime_7.6.3.tgz";
+        url  = "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz";
+        sha1 = "935122c74c73d2240cafd32ddb5fc2a6cd35cf1f";
+      };
+    }
+    {
       name = "_babel_template___template_7.4.4.tgz";
       path = fetchurl {
         name = "_babel_template___template_7.4.4.tgz";
@@ -890,11 +898,11 @@
       };
     }
     {
-      name = "_material_ui_icons___icons_4.4.3.tgz";
+      name = "_material_ui_icons___icons_4.5.1.tgz";
       path = fetchurl {
-        name = "_material_ui_icons___icons_4.4.3.tgz";
-        url  = "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.4.3.tgz";
-        sha1 = "5d4346ddbb2673a1b57ebc78fd6d50bcd88711db";
+        name = "_material_ui_icons___icons_4.5.1.tgz";
+        url  = "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.5.1.tgz";
+        sha1 = "6963bad139e938702ece85ca43067688018f04f8";
       };
     }
     {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ma27 
