### PR TITLE
vifm: refactor to add a vifm-full package

### DIFF
--- a/pkgs/applications/misc/vifm/default.nix
+++ b/pkgs/applications/misc/vifm/default.nix
@@ -1,11 +1,15 @@
-{ stdenv, fetchurl
+{ stdenv, fetchurl, makeWrapper
 , pkgconfig
 , ncurses, libX11
 , utillinux, file, which, groff
+
+  # adds support for handling removable media (vifm-media). Linux only!
+, mediaSupport ? false, python3 ? null, udisks2 ? null, lib ? null 
 }:
 
-stdenv.mkDerivation rec {
-  pname = "vifm";
+let isFullPackage = mediaSupport;
+in stdenv.mkDerivation rec {
+  pname = if isFullPackage then "vifm-full" else "vifm";
   version = "0.10.1";
 
   src = fetchurl {
@@ -13,13 +17,24 @@ stdenv.mkDerivation rec {
     sha256 = "0fyhxh7ndjn8fyjhj14ymkr3pjcs3k1xbs43g7xvvq85vdb6y04r";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
   buildInputs = [ ncurses libX11 utillinux file which groff ];
 
+  postFixup = let
+    path = lib.makeBinPath 
+      [ udisks2 
+        (python3.withPackages (p: [p.dbus-python]))
+      ];
+
+    wrapVifmMedia = "wrapProgram $out/share/vifm/vifm-media --prefix PATH : ${path}";
+  in ''
+    ${if mediaSupport then wrapVifmMedia else ""}
+  '';
+
   meta = with stdenv.lib; {
-    description = "A vi-like file manager";
+    description = ''A vi-like file manager${if isFullPackage then "; Includes support for optional features" else ""}'';
     maintainers = with maintainers; [ raskin ];
-    platforms = platforms.unix;
+    platforms = if mediaSupport then platforms.linux else platforms.unix;
     license = licenses.gpl2;
     downloadPage = "https://vifm.info/downloads.shtml";
     homepage = https://vifm.info/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6942,6 +6942,11 @@ in
 
   vifm = callPackage ../applications/misc/vifm { };
 
+  vifm-full = callPackage ../applications/misc/vifm { 
+    mediaSupport = true;
+    inherit lib udisks2 python3;
+  };
+
   viking = callPackage ../applications/misc/viking {
     inherit (gnome2) scrollkeeper;
   };


### PR DESCRIPTION
###### Motivation for this change

vifm includes some optional features what are currently no-op due
to missing dependencies. Once such example is `vifm-media`.

vimfm-media is a Linux script included with vifm which can be used to
mount/umount removable media from within vifm. However, vifm-media
has additional dependencies, namely Python, dbus, and a supported
back-end such as udisks2. While vimfm-media is currently installed,
it fails with the error "No supported backend found."

This change adds optional support for vifm-media via the new package
vifm-full; Opening for the opportunity to add whatever optional
dependencies I have not considered in this change in the future,
while not generously increasing the closure size of the original
vifm package.

For reference, vifm has a closure size of 41,164,432 while the new
vifm-full increases this to 382,642,536. Calculated with
`nix path-info -S`

Note: While vifm-media supports numerous back-ends, this change only
adds support for udisks2. In addition, vifm-media is not supported on
MacOS/OSX, for which upstream provides an alternative script.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Using media support in vifm-full

With vifm-full, when you use the :media command you're presented with a list of mountable and mounted removable media devices (ex. USB flash drive). Select one with ENTER to mount it (if needed) and navigate to the mount point. To unmount, use the :media command but press the "m" key instead of ENTER.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ raskin
