### PR TITLE
python3Packages.gplaycli: 3.25 -> 3.26

### DIFF
--- a/pkgs/development/python-modules/gplaycli/default.nix
+++ b/pkgs/development/python-modules/gplaycli/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonPackage rec {
   pname = "gplaycli";
-  version = "3.25";
+  version = "3.26";
 
   src = fetchFromGitHub {
     owner = "matlink";
     repo = "gplaycli";
     rev = version;
-    sha256 = "1rygx5cg4b1vwpkiaq6jcpbc1ly7cspslv3sy7x8n8ba61ryq6h4";
+    sha256 = "188237d40q35dp5xs7hg4ybhvsyxi0bsqx5dk4ws9007n596in5f";
   };
 
   disabled = !isPy3k;


### PR DESCRIPTION
###### Motivation for this change
broken by https://github.com/NixOS/nixpkgs/commit/09c7eccd293ab194f6fa32aab73ba22cd10551a2

bumping it fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
