### PR TITLE
boxes: init at 1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7652,4 +7652,10 @@
     githubId = 50867187;
     name = "Rakesh Gupta";
   };
+  waiting-for-dev = {
+    email = "marc@lamarciana.com";
+    github = "waiting-for-dev";
+    githubId = 52650;
+    name = "Marc Busqué";
+  };
 }

--- a/pkgs/tools/text/boxes/default.nix
+++ b/pkgs/tools/text/boxes/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, bison, flex }:
+
+stdenv.mkDerivation rec {
+  pname = "boxes";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "ascii-boxes";
+    repo = "boxes";
+    rev = "v${version}";
+    sha256 = "0b12rsynrmkldlwcb62drk33kk0aqwbj10mq5y5x3hjf626gjwsi";
+  };
+
+  # Building instructions:
+  # https://boxes.thomasjensen.com/build.html#building-on-linux--unix
+  nativeBuildInputs = [ bison flex ];
+
+  dontConfigure = true;
+
+  # Makefile references a system wide config file in '/usr/share'. Instead, we
+  # move it within the store by default.
+  preBuild = ''
+    substituteInPlace Makefile \
+      --replace "GLOBALCONF = /usr/share/boxes" \
+                "GLOBALCONF=${placeholder "out"}/share/boxes/boxes-config"
+  '';
+
+  makeFlags = stdenv.lib.optionals stdenv.isDarwin [ "CC=cc" ];
+
+  installPhase = ''
+    install -Dm755 -t $out/bin src/boxes
+    install -Dm644 -t $out/share/boxes boxes-config
+    install -Dm644 -t $out/share/man/man1 doc/boxes.1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Command line ASCII boxes unlimited!";
+    longDescription = ''
+      Boxes is a command line filter program that draws ASCII art boxes around
+      your input text.
+    '';
+    homepage = https://boxes.thomasjensen.com;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ waiting-for-dev ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -724,6 +724,8 @@ in
 
   brewtarget = libsForQt5.callPackage ../applications/misc/brewtarget { } ;
 
+  boxes = callPackage ../tools/text/boxes { };
+
   ec2_api_tools = callPackage ../tools/virtualization/ec2-api-tools { };
 
   ec2_ami_tools = callPackage ../tools/virtualization/ec2-ami-tools { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds [boxes](https://boxes.thomasjensen.com/) package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

###### Comments

This is my first derivation, hope everything is fine. I have some doubts about the issue with the system wide config file used in boxes. The file is defined in the `Makefile` and defaults to `/usr/share/boxes`. In the derivation I'm changing it for `$out/boxes-config`. Individual users can define its own config file but, anyway, I'm not sure if there is a better way to go. Also, it would be nice to set the new config file path in a `mkDerivation` attribute, so that it can be overriden easily if needed. However, if I'm not wrong, I have no way to access `$out` from there, so it's not possible.