### PR TITLE
uw-ttyp0: init at 1.3

### DIFF
--- a/pkgs/data/fonts/uw-ttyp0/default.nix
+++ b/pkgs/data/fonts/uw-ttyp0/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, perl, fetchurl, bdftopcf, mkfontdir, mkfontscale }:
+
+stdenv.mkDerivation rec {
+  version = "1.3";
+  name = "uw-ttyp0-${version}";
+
+  src = fetchurl {
+    url = "https://people.mpi-inf.mpg.de/~uwe/misc/uw-ttyp0/${name}.tar.gz";
+    sha256 = "1vp053bwv8sr40p3pn4sjaiq570zp7knh99z9ynk30v7ml4cz2i8";
+  };
+
+  nativeBuildInputs = [ perl mkfontdir bdftopcf ];
+
+  postConfigure =
+    ''
+    echo "COPYTO AccStress PApostropheAscii" >> VARIANTS.dat
+    echo "COPYTO PAmComma AccGraveAscii" >> VARIANTS.dat
+    echo "COPYTO Digit0Slashed Digit0" >> VARIANTS.dat
+    echo "COPYTO MTilde AccTildeAscii" >> VARIANTS.dat
+    echo "COPYTO Space SpaceNoBreak" >> VARIANTS.dat
+    echo "COPYTO PHyphenMinus PHyphenSoft" >> VARIANTS.dat
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Monospace Bitmap Screen Fonts for X11";
+    homepage = https://people.mpi-inf.mpg.de/~uwe/misc/uw-ttyp0/;
+    downloadPage = https://people.mpi-inf.mpg.de/~uwe/misc/uw-ttyp0/;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17713,6 +17713,8 @@ in
 
   unscii = callPackage ../data/fonts/unscii { };
 
+  uw-ttyp0 = callPackage ../data/fonts/uw-ttyp0 { };
+
   vanilla-dmz = callPackage ../data/icons/vanilla-dmz { };
 
   vdrsymbols = callPackage ../data/fonts/vdrsymbols { };


### PR DESCRIPTION
###### Motivation for this change

Add [uw-ttyp0](https://people.mpi-inf.mpg.de/~uwe/misc/uw-ttyp0/) font to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

So this is the first nixpkg I am submitting, please bear with me.
Tested on my local NixOS installation. 