### PR TITLE
fido2luks: init at 0.2.2

### DIFF
--- a/pkgs/tools/security/fido2luks/default.nix
+++ b/pkgs/tools/security/fido2luks/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, rustPlatform
+, fetchFromGitHub
+, cryptsetup
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "fido2luks";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "shimunn";
+    repo = pname;
+    rev = version;
+    sha256 = "018qzbgmgm0f0d0c7i54nqqjbr4k5mzy1xfavi6hpifjll971wci";
+  };
+
+  buildInputs = [ cryptsetup ];
+  nativeBuildInputs = [ pkg-config ];
+
+  cargoSha256 = "1kf757wxxk5h8dfbz588qw1pnyjbg5qzr7rz14i7x8rhmn5xwb74";
+  verifyCargoDeps = true;
+
+  meta = with stdenv.lib; {
+    description = "Decrypt your LUKS partition using a FIDO2 compatible authenticator";
+    homepage = "https://github.com/shimunn/fido2luks";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ prusnak mmahut ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3238,6 +3238,8 @@ in
 
   flux = callPackage ../development/compilers/flux { };
 
+  fido2luks = callPackage ../tools/security/fido2luks {};
+
   fierce = callPackage ../tools/security/fierce { };
 
   figlet = callPackage ../tools/misc/figlet { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New package allowing to use of FIDO2 tokens for LUKS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
