### PR TITLE
libreoffice: fix build with poppler-0.83

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pam, python3, libxslt, perl, ArchiveZip, gettext
+{ stdenv, fetchurl, fetchpatch, pam, python3, libxslt, perl, ArchiveZip, gettext
 , IOCompress, zlib, libjpeg, expat, freetype, libwpd
 , libxml2, db, curl, fontconfig, libsndfile, neon
 , bison, flex, zip, unzip, gtk3, gtk2, libmspack, getopt, file, cairo, which
@@ -73,6 +73,12 @@ in stdenv.mkDerivation rec {
 
   patches = [
     ./xdg-open-brief.patch
+    # poppler-0.82 compatibility:
+    (fetchpatch {
+      url = "https://github.com/LibreOffice/core/commit/2eadd46a.patch";
+      sha256 = "1mpipdfxvixjziizbhfbpybpzlg1ijw7s0yqjpmq5d7pf3pvkm4n";
+    })
+    ./poppler-0.83.patch
   ];
 
   tarballPath = "external/tarballs";

--- a/pkgs/applications/office/libreoffice/poppler-0.83.patch
+++ b/pkgs/applications/office/libreoffice/poppler-0.83.patch
@@ -1,0 +1,48 @@
+diff --git a/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.cxx b/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.cxx
+index 26048177e87d..da7736f607f9 100644
+--- a/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.cxx
++++ b/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.cxx
+@@ -491,12 +491,12 @@ void PDFOutDev::writeFontFile( GfxFont* gfxFont ) const
+     gfree(pBuf);
+ }
+ 
+-void PDFOutDev::printPath( GfxPath* pPath )
++void PDFOutDev::printPath( const GfxPath* pPath )
+ {
+     int nSubPaths = pPath ? pPath->getNumSubpaths() : 0;
+     for( int i=0; i<nSubPaths; i++ )
+     {
+-        GfxSubpath* pSub  = pPath->getSubpath( i );
++        const GfxSubpath* pSub  = pPath->getSubpath( i );
+         const int nPoints = pSub->getNumPoints();
+ 
+         printf( " subpath %d", pSub->isClosed() );
+diff --git a/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.hxx b/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.hxx
+index 02f6b59f6f15..1c7451a78601 100644
+--- a/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.hxx
++++ b/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.hxx
+@@ -149,7 +149,7 @@ namespace pdfi
+ 
+         int  parseFont( long long nNewId, GfxFont* pFont, GfxState* state ) const;
+         void writeFontFile( GfxFont* gfxFont ) const;
+-        static void printPath( GfxPath* pPath );
++        static void printPath( const GfxPath* pPath );
+ 
+     public:
+         explicit PDFOutDev( PDFDoc* pDoc );
+diff --git a/sdext/source/pdfimport/xpdfwrapper/wrapper_gpl.cxx b/sdext/source/pdfimport/xpdfwrapper/wrapper_gpl.cxx
+index 42178b650cdd..b1a54bd09c5f 100644
+--- a/sdext/source/pdfimport/xpdfwrapper/wrapper_gpl.cxx
++++ b/sdext/source/pdfimport/xpdfwrapper/wrapper_gpl.cxx
+@@ -68,7 +68,11 @@ int main(int argc, char **argv)
+     }
+ 
+     // read config file
++#if POPPLER_CHECK_VERSION(0, 83, 0)
++    globalParams = std::make_unique<GlobalParams>();
++#else
+     globalParams = new GlobalParams();
++#endif
+     globalParams->setErrQuiet(true);
+ #if defined(_MSC_VER)
+     globalParams->setupBaseFonts(nullptr);

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pam, python3, libxslt, perl, ArchiveZip, gettext
+{ stdenv, fetchurl, fetchpatch, pam, python3, libxslt, perl, ArchiveZip, gettext
 , IOCompress, zlib, libjpeg, expat, freetype, libwpd
 , libxml2, db, curl, fontconfig, libsndfile, neon
 , bison, flex, zip, unzip, gtk3, gtk2, libmspack, getopt, file, cairo, which
@@ -73,6 +73,11 @@ in stdenv.mkDerivation rec {
 
   patches = [
     ./xdg-open-brief.patch
+    (fetchpatch {
+      url = "https://github.com/LibreOffice/core/commit/2eadd46a.patch";
+      sha256 = "1mpipdfxvixjziizbhfbpybpzlg1ijw7s0yqjpmq5d7pf3pvkm4n";
+    })
+    ./poppler-0.83.patch
   ];
 
   tarballPath = "external/tarballs";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes: #74948

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
