### PR TITLE
pkgs/build-support/trivial-builders: add runCommandLocal

### DIFF
--- a/doc/builders/trivial-builders.xml
+++ b/doc/builders/trivial-builders.xml
@@ -52,11 +52,11 @@
   </varlistentry>
   <varlistentry xml:id="trivial-builder-runCommandLocal">
    <term>
-    <literal>runCommandLocal</literal>, <literal>runCommandCCLocal</literal>
+    <literal>runCommandLocal</literal>
    </term>
    <listitem>
     <para>
-     Variants of <literal>runCommand</literal> and <literal>runCommandCC</literal> that force the derivation to be built locally, it is not substituted. This is intended for very cheap commands (&lt;1s execution time). It saves on the network roundrip and can speed up a build.
+     Variant of <literal>runCommand</literal> that forces the derivation to be built locally, it is not substituted. This is intended for very cheap commands (&lt;1s execution time). It saves on the network roundrip and can speed up a build.
     </para>
     <note><para>
       This sets <link xlink:href="https://nixos.org/nix/manual/#adv-attr-allowSubstitutes"><literal>allowSubstitutes</literal> to <literal>false</literal></link>, so only use <literal>runCommandLocal</literal> if you are certain the user will always have a builder for the <literal>system</literal> of the derivation. This should be true for most trivial use cases (e.g. just copying some files to a different location or adding symlinks), because there the <literal>system</literal> is usually the same as <literal>builtins.currentSystem</literal>.

--- a/doc/builders/trivial-builders.xml
+++ b/doc/builders/trivial-builders.xml
@@ -7,7 +7,7 @@
   Nixpkgs provides a couple of functions that help with building derivations. The most important one, <function>stdenv.mkDerivation</function>, has already been documented above. The following functions wrap <function>stdenv.mkDerivation</function>, making it easier to use in certain cases.
  </para>
  <variablelist>
-  <varlistentry>
+  <varlistentry xml:id="trivial-builder-runCommand">
    <term>
     <literal>runCommand</literal>
    </term>
@@ -40,7 +40,7 @@
 </programlisting>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="trivial-builder-runCommandCC">
    <term>
     <literal>runCommandCC</literal>
    </term>
@@ -50,7 +50,7 @@
     </para>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="trivial-builder-runCommandLocal">
    <term>
     <literal>runCommandLocal</literal>, <literal>runCommandCCLocal</literal>
    </term>
@@ -63,7 +63,7 @@
     </para></note>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="trivial-builder-writeText">
    <term>
     <literal>writeTextFile</literal>, <literal>writeText</literal>, <literal>writeTextDir</literal>, <literal>writeScript</literal>, <literal>writeScriptBin</literal>
    </term>
@@ -76,7 +76,7 @@
     </para>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="trivial-builder-symlinkJoin">
    <term>
     <literal>symlinkJoin</literal>
    </term>

--- a/doc/builders/trivial-builders.xml
+++ b/doc/builders/trivial-builders.xml
@@ -52,6 +52,19 @@
   </varlistentry>
   <varlistentry>
    <term>
+    <literal>runCommandLocal</literal>, <literal>runCommandCCLocal</literal>
+   </term>
+   <listitem>
+    <para>
+     Variants of <literal>runCommand</literal> and <literal>runCommandCC</literal> that force the derivation to be built locally, it is not substituted. This is intended for very cheap commands (&lt;1s execution time). It saves on the network roundrip and can speed up a build.
+    </para>
+    <note><para>
+      This sets <link xlink:href="https://nixos.org/nix/manual/#adv-attr-allowSubstitutes"><literal>allowSubstitutes</literal> to <literal>false</literal></link>, so only use <literal>runCommandLocal</literal> if you are certain the user will always have a builder for the <literal>system</literal> of the derivation. This should be true for most trivial use cases (e.g. just copying some files to a different location or adding symlinks), because there the <literal>system</literal> is usually the same as <literal>builtins.currentSystem</literal>.
+    </para></note>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
     <literal>writeTextFile</literal>, <literal>writeText</literal>, <literal>writeTextDir</literal>, <literal>writeScript</literal>, <literal>writeScriptBin</literal>
    </term>
    <listitem>

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -45,8 +45,8 @@ rec {
   runCommandNoCCLocal = runCommand' true stdenvNoCC;
 
   runCommandCC = runCommand' false stdenv;
-  runCommandCCLocal = runCommand' true stdenv;
-
+  # `runCommandCCLocal` left out on purpose.
+  # We shouldn’t force the user to have a cc in scope.
 
   /* Writes a text file to the nix store.
    * The contents of text is added to the file in the store.


### PR DESCRIPTION
A definition I’ve been copy-pasting everywhere so far, so it’s finally
time to add it to nixpkgs.

I’m using a remote builder for my regular nix builds, so trivial
`runCommand`s which first try a substitution and then copy the inputs
to the builder to run for 0.2s are quite noticable.

If we just always build these, we gain some build time, so let’s make
it easy to switch from remote to local.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Infinisil 
