### PR TITLE
phantomjs2: Fix compilation when using clang60

### DIFF
--- a/pkgs/development/tools/phantomjs2/default.nix
+++ b/pkgs/development/tools/phantomjs2/default.nix
@@ -69,6 +69,10 @@ in stdenv.mkDerivation rec {
       --replace "QT_MINOR_VERSION, 5" "QT_MINOR_VERSION, 9"
   '';
 
+  # Avoids error in webpage.cpp:80:89:
+  # invalid suffix on literal; C++11 requires a space between litend identifier
+  NIX_CFLAGS_COMPILE = "-Wno-reserved-user-defined-literal";
+
   __impureHostDeps = stdenv.lib.optional stdenv.isDarwin "/usr/lib/libicucore.dylib";
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
Fixes:
```
webpage.cpp:80:89: error: invalid suffix on literal; C++11 requires a space between litend identifier [-Wreserved-user-defined-literal]
```

Fix taken from: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=228223

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @volth 
cc @lukeadams 
cc @bkchr 
cc @globin 
cc @domenkozar 
