### PR TITLE
Add some documentation for texlive

### DIFF
--- a/doc/languages-frameworks/texlive.xml
+++ b/doc/languages-frameworks/texlive.xml
@@ -93,16 +93,14 @@ let
       runHook postUnpack
     '';
 
-    nativeBuildInputs = [ texlive.combined.scheme-medium ];
+    nativeBuildInputs = [ texlive.combined.scheme-small ];
 
     dontConfigure = true;
 
     buildPhase = ''
       runHook preBuild
 
-      # Generate documentation
-      latexmk -pdf foiltex.dtx
-      # Generate style files
+      # Generate the style files
       latex foiltex.ins
 
       runHook postBuild
@@ -113,7 +111,7 @@ let
 
       path="$out/tex/latex/foiltex"
       mkdir -p "$path"
-      cp *.{cls,def,clo,pdf} "$path/"
+      cp *.{cls,def,clo} "$path/"
 
       runHook postInstall
     '';

--- a/doc/languages-frameworks/texlive.xml
+++ b/doc/languages-frameworks/texlive.xml
@@ -62,7 +62,7 @@ nix-repl> texlive.collection-<TAB>
  <section xml:id="sec-language-texlive-custom-packages">
   <title>Custom packages</title>
   <para>
-    You may find that you need to use an external TeX package. A derivation for such package has to provide contents of the "texmf" directory in its output and provide a <varname>tlType</varname> attribute. Here is a (very verbose) example:
+    You may find that you need to use an external TeX package. A derivation for such package has to provide contents of the "texmf" directory in its output and provide the <varname>tlType</varname> attribute. Here is a (very verbose) example:
 <programlisting><![CDATA[
 with import <nixpkgs> {};
 

--- a/doc/languages-frameworks/texlive.xml
+++ b/doc/languages-frameworks/texlive.xml
@@ -62,20 +62,90 @@ nix-repl> texlive.collection-<TAB>
  <section xml:id="sec-language-texlive-custom-packages">
   <title>Custom packages</title>
   <para>
-    You may find that you need to add your own package to the combination. This is currently not handled in a user-friendly way by the combine function. Here is a hackish way to do it, as an example:
-<programlisting>
+    You may find that you need to use an external TeX package. A derivation for such package has to provide contents of the "texmf" directory in its output and provide a <varname>tlType</varname> attribute. Here is a (very verbose) example:
+<programlisting><![CDATA[
+with import <nixpkgs> {};
+
 let
-  customDerivation = stdenvNoCC.mkDerivation {
-    # build your derivation here, its output should have folder structure
-    # similar to what would be expected in /usr/share/texmf in a regular OS.
-    passthru = { tlType = "run"; pname = "customDerivation"; };
+  foiltex_run = stdenvNoCC.mkDerivation {
+    pname = "latex-foiltex";
+    version = "2.1.4b";
+    passthru.tlType = "run";
+
+    srcs = [
+      (fetchurl {
+        url = "http://mirrors.ctan.org/macros/latex/contrib/foiltex/foiltex.dtx";
+        sha256 = "07frz0krpz7kkcwlayrwrj2a2pixmv0icbngyw92srp9fp23cqpz";
+      })
+      (fetchurl {
+        url = "http://mirrors.ctan.org/macros/latex/contrib/foiltex/foiltex.ins";
+        sha256 = "09wkyidxk3n3zvqxfs61wlypmbhi1pxmjdi1kns9n2ky8ykbff99";
+      })
+    ];
+
+    unpackPhase = ''
+      runHook preUnpack
+
+      for _src in $srcs; do
+        cp "$_src" $(stripHash "$_src")
+      done
+
+      runHook postUnpack
+    '';
+
+    nativeBuildInputs = [ texlive.combined.scheme-medium ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      # Generate documentation
+      latexmk -pdf foiltex.dtx
+      # Generate style files
+      latex foiltex.ins
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      path="$out/tex/latex/foiltex"
+      mkdir -p "$path"
+      cp *.{cls,def,clo,pdf} "$path/"
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "A LaTeX2e class for overhead transparencies";
+      license = licenses.unfreeRedistributable;
+      maintainers = with maintainers; [ veprbl ];
+      platforms = platforms.all;
+    };
   };
+  foiltex = { pkgs = [ foiltex_run ]; };
+
+  latex_with_foiltex = texlive.combine { inherit (texlive) scheme-small; inherit foiltex; };
 in
-  texlive.combine {
-    # inherit (texlive) whatever-you-want;
-    customPackage = { pkgs = [ customDerivation ]; };
-  }
-</programlisting>
+  runCommand "test.pdf" {
+    nativeBuildInputs = [ latex_with_foiltex ];
+  } ''
+cat >test.tex <<EOF
+\documentclass{foils}
+
+\title{Presentation title}
+\date{}
+
+\begin{document}
+\maketitle
+\end{document}
+EOF
+  pdflatex test.tex
+  cp test.pdf $out
+''
+]]></programlisting>
   </para>
  </section>
 

--- a/doc/languages-frameworks/texlive.xml
+++ b/doc/languages-frameworks/texlive.xml
@@ -125,7 +125,10 @@ let
   };
   foiltex = { pkgs = [ foiltex_run ]; };
 
-  latex_with_foiltex = texlive.combine { inherit (texlive) scheme-small; inherit foiltex; };
+  latex_with_foiltex = texlive.combine {
+    inherit (texlive) scheme-small;
+    inherit foiltex;
+  };
 in
   runCommand "test.pdf" {
     nativeBuildInputs = [ latex_with_foiltex ];

--- a/doc/languages-frameworks/texlive.xml
+++ b/doc/languages-frameworks/texlive.xml
@@ -59,6 +59,27 @@ nix-repl> texlive.collection-<TAB>
   </itemizedlist>
  </section>
 
+ <section xml:id="sec-language-texlive-custom-packages">
+  <title>Custom packages</title>
+  <para>
+    You may find that you need to add your own package to the combination. This is currently not handled in a user-friendly way by the combine function. Here is a hackish way to do it, as an example:
+<programlisting>
+let
+  customDerivation = runCommand "customDerivation" {
+    passthru = { tlType = "run"; pname = "customDerivation"; };
+  } ''
+  # build your derivation here, its output should have folder structure
+  # similar to what would be expected in /usr/share/texmf in a regular OS.
+  '';
+in
+  texlive.combine {
+    # inherit (texlive) whatever-you-want;
+    customPackage = { pkgs = [ customDerivation ]; };
+  }
+</programlisting>
+  </para>
+ </section>
+
  <section xml:id="sec-language-texlive-known-problems">
   <title>Known problems</title>
 

--- a/doc/languages-frameworks/texlive.xml
+++ b/doc/languages-frameworks/texlive.xml
@@ -65,12 +65,11 @@ nix-repl> texlive.collection-<TAB>
     You may find that you need to add your own package to the combination. This is currently not handled in a user-friendly way by the combine function. Here is a hackish way to do it, as an example:
 <programlisting>
 let
-  customDerivation = runCommand "customDerivation" {
+  customDerivation = stdenvNoCC.mkDerivation {
+    # build your derivation here, its output should have folder structure
+    # similar to what would be expected in /usr/share/texmf in a regular OS.
     passthru = { tlType = "run"; pname = "customDerivation"; };
-  } ''
-  # build your derivation here, its output should have folder structure
-  # similar to what would be expected in /usr/share/texmf in a regular OS.
-  '';
+  };
 in
   texlive.combine {
     # inherit (texlive) whatever-you-want;


### PR DESCRIPTION
###### Motivation for this change

Provides documentation for adding custom packages to `texlive.combine`

Fixes: #17748

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vcunat @veprbl @lovek323 @jwiegley @raskin
