### PR TITLE
home-assistant-frontend: 20190919.0 -> 20191002.2

### DIFF
--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,11 +4,11 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20190919.0";
+  version = "20191002.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1xdw8fj4njc3sf15mlyiwigrwf89xsz4r2dsv6zs5fnl512r439a";
+    sha256 = "1d2n60dm7wikk986a140lhwmg1ahi2f6bvf1hvz9kaniq6ff40gw";
   };
 
   # no Python tests implemented


### PR DESCRIPTION
##### Motivation for this change
The version of the home assistant frontend is out of sync with the version of the backend.
https://github.com/home-assistant/home-assistant/blob/0.100.3/homeassistant/components/frontend/manifest.json

###### Things done
Bump home-assistant-frontend to the appropriate version for home assistant v0.100.3

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dotlambda @globin 
