### PR TITLE
upower: load config from /etc

### DIFF
--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -54,6 +54,8 @@ in
 
     systemd.packages = [ cfg.package ];
 
+    environment.etc."UPower/UPower.conf".source = "${cfg.package}/etc/UPower/UPower.conf";
+
   };
 
 }

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
 
   installFlags = [
     "historydir=$(TMPDIR)/foo"
-    "sysconfdir=$(out)/etc"
+    "sysconfdir=${placeholder "out"}/etc"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -52,12 +52,14 @@ stdenv.mkDerivation {
     "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
     "--with-systemdutildir=${placeholder "out"}/lib/systemd"
     "--with-udevrulesdir=${placeholder "out"}/lib/udev/rules.d"
+    "--sysconfdir=/etc"
   ];
 
   doCheck = false; # fails with "env: './linux/integration-test': No such file or directory"
 
   installFlags = [
     "historydir=$(TMPDIR)/foo"
+    "sysconfdir=$(out)/etc"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
In the process of making UPower.conf customizable (#73968), it came up that UPower doesn't load its config from /etc by default.


###### Things done

The UPower derivation is modified to make it load its config from /etc at runtime, but still install the default config to its nix store path as before.

The UPower module is modified to symlink the default config into /etc.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace
