### PR TITLE
python: spectral-cube: 0.4.4 -> 0.4.5

### DIFF
--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchPypi
+, fetchFromGitHub
 , buildPythonPackage
 , astropy
 , radio_beam
@@ -10,11 +10,14 @@
 
 buildPythonPackage rec {
   pname = "spectral-cube";
-  version = "0.4.4";
+  version = "0.4.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "9051ede204b1e25b6358b5e0e573b624ec0e208c24eb03a7ed4925b745c93b5e";
+  # Fetch from GitHub instead of PyPi, as 0.4.5 isn't available in PyPi
+  src = fetchFromGitHub {
+    owner = "radio-astro-tools";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xc1m6vpl0bm600fx9vypa7zcvwg7yvhgn0w89y6v9d1vl0qcs7z";
   };
 
   propagatedBuildInputs = [ astropy radio_beam ];
@@ -40,8 +43,6 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ smaret ];
-    broken = true;
   };
 }
-
 


### PR DESCRIPTION
###### Motivation for this change

Update spectral-cube to the latest upstream. The current version in nixpkgs (0.4.4) is broken because the tests fail (radio-astro-tools/spectral-cube#591). This new release fixes the tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

