### PR TITLE
nixos/powerdns: Use upstream systemd service file

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -495,6 +495,11 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
      In the <literal>resilio</literal> module, <xref linkend="opt-services.resilio.httpListenAddr"/> has been changed to listen to <literal>[::1]</literal> instead of <literal>0.0.0.0</literal>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     powerdns no longer runs in a chrooted environment. Make sure file paths used in <link>opt-services.powerdns.extraConfig</link> are updated.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/networking/powerdns.nix
+++ b/nixos/modules/services/networking/powerdns.nix
@@ -14,35 +14,24 @@ in {
         type = types.lines;
         default = "launch=bind";
         description = ''
-          Extra lines to be added verbatim to pdns.conf.
-          Powerdns will chroot to /var/lib/powerdns.
-          So any file, powerdns is supposed to be read,
-          should be in /var/lib/powerdns and needs to specified
-          relative to the chroot.
+          Extra lines to be added verbatim to the config file.
         '';
       };
     };
   };
 
   config = mkIf config.services.powerdns.enable {
-    systemd.services.pdns = {
-      unitConfig.Documentation = "man:pdns_server(1) man:pdns_control(1)";
-      description = "Powerdns name server";
-      wantedBy = [ "multi-user.target" ];
-      after = ["network.target" "mysql.service" "postgresql.service" "openldap.service"];
+    systemd = {
+      packages = [ pkgs.powerdns ];
 
-      serviceConfig = {
-        Restart="on-failure";
-        RestartSec="1";
-        StartLimitInterval="0";
-        PrivateDevices=true;
-        CapabilityBoundingSet="CAP_CHOWN CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_CHROOT";
-        NoNewPrivileges=true;
-        ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p /var/lib/powerdns";
-        ExecStart = "${pkgs.powerdns}/bin/pdns_server --setuid=nobody --setgid=nogroup --chroot=/var/lib/powerdns --socket-dir=/ --daemon=no --guardian=no --disable-syslog --write-pid=no --config-dir=${configDir}";
-        ProtectSystem="full";
-        ProtectHome=true;
-        RestrictAddressFamilies="AF_UNIX AF_INET AF_INET6";
+      services.pdns = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = [
+            ""
+            "${pkgs.powerdns}/bin/pdns_server --guardian=no --daemon=no --disable-syslog --log-timestamp=no --write-pid=no --config-dir=${configDir}"
+          ];
+        };
       };
     };
   };

--- a/pkgs/servers/dns/powerdns/default.nix
+++ b/pkgs/servers/dns/powerdns/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig
 , boost, libyamlcpp, libsodium, sqlite, protobuf, botan2, openssl
 , mysql57, postgresql, lua, openldap, geoip, curl, opendbx, unixODBC
+, systemd, withSystemd ? stdenv.isLinux
 }:
 
 stdenv.mkDerivation rec {
@@ -16,14 +17,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost mysql57.connector-c postgresql lua openldap sqlite protobuf geoip
     libyamlcpp libsodium curl opendbx unixODBC botan2 openssl
-  ];
+  ] ++ stdenv.lib.optional withSystemd systemd;
 
   # nix destroy with-modules arguments, when using configureFlags
   preConfigure = ''
     configureFlagsArray=(
       "--with-modules=bind gmysql geoip godbc gpgsql gsqlite3 ldap lua mydns opendbx pipe random remote"
       --with-sqlite3
-      --with-socketdir=/var/lib/powerdns
+      --with-socketdir=/run/pdns
       --with-libcrypto=${openssl.dev}
       --enable-libsodium
       --enable-botan


### PR DESCRIPTION
###### Motivation for this change

Use upstream systemd service file, reducing maintainer overhead.

Note: powerdns no longer runs inside a chrooted environment. This seems to be
against the policy of the upstream developers [[link]](https://github.com/PowerDNS/pdns/issues/4179#issuecomment-436156685).

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Mic92 