### PR TITLE
plasma5.plasma-workspace: fix patch

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-workspace/plasma-workspace.patch
+++ b/pkgs/desktops/plasma-5/plasma-workspace/plasma-workspace.patch
@@ -1,9 +1,8 @@
 diff --git a/sddm-theme/theme.conf.cmake b/sddm-theme/theme.conf.cmake
-index 69d3070..52e9102 100644
+index ea9a943..f98ddd2 100644
 --- a/sddm-theme/theme.conf.cmake
 +++ b/sddm-theme/theme.conf.cmake
-@@ -1,5 +1,5 @@
- [General]
+@@ -2,4 +2,4 @@
  type=image
  color=#1d99f3
  fontSize=10
@@ -37,7 +36,7 @@ index 493218e..d507aa5 100644
 +    return system( NIXPKGS_KDOSTARTUPCONFIG5 );
      }
 diff --git a/startkde/startkde.cmake b/startkde/startkde.cmake
-index b68f0c6..a0ec214 100644
+index b68f0c6..97a13a1 100644
 --- a/startkde/startkde.cmake
 +++ b/startkde/startkde.cmake
 @@ -1,22 +1,31 @@
@@ -443,7 +442,7 @@ index b68f0c6..a0ec214 100644
  if test $? -eq 255; then
    # Startup error
    echo 'startkde: Could not start ksmserver. Check your installation.'  1>&2
-@@ -286,36 +387,36 @@ fi
+@@ -286,19 +387,19 @@ fi
  #Anything after here is logout
  #It is not called after shutdown/restart
 
@@ -465,13 +464,12 @@ index b68f0c6..a0ec214 100644
              # ask remaining drkonqis to die in a graceful way
 -            qdbus | grep 'org.kde.drkonqi-' | while read address ; do
 -                qdbus "$address" "/MainApplication" "quit"
--            done
--            break
 +            @NIXPKGS_QDBUS@ | @NIXPKGS_GREP@ 'org.kde.drkonqi-' | while read address ; do
 +                @NIXPKGS_QDBUS@ "$address" "/MainApplication" "quit"
+             done
+             break
          fi
-     done
- fi
+@@ -307,15 +408,17 @@ fi
 
  echo 'startkde: Shutting down...'  1>&2
  # just in case
@@ -1008,5 +1006,3 @@ index dcb473a..0988740 100644
 
  echo 'startplasmacompositor: Shutting down...'  1>&2
 
---
-2.19.2


### PR DESCRIPTION
At some point a patch accidentally removed

```
done
break
```
from an if then/while loop in `startkde`.

Which still breaks, but not the way we want...

```
plasma-workspace-5.16.5/bin/startkde: line 403: syntax error near unexpected token `fi'
plasma-workspace-5.16.5/bin/startkde: line 403: `        fi'
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I've been having more problems with KDE lately than normal and while I was going through my journalctl I came across the error message. I'm not sure if it's related to my logout problems or not but... hopefully.

unpackPhase had this source (startkde.cmake)

```
if test x"$wait_drkonqi"x = x"true"x ; then
    # wait for remaining drkonqi instances with timeout (in seconds)
    wait_drkonqi_timeout=`kreadconfig5 --file startkderc --group WaitForDrKonqi --key Timeout --default 900`
    wait_drkonqi_counter=0
    while qdbus | grep "^[^w]*org.kde.drkonqi" > /dev/null ; do
        sleep 5
        wait_drkonqi_counter=$((wait_drkonqi_counter+5))
        if test "$wait_drkonqi_counter" -ge "$wait_drkonqi_timeout" ; then
            # ask remaining drkonqis to die in a graceful way
            qdbus | grep 'org.kde.drkonqi-' | while read address ; do
                qdbus "$address" "/MainApplication" "quit"
            done
            break
        fi
    done
fi

```

After the patchPhase
```
if [ x"$wait_drkonqi"x = x"true"x ]; then
    # wait for remaining drkonqi instances with timeout (in seconds)
    wait_drkonqi_timeout=$(@NIXPKGS_KREADCONFIG5@ --file startkderc --group WaitForDrKonqi --key Timeout --default 900)
    wait_drkonqi_counter=0
    while @NIXPKGS_QDBUS@ | @NIXPKGS_GREP@ -q "^[^w]*org.kde.drkonqi" ; do
        sleep 5
        wait_drkonqi_counter=$((wait_drkonqi_counter+5))
        if [ "$wait_drkonqi_counter" -ge "$wait_drkonqi_timeout" ]; then
            # ask remaining drkonqis to die in a graceful way
            @NIXPKGS_QDBUS@ | @NIXPKGS_GREP@ 'org.kde.drkonqi-' | while read address ; do
                @NIXPKGS_QDBUS@ "$address" "/MainApplication" "quit"
        fi
    done
fi
```
What ends up in bin/startkde
```
if [ x"$wait_drkonqi"x = x"true"x ]; then
    # wait for remaining drkonqi instances with timeout (in seconds)
    wait_drkonqi_timeout=$(/nix/store/s9a9fv0nkq1zaqxcs6p19fg4d6p6nrv2-kconfig-5.62.0-bin/bin/kreadconfig5 --file startkderc --group WaitForDrKonqi --key Timeout --default 900)
    wait_drkonqi_counter=0
    while /nix/store/8cimdfy053rw5lgsm570c4m0rffb4g4g-qttools-5.12.5-bin/bin/qdbus | /nix/store/20b535jb98hy7k4z8vkrlkjma212a3l5-gnugrep-3.3/bin/grep -q "^[^w]*org.kde.drkonqi" ; do
        sleep 5
        wait_drkonqi_counter=$((wait_drkonqi_counter+5))
        if [ "$wait_drkonqi_counter" -ge "$wait_drkonqi_timeout" ]; then
            # ask remaining drkonqis to die in a graceful way
            /nix/store/8cimdfy053rw5lgsm570c4m0rffb4g4g-qttools-5.12.5-bin/bin/qdbus | /nix/store/20b535jb98hy7k4z8vkrlkjma212a3l5-gnugrep-3.3/bin/grep 'org.kde.drkonqi-' | while read address ; do
                /nix/store/8cimdfy053rw5lgsm570c4m0rffb4g4g-qttools-5.12.5-bin/bin/qdbus "$address" "/MainApplication" "quit"
        fi
    done
fi

```
What shellcheck had to say about that (in red, really angry!)
```
In /run/current-system/sw/bin/startkde line 399:
        if [ "$wait_drkonqi_counter" -ge "$wait_drkonqi_timeout" ]; then
                                                                    ^-- SC1009: The mentioned syntax error was in this then clause.


In /run/current-system/sw/bin/startkde line 401:
            /nix/store/8cimdfy053rw5lgsm570c4m0rffb4g4g-qttools-5.12.5-bin/bin/qdbus | /nix/store/20b535jb98hy7k4z8vkrlkjma212a3l5-gnugrep-3.3/bin/grep 'org.kde.drkonqi-' | while read address ; do
                                                                                                                                                                             ^-- SC1073: Couldn't parse this while loop. Fix to allow more checks.
                                                                                                                                                                                                  ^-- SC1061: Couldn't find 'done' for this 'do'.


In /run/current-system/sw/bin/startkde line 403:
        fi
        ^-- SC1062: Expected 'done' matching previously mentioned 'do'.
          ^-- SC1072: Unexpected keyword/token. Fix any mentioned problems and try again.

For more information:
  https://www.shellcheck.net/wiki/SC1061 -- Couldn't find 'done' for this 'do'.
  https://www.shellcheck.net/wiki/SC1062 -- Expected 'done' matching previous...
  https://www.shellcheck.net/wiki/SC1072 -- Unexpected keyword/token. Fix any...
```
And now, what you've all been waiting for....!

What it looks like with this patch
```
if [ x"$wait_drkonqi"x = x"true"x ]; then
    # wait for remaining drkonqi instances with timeout (in seconds)
    wait_drkonqi_timeout=$(/nix/store/8h096wmzmxpfz25bxsxm3zyrpaf1iw90-kconfig-5.62.0-bin/bin/kreadconfig5 --file startkderc --group WaitForDrKonqi --key Timeout --default 900)
    wait_drkonqi_counter=0
    while /nix/store/bd56x7j9cas7pg37cm2b9gvzv16qbd3h-qttools-5.12.6-bin/bin/qdbus | /nix/store/20b535jb98hy7k4z8vkrlkjma212a3l5-gnugrep-3.3/bin/grep -q "^[^w]*org.kde.drkonqi" ; do
        sleep 5
        wait_drkonqi_counter=$((wait_drkonqi_counter+5))
        if [ "$wait_drkonqi_counter" -ge "$wait_drkonqi_timeout" ]; then
            # ask remaining drkonqis to die in a graceful way
            /nix/store/bd56x7j9cas7pg37cm2b9gvzv16qbd3h-qttools-5.12.6-bin/bin/qdbus | /nix/store/20b535jb98hy7k4z8vkrlkjma212a3l5-gnugrep-3.3/bin/grep 'org.kde.drkonqi-' | while read address ; do
                /nix/store/bd56x7j9cas7pg37cm2b9gvzv16qbd3h-qttools-5.12.6-bin/bin/qdbus "$address" "/MainApplication" "quit"
            done
            break
        fi
    done
fi
```
Which makes shellcheck a bit less angry about that and start mentioning the rest of the file should use globbing and that read without -r mangles backslashes. Whatever that means.

###### Things done
I spent way too long (hours, if not days) trying to figure out how all of this worked... and all just so I could do what ultimately amounts to nothing more than adding two lines to a bash script. Well, not removing two lines from a cmake file. :)

~/projects/nixpkgs tracks NixOS/nixpkgs master, and pr-nixpkgs has this PR... (after unpackPhase and patchPhase)
```
[nix-shell:~/projects/nixpkgs]$ diff -ru plasma-workspace-5.16.5/ ~/projects/github/pr-nixpkgs/plasma-workspace-5.16.5/
```
```
diff -ru plasma-workspace-5.16.5/startkde/startkde.cmake /home/kiwi/projects/github/pr-nixpkgs/plasma-workspace-5.16.5/startkde/startkde.cmake
--- plasma-workspace-5.16.5/startkde/startkde.cmake	2019-12-02 10:33:10.319036592 +0000
+++ /home/kiwi/projects/github/pr-nixpkgs/plasma-workspace-5.16.5/startkde/startkde.cmake	2019-12-02 08:37:56.851321636 +0000
@@ -400,6 +400,8 @@
             # ask remaining drkonqis to die in a graceful way
             @NIXPKGS_QDBUS@ | @NIXPKGS_GREP@ 'org.kde.drkonqi-' | while read address ; do
                 @NIXPKGS_QDBUS@ "$address" "/MainApplication" "quit"
+            done
+            break
         fi
     done
 fi
```
I don't know that this change would matter; but plasma5 tests still passed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
