### PR TITLE
gegl_0_4: disabling jasper, fixing build

### DIFF
--- a/pkgs/development/libraries/gegl/4.0.nix
+++ b/pkgs/development/libraries/gegl/4.0.nix
@@ -105,6 +105,9 @@ stdenv.mkDerivation rec {
     "-Dlibv4l=disabled"
     "-Dlibv4l2=disabled"
     "-Dumfpack=disabled"
+    # Disabled due to multiple vulnerabilities, see
+    # https://github.com/NixOS/nixpkgs/pull/73586
+    "-Djasper=disabled"
   ];
 
   # TODO: Fix missing math symbols in gegl seamless clone.


### PR DESCRIPTION
###### Motivation for this change

Jasper has been recently marked as insecure and removed from a bunch
of places due to some known vulnerabilities and upstream not moving
forward. This was done in https://github.com/NixOS/nixpkgs/pull/73586

This prevents gegl_0_4 from building, as jasper is a runtime dependency
per default. There is an upstream issue for that, but it does not seem
to have made progress yet: https://gitlab.gnome.org/GNOME/gegl/issues/35

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @c0bw3b @jtojnar 
