### PR TITLE
mesa-demos: init at 8.4.0

### DIFF
--- a/pkgs/tools/graphics/mesa-demos/default.nix
+++ b/pkgs/tools/graphics/mesa-demos/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Collection of demos and test programs for OpenGL and Mesa";
-    homepage = https://www.mesa3d.org/;
+    homepage = "https://www.mesa3d.org/";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ andersk ];

--- a/pkgs/tools/graphics/mesa-demos/default.nix
+++ b/pkgs/tools/graphics/mesa-demos/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, freeglut, glew, libGL, libGLU, libX11, libXext, mesa, pkg-config, wayland }:
+
+stdenv.mkDerivation rec {
+  pname = "mesa-demos";
+  version = "8.4.0";
+
+  src = fetchurl {
+    url = "ftp://ftp.freedesktop.org/pub/mesa/demos/${pname}-${version}.tar.bz2";
+    sha256 = "0zgzbz55a14hz83gbmm0n9gpjnf5zadzi2kjjvkn6khql2a9rs81";
+  };
+
+  buildInputs = [ freeglut glew libX11 libXext libGL libGLU mesa mesa.osmesa wayland ];
+  nativeBuildInputs = [ pkg-config ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Collection of demos and test programs for OpenGL and Mesa";
+    homepage = https://www.mesa3d.org/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ andersk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4492,6 +4492,8 @@ in
 
   memtester = callPackage ../tools/system/memtester { };
 
+  mesa-demos = callPackage ../tools/graphics/mesa-demos { };
+
   mhonarc = perlPackages.MHonArc;
 
   minergate = callPackage ../applications/misc/minergate { };


### PR DESCRIPTION
###### Motivation for this change

`mesa-demos` is a superset of the existing `glxinfo` package; `glxinfo` bypasses the upstream build system and manually compiles a small number of binaries. There are many other useful utilities in `mesa-demos`: I wanted `eglinfo` and `es2gears_wayland`, for example. There are also perhaps many useless ones (the total is 316). So I decided to package them all with the upstream package name and leave `glxinfo` as is. I would be open to other suggestions regarding what we should do with `glxinfo`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar (maintainer of `glxinfo`)
