### PR TITLE
dnnl: init at 1.1.2

### DIFF
--- a/pkgs/development/libraries/dnnl/bash-to-sh.patch
+++ b/pkgs/development/libraries/dnnl/bash-to-sh.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index f6810246..e1d2a1f1 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -72,7 +72,7 @@ if(UNIX OR MINGW)
+     set(test_c_symbols "${CMAKE_CURRENT_BINARY_DIR}/test_c_symbols.c")
+     add_custom_command(
+         OUTPUT ${test_c_symbols}
+-        COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/generate_c_symbols_refs.sh
++        COMMAND @bash@/bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/generate_c_symbols_refs.sh
+         ${CMAKE_CURRENT_SOURCE_DIR}/.. ${test_c_symbols} ${include_dirs}
+     )
+     register_exe(test_c_symbols-c ${test_c_symbols} "test")

--- a/pkgs/development/libraries/dnnl/default.nix
+++ b/pkgs/development/libraries/dnnl/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchFromGitHub, substituteAll, cmake, bash }:
+
+stdenv.mkDerivation rec {
+  pname = "dnnl";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "mkl-dnn";
+    rev = "v${version}";
+    sha256 = "150cdyfiw4izvzmbmdqidwadppb1qjmzhpaqjczm397ygi1m92l1";
+  };
+
+  # Generic fix upstreamed in https://github.com/intel/mkl-dnn/pull/631
+  # Delete patch when 1.2.0 is released
+  patches = [ (substituteAll {
+    src = ./bash-to-sh.patch;
+    inherit bash;
+  }) ];
+
+  outputs = [ "out" "dev" "doc" ];
+
+  nativeBuildInputs = [ cmake ];
+
+  # The test driver doesn't add an RPath to the build libdir
+  preCheck = ''
+    export LD_LIBRARY_PATH=$PWD/src
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Deep Neural Network Library (DNNL)";
+    homepage = "https://intel.github.io/mkl-dnn/dev_guide_transition_to_dnnl.html";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ alexarice bhipple ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11145,6 +11145,8 @@ in
 
   dhex = callPackage ../applications/editors/dhex { };
 
+  dnnl = callPackage ../development/libraries/dnnl { };
+
   double-conversion = callPackage ../development/libraries/double-conversion { };
 
   dclib = callPackage ../development/libraries/dclib { };


### PR DESCRIPTION
This commit continues the work proposed in #68014, and provides an entirely FOSS
variant of the `dnnl` package. Updates to add an `mkl` flavor will be added
later, pending discussion about the cleanest way to overlay this consistently.

Fixes #67982, closes #68014

Co-authored-by: Alex Rice <alexrice999@hotmail.co.uk>


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @alexarice @jonringer @stites @Ericson2314 