### PR TITLE
geany: clean up and switch to GTK3

### DIFF
--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -1,36 +1,51 @@
-{ stdenv, fetchurl, gtk2, which, pkgconfig, intltool, file, libintl, hicolor-icon-theme }:
-
-with stdenv.lib;
-
-let
-  version = "1.36";
-in
+{ stdenv
+, fetchurl
+, gtk3
+, which
+, pkgconfig
+, intltool
+, file
+, libintl
+, hicolor-icon-theme
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "geany";
-  inherit version;
+  version = "1.36";
+
+  outputs = [ "out" "dev" "doc" "man" ];
 
   src = fetchurl {
     url = "https://download.geany.org/${pname}-${version}.tar.bz2";
     sha256 = "0gnm17cr4rf3pmkf0axz4a0fxwnvp55ji0q0lzy88yqbshyxv14i";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool libintl ];
-  buildInputs = [ gtk2 which file hicolor-icon-theme ];
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    libintl
+    which
+    file
+    hicolor-icon-theme
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+  ];
 
   doCheck = true;
 
   enableParallelBuilding = true;
 
-  patchPhase = "patchShebangs .";
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "Small and lightweight IDE";
     longDescription = ''
       Geany is a small and lightweight Integrated Development Environment.
       It was developed to provide a small and fast IDE, which has only a few dependencies from other packages.
       Another goal was to be as independent as possible from a special Desktop Environment like KDE or GNOME.
-      Geany only requires the GTK2 runtime libraries.
+      Geany only requires the GTK runtime libraries.
       Some basic features of Geany:
       - Syntax highlighting
       - Code folding
@@ -45,7 +60,7 @@ stdenv.mkDerivation rec {
       - Simple project management
       - Plugin interface
     '';
-    homepage = https://www.geany.org/;
+    homepage = "https://www.geany.org/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ frlan ];
     platforms = platforms.all;

--- a/pkgs/applications/editors/geany/with-vte.nix
+++ b/pkgs/applications/editors/geany/with-vte.nix
@@ -1,8 +1,24 @@
-{ runCommand, makeWrapper, geany, gnome2 }:
-let name = builtins.replaceStrings ["geany-"] ["geany-with-vte-"] geany.name;
-in
-runCommand name { nativeBuildInputs = [ makeWrapper ]; inherit (geany.meta); } "
-   mkdir -p $out
-   ln -s ${geany}/share $out
-   makeWrapper ${geany}/bin/geany $out/bin/geany --prefix LD_LIBRARY_PATH : ${gnome2.vte}/lib
-"
+{ symlinkJoin
+, makeWrapper
+, geany
+, lndir
+, vte
+}:
+
+symlinkJoin {
+  name = "geany-with-vte-${geany.version}";
+
+  # TODO: add geany-plugins
+  paths = with geany; [ out doc man ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    # need to replace the directory since it is a symlink
+    rm -r $out/bin; mkdir $out/bin
+    makeWrapper ${geany}/bin/geany $out/bin/geany \
+      --prefix LD_LIBRARY_PATH : ${vte}/lib
+  '';
+
+  inherit (geany.meta);
+}


### PR DESCRIPTION
GTK 2 has been deprecated for ages now.

Also split the outputs and convert geany-with-vte to symlinkJoin for easier merging.

Closes: https://github.com/NixOS/nixpkgs/pull/53409