### PR TITLE
mnemosyne: fix application

### DIFF
--- a/pkgs/development/python-modules/cheroot/default.nix
+++ b/pkgs/development/python-modules/cheroot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, buildPythonPackage, pythonAtLeast
+{ stdenv, fetchPypi, buildPythonPackage, pythonAtLeast, isPy3k
 , more-itertools, six, setuptools_scm, setuptools-scm-git-archive
 , pytest, pytestcov, portend, pytest-testmon, pytest-mock
 , backports_unittest-mock, pyopenssl, requests, trustme, requests-unixsocket
@@ -9,6 +9,8 @@ let inherit (stdenv) lib; in
 buildPythonPackage rec {
   pname = "cheroot";
   version = "8.2.1";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/games/mnemosyne/default.nix
+++ b/pkgs/games/mnemosyne/default.nix
@@ -1,5 +1,6 @@
 { fetchurl
 , python
+, anki
 }:
 
 python.pkgs.buildPythonApplication rec {
@@ -11,22 +12,31 @@ python.pkgs.buildPythonApplication rec {
     sha256 = "0xcwikq51abrlqfn5bv7kcw1ccd3ip0w6cjd5vnnzwnaqwdj8cb3";
   };
 
+  nativeBuildInputs = with python.pkgs; [ wrapPython pyqtwebengine.wrapQtAppsHook ];
+
+  buildInputs = [ anki ];
+
   propagatedBuildInputs = with python.pkgs; [
+    pyqtwebengine
     pyqt5
     matplotlib
     cherrypy
     cheroot
     webob
-    pillow
   ];
-
-  # No tests/ directrory in tarball
-  doCheck = false;
 
   prePatch = ''
     substituteInPlace setup.py --replace /usr $out
     find . -type f -exec grep -H sys.exec_prefix {} ';' | cut -d: -f1 | xargs sed -i s,sys.exec_prefix,\"$out\",
   '';
+
+  # No tests/ directrory in tarball
+  doCheck = false;
+
+  dontWrapQtApps = true;
+  makeWrapperArgs = [
+    "\${qtWrapperArgs[@]}"
+  ];
 
   postInstall = ''
     mkdir -p $out/share


### PR DESCRIPTION
###### Motivation for this change

This application has been missing some dependencies and the
correct environment for Qt. Additionally I added a depdency
on anki to support the import feature.

The project has also moved development to Github, as very briefly
mentioned on https://mnemosyne-proj.org/contributing.php but the
2.6.1 version released there seems to differ and causes a bunch
of new problems, so leaving it for now.

Related to: https://github.com/NixOS/nixpkgs/pull/73927

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lverns @dotlambda 
