### PR TITLE
python3Packages.slicedimage: add tifffile dependency

### DIFF
--- a/pkgs/development/python-modules/slicedimage/default.nix
+++ b/pkgs/development/python-modules/slicedimage/default.nix
@@ -12,6 +12,7 @@
 , six
 , pytest
 , isPy27
+, tifffile
 }:
 
 buildPythonPackage rec {
@@ -31,14 +32,16 @@ buildPythonPackage rec {
     requests
     scikitimage
     six
+    tifffile
   ] ++ lib.optionals isPy27 [ pathlib enum34 ];
 
   checkInputs = [
     pytest
   ];
 
+  # ignore tests which require setup
   checkPhase = ''
-    pytest
+    pytest --ignore tests/io_
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing another package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[0 built (1 failed), 2 copied (9.4 MiB), 0.9 MiB DL]
error: build of '/nix/store/i3il08ishm9y5fdx5icy527s8cv1anzm-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/74434
1 package failed to build:
python37Packages.starfish

1 package were built:
python37Packages.slicedimage
```