### PR TITLE
docker-container: Remove /etc symlink

### DIFF
--- a/nixos/modules/profiles/docker-container.nix
+++ b/nixos/modules/profiles/docker-container.nix
@@ -2,6 +2,8 @@
 
 with lib;
 
+let inherit (pkgs) writeScript; in
+
 let
  pkgs2storeContents = l : map (x: { object = x; symlink = "none"; }) l;
 
@@ -30,7 +32,12 @@ in {
     ];
 
     # Some container managers like lxc need these
-    extraCommands = "mkdir -p proc sys dev";
+    extraCommands =
+      let script = writeScript "extra-commands.sh" ''
+            rm etc
+            mkdir -p proc sys dev etc
+          '';
+      in script;
   };
 
   boot.isContainer = true;


### PR DESCRIPTION

###### Motivation for this change

The system output usually contains a symlink from /etc to the static
configuration for the benefit of the stage-1 script in the initrd. The stage-2
script is usually started in the real root without such a symlink. In a
container, there is no stage-1 and the system output is used directly as a real
root. If the symlink is present, setup-etc.pl will create a symlink cycle and
the system cannot boot. There is no reason for the /etc link to exist in a
container because setup-etc.pl will create the necessary files. The container
module will now remove the /etc symlink and create an empty directory. The empty
/etc is for container managers to populate it with site-specific settings; for
example, to set the hostname. This is required to boot NixOS in an LXC container
on another host.

See also: #9735

@grahamc I asked you to review this because I expect you will have opinions about running NixOS in a container. :smile: However, this module has not seen a lot of love recently (or ever) so I can't tell from the Git history who is qualified. If you feel someone is more qualified, please refer me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

