### PR TITLE
egl-wayland: fix build

### DIFF
--- a/pkgs/development/libraries/egl-wayland/default.nix
+++ b/pkgs/development/libraries/egl-wayland/default.nix
@@ -6,6 +6,7 @@
 , ninja
 , libX11
 , mesa
+, libGL
 , wayland
 }:
 
@@ -50,6 +51,10 @@ in stdenv.mkDerivation rec {
     sha256 = "0wvamjcfycd7rgk7v14g2rin55xin9rfkxmivyay3cm08vnl7y1d";
   };
 
+  # Add missing include
+  # https://github.com/NVIDIA/egl-wayland/pull/24
+  patches = [ ./eglmesaext.patch ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -60,6 +65,7 @@ in stdenv.mkDerivation rec {
     eglexternalplatform
     libX11
     mesa
+    libGL
     wayland
   ];
 

--- a/pkgs/development/libraries/egl-wayland/eglmesaext.patch
+++ b/pkgs/development/libraries/egl-wayland/eglmesaext.patch
@@ -1,0 +1,12 @@
+diff --git a/src/wayland-eglsurface.c b/src/wayland-eglsurface.c
+index 01c9cb3..45736b0 100644
+--- a/src/wayland-eglsurface.c
++++ b/src/wayland-eglsurface.c
+@@ -37,6 +37,7 @@
+ #include <sys/types.h>
+ #include <netinet/in.h>
+ #include <fcntl.h>
++#include <EGL/eglmesaext.h>
+ 
+ #define WL_EGL_WINDOW_DESTROY_CALLBACK_SINCE 3
+ 


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add headers that got moved in #72999.
Also contains patch for a missing include which ist reported upstream: NVIDIA/egl-wayland#24

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @hedning @primeos @adisbladis
