### PR TITLE
ocamlPackages.metrics: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/metrics/default.nix
+++ b/pkgs/development/ocaml-modules/metrics/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchurl, buildDunePackage, alcotest, fmt }:
+
+buildDunePackage rec {
+  pname = "metrics";
+  version = "0.1.0";
+
+  minimumOCamlVersion = "4.04";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/metrics/releases/download/${version}/metrics-${version}.tbz";
+    sha256 = "0jy88anrx3rh19046rrbrjmx922zvz3wlqkk8asilqv9pbvpnp1a";
+  };
+
+  propagatedBuildInputs = [ fmt ];
+
+  checkInputs = lib.optional doCheck alcotest;
+
+  doCheck = true;
+
+  meta = {
+    description = "Metrics infrastructure for OCaml";
+    homepage = "https://github.com/mirage/metrics";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/metrics/lwt.nix
+++ b/pkgs/development/ocaml-modules/metrics/lwt.nix
@@ -1,0 +1,14 @@
+{ buildDunePackage, ocaml_lwt, metrics }:
+
+buildDunePackage {
+  pname = "metrics-lwt";
+
+  inherit (metrics) version src;
+
+  propagatedBuildInputs = [ ocaml_lwt metrics ];
+
+  meta = metrics.meta // {
+    description = "Lwt backend for the Metrics library";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/metrics/unix.nix
+++ b/pkgs/development/ocaml-modules/metrics/unix.nix
@@ -1,0 +1,19 @@
+{ lib, buildDunePackage, gnuplot, ocaml_lwt, metrics, metrics-lwt, mtime, uuidm }:
+
+buildDunePackage rec {
+
+  pname = "metrics-unix";
+
+  inherit (metrics) version src;
+
+  propagatedBuildInputs = [ gnuplot ocaml_lwt metrics mtime uuidm ];
+
+  checkInputs = lib.optional doCheck metrics-lwt;
+
+  doCheck = true;
+
+  meta = metrics.meta // {
+    description = "Unix backend for the Metrics library";
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -460,6 +460,8 @@ let
 
     merlin-extend = callPackage ../development/ocaml-modules/merlin-extend { };
 
+    metrics = callPackage ../development/ocaml-modules/metrics { };
+
     mezzo = callPackage ../development/compilers/mezzo { };
 
     minisat = callPackage ../development/ocaml-modules/minisat { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -462,6 +462,8 @@ let
 
     metrics = callPackage ../development/ocaml-modules/metrics { };
 
+    metrics-lwt = callPackage ../development/ocaml-modules/metrics/lwt.nix { };
+
     mezzo = callPackage ../development/compilers/mezzo { };
 
     minisat = callPackage ../development/ocaml-modules/minisat { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -464,6 +464,8 @@ let
 
     metrics-lwt = callPackage ../development/ocaml-modules/metrics/lwt.nix { };
 
+    metrics-unix = callPackage ../development/ocaml-modules/metrics/unix.nix { };
+
     mezzo = callPackage ../development/compilers/mezzo { };
 
     minisat = callPackage ../development/ocaml-modules/minisat { };


### PR DESCRIPTION
###### Motivation for this change

Dependencies of irmin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
