### PR TITLE
pythonPackage.XlsxWriter: 1.2.1 -> 1.2.6

### DIFF
--- a/pkgs/development/python-modules/XlsxWriter/default.nix
+++ b/pkgs/development/python-modules/XlsxWriter/default.nix
@@ -3,7 +3,7 @@
 buildPythonPackage rec {
 
   pname = "XlsxWriter";
-  version = "1.2.1";
+  version = "1.2.6";
 
   # PyPI release tarball doesn't contain tests so let's use GitHub. See:
   # https://github.com/jmcnamara/XlsxWriter/issues/327
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     owner = "jmcnamara";
     repo = pname;
     rev = "RELEASE_${version}";
-    sha256 = "0br8ib9n17dfprfly93mjkhdhpndb7i4g57lwscvp2s69ssql32s";
+    sha256 = "05y1py5mn1m65bbwhinzv84jd3xj8snvf2795flw0xbxnkn8nd8p";
   };
 
   meta = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update Python package XlsxWriter.

nix-review:

```
[...]$ nix-review pr 74340
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nix-review/0 pull/74340/head:refs/nix-review/1
remote: Enumerating objects: 2207, done.
remote: Counting objects: 100% (2207/2207), done.
remote: Compressing objects: 100% (22/22), done.
remote: Total 4025 (delta 2194), reused 2185 (delta 2185), pack-reused 1818
Receiving objects: 100% (4025/4025), 2.30 MiB | 1.74 MiB/s, done.
Resolving deltas: 100% (2927/2927), completed with 837 local objects.
From https://github.com/NixOS/nixpkgs
   e89b21504f3..bfdd3e1fe24  master               -> refs/nix-review/0
   8ea66b0151a..8c4c1274b24  refs/pull/74340/head -> refs/nix-review/1
$ git worktree add /home/jluttine/.cache/nix-review/pr-74340/nixpkgs bfdd3e1fe24b4868b87da761ce96a773b18ebfd8
Preparing worktree (detached HEAD bfdd3e1fe24)
Updating files: 100% (20394/20394), done.
HEAD is now at bfdd3e1fe24 chefdk: fix build (#74314)
$ nix-env -f /home/jluttine/.cache/nix-review/pr-74340/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 8c4c1274b243ef3081c73e6b6b0c4f18988616a7
Automatic merge went well; stopped before committing as requested
$ nix-env -f /home/jluttine/.cache/nix-review/pr-74340/nixpkgs -qaP --xml --out-path --show-trace --meta
$ nix build --no-link --keep-going --max-jobs 8 --option build-use-sandbox true -f /home/jluttine/.cache/nix-review/pr-74340/build.nix
warning: ignoring the user-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
builder for '/nix/store/whhq5k1sb57wi1kwnyplij85xyrxh1q3-python3.8-canmatrix-0.8.drv' failed with exit code 1; last 10 log lines:

  src/canmatrix/tests/test_dbc.py::test_export_of_unknown_defines
  src/canmatrix/tests/test_dbc.py::test_export_of_unknown_defines
  src/canmatrix/tests/test_dbc.py::test_export_of_unknown_defines
  src/canmatrix/tests/test_dbc.py::test_export_of_unknown_defines
    /build/source/src/canmatrix/formats/dbc.py:70: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
      logger.warn("dbc export of attribute type {} not supported; replaced by STRING".format(define.type))

  -- Docs: https://docs.pytest.org/en/latest/warnings.html
  ================== 1 failed, 192 passed, 10 warnings in 1.36s ==================
cannot build derivation '/nix/store/ry7c7ybmycn22qzv265rbm77kfap32q4-python3.8-canopen-0.5.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/9kb6nw2553wmk0if3jrw52i19018s1mp-env.drv': 2 dependencies couldn't be built
[11 built (1 failed), 241 copied (617.6 MiB), 117.8 MiB DL]
error: build of '/nix/store/9kb6nw2553wmk0if3jrw52i19018s1mp-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/74340
2 package failed to build:
python38Packages.canmatrix python38Packages.canopen

11 package were built:
python27Packages.XlsxWriter python27Packages.canmatrix python27Packages.canopen python27Packages.shodan python37Packages.XlsxWriter python37Packages.canmatrix python37Packages.canopen python37Packages.shodan python38Packages.XlsxWriter python38Packages.shodan theharvester

[0.0 MiB DL]
error: build log of '/nix/store/ry7c7ybmycn22qzv265rbm77kfap32q4-python3.8-canopen-0.5.1.drv' is not available
$ nix-shell /home/jluttine/.cache/nix-review/pr-74340/shell.nix
these paths will be fetched (1.51 MiB download, 8.27 MiB unpacked):
  /nix/store/apzd08v6qq95ppvkr5jp9m516q1nys4s-readline-7.0p5
  /nix/store/fpl4264jl7sczq7qpn04yc52gvq1195y-bash-interactive-4.4-p23-info
  /nix/store/kmzigdidq84lhrkwgm435m62x72xqvxh-bash-interactive-4.4-p23-dev
  /nix/store/vs7zapqwngylvpydpv5dg3gk1va8dj8w-bash-interactive-4.4-p23
  /nix/store/w4lsjhdlw9gjv9j1lps8g6m1w3w9mprb-bash-interactive-4.4-p23-man
  /nix/store/yjxj890hgn8lz9nxjlppnsiq43isr8h4-bash-interactive-4.4-p23-doc
copying path '/nix/store/yjxj890hgn8lz9nxjlppnsiq43isr8h4-bash-interactive-4.4-p23-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/fpl4264jl7sczq7qpn04yc52gvq1195y-bash-interactive-4.4-p23-info' from 'https://cache.nixos.org'...
copying path '/nix/store/w4lsjhdlw9gjv9j1lps8g6m1w3w9mprb-bash-interactive-4.4-p23-man' from 'https://cache.nixos.org'...
copying path '/nix/store/apzd08v6qq95ppvkr5jp9m516q1nys4s-readline-7.0p5' from 'https://cache.nixos.org'...
copying path '/nix/store/vs7zapqwngylvpydpv5dg3gk1va8dj8w-bash-interactive-4.4-p23' from 'https://cache.nixos.org'...
copying path '/nix/store/kmzigdidq84lhrkwgm435m62x72xqvxh-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...

[nix-shell:~/.cache/nix-review/pr-74340]$
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

