### PR TITLE
gst_all_1.gst-plugins-good: fix build with gtkSupport

### DIFF
--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -44,7 +44,7 @@
 assert gtkSupport -> gtk3 != null;
 
 let
-  inherit (stdenv.lib) optional optionals;
+  inherit (stdenv.lib) optionals;
 in
 stdenv.mkDerivation rec {
   pname = "gst-plugins-good";
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
     xorg.libXfixes
     xorg.libXdamage
     wavpack
-  ] ++ optional gtkSupport [
+  ] ++ optionals gtkSupport [
     # for gtksink
     gtk3
   ] ++ optionals stdenv.isDarwin [


### PR DESCRIPTION
Targetting staging-next because the issue is already there:

https://hydra.nixos.org/build/107276178/nixlog/1

Fixes regression from https://github.com/NixOS/nixpkgs/pull/70690