### PR TITLE
linux-testing-drm-next: init at 5.5-2019-11-27

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing-drm-next.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-drm-next.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPackages, fetchgit, perl, buildLinux, modDirVersionArg ? null, ... } @ args:
+
+with stdenv.lib;
+
+buildLinux (args // rec {
+  version = "5.5-2019-11-27";
+  modDirVersion = "5.4.0-rc7";
+
+  src = fetchgit {
+    url = "https://anongit.freedesktop.org/git/drm/drm.git";
+    rev = "acc61b8929365e63a3e8c8c8913177795aa45594";
+    sha256 = "0zaxq57zz5jfyscfsq5gq0fx7mr2z9nqgyb2r0sydx33z7ddl4is";
+  };
+
+  extraMeta = {
+    branch = "drm-next";
+    hydraPlatforms = [];
+  };
+} // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16254,6 +16254,12 @@ in
       ];
   };
 
+  linux_testing_drm_next = callPackage ../os-specific/linux/kernel/linux-testing-drm-next.nix {
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+    ];
+  };
+
   linux_hardkernel_4_14 = callPackage ../os-specific/linux/kernel/linux-hardkernel-4.14.nix {
     kernelPatches = [
       kernelPatches.bridge_stp_helper
@@ -16480,6 +16486,9 @@ in
 
   # Build a kernel with bcachefs module
   linuxPackages_testing_bcachefs = recurseIntoAttrs (linuxPackagesFor pkgs.linux_testing_bcachefs);
+
+  # Build a kernel for drm-next branch
+  linuxPackages_testing_drm_next = recurseIntoAttrs (linuxPackagesFor pkgs.linux_testing_drm_next);
 
   # Build a kernel for Xen dom0
   linuxPackages_xen_dom0 = recurseIntoAttrs (linuxPackagesFor (pkgs.linux.override { features.xen_dom0=true; }));


### PR DESCRIPTION
###### Motivation for this change
drm-next is a Linux kernel branch that contains the newest changes for graphics drivers and would be especially useful for people with newer graphics cards and want the most up to date drivers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NeQuissimus 