### PR TITLE
python3Packages.behave: use pytest_4

### DIFF
--- a/pkgs/development/python-modules/behave/default.nix
+++ b/pkgs/development/python-modules/behave/default.nix
@@ -1,9 +1,10 @@
 { stdenv, fetchPypi, fetchpatch
 , buildPythonApplication, python, pythonOlder
-, mock, nose, pathpy, pyhamcrest, pytest
+, mock, nose, pathpy, pyhamcrest, pytest_4
 , glibcLocales, parse, parse-type, six
 , traceback2
 }:
+
 buildPythonApplication rec {
   pname = "behave";
   version = "1.2.6";
@@ -21,7 +22,7 @@ buildPythonApplication rec {
     })
   ];
 
-  checkInputs = [ mock nose pathpy pyhamcrest pytest ];
+  checkInputs = [ mock nose pathpy pyhamcrest pytest_4 ];
   buildInputs = [ glibcLocales ];
   propagatedBuildInputs = [ parse parse-type six ] ++ stdenv.lib.optional (pythonOlder "3.0") traceback2;
 


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[0 built (1 failed)]
error: build of '/nix/store/ids4x92xnwi4031m8lkgngjqppbwwj8a-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/74416
2 package failed to build:
python38Packages.behave python38Packages.python-docx

2 package were built:
python37Packages.behave python37Packages.python-docx
```