### PR TITLE
bash-completion: Fix tests with musl.

### DIFF
--- a/pkgs/shells/bash/bash-completion/default.nix
+++ b/pkgs/shells/bash/bash-completion/default.nix
@@ -1,4 +1,6 @@
 { stdenv, fetchFromGitHub
+, lib
+, fetchpatch
 , autoreconfHook
 , python3Packages
 , bashInteractive
@@ -6,6 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "bash-completion";
+  # TODO: Remove musl patch below upon next release!
   version = "2.9";
 
   src = fetchFromGitHub {
@@ -26,6 +29,15 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001-Revert-build-Do-cmake-pc-and-profile-variable-replac.patch
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
+    # TODO: Remove when https://github.com/scop/bash-completion/commit/2cdac1b9f24df62a1fa80c1824ee8524c9b02393
+    #       is availabe in a release in nixpkgs. see https://github.com/scop/bash-completion/issues/312.
+    # Fixes a test failure with musl.
+    (fetchpatch {
+     url = "https://github.com/scop/bash-completion/commit/2cdac1b9f24df62a1fa80c1824ee8524c9b02393.patch";
+     name = "bash-completion-musl-test_iconv-skip-option-completion-if-help-fails";
+     sha256 = "1l53d62zf01k625nzw3vcrxky93h7bzdpchgk4argxalrn17ckvb";
+    })
   ];
 
   # ignore ip_addresses because it tries to touch network


### PR DESCRIPTION
###### Motivation for this change

Fixes test error

    self = <test_iconv.TestIconv object at 0x7ffff52f3410>
    completion = <CompletionResult []>

        @pytest.mark.complete("iconv -")
        def test_1(self, completion):
    >       assert completion
    E       assert <CompletionResult []>

    ../t/test_iconv.py:7: AssertionError

by applying upstream commit not present in a newer release.

See

* https://github.com/scop/bash-completion/commit/2cdac1b9f24df62a1fa80c1824ee8524c9b02393
* https://github.com/scop/bash-completion/issues/312

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti 