### PR TITLE
nixos/tests/gnome3: port to python

### DIFF
--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -46,7 +46,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       machine.wait_for_unit("default.target", "alice")
 
       # Check that logging in has given the user ownership of devices.
-      machine.succeed("getfacl -p /dev/snd/timer | grep -q alice")
+      assert "alice" in machine.succeed("getfacl -p /dev/snd/timer")
 
       # Wait for the wayland server
       machine.wait_for_file("/run/user/1000/wayland-0")

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "gnome3";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = pkgs.gnome3.maintainers;
@@ -38,27 +38,36 @@ import ./make-test.nix ({ pkgs, ...} : {
     wmClass = "${gdbus} ${eval} global.display.focus_window.wm_class";
   in ''
       # wait for gdm to start
-      $machine->waitForUnit("display-manager.service");
+      machine.wait_for_unit("display-manager.service")
+
+      machine.sleep(5)
 
       # wait for alice to be logged in
-      $machine->waitForUnit("default.target","alice");
+      machine.wait_for_unit("default.target", "alice")
 
       # Check that logging in has given the user ownership of devices.
-      $machine->succeed("getfacl -p /dev/snd/timer | grep -q alice");
+      machine.succeed("getfacl -p /dev/snd/timer | grep -q alice")
 
       # Wait for the wayland server
-      $machine->waitForFile("/run/user/1000/wayland-0");
+      machine.wait_for_file("/run/user/1000/wayland-0")
 
       # Wait for gnome shell, correct output should be "(true, 'false')"
-      $machine->waitUntilSucceeds("su - alice -c '${startingUp} | grep -q true,..false'");
+      machine.wait_until_succeeds(
+          "su - alice -c '${startingUp} | grep -q true,..false'"
+      )
 
       # open a terminal
-      $machine->succeed("su - alice -c '${bus} gnome-terminal'");
+      machine.succeed(
+          "su - alice -c '${bus} gnome-terminal'"
+      )
+
       # and check it's there
-      $machine->waitUntilSucceeds("su - alice -c '${wmClass} | grep -q gnome-terminal-server'");
+      machine.wait_until_succeeds(
+          "su - alice -c '${wmClass} | grep -q gnome-terminal-server'"
+      )
 
       # wait to get a nice screenshot
-      $machine->sleep(20);
-      $machine->screenshot("screen");
+      machine.sleep(20)
+      machine.screenshot("screen")
     '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Port `gnome3` test to python for https://github.com/NixOS/nixpkgs/issues/72828

###### Things done
Ported `gnome3` tests to python.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) `nixos/tests/gnome3.nix`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
