### PR TITLE
minijail: install .pc files and scoped_minijail.h

### DIFF
--- a/pkgs/tools/system/minijail/default.nix
+++ b/pkgs/tools/system/minijail/default.nix
@@ -20,13 +20,20 @@ stdenv.mkDerivation rec {
     sed -i '/#include <asm\/siginfo.h>/ d' signal_handler.c
   '';
 
+  postPatch = ''
+    patchShebangs platform2_preinstall.sh
+  '';
+
+  postBuild = ''
+    ./platform2_preinstall.sh ${version} $out/include/chromeos
+  '';
+
   installPhase = ''
-    mkdir -p $out/lib
+    mkdir -p $out/lib/pkgconfig $out/include/chromeos $out/bin
     cp -v *.so $out/lib
-    mkdir -p $out/include
-    cp -v libminijail.h $out/include
-    mkdir -p $out/bin
-    cp minijail0 $out/bin
+    cp -v *.pc $out/lib/pkgconfig
+    cp -v libminijail.h scoped_minijail.h $out/include/chromeos
+    cp -v minijail0 $out/bin
   '';
 
   meta = {


### PR DESCRIPTION
This matches the behaviour of the Chromium OS ebuild for this package:
https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay/+/cd6d6815b1604105cb6b8c40b2e0c3f15f401e3b/chromeos-base/minijail/minijail-10-r38.ebuild#47

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
