### PR TITLE
azure-cli: 2.0.76 -> 2.0.77

### DIFF
--- a/pkgs/development/python-modules/azure-loganalytics/default.nix
+++ b/pkgs/development/python-modules/azure-loganalytics/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, python
+, isPy3k
 , msrest
 , azure-common
 }:
@@ -20,6 +22,10 @@ buildPythonPackage rec {
     azure-common
   ];
 
+  postInstall = lib.optionalString isPy3k ''
+    rm -rf $out/${python.sitePackages}/azure/__init__.py
+  '';
+
   # has no tests
   doCheck = false;
 
@@ -27,6 +33,6 @@ buildPythonPackage rec {
     description = "This is the Microsoft Azure Log Analytics Client Library";
     homepage = "https://github.com/Azure/azure-sdk-for-python";
     license = licenses.mit;
-    maintainers = with maintainers; [ mwilsoninsight ];
+    maintainers = with maintainers; [ mwilsoninsight jonringer ];
   };
 }

--- a/pkgs/development/python-modules/azure-mgmt-appconfiguration/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-appconfiguration/default.nix
@@ -5,13 +5,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.1.0";
+  version = "0.3.0";
   pname = "azure-mgmt-appconfiguration";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0z2f0rbv7drdxihny479bv80bnhgvx8gb2pr0jvbaslll6d6rxig";
+    sha256 = "1igl3ikdwcz7d2zcja5nm2qjysjh53vgwzcc96lylypmq6z4aq1s";
     extension = "zip";
   };
 

--- a/pkgs/development/python-modules/azure-mgmt-compute/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-compute/default.nix
@@ -7,13 +7,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "9.0.0";
+  version = "10.0.0";
   pname = "azure-mgmt-compute";
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "06795ccb7377eaa3864819a1c63b9bfe9957a58814c65025aef89e9cd81190fc";
+    sha256 = "1s3bx6knxw5dxycp43yimvgrh0i19drzd09asglcwz2x5mr3bpyg";
   };
 
   postInstall = if isPy3k then "" else ''

--- a/pkgs/development/python-modules/azure-mgmt-monitor/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-monitor/default.nix
@@ -28,8 +28,8 @@ buildPythonPackage rec {
   ];
 
   postInstall = lib.optionalString isPy3k ''
-    rm $out/${python.sitePackages}/azure/__init__.py
-    rm $out/${python.sitePackages}/azure/mgmt/__init__.py
+    rm -rf $out/${python.sitePackages}/azure/__init__.py
+    rm -rf $out/${python.sitePackages}/azure/mgmt/__init__.py
   '';
 
   # has no tests

--- a/pkgs/tools/admin/azure-cli/default.nix
+++ b/pkgs/tools/admin/azure-cli/default.nix
@@ -1,16 +1,16 @@
-{ lib, python, fetchFromGitHub, installShellFiles }:
+{ stdenv, lib, python, fetchFromGitHub, installShellFiles }:
 
 let
-  version = "2.0.76";
+  version = "2.0.77";
   src = fetchFromGitHub {
     owner = "Azure";
     repo = "azure-cli";
     rev = "azure-cli-${version}";
-    sha256 = "0zfy8nhw4nx0idh94qidr06vsfxgdk2ky0ih76s27121pdwr05aa";
+    sha256 = "1qd6di8cqwhpcsqcx6g3scmwj90m15r695y5977q6a3qy13knisv";
   };
 
   # put packages that needs to be overriden in the py package scope
-  py = import ./python-packages.nix { inherit python lib src version; };
+  py = import ./python-packages.nix { inherit stdenv python lib src version; };
 in
 py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage {
   pname = "azure-cli";
@@ -45,6 +45,7 @@ py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage {
     azure-functions-devops-build
     azure-graphrbac
     azure-keyvault
+    azure-loganalytics
     azure-mgmt-advisor
     azure-mgmt-apimanagement
     azure-mgmt-applicationinsights
@@ -173,6 +174,7 @@ py.pkgs.toPythonApplication (py.pkgs.buildAzureCliPackage {
     "azure_functions_devops_build"
     "azure.graphrbac"
     "azure.keyvault"
+    "azure.loganalytics"
     "azure.mgmt.advisor"
     "azure.mgmt.apimanagement"
     "azure.mgmt.applicationinsights"

--- a/pkgs/tools/admin/azure-cli/python-packages.nix
+++ b/pkgs/tools/admin/azure-cli/python-packages.nix
@@ -1,4 +1,4 @@
-{ python, lib, src, version }:
+{ stdenv, python, lib, src, version }:
 
 let
   buildAzureCliPackage = with py.pkgs; attrs: buildPythonPackage (attrs // {
@@ -53,31 +53,37 @@ let
         propagatedBuildInputs = with self; [
           adal
           argcomplete
+          azure-common
           azure-cli-telemetry
+          azure-mgmt-resource
           colorama
-          jmespath
           humanfriendly
+          jmespath
           knack
           msrest
           msrestazure
           paramiko
+          psutil
           pygments
           pyjwt
           pyopenssl
+          pyperclip
           pyyaml
           requests
           six
-          azure-mgmt-resource
           tabulate
-          pyperclip
-          psutil
         ]
         ++ lib.optionals isPy3k [ antlr4-python3-runtime ]
         ++ lib.optionals (!isPy3k) [ enum34 futures antlr4-python2-runtime ndg-httpsclient ];
 
+        doCheck = stdenv.isLinux;
         # ignore test that does network call
         checkPhase = ''
-          HOME=$TMPDIR pytest --ignore=azure/cli/core/tests/test_profile.py
+          rm azure/{,cli/}__init__.py
+          python -c 'import azure.common; print(azure.common)'
+          PYTHONPATH=$PWD:$PYTHONPATH HOME=$TMPDIR pytest \
+            --ignore=azure/cli/core/tests/test_profile.py \
+            --ignore=azure/cli/core/tests/test_generic_update.py
         '';
 
         pythonImportsCheck = [
@@ -108,14 +114,14 @@ let
       azure-mgmt-resource = overrideAzureMgmtPackage super.azure-mgmt-resource "4.0.0" "zip"
         "0gy89bi89ikg5hps8rvnq28r33lixci3sk2m86jvziv9fh9rz41b";
 
-      azure-mgmt-compute = overrideAzureMgmtPackage super.azure-mgmt-compute "8.0.0" "zip"
-        "06hmf9iq2yqpmmvw7pr9zm4v427q03i436lnin3aczizfndrk76i";
+      azure-mgmt-compute = overrideAzureMgmtPackage super.azure-mgmt-compute "10.0.0" "zip"
+        "1s3bx6knxw5dxycp43yimvgrh0i19drzd09asglcwz2x5mr3bpyg";
 
       azure-mgmt-consumption = overrideAzureMgmtPackage super.azure-mgmt-consumption "2.0.0" "zip"
         "12ai4qps73ivawh0yzvgb148ksx02r30pqlvfihx497j62gsi1cs";
 
-      azure-mgmt-containerservice = overrideAzureMgmtPackage super.azure-mgmt-containerservice "7.0.0" "zip"
-        "104w7rxv7hy84yzddbbpkjqha04ghr0zz9qy788n3wl69cj4cv1a";
+      azure-mgmt-containerservice = overrideAzureMgmtPackage super.azure-mgmt-containerservice "8.0.0" "zip"
+        "0akpm12xj453dp84dfdpi06phr4q0hknr5l7bz96zbc8iand78wg";
 
       azure-mgmt-cosmosdb = overrideAzureMgmtPackage super.azure-mgmt-cosmosdb "0.8.0" "zip"
         "0iakxb2rr1w9171802m9syjzqas02vjah711mpagbgcj549mjysb";
@@ -129,8 +135,8 @@ let
       azure-mgmt-devtestlabs = overrideAzureMgmtPackage super.azure-mgmt-devtestlabs "2.2.0" "zip"
         "15lpyv9z8ss47rjmg1wx5akh22p9br2vckaj7jk3639vi38ac5nl";
 
-      azure-mgmt-netapp = overrideAzureMgmtPackage super.azure-mgmt-netapp "0.6.0" "zip"
-        "10ymvyj386z9bjdm2g1b5a4vfnn87ig2zm6xn2xddvbpy0jxnyfv";
+      azure-mgmt-netapp = overrideAzureMgmtPackage super.azure-mgmt-netapp "0.7.0" "zip"
+        "0cf4pknb5y2yz4jqwg7xm626zkfx8i8hqcr3dkvq21lrx7fz96r3";
 
       azure-mgmt-dns = overrideAzureMgmtPackage super.azure-mgmt-dns "2.1.0" "zip"
         "1l55py4fzzwhxlmnwa41gpmqk9v2ncc79w7zq11sm9a5ynrv2c1p";
@@ -144,8 +150,8 @@ let
       azure-mgmt-web = overrideAzureMgmtPackage super.azure-mgmt-web "0.42.0" "zip"
         "0vp40i9aaw5ycz7s7qqir6jq7327f7zg9j9i8g31qkfl1h1c7pdn";
 
-      azure-mgmt-reservations = overrideAzureMgmtPackage super.azure-mgmt-reservations "0.3.2" "zip"
-        "0nksxjh5kh09dr0zw667fg8mzik4ymvfq3dipwag6pynbqr9ls4l";
+      azure-mgmt-reservations = overrideAzureMgmtPackage super.azure-mgmt-reservations "0.6.0" "zip"
+        "16ycni3cjl9c0mv419gy5rgbrlg8zp0vnr6aj8z8p2ypdw6sgac3";
 
       azure-mgmt-security = overrideAzureMgmtPackage super.azure-mgmt-security "0.1.0" "zip"
         "1cb466722bs0ribrirb32kc299716pl0pwivz3jyn40dd78cwhhx";
@@ -165,8 +171,8 @@ let
       azure-mgmt-containerregistry = overrideAzureMgmtPackage super.azure-mgmt-containerregistry "3.0.0rc7" "zip"
         "1bzfpbz186dhnxn0blgr20xxnk67gkr8ysn2b3f1r41bq9hz97xp";
 
-      azure-mgmt-monitor = overrideAzureMgmtPackage super.azure-mgmt-monitor "0.5.2" "zip"
-        "1r01aq5rbynbc1my4qljdifjdj9h65bh8cdzgd7vm4ij7r48v9gi";
+      azure-mgmt-monitor = overrideAzureMgmtPackage super.azure-mgmt-monitor "0.7.0" "zip"
+        "1pprvk5255b6brbw73g0g13zygwa7a2px5x08wy3153rqlzan5l2";
 
       azure-mgmt-advisor =  overrideAzureMgmtPackage super.azure-mgmt-advisor "2.0.1" "zip"
         "1wsfkprdrn22mwm24y2zlcms8ppp7jwq3s86r3ymbl29pbaxca8r";
@@ -232,17 +238,6 @@ let
             --replace "azure-namespace-package = azure-mgmt-datalake-nspkg" ""
         '';
       });
-
-
-
-
-
-
-
-
-
-
-
 
     };
   };


### PR DESCRIPTION
###### Motivation for this change
new bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
azure-cli python27Packages.azure-loganalytics python27Packages.azure-mgmt-compute python37Packages.azure-loganalytics python37Packages.azure-mgmt-appconfiguration python37Packages.azure-mgmt-compute python37Packages.azure-mgmt-monitor python38Packages.azure-loganalytics python38Packages.azure-mgmt-appconfiguration python38Packages.azure-mgmt-compute python38Packages.azure-mgmt-monitor
```