### PR TITLE
matomo: 3.11.0 -> 3.13.0

### DIFF
--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -3,8 +3,8 @@
 let
   versions = {
     matomo = {
-      version = "3.11.0";
-      sha256 = "1fbnmmzzsi3dfm9qm30wypxjcazl37mryaik9mlrb19hnp2md40q";
+      version = "3.13.0";
+      sha256 = "0h4jqibb86zw5l26r927qrbjhba8c79pc4xp3hgpi25p3fjncax8";
     };
 
     matomo-beta = {
@@ -74,15 +74,22 @@ stdenv.mkDerivation rec {
     "vendor/leafo/lessphp/package.sh"
     "vendor/pear/archive_tar/sync-php4"
     "vendor/szymach/c-pchart/coverage.sh"
+    # drupal_test.sh does not exist in 3.12.0-b3; added for 3.13.0
+    "vendor/twig/twig/drupal_test.sh"
   ];
 
   # This fixes the consistency check in the admin interface
+  #
+  # The filesToFix list may contain files that are exclusive to only one of the versions we build
+  # make sure to test for existence to avoid erroring on an incompatible version and failing
   postFixup = ''
     pushd $out/share > /dev/null
     for f in $filesToFix; do
-      length="$(wc -c "$f" | cut -d' ' -f1)"
-      hash="$(md5sum "$f" | cut -d' ' -f1)"
-      sed -i "s:\\(\"$f\"[^(]*(\\).*:\\1\"$length\", \"$hash\"),:g" config/manifest.inc.php
+      if [ -f "$f" ]; then
+        length="$(wc -c "$f" | cut -d' ' -f1)"
+        hash="$(md5sum "$f" | cut -d' ' -f1)"
+        sed -i "s:\\(\"$f\"[^(]*(\\).*:\\1\"$length\", \"$hash\"),:g" config/manifest.inc.php
+      fi
     done
     popd > /dev/null
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The long awaited update to Matomo 3.12.0 has finally arrived! Here it comes... wait what do you mean you missed it?! Oh no, too slow! Well here's 3.13.0 instead!

###### Things done

I checked out [this other PR](https://github.com/NixOS/nixpkgs/pull/73577) before I made these additional changes. Now that one is clearly inferior at this point and should be closed in favor of this one so that I don't have to redo everything. :smile:

I had to add an additional file to the list to fix; and then add in a check to keep the builds succeeding. The matomo-beta would fail when `wc` tried to count a non-existent file that is only in the latest and greatest. No file? No problem! nop!
<del>I also removed the recently (within the last few months, I'm sure) deprecated PermissionsStartOnly; and while I'm not certain that there aren't additional necessary changes that I am unaware of I do know I've been running it in production...</del>


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @florianjacob @aanderse @dasJ @Kiwi 
