### PR TITLE
test-driver.py: sleep in between executing things periodically inside the vm

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -331,6 +331,7 @@ class Machine:
                         )
             if state == "active":
                 return True
+            time.sleep(1)
 
     def get_unit_info(self, unit: str, user: Optional[str] = None) -> Dict[str, str]:
         status, lines = self.systemctl('--no-pager show "{}"'.format(unit), user)
@@ -426,6 +427,7 @@ class Machine:
                 status, output = self.execute(command)
                 if status == 0:
                     return output
+                time.sleep(1)
 
     def wait_until_fails(self, command: str) -> str:
         with self.nested("waiting for failure: {}".format(command)):
@@ -433,6 +435,7 @@ class Machine:
                 status, output = self.execute(command)
                 if status != 0:
                     return output
+                time.sleep(1)
 
     def wait_for_shutdown(self) -> None:
         if not self.booted:
@@ -460,6 +463,7 @@ class Machine:
                 text = self.get_tty_text(tty)
                 if len(matcher.findall(text)) > 0:
                     return True
+                time.sleep(1)
 
     def send_chars(self, chars: List[str]) -> None:
         with self.nested("sending keys ‘{}‘".format(chars)):
@@ -472,6 +476,7 @@ class Machine:
                 status, _ = self.execute("test -e {}".format(filename))
                 if status == 0:
                     return True
+                time.sleep(1)
 
     def wait_for_open_port(self, port: int) -> None:
         def port_is_open(_: Any) -> bool:
@@ -712,6 +717,7 @@ class Machine:
                 status, _ = self.execute("[ -e /tmp/.X11-unix/X0 ]")
                 if status == 0:
                     return
+                time.sleep(1)
 
     def get_window_names(self) -> List[str]:
         return self.succeed(


### PR DESCRIPTION
while it's fine to use an endless loop on a blocking socket, we
can't do the same with executing commands inside the VM. instead, wait
1sec in between each interval.

###### Motivation for this change
I saw a lot of spam while waiting for a `wait_until_succeeds` method to finish inside a nixos vm test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc
