### PR TITLE
[r19.09] haproxy: add patches for CVE-2019-19330

### DIFF
--- a/pkgs/tools/networking/haproxy/1.9.8-CVE-2019-19330-part2.patch
+++ b/pkgs/tools/networking/haproxy/1.9.8-CVE-2019-19330-part2.patch
@@ -1,0 +1,96 @@
+Context-adjusted from upstream https://git.haproxy.org/?p=haproxy.git;a=patch;h=54f53ef7ce4102be596130b44c768d1818570344
+
+diff --git a/src/h2.c b/src/h2.c
+index f034e3d..f35abc1 100644
+--- a/src/h2.c
++++ b/src/h2.c
+@@ -45,6 +45,23 @@ struct h2_frame_definition h2_frame_definition[H2_FT_ENTRIES] =	{
+ 	 [H2_FT_CONTINUATION ] = { .dir = 3, .min_id = 1, .max_id = H2_MAX_STREAM_ID, .min_len = 0, .max_len = H2_MAX_FRAME_LEN, },
+ };
+ 
++/* Looks into <ist> for forbidden characters for header values (0x00, 0x0A,
++ * 0x0D), starting at pointer <start> which must be within <ist>. Returns
++ * non-zero if such a character is found, 0 otherwise. When run on unlikely
++ * header match, it's recommended to first check for the presence of control
++ * chars using ist_find_ctl().
++ */
++static int has_forbidden_char(const struct ist ist, const char *start)
++{
++	do {
++		if ((uint8_t)*start <= 0x0d &&
++		    (1U << (uint8_t)*start) & ((1<<13) | (1<<10) | (1<<0)))
++			return 1;
++		start++;
++	} while (start < ist.ptr + ist.len);
++	return 0;
++}
++
+ /* Parse the Content-Length header field of an HTTP/2 request. The function
+  * checks all possible occurrences of a comma-delimited value, and verifies
+  * if any of them doesn't match a previous value. It returns <0 if a value
+@@ -309,6 +326,7 @@ int h2_make_htx_request(struct http_hdr *list, struct htx *htx, unsigned int *ms
+ 	uint32_t used = htx_used_space(htx);
+ 	struct htx_sl *sl = NULL;
+ 	unsigned int sl_flags = 0;
++	const char *ctl;
+ 
+ 	lck = ck = -1; // no cookie for now
+ 	fields = 0;
+@@ -327,6 +345,13 @@ int h2_make_htx_request(struct http_hdr *list, struct htx *htx, unsigned int *ms
+ 			phdr = h2_str_to_phdr(list[idx].n);
+ 		}
+ 
++		/* RFC7540#10.3: intermediaries forwarding to HTTP/1 must take care of
++		 * rejecting NUL, CR and LF characters.
++		 */
++		ctl = ist_find_ctl(list[idx].v);
++		if (unlikely(ctl) && has_forbidden_char(list[idx].v, ctl))
++			goto fail;
++
+ 		if (phdr > 0 && phdr < H2_PHDR_NUM_ENTRIES) {
+ 			/* insert a pseudo header by its index (in phdr) and value (in value) */
+ 			if (fields & ((1 << phdr) | H2_PHDR_FND_NONE)) {
+@@ -553,6 +578,7 @@ int h2_make_htx_response(struct http_hdr *list, struct htx *htx, unsigned int *m
+ 	uint32_t used = htx_used_space(htx);
+ 	struct htx_sl *sl = NULL;
+ 	unsigned int sl_flags = 0;
++	const char *ctl;
+ 
+ 	fields = 0;
+ 	for (idx = 0; list[idx].n.len != 0; idx++) {
+@@ -570,6 +596,13 @@ int h2_make_htx_response(struct http_hdr *list, struct htx *htx, unsigned int *m
+ 			phdr = h2_str_to_phdr(list[idx].n);
+ 		}
+ 
++		/* RFC7540#10.3: intermediaries forwarding to HTTP/1 must take care of
++		 * rejecting NUL, CR and LF characters.
++		 */
++		ctl = ist_find_ctl(list[idx].v);
++		if (unlikely(ctl) && has_forbidden_char(list[idx].v, ctl))
++			goto fail;
++
+ 		if (phdr > 0 && phdr < H2_PHDR_NUM_ENTRIES) {
+ 			/* insert a pseudo header by its index (in phdr) and value (in value) */
+ 			if (fields & ((1 << phdr) | H2_PHDR_FND_NONE)) {
+@@ -675,6 +708,7 @@ int h2_make_htx_response(struct http_hdr *list, struct htx *htx, unsigned int *m
+  */
+ int h2_make_htx_trailers(struct http_hdr *list, struct htx *htx)
+ {
++	const char *ctl;
+ 	struct htx_blk *blk;
+ 	char *out;
+ 
+@@ -705,6 +739,13 @@ int h2_make_htx_trailers(struct http_hdr *list, struct htx *htx)
+ 		    isteq(list[idx].n, ist("transfer-encoding")))
+ 			goto fail;
+ 
++		/* RFC7540#10.3: intermediaries forwarding to HTTP/1 must take care of
++		 * rejecting NUL, CR and LF characters.
++		 */
++		ctl = ist_find_ctl(list[idx].v);
++		if (unlikely(ctl) && has_forbidden_char(list[idx].v, ctl))
++			goto fail;
++
+ 		len += list[idx].n.len + 2 + list[idx].v.len + 2;
+ 	}
+ 

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,6 +1,6 @@
 { useLua ? !stdenv.isDarwin
 , usePcre ? true
-, stdenv, fetchurl
+, stdenv, fetchurl, fetchpatch
 , openssl, zlib, lua5_3 ? null, pcre ? null
 }:
 
@@ -15,6 +15,20 @@ stdenv.mkDerivation rec {
     url = "https://www.haproxy.org/download/${stdenv.lib.versions.majorMinor version}/src/${pname}-${version}.tar.gz";
     sha256 = "1via9k84ycrdr8qh4qchcbqgpv0gynm3ra23nwsvqwfqvc0376id";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-19330-part1.patch";
+      url = "https://git.haproxy.org/?p=haproxy.git;a=patch;h=8f3ce06f14e13719c9353794d60001eab8d43717";
+      sha256 = "14hzbv5hdxffiwxwdka1d50w2lpv9jhazrrg729nwbpz7hy2cn6c";
+    })
+    ./1.9.8-CVE-2019-19330-part2.patch
+    (fetchpatch {
+      name = "CVE-2019-19330-part3.patch";
+      url = "https://git.haproxy.org/?p=haproxy.git;a=patch;h=146f53ae7e97dbfe496d0445c2802dd0a30b0878";
+      sha256 = "1dv53l3yq9b3iym5x3985sb2lg0mwjyvn8ylkr6rwj0nm9bnshln";
+    })
+  ];
 
   buildInputs = [ openssl zlib ]
     ++ stdenv.lib.optional useLua lua5_3


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-19330

Patch needed a small amount of context-adjustment to apply, so included in-repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
