### PR TITLE
nixos/pantheon fix GNOME_SESSION_DEBUG conflict

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -159,7 +159,7 @@ in
     # Override GSettings schemas
     environment.sessionVariables.NIX_GSETTINGS_OVERRIDES_DIR = "${nixos-gsettings-desktop-schemas}/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas";
 
-    environment.sessionVariables.GNOME_SESSION_DEBUG = optionalString cfg.debug "1";
+    environment.sessionVariables.GNOME_SESSION_DEBUG = mkIf cfg.debug "1";
 
     # Settings from elementary-default-settings
     environment.sessionVariables.GTK_CSD = "1";


### PR DESCRIPTION
When session debugging was enabled in GNOME but not in Pantheon

```nix
{
  services.xserver = {
    desktopManager.pantheon = {
      enable = true;
    };
    desktopManager.gnome3 = {
      enable = true;
      debug = true;
    };
  };
}
```

it caused a conflict:

	error: The option `environment.sessionVariables.GNOME_SESSION_DEBUG' has conflicting definitions, in `<nixpkgs/nixos/modules/services/x11/desktop-managers/pantheon.nix>' and `<nixpkgs/nixos/modules/services/x11/desktop-managers/gnome3.nix>'.


Note that this still does not allow parallel installation of both environments due to the conflict of `NIX_GSETTINGS_OVERRIDES_DIR` but there is not much we can do about that without https://github.com/NixOS/nixpkgs/issues/54150.

cc @worldofpeace