### PR TITLE
python3.pkgs.babelgladeextractor: 0.6.0 → 0.6.1

### DIFF
--- a/pkgs/development/python-modules/babelgladeextractor/default.nix
+++ b/pkgs/development/python-modules/babelgladeextractor/default.nix
@@ -3,23 +3,21 @@
 , buildPythonPackage
 , fetchPypi
 , Babel
-, lxml
 }:
 
 buildPythonPackage rec {
   pname = "babelgladeextractor";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchPypi {
     pname = "BabelGladeExtractor";
     inherit version;
     extension = "tar.bz2";
-    sha256 = "18m5vi3sj2h26ibmb6fzfjs2lscg757ivk1bjgkn1haf9gdwyjj6";
+    sha256 = "1jhs12pliz54dbnigib1h8ywfzsj1g32c1vhspvg46f5983nvf93";
   };
 
   propagatedBuildInputs = [
     Babel
-    lxml # TODO: remove in 0.7.0
   ];
 
   # Tests missing

--- a/pkgs/tools/security/gnome-keysign/default.nix
+++ b/pkgs/tools/security/gnome-keysign/default.nix
@@ -28,6 +28,14 @@ python3.pkgs.buildPythonApplication rec {
       url = "https://gitlab.gnome.org/GNOME/gnome-keysign/commit/216c3677e68960afc517edc00529323e85909323.patch";
       sha256 = "1w410gvcridbq26sry7fxn49v59ss2lc0w5ab7csva8rzs1nc990";
     })
+
+    # stop requiring lxml (no longer used)
+    # https://gitlab.gnome.org/GNOME/gnome-keysign/merge_requests/23
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-keysign/commit/ffc6f40584d7564951e1c8b6d18d4f8a6a3fa09d.patch";
+      sha256 = "1hs6mmhi2f21kvy26llzvp37yf0i0dr69d18r641139nr6qg6kwy";
+      includes = [ "setup.py" ];
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/gnome-keysign/babel-glade/compare/0.6.0...0.6.1