### PR TITLE
python3Packages.nose-exclude: disable tests for darwin

### DIFF
--- a/pkgs/development/python-modules/nose-exclude/default.nix
+++ b/pkgs/development/python-modules/nose-exclude/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , buildPythonPackage
 , fetchPypi
 , nose
@@ -14,6 +15,9 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ nose ];
+
+  # "OSError: AF_UNIX path too long" for darwin
+  doCheck = !stdenv.isDarwin;
 
   meta = {
     license = lib.licenses.lgpl21;


### PR DESCRIPTION
###### Motivation for this change
trying to fix darwin packages

"OSError: AF_UNIX path too long"

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
