### PR TITLE
python3Packages.azure-mgmt-kusto: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/azure-mgmt-kusto/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-kusto/default.nix
@@ -5,13 +5,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.4.0";
+  version = "0.5.0";
   pname = "azure-mgmt-kusto";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1sx8f98206wccj0mbmb75c4wyhf57g3pnkhl9wn70lqzi9n4mk0b";
+    sha256 = "0r6j3yp7ys0zgszqdjm6y90nigsapni4xhfpfgyk5c5qbgdpl93w";
     extension = "zip";
   };
 


### PR DESCRIPTION
###### Motivation for this change
bumping packages I maintained

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/74884
3 package were built:
azure-cli python37Packages.azure-mgmt-kusto python38Packages.azure-mgmt-kusto
```