### PR TITLE
cargo-edit: 0.3.3 -> 0.4.1

### DIFF
--- a/pkgs/tools/package-management/cargo-edit/default.nix
+++ b/pkgs/tools/package-management/cargo-edit/default.nix
@@ -4,20 +4,30 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-edit";
-  version = "0.3.3";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "killercup";
     repo = pname;
     rev = "v${version}";
-    sha256 = "05b64bm9441crw74xlywjg2y3psljk2kf9xsrixaqwbnnahi0mm5";
+    sha256 = "087l8qdwfnnklw6zyjwflxh7hyhh4r7wala36cc4lrj7lag2xm9n";
   };
 
-  cargoSha256 = "1hjjw3i35vqr6nxsv2m3izq4x8c2a6wvl5c2kjlpg6shy9j2mjaa";
+  cargoSha256 = "1ih1p9jdwr1ymq2p6ipz6rybi17f3qn65kn4bqkgzx36afvpnd5l";
 
   nativeBuildInputs = lib.optional (!stdenv.isDarwin) pkgconfig;
   buildInputs = lib.optional (!stdenv.isDarwin) openssl;
   propagatedBuildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+
+  patches = [
+    # https://github.com/killercup/cargo-edit/pull/362
+    ./no_upgrade_index_in_tests.patch
+  ];
+
+  # The default `/build` will fail the test (seems) due to permission problem.
+  preCheck = ''
+    export TMPDIR="/tmp"
+  '';
 
   meta = with lib; {
     description = "A utility for managing cargo dependencies from the command line";

--- a/pkgs/tools/package-management/cargo-edit/no_upgrade_index_in_tests.patch
+++ b/pkgs/tools/package-management/cargo-edit/no_upgrade_index_in_tests.patch
@@ -1,0 +1,123 @@
+diff --git a/src/bin/add/main.rs b/src/bin/add/main.rs
+index 41cde585..848612b3 100644
+--- a/src/bin/add/main.rs
++++ b/src/bin/add/main.rs
+@@ -87,7 +87,7 @@ fn handle_add(args: &Args) -> Result<()> {
+     let mut manifest = Manifest::open(manifest_path)?;
+     let deps = &args.parse_dependencies()?;
+ 
+-    if !args.offline {
++    if !args.offline && std::env::var("CARGO_IS_TEST").is_err() {
+         let url = registry_url(
+             &find(&manifest_path)?,
+             args.registry.as_ref().map(String::as_ref),
+diff --git a/src/bin/upgrade/main.rs b/src/bin/upgrade/main.rs
+index cf2414da..c066e6f4 100644
+--- a/src/bin/upgrade/main.rs
++++ b/src/bin/upgrade/main.rs
+@@ -409,7 +409,7 @@ fn process(args: Args) -> Result<()> {
+         ..
+     } = args;
+ 
+-    if !args.offline && !to_lockfile {
++    if !args.offline && !to_lockfile && std::env::var("CARGO_IS_TEST").is_err() {
+         let url = registry_url(&find(&manifest_path)?, None)?;
+         update_registry_index(&url)?;
+     }
+@@ -427,7 +427,7 @@ fn process(args: Args) -> Result<()> {
+ 
+         // Update indices for any alternative registries, unless
+         // we're offline.
+-        if !args.offline {
++        if !args.offline && std::env::var("CARGO_IS_TEST").is_err() {
+             for registry_url in existing_dependencies
+                 .0
+                 .values()
+diff --git a/tests/cargo-add.rs b/tests/cargo-add.rs
+index fbdbf4e2..612ffa78 100644
+--- a/tests/cargo-add.rs
++++ b/tests/cargo-add.rs
+@@ -1184,6 +1184,7 @@ fn add_prints_message() {
+         "--vers=0.6.0",
+         &format!("--manifest-path={}", manifest),
+     ])
++    .with_env(&[("CARGO_IS_TEST", "1")])
+     .succeeds()
+     .and()
+     .stdout()
+@@ -1204,6 +1205,7 @@ fn add_prints_message_with_section() {
+         "--vers=0.1.0",
+         &format!("--manifest-path={}", manifest),
+     ])
++    .with_env(&[("CARGO_IS_TEST", "1")])
+     .succeeds()
+     .and()
+     .stdout()
+@@ -1224,6 +1226,7 @@ fn add_prints_message_for_dev_deps() {
+         "0.8.0",
+         &format!("--manifest-path={}", manifest),
+     ])
++    .with_env(&[("CARGO_IS_TEST", "1")])
+     .succeeds()
+     .and()
+     .stdout()
+@@ -1244,6 +1247,7 @@ fn add_prints_message_for_build_deps() {
+         "0.1.0",
+         &format!("--manifest-path={}", manifest),
+     ])
++    .with_env(&[("CARGO_IS_TEST", "1")])
+     .succeeds()
+     .and()
+     .stdout()
+diff --git a/tests/cargo-upgrade.rs b/tests/cargo-upgrade.rs
+index b11a88dc..cf117940 100644
+--- a/tests/cargo-upgrade.rs
++++ b/tests/cargo-upgrade.rs
+@@ -385,6 +385,7 @@ fn upgrade_workspace() {
+ 
+ /// Detect if attempting to run against a workspace root and give a helpful warning.
+ #[test]
++#[cfg(feature = "test-external-apis")]
+ fn detect_workspace() {
+     let (_tmpdir, root_manifest, _workspace_manifests) = copy_workspace_test();
+ 
+@@ -414,6 +415,7 @@ fn invalid_manifest() {
+         "--manifest-path",
+         &manifest,
+     ])
++    .with_env(&[("CARGO_IS_TEST", "1")])
+     .fails_with(1)
+     .and()
+     .stderr()
+@@ -442,6 +444,7 @@ fn invalid_root_manifest() {
+         "--manifest-path",
+         &manifest,
+     ])
++    .with_env(&[("CARGO_IS_TEST", "1")])
+     .fails_with(1)
+     .and()
+     .stderr()
+@@ -457,6 +460,7 @@ fn unknown_flags() {
+         "foo",
+         "--flag",
+     ])
++    .with_env(&[("CARGO_IS_TEST", "1")])
+     .fails_with(1)
+     .and()
+     .stderr()
+@@ -473,6 +477,7 @@ For more information try --help ",
+ 
+ // Verify that an upgraded Cargo.toml matches what we expect.
+ #[test]
++#[cfg(feature = "test-external-apis")]
+ fn upgrade_to_lockfile() {
+     let (tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.lockfile_source");
+     fs::copy(
+@@ -489,6 +494,7 @@ fn upgrade_to_lockfile() {
+ }
+ 
+ #[test]
++#[cfg(feature = "test-external-apis")]
+ fn upgrade_workspace_to_lockfile() {
+     let (tmpdir, root_manifest, _workspace_manifests) = copy_workspace_test();
+ 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upgrade and fix broken tests.

Related: #70917
Upstream PR of the patch: https://github.com/killercup/cargo-edit/pull/362

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
