### PR TITLE
gaia: 2.4.5 -> 2.4.6

### DIFF
--- a/pkgs/development/libraries/gaia/default.nix
+++ b/pkgs/development/libraries/gaia/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , libyaml
 , swig
+, eigen
 , pkgconfig
 , wafHook
 , makeWrapper
@@ -19,13 +20,13 @@ assert pythonSupport -> pythonPackages != null;
 
 stdenv.mkDerivation rec {
   pname = "gaia";
-  version = "2.4.5";
+  version = "2.4.6";
 
   src = fetchFromGitHub {
     owner = "MTG";
     repo = "gaia";
     rev = "v${version}";
-    sha256 = "12jxb354s2dblr2ghnl3w05m23jgzvrrgywfj8jaa32j3gw48fv2";
+    sha256 = "03vmdq7ca4f7zp2f4sxyqa8sdpdma3mn9fz4z7d93qryl0bhi7z3";
   };
 
   # Fix installation error when waf tries to put files in /etc/
@@ -50,6 +51,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libyaml
+    eigen
     qt4
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
