### PR TITLE
pythonPackages.sphinxcontrib-katex: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-katex/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-katex/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, sphinx }:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-katex";
+  version = "0.5.1";
+
+  # pkgutil namespaces are broken in nixpkgs (because they can't scan multiple
+  # directories). But python2 is EOL, so not supporting it should be ok.
+  disabled = pythonOlder "3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qssq2qc12rnwb6yhw3xj69cwij3jp3sqzwb6n85qp36g4vxrkb6";
+  };
+
+  propagatedBuildInputs = [ sphinx ];
+
+  # There are no unit tests
+  doCheck = false;
+  pythonImportsCheck = [ "sphinxcontrib.katex" ];
+
+  meta = with lib; {
+    description = "Sphinx extension using KaTeX to render math in HTML";
+    homepage = "https://github.com/hagenw/sphinxcontrib-katex";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5630,6 +5630,8 @@ in {
 
   sphinxcontrib-jsmath = callPackage ../development/python-modules/sphinxcontrib-jsmath {};
 
+  sphinxcontrib-katex = callPackage ../development/python-modules/sphinxcontrib-katex { };
+
   sphinxcontrib-qthelp = callPackage ../development/python-modules/sphinxcontrib-qthelp {};
 
   sphinxcontrib-serializinghtml = callPackage ../development/python-modules/sphinxcontrib-serializinghtml {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add Sphinx extension for KaTeX.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
