### PR TITLE
pythonPackages.testing-postgresql: init at unstable-2017-10-31

### DIFF
--- a/pkgs/development/python-modules/testing-common-database/default.nix
+++ b/pkgs/development/python-modules/testing-common-database/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi  }:
+
+buildPythonPackage rec {
+  pname = "testing.common.database";
+  version = "2.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wvdv0frl7xib05sixjv9m6jywaa2wdhdhsqqdfk45akk2r80pcn";
+  };
+
+  # There are no unit tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "utilities for testing.* packages";
+    homepage = "https://github.com/tk0miya/testing.common.database";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/development/python-modules/testing-postgresql/default.nix
+++ b/pkgs/development/python-modules/testing-postgresql/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchFromGitHub, postgresql, testing-common-database
+, pg8000, pytestCheckHook, psycopg2, sqlalchemy }:
+
+buildPythonPackage rec {
+  pname = "testing.postgresql";
+  # Version 1.3.0 isn't working so let's use the latest commit from GitHub
+  version = "unstable-2017-10-31";
+
+  src = fetchFromGitHub {
+    owner = "tk0miya";
+    repo = pname;
+    rev = "c81ded434d00ec8424de0f9e1f4063c778c6aaa8";
+    sha256 = "1asqsi38di768i1sc1qm1k068dj0906ds6lnx7xcbxws0s25m2q3";
+  };
+
+  # Add PostgreSQL to search path
+  prePatch = ''
+    substituteInPlace src/testing/postgresql.py \
+      --replace "/usr/local/pgsql" "${postgresql}"
+  '';
+
+  propagatedBuildInputs = [ testing-common-database pg8000 ];
+
+  # Fix tests for Darwin build. See:
+  # https://github.com/NixOS/nixpkgs/pull/74716#issuecomment-598546916
+  __darwinAllowLocalNetworking = true;
+
+  checkInputs = [ pytestCheckHook psycopg2 sqlalchemy ];
+
+  meta = with lib; {
+    description = "Use temporary postgresql instance in testing";
+    homepage = "https://github.com/tk0miya/testing.postgresql";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7120,6 +7120,8 @@ in {
 
   textfsm = callPackage ../development/python-modules/textfsm { };
 
+  testing-common-database = callPackage ../development/python-modules/testing-common-database { };
+
   testpath = callPackage ../development/python-modules/testpath { };
 
   testrepository = callPackage ../development/python-modules/testrepository { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7122,6 +7122,8 @@ in {
 
   testing-common-database = callPackage ../development/python-modules/testing-common-database { };
 
+  testing-postgresql = callPackage ../development/python-modules/testing-postgresql { };
+
   testpath = callPackage ../development/python-modules/testpath { };
 
   testrepository = callPackage ../development/python-modules/testrepository { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add `testing.postgresql` Python package and its dependencies and fixes to dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
