### PR TITLE
buildah: 1.11.5 -> 1.11.6

### DIFF
--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -4,13 +4,13 @@
 
 buildGoPackage rec {
   pname = "buildah";
-  version = "1.11.5";
+  version = "1.11.6";
 
   src = fetchFromGitHub {
     owner  = "containers";
     repo   = "buildah";
     rev    = "v${version}";
-    sha256 = "09bfv2pypd66dnqvrhgcg35fsahi2k0kn5dnnbfqc39g0vfz29r7";
+    sha256 = "0slhq11nmqsp2rjfwldvcwlpj823ckfpipggkaxhcb66dv8ymm7n";
   };
 
   outputs = [ "bin" "man" "out" ];
@@ -18,8 +18,14 @@ buildGoPackage rec {
   goPackagePath = "github.com/containers/buildah";
   excludedPackages = [ "tests" ];
 
+  # Disable module-mode, because Go 1.13 automatically enables it if there is
+  # go.mod file. Remove after https://github.com/NixOS/nixpkgs/pull/73380
+  GO111MODULE = "off";
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gpgme libgpgerror lvm2 btrfs-progs ostree libselinux libseccomp ];
+
+  patches = [ ./disable-go-module-mode.patch ];
 
   buildPhase = ''
     pushd go/src/${goPackagePath}

--- a/pkgs/development/tools/buildah/disable-go-module-mode.patch
+++ b/pkgs/development/tools/buildah/disable-go-module-mode.patch
@@ -1,0 +1,33 @@
+From e2d12e52b3638a320a8d69ea4b392b60f44ea57f Mon Sep 17 00:00:00 2001
+From: Mario Rodas <marsam@users.noreply.github.com>
+Date: Wed, 4 Dec 2019 21:07:33 -0500
+Subject: [PATCH] Do not check Go module-mode availability
+
+Since buildah vendorizes its dependencies we use buildGoPackage which
+does not uses Go module-mode.  The module-mode check will be true
+because nixpkgs uses Go 1.13 by default, and building go modules with
+buildGoPackage may lead to inconsistencies.
+---
+ Makefile | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 9d04177d..4cf9b6a2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -15,12 +15,7 @@ BUILDAH := buildah
+ GO := go
+ GO110 := 1.10
+ GOVERSION := $(findstring $(GO110),$(shell go version))
+-# test for go module support
+-ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
+-export GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
+-else
+ export GO_BUILD=$(GO) build
+-endif
+ 
+ GIT_COMMIT ?= $(if $(shell git rev-parse --short HEAD),$(shell git rev-parse --short HEAD),$(error "git failed"))
+ SOURCE_DATE_EPOCH ?= $(if $(shell date +%s),$(shell date +%s),$(error "date failed"))
+-- 
+2.24.0
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/containers/buildah/releases/tag/v1.11.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Profpatsch @vdemeester @saschagrunert
