### PR TITLE
ocamlPackages.genspio: init at 0.0.2 with dependencies

### DIFF
--- a/pkgs/development/ocaml-modules/genspio/default.nix
+++ b/pkgs/development/ocaml-modules/genspio/default.nix
@@ -1,0 +1,32 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, nonstd, sosa
+}:
+
+buildDunePackage rec {
+  pname = "genspio";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "hammerlab";
+    repo = pname;
+    rev = "${pname}.${version}";
+    sha256 = "0cp6p1f713sfv4p2r03bzvjvakzn4ili7hf3a952b3w1k39hv37x";
+  };
+
+  minimumOCamlVersion = "4.03";
+
+  propagatedBuildInputs = [ nonstd sosa ];
+
+  configurePhase = ''
+    ocaml please.mlt configure
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = https://smondet.gitlab.io/genspio-doc/;
+    description = "Typed EDSL to generate POSIX Shell scripts";
+    license = licenses.asl20;
+    maintainers = [ maintainers.alexfmpe ];
+  };
+}

--- a/pkgs/development/ocaml-modules/nonstd/default.nix
+++ b/pkgs/development/ocaml-modules/nonstd/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromBitbucket, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "nonstd";
+  version = "0.0.3";
+
+  minimumOCamlVersion = "4.02";
+
+  src = fetchFromBitbucket {
+    owner = "smondet";
+    repo = pname;
+    rev = "${pname}.${version}";
+    sha256 = "0ccjwcriwm8fv29ij1cnbc9win054kb6pfga3ygzdbjpjb778j46";
+  };
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = https://bitbucket.org/smondet/nonstd;
+    description = "Non-standard mini-library";
+    license = licenses.isc;
+    maintainers = [ maintainers.alexfmpe ];
+  };
+}

--- a/pkgs/development/ocaml-modules/sosa/default.nix
+++ b/pkgs/development/ocaml-modules/sosa/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromGitHub, stdenv
+, findlib, nonstd, ocaml, ocamlbuild
+}:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-sosa-${version}";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "hammerlab";
+    repo = "sosa";
+    rev = "sosa.${version}";
+    sha256 = "053hdv6ww0q4mivajj4iyp7krfvgq8zajq9d8x4mia4lid7j0dyk";
+  };
+
+  buildInputs = [ nonstd ocaml ocamlbuild findlib ];
+
+  buildPhase = "make build";
+
+  createFindlibDestdir = true;
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = http://www.hammerlab.org/docs/sosa/master/index.html;
+    description = "Sane OCaml String API";
+    license = licenses.isc;
+    maintainers = [ maintainers.alexfmpe ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -300,6 +300,8 @@ let
 
     gen = callPackage ../development/ocaml-modules/gen { };
 
+    genspio = callPackage ../development/ocaml-modules/genspio { };
+
     gmap = callPackage ../development/ocaml-modules/gmap { };
 
     gnuplot = callPackage ../development/ocaml-modules/gnuplot {
@@ -573,6 +575,8 @@ let
 
     nocrypto =  callPackage ../development/ocaml-modules/nocrypto { };
 
+    nonstd =  callPackage ../development/ocaml-modules/nonstd { };
+
     notty = callPackage ../development/ocaml-modules/notty { };
 
     npy = callPackage ../development/ocaml-modules/npy {
@@ -755,6 +759,8 @@ let
     };
 
     seq = callPackage ../development/ocaml-modules/seq { };
+
+    sosa = callPackage ../development/ocaml-modules/sosa { };
 
     spacetime_lib = callPackage ../development/ocaml-modules/spacetime_lib { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Dependency of [tezos](https://gitlab.com/tezos/tezos)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
