### PR TITLE
pythonPackages.moviepy: switch to opencv3

### DIFF
--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -11,7 +11,7 @@
 , tqdm
 # Advanced image processing (triples size of output)
 , advancedProcessing ? false
-, opencv ? null
+, opencv3 ? null
 , scikitimage ? null
 , scikitlearn ? null
 , scipy ? null
@@ -20,7 +20,7 @@
 }:
 
 assert advancedProcessing -> (
-  opencv != null && scikitimage != null && scikitlearn != null
+  opencv3 != null && scikitimage != null && scikitlearn != null
   && scipy != null && matplotlib != null && youtube-dl != null);
 
 buildPythonPackage rec {
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     numpy decorator imageio imageio-ffmpeg tqdm requests proglog
   ] ++ (stdenv.lib.optionals advancedProcessing [
-    opencv scikitimage scikitlearn scipy matplotlib youtube-dl
+    opencv3 scikitimage scikitlearn scipy matplotlib youtube-dl
   ]);
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
opencv2 is essentially EOL and has security concerns

The package's `setup.py` itself does list its opencv dependency as `opencv-python>=3.0,<4.0` so this "should be fine".

It's a tricky package to test - the tests are present in the github repo, but even then they are very much not self-contained, and none of the tests seem to cover any of the opencv-provided functionality anyway.

The package itself is a bit problematic tbh, with undeclared runtime dependencies on cli tools like `ffmpeg` being present.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
