### PR TITLE
doctl: 1.31.2 -> 1.35.0

### DIFF
--- a/pkgs/development/tools/doctl/default.nix
+++ b/pkgs/development/tools/doctl/default.nix
@@ -4,8 +4,8 @@ buildGoPackage rec {
   pname = "doctl";
   version = "${major}.${minor}.${patch}";
   major = "1";
-  minor = "31";
-  patch = "2";
+  minor = "35";
+  patch = "0";
   goPackagePath = "github.com/digitalocean/doctl";
 
   excludedPackages = ''\(doctl-gen-doc\|install-doctl\|release-doctl\)'';
@@ -21,7 +21,7 @@ buildGoPackage rec {
     owner  = "digitalocean";
     repo   = "doctl";
     rev    = "v${version}";
-    sha256 = "1q71kfjiav8xfw1bb3dziik1d0jr84hl83d3sx3cak0nd9nmakgs";
+    sha256 = "1blg4xd01vvr8smpii60jlk7rg1cg64115azixw9q022f7cnfiyw";
   };
 
   meta = {


### PR DESCRIPTION
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
No idea what it is supposed to do. I got a binary built but with some errors displayed first.
```
$ nix-shell -p nix-review --run "nix-review pr 75000"
$ git fetch --force https://github.com/NixOS/nixpkgs master:refs/nix-review/0 pull/75000/head:refs/nix-review/1
remote: Enumerating objects: 24, done.
remote: Counting objects: 100% (24/24), done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 31 (delta 18), reused 16 (delta 16), pack-reused 7
Unpacking objects: 100% (31/31), done.
From https://github.com/NixOS/nixpkgs
 * [new branch]              master               -> refs/nix-review/0
 * [new ref]                 refs/pull/75000/head -> refs/nix-review/1
$ git worktree add ./.review/pr-75000 ff954e075994e351dbe277e4c3eed6dba831774a
Preparing worktree (detached HEAD ff954e07599)
Checking out files: 100% (20407/20407), done.
HEAD is now at ff954e07599 Merge pull request #74321 from romildo/upd.connman-notify
error: while querying the derivation named 'nix-2.4pre20191022_9cac895':
while evaluating the attribute 'src' of the derivation 'nix-2.4pre20191022_9cac895' at /home/thu/projects/nixpkgs/.review/pr-75000/pkgs/tools/package-management/nix/default.nix:28:14:
unknown hash algorithm '', at /home/thu/projects/nixpkgs/.review/pr-75000/pkgs/build-support/fetchurl/default.nix:119:3
$ git merge --no-commit e63832ae21dfea7b98b94b0d8a97c2ce381fe3d1
Automatic merge went well; stopped before committing as requested
error: while querying the derivation named 'nix-2.4pre20191022_9cac895':
while evaluating the attribute 'src' of the derivation 'nix-2.4pre20191022_9cac895' at /home/thu/projects/nixpkgs/.review/pr-75000/pkgs/tools/package-management/nix/default.nix:28:14:
unknown hash algorithm '', at /home/thu/projects/nixpkgs/.review/pr-75000/pkgs/build-support/fetchurl/default.nix:119:3
Building in /run/user/1000/nix-review-_gpd20oc
$ nix-shell --no-out-link --keep-going --max-jobs 8 --option build-use-sandbox true --run true -p doctl
https://github.com/NixOS/nixpkgs/pull/75000
$ nix-shell -p doctl

[nix-shell:~/projects/nixpkgs]$ which doctl
/nix/store/yiy87164yk73aknnfii37w33lg521sbz-doctl-1.35.0-bin/bin/doctl

[nix-shell:~/projects/nixpkgs]$ exit
$ git worktree prune
```
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
Previously:
```
$ nix path-info -S /nix/store/g4akkf9qg59dal7l0qd8yxfn07xqcbsb-doctl-1.31.2-bin/bin/doctl
/nix/store/g4akkf9qg59dal7l0qd8yxfn07xqcbsb-doctl-1.31.2-bin       48976424
```
  After
```
nix path-info -S /nix/store/wszxllpx9bai6gd7d0nc2nk4w0wjrvs0-doctl-1.35.0-bin/bin/doctl
/nix/store/yiy87164yk73aknnfii37w33lg521sbz-doctl-1.35.0-bin       78187088
```
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @langston-barrett 
