### PR TITLE
gdk-pixbuf: fix setup hook

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/setup-hook.sh
+++ b/pkgs/development/libraries/gdk-pixbuf/setup-hook.sh
@@ -4,7 +4,7 @@ findGdkPixbufLoaders() {
 	local loadersCache="$1/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
 	if [[ -f "$loadersCache" ]]; then
 		if [[ -f "${GDK_PIXBUF_MODULE_FILE-}" ]]; then
-			if [[ "$(cat "$loadersCache" | wc -l)" > "$(cat "$GDK_PIXBUF_MODULE_FILE" | wc -l)" ]]; then
+			if (( "$(cat "$loadersCache" | wc -l)" > "$(cat "$GDK_PIXBUF_MODULE_FILE" | wc -l)" )); then
 				export GDK_PIXBUF_MODULE_FILE="$loadersCache"
 			fi
 		else


### PR DESCRIPTION
b78e84097fab tried to make the script better but used the wrong test
syntax: `[[ 113 > 99 ]]` is false. This caused the librsvg not being added
to `$GDK_PIXBUF_MODULE_FILE`.

Fixes: https://github.com/NixOS/nixpkgs/pull/73586#issuecomment-560106317

cc @Ericson2314 @c0bw3b @d-goldin