### PR TITLE
kubeprompt: init at 0.3.0

### DIFF
--- a/pkgs/development/tools/kubeprompt/default.nix
+++ b/pkgs/development/tools/kubeprompt/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubeprompt";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "jlesquembre";
+    repo = pname;
+    rev = version;
+    sha256 = "1a0xi31bd7n2zrx2z4srhvixlbj028h63dlrjzqxgmgn2w6akbz2";
+  };
+
+  preBuild = ''
+    export buildFlagsArray+=(
+      "-ldflags=
+        -w -s
+        -X ${goPackagePath}/pkg/version.Version=${version}")
+  '';
+
+  goPackagePath = "github.com/jlesquembre/kubeprompt";
+  modSha256 = "0rbpdk2dixywn3wcdgz48f3xw3b7fk8xh7mrlx27wz7fq5wj9v8f";
+
+  meta = with stdenv.lib; {
+    description = "Kubernetes prompt";
+    homepage = "https://github.com/jlesquembre/kubeprompt";
+    license = licenses.epl20;
+    maintainers = with maintainers; [ jlesquembre ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9862,6 +9862,8 @@ in
 
   kube-prompt = callPackage ../development/tools/kube-prompt { };
 
+  kubeprompt = callPackage ../development/tools/kubeprompt { };
+
   kubicorn = callPackage ../development/tools/kubicorn {  };
 
   kustomize = callPackage ../development/tools/kustomize { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I'm the maintainer for [kubeprompt](https://github.com/jlesquembre/kubeprompt) and I'd like to add (and maintain) it to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


