### PR TITLE
rstudio: use qt5's mkDerivation

### DIFF
--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchurl, fetchFromGitHub, makeDesktopItem, cmake, boost, zlib
+{ lib, mkDerivation, fetchurl, fetchFromGitHub, makeDesktopItem, cmake, boost, zlib
 , openssl, R, qtbase, qtxmlpatterns, qtsensors, qtwebengine, qtwebchannel
 , libuuid, hunspellDicts, unzip, ant, jdk, gnumake, makeWrapper, pandoc
 , llvmPackages
 }:
 
-with stdenv.lib;
+with lib;
 let
   verMajor = "1";
   verMinor = "2";
@@ -13,7 +13,7 @@ let
   ginVer = "2.1.2";
   gwtVer = "2.8.1";
 in
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "RStudio";
   inherit version;
 
@@ -116,15 +116,16 @@ stdenv.mkDerivation rec {
     mimeType = "text/x-r-source;text/x-r;text/x-R;text/x-r-doc;text/x-r-sweave;text/x-r-markdown;text/x-r-html;text/x-r-presentation;application/x-r-data;application/x-r-project;text/x-r-history;text/x-r-profile;text/x-tex;text/x-markdown;text/html;text/css;text/javascript;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;";
   };
 
+  qtWrapperArgs = [ ''--suffix PATH : ${gnumake}/bin'' ];
+
   postInstall = ''
-      wrapProgram $out/bin/rstudio --suffix PATH : ${gnumake}/bin
       mkdir $out/share
       cp -r ${desktopItem}/share/applications $out/share
       mkdir $out/share/icons
       ln $out/rstudio.png $out/share/icons
   '';
 
-  meta = with stdenv.lib;
+  meta = with lib;
     { description = "Set of integrated tools for the R language";
       homepage = https://www.rstudio.com/;
       license = licenses.agpl3;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This fixes QT5 at runtime. See tracking issue #65399.
Fixes #74298.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ehmry @changlinli @ciil
