### PR TITLE
hpe-ltfs: init at 3.4.2_Z7550-02501

### DIFF
--- a/pkgs/tools/backup/hpe-ltfs/default.nix
+++ b/pkgs/tools/backup/hpe-ltfs/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, fuse, icu, pkgconfig, libxml2, libuuid }:
+
+stdenv.mkDerivation rec {
+  version = "3.4.2_Z7550-02501";
+  pname = "hpe-ltfs";
+
+  src = fetchFromGitHub {
+    rev = version;
+    owner = "nix-community";
+    repo = "hpe-ltfs";
+    sha256 = "193593hsc8nf5dn1fkxhzs1z4fpjh64hdkc8q6n9fgplrpxdlr4s";
+  };
+
+  sourceRoot = "source/ltfs";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ 
+    fuse icu libxml2 libuuid
+  ];
+
+  meta = with stdenv.lib; {
+    description = "HPE's implementation of the open-source tape filesystem standard ltfs";
+    homepage = https://support.hpe.com/hpesc/public/km/product/1009214665/Product;
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.redvers ];
+    platforms = platforms.linux;
+    downloadPage = https://github.com/nix-community/hpe-ltfs;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -911,6 +911,8 @@ in
 
   glyr = callPackage ../tools/audio/glyr { };
 
+  hpe-ltfs = callPackage ../tools/backup/hpe-ltfs { };
+
   httperf = callPackage ../tools/networking/httperf { };
 
   ili2c = callPackage ../tools/misc/ili2c { };


### PR DESCRIPTION
###### Motivation for this change

Adding ltfs, Linear Tape File System FUSE drivers and userspace tools to NixOS.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @redvers 
