### PR TITLE
libtermkey: compile with unibilium

### DIFF
--- a/pkgs/development/libraries/libtermkey/default.nix
+++ b/pkgs/development/libraries/libtermkey/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchzip, libtool, pkgconfig, ncurses }:
+{ stdenv, lib, fetchzip, libtool, pkgconfig, ncurses, unibilium }:
 
 stdenv.mkDerivation rec {
   pname = "libtermkey";
@@ -13,11 +13,12 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=$(out)" ]
     ++ stdenv.lib.optional stdenv.isDarwin "LIBTOOL=${libtool}/bin/libtool";
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libtool ncurses ];
+  nativeBuildInputs = [ libtool pkgconfig ];
+  buildInputs = [ ncurses unibilium ];
 
   meta = with lib; {
     description = "Terminal keypress reading library";
+    homepage = http://www.leonerd.org.uk/code/libtermkey;
     license = licenses.mit;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

While working on neovim, I noticed the functionaltests were failing https://github.com/neovim/neovim/pull/11429. There are bugs in libtermkey that can't load the terminfo driver for some values of TERM. As per libtermkey's author:
```
To be honest, unibilium is basically a requirement now. I
might just change the code to throw away the other bits and make it a
dependency.

```
building with unibilium solved all my issues.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
