### PR TITLE
agda-categories: init at 0.1

### DIFF
--- a/pkgs/development/libraries/agda/agda-categories/default.nix
+++ b/pkgs/development/libraries/agda/agda-categories/default.nix
@@ -1,0 +1,28 @@
+{ lib, agda, fetchFromGitHub, AgdaStdlib }:
+
+agda.mkDerivation (self: rec {
+  version = "0.1";
+  pname = "agda-categories";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "agda";
+    repo = pname;
+    rev = "release/v${version}";
+    sha256 = "0m4pjy92jg6zfziyv0bxv5if03g8k4413ld8c3ii2xa8bzfn04m2";
+  };
+
+  # Remove the dependency in the agda file as this breaks the current agda infrastructure
+  patches = [ ./depend.patch ];
+  sourceDirectories = [ "Categories" "Relation" ];
+
+  buildDepends = [ AgdaStdlib ];
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "A new Categories library";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ alexarice ];
+  };
+})

--- a/pkgs/development/libraries/agda/agda-categories/depend.patch
+++ b/pkgs/development/libraries/agda/agda-categories/depend.patch
@@ -1,0 +1,9 @@
+diff --git a/agda-categories.agda-lib b/agda-categories.agda-lib
+index cc76242..888b196 100644
+--- a/agda-categories.agda-lib
++++ b/agda-categories.agda-lib
+@@ -1,3 +1,2 @@
+ name: agda-categories
+-depend: standard-library
+ include: .
+\ No newline at end of file

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6638,7 +6638,7 @@ in
   thin-provisioning-tools = callPackage ../tools/misc/thin-provisioning-tools {  };
 
   tiled = libsForQt5.callPackage ../applications/editors/tiled { };
-  
+
   tiledb = callPackage ../development/libraries/tiledb { };
 
   timemachine = callPackage ../applications/audio/timemachine { };
@@ -14669,6 +14669,8 @@ in
   };
 
   agdaBase = callPackage ../development/libraries/agda/agda-base { };
+
+  agda-categories = callPackage ../development/libraries/agda/agda-categories { };
 
   agdaIowaStdlib = callPackage ../development/libraries/agda/agda-iowa-stdlib { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
agda-categories was not part of nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Fuuzetsu as I think you know what is going on with agda stuff.

Few notes on this:
- I had to patch the .agda-lib file to remove the dependency as otherwise it fails saying it cannot find it. This is due to the way the agda infrastructure is set up on nix I believe, it might be worth fixing this instead of hacking round it like I have done
- This took 18GB of ram to build, can hydra cope with that
