### PR TITLE
pick-colour-picker: init at unstable-2019-10-11

### DIFF
--- a/pkgs/applications/graphics/pick-colour-picker/default.nix
+++ b/pkgs/applications/graphics/pick-colour-picker/default.nix
@@ -1,0 +1,66 @@
+{ stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, pygobject3
+, pycairo
+, glib
+, gtk3
+, gobject-introspection
+, wrapGAppsHook
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "pick-colour-picker";
+  version = "unstable-2019-10-11"; # "1.5.0-3ec940"
+
+  src = fetchFromGitHub {
+    owner = "stuartlangridge";
+    repo = "ColourPicker";
+    rev = "3ec9406d787ce373f6db0d520ed38a921edb9473";
+    sha256 = "04l8ch9297nhkgcmyhsbg0il424c8vy0isns1c7aypn0zp0dc4zd";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  pythonPath = [
+    pygobject3
+    pycairo
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+  ];
+
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  # this must be false, otherwise the gobject-introspection hook doesn't run
+  strictDeps = false;
+
+  preDistPhases = [ "fixupIconPath" ];
+
+  fixupIconPath = ''
+    pickLoc="$out/${python.sitePackages}/pick"
+    shareLoc=$(echo "$out/${python.sitePackages}/nix/store/"*)
+    mv "$shareLoc/share" "$out/share"
+
+    sed "s|os.environ.get('SNAP'), \"usr\"|'$out'|g" -i "$pickLoc/__main__.py"
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://kryogenix.org/code/pick/";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    description = "A colour picker that remembers where you picked colours from";
+    maintainers = [ maintainers.mkg20001 ];
+
+    longDescription = ''
+      Pick lets you pick colours from anywhere on your screen. Choose the colour you want and Pick remembers it, names it, and shows you a screenshot so you can remember where you got it from.
+
+      Zoom all the way in to pixels to pick just the right one. Show your colours in your choice of format: rgba() or hex, CSS or Gdk or Qt, whichever you prefer. Copy to the clipboard ready for pasting into code or graphics apps.
+      '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24962,6 +24962,10 @@ in
 
   rfc-bibtex = python3Packages.callPackage ../development/python-modules/rfc-bibtex { };
 
+  pick-colour-picker = python3Packages.callPackage ../applications/graphics/pick-colour-picker {
+    inherit (pkgs) glib gtk3 gobject-introspection wrapGAppsHook;
+  };
+
   rpl = callPackage ../tools/text/rpl {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Need this for myself. Other might need it, too

###### Things done
Added python package "pick-colour-picker"

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
