### PR TITLE
libappindicator: remove python2

### DIFF
--- a/pkgs/development/libraries/libappindicator/default.nix
+++ b/pkgs/development/libraries/libappindicator/default.nix
@@ -1,19 +1,18 @@
 # TODO: Resolve the issues with the Mono bindings.
 
-{ stdenv, fetchurl, lib, file
+{ stdenv, fetchurl, fetchpatch, lib, file
 , pkgconfig, autoconf
 , glib, dbus-glib, gtkVersion ? "3"
 , gtk2 ? null, libindicator-gtk2 ? null, libdbusmenu-gtk2 ? null
 , gtk3 ? null, libindicator-gtk3 ? null, libdbusmenu-gtk3 ? null
-, python2Packages, gobject-introspection, vala
+, vala, gobject-introspection
 , monoSupport ? false, mono ? null, gtk-sharp-2_0 ? null
  }:
 
 with lib;
 
-let
-  inherit (python2Packages) python pygobject2 pygtk;
-in stdenv.mkDerivation rec {
+
+stdenv.mkDerivation rec {
   name = let postfix = if gtkVersion == "2" && monoSupport then "sharp" else "gtk${gtkVersion}";
           in "libappindicator-${postfix}-${version}";
   version = "${versionMajor}.${versionMinor}";
@@ -25,7 +24,7 @@ in stdenv.mkDerivation rec {
     sha256 = "17xlqd60v0zllrxp8bgq3k5a1jkj0svkqn8rzllcyjh8k0gpr46m";
   };
 
-  nativeBuildInputs = [ pkgconfig autoconf ];
+  nativeBuildInputs = [ pkgconfig autoconf vala gobject-introspection ];
 
   propagatedBuildInputs =
     if gtkVersion == "2"
@@ -34,14 +33,20 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     glib dbus-glib
-    python pygobject2 pygtk gobject-introspection vala
   ] ++ (if gtkVersion == "2"
     then [ libindicator-gtk2 ] ++ optionals monoSupport [ mono gtk-sharp-2_0 ]
     else [ libindicator-gtk3 ]);
 
+  patches = [
+    # Remove python2 from libappindicator.
+    (fetchpatch {
+      name = "no-python.patch";
+      url = "https://src.fedoraproject.org/rpms/libappindicator/raw/8508f7a52437679fd95a79b4630373f08315f189/f/nopython.patch";
+      sha256 = "18b1xzvwsbhhfpbzf5zragij4g79pa04y1dk6v5ci1wsjvii725s";
+    })
+  ];
+
   postPatch = ''
-    substituteInPlace configure.ac \
-      --replace '=codegendir pygtk-2.0' '=codegendir pygobject-2.0'
     autoconf
     for f in {configure,ltmain.sh,m4/libtool.m4}; do
       substituteInPlace $f \
@@ -64,7 +69,7 @@ in stdenv.mkDerivation rec {
   doCheck = false; # generates shebangs in check phase, too lazy to fix
 
   installFlags = [
-    "sysconfdir=\${out}/etc"
+    "sysconfdir=${placeholder "out"}/etc"
     "localstatedir=\${TMPDIR}"
   ];
 


### PR DESCRIPTION
###### Motivation for this change
:wave: Would be nice if, in general, less things depended on this in nixpkgs.
stuff found when doing https://github.com/NixOS/nixpkgs/pull/74295#issuecomment-559217359

It's possible something needed this, but idc, let them break for now :rofl: .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
