### PR TITLE
plplot: init at 5.15.0

### DIFF
--- a/pkgs/development/libraries/plplot/default.nix
+++ b/pkgs/development/libraries/plplot/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, cmake }:
+
+stdenv.mkDerivation rec {
+  pname   = "plplot";
+  version = "5.15.0";
+
+  src = fetchurl {
+    url = "https://downloads.sourceforge.net/project/${pname}/${pname}/${version}%20Source/${pname}-${version}.tar.gz";
+    sha256 = "0ywccb6bs1389zjfmc9zwdvdsvlpm7vg957whh6b5a96yvcf8bdr";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=OFF" "-DBUILD_TEST=ON" ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform scientific graphics plotting library";
+    homepage    = "https://plplot.org";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms   = platforms.unix;
+    license     = licenses.lgpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3817,6 +3817,8 @@ in
 
   pixz = callPackage ../tools/compression/pixz { };
 
+  plplot = callPackage ../development/libraries/plplot { };
+
   pxattr = callPackage ../tools/archivers/pxattr { };
 
   pxz = callPackage ../tools/compression/pxz { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
