### PR TITLE
Various fetchcargo improvements

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -4,6 +4,7 @@
 , cargoSha256 ? "unset"
 , src ? null
 , srcs ? null
+, unpackPhase ? null
 , cargoPatches ? []
 , patches ? []
 , sourceRoot ? null
@@ -29,7 +30,7 @@ assert buildType == "release" || buildType == "debug";
 let
   cargoDeps = if cargoVendorDir == null
     then fetchcargo {
-        inherit name src srcs sourceRoot cargoUpdateHook;
+        inherit name src srcs sourceRoot unpackPhase cargoUpdateHook;
         copyLockfile = verifyCargoDeps;
         patches = cargoPatches;
         sha256 = cargoSha256;

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -18,9 +18,9 @@ let cargo-vendor-normalise = stdenv.mkDerivation {
 };
 in
 { name ? "cargo-deps"
-, src
-, srcs
-, patches
+, src ? null
+, srcs ? []
+, patches ? []
 , sourceRoot
 , sha256
 , cargoUpdateHook ? ""

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -26,11 +26,11 @@ in
 , cargoUpdateHook ? ""
 , # whenever to also include the Cargo.lock in the output
   copyLockfile ? false
-}:
-stdenv.mkDerivation {
+, ...
+} @ args:
+stdenv.mkDerivation ({
   name = "${name}-vendor";
   nativeBuildInputs = [ cacert git cargo-vendor-normalise cargo ];
-  inherit src srcs patches sourceRoot;
 
   phases = "unpackPhase patchPhase installPhase";
 
@@ -76,4 +76,6 @@ stdenv.mkDerivation {
 
   impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
   preferLocalBuild = true;
-}
+} // (builtins.removeAttrs args [
+  "name" "sha256" "cargoUpdateHook" "copyLockfile"
+]))

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -19,17 +19,17 @@
     }.${cpu.name} or cpu.name;
   in "${cpu_}-${vendor.name}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
 
-  makeRustPlatform = { rustc, cargo, ... }: {
+  makeRustPlatform = { rustc, cargo, ... }: rec {
     rust = {
       inherit rustc cargo;
     };
 
-    buildRustPackage = callPackage ../../../build-support/rust {
-      inherit rustc cargo;
+    fetchcargo = buildPackages.callPackage ../../../build-support/rust/fetchcargo.nix {
+      inherit cargo;
+    };
 
-      fetchcargo = buildPackages.callPackage ../../../build-support/rust/fetchcargo.nix {
-        inherit cargo;
-      };
+    buildRustPackage = callPackage ../../../build-support/rust {
+      inherit rustc cargo fetchcargo;
     };
 
     rustcSrc = callPackage ./rust-src.nix {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Most stdenv wrappers already forward unused arguments -- it allows greater customisation.  We just have to be careful to remove arguments we're using that shouldn't be passed to stdenv.  I've been conservative here, because fetchcargo checksums shouldn't change lightly.

- If a custom unpackPhase is used for the package, it needs to also be used for fetchcargo so the same source is available for vendoring.

- I exposed `fetchcargo` as `rustPlatform.fetchcargo`, because it might be useful to provide from another derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
