### PR TITLE
bazel: take into account system wide bazelrc configuration if it exists

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_rc.patch
+++ b/pkgs/development/tools/build-managers/bazel/bazel_rc.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/cpp/option_processor.cc b/src/main/cpp/option_processor.cc
+index 8f8f15685f..a7ae52d1e4 100644
+--- a/src/main/cpp/option_processor.cc
++++ b/src/main/cpp/option_processor.cc
+@@ -56,7 +56,7 @@ OptionProcessor::OptionProcessor(
+     : workspace_layout_(workspace_layout),
+       startup_options_(std::move(default_startup_options)),
+       parse_options_called_(false),
+-      system_bazelrc_path_(BAZEL_SYSTEM_BAZELRC_PATH) {}
++      system_bazelrc_path_("@bazelSystemBazelRCPath@") {}
+ 
+ OptionProcessor::OptionProcessor(
+     const WorkspaceLayout* workspace_layout,

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -133,6 +133,9 @@ let
       build --override_repository=${remote_java_tools.name}=${remote_java_tools}
       build --distdir=${distDir}
       startup --server_javabase=${runJdk}
+
+      # load default location for the system wide configuration
+      try-import /etc/bazel.bazelrc
     '';
   };
 

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -132,6 +132,7 @@ let
     text = ''
       build --override_repository=${remote_java_tools.name}=${remote_java_tools}
       build --distdir=${distDir}
+      startup --server_javabase=${runJdk}
     '';
   };
 
@@ -483,8 +484,6 @@ stdenv.mkDerivation rec {
     # if it can’t find something in tools, it calls $out/bin/bazel-real
     cp ./bazel_src/scripts/packages/bazel.sh $out/bin/bazel
     mv ./bazel_src/output/bazel $out/bin/bazel-real
-
-    wrapProgram "$out/bin/bazel" --add-flags --server_javabase="${runJdk}"
 
     # shell completion files
     mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -171,6 +171,13 @@ stdenv.mkDerivation rec {
       src = ./strict_action_env.patch;
       strictActionEnvPatch = defaultShellPath;
     })
+
+    # bazel reads its system bazelrc in /etc
+    # override this path to a builtin one
+    (substituteAll {
+      src = ./bazel_rc.patch;
+      bazelSystemBazelRCPath = bazelRC;
+    })
   ] ++ lib.optional enableNixHacks ./nix-hacks.patch;
 
 
@@ -431,12 +438,6 @@ stdenv.mkDerivation rec {
       mv runfiles.bash.tmp tools/bash/runfiles/runfiles.bash
 
       patchShebangs .
-
-      # bazel reads its system bazelrc in /etc
-      # override this path to a builtin one
-      substituteInPlace \
-        src/main/cpp/option_processor.cc \
-        --replace BAZEL_SYSTEM_BAZELRC_PATH "\"${bazelRC}\""
     '';
     in lib.optionalString stdenv.hostPlatform.isDarwin darwinPatches
      + genericPatches;


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

closes #70911

This was extracted from https://github.com/NixOS/nixpkgs/pull/73309 to respect separation of concern.

Edit: after a few discussion with @flokli, this PR also refactors a bit of the bazelrc configuration handling:

- the new bazelrc file is generated in its own nix store path. That's cleaner.
- the replacement in the bazel source code is done using a patch, this way a regression will be catched earlier on.
- the wrap of bazel was replaced by entries in the bazelrc file

cc @flokli 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli
