### PR TITLE
go: do not replace path to zoneinfo.zip and mime.types

### DIFF
--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -97,7 +97,10 @@ stdenv.mkDerivation rec {
     rm src/net/cgo_unix_test.go
 
   '' + optionalString stdenv.isLinux ''
-    sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
+    # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
+    # that run outside a nix server
+    sed -i 's,\"/usr/share/zoneinfo/,"${tzdata}/share/zoneinfo/\"\,\n\t&,' src/time/zoneinfo_unix.go
+
   '' + optionalString stdenv.isAarch32 ''
     echo '#!${runtimeShell}' > misc/cgo/testplugin/test.bash
   '' + optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -57,8 +57,8 @@ stdenv.mkDerivation rec {
       --replace '#!/usr/bin/env bash' '#!${runtimeShell}'
 
     # Patch the mimetype database location which is missing on NixOS.
-    substituteInPlace src/mime/type_unix.go \
-      --replace '/etc/mime.types' '${mailcap}/etc/mime.types'
+    # but also allow static binaries built with NixOS to run outside nix
+    sed -i 's,\"/etc/mime.types,"${mailcap}/etc/mime.types\"\,\n\t&,' src/mime/type_unix.go
 
     # Disabling the 'os/http/net' tests (they want files not available in
     # chroot builds)

--- a/pkgs/development/compilers/go/1.4.nix
+++ b/pkgs/development/compilers/go/1.4.nix
@@ -61,7 +61,9 @@ stdenv.mkDerivation rec {
 
     sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
   '' + lib.optionalString stdenv.isLinux ''
-    sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
+    # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
+    # that run outside a nix server
+    sed -i 's,\"/usr/share/zoneinfo/,"${tzdata}/share/zoneinfo/\"\,\n\t&,' src/time/zoneinfo_unix.go
 
     # Find the loader dynamically
     LOADER="$(find ${lib.getLib libc}/lib -name ld-linux\* | head -n 1)"


### PR DESCRIPTION
Prepend the nix path to the zoneinfo.zip file and keep the original alternatives
to allow go programs built using nix to run on non nix servers.

see https://github.com/NixOS/nixpkgs/issues/54603

###### Motivation for this change

Fixes: #54603 

Allow Go programs built using nix to run on servers that don't have nix

###### Things done

I am very new to nix and could not figure out how to test this branch locally, reading 
https://nixos.org/nixpkgs/manual/#chap-submitting-changes

I don't know what to replace this like with:

```
nix-env -i pkg-name -f <path to your local nixpkgs folder>
```



```
$ nix-env -i go -f /nix/store

[...] many warning similar to:
warning: name collision in input Nix expressions, skipping '/nix/store/mcgh4v55zwfp6f1x4b4zrdp6lrzki475-user-environment/nixpkgs'
[...] and finally:
error: cannot auto-call a function that has an argument without a default value ('derivations')

```

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @veprbl 
