### PR TITLE
[19.09] lib/versions: expose splitVersion

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -135,5 +135,7 @@ let
       mergeAttrsByFuncDefaultsClean mergeAttrBy
       fakeSha256 fakeSha512
       nixType imap;
+    inherit (versions)
+      splitVersion;
   });
 in lib

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -1,13 +1,15 @@
 /* Version string functions. */
 { lib }:
 
-let
+rec {
 
+  /* Break a version string into its component parts.
+
+     Example:
+       splitVersion "1.2.3"
+       => ["1" "2" "3"]
+  */
   splitVersion = builtins.splitVersion or (lib.splitString ".");
-
-in
-
-{
 
   /* Get the major version string from a string.
 


### PR DESCRIPTION
###### Motivation for this change
noticed stable wasn't eval'ing due to this needing to be backported example: https://github.com/NixOS/nixpkgs/pull/74815



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
