### PR TITLE
pythonPackages.fastparquet: 0.2.1 -> 0.3.2

### DIFF
--- a/pkgs/development/python-modules/fastparquet/default.nix
+++ b/pkgs/development/python-modules/fastparquet/default.nix
@@ -1,13 +1,15 @@
-{ lib, buildPythonPackage, fetchPypi, numba, numpy, pandas, pytestrunner,
+{ lib, buildPythonPackage, fetchFromGitHub, numba, numpy, pandas, pytestrunner,
 thrift, pytest, python-snappy, lz4 }:
 
 buildPythonPackage rec {
   pname = "fastparquet";
   version = "0.3.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "d81dcec444f4c4829234b9baac57c7125b8fbe9119c2eca2dee922650db49205";
+  src = fetchFromGitHub {
+    owner = "dask";
+    repo = pname;
+    rev = version;
+    sha256 = "142kmyddaq6mvmca23abwns1csn8f3lk9c8mbxwxrg4wa1dh0lb4";
   };
 
   postPatch = ''
@@ -19,9 +21,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [ pytestrunner ];
   propagatedBuildInputs = [ numba numpy pandas thrift ];
   checkInputs = [ pytest python-snappy lz4 ];
-
-  # test_data/ missing in PyPI tarball
-  doCheck = false;
 
   meta = with lib; {
     description = "A python implementation of the parquet format";

--- a/pkgs/development/python-modules/fastparquet/default.nix
+++ b/pkgs/development/python-modules/fastparquet/default.nix
@@ -1,20 +1,13 @@
-{ lib, buildPythonPackage, fetchPypi, fetchpatch, numba, numpy, pandas,
-pytestrunner, thrift, pytest, python-snappy, lz4 }:
+{ lib, buildPythonPackage, fetchPypi, numba, numpy, pandas, pytestrunner,
+thrift, pytest, python-snappy, lz4 }:
 
 buildPythonPackage rec {
   pname = "fastparquet";
-  version = "0.2.1";
+  version = "0.3.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "183wdmhnhnlsd7908n3d2g4qnb49fcipqfshghwpbdwdzjpa0day";
-  };
-
-  # Fixes for recent pandas version
-  # See https://github.com/dask/fastparquet/pull/396
-  patches = fetchpatch {
-    url = https://github.com/dask/fastparquet/commit/31fb3115598d1ab62a5c8bf7923a27c16f861529.patch;
-    sha256 = "0r1ig4rydmy4j85dgb52qbsx6knxdwn4dn9h032fg3p6xqq0zlpm";
+    sha256 = "d81dcec444f4c4829234b9baac57c7125b8fbe9119c2eca2dee922650db49205";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
