### PR TITLE
ssm-agent: 2.0.633.0 -> 2.3.760.0

### DIFF
--- a/nixos/modules/services/misc/ssm-agent.nix
+++ b/nixos/modules/services/misc/ssm-agent.nix
@@ -35,7 +35,7 @@ in {
 
       path = [ fake-lsb-release ];
       serviceConfig = {
-        ExecStart = "${cfg.package.bin}/bin/agent";
+        ExecStart = "${cfg.package.bin}/bin/amazon-ssm-agent";
         KillMode = "process";
         Restart = "on-failure";
         RestartSec = "15min";


### PR DESCRIPTION
Bumping version and switching to Amazon's executable names

###### Motivation for this change

To bring the ssm-agent up to date and support new features like AWS Session Manager and SSM SSH.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Tested `aws ssm start-session` works, as does using it as an ssh ProxyCommand. Also tested ssm runShellScript via the AWS console.

###### Notify maintainers

cc @copumpkin