### PR TITLE
Revert "environment.noXlibs: do not pull gobject-introspection"

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -35,7 +35,6 @@ with lib;
       networkmanager-vpnc = super.networkmanager-vpnc.override { withGnome = false; };
       networkmanager-iodine = super.networkmanager-iodine.override { withGnome = false; };
       gobject-introspection = super.gobject-introspection.override { x11Support = false; };
-      polkit = super.polkit.override { withGnome = false; };
     }));
   };
 }

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -2,7 +2,7 @@
 , intltool, spidermonkey_60 , gobject-introspection, libxslt, docbook_xsl, dbus
 , docbook_xml_dtd_412, gtk-doc, coreutils
 , useSystemd ? (stdenv.isLinux && !stdenv.hostPlatform.isMusl), systemd, elogind
-, withGnome ? true
+, withIntrospection ? true
 # A few tests currently fail on musl (polkitunixusertest, polkitunixgrouptest, polkitidentitytest segfault).
 # Not yet investigated; it may be due to the "Make netgroup support optional"
 # patch not updating the tests correctly yet, or doing something wrong,
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     [ expat pam spidermonkey_60 ]
     # On Linux, fall back to elogind when systemd support is off.
     ++ stdenv.lib.optional stdenv.isLinux (if useSystemd then systemd else elogind)
-    ++ stdenv.lib.optional withGnome gobject-introspection;
+    ++ stdenv.lib.optional withIntrospection gobject-introspection;
 
   propagatedBuildInputs = [
     glib # in .pc Requires
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
     "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
     "--with-polkitd-user=polkituser" #TODO? <nixos> config.ids.uids.polkituser
     "--with-os-type=NixOS" # not recognized but prevents impurities on non-NixOS
-    (if withGnome then "--enable-introspection" else "--disable-introspection")
+    (if withIntrospection then "--enable-introspection" else "--disable-introspection")
   ] ++ stdenv.lib.optional (!doCheck) "--disable-test";
 
   makeFlags = [


### PR DESCRIPTION
Introspection has nothing to do with GNOME

Reverts NixOS/nixpkgs#74715