### PR TITLE
kitty: fix loading of library

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -64,8 +64,10 @@ buildPythonApplication rec {
   outputs = [ "out" "terminfo" ];
 
   patches = [
+    ./fix-paths.patch
+  ] ++ stdenv.lib.optionals stdenv.isLinux [
     (substituteAll {
-      src = ./fix-paths.patch;
+      src = ./library-paths.patch;
       libstartup_notification = "${libstartup_notification}/lib/libstartup-notification-1.so";
       libcanberra = "${libcanberra}/lib/libcanberra.so";
     })

--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -67,6 +67,7 @@ buildPythonApplication rec {
     (substituteAll {
       src = ./fix-paths.patch;
       libstartup_notification = "${libstartup_notification}/lib/libstartup-notification-1.so";
+      libcanberra = "${libcanberra}/lib/libcanberra.so";
     })
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     ./no-lto.patch

--- a/pkgs/applications/misc/kitty/fix-paths.patch
+++ b/pkgs/applications/misc/kitty/fix-paths.patch
@@ -8,6 +8,16 @@
 +    static const char* libname = "@libstartup_notification@";
      // some installs are missing the .so symlink, so try the full name
      static const char* libname2 = "libstartup-notification-1.so.0";
+     static const char* libname3 = "libstartup-notification-1.so.0.0.0";
+@@ -105,7 +105,7 @@ load_libcanberra_functions(void) {
+ 
+ static void
+ load_libcanberra(void) {
+-    static const char* libname = "libcanberra.so";
++    static const char* libname = "@libcanberra@";
+     // some installs are missing the .so symlink, so try the full name
+     static const char* libname2 = "libcanberra.so.0";
+     static const char* libname3 = "libcanberra.so.0.2.5";
 
 --- a/docs/Makefile
 +++ b/docs/Makefile

--- a/pkgs/applications/misc/kitty/fix-paths.patch
+++ b/pkgs/applications/misc/kitty/fix-paths.patch
@@ -1,24 +1,3 @@
---- a/kitty/desktop.c
-+++ b/kitty/desktop.c
-@@ -30,7 +30,7 @@
- static PyObject*
- init_x11_startup_notification(PyObject UNUSED *self, PyObject *args) {
-     static bool done = false;
--    static const char* libname = "libstartup-notification-1.so";
-+    static const char* libname = "@libstartup_notification@";
-     // some installs are missing the .so symlink, so try the full name
-     static const char* libname2 = "libstartup-notification-1.so.0";
-     static const char* libname3 = "libstartup-notification-1.so.0.0.0";
-@@ -105,7 +105,7 @@ load_libcanberra_functions(void) {
- 
- static void
- load_libcanberra(void) {
--    static const char* libname = "libcanberra.so";
-+    static const char* libname = "@libcanberra@";
-     // some installs are missing the .so symlink, so try the full name
-     static const char* libname2 = "libcanberra.so.0";
-     static const char* libname3 = "libcanberra.so.0.2.5";
-
 --- a/docs/Makefile
 +++ b/docs/Makefile
 @@ -3,7 +3,7 @@

--- a/pkgs/applications/misc/kitty/library-paths.patch
+++ b/pkgs/applications/misc/kitty/library-paths.patch
@@ -1,0 +1,20 @@
+--- a/kitty/desktop.c
++++ b/kitty/desktop.c
+@@ -30,7 +30,7 @@
+ static PyObject*
+ init_x11_startup_notification(PyObject UNUSED *self, PyObject *args) {
+     static bool done = false;
+-    static const char* libname = "libstartup-notification-1.so";
++    static const char* libname = "@libstartup_notification@";
+     // some installs are missing the .so symlink, so try the full name
+     static const char* libname2 = "libstartup-notification-1.so.0";
+     static const char* libname3 = "libstartup-notification-1.so.0.0.0";
+@@ -105,7 +105,7 @@ load_libcanberra_functions(void) {
+ 
+ static void
+ load_libcanberra(void) {
+-    static const char* libname = "libcanberra.so";
++    static const char* libname = "@libcanberra@";
+     // some installs are missing the .so symlink, so try the full name
+     static const char* libname2 = "libcanberra.so.0";
+     static const char* libname3 = "libcanberra.so.0.2.5";


### PR DESCRIPTION
When trying to play a sound, kitty prints an error message because it cannot find `libcanberra.so`:
```
Failed to load libcanberra.so, cannot play beep sound, with error: libcanberra.so.0.2.5: cannot open shared object file: No such file or directory
```
This is fixed by patching the path to the library.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tex @rvolosatovs @Ma27