### PR TITLE
Revert "python.pkgs.Cython: 0.29.14 -> 0.29.15"

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -26,11 +26,11 @@ let
 
 in buildPythonPackage rec {
   pname = "Cython";
-  version = "0.29.15";
+  version = "0.29.14";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "050lh336791yl76krn44zm2dz00mlhpb26bk9fq9wcfh0f3vpmp4";
+    sha256 = "e4d6bb8703d0319eb04b7319b12ea41580df44fd84d83ccda13ea463c6801414";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/74388#issuecomment-560490284

No trace on the [releases page](https://github.com/cython/cython/releases), [pypi](https://pypi.org/project/Cython/#history) or [repology](https://repology.org/project/python:cython/versions). Not sure what happened here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
