### PR TITLE
texlive: use texlive.info snapshot

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -100,11 +100,15 @@ let
               map (up: "${up}/${urlName}.tar.xz") urlPrefixes
             );
 
-      # Upstream refuses to distribute stable tarballs,
-      # so we host snapshots on IPFS or on our own servers.
-      # Common packages should get served from the binary cache anyway.
-      # See discussions, e.g. https://github.com/NixOS/nixpkgs/issues/24683
+      # The tarballs on CTAN mirrors for the current release are constantly
+      # receiving updates, so we can't use those directly. Stable snapshots
+      # need to be used instead. Ideally, for the release branches of NixOS we
+      # should be switching to the tlnet-final versions
+      # (https://tug.org/historic/).
       urlPrefixes = args.urlPrefixes or [
+        # Snapshots hosted by one of the texlive release managers
+        https://texlive.info/tlnet-archive/2019/10/19/tlnet/archive
+
         # Mirror hosted by @veprbl
         http://146.185.144.154/texlive-2019
 


### PR DESCRIPTION
###### Motivation for this change

Recently I've been told that there are some daily snapshots of tlnet/archive available [1].  @norbusan kindly agreed to allow us to use that mirror of his [2][3]. This PR is switching `texlive` to use it as a primary download.

Thanks to @dtzWill for pointing out the mailinglist thread.

[1] https://tug.org/pipermail/tex-live/2019-November/044445.html
[2] https://tug.org/pipermail/tex-live/2019-November/044452.html
[3] https://tug.org/pipermail/tex-live/2019-November/044456.html

###### Things done

- [x] Compared checksums for tarballs against tarballs from my mirror using sha256sum
- [x] Rebuilt texlive.combined.scheme-full with `--option subsituters ""`
