### PR TITLE
nixosTests.nat: port to python

### DIFF
--- a/nixos/tests/nat.nix
+++ b/nixos/tests/nat.nix
@@ -3,7 +3,7 @@
 # client on the inside network, a server on the outside network, and a
 # router connected to both that performs Network Address Translation
 # for the client.
-import ./make-test.nix ({ pkgs, lib, withFirewall, withConntrackHelpers ? false, ... }:
+import ./make-test-python.nix ({ pkgs, lib, withFirewall, withConntrackHelpers ? false, ... }:
   let
     unit = if withFirewall then "firewall" else "nat";
 
@@ -69,49 +69,52 @@ import ./make-test.nix ({ pkgs, lib, withFirewall, withConntrackHelpers ? false,
         routerDummyNoNatClosure = nodes.routerDummyNoNat.config.system.build.toplevel;
         routerClosure = nodes.router.config.system.build.toplevel;
       in ''
-        $client->start;
-        $router->start;
-        $server->start;
+        client.start()
+        router.start()
+        server.start()
 
         # The router should have access to the server.
-        $server->waitForUnit("network.target");
-        $server->waitForUnit("httpd");
-        $router->waitForUnit("network.target");
-        $router->succeed("curl --fail http://server/ >&2");
+        server.wait_for_unit("network.target")
+        server.wait_for_unit("httpd")
+        router.wait_for_unit("network.target")
+        router.succeed("curl --fail http://server/ >&2")
 
         # The client should be also able to connect via the NAT router.
-        $router->waitForUnit("${unit}");
-        $client->waitForUnit("network.target");
-        $client->succeed("curl --fail http://server/ >&2");
-        $client->succeed("ping -c 1 server >&2");
+        router.wait_for_unit("${unit}")
+        client.wait_for_unit("network.target")
+        client.succeed("curl --fail http://server/ >&2")
+        client.succeed("ping -c 1 server >&2")
 
         # Test whether passive FTP works.
-        $server->waitForUnit("vsftpd");
-        $server->succeed("echo Hello World > /home/ftp/foo.txt");
-        $client->succeed("curl -v ftp://server/foo.txt >&2");
+        server.wait_for_unit("vsftpd")
+        server.succeed("echo Hello World > /home/ftp/foo.txt")
+        client.succeed("curl -v ftp://server/foo.txt >&2")
 
         # Test whether active FTP works.
-        $client->${if withConntrackHelpers then "succeed" else "fail"}(
-          "curl -v -P - ftp://server/foo.txt >&2");
+        client.${if withConntrackHelpers then "succeed" else "fail"}("curl -v -P - ftp://server/foo.txt >&2")
 
         # Test ICMP.
-        $client->succeed("ping -c 1 router >&2");
-        $router->succeed("ping -c 1 client >&2");
+        client.succeed("ping -c 1 router >&2")
+        router.succeed("ping -c 1 client >&2")
 
         # If we turn off NAT, the client shouldn't be able to reach the server.
-        $router->succeed("${routerDummyNoNatClosure}/bin/switch-to-configuration test 2>&1");
-        $client->fail("curl --fail --connect-timeout 5 http://server/ >&2");
-        $client->fail("ping -c 1 server >&2");
+        router.succeed(
+            "${routerDummyNoNatClosure}/bin/switch-to-configuration test 2>&1"
+        )
+        client.fail("curl --fail --connect-timeout 5 http://server/ >&2")
+        client.fail("ping -c 1 server >&2")
 
         # And make sure that reloading the NAT job works.
-        $router->succeed("${routerClosure}/bin/switch-to-configuration test 2>&1");
+        router.succeed(
+            "${routerClosure}/bin/switch-to-configuration test 2>&1"
+        )
         # FIXME: this should not be necessary, but nat.service is not started because
         #        network.target is not triggered
         #        (https://github.com/NixOS/nixpkgs/issues/16230#issuecomment-226408359)
         ${lib.optionalString (!withFirewall) ''
-          $router->succeed("systemctl start nat.service");
+          router.succeed("systemctl start nat.service")
         ''}
-        $client->succeed("curl --fail http://server/ >&2");
-        $client->succeed("ping -c 1 server >&2");
+        client.succeed("curl --fail http://server/ >&2")
+        client.succeed("ping -c 1 server >&2")
       '';
   })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rbvermaa 
