### PR TITLE
nixos/version: PRETTY_NAME in /etc/os-release uses the release now

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -236,6 +236,13 @@
      release announcement</link> for more information.
     </para>
    </listitem>
+   <listitem>
+     <para>
+       <literal>PRETTY_NAME</literal> in <literal>/etc/os-release</literal>
+       uses the release now instead of full version
+       to be more suitable for presentation to the user
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -92,7 +92,7 @@ in
         VERSION="${cfg.version} (${cfg.codeName})"
         VERSION_CODENAME=${toLower cfg.codeName}
         VERSION_ID="${cfg.version}"
-        PRETTY_NAME="NixOS ${cfg.version} (${cfg.codeName})"
+        PRETTY_NAME="NixOS ${cfg.release} (${cfg.codeName})"
         LOGO="nix-snowflake"
         HOME_URL="https://nixos.org/"
         DOCUMENTATION_URL="https://nixos.org/nixos/manual/index.html"


### PR DESCRIPTION
 instead of full version to be more suitable for presentation to the user

![VirtualBox_TEST_02_12_2019_19_46_58](https://user-images.githubusercontent.com/91113/69987456-d6daae00-153f-11ea-9efd-25d9be230f70.png)

![Screenshot from 2019-12-02 20-05-24](https://user-images.githubusercontent.com/91113/69987467-db9f6200-153f-11ea-9da2-bc4f1fadbd2c.png)

###### Motivation for this change

Fix https://github.com/NixOS/nixpkgs/issues/74276

This fits the purpose of `PRETTY_NAME` more:

>A pretty operating system name in a format suitable for presentation to the user. May or may not contain a release code name or OS version of some kind, as suitable. If not set, defaults to "PRETTY_NAME="Linux"". Example: "PRETTY_NAME="Fedora 17 (Beefy Miracle)"".

https://www.freedesktop.org/software/systemd/man/os-release.html

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edolstra 
