### PR TITLE
ramp-workflow: init at v0.2.0+53.gf48b024

### DIFF
--- a/pkgs/development/python-modules/ramp-workflow/default.nix
+++ b/pkgs/development/python-modules/ramp-workflow/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, scipy
+, pandas
+, scikitlearn
+, cloudpickle
+, click
+, pytest
+, pytestcov
+, codecov
+, flake8
+, nbconvert
+, jupyter_client
+, seaborn
+, netcdf4
+, xarray
+, scikitimage
+, joblib
+, Keras
+, tensorflow
+}:
+
+buildPythonPackage rec {
+  pname = "ramp-workflow";
+  version = "v0.2.0+53.gf48b024";
+
+  # checks not working atm
+  # see https://github.com/paris-saclay-cds/ramp-workflow/issues/192
+  doCheck = false;
+  checkInputs = [
+    pytest pytestcov codecov flake8 nbconvert jupyter_client seaborn netcdf4 xarray scikitimage joblib Keras tensorflow
+  ];
+
+  propagatedBuildInputs = [
+    numpy scipy pandas scikitlearn cloudpickle click
+  ];
+
+  src = fetchFromGitHub {
+    owner = "paris-saclay-cds";
+    repo = pname;
+    rev = "f48b024642c0756d9e12717067cbca224e34b9ce";
+    sha256 = "1xlw3jyfn3nkfbryj8dcm04h5l82w2bhds8cynik7v6mds4jxgll";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/paris-saclay-cds/ramp-workflow;
+    description = "Build, manage, and optimize data analytics workflows";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.GuillaumeDesforges ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5021,6 +5021,8 @@ in {
 
   Pyro4 = callPackage ../development/python-modules/pyro4 { };
 
+  ramp-workflow = callPackage ../development/python-modules/ramp-workflow {};
+
   root_numpy = callPackage ../development/python-modules/root_numpy { };
 
   rootpy = callPackage ../development/python-modules/rootpy { };


### PR DESCRIPTION
###### Motivation for this change
`ramp-workflow` was not part of nixpkgs.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
