### PR TITLE
libnftnl,nftables,iptables,ebtables: bumpers

### DIFF
--- a/pkgs/development/libraries/libnftnl/default.nix
+++ b/pkgs/development/libraries/libnftnl/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, libmnl }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.4";
+  version = "1.1.5";
   pname = "libnftnl";
 
   src = fetchurl {
     url = "https://netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
-    sha256 = "087dfc2n4saf2k68hyi4byvgz5grwpw5kfjvmkpn3wmd8y1riiy8";
+    sha256 = "1wqlxf76bkqf3qhka9sw32qhb2ni20q1k6rn3iril2kw482lvpk6";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/os-specific/linux/ebtables/default.nix
+++ b/pkgs/os-specific/linux/ebtables/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ebtables";
-  version = "2.0.10-4";
+  version = "2.0.11";
 
   src = fetchurl {
-    url = "mirror://sourceforge/ebtables/ebtables-v${version}.tar.gz";
-    sha256 = "0pa5ljlk970yfyhpf3iqwfpbc30j8mgn90fapw9cfz909x47nvyw";
+    url = "http://ftp.netfilter.org/pub/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "0apxgmkhsk3vxn9q3libxn3dgrdljrxyy4mli2gk49m7hi3na7xp";
   };
 
   makeFlags =
@@ -14,11 +14,6 @@ stdenv.mkDerivation rec {
       "ETCDIR=$(out)/etc" "INITDIR=$(TMPDIR)" "SYSCONFIGDIR=$(out)/etc/sysconfig"
       "LOCALSTATEDIR=/var"
     ];
-
-  preBuild =
-    ''
-      substituteInPlace Makefile --replace '-o root -g root' ""
-    '';
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
 

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -6,12 +6,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.8.3";
+  version = "1.8.4";
   pname = "iptables";
 
   src = fetchurl {
     url = "https://www.netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
-    sha256 = "106xkkg5crsscjlinxvqvprva23fwwqfgrzl8m2nn841841sqg52";
+    sha256 = "0z0mgs1ghvn3slc868mgbf2g26njgrzcy5ggyb5w4i55j1a3lflr";
   };
 
   nativeBuildInputs = [ pkgconfig pruneLibtoolFiles flex bison ];

--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -10,12 +10,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "0.9.2";
+  version = "0.9.3";
   pname = "nftables";
 
   src = fetchurl {
     url = "https://netfilter.org/projects/nftables/files/${pname}-${version}.tar.bz2";
-    sha256 = "1x8kalbggjq44j4916i6vyv1rb20dlh1dcsf9xvzqsry2j063djw";
+    sha256 = "0y6vbqp6x8w165q65h4n9sba1406gaz0d4744gqszbm7w9f92swm";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).