### PR TITLE
qtspim: init at 722

### DIFF
--- a/pkgs/applications/virtualization/spim/default.nix
+++ b/pkgs/applications/virtualization/spim/default.nix
@@ -1,0 +1,77 @@
+{ mkDerivation, lib, fetchsvn, qmake, qtbase, qttools, bison, flex }:
+
+mkDerivation rec {
+  pname = "QtSpim";
+  version = "722";
+
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/spimsimulator/code";
+    rev = version;
+    sha256 = "1hfz41ra93pdd2pri5hibl63sg9yyk12a8nhdkmgj7h9bwgqxw6b";
+  };
+
+  sourceRoot = "code-r${version}/QtSpim";
+
+  nativeBuildInputs = [ bison flex qmake ];
+
+  buildInputs = [ qtbase qttools ];
+
+  # Remove build artifacts from the repo
+  preConfigure = ''
+    rm parser_yacc.h
+    rm parser_yacc.cpp
+    rm scanner_lex.cpp
+
+    rm help/qtspim.qhc
+  '';
+
+  # Fix bug in a generated Makefile
+  postConfigure = ''
+    substituteInPlace Makefile --replace '$(MOVE) help/qtspim.qhc help/qtspim.qhc;' ""
+  '';
+
+  # Fix documentation path
+  postPatch = ''
+    substituteInPlace menu.cpp --replace "/usr/lib/qtspim/help/qtspim.qhc" "$out/share/qtspim/help/qtspim.qhc"
+    substituteInPlace menu.cpp --replace "/usr/lib/qtspim/bin/assistant" "${qttools.dev}/bin/assistant"
+
+    substituteInPlace ../Setup/qtspim_debian_deployment/qtspim.desktop \
+      --replace "/usr/lib/qtspim/qtspim.png" "$out/share/qtspim/qtspim.png" \
+      --replace "/usr/bin/qtspim" "$out/bin/qtspim"
+  '';
+
+  buildPhase = ''
+    export QT_PLUGIN_PATH="${qtbase.bin}/${qtbase.qtPluginPrefix}"
+    export QT_QPA_PLATFORM_PLUGIN_PATH="${qtbase.bin}/${qtbase.qtPluginPrefix}/platforms"
+    make
+  '';
+
+  installPhase = ''
+    install -Dm0755 QtSpim $out/bin/qtspim
+
+    install -D ../Documentation/qtspim.man $out/share/man/man1/qtspim.1
+    gzip -f --best $out/share/man/man1/qtspim.1
+
+    install -Dm0644 help/qtspim.qch $out/share/qtspim/help/qtspim.qch
+    install -Dm0644 help/qtspim.qhc $out/share/qtspim/help/qtspim.qhc
+
+    install -Dm0644 ../Setup/qtspim_debian_deployment/qtspim.desktop $out/share/applications/qtspim.desktop
+    install -Dm0644 ../Setup/qtspim_debian_deployment/copyright $out/share/licenses/qtspim/copyright
+    install -Dm0644 ../Setup/NewIcon48x48.png $out/share/qtspim/qtspim.png
+
+    install -Dm0644 ../helloworld.s $out/share/qtspim/helloworld.s
+  '';
+
+  meta = with lib; {
+    description = "SPIM MIPS simulator";
+    longDescription = ''
+      SPIM is a self-contained simulator that runs MIPS32 assembly language programs.
+      SPIM also provides a simple debugger and minimal set of operating system services.
+    '';
+
+    homepage = "https://sourceforge.net/projects/spimsimulator";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ aske ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2013,6 +2013,8 @@ in
 
   socklog = callPackage ../tools/system/socklog { };
 
+  qtspim = qt5.callPackage ../applications/virtualization/spim { };
+
   staccato = callPackage ../tools/text/staccato { };
 
   stagit = callPackage ../development/tools/stagit { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add a MIPS32 simulator.

To build a documentation I've needed to set `QT_QPA_PLATFORM_PATH` and `QT_PLUGIN_PATH` because `qhelpgenerator` failed with:
```
qt.qpa.plugin: Could not find the Qt platform plugin "minimal" in ""
```
Either way after installation I did not manage to make `qtspim` find its help file, so I added a patch disabling doc building to save some build time.

@ttuegel maybe you have ideas on what's going on?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
