### PR TITLE
ocamlPackages.merlin: 3.3.2 → 3.3.3

### DIFF
--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -1,21 +1,19 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, yojson }:
+{ lib, fetchurl, buildDunePackage, yojson }:
 
 buildDunePackage rec {
   pname = "merlin";
-  version = "3.3.2";
+  version = "3.3.3";
 
   minimumOCamlVersion = "4.02.1";
 
-  src = fetchFromGitHub {
-    owner = "ocaml";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "1z9mcxflraj15sbz6q7f84n31n9fsialw7z8bi3r1biz68nypva9";
+  src = fetchurl {
+    url = "https://github.com/ocaml/merlin/releases/download/v${version}/merlin-v${version}.tbz";
+    sha256 = "05dfkbpbb7nvs4g6y0iw7a9f73ygvhs9l45l2g56y7zagvs9x43j";
   };
 
   buildInputs = [ yojson ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "An editor-independent tool to ease the development of programs in OCaml";
     homepage = "https://github.com/ocaml/merlin";
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

