### PR TITLE
nixosTests.containers*: port rest to python

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -57,6 +57,7 @@ in
   containers-ip = handleTest ./containers-ip.nix {};
   containers-macvlans = handleTest ./containers-macvlans.nix {};
   containers-physical_interfaces = handleTest ./containers-physical_interfaces.nix {};
+  containers-portforward = handleTest ./containers-portforward.nix {};
   containers-restart_networking = handleTest ./containers-restart_networking.nix {};
   containers-tmpfs = handleTest ./containers-tmpfs.nix {};
   couchdb = handleTest ./couchdb.nix {};

--- a/nixos/tests/containers-extra_veth.nix
+++ b/nixos/tests/containers-extra_veth.nix
@@ -1,7 +1,7 @@
 # Test for NixOS' container support.
 
-import ./make-test.nix ({ pkgs, ...} : {
-  name = "containers-bridge";
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "containers-extra_veth";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ kampfschlaefer ];
   };
@@ -52,52 +52,43 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   testScript =
     ''
-      $machine->waitForUnit("default.target");
-      $machine->succeed("nixos-container list") =~ /webserver/ or die;
+      machine.wait_for_unit("default.target")
+      assert "webserver" in machine.succeed("nixos-container list")
 
-      # Status of the webserver container.
-      $machine->succeed("nixos-container status webserver") =~ /up/ or die;
+      with subtest("Status of the webserver container is up"):
+          assert "up" in machine.succeed("nixos-container status webserver")
 
-      # Debug
-      #$machine->succeed("nixos-container run webserver -- ip link >&2");
+      with subtest("Ensure that the veths are inside the container"):
+          assert "state UP" in machine.succeed(
+              "nixos-container run webserver -- ip link show veth1"
+          )
+          assert "state UP" in machine.succeed(
+              "nixos-container run webserver -- ip link show veth2"
+          )
 
-      # Ensure that the veths are inside the container
-      $machine->succeed("nixos-container run webserver -- ip link show veth1") =~ /state UP/ or die;
-      $machine->succeed("nixos-container run webserver -- ip link show veth2") =~ /state UP/ or die;
+      with subtest("Ensure the presence of the extra veths"):
+          assert "state UP" in machine.succeed("ip link show veth1")
+          assert "state UP" in machine.succeed("ip link show veth2")
 
-      # Debug
-      #$machine->succeed("ip link >&2");
+      with subtest("Ensure the veth1 is part of br1 on the host"):
+          assert "master br1" in machine.succeed("ip link show veth1")
 
-      # Ensure the presence of the extra veths
-      $machine->succeed("ip link show veth1") =~ /state UP/ or die;
-      $machine->succeed("ip link show veth2") =~ /state UP/ or die;
+      with subtest("Ping on main veth"):
+          machine.succeed("ping -n -c 1 192.168.0.100")
+          machine.succeed("ping -n -c 1 fc00::2")
 
-      # Ensure the veth1 is part of br1 on the host
-      $machine->succeed("ip link show veth1") =~ /master br1/ or die;
+      with subtest("Ping on the first extra veth"):
+          machine.succeed("ping -n -c 1 192.168.1.100 >&2")
 
-      # Debug
-      #$machine->succeed("ip -4 a >&2");
-      #$machine->succeed("ip -4 r >&2");
-      #$machine->succeed("nixos-container run webserver -- ip link >&2");
-      #$machine->succeed("nixos-container run webserver -- ip -4 a >&2");
-      #$machine->succeed("nixos-container run webserver -- ip -4 r >&2");
+      with subtest("Ping on the second extra veth"):
+          machine.succeed("ping -n -c 1 192.168.2.100 >&2")
 
-      # Ping on main veth
-      $machine->succeed("ping -n -c 1 192.168.0.100");
-      $machine->succeed("ping -n -c 1 fc00::2");
+      with subtest("Container can be stopped"):
+          machine.succeed("nixos-container stop webserver")
+          machine.fail("ping -n -c 1 192.168.1.100 >&2")
+          machine.fail("ping -n -c 1 192.168.2.100 >&2")
 
-      # Ping on the first extra veth
-      $machine->succeed("ping -n -c 1 192.168.1.100 >&2");
-
-      # Ping on the second extra veth
-      $machine->succeed("ping -n -c 1 192.168.2.100 >&2");
-
-      # Stop the container.
-      $machine->succeed("nixos-container stop webserver");
-      $machine->fail("ping -n -c 1 192.168.1.100 >&2");
-      $machine->fail("ping -n -c 1 192.168.2.100 >&2");
-
-      # Destroying a declarative container should fail.
-      $machine->fail("nixos-container destroy webserver");
+      with subtest("Destroying a declarative container should fail"):
+          machine.fail("nixos-container destroy webserver")
     '';
 })

--- a/nixos/tests/containers-macvlans.nix
+++ b/nixos/tests/containers-macvlans.nix
@@ -6,7 +6,7 @@ let
   containerIp2 = "192.168.1.254";
 in
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-macvlans";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ montag451 ];
@@ -64,19 +64,23 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   testScript = ''
-    startAll;
-    $machine1->waitForUnit("default.target");
-    $machine2->waitForUnit("default.target");
+    start_all()
+    machine1.wait_for_unit("default.target")
+    machine2.wait_for_unit("default.target")
 
-    # Ping between containers to check that macvlans are created in bridge mode
-    $machine1->succeed("nixos-container run test1 -- ping -n -c 1 ${containerIp2}");
+    with subtest(
+        "Ping between containers to check that macvlans are created in bridge mode"
+    ):
+        machine1.succeed("nixos-container run test1 -- ping -n -c 1 ${containerIp2}")
 
-    # Ping containers from the host (machine1)
-    $machine1->succeed("ping -n -c 1 ${containerIp1}");
-    $machine1->succeed("ping -n -c 1 ${containerIp2}");
+    with subtest("Ping containers from the host (machine1)"):
+        machine1.succeed("ping -n -c 1 ${containerIp1}")
+        machine1.succeed("ping -n -c 1 ${containerIp2}")
 
-    # Ping containers from the second machine to check that containers are reachable from the outside
-    $machine2->succeed("ping -n -c 1 ${containerIp1}");
-    $machine2->succeed("ping -n -c 1 ${containerIp2}");
+    with subtest(
+        "Ping containers from the second machine to check that containers are reachable from the outside"
+    ):
+        machine2.succeed("ping -n -c 1 ${containerIp1}")
+        machine2.succeed("ping -n -c 1 ${containerIp2}")
   '';
 })

--- a/nixos/tests/containers-physical_interfaces.nix
+++ b/nixos/tests/containers-physical_interfaces.nix
@@ -1,5 +1,5 @@
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-physical_interfaces";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ kampfschlaefer ];
@@ -86,48 +86,51 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    subtest "prepare server", sub {
-      $server->waitForUnit("default.target");
-      $server->succeed("ip link show dev eth1 >&2");
-    };
+    with subtest("Prepare server"):
+        server.wait_for_unit("default.target")
+        server.succeed("ip link show dev eth1 >&2")
 
-    subtest "simple physical interface", sub {
-      $server->succeed("nixos-container start server");
-      $server->waitForUnit("container\@server");
-      $server->succeed("systemctl -M server list-dependencies network-addresses-eth1.service >&2");
+    with subtest("Simple physical interface is up"):
+        server.succeed("nixos-container start server")
+        server.wait_for_unit("container@server")
+        server.succeed(
+            "systemctl -M server list-dependencies network-addresses-eth1.service >&2"
+        )
 
-      # The other tests will ping this container on its ip. Here we just check
-      # that the device is present in the container.
-      $server->succeed("nixos-container run server -- ip a show dev eth1 >&2");
-    };
+        # The other tests will ping this container on its ip. Here we just check
+        # that the device is present in the container.
+        server.succeed("nixos-container run server -- ip a show dev eth1 >&2")
 
-    subtest "physical device in bridge in container", sub {
-      $bridged->waitForUnit("default.target");
-      $bridged->succeed("nixos-container start bridged");
-      $bridged->waitForUnit("container\@bridged");
-      $bridged->succeed("systemctl -M bridged list-dependencies network-addresses-br0.service >&2");
-      $bridged->succeed("systemctl -M bridged status -n 30 -l network-addresses-br0.service");
-      $bridged->succeed("nixos-container run bridged -- ping -w 10 -c 1 -n 10.10.0.1");
-    };
+    with subtest("Physical device in bridge in container can ping server"):
+        bridged.wait_for_unit("default.target")
+        bridged.succeed("nixos-container start bridged")
+        bridged.wait_for_unit("container@bridged")
+        bridged.succeed(
+            "systemctl -M bridged list-dependencies network-addresses-br0.service >&2",
+            "systemctl -M bridged status -n 30 -l network-addresses-br0.service",
+            "nixos-container run bridged -- ping -w 10 -c 1 -n 10.10.0.1",
+        )
 
-    subtest "physical device in bond in container", sub {
-      $bonded->waitForUnit("default.target");
-      $bonded->succeed("nixos-container start bonded");
-      $bonded->waitForUnit("container\@bonded");
-      $bonded->succeed("systemctl -M bonded list-dependencies network-addresses-bond0 >&2");
-      $bonded->succeed("systemctl -M bonded status -n 30 -l network-addresses-bond0 >&2");
-      $bonded->succeed("nixos-container run bonded -- ping -w 10 -c 1 -n 10.10.0.1");
-    };
+    with subtest("Physical device in bond in container can ping server"):
+        bonded.wait_for_unit("default.target")
+        bonded.succeed("nixos-container start bonded")
+        bonded.wait_for_unit("container@bonded")
+        bonded.succeed(
+            "systemctl -M bonded list-dependencies network-addresses-bond0 >&2",
+            "systemctl -M bonded status -n 30 -l network-addresses-bond0 >&2",
+            "nixos-container run bonded -- ping -w 10 -c 1 -n 10.10.0.1",
+        )
 
-    subtest "physical device in bond in bridge in container", sub {
-      $bridgedbond->waitForUnit("default.target");
-      $bridgedbond->succeed("nixos-container start bridgedbond");
-      $bridgedbond->waitForUnit("container\@bridgedbond");
-      $bridgedbond->succeed("systemctl -M bridgedbond list-dependencies network-addresses-br0.service >&2");
-      $bridgedbond->succeed("systemctl -M bridgedbond status -n 30 -l network-addresses-br0.service");
-      $bridgedbond->succeed("nixos-container run bridgedbond -- ping -w 10 -c 1 -n 10.10.0.1");
-    };
+    with subtest("Physical device in bond in bridge in container can ping server"):
+        bridgedbond.wait_for_unit("default.target")
+        bridgedbond.succeed("nixos-container start bridgedbond")
+        bridgedbond.wait_for_unit("container@bridgedbond")
+        bridgedbond.succeed(
+            "systemctl -M bridgedbond list-dependencies network-addresses-br0.service >&2",
+            "systemctl -M bridgedbond status -n 30 -l network-addresses-br0.service",
+            "nixos-container run bridgedbond -- ping -w 10 -c 1 -n 10.10.0.1",
+        )
   '';
 })

--- a/nixos/tests/containers-portforward.nix
+++ b/nixos/tests/containers-portforward.nix
@@ -7,7 +7,7 @@ let
   containerPort = 80;
 in 
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "containers-portforward";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aristid aszlig eelco kampfschlaefer ianwookim ];
@@ -36,27 +36,27 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   testScript =
     ''
-      $machine->succeed("nixos-container list") =~ /webserver/ or die;
+      container_list = machine.succeed("nixos-container list")
+      assert "webserver" in container_list
 
       # Start the webserver container.
-      $machine->succeed("nixos-container start webserver");
+      machine.succeed("nixos-container start webserver")
 
       # wait two seconds for the container to start and the network to be up
-      sleep 2;
+      machine.sleep(2)
 
       # Since "start" returns after the container has reached
       # multi-user.target, we should now be able to access it.
-      #my $ip = $machine->succeed("nixos-container show-ip webserver");
-      #chomp $ip;
-      $machine->succeed("ping -n -c1 ${hostIp}");
-      $machine->succeed("curl --fail http://${hostIp}:${toString hostPort}/ > /dev/null");
+      # ip = machine.succeed("nixos-container show-ip webserver").strip()
+      machine.succeed("ping -n -c1 ${hostIp}")
+      machine.succeed("curl --fail http://${hostIp}:${toString hostPort}/ > /dev/null")
 
       # Stop the container.
-      $machine->succeed("nixos-container stop webserver");
-      $machine->fail("curl --fail --connect-timeout 2 http://${hostIp}:${toString hostPort}/ > /dev/null");
+      machine.succeed("nixos-container stop webserver")
+      machine.fail("curl --fail --connect-timeout 2 http://${hostIp}:${toString hostPort}/ > /dev/null")
 
       # Destroying a declarative container should fail.
-      $machine->fail("nixos-container destroy webserver");
+      machine.fail("nixos-container destroy webserver")
     '';
 
 })

--- a/nixos/tests/containers-restart_networking.nix
+++ b/nixos/tests/containers-restart_networking.nix
@@ -16,7 +16,7 @@ let
       };
     };
   };
-in import ./make-test.nix ({ pkgs, ...} :
+in import ./make-test-python.nix ({ pkgs, ...} :
 {
   name = "containers-restart_networking";
   meta = with pkgs.stdenv.lib.maintainers; {
@@ -64,50 +64,52 @@ in import ./make-test.nix ({ pkgs, ...} :
     eth1_bridged = nodes.client_eth1.config.system.build.toplevel;
     eth1_rstp = nodes.client_eth1_rstp.config.system.build.toplevel;
   in ''
-    $client->start();
+    client.start()
 
-    $client->waitForUnit("default.target");
+    client.wait_for_unit("default.target")
 
-    subtest "initial state", sub {
-      $client->succeed("ping 192.168.1.122 -c 1 -n >&2");
-      $client->succeed("nixos-container run webserver -- ping -c 1 -n 192.168.1.1 >&2");
+    with subtest("Initial configuration connectivity check"):
+        client.succeed("ping 192.168.1.122 -c 1 -n >&2")
+        client.succeed("nixos-container run webserver -- ping -c 1 -n 192.168.1.1 >&2")
 
-      $client->fail("ip l show eth1 |grep \"master br0\" >&2");
-      $client->fail("grep eth1 /run/br0.interfaces >&2");
-    };
+        client.fail("ip l show eth1 |grep 'master br0' >&2")
+        client.fail("grep eth1 /run/br0.interfaces >&2")
 
-    subtest "interfaces without stp", sub {
-      $client->succeed("${eth1_bridged}/bin/switch-to-configuration test >&2");
+    with subtest("Bridged configuration without STP preserves connectivity"):
+        client.succeed(
+            "${eth1_bridged}/bin/switch-to-configuration test >&2"
+        )
 
-      $client->succeed("ping 192.168.1.122 -c 1 -n >&2");
-      $client->succeed("nixos-container run webserver -- ping -c 1 -n 192.168.1.2 >&2");
+        client.succeed(
+            "ping 192.168.1.122 -c 1 -n >&2",
+            "nixos-container run webserver -- ping -c 1 -n 192.168.1.2 >&2",
+            "ip l show eth1 |grep 'master br0' >&2",
+            "grep eth1 /run/br0.interfaces >&2",
+        )
 
-      $client->succeed("ip l show eth1 |grep \"master br0\" >&2");
-      $client->succeed("grep eth1 /run/br0.interfaces >&2");
-    };
-
-    # activating rstp needs another service, therefor the bridge will restart and the container will loose its connectivity
-    #subtest "interfaces with rstp", sub {
-    #  $client->succeed("${eth1_rstp}/bin/switch-to-configuration test >&2");
-    #  $client->execute("ip -4 a >&2");
-    #  $client->execute("ip l >&2");
+    #  activating rstp needs another service, therefore the bridge will restart and the container will lose its connectivity
+    # with subtest("Bridged configuration with STP"):
+    #     client.succeed("${eth1_rstp}/bin/switch-to-configuration test >&2")
+    #     client.execute("ip -4 a >&2")
+    #     client.execute("ip l >&2")
     #
-    #  $client->succeed("ping 192.168.1.122 -c 1 -n >&2");
-    #  $client->succeed("nixos-container run webserver -- ping -c 1 -n 192.168.1.2 >&2");
-    #
-    #  $client->succeed("ip l show eth1 |grep \"master br0\" >&2");
-    #  $client->succeed("grep eth1 /run/br0.interfaces >&2");
-    #};
+    #     client.succeed(
+    #         "ping 192.168.1.122 -c 1 -n >&2",
+    #         "nixos-container run webserver -- ping -c 1 -n 192.168.1.2 >&2",
+    #         "ip l show eth1 |grep 'master br0' >&2",
+    #         "grep eth1 /run/br0.interfaces >&2",
+    #     )
 
-    subtest "back to no interfaces and no stp", sub {
-      $client->succeed("${originalSystem}/bin/switch-to-configuration test >&2");
+    with subtest("Reverting to initial configuration preserves connectivity"):
+        client.succeed(
+            "${originalSystem}/bin/switch-to-configuration test >&2"
+        )
 
-      $client->succeed("ping 192.168.1.122 -c 1 -n >&2");
-      $client->succeed("nixos-container run webserver -- ping -c 1 -n 192.168.1.1 >&2");
+        client.succeed("ping 192.168.1.122 -c 1 -n >&2")
+        client.succeed("nixos-container run webserver -- ping -c 1 -n 192.168.1.1 >&2")
 
-      $client->fail("ip l show eth1 |grep \"master br0\" >&2");
-      $client->fail("grep eth1 /run/br0.interfaces >&2");
-    };
+        client.fail("ip l show eth1 |grep 'master br0' >&2")
+        client.fail("grep eth1 /run/br0.interfaces >&2")
   '';
 
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @kampfschlaefer @tfc @flokli @worldofpeace 
