### PR TITLE
buildbot: 2.5.0 -> 2.5.1

### DIFF
--- a/pkgs/development/python-modules/buildbot/default.nix
+++ b/pkgs/development/python-modules/buildbot/default.nix
@@ -25,11 +25,11 @@ let
 
   package = buildPythonPackage rec {
     pname = "buildbot";
-    version = "2.5.0";
+    version = "2.5.1";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "06dza7kggybz8nf3i1skkadwrq9s0nkpqjfahifysaag3j3b5rp4";
+      sha256 = "13ddpcbndb22zlg9gjsf2pbgad45g1w5cg4a3z83085fkgnib7sr";
     };
 
     propagatedBuildInputs = [
@@ -74,13 +74,6 @@ let
       # This patch disables the test that tries to read /etc/os-release which
       # is not accessible in sandboxed builds.
       ./skip_test_linux_distro.patch
-      # Work around https://github.com/glyph/automat/issues/117
-      (fetchpatch {
-        url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/buildbot-automat-117.diff?h=packages/buildbot&id=7904292340f98578adfe783a09e9eb4c5b1d4632";
-        name = "buildbot-automat-117.diff";
-        stripLen = 1;
-        sha256 = "0rng6f8nvghkihajz9m925rdp9q3c395bj4wc7r2s1minv613hba";
-      })
     ];
 
     postPatch = ''

--- a/pkgs/development/python-modules/buildbot/pkg.nix
+++ b/pkgs/development/python-modules/buildbot/pkg.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "buildbot-pkg";
-  version = "2.5.0";
+  version = "2.5.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1my9a791y6hsazzqs3f3svl6zw28x3qwj0a0vxffybqdij650nvw";
+    sha256 = "1g87pddsyas1r0f6z29047cwnz7ds4925f6n9g7b0pkj3k73ci06";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/buildbot/plugins.nix
+++ b/pkgs/development/python-modules/buildbot/plugins.nix
@@ -7,7 +7,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "0awy96pb9s9g0nrmlrvqf5zi878z6mvj653inf9sm89x601a6lp1";
+      sha256 = "00k5dbcwzqlyk4lcp5qh1q8xbrxmg9gzqs7vl2r6f3wxi4ydb5nw";
     };
 
     # Remove unneccessary circular dependency on buildbot
@@ -36,7 +36,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "0bp7bbq6rq1kdg3pf8plcpc4amam0pks5dlmyqj6bn29skfa5h1j";
+      sha256 = "0ai334y779jwqabrn2yjma41pw0a9k1qy7v68qbjd22n4my227ma";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -58,7 +58,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "1mxxkqzh4a6574n2lk2ndi77d9g93hjpkwsqizj911n6ibsn4qw3";
+      sha256 = "1j450hwvg729mivzijbrx8ngalx56qvrx8mwwgy8arfwpnyfkr9l";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -80,7 +80,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "1fkrd5crbgqgp8mr8qgfy559f59ys6hrspddzk3fwg5hrsckkjwr";
+      sha256 = "19w8is5s7d7l60mlchh1zd9nidpkswi8fivfa36b97plibn0jgw1";
     };
 
     buildInputs = [ buildbot-pkg ];
@@ -102,7 +102,7 @@
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "0cvbizcc92df08xcs8w6ah51yfilxz7sx9g8bbdrvw6m586ziczb";
+      sha256 = "1zl7y08rkw7bya6cli44msvcdgirsyfg3kxpf2z82vwgc6bwi785";
     };
 
     buildInputs = [ buildbot-pkg ];

--- a/pkgs/development/python-modules/buildbot/worker.nix
+++ b/pkgs/development/python-modules/buildbot/worker.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage (rec {
   pname = "buildbot-worker";
-  version = "2.5.0";
+  version = "2.5.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "05c8q6ykharry4lv47imh6agq55fxar8a9ldwx46clb480qwyc43";
+    sha256 = "1kpj85x8xflrccvy840v9bl3q1j63rk9kahj1qirbai1fxwvzbik";
   };
 
   propagatedBuildInputs = [ twisted future ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates buildbot to the latest version.

Supersedes #74170.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nand0p @ryansydnor
