### PR TITLE
buku: fix bukuserver (missing module)

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -27,6 +27,7 @@ with python3.pkgs; buildPythonApplication rec {
     requests
     urllib3
     flask
+    flask-admin
     flask-api
     flask-bootstrap
     flask-paginate


### PR DESCRIPTION
###### Motivation for this change

`bukuserver` crashes on startup:

<details>
<summary><samp>No module named 'flask_admin'</samp></summary>

```
Traceback (most recent call last):
  File "/nix/store/5qi5nyzyj794d90jk4i91xbwnzc8p3qb-buku-4.2.2/bin/.bukuserver-wrapped", line 6, in <module>
    from bukuserver.server import cli
  File "/nix/store/5qi5nyzyj794d90jk4i91xbwnzc8p3qb-buku-4.2.2/lib/python3.7/site-packages/bukuserver/server.py", line 10, in <module>
    from flask_admin import Admin
ModuleNotFoundError: No module named 'flask_admin'
```
</details>

I just had to add the `flask-admin` package to the wrapper's PATH.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ~~Ensured that relevant documentation is up to date~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matthiasbeyer @infinisil