### PR TITLE
buildUBoot: allow passing custom src

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -4,24 +4,27 @@
 }:
 
 let
-  buildUBoot = { version ? "2019.10"
-            , filesToInstall
-            , installDir ? "$out"
-            , defconfig
-            , extraConfig ? ""
-            , extraPatches ? []
-            , extraMakeFlags ? []
-            , extraMeta ? {}
-            , ... } @ args:
-           stdenv.mkDerivation ({
-
+  defaultVersion = "2019.10";
+  defaultSrc = fetchurl {
+    url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
+    sha256 = "053hcrwwlacqh2niisn0zas95zkbffw5aw5sdhixs8lmfdq60vcd";
+  };
+  buildUBoot = {
+    version ? null
+  , src ? null
+  , filesToInstall
+  , installDir ? "$out"
+  , defconfig
+  , extraConfig ? ""
+  , extraPatches ? []
+  , extraMakeFlags ? []
+  , extraMeta ? {}
+  , ... } @ args: stdenv.mkDerivation ({
     pname = "uboot-${defconfig}";
-    inherit version;
 
-    src = fetchurl {
-      url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
-      sha256 = "053hcrwwlacqh2niisn0zas95zkbffw5aw5sdhixs8lmfdq60vcd";
-    };
+    version = if src == null then defaultVersion else version;
+
+    src = if src == null then defaultSrc else src;
 
     patches = [
       (fetchpatch {


### PR DESCRIPTION
We allowed passing another version, but that wasn't too useful, given we
hardcoded the hash of the fetchurl.
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
