### PR TITLE
[WIP]: initialRamdisk: Use systemd for initrd's /init

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -100,18 +100,6 @@ waitDevice() {
     fi
 }
 
-# Mount special file systems.
-specialMount() {
-  local device="$1"
-  local mountPoint="$2"
-  local options="$3"
-  local fsType="$4"
-
-  mkdir -m 0755 -p "$mountPoint"
-  mount -n -t "$fsType" -o "$options" "$device" "$mountPoint"
-}
-source @earlyMountScript@
-
 # Log the script output to /dev/kmsg or /run/log/stage-1-init.log.
 mkdir -p /tmp
 mkfifo /tmp/stage-1-init.log.fifo
@@ -589,11 +577,4 @@ fi
 
 mkdir -m 0755 -p $targetRoot/proc $targetRoot/sys $targetRoot/dev $targetRoot/run
 
-mount --move /proc $targetRoot/proc
-mount --move /sys $targetRoot/sys
-mount --move /dev $targetRoot/dev
-mount --move /run $targetRoot/run
-
-exec env -i $(type -P switch_root) "$targetRoot" "$stage2Init"
-
-fail # should never be reached
+exec env -i $(type -P systemctl) switch-root --no-block "$targetRoot" "$stage2Init"


### PR DESCRIPTION
###### Motivation for this change

- This parallelizes early boot.
- Systemd generators like the cryptsetup and fstab ones can be used to handle mounting and prompting for passwords.
- Plymouth can start much earlier, in early boot, making the boot graphics much cleaner.
- Systemd services from other packages can be used.
- systemd-ask-password can be used.

**NOTE:** This is a WIP. I'm opening this PR now mostly for feedback on the concept.

###### Things done

- [x] Set initrd's `/init` to the `systemd` binary.
- [x] Use `systemctl switch-root` instead of `switch_root`.
- [x] Minimize the size inflation. Currently this only inflates a base initrd by 1M. I'd like to get this down further though.
- [ ] Switch to fstab and crypttab generators.
- [ ] Make sure none of the NixOS tests have broken.
- [ ] Start plymouth in initrd.
- [ ] Use systemd for setting up the initrd network stack.
- [ ] Offer a trivial NixOS module interface for adding packages' systemd services to initrd.
- [ ] Use systemd's emergency.target on failure to boot.

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).