### PR TITLE
cpupower: explicitly set CC and LD to allow compilation with e…

### DIFF
--- a/pkgs/os-specific/linux/cpupower/default.nix
+++ b/pkgs/os-specific/linux/cpupower/default.nix
@@ -14,7 +14,11 @@ stdenv.mkDerivation {
     sed -i 's,/usr/bin/install,${buildPackages.coreutils}/bin/install,' Makefile
   '';
 
-  makeFlags = [ "CROSS=${stdenv.cc.targetPrefix}" ];
+  makeFlags = [
+    "CROSS=${stdenv.cc.targetPrefix}"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "LD=${stdenv.cc.targetPrefix}cc"
+  ];
 
   installFlags = stdenv.lib.mapAttrsToList
     (n: v: "${n}dir=${placeholder "out"}/${v}") {


### PR DESCRIPTION
###### Motivation for this change
I tried building `linuxPackages` with clang. `cpupower` failed to build, because it tries to use `gcc`. 

###### Things done
I verified that `cpupower` builds with clang `stdenv` (version 9) and successfully built `linuxPackages_5_4` with these changes (actually I am writing this on a system with clang built kernel right now). 

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
