### PR TITLE
sweet: init at 1.10.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2490,6 +2490,12 @@
     githubId = 40521440;
     name = "Haruka Akiyama";
   };
+  fuzen = {
+    email = "me@fuzen.cafe";
+    github = "fuzen-py";
+    githubId = 17859309;
+    name = "Fuzen";
+  };
   fuzzy-id = {
     email = "hacking+nixos@babibo.de";
     name = "Thomas Bach";

--- a/pkgs/data/themes/sweet/default.nix
+++ b/pkgs/data/themes/sweet/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  pname = "sweet";
+  version = "1.10.5";
+
+  srcs = [
+    (fetchurl {
+      url = "https://github.com/EliverLara/Sweet/releases/download/v${version}/Sweet-Ambar-Blue.zip";
+      sha256 = "11040hx8ci4vbnyaj63zj924v0ln7rjm9a28mcqdax60h3dp12lj";
+    })
+    (fetchurl {
+      url = "https://github.com/EliverLara/Sweet/releases/download/v${version}/Sweet-Ambar.zip";
+      sha256 = "0lvnjmirpwdav8q0bfbhybwkr2h6dilc7lhhj18xd2k57xadjmxr";
+    })
+    (fetchurl {
+      url = "https://github.com/EliverLara/Sweet/releases/download/v${version}/Sweet-Dark.zip";
+      sha256 = "0a7mh1pgvi8w1ahsmvgnmpdawm30lcjqk4zqvg0lqadsd04dn4h1";
+    })
+    (fetchurl {
+      url = "https://github.com/EliverLara/Sweet/releases/download/v${version}/Sweet-mars.zip";
+      sha256 = "0n2dkl35qrik10wvhvkayyra987p03g56pxhz5kc73cbsl5zd96l";
+    })
+    (fetchurl {
+      url = "https://github.com/EliverLara/Sweet/releases/download/v${version}/Sweet.zip";
+      sha256 = "0wwmc3wj2pjg4kimfkvcsimk3s4s7l7k000vxqi8yjlfs70f273c";
+    })
+  ];
+
+  nativeBuildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/share/themes/
+    cp -a Sweet* $out/share/themes/
+    rm $out/share/themes/*/{LICENSE,README*}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Light and dark colorful Gtk3.20+ theme";
+    homepage = "https://github.com/EliverLara/Sweet";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fuzen ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17557,6 +17557,8 @@ in
 
   shades-of-gray-theme = callPackage ../data/themes/shades-of-gray { };
 
+  sweet = callPackage ../data/themes/sweet { };
+
   mime-types = callPackage ../data/misc/mime-types { };
 
   shared-mime-info = callPackage ../data/misc/shared-mime-info { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Sweet theme is a popular theme on [r/unixporn](https://www.reddit.com/r/unixporn/), so I added created a package for it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
