### PR TITLE
python3Packages.chainer: 6.4.0 -> 6.5.0

### DIFF
--- a/pkgs/development/python-modules/chainer/default.nix
+++ b/pkgs/development/python-modules/chainer/default.nix
@@ -1,17 +1,25 @@
-{ stdenv, lib
-, buildPythonPackage, fetchPypi, isPy3k
-, filelock, protobuf, numpy, pytest, mock
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
+, filelock, protobuf, numpy, pytest, mock, typing-extensions
 , cupy, cudaSupport ? false
 }:
 
 buildPythonPackage rec {
   pname = "chainer";
-  version = "6.4.0";
+  version = "6.5.0";
+  disabled = !isPy3k; # python2.7 abandoned upstream
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "dacbcaa361cebdfbf6f212d138570333611b8f5de553093b1752c578b022a774";
+  # no tests in Pypi tarball
+  src = fetchFromGitHub {
+    owner = "chainer";
+    repo = "chainer";
+    rev = "v${version}";
+    sha256 = "0ha9fbl6sa3fbnsz3y1pg335iiskdbxw838m5j06zgzy156zna1x";
   };
+
+  # remove on 7.0 or 6.6 release
+  postPatch = ''
+    sed -i '/typing/d' setup.py
+  '';
 
   checkInputs = [
     pytest
@@ -22,12 +30,15 @@ buildPythonPackage rec {
     filelock
     protobuf
     numpy
+    typing-extensions
   ] ++ lib.optionals cudaSupport [ cupy ];
 
-  # In python3, test was failed...
-  doCheck = !isPy3k;
+  # avoid gpu tests
+  checkPhase = ''
+    pytest tests/chainer_tests/utils_tests -k 'not gpu and not cupy'
+  '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A flexible framework of neural networks for deep learning";
     homepage = https://chainer.org/;
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change
Noticed it was broken, decided to bump and add some tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

optuna broken on master
```
[0 built (1 failed), 1 copied (6.3 MiB), 1.4 MiB DL]
error: build of '/nix/store/hmv45ckrsm7v4jcfvqvk95hdslf4h8j5-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/74871
1 package failed to build:
python37Packages.optuna

2 package were built:
python37Packages.chainer python38Packages.chainer
```