### PR TITLE
gnuplot: 5.2.7 -> 5.2.8

### DIFF
--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -19,11 +19,12 @@ let
   withX = libX11 != null && !aquaterm && !stdenv.isDarwin;
 in
 (if withQt then mkDerivation else stdenv.mkDerivation) rec {
-  name = "gnuplot-5.2.7";
+  pname = "gnuplot";
+  version = "5.2.8";
 
   src = fetchurl {
-    url = "mirror://sourceforge/gnuplot/${name}.tar.gz";
-    sha256 = "1vglp4la40f5dpj0zdj63zprrkyjgzy068p35bz5dqxjyczm1zlp";
+    url = "mirror://sourceforge/gnuplot/${pname}-${version}.tar.gz";
+    sha256 = "0dxc52d17mpyb2xm24da1nvhlacryv0irwa0q5l1cjj0rx67d9k0";
   };
 
   nativeBuildInputs = [ makeWrapper pkgconfig texinfo ] ++ lib.optional withQt qttools;


### PR DESCRIPTION
###### Motivation for this change

http://www.gnuplot.info/ReleaseNotes_5_2_8.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lovek323