### PR TITLE
pythonPackages.sphinxcontrib-fulltoc: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-fulltoc/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-fulltoc/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, sphinx, pbr }:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-fulltoc";
+  version = "1.2.0";
+
+  # pkgutil namespaces are broken in nixpkgs (because they can't scan multiple
+  # directories). But python2 is EOL, so not supporting it, should be ok.
+  disabled = pythonOlder "3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1nbwflv9szyh37yr075xhck8b4gg2c7g3sa38mfi7wv7qhpxcif8";
+  };
+
+  nativeBuildInputs = [ pbr ];
+  propagatedBuildInputs = [ sphinx ];
+
+  # There are no unit tests
+  doCheck = false;
+  # Ensure package importing works
+  pythonImportsCheck = [ "sphinxcontrib.fulltoc" ];
+
+  meta = with lib; {
+    description = "Include a full table of contents in your Sphinx HTML sidebar";
+    homepage = "https://sphinxcontrib-fulltoc.readthedocs.org/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5626,6 +5626,8 @@ in {
 
   sphinxcontrib-devhelp = callPackage ../development/python-modules/sphinxcontrib-devhelp {};
 
+  sphinxcontrib-fulltoc = callPackage ../development/python-modules/sphinxcontrib-fulltoc { };
+
   sphinxcontrib-htmlhelp = callPackage ../development/python-modules/sphinxcontrib-htmlhelp {};
 
   sphinxcontrib-jsmath = callPackage ../development/python-modules/sphinxcontrib-jsmath {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add Sphinx extension fulltoc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
