### PR TITLE
libterm-neovim: 2019-08-28 -> 2019-10-08

### DIFF
--- a/pkgs/development/libraries/libvterm-neovim/default.nix
+++ b/pkgs/development/libraries/libvterm-neovim/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation {
   pname = "libvterm-neovim";
-  version = "2019-08-28";
+  version = "2019-10-08";
 
   src = fetchFromGitHub {
     owner = "neovim";
     repo = "libvterm";
-    rev = "1aa95e24d8f07a396aa80b7cd52f93e2b5bcca79";
-    sha256 = "0vjd397lqrfv4kc79i5izva4bynbymx3gllkg281fnk0b15vxfif";
+    rev = "7c72294d84ce20da4c27362dbd7fa4b08cfc91da";
+    sha256 = "111qyxq33x74dwdnqcnzlv9j0n8hxyribd6ppwcsxmyrniyw9qrk";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
###### Motivation for this change

Updating _libterm_ to the same version that neovim ships with fixes https://github.com/NixOS/nixpkgs/issues/74286.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rvolosatovs
