### PR TITLE
nixosTests.ipv6: port to python

### DIFF
--- a/nixos/tests/ipv6.nix
+++ b/nixos/tests/ipv6.nix
@@ -1,7 +1,7 @@
 # Test of IPv6 functionality in NixOS, including whether router
 # solicication/advertisement using radvd works.
 
-import ./make-test.nix ({ pkgs, lib, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ...} : {
   name = "ipv6";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ eelco ];
@@ -35,51 +35,52 @@ import ./make-test.nix ({ pkgs, lib, ...} : {
 
   testScript =
     ''
+      import re
+
       # Start the router first so that it respond to router solicitations.
-      $router->waitForUnit("radvd");
+      router.wait_for_unit("radvd")
 
-      startAll;
+      start_all()
 
-      $client->waitForUnit("network.target");
-      $server->waitForUnit("network.target");
-      $server->waitForUnit("httpd.service");
+      client.wait_for_unit("network.target")
+      server.wait_for_unit("network.target")
+      server.wait_for_unit("httpd.service")
 
       # Wait until the given interface has a non-tentative address of
       # the desired scope (i.e. has completed Duplicate Address
       # Detection).
-      sub waitForAddress {
-          my ($machine, $iface, $scope) = @_;
-          $machine->waitUntilSucceeds("[ `ip -o -6 addr show dev $iface scope $scope | grep -v tentative | wc -l` -ge 1 ]");
-          my $ip = (split /[ \/]+/, $machine->succeed("ip -o -6 addr show dev $iface scope $scope"))[3];
-          $machine->log("$scope address on $iface is $ip");
-          return $ip;
-      }
+      def wait_for_address(machine, iface, scope):
+          machine.wait_until_succeeds(
+              f"[ `ip -o -6 addr show dev {iface} scope {scope} | grep -v tentative | wc -l` -ge 1 ]"
+          )
+          output = machine.succeed(f"ip -o -6 addr show dev {iface} scope {scope}")
+          ip = re.search(r"inet6 ([0-9a-f:]{2,})/", output).group(1)
+          machine.log(f"{scope} address on {iface} is {ip}")
+          return ip
 
-      subtest "loopback address", sub {
-          $client->succeed("ping -c 1 ::1 >&2");
-          $client->fail("ping -c 1 ::2 >&2");
-      };
 
-      subtest "local link addressing", sub {
-          my $clientIp = waitForAddress $client, "eth1", "link";
-          my $serverIp = waitForAddress $server, "eth1", "link";
-          $client->succeed("ping -c 1 $clientIp%eth1 >&2");
-          $client->succeed("ping -c 1 $serverIp%eth1 >&2");
-      };
+      with subtest("Loopback address can be pinged"):
+          client.succeed("ping -c 1 ::1 >&2")
+          client.fail("ping -c 1 ::2 >&2")
 
-      subtest "global addressing", sub {
-          my $clientIp = waitForAddress $client, "eth1", "global";
-          my $serverIp = waitForAddress $server, "eth1", "global";
-          $client->succeed("ping -c 1 $clientIp >&2");
-          $client->succeed("ping -c 1 $serverIp >&2");
-          $client->succeed("curl --fail -g http://[$serverIp]");
-          $client->fail("curl --fail -g http://[$clientIp]");
-      };
-      subtest "privacy extensions", sub {
-          my $ip = waitForAddress $client, "eth1", "global temporary";
+      with subtest("Local link addresses can be obtained and pinged"):
+          client_ip = wait_for_address(client, "eth1", "link")
+          server_ip = wait_for_address(server, "eth1", "link")
+          client.succeed(f"ping -c 1 {client_ip}%eth1 >&2")
+          client.succeed(f"ping -c 1 {server_ip}%eth1 >&2")
+
+      with subtest("Global addresses can be obtained, pinged, and reached via http"):
+          client_ip = wait_for_address(client, "eth1", "global")
+          server_ip = wait_for_address(server, "eth1", "global")
+          client.succeed(f"ping -c 1 {client_ip} >&2")
+          client.succeed(f"ping -c 1 {server_ip} >&2")
+          client.succeed(f"curl --fail -g http://[{server_ip}]")
+          client.fail(f"curl --fail -g http://[{client_ip}]")
+
+      with subtest("Privacy extensions: Global temporary address can be obtained and pinged"):
+          ip = wait_for_address(client, "eth1", "global temporary")
           # Default route should have "src <temporary address>" in it
-          $client->succeed("ip r g ::2 | grep $ip");
-      };
+          client.succeed(f"ip r g ::2 | grep {ip}")
 
       # TODO: test reachability of a machine on another network.
     '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#72828

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
