### PR TITLE
ocamlPackages.conduit: 1.0.0 -> 1.4.0 and dependencies

### DIFF
--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -21,7 +21,6 @@ buildDunePackage rec {
     description = "Network connection library for TCP and SSL";
     license = stdenv.lib.licenses.isc;
     maintainers = with stdenv.lib.maintainers; [ alexfmpe vbgl ];
-    inherit (ocaml.meta) platforms;
-	  inherit (src.meta) homepage;
+    inherit (src.meta) homepage;
   };
 }

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, ocaml
+{ stdenv, fetchFromGitHub, buildDunePackage
 , ppx_sexp_conv, sexplib
 , astring, ipaddr, macaddr, uri,
 }:

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -1,26 +1,27 @@
-{ stdenv, fetchFromGitHub, buildDunePackage
-, ppx_sexp_conv
-, astring, ipaddr, uri
+{ stdenv, fetchFromGitHub, buildDunePackage, ocaml
+, ppx_sexp_conv, sexplib
+, astring, ipaddr, macaddr, uri,
 }:
 
 buildDunePackage rec {
   pname = "conduit";
-	version = "1.0.0";
+  version = "1.4.0";
 
-	src = fetchFromGitHub {
-		owner = "mirage";
-		repo = "ocaml-conduit";
-		rev = "v${version}";
-		sha256 = "1ryigzh7sfif1mly624fpm87aw5h60n5wzdlrvqsf71qcpxc6iiz";
-	};
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = "ocaml-conduit";
+    rev = "v${version}";
+    sha256 = "1qzamqcmf9ywz04bkwrv17mz9j6zq2w9h1xmnjvp11pnwrs2xq8l";
+  };
 
-	buildInputs = [ ppx_sexp_conv ];
-	propagatedBuildInputs = [ astring ipaddr uri ];
+  buildInputs = [ ppx_sexp_conv ];
+  propagatedBuildInputs = [ astring ipaddr macaddr sexplib uri ];
 
-	meta = {
-		description = "Network connection library for TCP and SSL";
-		license = stdenv.lib.licenses.isc;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
-		inherit (src.meta) homepage;
-	};
+  meta = {
+    description = "Network connection library for TCP and SSL";
+    license = stdenv.lib.licenses.isc;
+    maintainers = with stdenv.lib.maintainers; [ alexfmpe vbgl ];
+    inherit (ocaml.meta) platforms;
+	  inherit (src.meta) homepage;
+  };
 }

--- a/pkgs/development/ocaml-modules/conduit/lwt.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildDunePackage, ppx_sexp_conv, sexplib, conduit, ocaml_lwt }:
+{ stdenv, buildDunePackage, ppx_sexp_conv, conduit, ocaml_lwt }:
 
 if !stdenv.lib.versionAtLeast conduit.version "1.0"
 then conduit

--- a/pkgs/development/ocaml-modules/conduit/lwt.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildDunePackage, ppx_sexp_conv, conduit, ocaml_lwt }:
+{ stdenv, buildDunePackage, ppx_sexp_conv, sexplib, conduit, ocaml_lwt }:
 
 if !stdenv.lib.versionAtLeast conduit.version "1.0"
 then conduit

--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -19,7 +19,6 @@ buildDunePackage rec {
     homepage = https://github.com/mirage/ocaml-ipaddr;
     description = "A library for manipulation of IP (and MAC) address representations ";
     license = licenses.isc;
-    inherit (ocaml.meta) platforms;
     maintainers = with maintainers; [ alexfmpe ericbmerritt ];
   };
 }

--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, buildDunePackage, ocaml
-, macaddr, ounit, sexplib
+{ lib, buildDunePackage
+, macaddr, ounit
 }:
 
 buildDunePackage rec {
@@ -13,7 +13,7 @@ buildDunePackage rec {
 
   doCheck = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/mirage/ocaml-ipaddr;
     description = "A library for manipulation of IP (and MAC) address representations ";
     license = licenses.isc;

--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -4,14 +4,12 @@
 
 buildDunePackage rec {
   pname = "ipaddr";
-  version = "3.1.0";
 
-  src = fetchurl {
-    url = "https://github.com/mirage/ocaml-${pname}/archive/v${version}.tar.gz";
-    sha256 = "1hi3v5dzg6h4qb268ch3h6v61gsc8bv21ajhb35z37v5nsdmyzbh";
-  };
+  inherit (macaddr) version src;
 
-  buildInputs = [ macaddr ounit sexplib ];
+  buildInputs = [ ounit ];
+
+  propagatedBuildInputs = [ macaddr ];
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -1,20 +1,25 @@
-{ stdenv, fetchurl, buildDunePackage, sexplib, ppx_sexp_conv }:
+{ stdenv, fetchurl, buildDunePackage, ocaml
+, macaddr, ounit, sexplib
+}:
 
 buildDunePackage rec {
   pname = "ipaddr";
-  version = "2.8.0";
+  version = "3.1.0";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-${pname}/archive/${version}.tar.gz";
-    sha256 = "1amb1pbm9ybpxy6190qygpj6nmbzzs2r6vx4xh5r6v89szx9rfxw";
+    url = "https://github.com/mirage/ocaml-${pname}/archive/v${version}.tar.gz";
+    sha256 = "1hi3v5dzg6h4qb268ch3h6v61gsc8bv21ajhb35z37v5nsdmyzbh";
   };
 
-  propagatedBuildInputs = [ ppx_sexp_conv sexplib ];
+  buildInputs = [ macaddr ounit sexplib ];
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/mirage/ocaml-ipaddr;
     description = "A library for manipulation of IP (and MAC) address representations ";
     license = licenses.isc;
-    maintainers = [ maintainers.ericbmerritt ];
+    inherit (ocaml.meta) platforms;
+    maintainers = with maintainers; [ alexfmpe ericbmerritt ];
   };
 }

--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, buildDunePackage, ocaml
-, ppx_sexp_conv, sexplib
+{ lib, fetchurl, buildDunePackage
+, ppx_sexp_conv
 }:
 
 buildDunePackage rec {
@@ -17,7 +17,7 @@ buildDunePackage rec {
 
   doCheck = false; # ipaddr and macaddr tests are together, which requires mutual dependency
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/mirage/ocaml-ipaddr;
     description = "A library for manipulation of MAC address representations";
     license = licenses.isc;

--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, ocaml
+{ stdenv, fetchurl, buildDunePackage, ocaml
 , ppx_sexp_conv, sexplib
 }:
 
@@ -8,14 +8,10 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.04";
 
-  src = fetchFromGitHub {
-    owner = "mirage";
-    repo = "ocaml-ipaddr";
-    rev = "v${version}";
-    sha256 = "0g7wgfn06z7fhdk4hlblf7b5k2ws56z0l73gk7189p5wvrmbavvx";
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-ipaddr/archive/v${version}.tar.gz";
+    sha256 = "1hi3v5dzg6h4qb268ch3h6v61gsc8bv21ajhb35z37v5nsdmyzbh";
   };
-
-  buildInputs = [ sexplib ];
 
   propagatedBuildInputs = [ ppx_sexp_conv ];
 

--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -25,7 +25,6 @@ buildDunePackage rec {
     homepage = https://github.com/mirage/ocaml-ipaddr;
     description = "A library for manipulation of MAC address representations";
     license = licenses.isc;
-    inherit (ocaml.meta) platforms;
     maintainers = [ maintainers.alexfmpe ];
   };
 }

--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, buildDunePackage, ocaml
+, ppx_sexp_conv, sexplib
+}:
+
+buildDunePackage rec {
+  pname = "macaddr";
+  version = "3.1.0";
+
+  minimumOCamlVersion = "4.04";
+
+  src = fetchFromGitHub {
+    owner = "mirage";
+    repo = "ocaml-ipaddr";
+    rev = "v${version}";
+    sha256 = "0g7wgfn06z7fhdk4hlblf7b5k2ws56z0l73gk7189p5wvrmbavvx";
+  };
+
+  buildInputs = [ sexplib ];
+
+  propagatedBuildInputs = [ ppx_sexp_conv ];
+
+  doCheck = false; # ipaddr and macaddr tests are together, which requires mutual dependency
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mirage/ocaml-ipaddr;
+    description = "A library for manipulation of MAC address representations";
+    license = licenses.isc;
+    inherit (ocaml.meta) platforms;
+    maintainers = [ maintainers.alexfmpe ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -448,6 +448,8 @@ let
       lwt = ocaml_lwt;
     };
 
+    macaddr = callPackage ../development/ocaml-modules/macaddr { };
+
     macaque = callPackage ../development/ocaml-modules/macaque { };
 
     magic-mime = callPackage ../development/ocaml-modules/magic-mime { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/mirage/ocaml-conduit/blob/master/CHANGES.md#v140
https://github.com/mirage/ocaml-ipaddr/blob/master/CHANGES.md#v310-2019-03-02

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
