### PR TITLE
gmic, gmic-qt: switch to opencv3

### DIFF
--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -7,7 +7,7 @@
 , fetchFromGitLab
 , cmake
 , pkgconfig
-, opencv
+, opencv3
 , openexr
 , graphicsmagick
 , fftw
@@ -120,7 +120,7 @@ mkDerivation rec {
     libjpeg
     libtiff
     libpng
-    opencv
+    opencv3
     openexr
     graphicsmagick
     curl

--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -3,7 +3,7 @@
 , cmake
 , ninja
 , pkgconfig
-, opencv
+, opencv3
 , openexr
 , graphicsmagick
 , fftw
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     libjpeg
     libtiff
     libpng
-    opencv
+    opencv3
     openexr
     graphicsmagick
   ];


### PR DESCRIPTION
###### Motivation for this change
opencv2 is essentially EOL and has security concerns

opencv is reportedly only used for webcam input in `gmic`, and I've successfully managed to get webcam pictures with this built against `opencv3`.

Reverse dependencies `gimpPlugins.gmic` and `gimp-with-plugins` seem to be already broken on master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
