### PR TITLE
wire-desktop: fix a segfault when changing profile picture

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, makeDesktopItem
-
-, alsaLib, at-spi2-atk, atk, cairo, cups, dbus, dpkg, expat, fontconfig
-, freetype, gdk-pixbuf, glib, gtk3, hunspell, libX11, libXScrnSaver
-, libXcomposite, libXcursor, libXdamage, libXext, libXfixes, libXi, libXrandr
-, libXrender, libXtst, libnotify, libuuid, nspr, nss, pango, pciutils
-, pulseaudio, udev, xdg_utils, xorg
-
-, cpio, xar
+{ atomEnv
+, autoPatchelfHook
+, dpkg
+, fetchurl
+, makeDesktopItem
+, makeWrapper
+, stdenv
+, udev
+, wrapGAppsHook
+, cpio
+, xar
 }:
 
 let
@@ -18,13 +20,13 @@ let
   pname = "wire-desktop";
 
   version = {
-    x86_64-linux = "3.11.2912";
     x86_64-darwin = "3.10.3215";
+    x86_64-linux = "3.11.2912";
   }.${system} or throwSystem;
 
   sha256 = {
-    x86_64-linux = "1d2wa13d750dd2vslnvzf0ibwjmf5s299pxq0rs2x98y2sabw3sl";
     x86_64-darwin = "0ygm3fgy9k1dp2kjfwsrrwq1i88wgxc6k8y80yz61ivdawgph9wa";
+    x86_64-linux = "1d2wa13d750dd2vslnvzf0ibwjmf5s299pxq0rs2x98y2sabw3sl";
   }.${system} or throwSystem;
 
   meta = with stdenv.lib; {
@@ -40,11 +42,19 @@ let
         * Timed messages and chats
         * Synced across your phone, desktop and tablet
     '';
-    homepage = https://wire.com/;
-    downloadPage = https://wire.com/download/;
+    homepage = "https://wire.com/";
+    downloadPage = "https://wire.com/download/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ arianvp toonn worldofpeace ];
-    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+    maintainers = with maintainers; [
+      arianvp
+      kiwi
+      toonn
+      worldofpeace
+    ];
+    platforms = [
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
   };
 
   linux = stdenv.mkDerivation rec {
@@ -52,53 +62,54 @@ let
 
     src = fetchurl {
       url = "https://wire-app.wire.com/linux/debian/pool/main/"
-        + "Wire-${version}_amd64.deb";
+      + "Wire-${version}_amd64.deb";
       inherit sha256;
     };
 
     desktopItem = makeDesktopItem {
-      name = "wire-desktop";
-      exec = "wire-desktop %U";
-      icon = "wire-desktop";
+      categories = "Network;InstantMessaging;Chat;VideoConference";
       comment = "Secure messenger for everyone";
       desktopName = "Wire Desktop";
+      exec = "wire-desktop %U";
       genericName = "Secure messenger";
-      categories = "Network;InstantMessaging;Chat;VideoConference";
+      icon = "wire-desktop";
+      name = "wire-desktop";
     };
 
     dontBuild = true;
-    dontPatchELF = true;
     dontConfigure = true;
+    dontPatchELF = true;
+    dontWrapGApps = true;
 
-    nativeBuildInputs = [ dpkg ];
-    rpath = stdenv.lib.makeLibraryPath [
-      alsaLib at-spi2-atk atk cairo cups dbus expat fontconfig freetype
-      gdk-pixbuf glib gtk3 hunspell libX11 libXScrnSaver libXcomposite
-      libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
-      libXtst libnotify libuuid nspr nss pango pciutils pulseaudio
-      stdenv.cc.cc udev xdg_utils xorg.libxcb
+    nativeBuildInputs = [
+      autoPatchelfHook
+      dpkg
+      makeWrapper
+      wrapGAppsHook
     ];
+
+    buildInputs = atomEnv.packages;
 
     unpackPhase = "dpkg-deb -x $src .";
 
     installPhase = ''
-      mkdir -p "$out"
+      mkdir -p "$out/bin"
       cp -R "opt" "$out"
       cp -R "usr/share" "$out/share"
       chmod -R g-w "$out"
 
-      # Patch wire-desktop
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "${rpath}:$out/opt/Wire" \
-        "$out/opt/Wire/wire-desktop"
-
-      # Symlink to bin
-      mkdir -p "$out/bin"
-      ln -s "$out/opt/Wire/wire-desktop" "$out/bin/wire-desktop"
-
       # Desktop file
       mkdir -p "$out/share/applications"
       cp "${desktopItem}/share/applications/"* "$out/share/applications"
+    '';
+
+    runtimeDependencies = [
+      udev.lib
+    ];
+
+    postFixup = ''
+      makeWrapper $out/opt/Wire/wire-desktop $out/bin/wire-desktop \
+        "''${gappsWrapperArgs[@]}"
     '';
   };
 
@@ -107,17 +118,19 @@ let
 
     src = fetchurl {
       url = "https://github.com/wireapp/wire-desktop/releases/download/"
-        + "macos%2F${version}/Wire.pkg";
+      + "macos%2F${version}/Wire.pkg";
       inherit sha256;
     };
 
-    buildInputs = [ cpio xar ];
+    buildInputs = [
+      cpio
+      xar
+    ];
 
     unpackPhase = ''
       xar -xf $src
       cd com.wearezeta.zclient.mac.pkg
     '';
-
 
     buildPhase = ''
       cat Payload | gunzip -dc | cpio -i
@@ -129,6 +142,7 @@ let
     '';
   };
 
-in if stdenv.isDarwin
-  then darwin
-  else linux
+in
+if stdenv.isDarwin
+then darwin
+else linux


### PR DESCRIPTION
(wire-desktop:11531): GLib-GIO-ERROR **: 06:04:45.248: No GSettings schemas are installed on the system

and fix Fontconfig warning: "/etc/fonts/fonts.conf", line 86: unknown element "blank"

and tidied up the linux build greatly

and added kiwi as a maintainer

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
@worldofpeace made me try wire-desktop and it crashed when I tried to change my profile picture. So I thought I'd be nice and fix their package for once since they always help me with mine. :P

###### Things done
A while back @worldofpeace helped me package Simplenote and after my first miserable attempt they pointed me at wire-desktop for a better reference than the one I used. While trying to get their way to work we learned of an even easier/cleaner way to do these electron apps. It just so happens that switching to that method fixed the segfault. ;)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace 
