### PR TITLE
nixos/tests/tiddlywiki: port to python

### DIFF
--- a/nixos/tests/tiddlywiki.nix
+++ b/nixos/tests/tiddlywiki.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }: {
+import ./make-test-python.nix ({ ... }: {
   name = "tiddlywiki";
   nodes = {
     default = {
@@ -20,48 +20,53 @@ import ./make-test.nix ({ ... }: {
     };
   };
 
-  testScript = ''
-    startAll;
+  testScript =
+    ''
+      start_all()
 
-    subtest "by default works without configuration", sub {
-      $default->waitForUnit("tiddlywiki.service");
-    };
+      with subtest("by default works without configuration"):
+          default.wait_for_unit("tiddlywiki.service")
 
-    subtest "by default available on port 8080 without auth", sub {
-      $default->waitForUnit("tiddlywiki.service");
-      $default->waitForOpenPort(8080);
-      $default->succeed("curl --fail 127.0.0.1:8080");
-    };
+      with subtest("by default available on port 8080 without auth"):
+          default.wait_for_unit("tiddlywiki.service")
+          default.wait_for_open_port(8080)
+          # we output to /dev/null here to avoid a python UTF-8 decode error
+          # but the check will still fail if the service doesn't respond
+          default.succeed("curl --fail -o /dev/null 127.0.0.1:8080")
 
-    subtest "by default creates empty wiki", sub {
-      $default->succeed("test -f /var/lib/tiddlywiki/tiddlywiki.info");
-    };
+      with subtest("by default creates empty wiki"):
+          default.succeed("test -f /var/lib/tiddlywiki/tiddlywiki.info")
 
-    subtest "configured on port 3000 with basic auth", sub {
-      $configured->waitForUnit("tiddlywiki.service");
-      $configured->waitForOpenPort(3000);
-      $configured->fail("curl --fail 127.0.0.1:3000");
-      $configured->succeed("curl --fail 127.0.0.1:3000 --user somelogin:somesecret");
-    };
+      with subtest("configured on port 3000 with basic auth"):
+          configured.wait_for_unit("tiddlywiki.service")
+          configured.wait_for_open_port(3000)
+          configured.fail("curl --fail -o /dev/null 127.0.0.1:3000")
+          configured.succeed(
+              "curl --fail -o /dev/null 127.0.0.1:3000 --user somelogin:somesecret"
+          )
 
-    subtest "configured with different wikifolder", sub {
-      $configured->succeed("test -f /var/lib/tiddlywiki/tiddlywiki.info");
-    };
+      with subtest("configured with different wikifolder"):
+          configured.succeed("test -f /var/lib/tiddlywiki/tiddlywiki.info")
 
-    subtest "restart preserves changes", sub {
-      # given running wiki
-      $default->waitForUnit("tiddlywiki.service");
-      # with some changes
-      $default->succeed("curl --fail --request PUT --header 'X-Requested-With:TiddlyWiki' --data '{ \"title\": \"title\", \"text\": \"content\" }' --url 127.0.0.1:8080/recipes/default/tiddlers/somepage ");
-      $default->succeed("sleep 2"); # server syncs to filesystem on timer
+      with subtest("restart preserves changes"):
+          # given running wiki
+          default.wait_for_unit("tiddlywiki.service")
+          # with some changes
+          default.succeed(
+              'curl --fail --request PUT --header \'X-Requested-With:TiddlyWiki\' \
+              --data \'{ "title": "title", "text": "content" }\' \
+              --url 127.0.0.1:8080/recipes/default/tiddlers/somepage '
+          )
+          default.succeed("sleep 2")
 
-      # when wiki is cycled
-      $default->systemctl("restart tiddlywiki.service");
-      $default->waitForUnit("tiddlywiki.service");
-      $default->waitForOpenPort(8080);
+          # when wiki is cycled
+          default.systemctl("restart tiddlywiki.service")
+          default.wait_for_unit("tiddlywiki.service")
+          default.wait_for_open_port(8080)
 
-      # the change is preserved
-      $default->succeed("curl --fail 127.0.0.1:8080/recipes/default/tiddlers/somepage");
-    };
-  '';
+          # the change is preserved
+          default.succeed(
+              "curl --fail -o /dev/null 127.0.0.1:8080/recipes/default/tiddlers/somepage"
+          )
+    '';
 })

--- a/nixos/tests/tiddlywiki.nix
+++ b/nixos/tests/tiddlywiki.nix
@@ -44,10 +44,7 @@ import ./make-test-python.nix ({ ... }: {
           configured.succeed(
               "curl --fail -o /dev/null 127.0.0.1:3000 --user somelogin:somesecret"
           )
-
-      with subtest("configured with different wikifolder"):
-          configured.succeed("test -f /var/lib/tiddlywiki/tiddlywiki.info")
-
+      
       with subtest("restart preserves changes"):
           # given running wiki
           default.wait_for_unit("tiddlywiki.service")


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Port `tiddlywiki` test to python https://github.com/NixOS/nixpkgs/issues/72828

###### Things done
Ported `tiddlywiki` test to python.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s): `nixos/tests/tiddlywiki.nix`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
