### PR TITLE
Update CONTRIBUTING.md to reflect the introduction of issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,9 +6,8 @@ under the terms of [COPYING](../COPYING), which is an MIT-like license.
 ## Opening issues
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* [Submit an issue](https://github.com/NixOS/nixpkgs/issues) - assuming one does not already exist.
-  * Clearly describe the issue including steps to reproduce when it is a bug.
-  * Include information what version of nixpkgs and Nix are you using (nixos-version or git revision).
+* Make sure there is no open issue on the topic
+* [Submit a new issue](https://github.com/NixOS/nixpkgs/issues/new/choose) by choosing the kind of topic and fill out the template
 
 ## Submitting changes
 


### PR DESCRIPTION
###### Motivation for this change

to reflect the introduction of issue templates

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
