### PR TITLE
caddy: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/servers/caddy/default.nix
+++ b/pkgs/servers/caddy/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "caddy";
-  version = "1.0.3";
+  version = "1.0.4";
 
   goPackagePath = "github.com/caddyserver/caddy";
 
@@ -12,9 +12,9 @@ buildGoModule rec {
     owner = "caddyserver";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1n7i9w4vva5x5wry7gzkyfylk39x40ykv7ypf1ca3zbbk7w5x6mw";
+    sha256 = "0mqbaa9cshrqm5fggm5l5nzcnv8c9dvylcc4z7qj3322vl5cpfdc";
   };
-  modSha256 = "0np0mbs0mrn8scqa0dgvi7ya1707b3883prdaf1whsqrcr71ig8q";
+  modSha256 = "0f08smcnzmrj3v43v0qgyd11qwdbymbl86c9prais6sykgh1ld97";
 
   preBuild = ''
     cat << EOF > caddy/main.go

--- a/pkgs/servers/caddy/default.nix
+++ b/pkgs/servers/caddy/default.nix
@@ -28,9 +28,9 @@ buildGoModule rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://caddyserver.com;
+    homepage = "https://caddyserver.com";
     description = "Fast, cross-platform HTTP/2 web server with automatic HTTPS";
     license = licenses.asl20;
-    maintainers = with maintainers; [ rushmorem fpletz zimbatm ];
+    maintainers = with maintainers; [ rushmorem fpletz zimbatm filalex77 ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/caddyserver/caddy/releases/tag/v1.0.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
$ nix path-info -Sh /nix/store/qxym7h0ni197r0aw7ggadd2936c8y6ay-caddy-1.0.3
/nix/store/qxym7h0ni197r0aw7ggadd2936c8y6ay-caddy-1.0.3   45.5M
$ nix path-info -Sh /nix/store/hc3fxbfwiawr0hyc11869a44gkrjy00l-caddy-1.0.4
/nix/store/hc3fxbfwiawr0hyc11869a44gkrjy00l-caddy-1.0.4   46.3M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rushmorem @fpletz @zimbatm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/74833)
<!-- Reviewable:end -->
