### PR TITLE
egl-wayland: fix build

### DIFF
--- a/pkgs/development/libraries/egl-wayland/default.nix
+++ b/pkgs/development/libraries/egl-wayland/default.nix
@@ -5,8 +5,9 @@
 , meson
 , ninja
 , libX11
-, mesa
+, mesa_glu
 , wayland
+, fetchpatch
 }:
 
 let
@@ -50,6 +51,14 @@ in stdenv.mkDerivation rec {
     sha256 = "0wvamjcfycd7rgk7v14g2rin55xin9rfkxmivyay3cm08vnl7y1d";
   };
 
+  patches = [
+    # https://github.com/NVIDIA/egl-wayland/pull/24
+    (fetchpatch {
+      url = "https://github.com/NVIDIA/egl-wayland/commit/1f0230f5c41722d8ec0df2828e97188ffd0a11eb.patch";
+      sha256 = "16dgbm6gzaa6jx7fg9fy1sjpfhfp3r7036zri5q7kq1q02w3yhcm";
+    })
+  ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -59,7 +68,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     eglexternalplatform
     libX11
-    mesa
+    mesa_glu
     wayland
   ];
 


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
mesa-19.2.2 removed a bunch a headers, so we need mesa_glu and an
upstream fix for missing GLVND headers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
