### PR TITLE
nixos/tests/munin: port to python

### DIFF
--- a/nixos/tests/munin.nix
+++ b/nixos/tests/munin.nix
@@ -1,7 +1,7 @@
 # This test runs basic munin setup with node and cron job running on the same
 # machine.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "munin";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ domenkozar eelco ];
@@ -12,33 +12,33 @@ import ./make-test.nix ({ pkgs, ...} : {
       { config, ... }:
         {
           services = {
-           munin-node = {
+            munin-node = {
+              enable = true;
+              # disable a failing plugin to prevent irrelevant error message, see #23049
+              disabledPlugins = [ "apc_nis" ];
+            };
+            munin-cron = {
              enable = true;
-             # disable a failing plugin to prevent irrelevant error message, see #23049
-             disabledPlugins = [ "apc_nis" ];
-           };
-           munin-cron = {
-            enable = true;
-            hosts = ''
-              [${config.networking.hostName}]
-              address localhost
-            '';
-           };
+             hosts = ''
+               [${config.networking.hostName}]
+               address localhost
+             '';
+            };
           };
-          # long timeout to prevent hydra failure on high load
-          systemd.services.munin-node.serviceConfig.TimeoutStartSec = "10min";
+
+          # increase the systemd timer interval so it fires more often
+          systemd.timers.munin-cron.timerConfig.OnCalendar = pkgs.stdenv.lib.mkForce "*:*:0/10";
         };
     };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $one->waitForUnit("munin-node.service");
-    # make sure the node is actually listening
-    $one->waitForOpenPort(4949);
-    $one->succeed('systemctl start munin-cron');
-    # wait for munin-cron output
-    $one->waitForFile("/var/lib/munin/one/one-uptime-uptime-g.rrd");
-    $one->waitForFile("/var/www/munin/one/index.html");
+    with subtest("ensure munin-node starts and listens on 4949"):
+        one.wait_for_unit("munin-node.service")
+        one.wait_for_open_port(4949)
+    with subtest("ensure munin-cron output is correct"):
+        one.wait_for_file("/var/lib/munin/one/one-uptime-uptime-g.rrd")
+        one.wait_for_file("/var/www/munin/one/index.html")
   '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Port munin test to python for #72828 to march towards completion for test ports.

###### Things done
I noticed this test didn't even work to begin with, and it seems to be that the `munin-node` module doesn't even load a single usable plugin (which makes the `munin-cron` portion of this test fail). After a bit of trying to get a plugin to work, I finally decided a minimal working test ported to python was better than a broken non-ported test.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) `nixos/tests/munin.nix`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @domenkozar
