### PR TITLE
nixos: add myself to maintainers

### DIFF
--- a/nixos/modules/services/networking/dnschain.nix
+++ b/nixos/modules/services/networking/dnschain.nix
@@ -180,4 +180,6 @@ in
 
   };
 
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }

--- a/nixos/modules/services/networking/dnscrypt-wrapper.nix
+++ b/nixos/modules/services/networking/dnscrypt-wrapper.nix
@@ -197,4 +197,7 @@ in {
     };
 
   };
+
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }

--- a/nixos/modules/services/networking/fakeroute.nix
+++ b/nixos/modules/services/networking/fakeroute.nix
@@ -60,4 +60,6 @@ in
 
   };
 
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }

--- a/nixos/modules/services/networking/monero.nix
+++ b/nixos/modules/services/networking/monero.nix
@@ -224,15 +224,17 @@ in
       };
     };
 
-   assertions = singleton {
-     assertion = cfg.mining.enable -> cfg.mining.address != "";
-     message   = ''
+    assertions = singleton {
+      assertion = cfg.mining.enable -> cfg.mining.address != "";
+      message   = ''
        You need a Monero address to receive mining rewards:
        specify one using option monero.mining.address.
-    '';
-   };
+      '';
+    };
 
   };
+
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
 
 }
 

--- a/nixos/modules/services/networking/namecoind.nix
+++ b/nixos/modules/services/networking/namecoind.nix
@@ -201,4 +201,6 @@ in
 
   };
 
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }

--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -219,4 +219,6 @@ in {
      "To change extra Recursor settings use services.pdns-recursor.settings instead.")
   ];
 
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }

--- a/nixos/modules/services/networking/privoxy.nix
+++ b/nixos/modules/services/networking/privoxy.nix
@@ -109,4 +109,6 @@ in
 
   };
 
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -75,4 +75,6 @@ in
 
   };
 
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }

--- a/nixos/modules/services/torrent/magnetico.nix
+++ b/nixos/modules/services/torrent/magnetico.nix
@@ -213,4 +213,6 @@ in {
 
   };
 
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }

--- a/nixos/modules/services/x11/compton.nix
+++ b/nixos/modules/services/x11/compton.nix
@@ -284,4 +284,6 @@ in {
     environment.systemPackages = [ pkgs.compton ];
   };
 
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }

--- a/nixos/modules/services/x11/unclutter.nix
+++ b/nixos/modules/services/x11/unclutter.nix
@@ -71,4 +71,7 @@ in {
       serviceConfig.Restart = "always";
     };
   };
+
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }

--- a/nixos/modules/services/x11/urxvtd.nix
+++ b/nixos/modules/services/x11/urxvtd.nix
@@ -45,4 +45,6 @@ in {
     environment.variables.RXVT_SOCKET = "/run/user/$(id -u)/urxvtd-socket";
   };
 
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
+
 }


### PR DESCRIPTION
##### Motivation for this change
Add myself to nixos modules I wrote or use daily.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
