### PR TITLE
ghidra: 9.04 -> 9.1

### DIFF
--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -6,11 +6,11 @@
 
 in stdenv.mkDerivation {
 
-  name = "ghidra-9.0.4";
+  name = "ghidra-9.1";
 
   src = fetchurl {
-    url = https://ghidra-sre.org/ghidra_9.0.4_PUBLIC_20190516.zip;
-    sha256 = "1gqqxk57hswwgr97qisqivcfgjdxjipfdshyh4r76dyrfpa0q3d5";
+    url = https://ghidra-sre.org/ghidra_9.1_PUBLIC_20191023.zip;
+    sha256 = "0pl7s59008gvgwz4mxp7rz3xr3vaa12a6s5zvx2yr9jxx3gk1l99";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, unzip, lib, makeWrapper, autoPatchelfHook
-, openjdk11, pam, makeDesktopItem, imagemagick
+, openjdk11, pam, makeDesktopItem, icoutils
 }: let
 
   pkg_path = "$out/lib/ghidra";
@@ -32,7 +32,7 @@ in stdenv.mkDerivation {
   buildInputs = [
     stdenv.cc.cc.lib
     pam
-    imagemagick
+    icoutils
   ];
 
   dontStrip = true;
@@ -43,18 +43,13 @@ in stdenv.mkDerivation {
     cp -a * "${pkg_path}"
     ln -s ${desktopItem}/share/applications/* $out/share/applications
     
-    convert "${pkg_path}/support/ghidra.ico" ghidra.png
-    rm ghidra-3.png
-    for size in 16 24 32 48 64 128 256; do
-      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+    icotool -x "${pkg_path}/support/ghidra.ico"
+    rm ghidra_4_40x40x32.png
+    for f in ghidra_*.png; do
+      res=$(basename "$f" ".png" | cut -d"_" -f3 | cut -d"x" -f1-2)
+      mkdir -pv "$out/share/icons/hicolor/$res/apps"
+      mv "$f" "$out/share/icons/hicolor/$res/apps/ghidra.png"
     done;
-    mv ghidra-0.png "$out/share/icons/hicolor/16x16/apps/ghidra.png"
-    mv ghidra-1.png "$out/share/icons/hicolor/24x24/apps/ghidra.png"
-    mv ghidra-2.png "$out/share/icons/hicolor/32x32/apps/ghidra.png"
-    mv ghidra-4.png "$out/share/icons/hicolor/48x48/apps/ghidra.png"
-    mv ghidra-5.png "$out/share/icons/hicolor/64x64/apps/ghidra.png"
-    mv ghidra-6.png "$out/share/icons/hicolor/128x128/apps/ghidra.png"
-    mv ghidra-7.png "$out/share/icons/hicolor/256x256/apps/ghidra.png"
   '';
 
   postFixup = ''

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -1,8 +1,18 @@
 { stdenv, fetchurl, unzip, lib, makeWrapper, autoPatchelfHook
-, openjdk11, pam
+, openjdk11, pam, makeDesktopItem, imagemagick
 }: let
 
   pkg_path = "$out/lib/ghidra";
+
+  desktopItem = makeDesktopItem {
+    name = "ghidra";
+    exec = "ghidra";
+    icon = "ghidra";
+    desktopName = "Ghidra";
+    genericName = "Ghidra Software Reverse Engineering Suite";
+    categories = "Development;";
+  };
+
 
 in stdenv.mkDerivation {
 
@@ -22,13 +32,29 @@ in stdenv.mkDerivation {
   buildInputs = [
     stdenv.cc.cc.lib
     pam
+    imagemagick
   ];
 
   dontStrip = true;
 
   installPhase = ''
     mkdir -p "${pkg_path}"
+    mkdir -p "${pkg_path}" "$out/share/applications"
     cp -a * "${pkg_path}"
+    ln -s ${desktopItem}/share/applications/* $out/share/applications
+    
+    convert "${pkg_path}/support/ghidra.ico" ghidra.png
+    rm ghidra-3.png
+    for size in 16 24 32 48 64 128 256; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+    done;
+    mv ghidra-0.png "$out/share/icons/hicolor/16x16/apps/ghidra.png"
+    mv ghidra-1.png "$out/share/icons/hicolor/24x24/apps/ghidra.png"
+    mv ghidra-2.png "$out/share/icons/hicolor/32x32/apps/ghidra.png"
+    mv ghidra-4.png "$out/share/icons/hicolor/48x48/apps/ghidra.png"
+    mv ghidra-5.png "$out/share/icons/hicolor/64x64/apps/ghidra.png"
+    mv ghidra-6.png "$out/share/icons/hicolor/128x128/apps/ghidra.png"
+    mv ghidra-7.png "$out/share/icons/hicolor/256x256/apps/ghidra.png"
   '';
 
   postFixup = ''


### PR DESCRIPTION
Updated Ghidra from 9.04 to 9.1

###### Motivation for this change

https://ghidra-sre.org/releaseNotes_9.1_final.html

Updated Ghidra from 9.04 to 9.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ck3d
