### PR TITLE
pythonPackages.numpy: consistent mklSupport attribute

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1133,33 +1133,25 @@ self: super: {
 }
 ```
 
-### How to use Intel's MKL with numpy and scipy?
+### How to use Intel's MKL with numpy, scipy, pandas, pytorch, etc.?
 
-A `site.cfg` is created that configures BLAS based on the `blas` parameter
-of the `numpy` derivation. By passing in `mkl`, `numpy` and packages depending
-on `numpy` will be built with `mkl`.
+Many packages can use Intel's MKL instead of OpenBLAS. Since this is a
+proprietary package and only available on the `x86_64-{linux,darwin}` platforms,
+it is disabled by default and not built by Hydra. To enable it consistently for
+all of these packages, add this overlay:
 
-The following is an overlay that configures `numpy` to use `mkl`:
 ```nix
-self: super: {
-  python37 = super.python37.override {
-    packageOverrides = python-self: python-super: {
-      numpy = python-super.numpy.override {
-        blas = super.pkgs.mkl;
-      };
-    };
-  };
-}
+self: super: { mklSupport = true; }
 ```
+
+Numpy will also add the selected Blas implementation to its passthru for direct
+dependencies to read.
 
 `mkl` requires an `openmp` implementation when running with multiple processors.
 By default, `mkl` will use Intel's `iomp` implementation if no other is
 specified, but this is a runtime-only dependency and binary compatible with the
 LLVM implementation. To use that one instead, Intel recommends users set it with
 `LD_PRELOAD`.
-
-Note that `mkl` is only available on `x86_64-{linux,darwin}` platforms;
-moreover, Hydra is not building and distributing pre-compiled binaries using it.
 
 ### What inputs do `setup_requires`, `install_requires` and `tests_require` map to?
 


### PR DESCRIPTION
This commit makes `numpy` respect the `mklSupport` boolean attribute that is in
use in `pytorch` and other packages that have an MKL option.

While most packages that have this option depend on Numpy directly or
transitively, not all do; and it's more straightforward to have one config
option, since we generally want this to be applied consistently across our
library stack.

Note that this change as implemented should be backwards-compatible with the
previous numpy method for specifying MKL.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fridh @jonringer @alexarice @stites @markuskowa @smaret @costrouc @Ericson2314 