### PR TITLE
twinkle: init at 1.10.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4546,6 +4546,16 @@
     githubId = 22477669;
     name = "Mark K Gardner";
   };
+  mkg20001 = {
+    email = "mkg20001+nix@gmail.com";
+    github = "mkg20001";
+    githubId = 7735145;
+    name = "Maciej Krüger";
+    keys = [{
+      longkeyid = "rsa4096/0x0D948CE19CF49C5F";
+      fingerprint = "E90C BA34 55B3 6236 740C  038F 0D94 8CE1 9CF4 9C5F";
+    }];
+  };
   mlieberman85 = {
     email = "mlieberman85@gmail.com";
     github = "mlieberman85";

--- a/pkgs/applications/networking/instant-messengers/twinkle/default.nix
+++ b/pkgs/applications/networking/instant-messengers/twinkle/default.nix
@@ -1,0 +1,78 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, libxml2
+, libsndfile
+, file
+, readline
+, bison
+, flex
+, ucommon
+, ccrtp
+, qtbase
+, qttools
+, qtquickcontrols2
+, alsaLib
+, speex
+, ilbc
+, fetchurl
+, mkDerivation
+, bcg729
+}:
+
+mkDerivation rec {
+  pname = "twinkle";
+  version = "1.10.2";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "LubosD";
+    rev = "v${version}";
+    sha256 = "0s0gi03xwvzp02ah4q6j33r9jx9nbayr6dxlg2ck9pwbay1nq1hx";
+  };
+
+  buildInputs = [
+    libxml2
+    file # libmagic
+    libsndfile
+    readline
+    ucommon
+    ccrtp
+    qtbase
+    qttools
+    qtquickcontrols2
+    alsaLib
+    speex
+    ilbc
+  ];
+
+  patches = [
+    (fetchurl { # https://github.com/LubosD/twinkle/pull/152 patch for bcg729 1.0.2+
+      url = "https://github.com/LubosD/twinkle/compare/05082ae12051821b1d969e6672d9e4e5afe1bc07...7a6c533cda387652b5b4cb2a867be1a18585890c.patch";
+      sha256 = "39fc6cef3e88cfca8db44612b2d082fb618027b0f99509138d3c0d2777a494c2";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    bison
+    flex
+    bcg729
+  ];
+
+  cmakeFlags = [
+    "-DWITH_G729=On"
+    "-DWITH_SPEEX=On"
+    "-DWITH_ILBC=On"
+    /* "-DWITH_DIAMONDCARD=On" seems ancient and broken */
+  ];
+
+  meta = with stdenv.lib; {
+    changelog = "https://github.com/LubosD/twinkle/blob/${version}/NEWS";
+    description = "A SIP-based VoIP client";
+    homepage = "http://twinkle.dolezel.info/";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.mkg20001 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21578,6 +21578,8 @@ in
 
   ulauncher = callPackage ../applications/misc/ulauncher { };
 
+  twinkle = qt5.callPackage ../applications/networking/instant-messengers/twinkle { };
+
   umurmur = callPackage ../applications/networking/umurmur { };
 
   udocker = pythonPackages.callPackage ../tools/virtualization/udocker { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Need this for myself, useful for others as well.

###### Things done

Added the twinkle package

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers


