### PR TITLE
libvncserver: 0.9.11 -> 0.9.12

### DIFF
--- a/pkgs/development/libraries/libvncserver/default.nix
+++ b/pkgs/development/libraries/libvncserver/default.nix
@@ -1,41 +1,43 @@
-{stdenv, fetchurl, fetchpatch,
- libtool, libjpeg, openssl, zlib, libgcrypt, autoreconfHook, pkgconfig, libpng,
- systemd
+{ stdenv, fetchzip, fetchpatch, cmake
+, libjpeg, openssl, zlib, libgcrypt, libpng
+, systemd
 }:
 
 let
   s = # Generated upstream information
   rec {
-    baseName="libvncserver";
-    version="0.9.11";
-    name="${baseName}-${version}";
-    url="https://github.com/LibVNC/libvncserver/archive/LibVNCServer-${version}.tar.gz";
-    sha256="15189n09r1pg2nqrpgxqrcvad89cdcrca9gx6qhm6akjf81n6g8r";
+    pname = "libvncserver";
+    version = "0.9.12";
+    url = "https://github.com/LibVNC/libvncserver/archive/LibVNCServer-${version}.tar.gz";
+    sha256 = "1226hb179l914919f5nm2mlf8rhaarqbf48aa649p4rwmghyx9vm"; # unpacked archive checksum
   };
 in
 stdenv.mkDerivation {
-  inherit (s) name version;
-  src = fetchurl {
+  inherit (s) pname version;
+  src = fetchzip {
     inherit (s) url sha256;
   };
   patches = [
-    # CVE-2018-7225. Remove with the next release
     (fetchpatch {
-      url = https://salsa.debian.org/debian/libvncserver/raw/master/debian/patches/CVE-2018-7225.patch;
-      sha256 = "1hj1lzxsrdmzzl061vg0ncdpvfmvvkrpk8q12mp70qvszcqa7ja3";
+      name = "CVE-2018-20750.patch";
+      url = "https://github.com/LibVNC/libvncserver/commit/09e8fc02f59f16e2583b34fe1a270c238bd9ffec.patch";
+      sha256 = "004h50786nvjl3y3yazpsi2b767vc9gqrwm1ralj3zgy47kwfhqm";
+    })
+    (fetchpatch {
+      name = "CVE-2019-15681.patch";
+      url = "https://github.com/LibVNC/libvncserver/commit/d01e1bb4246323ba6fcee3b82ef1faa9b1dac82a.patch";
+      sha256 = "0hf0ss7all2m50z2kan4mck51ws44yim4ymn8p0d991y465y6l9s";
     })
   ];
-  preConfigure = ''
-    sed -e 's@/usr/include/linux@${stdenv.cc.libc}/include/linux@g' -i configure
-  '';
-  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  nativeBuildInputs = [ cmake ];
   buildInputs = [
-    libtool libjpeg openssl libgcrypt libpng
+    libjpeg openssl libgcrypt libpng
   ] ++ stdenv.lib.optional stdenv.isLinux systemd;
   propagatedBuildInputs = [ zlib ];
   meta = {
     inherit (s) version;
-    description =  "VNC server library";
+    description = "VNC server library";
+    homepage = "https://libvnc.github.io/";
     license = stdenv.lib.licenses.gpl2Plus ;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.unix;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Vuln roundup #73664 -- unstable channel

Version bump from 0.9.11 to 0.9.12 fixes:
* CVE-2018-6307
* CVE-2018-15126
* CVE-2018-15127
* CVE-2018-20019
* CVE-2018-20020
* CVE-2018-20021
* CVE-2018-20022
* CVE-2018-20023
* CVE-2018-20024
* CVE-2018-20748
* CVE-2018-20749

Upstream changelog is at https://github.com/LibVNC/libvncserver/releases/tag/LibVNCServer-0.9.12

Plus add two upstream patches to fix:
* CVE-2018-20750
* CVE-2019-15681

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @7c6f434c 

---

Result of `nix-review` [1](https://github.com/Mic92/nix-review)
<details>
  <summary>1 package failed to build:</summary>

  - blink (virt-manager-qt)
</details>
<details>
  <summary>10 package were build:</summary>

  - aqemu (virt-manager-qt)
  - gnome3.gnome-control-center (virt-manager-qt)
  - gnome3.gnome-remote-desktop (virt-manager-qt)
  - kdeApplications.krdc (virt-manager-qt)
  - kdeApplications.krfb (virt-manager-qt)
  - libvncserver (virt-manager-qt)
  - remmina (virt-manager-qt)
  - virtmanager-qt (virt-manager-qt)
  - virtscreen (virt-manager-qt)
  - x11vnc (virt-manager-qt)
</details>

`blink` is already failing on Hydra, because of `python27Packages.python-otr`

```console
builder for '/nix/store/gwl3yipahap9gxxdbcgf3l8s8f3zmmr2-python2.7-python-otr-1.2.0.drv' failed with exit code 1; last 10 log lines:
      from zope.interface import Interface, implements
  ImportError: No module named zope.interface
  
  
  ----------------------------------------------------------------------
  Ran 1 test in 0.000s
  
  FAILED (errors=1)
  Test failed: <unittest.runner.TextTestResult run=1 errors=1 failures=0>
  error: Test failed: <unittest.runner.TextTestResult run=1 errors=1 failures=0>
cannot build derivation '/nix/store/a8qry41l7m42bqfsqm132wv8srnvbzkq-python2.7-sipsimple-3.4.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/sdbwy0dycbaw4vayj2x19s2d1zxg4yvg-blink-3.2.0.drv': 1 dependencies couldn't be built
```