### PR TITLE
ssb-patchwork: 3.16.2 -> 3.17.1

### DIFF
--- a/pkgs/applications/networking/ssb/patchwork/default.nix
+++ b/pkgs/applications/networking/ssb/patchwork/default.nix
@@ -2,12 +2,12 @@
 
 let
   pname = "ssb-patchwork";
-  version = "3.16.2";
-  name = "${pname}-${version}";
+  version = "3.17.1";
+  name = "Patchwork-${version}";
 
   src = fetchurl {
-    url = "https://github.com/ssbc/patchwork/releases/download/v${version}/${pname}-${version}-x86_64.AppImage";
-    sha256 = "0hi9ysmwhiiww82a3mqdd2b1anj7qa41b46f6zb3q9d0b8nmvlz4";
+    url = "https://github.com/ssbc/patchwork/releases/download/v${version}/${name}.AppImage";
+    sha256 = "06wcgdcagmh80nr8nyrnz83wgq7j8r96hn3ccka7nmn02pdgvp3k";
   };
 
   binary = appimageTools.wrapType2 {


### PR DESCRIPTION
###### Motivation for this change

Bump `ssb-patchwork` to `3.17.1`. Nothing major happening here.

Tested and used locally for the past few days without any trouble, I guess it's time to merge that to nixpkgs.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli 
