### PR TITLE
python: pip-tools: 4.2.0 -> 4.3.0

### DIFF
--- a/pkgs/development/python-modules/pip-tools/default.nix
+++ b/pkgs/development/python-modules/pip-tools/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, fetchPypi, buildPythonPackage, pip, pytest, click, six, first
+{ stdenv, fetchPypi, buildPythonPackage, pip, pytest, click, six
 , setuptools_scm, git, glibcLocales, mock }:
 
 buildPythonPackage rec {
   pname = "pip-tools";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5427ea4dcc175649723985fbcace9b2d8f46f9adbcc63bc2d7b247d9bcc74917";
+    sha256 = "0x36mp3a3f3wandfc0g8d53gg2jkc14nhisbryzspcl9f05sbvq6";
   };
 
   LC_ALL = "en_US.UTF-8";
   checkInputs = [ pytest git glibcLocales mock ];
-  propagatedBuildInputs = [ pip click six first setuptools_scm ];
+  propagatedBuildInputs = [ pip click six setuptools_scm ];
 
   disabledTests = stdenv.lib.concatMapStringsSep " and " (s: "not " + s) [
     # Depend on network tests:
@@ -32,12 +32,8 @@ buildPythonPackage rec {
     "test_stdin"
     "test_upgrade_packages_option"
     "test_url_package"
-    # Expect specific version of "six":
     "test_editable_package"
-    "test_input_file_without_extension"
     "test_locally_available_editable_package_is_not_archived_in_cache_dir"
-    "test_no_candidates"
-    "test_no_candidates_pre"
   ];
 
   checkPhase = ''
@@ -50,6 +46,5 @@ buildPythonPackage rec {
     homepage = https://github.com/jazzband/pip-tools/;
     license = licenses.bsd3;
     maintainers = with maintainers; [ zimbatm ];
-    broken = true;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

There is a new pip-tools release. A commit [removing the test dependency
on six] is included in this release, so several tests that now pass are
being re-enabled in the check phase. The six-specific tests that still
don't pass require network access and remain disabled. Finally, drop the
dependency on first, which has been dropped by pip-tools. The full
changelog is available at https://github.com/jazzband/pip-tools/blob/f28d1a7d25c8a490071b01e48b3c1b393ada2e23/CHANGELOG.md#430-2019-11-25.

[removing the test dependency on six]: jazzband/pip-tools#939

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @zimbatm 
