### PR TITLE
WIP: gdb: Make target-independent and auto-load-safe-path with a wrapper

### DIFF
--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -8,12 +8,6 @@
 
 , pythonSupport ? stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.hostPlatform.isCygwin, python3 ? null
 , guile ? null
-, safePaths ? [
-   # $debugdir:$datadir/auto-load are whitelisted by default by GDB
-   "$debugdir" "$datadir/auto-load"
-   # targetPackages so we get the right libc when cross-compiling and using buildPackages.gdb
-   targetPackages.stdenv.cc.cc.lib
-  ]
 }:
 
 let
@@ -24,10 +18,7 @@ in
 assert pythonSupport -> python3 != null;
 
 stdenv.mkDerivation rec {
-  name =
-    stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform)
-                              (stdenv.targetPlatform.config + "-")
-    + basename;
+  name = basename;
 
   src = fetchurl {
     url = "mirror://gnu/gdb/${basename}.tar.xz";
@@ -62,8 +53,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-Wno-format-nonliteral";
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
-  configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (stdenv.targetPlatform != stdenv.hostPlatform) "target";
+  configurePlatforms = [ "build" "host" ];
 
   configureFlags = with stdenv.lib; [
     "--enable-targets=all" "--enable-64-bit-bfd"
@@ -75,7 +65,6 @@ stdenv.mkDerivation rec {
     "--with-gmp=${gmp.dev}"
     "--with-mpfr=${mpfr.dev}"
     "--with-expat" "--with-libexpat-prefix=${expat.dev}"
-    "--with-auto-load-safe-path=${builtins.concatStringsSep ":" safePaths}"
   ] ++ stdenv.lib.optional (!pythonSupport) "--without-python";
 
   postInstall =

--- a/pkgs/development/tools/misc/gdb/wrapper.nix
+++ b/pkgs/development/tools/misc/gdb/wrapper.nix
@@ -1,0 +1,49 @@
+{ stdenvNoCC, targetPackages
+, makeWrapper
+, gdb-unwrapped
+, safePaths ? [
+   # $debugdir:$datadir/auto-load are whitelisted by default by GDB
+   "$debugdir" "$datadir/auto-load"
+   # targetPackages so we get the right libc when cross-compiling and using buildPackages.gdb
+   targetPackages.stdenv.cc.cc.lib
+  ]
+}:
+
+let
+  gdb = gdb-unwrapped;
+
+  # Prefix for binaries. Customarily ends with a dash separator.
+  #
+  # TODO(@Ericson2314) Make unconditional, or optional but always true by
+  # default.
+  targetPrefix = stdenvNoCC.lib.optionalString
+    (stdenvNoCC.targetPlatform != stdenvNoCC.hostPlatform)
+    (stdenvNoCC.targetPlatform.config + "-");
+in
+  stdenvNoCC.mkDerivation {
+    name = gdb.name;
+    nativeBuildInputs = [ makeWrapper ];
+    propagatedUserEnvPkgs = [ gdb ];
+    phases = "installPhase fixupPhase";
+
+    # Find all gdb plugins in `safePaths` and
+    # mark these files as safe to load.
+    # TODO `set arch` in script too
+    installPhase = ''
+      mkdir -p $out/share/gdb
+      initScript=$out/share/gdb/gdbinit
+      touch $initScript
+
+      for safePath in ${stdenvNoCC.lib.concatStringsSep " " safePaths}; do
+        for plugin in $(find $safePath | grep -- '.*-gdb.*'); do
+          echo add-auto-load-safe-path $plugin >> $initScript
+        done
+      done
+
+      makeWrapper "${gdb}/bin/gdb" \
+        "$out/bin/${targetPrefix}gdb" \
+        --add-flags "-x $initScript"
+    '';
+
+    meta = gdb.meta;
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10471,7 +10471,9 @@ in
 
   bashdb = callPackage ../development/tools/misc/bashdb { };
 
-  gdb = callPackage ../development/tools/misc/gdb {
+  gdb = callPackage ../development/tools/misc/gdb/wrapper.nix { };
+
+  gdb-unwrapped = callPackage ../development/tools/misc/gdb {
     guile = null;
   };
 


### PR DESCRIPTION
###### Motivation for this change

The libgcc/compiler-rt used varies with the target platform.

I checked, and lldb doesn't have a similar notion of load prefix path,
so this stays a one-off wrapper for gdb for now.

Need to test to make sure all cross stuff works as expected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
