### PR TITLE
fetchFromGitiles: init

### DIFF
--- a/doc/builders/fetchers.xml
+++ b/doc/builders/fetchers.xml
@@ -107,6 +107,17 @@ stdenv.mkDerivation {
   </varlistentry>
   <varlistentry>
    <term>
+    <literal>fetchFromGitiles</literal>
+   </term>
+   <listitem>
+    <para>
+     This is used with Gitiles repositories. The arguments expected
+     are similar to fetchgit.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
     <literal>fetchFromBitbucket</literal>
    </term>
    <listitem>

--- a/pkgs/applications/misc/redis-desktop-manager/default.nix
+++ b/pkgs/applications/misc/redis-desktop-manager/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, lib, fetchgit, pkgconfig, libssh2
+{ stdenv, lib, fetchFromGitHub, fetchFromGitiles, pkgconfig, libssh2
 , qtbase, qtdeclarative, qtgraphicaleffects, qtimageformats, qtquickcontrols
 , qtsvg, qttools, qtquick1, qtcharts
 , qmake
 }:
 
 let
-  breakpad_lss = fetchgit {
+  breakpad_lss = fetchFromGitiles {
     url = "https://chromium.googlesource.com/linux-syscall-support";
     rev = "08056836f2b4a5747daff75435d10d649bed22f6";
     sha256 = "1ryshs2nyxwa0kn3rlbnd5b3fhna9vqm560yviddcfgdm2jyg0hz";
@@ -17,10 +17,11 @@ stdenv.mkDerivation rec {
   pname = "redis-desktop-manager";
   version = "0.9.1";
 
-  src = fetchgit {
-    url = "https://github.com/uglide/RedisDesktopManager.git";
+  src = fetchFromGitHub {
+    owner = "uglide";
+    repo = "RedisDesktopManager";
     fetchSubmodules = true;
-    rev = "refs/tags/${version}";
+    rev = version;
     sha256 = "0yd4i944d4blw8jky0nxl7sfkkj975q4d328rdcbhizwvf6dx81f";
   };
 

--- a/pkgs/build-support/fetchgitiles/default.nix
+++ b/pkgs/build-support/fetchgitiles/default.nix
@@ -1,0 +1,10 @@
+{ fetchzip, lib }:
+
+{ url, rev, name ? "source", ... } @ args:
+
+fetchzip ({
+  inherit name;
+  url = "${url}/+archive/${rev}.tar.gz";
+  stripRoot = false;
+  meta.homepage = url;
+} // removeAttrs args [ "url" "rev" ]) // { inherit rev; }

--- a/pkgs/development/python-modules/gyp/default.nix
+++ b/pkgs/development/python-modules/gyp/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , buildPythonPackage
-, fetchgit
+, fetchFromGitiles
 , isPy3k
 }:
 
@@ -9,8 +9,8 @@ buildPythonPackage {
   version = "2015-06-11";
   disabled = isPy3k;
 
-  src = fetchgit {
-    url = "https://chromium.googlesource.com/external/gyp.git";
+  src = fetchFromGitiles {
+    url = "https://chromium.googlesource.com/external/gyp";
     rev = "fdc7b812f99e48c00e9a487bd56751bbeae07043";
     sha256 = "1imgxsl4mr1662vsj2mlnpvvrbz71yk00w8p85vi5bkgmc6awgiz";
   };

--- a/pkgs/os-specific/linux/chromium-xorg-conf/default.nix
+++ b/pkgs/os-specific/linux/chromium-xorg-conf/default.nix
@@ -1,6 +1,6 @@
-{fetchgit }:
+{ fetchFromGitiles }:
 
-fetchgit {
+fetchFromGitiles {
   name = "chromium-xorg-conf";
   url = "https://chromium.googlesource.com/chromiumos/platform/xorg-conf";
   rev = "26fb9d57e195c7e467616b35b17e2b5d279c1514";

--- a/pkgs/tools/security/chaps/default.nix
+++ b/pkgs/tools/security/chaps/default.nix
@@ -1,9 +1,10 @@
-{ stdenv, fetchgit, fetchurl, trousers, leveldb, unzip, scons, pkgconfig
-, glib, dbus_cplusplus, dbus, protobuf, openssl, snappy, pam }:
+{ stdenv, fetchFromGitiles, fetchFromGitHub, fetchurl, trousers, leveldb, unzip
+, scons, pkgconfig, glib, dbus_cplusplus, dbus, protobuf, openssl, snappy, pam
+}:
 
 let
-  src_chromebase = fetchgit {
-    url = "https://chromium.googlesource.com/chromium/src/base.git";
+  src_chromebase = fetchFromGitiles {
+    url = "https://chromium.googlesource.com/chromium/src/base";
     rev = "2dfe404711e15e24e79799516400c61b2719d7af";
     sha256 = "2bd93a3ace4b6767db2c1bd1e16f426c97b8d2133a9cb15f8372b2516cfa65c5";
   };
@@ -13,7 +14,7 @@ let
     sha256 = "0nq98cpnv2jsx2byp4ilam6kydcnziflkc16ikydajmp4mcvpz16";
   };
 
-  src_platform2 = fetchgit {
+  src_platform2 = fetchFromGitiles {
     url = "https://chromium.googlesource.com/chromiumos/platform2";
     rev = "e999e989eaa71c3db7314fc7b4e20829b2b5473b";
     sha256 = "15n1bsv6r7cny7arx0hdb223xzzbk7vkxg2r7xajhl4nsj39adjh";
@@ -25,8 +26,9 @@ stdenv.mkDerivation rec {
   name = "chaps-0.42-6812";
   version = "0.42-6812";
 
-  src = fetchgit {
-    url = "https://github.com/google/chaps-linux";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "chaps-linux";
     rev = "989aadc45cdb216ca35b0c97d13fc691576fa1d7";
     sha256 = "0chk6pnn365d5kcz6vfqx1d0383ksk97icc0lzg0vvb0kvyj0ff1";
   };

--- a/pkgs/tools/system/minijail/default.nix
+++ b/pkgs/tools/system/minijail/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchgit, libcap }:
+{ stdenv, fetchFromGitiles, libcap }:
 
 stdenv.mkDerivation rec {
   shortname = "minijail";
   name = "${shortname}-${version}";
   version = "android-9.0.0_r3";
 
-  src = fetchgit {
+  src = fetchFromGitiles {
     url = "https://android.googlesource.com/platform/external/minijail";
     rev = version;
     sha256 = "1g1g52s3q61amcnx8cv1332sbixpck1bmjzgsrjiw5ix7chrzkp2";

--- a/pkgs/tools/system/vboot_reference/default.nix
+++ b/pkgs/tools/system/vboot_reference/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, libuuid, openssl, libyaml, lzma }:
+{ stdenv, fetchFromGitiles, pkgconfig, libuuid, openssl, libyaml, lzma }:
 
 stdenv.mkDerivation rec {
   version = "20180311";
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
 
   pname = "vboot_reference";
 
-  src = fetchgit {
-    url = https://chromium.googlesource.com/chromiumos/platform/vboot_reference;
+  src = fetchFromGitiles {
+    url = "https://chromium.googlesource.com/chromiumos/platform/vboot_reference";
     rev = checkout;
     sha256 = "1zja4ma6flch08h5j2l1hqnxmw2xwylidnddxxd5y2x05dai9ddj";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -358,6 +358,8 @@ in
 
   fetchFromGitLab = callPackage ../build-support/fetchgitlab {};
 
+  fetchFromGitiles = callPackage ../build-support/fetchgitiles {};
+
   fetchFromRepoOrCz = callPackage ../build-support/fetchrepoorcz {};
 
   fetchNuGet = callPackage ../build-support/fetchnuget { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This has the same motivation as fetchFromGitHub/fetchFromGitLab --
it's cheaper to download a tarball of a single revision than it is to
download a whole history.

I could have gone with domain/group/repo, like fetchFromGitLab, but it
would have made implementation more difficult, and this syntax means
it's a drop-in replacement for fetchgit, so I decided it wasn't worth
it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
