### PR TITLE
python3.pkgs.rpy2: 2.9.5 -> 3.2.2

### DIFF
--- a/pkgs/development/python-modules/rpy2/2.nix
+++ b/pkgs/development/python-modules/rpy2/2.nix
@@ -1,0 +1,108 @@
+{ lib
+, python
+, buildPythonPackage
+, fetchPypi
+, isPyPy
+, isPy27
+, readline
+, R
+, rWrapper
+, rPackages
+, pcre
+, lzma
+, bzip2
+, zlib
+, icu
+, singledispatch
+, six
+, jinja2
+, pytz
+, numpy
+, pytest
+, mock
+, extraRPackages ? []
+}:
+
+buildPythonPackage rec {
+    version = "2.8.6"; # python2 support dropped in 2.9.x
+    pname = "rpy2";
+    disabled = isPyPy;
+    src = fetchPypi {
+      inherit version pname;
+      sha256 = "162zki5c1apgv6qbafi7n66y4hgpgp43xag7q75qb6kv99ri6k80";
+    };
+    buildInputs = [
+      readline
+      R
+      pcre
+      lzma
+      bzip2
+      zlib
+      icu
+    ] ++ (with rPackages; [
+      # packages expected by the test framework
+      ggplot2
+      dplyr
+      RSQLite
+      broom
+      DBI
+      dbplyr
+      hexbin
+      lme4
+      tidyr
+
+      # is in upstream's `requires` although it shouldn't be -- this is easier than patching it away
+      pytest
+    ]) ++ extraRPackages ++ rWrapper.recommendedPackages;
+
+    nativeBuildInputs = [
+      R # needed at setup time to detect R_HOME (alternatively set R_HOME explicitly)
+    ];
+
+    patches = [
+      # R_LIBS_SITE is used by the nix r package to point to the installed R libraries.
+      # This patch sets R_LIBS_SITE when rpy2 is imported.
+      ./r-libs-site.patch
+    ];
+    postPatch = ''
+      substituteInPlace ${ if isPy27 then "rpy/rinterface/__init__.py" else "rpy2/rinterface_lib/embedded.py" } --replace '@NIX_R_LIBS_SITE@' "$R_LIBS_SITE"
+    '';
+
+    doPatchelf = false; # fails because of "missing filename"
+    patchelfPhase = "";
+
+    propagatedBuildInputs = [
+      singledispatch
+      six
+      jinja2
+      pytz
+      numpy
+    ];
+
+    checkInputs = [
+      pytest
+      mock
+    ];
+    # One remaining test failure caused by different unicode encoding.
+    # https://bitbucket.org/rpy2/rpy2/issues/488
+    doCheck = false;
+    checkPhase = ''
+      ${python.interpreter} -m 'rpy2'
+    '';
+
+    # For some reason libreadline.so is not found. Curiously `ldd _rinterface.so | grep readline` shows two readline entries:
+    # libreadline.so.6 => not found
+    # libreadline.so.6 => /nix/store/z2zhmrg6jcrn5iq2779mav0nnq4vm2q6-readline-6.3p08/lib/libreadline.so.6 (0x00007f333ac43000)
+    # There must be a better way to fix this, but I don't know it.
+    postFixup = ''
+      patchelf --add-needed ${readline}/lib/libreadline.so "$out/${python.sitePackages}/rpy2/rinterface/"_rinterface*.so
+    '';
+
+    meta = {
+      homepage = http://rpy.sourceforge.net/rpy2;
+      description = "Python interface to R";
+      license = lib.licenses.gpl2Plus;
+      platforms = lib.platforms.unix;
+      maintainers = with lib.maintainers; [ joelmo ];
+    };
+  }

--- a/pkgs/development/python-modules/rpy2/default.nix
+++ b/pkgs/development/python-modules/rpy2/default.nix
@@ -3,8 +3,6 @@
 , buildPythonPackage
 , fetchPypi
 , isPyPy
-, isPy27
-, readline
 , R
 , rWrapper
 , rPackages
@@ -13,38 +11,38 @@
 , bzip2
 , zlib
 , icu
-, singledispatch
-, six
+, ipython
 , jinja2
 , pytz
+, pandas
 , numpy
+, cffi
+, tzlocal
+, simplegeneric
 , pytest
-, mock
 , extraRPackages ? []
 }:
 
 buildPythonPackage rec {
-    version = if isPy27 then
-      "2.8.6" # python2 support dropped in 2.9.x
-    else
-      "2.9.5";
+    version = "3.2.2";
     pname = "rpy2";
+
     disabled = isPyPy;
     src = fetchPypi {
       inherit version pname;
-      sha256 = if isPy27 then
-        "162zki5c1apgv6qbafi7n66y4hgpgp43xag7q75qb6kv99ri6k80" # 2.8.x
-      else
-        "1nrj8pgyxrwrfdrxzb4j3z1adjwjx1mr8d1n5cmrz4nhlzy8w7xr"; # 2.9.x
+      sha256 = "0b3jpn9x7m2pccriyzgfsdb68qp6nq4ffhvjy1q2ar8wdxvmf5xp";
     };
+
     buildInputs = [
-      readline
       R
       pcre
       lzma
       bzip2
       zlib
       icu
+
+      # is in the upstream `requires` although it shouldn't be -- this is easier than patching it away
+      pytest
     ] ++ (with rPackages; [
       # packages expected by the test framework
       ggplot2
@@ -58,6 +56,10 @@ buildPythonPackage rec {
       tidyr
     ]) ++ extraRPackages ++ rWrapper.recommendedPackages;
 
+    checkPhase = ''
+      pytest
+    '';
+
     nativeBuildInputs = [
       R # needed at setup time to detect R_HOME (alternatively set R_HOME explicitly)
     ];
@@ -65,38 +67,26 @@ buildPythonPackage rec {
     patches = [
       # R_LIBS_SITE is used by the nix r package to point to the installed R libraries.
       # This patch sets R_LIBS_SITE when rpy2 is imported.
-      ./r-libs-site.patch
+      ./rpy2-3.x-r-libs-site.patch
     ];
     postPatch = ''
-      substituteInPlace rpy/rinterface/__init__.py --replace '@NIX_R_LIBS_SITE@' "$R_LIBS_SITE"
+      substituteInPlace 'rpy2/rinterface_lib/embedded.py' --replace '@NIX_R_LIBS_SITE@' "$R_LIBS_SITE"
     '';
 
     propagatedBuildInputs = [
-      singledispatch
-      six
+      ipython
       jinja2
       pytz
+      pandas
       numpy
+      cffi
+      tzlocal
+      simplegeneric
     ];
 
     checkInputs = [
       pytest
-      mock
     ];
-    # One remaining test failure caused by different unicode encoding.
-    # https://bitbucket.org/rpy2/rpy2/issues/488
-    doCheck = false;
-    checkPhase = ''
-      ${python.interpreter} -m 'rpy2.tests'
-    '';
-
-    # For some reason libreadline.so is not found. Curiously `ldd _rinterface.so | grep readline` shows two readline entries:
-    # libreadline.so.6 => not found
-    # libreadline.so.6 => /nix/store/z2zhmrg6jcrn5iq2779mav0nnq4vm2q6-readline-6.3p08/lib/libreadline.so.6 (0x00007f333ac43000)
-    # There must be a better way to fix this, but I don't know it.
-    postFixup = ''
-      patchelf --add-needed ${readline}/lib/libreadline.so "$out/${python.sitePackages}/rpy2/rinterface/"_rinterface*.so
-    '';
 
     meta = {
       homepage = http://rpy.sourceforge.net/rpy2;

--- a/pkgs/development/python-modules/rpy2/rpy2-3.x-r-libs-site.patch
+++ b/pkgs/development/python-modules/rpy2/rpy2-3.x-r-libs-site.patch
@@ -1,0 +1,21 @@
+diff --git a/rpy2/rinterface_lib/embedded.py b/rpy2/rinterface_lib/embedded.py
+index cc32b6d..3969ad0 100644
+--- a/rpy2/rinterface_lib/embedded.py
++++ b/rpy2/rinterface_lib/embedded.py
+@@ -113,6 +113,16 @@ def _initr(interactive: bool = True,
+         if isinitialized():
+             return None
+         os.environ['R_HOME'] = openrlib.R_HOME
++
++        # path to libraries
++        existing = os.environ.get('R_LIBS_SITE')
++        if existing is not None:
++            prefix = existing + ':'
++        else:
++            prefix = ''
++        additional = '@NIX_R_LIBS_SITE@'
++        os.environ['R_LIBS_SITE'] = prefix + additional
++
+         options_c = [ffi.new('char[]', o.encode('ASCII')) for o in _options]
+         n_options = len(options_c)
+         n_options_c = ffi.cast('int', n_options)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5032,7 +5032,9 @@ in {
 
   rpmfluff = callPackage ../development/python-modules/rpmfluff {};
 
-  rpy2 = callPackage ../development/python-modules/rpy2 {};
+  rpy2 = if isPy3k
+    then callPackage ../development/python-modules/rpy2 { }
+    else callPackage ../development/python-modules/rpy2/2.nix { };
 
   rtslib = callPackage ../development/python-modules/rtslib {};
 


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

There have been significant changes, therefore it doesn't make sense
anymore to maintain the python2 and python3 version in the same file.
We'll be able to drop the python2 version soon, some time after we have
switched sage to python3.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
