### PR TITLE
doc/contributing: mention icons & themes folders

### DIFF
--- a/doc/contributing/coding-conventions.xml
+++ b/doc/contributing/coding-conventions.xml
@@ -622,6 +622,16 @@ args.stdenv.mkDerivation (args // {
        </varlistentry>
        <varlistentry>
         <term>
+         If it’s an <emphasis>icon theme</emphasis>:
+        </term>
+        <listitem>
+         <para>
+          <filename>data/icons</filename>
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
          If it’s related to <emphasis>SGML/XML processing</emphasis>:
         </term>
         <listitem>
@@ -650,6 +660,17 @@ args.stdenv.mkDerivation (args // {
            </listitem>
           </varlistentry>
          </variablelist>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         If it’s a <emphasis>theme</emphasis> for a <emphasis>desktop environment</emphasis>,
+         a <emphasis>window manager</emphasis> or a <emphasis>display manager</emphasis>:
+        </term>
+        <listitem>
+         <para>
+          <filename>data/themes</filename>
+         </para>
         </listitem>
        </varlistentry>
       </variablelist>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Follow-up to #74060

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace @romildo 
