### PR TITLE
go_1_13, grafana-6.5.1: backport to 19.09

### DIFF
--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -233,7 +233,7 @@ stdenv.mkDerivation rec {
     homepage = http://golang.org/;
     description = "The Go Programming language";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ cstrahan orivej velovix mic92 rvolosatovs ];
+    maintainers = with maintainers; [ cstrahan orivej velovix mic92 rvolosatovs kalbasit ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -1,0 +1,239 @@
+{ stdenv, fetchurl, tzdata, iana-etc, runCommand
+, perl, which, pkgconfig, patch, procps, pcre, cacert, Security, Foundation
+, mailcap, runtimeShell
+, buildPackages, pkgsTargetTarget
+}:
+
+let
+
+  inherit (stdenv.lib) optionals optionalString;
+
+  goBootstrap = runCommand "go-bootstrap" {} ''
+    mkdir $out
+    cp -rf ${buildPackages.go_bootstrap}/* $out/
+    chmod -R u+w $out
+    find $out -name "*.c" -delete
+    cp -rf $out/bin/* $out/share/go/bin/
+  '';
+
+  goarch = platform: {
+    "i686" = "386";
+    "x86_64" = "amd64";
+    "aarch64" = "arm64";
+    "arm" = "arm";
+    "armv5tel" = "arm";
+    "armv6l" = "arm";
+    "armv7l" = "arm";
+  }.${platform.parsed.cpu.name} or (throw "Unsupported system");
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "go";
+  version = "1.13.1";
+
+  src = fetchurl {
+    url = "https://dl.google.com/go/go${version}.src.tar.gz";
+    sha256 = "0n4k42bbrj5g9b1kczkfsih049v43vqzaps7n69gmfa4jpk59wc1";
+  };
+
+  # perl is used for testing go vet
+  nativeBuildInputs = [ perl which pkgconfig patch procps ];
+  buildInputs = [ cacert pcre ]
+    ++ optionals stdenv.isLinux [ stdenv.cc.libc.out ]
+    ++ optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+
+  propagatedBuildInputs = optionals stdenv.isDarwin [ Security Foundation ];
+
+  hardeningDisable = [ "all" ];
+
+  prePatch = ''
+    patchShebangs ./ # replace /bin/bash
+
+    # This source produces shell script at run time,
+    # and thus it is not corrected by patchShebangs.
+    substituteInPlace misc/cgo/testcarchive/carchive_test.go \
+      --replace '#!/usr/bin/env bash' '#!${runtimeShell}'
+
+    # Patch the mimetype database location which is missing on NixOS.
+    substituteInPlace src/mime/type_unix.go \
+      --replace '/etc/mime.types' '${mailcap}/etc/mime.types'
+
+    # Disabling the 'os/http/net' tests (they want files not available in
+    # chroot builds)
+    rm src/net/{listen,parse}_test.go
+    rm src/syscall/exec_linux_test.go
+
+    # !!! substituteInPlace does not seems to be effective.
+    # The os test wants to read files in an existing path. Just don't let it be /usr/bin.
+    sed -i 's,/usr/bin,'"`pwd`", src/os/os_test.go
+    sed -i 's,/bin/pwd,'"`type -P pwd`", src/os/os_test.go
+    # Disable the unix socket test
+    sed -i '/TestShutdownUnix/aif true \{ return\; \}' src/net/net_test.go
+    # Disable the hostname test
+    sed -i '/TestHostname/aif true \{ return\; \}' src/os/os_test.go
+    # ParseInLocation fails the test
+    sed -i '/TestParseInSydney/aif true \{ return\; \}' src/time/format_test.go
+    # Remove the api check as it never worked
+    sed -i '/src\/cmd\/api\/run.go/ireturn nil' src/cmd/dist/test.go
+    # Remove the coverage test as we have removed this utility
+    sed -i '/TestCoverageWithCgo/aif true \{ return\; \}' src/cmd/go/go_test.go
+    # Remove the timezone naming test
+    sed -i '/TestLoadFixed/aif true \{ return\; \}' src/time/time_test.go
+    # Remove disable setgid test
+    sed -i '/TestRespectSetgidDir/aif true \{ return\; \}' src/cmd/go/internal/work/build_test.go
+    # Remove cert tests that conflict with NixOS's cert resolution
+    sed -i '/TestEnvVars/aif true \{ return\; \}' src/crypto/x509/root_unix_test.go
+    # TestWritevError hangs sometimes
+    sed -i '/TestWritevError/aif true \{ return\; \}' src/net/writev_test.go
+    # TestVariousDeadlines fails sometimes
+    sed -i '/TestVariousDeadlines/aif true \{ return\; \}' src/net/timeout_test.go
+
+    sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go
+
+    # Disable cgo lookup tests not works, they depend on resolver
+    rm src/net/cgo_unix_test.go
+
+  '' + optionalString stdenv.isLinux ''
+    sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
+  '' + optionalString stdenv.isAarch32 ''
+    echo '#!${runtimeShell}' > misc/cgo/testplugin/test.bash
+  '' + optionalString stdenv.isDarwin ''
+    substituteInPlace src/race.bash --replace \
+      "sysctl machdep.cpu.extfeatures | grep -qv EM64T" true
+    sed -i 's,strings.Contains(.*sysctl.*,true {,' src/cmd/dist/util.go
+    sed -i 's,"/etc","'"$TMPDIR"'",' src/os/os_test.go
+    sed -i 's,/_go_os_test,'"$TMPDIR"'/_go_os_test,' src/os/path_test.go
+
+    sed -i '/TestChdirAndGetwd/aif true \{ return\; \}' src/os/os_test.go
+    sed -i '/TestCredentialNoSetGroups/aif true \{ return\; \}' src/os/exec/exec_posix_test.go
+    sed -i '/TestRead0/aif true \{ return\; \}' src/os/os_test.go
+    sed -i '/TestSystemRoots/aif true \{ return\; \}' src/crypto/x509/root_darwin_test.go
+
+    sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/aif true \{ return\; \}' src/cmd/go/go_test.go
+    sed -i '/TestBuildDashIInstallsDependencies/aif true \{ return\; \}' src/cmd/go/go_test.go
+
+    sed -i '/TestDisasmExtld/aif true \{ return\; \}' src/cmd/objdump/objdump_test.go
+
+    sed -i 's/unrecognized/unknown/' src/cmd/link/internal/ld/lib.go
+
+    # TestCurrent fails because Current is not implemented on Darwin
+    sed -i 's/TestCurrent/testCurrent/g' src/os/user/user_test.go
+    sed -i 's/TestLookup/testLookup/g' src/os/user/user_test.go
+
+    touch $TMPDIR/group $TMPDIR/hosts $TMPDIR/passwd
+  '';
+
+  patches = [
+    ./remove-tools-1.11.patch
+    ./ssl-cert-file-1.13.patch
+    ./remove-test-pie-1.13.patch
+    ./creds-test.patch
+    ./go-1.9-skip-flaky-19608.patch
+    ./go-1.9-skip-flaky-20072.patch
+    ./skip-external-network-tests.patch
+    ./skip-nohup-tests.patch
+    # breaks under load: https://github.com/golang/go/issues/25628
+    ./skip-test-extra-files-on-386.patch
+  ];
+
+  postPatch = ''
+    find . -name '*.orig' -exec rm {} ';'
+  '';
+
+  GOOS = stdenv.targetPlatform.parsed.kernel.name;
+  GOARCH = goarch stdenv.targetPlatform;
+  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+  # Go will nevertheless build a for host system that we will copy over in
+  # the install phase.
+  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
+  GOHOSTARCH = goarch stdenv.buildPlatform;
+
+  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+  # to be different from CC/CXX
+  CC_FOR_TARGET = if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc"
+    else
+      null;
+  CXX_FOR_TARGET = if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}c++"
+    else
+      null;
+
+  GOARM = toString (stdenv.lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
+  GO386 = 387; # from Arch: don't assume sse2 on i686
+  CGO_ENABLED = 1;
+  # Hopefully avoids test timeouts on Hydra
+  GO_TEST_TIMEOUT_SCALE = 3;
+
+  # Indicate that we are running on build infrastructure
+  # Some tests assume things like home directories and users exists
+  GO_BUILDER_NAME = "nix";
+
+  GOROOT_BOOTSTRAP="${goBootstrap}/share/go";
+
+  postConfigure = ''
+    export GOCACHE=$TMPDIR/go-cache
+    # this is compiled into the binary
+    export GOROOT_FINAL=$out/share/go
+
+    export PATH=$(pwd)/bin:$PATH
+
+    # Independent from host/target, CC should produce code for the building system.
+    export CC=${buildPackages.stdenv.cc}/bin/cc
+    ulimit -a
+  '';
+
+  postBuild = ''
+    (cd src && ./make.bash)
+  '';
+
+  doCheck = stdenv.hostPlatform == stdenv.targetPlatform && !stdenv.isDarwin;
+
+  checkPhase = ''
+    runHook preCheck
+    (cd src && HOME=$TMPDIR GOCACHE=$TMPDIR/go-cache ./run.bash --no-rebuild)
+    runHook postCheck
+  '';
+
+  preInstall = ''
+    rm -r pkg/obj
+    # Contains the wrong perl shebang when cross compiling,
+    # since it is not used for anything we can deleted as well.
+    rm src/regexp/syntax/make_perl_groups.pl
+  '' + (if (stdenv.buildPlatform != stdenv.hostPlatform) then ''
+    mv bin/*_*/* bin
+    rmdir bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOHOSTOS}_${GOHOSTARCH} pkg/tool/${GOHOSTOS}_${GOHOSTARCH}
+    ''}
+  '' else if (stdenv.hostPlatform != stdenv.targetPlatform) then ''
+    rm -rf bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOOS}_${GOARCH} pkg/tool/${GOOS}_${GOARCH}
+    ''}
+  '' else "");
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $GOROOT_FINAL
+    cp -a bin pkg src lib misc api doc $GOROOT_FINAL
+    ln -s $GOROOT_FINAL/bin $out/bin
+    runHook postInstall
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  disallowedReferences = [ goBootstrap ];
+
+  meta = with stdenv.lib; {
+    branch = "1.13";
+    homepage = http://golang.org/;
+    description = "The Go Programming language";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cstrahan orivej velovix mic92 rvolosatovs ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/compilers/go/remove-test-pie-1.13.patch
+++ b/pkgs/development/compilers/go/remove-test-pie-1.13.patch
@@ -1,0 +1,34 @@
+diff --git a/src/cmd/dist/test.go b/src/cmd/dist/test.go
+index f63c94697c..f02eff7064 100644
+--- a/src/cmd/dist/test.go
++++ b/src/cmd/dist/test.go
+@@ -574,29 +574,6 @@ func (t *tester) registerTests() {
+ 		})
+ 	}
+ 
+-	// Test internal linking of PIE binaries where it is supported.
+-	if goos == "linux" && (goarch == "amd64" || goarch == "arm64") {
+-		t.tests = append(t.tests, distTest{
+-			name:    "pie_internal",
+-			heading: "internal linking of -buildmode=pie",
+-			fn: func(dt *distTest) error {
+-				t.addCmd(dt, "src", t.goTest(), "reflect", "-buildmode=pie", "-ldflags=-linkmode=internal", t.timeout(60))
+-				return nil
+-			},
+-		})
+-		// Also test a cgo package.
+-		if t.cgoEnabled {
+-			t.tests = append(t.tests, distTest{
+-				name:    "pie_internal_cgo",
+-				heading: "internal linking of -buildmode=pie",
+-				fn: func(dt *distTest) error {
+-					t.addCmd(dt, "src", t.goTest(), "os/user", "-buildmode=pie", "-ldflags=-linkmode=internal", t.timeout(60))
+-					return nil
+-				},
+-			})
+-		}
+-	}
+-
+ 	// sync tests
+ 	if goos != "js" { // js doesn't support -cpu=10
+ 		t.tests = append(t.tests, distTest{

--- a/pkgs/development/compilers/go/ssl-cert-file-1.13.patch
+++ b/pkgs/development/compilers/go/ssl-cert-file-1.13.patch
@@ -1,0 +1,64 @@
+diff --git a/src/crypto/x509/root_cgo_darwin.go b/src/crypto/x509/root_cgo_darwin.go
+index 255a8d3525..a467255a54 100644
+--- a/src/crypto/x509/root_cgo_darwin.go
++++ b/src/crypto/x509/root_cgo_darwin.go
+@@ -280,6 +280,8 @@ int CopyPEMRoots(CFDataRef *pemRoots, CFDataRef *untrustedPemRoots, bool debugDa
+ import "C"
+ import (
+ 	"errors"
++	"io/ioutil"
++	"os"
+ 	"unsafe"
+ )
+ 
+@@ -295,6 +297,13 @@ func loadSystemRoots() (*CertPool, error) {
+ 	buf := C.GoBytes(unsafe.Pointer(C.CFDataGetBytePtr(data)), C.int(C.CFDataGetLength(data)))
+ 	roots := NewCertPool()
+ 	roots.AppendCertsFromPEM(buf)
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots.AppendCertsFromPEM(data)
++			return roots, nil
++		}
++	}
+ 
+ 	if C.CFDataGetLength(untrustedData) == 0 {
+ 		return roots, nil
+diff --git a/src/crypto/x509/root_darwin.go b/src/crypto/x509/root_darwin.go
+index 2f6a8b8d60..b81889fe69 100644
+--- a/src/crypto/x509/root_darwin.go
++++ b/src/crypto/x509/root_darwin.go
+@@ -92,6 +92,14 @@ func execSecurityRoots() (*CertPool, error) {
+ 		verifyCh    = make(chan rootCandidate)
+ 	)
+ 
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots.AppendCertsFromPEM(data)
++			return roots, nil
++		}
++	}
++
+ 	// Using 4 goroutines to pipe into verify-cert seems to be
+ 	// about the best we can do. The verify-cert binary seems to
+ 	// just RPC to another server with coarse locking anyway, so
+diff --git a/src/crypto/x509/root_unix.go b/src/crypto/x509/root_unix.go
+index 48de50b4ea..750e12c6b4 100644
+--- a/src/crypto/x509/root_unix.go
++++ b/src/crypto/x509/root_unix.go
+@@ -38,6 +38,13 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
+ 
+ func loadSystemRoots() (*CertPool, error) {
+ 	roots := NewCertPool()
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots.AppendCertsFromPEM(data)
++			return roots, nil
++		}
++	}
+ 
+ 	files := certFiles
+ 	if f := os.Getenv(certFileEnv); f != "" {

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "grafana";
-  version = "6.5.0";
+  version = "6.5.1";
 
   goPackagePath = "github.com/grafana/grafana";
 
@@ -12,12 +12,12 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "0g1rlh8himv3njsviy95grd9cp64hm98s9lc0f1gy2lvi2f9bxx4";
+    sha256 = "1hcfn9dgx8vabadagm69dgk5sdyc1kxkbma2ryfdb0v6vpm01784";
   };
 
   srcStatic = fetchurl {
     url = "https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz";
-    sha256 = "1jqzgyh4cyj1m9cmyvmhfh79j4dac84j7l1pxs6ppbxc4ym07g8g";
+    sha256 = "1m2rxxgs8sf8qrg0bk3i2gy17q6n4nk4cwlp9bbffwmwcmf78gnw";
   };
 
   postPatch = ''

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "grafana";
-  version = "6.4.5";
+  version = "6.5.0";
 
   goPackagePath = "github.com/grafana/grafana";
 
@@ -12,12 +12,12 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "0chfskz3j0jc25fj7zpbs46lp6a426gz6nigiana04sqylmxm851";
+    sha256 = "0g1rlh8himv3njsviy95grd9cp64hm98s9lc0f1gy2lvi2f9bxx4";
   };
 
   srcStatic = fetchurl {
     url = "https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz";
-    sha256 = "0sfs8kv4sxacly39ddy05i3gv14i7d14fc1fb952kdx0zzm8zray";
+    sha256 = "1jqzgyh4cyj1m9cmyvmhfh79j4dac84j7l1pxs6ppbxc4ym07g8g";
   };
 
   postPatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7896,6 +7896,10 @@ in
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
   };
 
+  go_1_13 = callPackage ../development/compilers/go/1.13.nix {
+    inherit (darwin.apple_sdk.frameworks) Security Foundation;
+  };
+
   go = go_1_12;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14370,10 +14370,18 @@ in
     go = buildPackages.go_1_12;
   };
 
+  buildGo113Package = callPackage ../development/go-packages/generic {
+    go = buildPackages.go_1_13;
+  };
+
   buildGoPackage = buildGo112Package;
 
   buildGo112Module = callPackage ../development/go-modules/generic {
     go = buildPackages.go_1_12;
+  };
+
+  buildGo113Module = callPackage ../development/go-modules/generic {
+    go = buildPackages.go_1_13;
   };
 
   buildGoModule = buildGo112Module;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14681,7 +14681,9 @@ in
 
   gofish = callPackage ../servers/gopher/gofish { };
 
-  grafana = callPackage ../servers/monitoring/grafana { };
+  grafana = callPackage ../servers/monitoring/grafana {
+    buildGoPackage = buildGo113Package;
+  };
 
   grafana-loki = callPackage ../servers/monitoring/loki { };
 


### PR DESCRIPTION
###### Motivation for this change
#74474 

Go 1.13 is needed for building grafana >= 6.5.

###### Things done
Added a commit that only introduces `buildGo113{Package,Module}` without making them the new default.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).