### PR TITLE
netease-cloud-music: init at 1.2.0

### DIFF
--- a/pkgs/applications/audio/netease-cloud-music/default.nix
+++ b/pkgs/applications/audio/netease-cloud-music/default.nix
@@ -1,0 +1,82 @@
+{ stdenv, lib, fontconfig, zlib, libGL, glib, pango
+, gdk-pixbuf, freetype, atk, cairo, libsForQt5, xorg
+, sqlite, taglib, nss, nspr, cups, dbus, alsaLib
+, libpulseaudio, deepin, qt5, harfbuzz, p11-kit
+, libgpgerror, libudev0-shim, makeWrapper, dpkg, fetchurl }:
+let
+  rpath = lib.makeLibraryPath [
+    fontconfig.lib
+    zlib
+    stdenv.cc.cc.lib
+    libGL
+    glib
+    pango
+    gdk-pixbuf
+    freetype
+    atk
+    cairo
+    libsForQt5.vlc
+    sqlite
+    taglib
+    nss
+    nspr
+    cups.lib
+    dbus.lib
+    alsaLib
+    libpulseaudio
+    xorg.libX11
+    xorg.libXext
+    xorg.libXtst
+    xorg.libXdamage
+    xorg.libXScrnSaver
+    xorg.libxcb
+    xorg.libXi
+    deepin.qcef
+    qt5.qtwebchannel
+    qt5.qtbase
+    qt5.qtx11extras
+    qt5.qtdeclarative
+    harfbuzz
+    p11-kit
+    libgpgerror
+  ];   
+
+  runtimeLibs = lib.makeLibraryPath [ libudev0-shim ];
+
+in stdenv.mkDerivation rec {
+  pname = "netease-cloud-music";
+  version = "1.2.0";
+  src = fetchurl {
+    url    = "http://d1.music.126.net/dmusic/netease-cloud-music_1.2.0_amd64_deepin_stable_20190424.deb";
+    sha256 = "0hg8jqim77vd0fmk8gfbz2fmlj99byxcm9jn70xf7vk1sy7wp6h1";
+    curlOpts = "-A 'Mozilla/5.0'";
+  };
+  unpackCmd = "${dpkg}/bin/dpkg -x $src .";
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ qt5.wrapQtAppsHook makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r usr/* $out
+  '';
+
+  preFixup = ''
+    local exefile="$out/bin/netease-cloud-music"
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$exefile"
+    patchelf --set-rpath "$out/libs:$(patchelf --print-rpath "$exefile"):${rpath}" "$exefile"
+
+    wrapProgram $out/bin/netease-cloud-music \
+      --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+      --set QT_AUTO_SCREEN_SCALE_FACTOR 1 \
+      --set QCEF_INSTALL_PATH "${deepin.qcef}/lib/qcef"
+  '';
+
+  meta = {
+    description = "Client for Netease Cloud Music service";
+    homepage = https://music.163.com;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = [ stdenv.lib.maintainers.mlatus ];
+    license = stdenv.lib.licenses.unfreeRedistributable;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20161,6 +20161,8 @@ in
 
   neocomp  = callPackage ../applications/window-managers/neocomp { };
 
+  netease-cloud-music = callPackage ../applications/audio/netease-cloud-music {};
+
   nicotine-plus = callPackage ../applications/networking/soulseek/nicotine-plus {
     geoip = geoipWithDatabase;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add package for the client of Netease Cloud Music service

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
