### PR TITLE
gnome3.mutter: backport patches from gnome-3-34 branch

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,8 +1,35 @@
-{ fetchurl, fetchpatch, substituteAll, stdenv, pkgconfig, gnome3, gettext, gobject-introspection, upower, cairo
-, pango, cogl, json-glib, libstartup_notification, zenity, libcanberra-gtk3
-, ninja, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
-, gsettings-desktop-schemas, glib, gtk3, gnome-desktop
-, geocode-glib, pipewire, libgudev, libwacom, xwayland, meson
+{ fetchurl
+, fetchpatch
+, substituteAll
+, stdenv
+, pkgconfig
+, gnome3
+, gettext
+, gobject-introspection
+, upower
+, cairo
+, pango
+, cogl
+, json-glib
+, libstartup_notification
+, zenity
+, libcanberra-gtk3
+, ninja
+, xkeyboard_config
+, libxkbfile
+, libxkbcommon
+, libXtst
+, libinput
+, gsettings-desktop-schemas
+, glib
+, gtk3
+, gnome-desktop
+, geocode-glib
+, pipewire
+, libgudev
+, libwacom
+, xwayland
+, meson
 , gnome-settings-daemon
 , xorgserver
 , python3
@@ -25,46 +52,64 @@ stdenv.mkDerivation rec {
   };
 
   mesonFlags = [
-    "-Dxwayland-path=${xwayland}/bin/Xwayland"
+    "-Degl_device=true"
     "-Dinstalled_tests=false" # TODO: enable these
     "-Dwayland_eglstream=true"
-    "-Degl_device=true"
+    "-Dxwayland-path=${xwayland}/bin/Xwayland"
   ];
 
   propagatedBuildInputs = [
     # required for pkgconfig to detect mutter-clutter
-    libXtst
     json-glib
+    libXtst
     libcap_ng
   ];
 
   nativeBuildInputs = [
-    meson
-    pkgconfig
-    gettext
-    ninja
-    python3
-    # for cvt command
-    xorgserver
-    wrapGAppsHook
     desktop-file-utils
+    gettext
+    meson
+    ninja
+    pkgconfig
+    python3
+    wrapGAppsHook
+    xorgserver # for cvt command
   ];
 
   buildInputs = [
-    glib gobject-introspection gtk3 gsettings-desktop-schemas upower
-    gnome-desktop cairo pango cogl zenity libstartup_notification
-    geocode-glib libinput libgudev libwacom
-    libcanberra-gtk3 zenity xkeyboard_config libxkbfile
-    libxkbcommon pipewire xwayland egl-wayland
-    gnome-settings-daemon sysprof
+    cairo
+    cogl
+    egl-wayland
+    geocode-glib
+    glib
+    gnome-desktop
+    gnome-settings-daemon
+    gobject-introspection
+    gsettings-desktop-schemas
+    gtk3
+    libcanberra-gtk3
+    libgudev
+    libinput
+    libstartup_notification
+    libwacom
+    libxkbcommon
+    libxkbfile
+    pango
+    pipewire
+    sysprof
+    upower
+    xkeyboard_config
+    xwayland
+    zenity
+    zenity
   ];
 
   patches = [
     # Drop inheritable cap_sys_nice, to prevent the ambient set from leaking
     # from mutter/gnome-shell, see https://github.com/NixOS/nixpkgs/issues/71381
     ./drop-inheritable.patch
-   # TODO: submit upstream
-   ./0001-build-use-get_pkgconfig_variable-for-sysprof-dbusdir.patch
+    # TODO: submit upstream
+    ./0001-build-use-get_pkgconfig_variable-for-sysprof-dbusdir.patch
     (substituteAll {
       src = ./fix-paths.patch;
       inherit zenity;
@@ -84,18 +129,18 @@ stdenv.mkDerivation rec {
     ${glib.dev}/bin/glib-compile-schemas "$out/share/glib-2.0/schemas"
   '';
 
-  enableParallelBuilding = true;
-
   passthru = {
     updateScript = gnome3.updateScript {
-      packageName = "mutter";
-      attrPath = "gnome3.mutter";
+      packageName = pname;
+      attrPath = "gnome3.${pname}";
     };
   };
 
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
-    maintainers = gnome3.maintainers;
+    description = "A window manager for GNOME";
+    homepage = "https://gitlab.gnome.org/GNOME/mutter";
     license = licenses.gpl2;
+    maintainers = gnome3.maintainers;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -105,19 +105,33 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    # Drop inheritable cap_sys_nice, to prevent the ambient set from leaking
-    # from mutter/gnome-shell, see https://github.com/NixOS/nixpkgs/issues/71381
-    ./drop-inheritable.patch
-    # TODO: submit upstream
-    ./0001-build-use-get_pkgconfig_variable-for-sysprof-dbusdir.patch
-    (substituteAll {
-      src = ./fix-paths.patch;
-      inherit zenity;
+    # Fixes from gnome-3-34 branch 2019-11-29.
+    (fetchpatch {
+      name = "gnome-3-34-2019-11-29.patch";
+      url = "https://github.com/GNOME/mutter/compare/3.34.1...c0e76186da5b7baf7c8804c0ffa80232a5a6bf98.patch";
+      excludes = [
+        ".gitlab-ci.yml"
+        ".gitlab-ci/checkout-gnome-shell.sh"
+      ];
+      sha256 = "1qmxic83bd3dvg6isipqy8jaaksd7p5s3cb7h44zinq738n8d0fb";
     })
+
     # Fix build with libglvnd provided headers
     (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/mutter/commit/a444a4c5f58ea516ad3cd9d6ddc0056c3ca9bc90.patch";
       sha256 = "0imy2j8af9477jliwdq4jc40yw1cifsjjf196gnmwxr9rkj0hbrd";
+    })
+
+    # Drop inheritable cap_sys_nice, to prevent the ambient set from leaking
+    # from mutter/gnome-shell, see https://github.com/NixOS/nixpkgs/issues/71381
+    ./drop-inheritable.patch
+
+    # TODO: submit upstream
+    ./0001-build-use-get_pkgconfig_variable-for-sysprof-dbusdir.patch
+
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit zenity;
     })
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I did the most sane thing IMHO, which is to use a generated patch from GitHub.
Mostly to avoid our silly versioning for non-released commits.

###### Things done
Haven't been running with this commit, but have been using the same git rev from GitLab from my overlay.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

