### PR TITLE
home-assistant: Init packages needed for ZHA usage of zigpy deconz usb sticks

### DIFF
--- a/pkgs/development/python-modules/crccheck/default.nix
+++ b/pkgs/development/python-modules/crccheck/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, nose }:
+
+buildPythonPackage rec {
+  pname = "crccheck";
+  version = "0.6";
+
+  buildInputs = [ nose ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ckymm6s5kw08i1j35fy2cfha1hyq94pq1kc66brb552qgjs91jn";
+    extension = "zip";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Python library for CRCs and checksums";
+    homepage = "https://bitbucket.org/martin_scharrer/crccheck";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/pyserial-asyncio/default.nix
+++ b/pkgs/development/python-modules/pyserial-asyncio/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, pyserial }:
+
+buildPythonPackage rec {
+  pname = "pyserial-asyncio";
+  version = "0.4";
+
+  disabled = !isPy3k; # Doesn't support python older than 3.4
+
+  buildInputs = [ pyserial ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vlsb0d03krxlj7vpvyhpinnyxyy8s3lk5rs8ba2932dhyl7f1n4";
+  };
+
+  meta = with stdenv.lib; {
+    description = "asyncio extension package for pyserial";
+    homepage = "https://github.com/pyserial/pyserial-asyncio";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, aiohttp, zigpy
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "zha-quirks";
+  version = "0.0.28";
+
+  nativeBuildInputs = [ pytest ];
+  buildInputs = [ aiohttp zigpy ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "021z5f5dm74amxkqnz4s1690ydprciqg23jz3n4mpjlxyxbdfj73";
+  };
+
+  meta = with stdenv.lib; {
+    description = "ZHA Device Handlers are custom quirks implementations for Zigpy";
+    homepage = "https://github.com/dmulcahey/zha-device-handlers";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/zigpy-deconz/default.nix
+++ b/pkgs/development/python-modules/zigpy-deconz/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, aiohttp, crccheck, pyserial, pyserial-asyncio, pycryptodome, zigpy
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "zigpy-deconz";
+  version = "0.7.0";
+
+  nativeBuildInputs = [ pytest ];
+  buildInputs = [ aiohttp crccheck pycryptodome ];
+  propagatedBuildInputs = [ pyserial pyserial-asyncio zigpy ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "049k6lvgf6yjkinbbzm7gqrzqljk2ky9kfw8n53x8kjyfmfp71i2";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Library which communicates with Deconz radios for zigpy";
+    homepage = "https://github.com/zigpy/zigpy-deconz";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, aiohttp, crccheck, pycryptodome, pycrypto
+, pytest, pytest-asyncio, asynctest }:
+
+buildPythonPackage rec {
+  pname = "zigpy-homeassistant";
+  version = "0.11.0";
+
+  nativeBuildInputs = [ pytest pytest-asyncio asynctest ];
+  buildInputs = [ aiohttp pycryptodome ];
+  propagatedBuildInputs = [ crccheck pycrypto ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "021wg9yhz8dsif60r8s5621mf63bsayjjb2bimhq0am03ql0fysl";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Library implementing a ZigBee stack";
+    homepage = "https://github.com/zigpy/zigpy";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -644,7 +644,7 @@
     "sensehat" = ps: with ps; [  ];
     "sensibo" = ps: with ps; [  ];
     "sensor" = ps: with ps; [  ];
-    "serial" = ps: with ps; [  ];
+    "serial" = ps: with ps; [ pyserial-asyncio ];
     "serial_pm" = ps: with ps; [  ];
     "sesame" = ps: with ps; [  ];
     "seven_segments" = ps: with ps; [  ];
@@ -814,7 +814,7 @@
     "vicare" = ps: with ps; [  ];
     "vivotek" = ps: with ps; [  ];
     "vizio" = ps: with ps; [  ];
-    "vlc" = ps: with ps; [  ];
+    "vlc" = ps: with ps; [ python-vlc ];
     "vlc_telnet" = ps: with ps; [  ];
     "voicerss" = ps: with ps; [  ];
     "volkszaehler" = ps: with ps; [  ];
@@ -873,7 +873,7 @@
     "zengge" = ps: with ps; [  ];
     "zeroconf" = ps: with ps; [ aiohttp-cors zeroconf ];
     "zestimate" = ps: with ps; [ xmltodict ];
-    "zha" = ps: with ps; [  ];
+    "zha" = ps: with ps; [ zha-quirks zigpy-deconz zigpy ];
     "zhong_hong" = ps: with ps; [  ];
     "zigbee" = ps: with ps; [  ];
     "ziggo_mediabox_xl" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2276,6 +2276,8 @@ in {
 
   zict = callPackage ../development/python-modules/zict { };
 
+  zigpy = callPackage ../development/python-modules/zigpy { };
+
   digital-ocean = callPackage ../development/python-modules/digitalocean { };
 
   leather = callPackage ../development/python-modules/leather { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1730,6 +1730,8 @@ in {
 
   crc16 = callPackage ../development/python-modules/crc16 { };
 
+  crccheck = callPackage ../development/python-modules/crccheck { };
+
   croniter = callPackage ../development/python-modules/croniter { };
 
   csscompressor = callPackage ../development/python-modules/csscompressor {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2278,6 +2278,8 @@ in {
 
   zigpy = callPackage ../development/python-modules/zigpy { };
 
+  zigpy-deconz = callPackage ../development/python-modules/zigpy-deconz { };
+
   digital-ocean = callPackage ../development/python-modules/digitalocean { };
 
   leather = callPackage ../development/python-modules/leather { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4814,6 +4814,8 @@ in {
 
   pyserial = callPackage ../development/python-modules/pyserial {};
 
+  pyserial-asyncio = callPackage ../development/python-modules/pyserial-asyncio { };
+
   pysonos = callPackage ../development/python-modules/pysonos {};
 
   pymongo = callPackage ../development/python-modules/pymongo {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5773,6 +5773,8 @@ in {
 
   zfec = callPackage ../development/python-modules/zfec { };
 
+  zha-quirks = callPackage ../development/python-modules/zha-quirks { };
+
   zipp = callPackage ../development/python-modules/zipp { };
 
   zope_broken = callPackage ../development/python-modules/zope_broken { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
