### PR TITLE
micropython: init at 1.12

### DIFF
--- a/pkgs/development/interpreters/micropython/default.nix
+++ b/pkgs/development/interpreters/micropython/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, lib, fetchFromGitHub, pkgconfig, libffi, python3, readline }:
+
+stdenv.mkDerivation rec {
+  pname = "micropython";
+  version = "1.12";
+
+  src = fetchFromGitHub {
+    owner  = "micropython";
+    repo   = "micropython";
+    rev    = "v${version}";
+    sha256 = "1fsigdahnv5yn0mc7dr1y6h7g8ywg084pcgj6d64kb39w641n8j5";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig python3 ];
+
+  buildInputs = [ libffi readline ];
+
+  doCheck = true;
+
+  buildPhase = ''
+    make -C mpy-cross
+    make -C ports/unix
+  '';
+
+  checkPhase = ''
+    pushd tests
+    MICROPY_MICROPYTHON=../ports/unix/micropython ${python3.interpreter} ./run-tests
+    popd
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -Dm755 ports/unix/micropython $out/bin/micropython
+  '';
+
+  meta = with lib; {
+    description = "A lean and efficient Python implementation for microcontrollers and constrained systems";
+    homepage = "https://micropython.org";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ sgo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13227,6 +13227,8 @@ in
 
   micronucleus = callPackage ../development/tools/misc/micronucleus { };
 
+  micropython = callPackage ../development/interpreters/micropython { };
+
   mimalloc = callPackage ../development/libraries/mimalloc { };
 
   minizip = callPackage ../development/libraries/minizip { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds the unix port of MicroPython. A lean implementation of Python 3 for microcontrollers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

