### PR TITLE
qnotero: 1.0.0->2.1.1

### DIFF
--- a/pkgs/applications/office/qnotero/default.nix
+++ b/pkgs/applications/office/qnotero/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub, python3Packages
-}:
+{ stdenv, fetchFromGitHub, python3Packages, wrapQtAppsHook }:
 
 python3Packages.buildPythonPackage rec {
   pname = "qnotero";
@@ -13,7 +12,7 @@ python3Packages.buildPythonPackage rec {
     sha256 = "16ckcjxa3dgmz1y8gd57q2h84akra3j4bgl4fwv4m05bam3ml1xs";
   };
 
-  propagatedBuildInputs = [ python3Packages.pyqt5 ];
+  propagatedBuildInputs = [ python3Packages.pyqt5 wrapQtAppsHook ];
 
   patchPhase = ''
       substituteInPlace ./setup.py \
@@ -21,6 +20,10 @@ python3Packages.buildPythonPackage rec {
 
       substituteInPlace ./libqnotero/_themes/light.py \
          --replace "/usr/share" "$out/usr/share"
+  '';
+
+  preFixup = ''
+    wrapQtApp "$out"/bin/qnotero
   '';
 
   meta = {

--- a/pkgs/applications/office/qnotero/default.nix
+++ b/pkgs/applications/office/qnotero/default.nix
@@ -2,16 +2,15 @@
 }:
 
 python3Packages.buildPythonPackage rec {
-  name = "qnotero-${version}";
+  pname = "qnotero";
 
-  version = "1.0.0";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
-    owner = "smathot";
-    repo = "qnotero";
-    rev = "release/${version}";
-    name = "qnotero-${version}-src";
-    sha256 = "1d5a9k1llzn9q1qv1bfwc7gfflabh4riplz9jj0hf04b279y1bj0";
+    owner = "ealbiter";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "16ckcjxa3dgmz1y8gd57q2h84akra3j4bgl4fwv4m05bam3ml1xs";
   };
 
   propagatedBuildInputs = [ python3Packages.pyqt4 ];
@@ -20,7 +19,7 @@ python3Packages.buildPythonPackage rec {
       substituteInPlace ./setup.py \
         --replace "/usr/share" "usr/share"
 
-      substituteInPlace ./libqnotero/_themes/default.py \
+      substituteInPlace ./libqnotero/_themes/light.py \
          --replace "/usr/share" "$out/usr/share"
   '';
 

--- a/pkgs/applications/office/qnotero/default.nix
+++ b/pkgs/applications/office/qnotero/default.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonPackage rec {
     sha256 = "16ckcjxa3dgmz1y8gd57q2h84akra3j4bgl4fwv4m05bam3ml1xs";
   };
 
-  propagatedBuildInputs = [ python3Packages.pyqt4 ];
+  propagatedBuildInputs = [ python3Packages.pyqt5 ];
 
   patchPhase = ''
       substituteInPlace ./setup.py \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20795,7 +20795,7 @@ in
 
   qmmp = libsForQt5.callPackage ../applications/audio/qmmp { };
 
-  qnotero = callPackage ../applications/office/qnotero { };
+  qnotero = libsForQt5.callPackage ../applications/office/qnotero { };
 
   qrcode = callPackage ../tools/graphics/qrcode {};
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Old repo was archived,but fork by @ealbiter is still mantained

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nico202 
