### PR TITLE
gdb: Fix safe path for cross

### DIFF
--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ stdenv, targetPackages
 
 # Build time
 , fetchurl, pkgconfig, perl, texinfo, setupDebugInfoDirs, buildPackages
@@ -8,9 +8,12 @@
 
 , pythonSupport ? stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.hostPlatform.isCygwin, python3 ? null
 , guile ? null
-# $debugdir:$datadir/auto-load are whitelisted by default by GDB
-, safePaths ? [ "$debugdir" "$datadir/auto-load" stdenv.cc.cc.lib ]
-
+, safePaths ? [
+   # $debugdir:$datadir/auto-load are whitelisted by default by GDB
+   "$debugdir" "$datadir/auto-load"
+   # targetPackages so we get the right libc when cross-compiling and using buildPackages.gdb
+   targetPackages.stdenv.cc.cc.lib
+  ]
 }:
 
 let


### PR DESCRIPTION
###### Motivation for this change

I was wrong, `gdb` is currently target-specific, so this is fine for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
