### PR TITLE
xvfb-run: clean up and update package

### DIFF
--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python3, wrapGAppsHook, gettext, libsoup, gnome3, gtk3, gdk-pixbuf,
-  tag ? "", xvfb_run, dbus, glibcLocales, glib, glib-networking, gobject-introspection,
+  tag ? "", xvfb-run, dbus, glibcLocales, glib, glib-networking, gobject-introspection,
   gst_all_1, withGstPlugins ? true,
   xineBackend ? false, xineLib,
   withDbusPython ? false, withPyInotify ? false, withMusicBrainzNgs ? false, withPahoMqtt ? false,
@@ -18,7 +18,7 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [ wrapGAppsHook gettext ];
 
-  checkInputs = with python3.pkgs; [ pytest pytest_xdist pyflakes pycodestyle polib xvfb_run dbus.daemon glibcLocales ];
+  checkInputs = with python3.pkgs; [ pytest pytest_xdist pyflakes pycodestyle polib xvfb-run dbus.daemon glibcLocales ];
 
   buildInputs = [ gnome3.adwaita-icon-theme libsoup glib glib-networking gtk3 webkitgtk gdk-pixbuf keybinder3 gtksourceview libmodplug libappindicator-gtk3 kakasi gobject-introspection ]
     ++ (if xineBackend then [ xineLib ] else with gst_all_1;

--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -32,7 +32,7 @@
 , webkitgtk
 , wrapGAppsHook
 , dbus
-, xvfb_run
+, xvfb-run
 , glib
 }:
 
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
 
   checkInputs = [
     dbus
-    xvfb_run
+    xvfb-run
   ];
 
   outputs = [ "out" "devdoc" ];

--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -4,7 +4,7 @@
   # runtime dependencies
   imagemagick, libtiff, djvulibre, poppler_utils, ghostscript, unpaper, pdftk,
   # test dependencies
-  xvfb_run, liberation_ttf, file, tesseract }:
+  xvfb-run, liberation_ttf, file, tesseract }:
 
 with stdenv.lib;
 
@@ -88,7 +88,7 @@ perlPackages.buildPerlPackage rec {
     unpaper
     pdftk
 
-    xvfb_run
+    xvfb-run
     file
     tesseract # tests are expecting tesseract 3.x precisely
   ];

--- a/pkgs/applications/graphics/vimiv/default.nix
+++ b/pkgs/applications/graphics/vimiv/default.nix
@@ -2,7 +2,7 @@
 , gnome3
 
 # Test requirements
-, dbus, xvfb_run, xdotool
+, dbus, xvfb-run, xdotool
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -37,7 +37,7 @@ python3Packages.buildPythonApplication rec {
       vimiv/imageactions.py
   '';
 
-  checkInputs = [ python3Packages.nose dbus.daemon xvfb_run xdotool ];
+  checkInputs = [ python3Packages.nose dbus.daemon xvfb-run xdotool ];
   buildInputs = [ gnome3.adwaita-icon-theme librsvg ];
   propagatedBuildInputs = with python3Packages; [ pillow pygobject3 gtk3 ];
 

--- a/pkgs/applications/misc/girara/default.nix
+++ b/pkgs/applications/misc/girara/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, check, dbus, xvfb_run, glib, gtk, gettext, libiconv, json_c, libintl
+{ stdenv, fetchurl, meson, ninja, pkgconfig, check, dbus, xvfb-run, glib, gtk, gettext, libiconv, json_c, libintl
 }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "13vr62kkkqs2xsrmsn114n6c6084ix1qyjksczqsc3s2y3bdsmj4";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext check dbus xvfb_run ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext check dbus xvfb-run ];
   buildInputs = [ libintl libiconv json_c ];
   propagatedBuildInputs = [ glib gtk ];
 

--- a/pkgs/applications/misc/pytrainer/default.nix
+++ b/pkgs/applications/misc/pytrainer/default.nix
@@ -8,7 +8,7 @@
 , gobject-introspection
 , wrapGAppsHook
 , gtk3
-, xvfb_run
+, xvfb-run
 , webkitgtk
 , glib-networking
 , glibcLocales
@@ -62,7 +62,7 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = [
     gobject-introspection
     wrapGAppsHook
-    xvfb_run
+    xvfb-run
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/ulauncher/default.nix
+++ b/pkgs/applications/misc/ulauncher/default.nix
@@ -10,7 +10,7 @@
 , libappindicator
 , intltool
 , wmctrl
-, xvfb_run
+, xvfb-run
 }:
 
 python27Packages.buildPythonApplication rec  {
@@ -58,7 +58,7 @@ python27Packages.buildPythonApplication rec  {
     pytest
     pytest-mock
     pytestpep8
-    xvfb_run
+    xvfb-run
   ];
 
   patches = [

--- a/pkgs/applications/networking/calls/default.nix
+++ b/pkgs/applications/networking/calls/default.nix
@@ -15,7 +15,7 @@
 , dbus
 , vala
 , xorg
-, xvfb_run
+, xvfb-run
 , libxml2
 }:
 
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
 
   checkInputs = [
     dbus
-    xvfb_run
+    xvfb-run
   ];
 
   mesonFlags = [

--- a/pkgs/applications/networking/flent/default.nix
+++ b/pkgs/applications/networking/flent/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonApplication, fetchPypi, matplotlib, procps, pyqt5, python
-, pythonPackages, qt5, sphinx, xvfb_run }:
+, pythonPackages, qt5, sphinx, xvfb-run }:
 
 buildPythonApplication rec {
   pname = "flent";
@@ -12,7 +12,7 @@ buildPythonApplication rec {
   buildInputs = [ sphinx ];
   nativeBuildInputs = [ qt5.wrapQtAppsHook ];
   propagatedBuildInputs = [ matplotlib procps pyqt5 ];
-  checkInputs = [ procps pythonPackages.mock pyqt5 xvfb_run ];
+  checkInputs = [ procps pythonPackages.mock pyqt5 xvfb-run ];
 
   checkPhase = ''
     cat >test-runner <<EOF

--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -4,7 +4,7 @@
 , python3, gtk3, gobject-introspection, gnome3
 
 # Test dependencies
-, xvfb_run, dbus
+, xvfb-run, dbus
 
 # Optional dependencies
 , enableJingle ? true, farstream, gstreamer, gst-plugins-base, gst-libav, gst-plugins-ugly, libnice
@@ -50,7 +50,7 @@ python3.pkgs.buildPythonApplication rec {
     ++ lib.optionals enableOmemoPluginDependencies [ python-axolotl qrcode ]
     ++ extraPythonPackages python3.pkgs;
 
-  checkInputs = [ xvfb_run dbus.daemon ];
+  checkInputs = [ xvfb-run dbus.daemon ];
 
   checkPhase = ''
     xvfb-run dbus-run-session \

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -8,7 +8,7 @@
 , sqlcipher
 
 # Needed for running tests:
-, qtbase, xvfb_run
+, qtbase, xvfb-run
 
 , python3Packages
 }:
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   '';
 
   doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;
-  installCheckInputs = [ xvfb_run ];
+  installCheckInputs = [ xvfb-run ];
   installCheckPhase =
     lib.optionalString doInstallCheck ''
       xvfb-run -s '-screen 0 1024x768x24' make test \

--- a/pkgs/applications/office/paperwork/default.nix
+++ b/pkgs/applications/office/paperwork/default.nix
@@ -1,7 +1,7 @@
 { lib, python3Packages, gtk3, cairo
 , aspellDicts, buildEnv
 , gnome3, librsvg
-, xvfb_run, dbus, libnotify
+, xvfb-run, dbus, libnotify
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -46,7 +46,7 @@ python3Packages.buildPythonApplication rec {
     paths = lib.collect lib.isDerivation aspellDicts;
   }}/lib/aspell";
 
-  checkInputs = [ xvfb_run dbus.daemon ] ++ (with python3Packages; [ paperwork-backend ]);
+  checkInputs = [ xvfb-run dbus.daemon ] ++ (with python3Packages; [ paperwork-backend ]);
   buildInputs = [
     gnome3.adwaita-icon-theme libnotify librsvg
   ];

--- a/pkgs/applications/office/pympress/default.nix
+++ b/pkgs/applications/office/pympress/default.nix
@@ -1,7 +1,7 @@
 { lib
 , python3Packages
 , wrapGAppsHook
-, xvfb_run
+, xvfb-run
 , gtk3
 , gobject-introspection
 , libcanberra-gtk3

--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, itstool, python3, intltool, wrapGAppsHook
 , libxml2, gobject-introspection, gtk3, gtksourceview, gnome3
-, gsettings-desktop-schemas, dbus, xvfb_run
+, gsettings-desktop-schemas, dbus, xvfb-run
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -20,7 +20,7 @@ python3.pkgs.buildPythonApplication rec {
     gobject-introspection # fixes https://github.com/NixOS/nixpkgs/issues/56943 for now
   ];
   propagatedBuildInputs = with python3.pkgs; [ pygobject3 pycairo ];
-  checkInputs = [ xvfb_run python3.pkgs.pytest dbus gtksourceview gtk3 ];
+  checkInputs = [ xvfb-run python3.pkgs.pytest dbus gtksourceview gtk3 ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, which, pkgconfig, makeWrapper, libxcb, xcbutilkeysyms
 , xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification, libX11, pcre, libev
 , yajl, xcb-util-cursor, perl, pango, perlPackages, libxkbcommon
-, xorgserver, xvfb_run }:
+, xorgserver, xvfb-run }:
 
 stdenv.mkDerivation rec {
   pname = "i3";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     libstartup_notification libX11 pcre libev yajl xcb-util-cursor perl pango
     perlPackages.AnyEventI3 perlPackages.X11XCB perlPackages.IPCRun
     perlPackages.ExtUtilsPkgConfig perlPackages.InlineC
-    xorgserver xvfb_run
+    xorgserver xvfb-run
   ];
 
   configureFlags = [ "--disable-builddir" ];

--- a/pkgs/desktops/gnome-3/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem/default.nix
@@ -3,7 +3,7 @@
 , pkgconfig, gtk3, glib, gobject-introspection, totem-pl-parser
 , wrapGAppsHook, itstool, libxml2, vala, gnome3, grilo, grilo-plugins
 , libpeas, adwaita-icon-theme, gnome-desktop, gsettings-desktop-schemas
-, gdk-pixbuf, tracker, nautilus, xvfb_run }:
+, gdk-pixbuf, tracker, nautilus, xvfb-run }:
 
 stdenv.mkDerivation rec {
   pname = "totem";
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  checkInputs = [ xvfb_run ];
+  checkInputs = [ xvfb-run ];
 
   checkPhase = ''
     xvfb-run -s '-screen 0 800x600x24' \

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -2,7 +2,7 @@
 , desktop-file-utils, gnome-online-accounts, gsettings-desktop-schemas, adwaita-icon-theme
 , libcanberra-gtk3, libsecret, gmime, isocodes, libxml2, gettext, fetchpatch
 , sqlite, gcr, json-glib, itstool, libgee, gnome3, webkitgtk, python3
-, xvfb_run, dbus, shared-mime-info, libunwind, libunity, folks, glib-networking
+, xvfb-run, dbus, shared-mime-info, libunwind, libunity, folks, glib-networking
 , gobject-introspection, gspell, appstream-glib, libytnef, libhandy }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     libunwind libunity folks gspell libytnef libhandy
   ];
 
-  checkInputs = [ xvfb_run dbus ];
+  checkInputs = [ xvfb-run dbus ];
 
   mesonFlags = [
     "-Dcontractor=true" # install the contractor file (Pantheon specific)

--- a/pkgs/development/libraries/amtk/default.nix
+++ b/pkgs/development/libraries/amtk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, gtk3
-, pkgconfig, gnome3, dbus, xvfb_run }:
+, pkgconfig, gnome3, dbus, xvfb-run }:
 let
   version = "5.0.1";
   pname = "amtk";
@@ -23,7 +23,7 @@ in stdenv.mkDerivation {
   doCheck = stdenv.isLinux;
   checkPhase = ''
     export NO_AT_BRIDGE=1
-    ${xvfb_run}/bin/xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
+    ${xvfb-run}/bin/xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
       make check
   '';

--- a/pkgs/development/libraries/gtksourceview/3.x.nix
+++ b/pkgs/development/libraries/gtksourceview/3.x.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, atk, cairo, glib, gtk3, pango, vala
-, libxml2, perl, intltool, gettext, gnome3, gobject-introspection, dbus, xvfb_run, shared-mime-info }:
+, libxml2, perl, intltool, gettext, gnome3, gobject-introspection, dbus, xvfb-run, shared-mime-info }:
 
 stdenv.mkDerivation rec {
   pname = "gtksourceview";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool perl gobject-introspection vala ];
 
-  checkInputs = [ xvfb_run dbus ];
+  checkInputs = [ xvfb-run dbus ];
 
   buildInputs = [ atk cairo glib pango libxml2 gettext ];
 

--- a/pkgs/development/libraries/gtksourceview/4.x.nix
+++ b/pkgs/development/libraries/gtksourceview/4.x.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, atk, cairo, glib, gtk3, pango, fribidi, vala
-, libxml2, perl, gettext, gnome3, gobject-introspection, dbus, xvfb_run, shared-mime-info
+, libxml2, perl, gettext, gnome3, gobject-introspection, dbus, xvfb-run, shared-mime-info
 , meson, ninja }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext perl gobject-introspection vala ];
 
-  checkInputs = [ xvfb_run dbus ];
+  checkInputs = [ xvfb-run dbus ];
 
   buildInputs = [ atk cairo glib pango fribidi libxml2 ];
 

--- a/pkgs/development/libraries/libdazzle/default.nix
+++ b/pkgs/development/libraries/libdazzle/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ninja, meson, pkgconfig, vala, gobject-introspection, libxml2
-, gtk-doc, docbook_xsl, docbook_xml_dtd_43, dbus, xvfb_run, glib, gtk3, gnome3 }:
+, gtk-doc, docbook_xsl, docbook_xml_dtd_43, dbus, xvfb-run, glib, gtk3, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "libdazzle";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "01cmcrd75b7ns7j2b4p6h7pv68vjhkcl9zbvzzx7pf4vknxir61x";
   };
 
-  nativeBuildInputs = [ ninja meson pkgconfig vala gobject-introspection libxml2 gtk-doc docbook_xsl docbook_xml_dtd_43 dbus xvfb_run ];
+  nativeBuildInputs = [ ninja meson pkgconfig vala gobject-introspection libxml2 gtk-doc docbook_xsl docbook_xml_dtd_43 dbus xvfb-run ];
   buildInputs = [ glib gtk3 ];
 
   mesonFlags = [

--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitLab, meson, ninja, pkgconfig, gobject-introspection, vala
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43
 , gtk3, gnome3
-, dbus, xvfb_run, libxml2
+, dbus, xvfb-run, libxml2
 , hicolor-icon-theme
 }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     gtk-doc docbook_xsl docbook_xml_dtd_43
   ];
   buildInputs = [ gnome3.gnome-desktop gtk3 gnome3.glade libxml2 ];
-  checkInputs = [ dbus xvfb_run hicolor-icon-theme ];
+  checkInputs = [ dbus xvfb-run hicolor-icon-theme ];
 
   mesonFlags = [
     "-Dgtk_doc=true"

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, glib, pkgconfig, gettext, libxslt, python3, docbook_xsl, docbook_xml_dtd_42
-, libgcrypt, gobject-introspection, vala, gtk-doc, gnome3, gjs, libintl, dbus, xvfb_run }:
+, libgcrypt, gobject-introspection, vala, gtk-doc, gnome3, gjs, libintl, dbus, xvfb-run }:
 
 stdenv.mkDerivation rec {
   pname = "libsecret";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  installCheckInputs = [ python3 python3.pkgs.dbus-python python3.pkgs.pygobject3 xvfb_run dbus gjs ];
+  installCheckInputs = [ python3 python3.pkgs.dbus-python python3.pkgs.pygobject3 xvfb-run dbus gjs ];
 
   # needs to run after install because typelibs point to absolute paths
   doInstallCheck = false; # Failed to load shared library '/force/shared/libmock_service.so.0' referenced by the typelib

--- a/pkgs/development/python-modules/cartopy/default.nix
+++ b/pkgs/development/python-modules/cartopy/default.nix
@@ -3,7 +3,7 @@
 , cython, isPy27
 , six, pyshp, shapely, geos, numpy
 , gdal, pillow, matplotlib, pyepsg, pykdtree, scipy, owslib, fiona
-, xvfb_run
+, xvfb-run
 , proj_5 # see https://github.com/SciTools/cartopy/pull/1252 for status on proj 6 support
 }:
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   # also py2.7's tk is over-eager in trying to open an x display,
   # so give it xvfb
   checkPhase = let
-    maybeXvfbRun = lib.optionalString isPy27 "${xvfb_run}/bin/xvfb-run";
+    maybeXvfbRun = lib.optionalString isPy27 "${xvfb-run}/bin/xvfb-run";
   in ''
     export HOME=$(mktemp -d)
     ${maybeXvfbRun} pytest --pyargs cartopy \

--- a/pkgs/development/python-modules/dogtail/default.nix
+++ b/pkgs/development/python-modules/dogtail/default.nix
@@ -10,7 +10,7 @@
 , gsettings-desktop-schemas
 , fetchurl
 , dbus
-, xvfb_run
+, xvfb-run
 , wrapGAppsHook
 # , fetchPypi
 }:
@@ -33,7 +33,7 @@ buildPythonPackage {
     ./nix-support.patch
   ];
 
-  nativeBuildInputs = [ gobject-introspection dbus xvfb_run wrapGAppsHook ]; # for setup hooks
+  nativeBuildInputs = [ gobject-introspection dbus xvfb-run wrapGAppsHook ]; # for setup hooks
   propagatedBuildInputs = [ at-spi2-core gtk3 pygobject3 pyatspi pycairo ];
   strictDeps = false; # issue 56943
 

--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -1,10 +1,10 @@
-{ stdenv, R, libcxx, xvfb_run, utillinux, Cocoa, Foundation, gettext, gfortran }:
+{ stdenv, R, libcxx, xvfb-run, utillinux, Cocoa, Foundation, gettext, gfortran }:
 
 { name, buildInputs ? [], requireX ? false, ... } @ attrs:
 
 stdenv.mkDerivation ({
   buildInputs = buildInputs ++ [R gettext] ++
-                stdenv.lib.optionals requireX [utillinux xvfb_run] ++
+                stdenv.lib.optionals requireX [utillinux xvfb-run] ++
                 stdenv.lib.optionals stdenv.isDarwin [Cocoa Foundation gfortran];
 
   NIX_CFLAGS_COMPILE =
@@ -29,7 +29,7 @@ stdenv.mkDerivation ({
   rCommand = if requireX then
     # Unfortunately, xvfb-run has a race condition even with -a option, so that
     # we acquire a lock explicitly.
-    "flock ${xvfb_run} xvfb-run -a -e xvfb-error R"
+    "flock ${xvfb-run} xvfb-run -a -e xvfb-error R"
   else
     "R";
 

--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -29,9 +29,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = ''Starter script for an instance of Xvfb, the "fake" X server'';
-    inherit (src.meta) homepage;
-    license = licenses.gpl2;
+    description = "A wrapper for the Xvfb command which simplifies the task of running commands";
+    homepage = src.meta.homepage +  "debian/local";
+    license = licenses.mit;
     maintainers = with maintainers; [ b4dm4n ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     group = "xorg-team";
     owner = "xserver";
     repo = "xorg-server";
-    rev = "acb49777829b320d58a3a6c65828aabfffeb381e";
-    sha256 = "1ci6wzka62iwihccl4g48rm0fj119jg38z9nvxhwi0v7dvlvkwvh";
+    rev = "xorg-server-2_${version}";
+    sha256 = "03a2x0fds45j7dqsp31ifsr1bm8zl6yac925n0bqdf4sjiyscq20";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -432,6 +432,7 @@ mapAliases ({
   xf86_video_nouveau = xorg.xf86videonouveau; # added 2015-09
   xlibs = xorg; # added 2015-09
   xpraGtk3 = xpra; # added 2018-09-13
+  xvfb_run = xvfb-run; # added 2019-11-23
   youtubeDL = youtube-dl;  # added 2014-10-26
   zdfmediathk = mediathekview; # added 2019-01-19
   gnome_user_docs = gnome-user-docs; # added 2019-11-20

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7385,7 +7385,7 @@ in
 
   xv = callPackage ../tools/misc/xv {};
 
-  xvfb_run = callPackage ../tools/misc/xvfb-run { inherit (texFunctions) fontsConf; };
+  xvfb-run = callPackage ../tools/misc/xvfb-run { inherit (texFunctions) fontsConf; };
 
   xvkbd = callPackage ../tools/X11/xvkbd {};
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#72906

###### Things done

In addition to updating the package I also renamed it from `xvfb_run` to `xvfb-run` and added a backwards compatible alias, as `xvfb_run` is not an intuitive package name to install when trying to run the `xvfb-run` script.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
<details>
  <summary>nix-review result</summary>
  
  ```log
builder for '/nix/store/5807p8q8islcjxvk7nqziw0frld2pjv4-ping-0.6.0.drv' failed with exit code 1; last 10 log lines:
                      if(tempDataList.contains(variableName)){
                         ^^^^^^^^^^^^
  ../src/Application.vala:868.25-868.36: error: The name `tempDataList' does not exist in the context of `PingApp.setupSignals._lambda34_'
                          tempDataList[variableName] = new_text;
                          ^^^^^^^^^^^^
  ../src/Application.vala:869.67-869.78: error: The name `tempDataList' does not exist in the context of `PingApp.setupSignals._lambda34_'
                          testObjs[id].data = Soup.Form.encode_hash(tempDataList);
                                                                    ^^^^^^^^^^^^
  Compilation failed: 36 error(s), 8 warning(s)
  ninja: build stopped: subcommand failed.
cannot build derivation '/nix/store/m141iwy3anw90ygsrp243kva1xlljkbp-env.drv': 1 dependencies couldn't be built
[1 built (1 failed)]
error: build of '/nix/store/m141iwy3anw90ygsrp243kva1xlljkbp-env.drv' failed
1 package failed to build:
ping

102 package were built:
adapta-gtk-theme almanah amtk autokey balsa calls chrome-gnome-shell contrast coq_8_10 denemo empathy ephemeral epiphany flent fractal gImageReader gajim girara gitg glom gnome-builder gnome-latex gnome-photos gnome-podcasts gnome-usage gnome3.anjuta gnome3.cheese gnome3.devhelp gnome3.geary gnome3.gedit gnome3.gnome-calculator gnome3.gnome-calendar gnome3.gnome-contacts gnome3.gnome-control-center gnome3.gnome-music gnome3.gnome-session gnome3.gnome-shell gnome3.gnome-terminal gnome3.gnome-tweak-tool gnome3.gpaste gnome3.gtksourceview gnome3.gtksourceview4 gnome3.gtksourceviewmm gnome3.libdazzle gnome3.meld gnome3.mutter gnome3.nemiver gnome3.pomodoro gnome3.sushi gnome3.totem gnomeExtensions.gsconnect gobby5 gscan2pdf gtkd gtkpod gtksourceviewmm4 gtranslator gupnptools i3 i3-gaps i3-layout-manager i3-wk-switch jucipp kmymoney libhandy lutris lutris-free mate.mate-applets mate.pluma nasc notejot notes-up ocamlPackages.lablgtk3-sourceview3 pantheon.elementary-code pantheon.elementary-gsettings-schemas pantheon.elementary-onboarding pantheon.elementary-session-settings pantheon.notes-up paperwork polybarFull pspp python27Packages.cartopy python27Packages.i3ipc python27Packages.py3status python37Packages.dogtail python37Packages.i3ipc python37Packages.py3status python38Packages.dogtail python38Packages.i3ipc python38Packages.py3status pytrainer quilter rednotebook sequeler sysprof tepl tilix virtmanager xfce.mousepad xpad xvfb-run zathura
 ```
</details>

- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) (`210.2M -> 210.1M`)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @davidak
