### PR TITLE
pythonPackages.apsw: 3.29.0-r1 -> 3.30.1-r1

### DIFF
--- a/pkgs/development/python-modules/apsw/default.nix
+++ b/pkgs/development/python-modules/apsw/default.nix
@@ -3,7 +3,7 @@
 
 buildPythonPackage rec {
   pname = "apsw";
-  version = "3.29.0-r1";
+  version = "3.30.1-r1";
 
   disabled = isPyPy;
 
@@ -11,18 +11,10 @@ buildPythonPackage rec {
     owner = "rogerbinns";
     repo = "apsw";
     rev = version;
-    sha256 = "1p3sgmk9qwd0a634lirva44qgpyq0a74r9d70wxb6hsa52yjj9xb";
+    sha256 = "1zp38gj44bmzfxxpvgd7nixkp8vs2fpl839ag8vrh9z70dax22f0";
   };
 
   buildInputs = [ sqlite ];
-
-  patches = [
-    # Fixes a test failure with sqlite 3.30, see https://github.com/rogerbinns/apsw/issues/275
-    (fetchpatch {
-      url = "https://github.com/rogerbinns/apsw/commit/13df0b57bff59542978abf7c0a440c9274e3aac3.diff";
-      sha256 = "1wi1mfis2mr21389wdnvq44phg0bpm5vpwmxhvrj211vwfm0q7dv";
-    })
-  ];
 
   meta = with stdenv.lib; {
     description = "A Python wrapper for the SQLite embedded relational database engine";


### PR DESCRIPTION
+ removing a patch that is now included.

###### Motivation for this change

Updates apsw to the latest available version, fixing some build and test failure on python 3.8.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
