### PR TITLE
python3Packages.pyfxa: fix tests

### DIFF
--- a/pkgs/development/python-modules/pyfxa/default.nix
+++ b/pkgs/development/python-modules/pyfxa/default.nix
@@ -1,6 +1,6 @@
 { lib, buildPythonPackage, fetchPypi
 , requests, cryptography, pybrowserid, hawkauthlib, six
-, grequests, mock, responses, unittest2 }:
+, grequests, mock, responses, pytest }:
 
 buildPythonPackage rec {
   pname = "PyFxA";
@@ -21,8 +21,12 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    grequests mock responses unittest2
+    grequests mock responses pytest
   ];
+
+  checkPhase = ''
+    pytest
+  '';
 
   meta = with lib; {
     description = "Firefox Accounts client library for Python";


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing while reviewing: #74799

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[4 built, 3 copied (0.2 MiB), 0.1 MiB DL]
https://github.com/NixOS/nixpkgs/pull/74848
3 package were built:
python27Packages.pyfxa python37Packages.pyfxa python38Packages.pyfxa
```