### PR TITLE
gebaar-libinput: init at 0.0.5

### DIFF
--- a/pkgs/tools/inputmethods/gebaar-libinput/default.nix
+++ b/pkgs/tools/inputmethods/gebaar-libinput/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake, libinput, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "gebaar-libinput";
+  version = "0.0.5";
+
+  src = fetchFromGitHub {
+    owner = "Coffee2CodeNL";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1kqcgwkia1p195xr082838dvj1gqif9d63i8a52jb0lc32zzizh6";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ libinput zlib ];
+
+  meta = with lib; {
+    description = "Gebaar, A Super Simple WM Independent Touchpad Gesture Daemon for libinput";
+    homepage = "https://github.com/Coffee2CodeNL/gebaar-libinput";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ colemickens lovesegfault ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2436,6 +2436,8 @@ in
 
   evdevremapkeys = callPackage ../tools/inputmethods/evdevremapkeys { };
 
+  gebaar-libinput = callPackage ../tools/inputmethods/gebaar-libinput { };
+
   libpinyin = callPackage ../development/libraries/libpinyin { };
 
   libskk = callPackage ../development/libraries/libskk {


### PR DESCRIPTION
###### Motivation for this change
Wasn't packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @colemickens @andir
