### PR TITLE
ocamlPackages.git: 2.1.0 → 2.1.2

### DIFF
--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage
+{ lib, fetchurl, buildDunePackage
 , alcotest, git, mtime, nocrypto
 , angstrom, astring, cstruct, decompress, digestif, encore, duff, fmt
 , fpath, hex, ke, logs, lru, ocaml_lwt, ocamlgraph, ocplib-endian, uri, rresult
@@ -6,13 +6,11 @@
 
 buildDunePackage rec {
   pname = "git";
-	version = "2.1.0";
+	version = "2.1.2";
 
-	src = fetchFromGitHub {
-		owner = "mirage";
-		repo = "ocaml-git";
-		rev = version;
-		sha256 = "0v55zkwgml6i5hp0kzynbi58z6j15k3qgzg06b3h8pdbv5fwd1jp";
+	src = fetchurl {
+		url = "https://github.com/mirage/ocaml-git/releases/download/${version}/git-${version}.tbz";
+		sha256 = "0yyclsh255k7pvc2fcsdi8k2fcrr0by2nz6g3sqnwlimjyp7mz5j";
 	};
 
 	propagatedBuildInputs = [ angstrom astring cstruct decompress digestif encore duff fmt fpath hex ke logs lru ocaml_lwt ocamlgraph ocplib-endian uri rresult ];
@@ -23,6 +21,6 @@ buildDunePackage rec {
 		description = "Git format and protocol in pure OCaml";
 		license = lib.licenses.isc;
 		maintainers = [ lib.maintainers.vbgl ];
-		inherit (src.meta) homepage;
+		homepage = "https://github.com/mirage/ocaml-git";
 	};
 }

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -52,8 +52,8 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild cc-wrapper ];
-  buildInputs = [ ocamlbuild findlib topkg cpuid ocb-stubblr ppx_deriving ];
-  propagatedBuildInputs = [ cstruct ppx_sexp_conv sexplib zarith ] ++ optional withLwt cstruct-lwt;
+  buildInputs = [ ocamlbuild findlib topkg cpuid ocb-stubblr ];
+  propagatedBuildInputs = [ cstruct ppx_deriving ppx_sexp_conv sexplib zarith ] ++ optional withLwt cstruct-lwt;
 
   buildPhase = "${topkg.buildPhase} --with-lwt ${boolToString withLwt}";
   inherit (topkg) installPhase;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/mirage/ocaml-git/blob/2.1.2/CHANGES.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

