### PR TITLE
pythonPackages.gpapi: disable for python2

### DIFF
--- a/pkgs/development/python-modules/gpapi/default.nix
+++ b/pkgs/development/python-modules/gpapi/default.nix
@@ -1,8 +1,13 @@
-{ stdenv, buildPythonPackage, fetchPypi, requests, protobuf, pycryptodome }:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
+, requests
+, protobuf
+, pycryptodome
+}:
 
 buildPythonPackage rec {
   version = "0.4.4";
   pname = "gpapi";
+  disabled = pythonOlder "3.3"; # uses shutil.which(), added in 3.3
 
   src = fetchPypi {
     inherit version pname;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/commit/09c7eccd293ab194f6fa32aab73ba22cd10551a2 broke python2 build.

hydra jobs: https://hydra.nixos.org/eval/1558063#tabs-now-fail
hydra build log: https://hydra.nixos.org/build/107771619/nixlog/1

Uses shutil.which(), which was added in 3.3
No longer supports python2
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
