### PR TITLE
simplenote: 1.9.1 -> 1.11.0

### DIFF
--- a/pkgs/applications/misc/simplenote/default.nix
+++ b/pkgs/applications/misc/simplenote/default.nix
@@ -1,23 +1,37 @@
-{ atomEnv, autoPatchelfHook, dpkg, fetchurl, makeDesktopItem, makeWrapper
-, stdenv, udev, wrapGAppsHook }:
+{ atomEnv
+, autoPatchelfHook
+, dpkg
+, fetchurl
+, makeDesktopItem
+, makeWrapper
+, stdenv
+, udev
+, wrapGAppsHook
+}:
 
 let
   inherit (stdenv.hostPlatform) system;
 
+  throwSystem = throw "Unsupported system: ${system}";
+
   pname = "simplenote";
 
-  version = "1.9.1";
+  version = "1.11.0";
 
   sha256 = {
-    x86_64-linux = "1zqrjh1xfdpkpj1fsri9r4qkazh9j89pbj8vjr474b39v56v693j";
-  }.${system};
+    x86_64-linux = "1ljam1yfiy1lh6lrknrq7cdqpj1q7f655mxjiiwv3izp98qr1f8s";
+  }.${system} or throwSystem;
 
   meta = with stdenv.lib; {
     description = "The simplest way to keep notes";
     homepage = "https://github.com/Automattic/simplenote-electron";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ kiwi ];
-    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [
+      kiwi
+    ];
+    platforms = [
+      "x86_64-linux"
+    ];
   };
 
   linux = stdenv.mkDerivation rec {
@@ -31,14 +45,14 @@ let
     };
 
     desktopItem = makeDesktopItem {
-      name = "simplenote";
+      categories = "Development";
       comment = "Simplenote for Linux";
+      desktopName = "Simplenote";
       exec = "simplenote %U";
       icon = "simplenote";
-      type = "Application";
+      name = "simplenote";
       startupNotify = "true";
-      desktopName = "Simplenote";
-      categories = "Development";
+      type = "Application";
     };
 
     dontBuild = true;
@@ -46,9 +60,14 @@ let
     dontPatchELF = true;
     dontWrapGApps = true;
 
-    buildInputs = atomEnv.packages;
+    nativeBuildInputs = [
+      autoPatchelfHook
+      dpkg
+      makeWrapper
+      wrapGAppsHook
+    ];
 
-    nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook wrapGAppsHook ];
+    buildInputs = atomEnv.packages;
 
     unpackPhase = "dpkg-deb -x $src .";
 
@@ -62,14 +81,15 @@ let
       cp "${desktopItem}/share/applications/"* "$out/share/applications"
     '';
 
-    runtimeDependencies = [ udev.lib ];
+    runtimeDependencies = [
+      udev.lib
+    ];
 
     postFixup = ''
-      ls -ahl $out
       makeWrapper $out/opt/Simplenote/simplenote $out/bin/simplenote \
-      "''${gappsWrapperArgs[@]}"
+        "''${gappsWrapperArgs[@]}"
     '';
   };
 
 in
-  linux
+linux


### PR DESCRIPTION
also fixed this; Fontconfig warning: "/etc/fonts/fonts.conf", line 86: unknown element "blank"

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
