### PR TITLE
 python3Packages.azure-mgmt-imagebuilder: 0.2.1 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/azure-mgmt-imagebuilder/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-imagebuilder/default.nix
@@ -5,13 +5,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.2.1";
+  version = "0.3.0";
   pname = "azure-mgmt-imagebuilder";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0mwlvy4x5nr3hsz7wdpdhpzwarzzwz4225bfpd68hr0pcjgzspky";
+    sha256 = "0r4sxr3pbcci5qif1ip1lrix3cryj0b3asqch3zds4q705jiakc4";
     extension = "zip";
   };
 

--- a/pkgs/tools/admin/azure-cli/python-packages.nix
+++ b/pkgs/tools/admin/azure-cli/python-packages.nix
@@ -126,6 +126,9 @@ let
       azure-mgmt-cosmosdb = overrideAzureMgmtPackage super.azure-mgmt-cosmosdb "0.8.0" "zip"
         "0iakxb2rr1w9171802m9syjzqas02vjah711mpagbgcj549mjysb";
 
+      azure-mgmt-imagebuilder = overrideAzureMgmtPackage super.azure-mgmt-imagebuilder "0.2.1" "zip"
+        "0mwlvy4x5nr3hsz7wdpdhpzwarzzwz4225bfpd68hr0pcjgzspky";
+
       azure-mgmt-iothub = overrideAzureMgmtPackage super.azure-mgmt-iothub "0.8.2" "zip"
         "0w3w1d156rnkwjdarv3qvycklxr3z2j7lry7a3jfgj3ykzny12rq";
 


### PR DESCRIPTION
###### Motivation for this change
bumping packages I maintain

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 12 copied (6.7 MiB), 1.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/74883
3 package were built:
azure-cli python37Packages.azure-mgmt-imagebuilder python38Packages.azure-mgmt-imagebuilder
```