### PR TITLE
ocaml-crunch: init at 3.1.0

### DIFF
--- a/pkgs/development/tools/ocaml/crunch/default.nix
+++ b/pkgs/development/tools/ocaml/crunch/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildDunePackage, fetchurl, ocaml, cmdliner, opaline, ptime }:
+
+buildDunePackage rec {
+
+  pname = "crunch";
+  version = "3.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-crunch/releases/download/v${version}/crunch-v${version}.tbz";
+    sha256 = "0d26715a4h9r1wibnc12xy690m1kan7hrcgbb5qk8x78zsr67lnf";
+  };
+
+  propagatedBuildInputs = [ cmdliner ptime ];
+
+  outputs = [ "lib" "bin" "out" ];
+
+  installPhase = ''
+    ${opaline}/bin/opaline -prefix $bin -libdir $lib/lib/ocaml/${ocaml.version}/site-lib/
+  '';
+
+  meta = {
+    homepage = "https://github.com/mirage/ocaml-crunch";
+    description = "Convert a filesystem into a static OCaml module";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8554,6 +8554,8 @@ in
 
   ocamlPackages = recurseIntoAttrs ocaml-ng.ocamlPackages;
 
+  ocaml-crunch = ocamlPackages.crunch.bin;
+
   ocamlformat = callPackage ../development/tools/ocaml/ocamlformat { };
 
   orc = callPackage ../development/compilers/orc { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -185,6 +185,8 @@ let
 
     cpuid = callPackage ../development/ocaml-modules/cpuid { };
 
+    crunch = callPackage ../development/tools/ocaml/crunch { };
+
     cryptokit = callPackage ../development/ocaml-modules/cryptokit { };
 
     cstruct =


### PR DESCRIPTION
###### Motivation for this change

Dependency of graphql-cohttp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
