### PR TITLE
python3Packages.matrix-nio: add missing dependency (cachetools)

### DIFF
--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonPackage, fetchFromGitHub, git,
   attrs, future, peewee, h11, h2, atomicwrites, pycryptodome, sphinx, Logbook, jsonschema,
-  python-olm, unpaddedbase64, aiohttp }:
+  python-olm, unpaddedbase64, aiohttp, cachetools }:
 
 buildPythonPackage rec {
   pname = "nio";
@@ -36,6 +36,7 @@ buildPythonPackage rec {
     python-olm
     unpaddedbase64
     aiohttp
+    cachetools
   ];
 
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

This adds a missing propagated build input: https://github.com/poljar/matrix-nio/blob/0.6/setup.py#L39

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tilpner 
