### PR TITLE
ocamlPackages.dum: init at 1.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/dum/default.nix
+++ b/pkgs/development/ocaml-modules/dum/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildOcaml, ocaml
+{ lib, fetchFromGitHub, buildOcaml, ocaml
 , easy-format
 }:
 
@@ -19,11 +19,10 @@ buildOcaml rec {
 
   doCheck = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/mjambon/dum;
     description = "Inspect the runtime representation of arbitrary OCaml values";
     license = licenses.lgpl21Plus;
-    inherit (ocaml.meta) platforms;
     maintainers = [ maintainers.alexfmpe ];
   };
 }

--- a/pkgs/development/ocaml-modules/dum/default.nix
+++ b/pkgs/development/ocaml-modules/dum/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, buildOcaml, ocaml
+, easy-format
+}:
+
+buildOcaml rec {
+  name = "dum";
+  version = "1.0.1";
+
+  minimumOCamlVersion = "4.06";
+
+  src = fetchFromGitHub {
+    owner = "mjambon";
+    repo = name;
+    rev = "v${version}";
+    sha256 = "0yrxl97szjc0s2ghngs346x3y0xszx2chidgzxk93frjjpsr1mlr";
+  };
+
+  buildInputs = [ easy-format ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mjambon/dum;
+    description = "Inspect the runtime representation of arbitrary OCaml values";
+    license = licenses.lgpl21Plus;
+    inherit (ocaml.meta) platforms;
+    maintainers = [ maintainers.alexfmpe ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -227,6 +227,8 @@ let
 
     duff = callPackage ../development/ocaml-modules/duff { };
 
+    dum = callPackage ../development/ocaml-modules/dum { };
+
     dune = callPackage ../development/tools/ocaml/dune { };
 
     earley = callPackage ../development/ocaml-modules/earley { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Dependency of [tezos](https://gitlab.com/tezos/tezos)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
