### PR TITLE
gtk3: fix build on 32-bit ARM

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -4,7 +4,7 @@
 , gobjectSupport ? true, glib
 , xcbSupport ? x11Support, libxcb, xcbutil # no longer experimental since 1.12
 , libGLSupported ? stdenv.lib.elem stdenv.hostPlatform.system stdenv.lib.platforms.mesaPlatforms
-, glSupport ? config.cairo.gl or (libGLSupported && stdenv.isLinux && !stdenv.isAarch32 && !stdenv.isMips)
+, glSupport ? config.cairo.gl or (libGLSupported && stdenv.isLinux)
 , libGL ? null # libGLU libGL is no longer a big dependency
 , pdfSupport ? true
 , darwin


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Mesa [recently stopped installing `EGL/eglplatform.h`](https://github.com/mesa3d/mesa/commit/8355658fa857536d948773b361c5ede770e637a3) because it is provided by `libglvnd`. `epoxy`'s headers includes `eglplatform.h`, and `epoxy` is in turn required by `gtk3`. This caused the build of `gtk3` to fail on armv7l. The reason it didn't fail on other platforms is that `libGL` (which propagates `libglvnd`) is normally propagated by `cairo`. Back in 2013, [GL support was disabled in cairo on 32-bit ARM](https://github.com/NixOS/nixpkgs/commit/a0893d472e0ef8335015fe8a710df2e348a9ba69) because apparently mesa didn't build. This is no longer the case, so this PR re-enables GL support in cairo on ARM and MIPS. I don't have a way to test MIPS, and I'm not even sure anyone tests it anymore.

This PR does not fix the root cause of the problem, which is that `epoxy.dev` should propagate `libGL.dev` (or maybe `libglvnd.dev`), but I'll leave that to others if they want to tackle it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

gtk3: @7c6f434c @vcunat @lethalman @worldofpeace
epoxy: @cillianderoiste
cairo: nobody...