### PR TITLE
spago: init at 0.12.1.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2594,6 +2594,7 @@ package-maintainers:
   cdepillabout:
     - pretty-simple
     - purescript
+    - spago
     - termonad
 
 unsupported-platforms:

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -636,4 +636,60 @@ self: super: builtins.intersectAttrs super {
   # need it during the build itself, too.
   cairo = addBuildTool super.cairo self.buildHaskellPackages.gtk2hs-buildtools;
   pango = disableHardening (addBuildTool super.pango self.buildHaskellPackages.gtk2hs-buildtools) ["fortify"];
+
+  spago =
+    let
+      # Spago basically compiles with LTS-14, but it requires a newer version
+      # of directory.  This is to work around a bug only present on windows, so
+      # we can safely jailbreak spago and use the older directory package from
+      # LTS-14.
+      spagoWithOverrides = doJailbreak (super.spago.override {
+        # spago requires the latest version of dhall.
+        directory = self.dhall_1_27_0;
+      });
+
+      docsSearchAppJsFile = pkgs.fetchurl {
+        url = "https://github.com/spacchetti/purescript-docs-search/releases/download/v0.0.5/docs-search-app.js";
+        sha256 = "11721x455qzh40vzfmralaynn9v8b5wix86r107hhs08vhryjib2";
+      };
+
+      purescriptDocsSearchFile = pkgs.fetchurl {
+        url = "https://github.com/spacchetti/purescript-docs-search/releases/download/v0.0.5/purescript-docs-search";
+        sha256 = "16p1fmdvpwz1yswav8qjsd26c9airb22xncqw1rjnbd8lcpqx0p5";
+      };
+
+      spagoFixHpack = overrideCabal spagoWithOverrides (drv: {
+        postUnpack = (drv.postUnpack or "") + ''
+          # The source for spago is pulled directly from GitHub.  It uses a
+          # package.yaml file with hpack, not a .cabal file.  In the package.yaml file,
+          # it uses defaults from the master branch of the hspec repo.  It will try to
+          # fetch these at build-time (but it will fail if running in the sandbox).
+          #
+          # The following line modifies the package.yaml to not pull in
+          # defaults from the hspec repo.
+          substituteInPlace "$sourceRoot/package.yaml" --replace 'defaults: hspec/hspec@master' ""
+
+          # Spago includes the following two files directly into the binary
+          # with Template Haskell.  They are fetched at build-time from the
+          # `purescript-docs-search` repo above.  If they cannot be fetched at
+          # build-time, they are pulled in from the `templates/` directory in
+          # the spago source.
+          #
+          # However, they are not actually available in the spago source, so they
+          # need to fetched with nix and put in the correct place.
+          # https://github.com/spacchetti/spago/issues/510
+          cp ${docsSearchAppJsFile} "$sourceRoot/templates/docs-search-app.js"
+          cp ${purescriptDocsSearchFile} "$sourceRoot/templates/purescript-docs-search"
+        '';
+      });
+
+      # Haddock generation is broken for spago.
+      # https://github.com/spacchetti/spago/issues/511
+      spagoWithoutHaddocks = dontHaddock spagoFixHpack;
+
+      # Because of the problem above with pulling in hspec defaults to the
+      # package.yaml file, the tests are disabled.
+      spagoWithoutChecks = dontCheck spagoWithoutHaddocks;
+    in
+    spagoWithoutChecks;
 }

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -13,4 +13,7 @@ self: super: {
   # https://github.com/channable/vaultenv/issues/1
   vaultenv = self.callPackage ../tools/haskell/vaultenv { };
 
+  # spago is not released to Hackage.
+  # https://github.com/spacchetti/spago/issues/512
+  spago = self.callPackage ../tools/purescript/spago { };
 }

--- a/pkgs/development/tools/purescript/spago/default.nix
+++ b/pkgs/development/tools/purescript/spago/default.nix
@@ -1,0 +1,47 @@
+{ mkDerivation, aeson, aeson-pretty, ansi-terminal, async-pool
+, base, bower-json, bytestring, Cabal, containers, dhall, directory
+, either, exceptions, extra, fetchgit, file-embed, filepath, foldl
+, fsnotify, github, Glob, hpack, hspec, hspec-discover
+, hspec-megaparsec, http-client, http-conduit, lens-family-core
+, megaparsec, mtl, network-uri, open-browser, optparse-applicative
+, prettyprinter, process, QuickCheck, retry, rio, rio-orphans, safe
+, semver-range, stdenv, stm, tar, template-haskell, temporary, text
+, time, transformers, turtle, unliftio, unordered-containers
+, vector, versions, zlib
+}:
+mkDerivation {
+  pname = "spago";
+  version = "0.12.1.0";
+  src = fetchgit {
+    url = "https://github.com/spacchetti/spago";
+    sha256 = "17xgp75yxangmb65sv3raysad31kmc109c4q4aj9dgcdqz23fcn2";
+    rev = "a4679880402ead320f8be2f091b25d30e27b62df";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson aeson-pretty ansi-terminal async-pool base bower-json
+    bytestring Cabal containers dhall directory either exceptions
+    file-embed filepath foldl fsnotify github Glob http-client
+    http-conduit lens-family-core megaparsec mtl network-uri
+    open-browser prettyprinter process retry rio rio-orphans safe
+    semver-range stm tar template-haskell temporary text time
+    transformers turtle unliftio unordered-containers vector versions
+    zlib
+  ];
+  libraryToolDepends = [ hpack ];
+  executableHaskellDepends = [
+    aeson-pretty async-pool base bytestring containers dhall filepath
+    github lens-family-core megaparsec optparse-applicative process
+    retry stm temporary text time turtle vector
+  ];
+  testHaskellDepends = [
+    base containers directory extra hspec hspec-megaparsec megaparsec
+    process QuickCheck temporary text turtle versions
+  ];
+  testToolDepends = [ hspec-discover ];
+  prePatch = "hpack";
+  homepage = "https://github.com/spacchetti/spago#readme";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8111,6 +8111,8 @@ in
   psc-package = haskell.lib.justStaticExecutables
     (haskellPackages.callPackage ../development/compilers/purescript/psc-package { });
 
+  spago = haskell.lib.justStaticExecutables haskellPackages.spago;
+
   tacacsplus = callPackage ../servers/tacacsplus { };
 
   tamarin-prover =


### PR DESCRIPTION
This commit adds the spago package, a PureScript package manager and build tool.

https://github.com/spacchetti/spago

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

Since `spago` is a Haskell package, cc @peti.
