### PR TITLE
dsf2flac: init at 0.1Rev54

### DIFF
--- a/pkgs/applications/audio/dsf2flac/default.nix
+++ b/pkgs/applications/audio/dsf2flac/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, boost, flac, id3lib, pkg-config
+, taglib, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "dsf2flac";
+  version = "unstable-2018-01-02";
+
+  src = fetchFromGitHub {
+    owner = "hank";
+    repo = pname;
+    rev = "b0cf5aa6ddc60df9bbfeed25548e443c99f5cb16";
+    sha256 = "15j5f82v7lgs0fkgyyynl82cb1rsxyr9vw3bpzra63nacbi9g8lc";
+  };
+
+  buildInputs = [ boost flac id3lib taglib zlib ];
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    export LIBS="$LIBS -lz"
+  '';
+
+  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ];
+
+  meta = with stdenv.lib; {
+    description = "A DSD to FLAC transcoding tool";
+    homepage = "https://github.com/hank/dsf2flac";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ dmrauh ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19225,6 +19225,8 @@ in
 
   drumgizmo = callPackage ../applications/audio/drumgizmo { };
 
+  dsf2flac = callPackage ../applications/audio/dsf2flac { };
+
   dunst = callPackage ../applications/misc/dunst { };
 
   du-dust = callPackage ../tools/misc/dust { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I needed a tool to transcode audio files from DSD to FLAC and `dsf2flac` was not part of nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).