### PR TITLE
python3Packages.tesserocr: init at 2.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4666,6 +4666,12 @@
     githubId = 2881922;
     name = "Francis St-Amour";
   };
+  mtrsk = {
+    email = "marcos.schonfinkel@protonmail.com";
+    github = "mtrsk";
+    githubId = 16356569;
+    name = "Marcos Benevides";
+  };
   mredaelli = {
     email = "massimo@typish.io";
     github = "mredaelli";

--- a/pkgs/development/python-modules/tesserocr/default.nix
+++ b/pkgs/development/python-modules/tesserocr/default.nix
@@ -1,0 +1,34 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  # build dependencies
+  cython,
+  leptonica,
+  pkg-config,
+  tesseract,
+  # extra python packages
+  pillow
+}:
+
+buildPythonPackage rec {
+  pname = "tesserocr";
+  version = "2.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0nj33mwvppacy6p5mqk9a4x26hx9ailshgad84ks60wyms6rgjiv";
+  };
+
+  nativeBuildInputs = [ cython pkg-config ];
+  buildInputs = [ leptonica tesseract ];
+  propagatedBuildInputs = [ pillow ];
+
+  meta = with lib; {
+    description = "A simple, Pillow-friendly, wrapper around the tesseract-ocr API for Optical Character Recognition (OCR)";
+    homepage = "https://github.com/sirfz/tesserocr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ mtrsk ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1325,6 +1325,8 @@ in {
 
   tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };
 
+  tesserocr = callPackage ../development/python-modules/tesserocr { };
+
   trueskill = callPackage ../development/python-modules/trueskill { };
 
   trustme = callPackage ../development/python-modules/trustme {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is an attempt of adding [tesserocr](https://pypi.org/project/tesserocr/) to nixpkgs, there are already some wrappers for tesseract in `nixpkgs`, but I need this one and it seems there's no derivation yet (so I put myself as maintainer).

Any comments on this derivation are always welcome. I'm currently not sure on how to test a python library, but the derivation compiles.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
