### PR TITLE
python3Packages.fido2: 0.7.3 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/fido2/default.nix
+++ b/pkgs/development/python-modules/fido2/default.nix
@@ -1,15 +1,19 @@
-{ lib, buildPythonPackage, fetchPypi
-, six, cryptography
-, mock, pyfakefs
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+, cryptography
+, mock
+, pyfakefs
 }:
 
 buildPythonPackage rec {
   pname = "fido2";
-  version = "0.7.3";
+  version = "0.8.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8b592ec0e51348f29636706fe3266423a0e41c35c9df63a259a91488450c1285";
+    sha256 = "1hzprnd407g2xh9kyv8j8pq949hwr1snmg3fp65pqfbghzv6i424";
   };
 
   propagatedBuildInputs = [ six cryptography ];
@@ -18,7 +22,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Provides library functionality for FIDO 2.0, including communication with a device over USB.";
-    homepage = https://github.com/Yubico/python-fido2;
-    license = licenses.mpl20;
+    homepage = "https://github.com/Yubico/python-fido2";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ prusnak ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version update, fixes #74805

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
