### PR TITLE
emacs: do not use seq package from elpa for emacs >= 27

### DIFF
--- a/pkgs/applications/editors/emacs-modes/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-packages.nix
@@ -40,6 +40,9 @@ self: let
       cl-lib = null; # builtin
       tle = null; # builtin
       advice = null; # builtin
+      seq = if lib.versionAtLeast self.emacs.version "27"
+            then null
+            else super.seq;
     };
 
     elpaPackages = super // overrides;


### PR DESCRIPTION
The `seq` package that comes with emacs 27 is newer than that provided
by ELPA. Various packages list `seq` as an input, causing it to be
imported from ELPA in addition to the (newer) version bundled with
emacs. Relying on the version packaged with emacs resolves the
conflict.

Fixes #73346

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
