### PR TITLE
NEW Athame-zsh

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7670,4 +7670,9 @@
     githubId = 52650;
     name = "Marc Busqué";
   };
+  bananPasha = {
+    name = "Pavlo Vlasenko";
+    email = "smidy999green@gmail.com";
+    github = "BananchickPasha";
+  };
 }

--- a/pkgs/shells/zsh/athame-zsh.nix
+++ b/pkgs/shells/zsh/athame-zsh.nix
@@ -1,0 +1,34 @@
+{stdenv, vim, zsh, ncurses, isNeovim ? false}:
+let athame = fetchGit {
+      rev = "ded4200cb3312334d99ace794c4b308cd45f6b6e";
+      url = "https://github.com/ardagnir/athame";
+    };
+    vimbed = fetchGit {
+      rev = "6b8e8cb45353167988c7bbbe2d9cd4d41989e490";
+      url = "https://github.com/ardagnir/vimbed";
+    };
+    vimbin = if isNeovim then "${vim}/bin/nvim" else "${vim}/bin/vim";
+in
+zsh.overrideAttrs(o: {
+  pname = "athame-zsh";
+  unpackPhase = ''
+    tar xf $src
+    mv zsh-${o.version}/* ./
+    cp "${athame}/athame".* ./Src/Zle
+    cp ${athame}/athame_util.h ./Src/Zle
+    cp ${athame}/athame_zsh.h ./Src/Zle/athame_intermediary.h
+    cp -r ${vimbed} ./Src/Zle/vimbed
+    '';
+  #patches = o.upstreamPatches;
+  buildInputs = [vim ncurses zsh];
+  makeFlags = [
+    "ATHAME_VIM_BIN=${vimbin}"
+    #"SHLIB_LIBS=\"-lncurses -lutil\""
+    "ATHAME_USE_JOBS_DEFAULT=1"
+  ];
+  postPatch = ''
+    #echo \'#!/bin/sh\' > patcher.sh
+    #sed -i 's|-Wl,-rpath,$(libdir) ||g' support/shobj-conf
+    patch -p1 -i ${athame}/zsh.patch
+    '';
+})

--- a/pkgs/shells/zsh/athame-zsh.nix
+++ b/pkgs/shells/zsh/athame-zsh.nix
@@ -19,11 +19,9 @@ zsh.overrideAttrs(o: {
     cp ${athame}/athame_zsh.h ./Src/Zle/athame_intermediary.h
     cp -r ${vimbed} ./Src/Zle/vimbed
     '';
-  #patches = o.upstreamPatches;
   buildInputs = [vim ncurses zsh];
   makeFlags = [
     "ATHAME_VIM_BIN=${vimbin}"
-    #"SHLIB_LIBS=\"-lncurses -lutil\""
     "ATHAME_USE_JOBS_DEFAULT=1"
   ];
   postPatch = ''

--- a/pkgs/shells/zsh/athame-zsh.nix
+++ b/pkgs/shells/zsh/athame-zsh.nix
@@ -31,4 +31,11 @@ zsh.overrideAttrs(o: {
     #sed -i 's|-Wl,-rpath,$(libdir) ||g' support/shobj-conf
     patch -p1 -i ${athame}/zsh.patch
     '';
+  meta = with stdenv.lib; {
+    description = "Athame patches zsh to add full Vim support by routing your keystrokes through an actual Vim process.";
+    homepage = https://github.com/ardagnir/athame;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ bananPasha ];
+  };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -669,7 +669,9 @@ in
   };
 
   async = callPackage ../development/tools/async {};
-
+  
+  athame-zsh = callPackage ../shells/zsh/athame-zsh.nix {};
+  
   atheme = callPackage ../servers/irc/atheme { };
 
   atinout = callPackage ../tools/networking/atinout { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
There wasn't this package so i decided to add it

###### Things done
It works, but user has to create ~/.athamerc manually. 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
