### PR TITLE
nixos/tests/timezone: port to python

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -267,6 +267,7 @@ in
   taskserver = handleTest ./taskserver.nix {};
   telegraf = handleTest ./telegraf.nix {};
   tiddlywiki = handleTest ./tiddlywiki.nix {};
+  timezone = handleTest ./timezone.nix {};
   tinydns = handleTest ./tinydns.nix {};
   tor = handleTest ./tor.nix {};
   transmission = handleTest ./transmission.nix {};

--- a/nixos/tests/timezone.nix
+++ b/nixos/tests/timezone.nix
@@ -1,45 +1,50 @@
-{
-  timezone-static = import ./make-test.nix ({ pkgs, ... }: {
-    name = "timezone-static";
-    meta.maintainers = with pkgs.lib.maintainers; [ lheckemann ];
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "timezone";
+  meta.maintainers = with pkgs.lib.maintainers; [ lheckemann ];
 
-    machine.time.timeZone = "Europe/Amsterdam";
+  nodes = {
+    node_eutz = { pkgs, ... }: {
+      time.timeZone = "Europe/Amsterdam";
+    };
 
-    testScript = ''
-      $machine->waitForUnit("dbus.socket");
-      $machine->fail("timedatectl set-timezone Asia/Tokyo");
-      my @dateResult = $machine->execute('date -d @0 "+%Y-%m-%d %H:%M:%S"');
-      $dateResult[1] eq "1970-01-01 01:00:00\n" or die "Timezone seems to be wrong";
-    '';
-  });
+    node_nulltz = { pkgs, ... }: {
+      time.timeZone = null;
+    };
+  };
 
-  timezone-imperative = import ./make-test.nix ({ pkgs, ... }: {
-    name = "timezone-imperative";
-    meta.maintainers = with pkgs.lib.maintainers; [ lheckemann ];
+  testScript = { nodes, ... }: ''
+      node_eutz.wait_for_unit("dbus.socket")
 
-    machine.time.timeZone = null;
+      with subtest("static - Ensure timezone change gives the correct result"):
+          node_eutz.fail("timedatectl set-timezone Asia/Tokyo")
+          date_result = node_eutz.succeed('date -d @0 "+%Y-%m-%d %H:%M:%S"')
+          assert date_result == "1970-01-01 01:00:00\n", "Timezone seems to be wrong"
 
-    testScript = ''
-      $machine->waitForUnit("dbus.socket");
+      node_nulltz.wait_for_unit("dbus.socket")
 
-      # Should default to UTC
-      my @dateResult = $machine->execute('date -d @0 "+%Y-%m-%d %H:%M:%S"');
-      print $dateResult[1];
-      $dateResult[1] eq "1970-01-01 00:00:00\n" or die "Timezone seems to be wrong";
+      with subtest("imperative - Ensure timezone defaults to UTC"):
+          date_result = node_nulltz.succeed('date -d @0 "+%Y-%m-%d %H:%M:%S"')
+          print(date_result)
+          assert (
+              date_result == "1970-01-01 00:00:00\n"
+          ), "Timezone seems to be wrong (not UTC)"
 
-      $machine->succeed("timedatectl set-timezone Asia/Tokyo");
+      with subtest("imperative - Ensure timezone adjustment produces expected result"):
+          node_nulltz.succeed("timedatectl set-timezone Asia/Tokyo")
 
-      # Adjustment should be taken into account
-      my @dateResult = $machine->execute('date -d @0 "+%Y-%m-%d %H:%M:%S"');
-      print $dateResult[1];
-      $dateResult[1] eq "1970-01-01 09:00:00\n" or die "Timezone was not adjusted";
+          # Adjustment should be taken into account
+          date_result = node_nulltz.succeed('date -d @0 "+%Y-%m-%d %H:%M:%S"')
+          print(date_result)
+          assert date_result == "1970-01-01 09:00:00\n", "Timezone was not adjusted"
 
-      # Adjustment should persist across a reboot
-      $machine->shutdown;
-      $machine->waitForUnit("dbus.socket");
-      my @dateResult = $machine->execute('date -d @0 "+%Y-%m-%d %H:%M:%S"');
-      print $dateResult[1];
-      $dateResult[1] eq "1970-01-01 09:00:00\n" or die "Timezone adjustment was not persisted";
-    '';
-  });
-}
+      with subtest("imperative - Ensure timezone adjustment persists across reboot"):
+          # Adjustment should persist across a reboot
+          node_nulltz.shutdown()
+          node_nulltz.wait_for_unit("dbus.socket")
+          date_result = node_nulltz.succeed('date -d @0 "+%Y-%m-%d %H:%M:%S"')
+          print(date_result)
+          assert (
+              date_result == "1970-01-01 09:00:00\n"
+          ), "Timezone adjustment was not persisted"
+  '';
+})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Port `timezone` test to python for https://github.com/NixOS/nixpkgs/issues/72828

###### Things done
Ported `timezone` test to python.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) `nixos/tests/timezone.nix`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lheckemann 
