### PR TITLE
treewide: reference nixos tests in packages

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, fetchpatch, openssl, zlib, pcre, libxml2, libxslt
+, nixosTests
 , substituteAll, gd, geoip, perl
 , withDebug ? false
 , withStream ? true
@@ -109,7 +110,10 @@ stdenv.mkDerivation {
     mv $out/sbin $out/bin
   '';
 
-  passthru.modules = modules;
+  passthru = {
+    modules = modules;
+    tests.nginx = nixosTests.nginx;
+  };
 
   meta = {
     description = "A reverse proxy and lightweight webserver";

--- a/pkgs/servers/nosql/redis/default.nix
+++ b/pkgs/servers/nosql/redis/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lua, jemalloc }:
+{ stdenv, fetchurl, lua, jemalloc, nixosTests }:
 
 stdenv.mkDerivation rec {
   version = "5.0.6";
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   doCheck = false; # needs tcl
+
+  passthru.tests.redis = nixosTests.redis;
 
   meta = with stdenv.lib; {
     homepage = https://redis.io;

--- a/pkgs/tools/networking/ferm/default.nix
+++ b/pkgs/tools/networking/ferm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, perl, ebtables, ipset, iptables }:
+{ stdenv, fetchurl, makeWrapper, perl, ebtables, ipset, iptables, nixosTests }:
 
 stdenv.mkDerivation rec {
   version = "2.4.1";
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
       wrapProgram "$i" --prefix PATH : "${iptables}/bin:${ipset}/bin:${ebtables}/bin"
     done
   '';
+
+  passthru.tests.ferm = nixosTests.ferm;
 
   meta = {
     homepage = http://ferm.foo-projects.org/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

so @r-ryantm can pick them up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
