### PR TITLE
pacman: 5.1.3 -> 5.2.1

### DIFF
--- a/pkgs/tools/package-management/pacman/default.nix
+++ b/pkgs/tools/package-management/pacman/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, lib, fetchurl, autoreconfHook, pkgconfig, perl, libarchive, openssl,
-zlib, bzip2, lzma, curl, runtimeShell }:
+{ stdenv, lib, fetchurl, pkgconfig, perl, libarchive, openssl, zlib, bzip2,
+lzma, curl, runtimeShell }:
 
 stdenv.mkDerivation rec {
   pname = "pacman";
-  version = "5.1.3";
+  version = "5.2.1";
 
   src = fetchurl {
-    url = "https://git.archlinux.org/pacman.git/snapshot/pacman-${version}.tar.gz";
-    sha256 = "108xp6dhvp02jnzskhgzjmp9jvrxhhkffvmpvs3rrif7vj47xd76";
+    url = "https://sources.archlinux.org/other/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "04pkb8qvkldrayfns8cx4fljl4lyys1dqvlf7b5kkl2z4q3w8c0r";
   };
 
   enableParallelBuilding = true;
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "sysconfdir=${placeholder "out"}/etc" ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ curl perl libarchive openssl zlib bzip2 lzma ];
 
   postFixup = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates pacman to the latest version. `configure.ac` has a problem in the git tarball, causing the following error:
```
./configure: line 14968: syntax error near unexpected token `$file_version,'
./configure: line 14968: `      AX_COMPARE_VERSION($file_version, ge, 5.38, with_file_seccomp=yes)'
```
I switched to using the release tarball used by the official Arch package, which seems to have been fixed. This also eliminates the need for `autoreconfHook`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mt-caret 
