### PR TITLE
cargo-deb: 1.21.1 -> 1.23.0

### DIFF
--- a/pkgs/tools/package-management/cargo-deb/default.nix
+++ b/pkgs/tools/package-management/cargo-deb/default.nix
@@ -2,18 +2,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deb";
-  version = "1.21.1";
+  version = "1.23.0";
 
   src = fetchFromGitHub {
     owner = "mmstick";
     repo = "cargo-deb";
     rev = "v${version}";
-    sha256 = "10b25a0cnrd2bhf38yqc32l06vp6sdlfcpa6n9718yipp7b60cq2";
+    sha256 = "0jjhbs48f0rprzxnfgav6mjbyvcqnr7xq1qgyjxwd61z8g3m8hx8";
   };
 
   buildInputs = with stdenv; lib.optionals isDarwin [ Security ];
 
-  cargoSha256 = "182ayprs2awmz7lzqkhawrmpfjla3jcj58q8g8c908gchkh05kns";
+  cargoSha256 = "03z9hq873jfsbssnd3kr5vz9lx9mvhb1navb2glm6kkw1k2zm4d2";
 
   meta = with stdenv.lib; {
     description = "Generate Debian packages from information in Cargo.toml";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/mmstick/cargo-deb/releases/tag/v1.23.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/xmglks60vlfsy8yv19dfylshb6hg8j1y-cargo-deb-1.21.1	  28.5M
/nix/store/bkzxvvx2w7zrdm09h5g2nqdhp5lc9dz3-cargo-deb-1.23.0	  28.5M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/74983)
<!-- Reviewable:end -->
