### PR TITLE
ocamlPackages.cryptokit: 1.13 → 1.14

### DIFF
--- a/pkgs/development/ocaml-modules/cryptokit/default.nix
+++ b/pkgs/development/ocaml-modules/cryptokit/default.nix
@@ -5,9 +5,9 @@ assert stdenv.lib.versionAtLeast ocaml.version "3.12";
 let param =
   if stdenv.lib.versionAtLeast ocaml.version "4.02"
   then {
-    version = "1.13";
-    url = https://github.com/xavierleroy/cryptokit/archive/release113.tar.gz;
-    sha256 = "1f4jjnp2a911nqw0hbijyv9vygkk6kw5zx75qs49hfm3by6ij8rq";
+    version = "1.14";
+    url = https://github.com/xavierleroy/cryptokit/archive/release114.tar.gz;
+    sha256 = "0wkh72idkb7dahiwyl94hhbq27cc7x9fnmxkpnbqli6wi8wd7d05";
     inherit zarith;
   } else {
     version = "1.10";
@@ -25,8 +25,8 @@ stdenv.mkDerivation {
     inherit (param) url sha256;
   };
 
-  buildInputs = [ zlib ocaml findlib ocamlbuild ncurses ];
-  propagatedBuildInputs = [ param.zarith ];
+  buildInputs = [ ocaml findlib ocamlbuild ncurses ];
+  propagatedBuildInputs = [ param.zarith zlib ];
 
   buildFlags = "setup.data build";
 


### PR DESCRIPTION
###### Motivation for this change

Bug fixes and improvements: https://github.com/xavierleroy/cryptokit/releases/tag/release114

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @maggesi
