### PR TITLE
yafaray-core: switch to opencv4

### DIFF
--- a/pkgs/tools/graphics/yafaray-core/default.nix
+++ b/pkgs/tools/graphics/yafaray-core/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, opencv, zlib
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, opencv4, zlib
 , libxml2, freetype, libjpeg, libtiff, swig, openexr
 , ilmbase, boost165
 , withPython ? true, python35
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     '';
 
     buildInputs = [
-      cmake pkgconfig boost165 opencv zlib libxml2 freetype libjpeg libtiff
+      cmake pkgconfig boost165 opencv4 zlib libxml2 freetype libjpeg libtiff
       swig openexr ilmbase
     ] ++ stdenv.lib.optional withPython python35;
 


### PR DESCRIPTION
###### Motivation for this change
opencv2 is essentially EOL and has security concerns

OpenCV is used for image denoising in `yafaray-core`

Tested this by rendering the extremely convenient, denoising-enabled test scene provided in the yafaray source https://github.com/YafaRay/Core/tree/master/tests/test01 , which incidentally would probably be fairly easy to turn into an `installCheck` in case anyone wanted to have a go - the only tricky thing would be to allow a tolerance of difference against the reference image, due to e.g. image noise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Hodapp87 
