### PR TITLE
python: reproject: 0.5.1 -> 0.6

### DIFF
--- a/pkgs/development/python-modules/reproject/default.nix
+++ b/pkgs/development/python-modules/reproject/default.nix
@@ -6,24 +6,35 @@
 , astropy-healpix
 , astropy-helpers
 , scipy
+, pytest
+, pytest-astropy
+, cython
 }:
 
 buildPythonPackage rec {
   pname = "reproject";
-  version = "0.5.1";
-
-  doCheck = false; # tests require pytest-astropy
+  version = "0.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "069rha55cbm8vsi1qf8zydds42lgkcc97sd57hmjw1mgiz025xrp";
+    sha256 = "484fde86d70d972d703038f138d7c2966ddf51171a6e79bd84e82ea270e27af3";
   };
 
   propagatedBuildInputs = [ numpy astropy astropy-healpix astropy-helpers scipy ];
 
+  nativeBuildInputs = [ astropy-helpers cython ];
+
   # Disable automatic update of the astropy-helper module
   postPatch = ''
     substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  checkInputs = [ pytest pytest-astropy ];
+
+  # Tests must be run in the build directory
+  checkPhase = ''
+    cd build/lib*
+    pytest
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

 - Update reproject to the latest upstream
 - Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

