### PR TITLE
zsh-powerlevel9k: 2017-11-10 -> v0.6.7

### DIFF
--- a/pkgs/shells/zsh/zsh-powerlevel9k/default.nix
+++ b/pkgs/shells/zsh/zsh-powerlevel9k/default.nix
@@ -3,14 +3,14 @@
 # To make use of this derivation, use
 # `programs.zsh.promptInit = "source ${pkgs.zsh-powerlevel9k}/share/zsh-powerlevel9k/powerlevel9k.zsh-theme";`
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec{
   pname = "powerlevel9k";
-  version = "2017-11-10";
+  version = "0.6.7";
   src = fetchFromGitHub {
-    owner = "bhilburn";
+    owner = "Powerlevel9k";
     repo = "powerlevel9k";
-    rev = "87acc51acab3ed4fd33cda2386abed6f98c80720";
-    sha256 = "0v1dqg9hvycdkcvklg2njff97xwr8rah0nyldv4xm39r77f4yfvq";
+    rev = "v${version}";
+    sha256 = "1pyg3dzr715bcm7yqanfh682yclvnb0hm6ld1x3jqx2hddqzs2js";
   };
 
   installPhase= ''


### PR DESCRIPTION
###### Motivation for this change
Upgrade zsh-powerlevel9k from 2017-11-10  to v.0.6.7

###### Things done

- [ x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x] Ensured that relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @volth 
