### PR TITLE
e2fsprogs: allow static build

### DIFF
--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, fetchurl, fetchpatch, pkgconfig, libuuid, gettext, texinfo }:
+{ stdenv, buildPackages, fetchurl, fetchpatch, pkgconfig, libuuid, gettext, texinfo, shared ? true }:
 
 stdenv.mkDerivation rec {
   pname = "e2fsprogs";
@@ -36,7 +36,9 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     if stdenv.isLinux then [
-      "--enable-elf-shlibs"
+      # It seems that the e2fsprogs is one of the few packages that cannot be
+      # build with shared and static libs.
+      (if shared then "--enable-elf-shlibs" else "--disable-elf-shlibs")
       "--enable-symlink-install"
       "--enable-relative-symlinks"
       "--with-crond-dir=no"

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -82,14 +82,15 @@ in {
   } // optionalAttrs super.stdenv.hostPlatform.isDarwin {
     pythonSupport = false;
   });
-  zlib = (super.zlib.override {
+  zlib = super.zlib.override {
     static = true;
     shared = false;
+    splitStaticOutput = false;
 
     # Don’t use new stdenv zlib because
     # it doesn’t like the --disable-shared flag
     stdenv = super.stdenv;
-  }).static;
+  };
   xz = super.xz.override {
     enableStatic = true;
   };
@@ -175,6 +176,10 @@ in {
   curl = super.curl.override {
     # a very sad story: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=439039
     gssSupport = false;
+  };
+
+  e2fsprogs = super.e2fsprogs.override {
+    shared = false;
   };
 
   brotli = super.brotli.override {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This enable building `pkgsStatic.e2fsprogs`.

The zlib changes is to avoid the error

```
disk-utils/fsck.cramfs.c:53:10: fatal error: zlib.h: No such file or directory
```

which makes sense because `zlib.static` does not include headers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edolstra (listed as e2fsprogs mantainer)
cc @nh2 @matthewbauer (involved in static build of zlib)
