### PR TITLE
gertty: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1667,6 +1667,12 @@
     email = "christoph.senjak@googlemail.com";
     name = "Christoph-Simon Senjak";
   };
+  dav1d23 = {
+    email = "petrodavi@gmail.com";
+    github = "dav1d23";
+    githubId = 10028479;
+    name = "David Petroni";
+  };
   david50407 = {
     email = "me@davy.tw";
     github = "david50407";

--- a/pkgs/development/python-modules/gertty/default.nix
+++ b/pkgs/development/python-modules/gertty/default.nix
@@ -1,0 +1,40 @@
+# Python3 should be used, because
+# "GitPython-3.1.0 not supported for interpreter python2.7"
+{ python3, lib }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "gertty";
+  version = "1.6.0";
+
+  buildInputs = with python3.pkgs; [
+    pbr
+    voluptuous
+    dateutil
+    requests
+    urwid
+    ply
+    ordereddict
+    alembic
+    GitPython
+    pyyaml
+  ];
+
+  propagatedBuildInputs = buildInputs;
+  
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "1pvpca59z5rcir7lz2yimwiqjvd8yhnwjskxna2bslyfwv996d8w";
+  };
+
+  # It uses tox, and tox tries to create a virtualenv and download
+  # flake8. Moreover, it looks like there are not really tests.
+  doCheck = false;
+
+  meta = {
+    homepage = "http://ttygroup.org/gertty/index.html";
+    description = "Gertty is a console-based interface to the Gerrit Code Review system.";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ dav1d23 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -721,6 +721,8 @@ in {
 
   getmac = callPackage ../development/python-modules/getmac { };
 
+  gertty = callPackage ../development/python-modules/gertty { };
+
   gidgethub = callPackage ../development/python-modules/gidgethub { };
 
   gin-config = callPackage ../development/python-modules/gin-config { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add gertty package to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
