### PR TITLE
dump1090: 2014-10-31 -> 3.7.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -206,6 +206,14 @@
      <option>hardware.bluetooth.enable</option>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <literal>dump1090</literal> derivation has been changed to use FlightAware's dump1090
+     as its upstream. However, this version does not have an internal webserver anymore. The
+     assets in the <literal>share/dump1090</literal> directory of the derivation can be used
+     in conjunction with an external webserver to replace this functionality.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/applications/radio/dump1090/default.nix
+++ b/pkgs/applications/radio/dump1090/default.nix
@@ -1,21 +1,31 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libusb, rtl-sdr }:
+{ stdenv
+, fetchFromGitHub
+, pkgconfig
+, libbladeRF
+, libusb
+, ncurses
+, rtl-sdr
+}:
 
 stdenv.mkDerivation rec {
   pname = "dump1090";
-  version = "2014-10-31";
+  version = "3.7.2";
 
   src = fetchFromGitHub {
-    owner = "MalcolmRobb";
+    owner = "flightaware";
     repo = pname;
-    rev = "bff92c4ad772a0a8d433f788d39dae97e00e4dbe";
-    sha256 = "06aaj9gpz5v4qzvnp8xf18wdfclp0jvn3hflls79ly46gz2dh9hy";
+    rev = "v${version}";
+    sha256 = "0vlv9bd805kid202xxkrnl51rh02cyrl055gbcqlqgk51j5rrq8w";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ libusb rtl-sdr ];
-
-  makeFlags = [ "PREFIX=$(out)" ];
+  buildInputs = [
+    libbladeRF
+    libusb
+    ncurses
+    rtl-sdr
+  ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share
@@ -25,8 +35,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A simple Mode S decoder for RTLSDR devices";
-    homepage = https://github.com/MalcolmRobb/dump1090;
-    license = licenses.bsd3;
+    homepage = "https://github.com/flightaware/dump1090";
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ earldouglas ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The derivation uses an upstream for dump1090 that has not been updated
since 2014. FlightAware seems to have the most actively maintained
version of dump1090, so this change switches to FlightAware's
version, bringing 5 years of improvements.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @earldouglas
