### PR TITLE
hyperopt: init at 0.2.2

### DIFF
--- a/pkgs/development/python-modules/hyperopt/default.nix
+++ b/pkgs/development/python-modules/hyperopt/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, pandas
+, scikitlearn
+, future
+, tqdm
+, cloudpickle
+, decorator
+, nose
+, ipython
+, ipyparallel
+, matplotlib
+}:
+
+let
+  # this package needs networkx 2.2 specifically
+  networkx-2_2 = buildPythonPackage rec {
+    pname = "networkx";
+    version = "2.2";
+
+    doCheck = false;
+    propagatedBuildInputs = [
+      decorator
+    ];
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "45e56f7ab6fe81652fb4bc9f44faddb0e9025f469f602df14e3b2551c2ea5c8b";
+      extension = "zip";
+    };
+  };
+in
+  buildPythonPackage rec {
+    pname = "hyperopt";
+    version = "0.2.2";
+
+    # checks not working at the moment
+    # see https://github.com/hyperopt/hyperopt/issues/580
+    doCheck = false;
+    checkInputs = [ nose ipython ipyparallel matplotlib ];
+
+    propagatedBuildInputs = [
+      numpy scipy pandas scikitlearn networkx-2_2 future tqdm cloudpickle
+    ];
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "0mf4zligyhracyfx02ayrvdnxwxsbr912sfby167pgi3fy3vjyfb";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = "https://github.com/hyperopt/hyperopt";
+      description = "Hyperopt is a Python library for serial and parallel optimization over awkward search spaces";
+      license = licenses.bsd3;
+      maintainers = [ maintainers.GuillaumeDesforges ];
+    };
+  }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5178,6 +5178,8 @@ in {
 
   hvplot = callPackage ../development/python-modules/hvplot { };
 
+  hyperopt = callPackage ../development/python-modules/hyperopt { };
+
   guzzle_sphinx_theme = callPackage ../development/python-modules/guzzle_sphinx_theme { };
 
   sphinx-testing = callPackage ../development/python-modules/sphinx-testing { };


### PR DESCRIPTION
###### Motivation for this change
`hyperopt` was not part of nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Additional information
I have tested the package using the example from hyperopt readme.