### PR TITLE
nix-linter: init at 2019-04-26

### DIFF
--- a/pkgs/development/tools/analysis/nix-linter/default.nix
+++ b/pkgs/development/tools/analysis/nix-linter/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, parallel-io
+, fixplate
+, pandoc
+, tasty
+, tasty-hunit
+, tasty-th
+, streamly
+, mtl
+, path-io
+, path
+, pretty-terminal
+, text
+, base
+, aeson
+, cmdargs
+, containers
+, hnix
+, bytestring
+}:
+
+mkDerivation rec {
+  pname = "nix-linter-unstable";
+  version = "2019-04-26";
+
+  src = fetchFromGitHub {
+    owner = "Synthetica9";
+    repo = "nix-linter";
+    rev = "4aaf60195cd2d9f9e2345fbdf4aac48e1451292c";
+    sha256 = "0c7rcjaxd8z0grwambsw46snv7cg66h3pszw3549z4xz0i60yq87";
+  };
+
+  isLibrary = false;
+  isExecutable = true;
+  libraryHaskellDepends = [ parallel-io fixplate pandoc ];
+  executableHaskellDepends = [ streamly mtl path-io path pretty-terminal text base aeson cmdargs containers hnix bytestring ];
+  testHaskellDepends = [ tasty tasty-hunit tasty-th ];
+
+  description = "Linter for Nix(pkgs), based on hnix";
+  homepage = "https://github.com/Synthetica9/nix-linter";
+  license = lib.licenses.bsd3;
+  maintainers = [ lib.maintainers.marsam ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24766,6 +24766,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  nix-linter = haskellPackages.callPackage ../development/tools/analysis/nix-linter { };
+
   nix-pin = callPackage ../tools/package-management/nix-pin { };
 
   nix-prefetch = callPackage ../tools/package-management/nix-prefetch { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add https://github.com/Synthetica9/nix-linter

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @cdepillabout 
