### PR TITLE
stretchly: 0.19.1 -> 0.21.0

### DIFF
--- a/pkgs/applications/misc/stretchly/default.nix
+++ b/pkgs/applications/misc/stretchly/default.nix
@@ -1,8 +1,12 @@
 { GConf
 , alsaLib
 , at-spi2-atk
+, at-spi2-core
 , atk
+, buildFHSUserEnv
 , cairo
+, common-updater-scripts
+, coreutils
 , cups
 , dbus
 , expat
@@ -29,15 +33,19 @@
 , libnotify
 , libpciaccess
 , libpng12
+, libuuid
 , libxcb
 , nspr
 , nss
 , pango
 , pciutils
 , pulseaudio
+, runtimeShell
 , stdenv
 , udev
 , wrapGAppsHook
+, writeScript
+, file
 }:
 
 let
@@ -45,6 +53,7 @@ let
     GConf
     alsaLib
     at-spi2-atk
+    at-spi2-core
     atk
     cairo
     cups
@@ -71,6 +80,7 @@ let
     libnotify
     libpciaccess
     libpng12
+    libuuid
     libxcb
     nspr
     nss
@@ -82,58 +92,96 @@ let
   ];
 
   libPath = lib.makeLibraryPath libs;
+
+  stretchly =
+    stdenv.mkDerivation rec {
+      pname = "stretchly";
+      version = "0.21.0";
+
+      src = fetchurl {
+        url = "https://github.com/hovancik/stretchly/releases/download/v${version}/stretchly-${version}.tar.xz";
+        sha256 = "1gyyr22xq8s4miiacs8wqhp7lxnwvkvlwhngnq8671l62s6iyjzl";
+      };
+
+      nativeBuildInputs = [
+        wrapGAppsHook
+        coreutils
+      ];
+
+      buildInputs = libs;
+
+      dontPatchELF = true;
+      dontBuild = true;
+      dontConfigure = true;
+
+      installPhase = ''
+        mkdir -p $out/bin $out/lib/stretchly
+        cp -r ./* $out/lib/stretchly/
+        ln -s $out/lib/stretchly/stretchly $out/bin/
+      '';
+
+      preFixup = ''
+        patchelf --set-rpath "${libPath}" $out/lib/stretchly/libffmpeg.so
+        patchelf --set-rpath "${libPath}" $out/lib/stretchly/libEGL.so
+        patchelf --set-rpath "${libPath}" $out/lib/stretchly/libGLESv2.so
+        patchelf --set-rpath "${libPath}" $out/lib/stretchly/swiftshader/libEGL.so
+        patchelf --set-rpath "${libPath}" $out/lib/stretchly/swiftshader/libGLESv2.so
+
+        patchelf \
+          --set-rpath "$out/lib/stretchly:${libPath}" \
+          --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          $out/lib/stretchly/stretchly
+
+        patchelf \
+          --set-rpath "$out/lib/stretchly:${libPath}" \
+          --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          $out/lib/stretchly/chrome-sandbox
+      '';
+
+      meta = with stdenv.lib; {
+        description = "A break time reminder app";
+        longDescription = ''
+          stretchly is a cross-platform electron app that reminds you to take
+          breaks when working on your computer. By default, it runs in your tray
+          and displays a reminder window containing an idea for a microbreak for 20
+          seconds every 10 minutes. Every 30 minutes, it displays a window
+          containing an idea for a longer 5 minute break.
+        '';
+        homepage = https://hovancik.net/stretchly;
+        downloadPage = https://hovancik.net/stretchly/downloads/;
+        license = licenses.bsd2;
+        maintainers = with maintainers; [ cdepillabout ];
+        platforms = platforms.linux;
+      };
+    };
+
 in
 
-stdenv.mkDerivation rec {
-  pname = "stretchly";
-  version = "0.19.1";
+buildFHSUserEnv {
+  inherit (stretchly) meta;
 
-  src = fetchurl {
-    url = "https://github.com/hovancik/stretchly/releases/download/v${version}/stretchly-${version}.tar.xz";
-    sha256 = "1q2wxfqs8qv9b1rfh5lhmyp3rrgdl05m6ihsgkxlgp0yzi07afz8";
-  };
+  name = "stretchly";
 
-  nativeBuildInputs = [
-    wrapGAppsHook
+  targetPkgs = pkgs: [
+     stretchly
   ];
 
-  buildInputs = libs;
+  runScript = "stretchly";
 
-  dontPatchELF = true;
-  dontBuild = true;
-  dontConfigure = true;
+  passthru = {
+    updateScript = writeScript "update-stretchly" ''
+      #!${runtimeShell}
 
-  installPhase = ''
-    mkdir -p $out/bin $out/lib/stretchly
-    cp -r ./* $out/lib/stretchly/
-    ln -s $out/lib/stretchly/libffmpeg.so $out/lib/
-    ln -s $out/lib/stretchly/libnode.so $out/lib/
-    ln -s $out/lib/stretchly/stretchly $out/bin/
-  '';
+      set -eu -o pipefail
 
-  preFixup = ''
-    patchelf --set-rpath "${libPath}" $out/lib/stretchly/libffmpeg.so
-    patchelf --set-rpath "${libPath}" $out/lib/stretchly/libnode.so
+      # get the latest release version
+      latest_version=$(curl -s https://api.github.com/repos/hovancik/stretchly/releases/latest | jq --raw-output .tag_name | sed -e 's/^v//')
 
-    patchelf \
-      --set-rpath "$out/lib/stretchly:${libPath}" \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      $out/lib/stretchly/stretchly
-  '';
+      echo "updating to $latest_version..."
 
-  meta = with stdenv.lib; {
-    description = "A break time reminder app";
-    longDescription = ''
-      stretchly is a cross-platform electron app that reminds you to take
-      breaks when working on your computer. By default, it runs in your tray
-      and displays a reminder window containing an idea for a microbreak for 20
-      seconds every 10 minutes. Every 30 minutes, it displays a window
-      containing an idea for a longer 5 minute break.
+      ${common-updater-scripts}/bin/update-source-version stretchly.passthru.stretchlyWrapped "$latest_version"
     '';
-    homepage = https://hovancik.net/stretchly;
-    downloadPage = https://hovancik.net/stretchly/downloads/;
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ cdepillabout ];
-    platforms = platforms.linux;
+
+    stretchlyWrapped = stretchly;
   };
 }


### PR DESCRIPTION
Update [stretchly](https://github.com/hovancik/stretchly) to version 0.21.0.

I've changed this to use `buildFHSUserEnv` since I couldn't get this new version working with just `patchelf`.  Electron apps are a pain on Nix.

I also added an automatic update script that should work with `nix-shell maintainers/scripts/update.nix --argstr package stretchly`.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
