### PR TITLE
Revert "python: imbalanced-learn: 0.4.3 -> 0.5.0"

### DIFF
--- a/pkgs/development/python-modules/imbalanced-learn/0.4.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/0.4.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "imbalanced-learn";
-  version = "0.5.0";
+  version = "0.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5df760537886678ef9e25f5bad96d194c5fc66f62de84488069acf5d4b0119d5";
+    sha256 = "5bd9e86e40ce4001a57426541d7c79b18143cbd181e3330c1a3e5c5c43287083";
   };
 
   propagatedBuildInputs = [ scikitlearn ];


### PR DESCRIPTION
###### Motivation for this change
frozen version was not meant to be bumped

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/74401
1 package were built:
python27Packages.imbalanced-learn
```