### PR TITLE
sourcehut.listssrht: add pygit2

### DIFF
--- a/pkgs/applications/version-management/sourcehut/lists.nix
+++ b/pkgs/applications/version-management/sourcehut/lists.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, buildPythonPackage
 , python
-, srht, asyncpg, unidiff, aiosmtpd, emailthreads }:
+, srht, asyncpg, unidiff, aiosmtpd, pygit2, emailthreads }:
 
 buildPythonPackage rec {
   pname = "listssrht";
@@ -20,6 +20,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     srht
+    pygit2
     asyncpg
     unidiff
     aiosmtpd


### PR DESCRIPTION
###### Motivation for this change
while reviewing #74556, i noticed this failure

```
  File "/nix/store/dra8l6vjjjvfma90lj2whqkimr1n6r8b-python3.7-listssrht-0.38.3/bin/.listssrht-lmtp-wrapped", line 8, in <module>
    from listssrht.types.listaccess import ListAccess
  File "/nix/store/dra8l6vjjjvfma90lj2whqkimr1n6r8b-python3.7-listssrht-0.38.3/lib/python3.7/site-packages/listssrht/types/__init__.py", line 3, in <module>
    from listssrht.types.email import Email
  File "/nix/store/dra8l6vjjjvfma90lj2whqkimr1n6r8b-python3.7-listssrht-0.38.3/lib/python3.7/site-packages/listssrht/types/email.py", line 3, in <module>
    import pygit2
ModuleNotFoundError: No module named 'pygit2'
```
now it fails with actual runtime error because I don't know how to use it :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
