### PR TITLE
python3Packages.responses: 0.10.6 -> 0.10.7

### DIFF
--- a/pkgs/development/python-modules/responses/default.nix
+++ b/pkgs/development/python-modules/responses/default.nix
@@ -1,16 +1,33 @@
-{ buildPythonPackage, fetchPypi
-, cookies, mock, requests, six }:
+{ buildPythonPackage
+, fetchPypi
+, lib
+, cookies
+, mock
+, requests
+, six
+, flake8
+, pytest
+, pytestcov
+, pytest-localserver
+}:
 
 buildPythonPackage rec {
   pname = "responses";
-  version = "0.10.6";
+  version = "0.10.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "502d9c0c8008439cfcdef7e251f507fcfdd503b56e8c0c87c3c3e3393953f790";
+    sha256 = "0fv28b89bhpba3kyfhay8284dw0yapafs178qxmi1ilzl53fbm26";
   };
 
+  nativeBuildInputs = [ flake8 pytest pytestcov pytest-localserver ];
   propagatedBuildInputs = [ cookies mock requests six ];
 
-  doCheck = false;
+  meta = with lib; {
+    description = "A utility library for mocking out the requests Python library";
+    homepage = "https://github.com/getsentry/responses";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ mtrsk ];
+    platforms = platforms.linux;
+  };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Removed `doCheck = false` and added the necessary deps so the unit tests are run. Added some meta info in the derivation and bumped the version from `0.10.6` to `0.10.7`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
