### PR TITLE
ocamlPackages.dispatch: init at 0.4.1; ocamlPackages.webmachine: init at 0.6.1

### DIFF
--- a/pkgs/development/ocaml-modules/dispatch/default.nix
+++ b/pkgs/development/ocaml-modules/dispatch/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildDunePackage, fetchFromGitHub, alcotest, result }:
+
+buildDunePackage rec {
+  pname = "dispatch";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "inhabitedtype";
+    repo = "ocaml-dispatch";
+    rev = "${version}";
+    sha256 = "05kb9zcihk50r2haqz8vrlr7kmaka6vrs4j1z500lmnl877as6qr";
+  };
+
+  propagatedBuildInputs = [ result ];
+
+  checkInputs = lib.optional doCheck alcotest;
+
+  doCheck = true;
+
+  meta = {
+    inherit (src.meta) homepage;
+    license = lib.licenses.bsd3;
+    description = "Path-based dispatching for client- and server-side applications";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/webmachine/default.nix
+++ b/pkgs/development/ocaml-modules/webmachine/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildDunePackage, fetchFromGitHub
+, cohttp, dispatch, ptime
+, ounit
+}:
+
+buildDunePackage rec {
+  pname = "webmachine";
+  version = "0.6.1";
+
+  minimumOCamlVersion = "4.04";
+
+  src = fetchFromGitHub {
+    owner = "inhabitedtype";
+    repo = "ocaml-webmachine";
+    rev = "${version}";
+    sha256 = "0kpbxsvjzylbxmxag77k1c8m8mwn4f4xscqk2i7fc591llgq9fp3";
+  };
+
+  propagatedBuildInputs = [ cohttp dispatch ptime ];
+
+  checkInputs = lib.optional doCheck ounit;
+
+  doCheck = true;
+
+  meta = {
+    inherit (src.meta) homepage;
+    license = lib.licenses.bsd3;
+    description = "A REST toolkit for OCaml";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -217,6 +217,8 @@ let
 
     digestif =  callPackage ../development/ocaml-modules/digestif { };
 
+    dispatch =  callPackage ../development/ocaml-modules/dispatch { };
+
     dolmen =  callPackage ../development/ocaml-modules/dolmen { };
 
     dolog = callPackage ../development/ocaml-modules/dolog { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -827,6 +827,8 @@ let
 
     wasm = callPackage ../development/ocaml-modules/wasm { };
 
+    webmachine = callPackage ../development/ocaml-modules/webmachine { };
+
     wtf8 = callPackage ../development/ocaml-modules/wtf8 { };
 
     x509 = callPackage ../development/ocaml-modules/x509 { };


### PR DESCRIPTION
###### Motivation for this change

Dependencies of irmin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
