### PR TITLE
qjoypad: 4.1.0 -> 4.3.0

### DIFF
--- a/pkgs/tools/misc/qjoypad/default.nix
+++ b/pkgs/tools/misc/qjoypad/default.nix
@@ -1,20 +1,20 @@
-{ lib, stdenv, fetchurl, pkg-config, libX11, libXtst, qt4 }:
-stdenv.mkDerivation rec {
-  name = "qjoypad-4.1.0";
-  src = fetchurl {
-    url = "mirror://sourceforge/qjoypad/${name}.tar.gz";
-    sha256 = "1jlm7i26nfp185xrl41kz5z6fgvyj51bjpz48cg27xx64y40iamm";
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, libX11, libXtst, qtbase, qttools, qtx11extras }:
+
+mkDerivation rec {
+  pname = "qjoypad";
+  version = "4.3.0";
+
+  src = fetchFromGitHub {
+    owner = "panzi";
+    repo = "qjoypad";
+    rev = "v${version}";
+    sha256 = "0ps85ncqmy8jz3zzyv5f5z4564kkgcl799ri4kcz407mjyc4fvs6";
   };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libX11 libXtst qt4 ];
-  NIX_LDFLAGS = "-lX11";
-  patchPhase = ''
-    cd src
-    substituteInPlace config --replace /bin/bash ${stdenv.shell}
-    mkdir -p $out
-    export NIX_LDFLAGS="$NIX_LDFLAGS -rpath ${libX11}/lib"
-  '';
-  meta = {
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ libX11 libXtst qtbase qttools qtx11extras ];
+  NIX_LDFLAGS = [ "-lX11" ];
+  meta = with lib; {
     description = "A program that lets you use gaming devices anywhere";
     longDescription = ''
       A simple Linux/QT program that lets you use your gaming devices
@@ -32,9 +32,9 @@ stdenv.mkDerivation rec {
       of gaming devices in Linux, and makes the Linux gaming
       experience just a little bit nicer.
     '';
-    homepage = "http://qjoypad.sourceforge.net";
-    license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ astsmtl ];
-    platforms = with lib.platforms; linux;
+    homepage = "https://github.com/panzi/qjoypad";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ astsmtl ];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/tools/misc/qjoypad/default.nix
+++ b/pkgs/tools/misc/qjoypad/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitHub, cmake, pkgconfig, libX11, libXtst, qtbase, qttools, qtx11extras }:
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkg-config, libX11, libXtst, qtbase, qttools, qtx11extras }:
 
 mkDerivation rec {
   pname = "qjoypad";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7425,7 +7425,7 @@ in
 
   qhull = callPackage ../development/libraries/qhull { };
 
-  qjoypad = callPackage ../tools/misc/qjoypad { };
+  qjoypad = libsForQt5.callPackage ../tools/misc/qjoypad { };
 
   qosmic = libsForQt5.callPackage ../applications/graphics/qosmic { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Switching to Qt5 makes the package play well with modern desktop environments. Tested on Ubuntu 18.04, default Ubuntu session.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @astsmtl
