### PR TITLE
Update eth-utils and and eth-typing

### DIFF
--- a/pkgs/development/python-modules/eth-typing/default.nix
+++ b/pkgs/development/python-modules/eth-typing/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "eth-typing";
-  version = "2.1.0";
+  version = "2.2.1";
 
   # Tests are missing from the PyPI source tarball so let's use GitHub
   # https://github.com/ethereum/eth-typing/issues/8
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner = "ethereum";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0chrrfw3kdaihgr2ryhljf56bflipzmfxai688xrc2yk7yiqnll5";
+    sha256 = "0k9jydsclk81qpkvl7hpchwclm3c89gyzlk17480wcw90nkps9ap";
   };
 
   # setuptools-markdown uses pypandoc which is broken at the moment

--- a/pkgs/development/python-modules/eth-utils/default.nix
+++ b/pkgs/development/python-modules/eth-utils/default.nix
@@ -3,7 +3,7 @@
 
 buildPythonPackage rec {
   pname = "eth-utils";
-  version = "1.7.0";
+  version = "1.8.1";
 
   # Tests are missing from the PyPI source tarball so let's use GitHub
   # https://github.com/ethereum/eth-utils/issues/130
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     owner = "ethereum";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0hhhdz764xgwj5zg3pjzpx10vh54q7kbvlnj9d67qkgwl3fkfgw2";
+    sha256 = "0kr4hw2l1ck22sk187wvg2pxh3mknjp2xjxjizgwvdsxqqqsxpg4";
   };
 
   checkInputs = [ pytest hypothesis ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update Python packages `eth-utils` and `eth-typing`.

Running nix review:

```
[...]$ nix-review rev -b nixos-unstable update-eth-utils-and-typing
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs nixos-unstable:refs/nix-review/0
$ git worktree add /home/jluttine/.cache/nix-review/rev-2a98a44f75d6e2fcb4298b332194fd80024eb4ea/nixpkgs e89b21504f3e61e535229afa0b121defb52d2a50
Preparing worktree (detached HEAD e89b21504f3)
Updating files: 100% (20378/20378), done.
HEAD is now at e89b21504f3 Merge pull request #73729 from marsam/update-ibm-plex
$ nix-env -f /home/jluttine/.cache/nix-review/rev-2a98a44f75d6e2fcb4298b332194fd80024eb4ea/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 2a98a44f75d6e2fcb4298b332194fd80024eb4ea
Updating e89b21504f3..2a98a44f75d
Fast-forward
 pkgs/development/python-modules/eth-typing/default.nix | 4 ++--
 pkgs/development/python-modules/eth-utils/default.nix  | 4 ++--
 2 files changed, 4 insertions(+), 4 deletions(-)
$ nix-env -f /home/jluttine/.cache/nix-review/rev-2a98a44f75d6e2fcb4298b332194fd80024eb4ea/nixpkgs -qaP --xml --out-path --show-trace --meta
$ nix build --no-link --keep-going --max-jobs 8 --option build-use-sandbox true -f /home/jluttine/.cache/nix-review/rev-2a98a44f75d6e2fcb4298b332194fd80024eb4ea/build.nix
warning: ignoring the user-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
[16 built, 52 copied (69.8 MiB), 25.7 MiB DL]
16 package were built:
electron-cash electrum keepkey_agent python37Packages.eth-typing python37Packages.eth-utils python37Packages.keepkey python37Packages.rlp python37Packages.trezor trezor_agent python38Packages.eth-typing python38Packages.eth-utils python38Packages.keepkey python38Packages.keepkey_agent python38Packages.rlp python38Packages.trezor python38Packages.trezor_agent

[0.0 MiB DL]
$ nix-shell /home/jluttine/.cache/nix-review/rev-2a98a44f75d6e2fcb4298b332194fd80024eb4ea/shell.nix

[nix-shell:~/.cache/nix-review/rev-2a98a44f75d6e2fcb4298b332194fd80024eb4ea]$
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
