### PR TITLE
heimer: init at 1.12.0

### DIFF
--- a/pkgs/applications/misc/heimer/default.nix
+++ b/pkgs/applications/misc/heimer/default.nix
@@ -7,7 +7,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "juzzlin";
     repo = pname;
-    rev = "refs/tags/${version}";
+    rev = version;
     sha256 = "1gw4w6cvr3vb4zdb1kq8gwmadh2lb0jd0bd2hc7cw2d5kdbjaln7";
   };
 

--- a/pkgs/applications/misc/heimer/default.nix
+++ b/pkgs/applications/misc/heimer/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchFromGitHub, cmake, qttools, qtbase }:
+{ mkDerivation, lib, fetchFromGitHub, cmake, qttools, qtbase }:
 
 mkDerivation rec {
   pname = "heimer";
@@ -13,4 +13,11 @@ mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ qttools qtbase ];
+
+  meta = with lib; {
+    description = "Simple cross-platform mind map and note-taking tool written in Qt";
+    homepage = "https://github.com/juzzlin/Heimer";
+    license = licenses.gpl3;
+    maintainers  = with maintainers; [ dtzWill ];
+  };
 }

--- a/pkgs/applications/misc/heimer/default.nix
+++ b/pkgs/applications/misc/heimer/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "heimer";
-  version = "1.11.0";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "juzzlin";
     repo = pname;
     rev = "refs/tags/${version}";
-    sha256 = "0k1p92viwj2p357rp2ypfljkzxrcvrq3lc76f0872c55zrf253wp";
+    sha256 = "1gw4w6cvr3vb4zdb1kq8gwmadh2lb0jd0bd2hc7cw2d5kdbjaln7";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/misc/heimer/default.nix
+++ b/pkgs/applications/misc/heimer/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, fetchFromGitHub, cmake, qttools, qtbase }:
+
+mkDerivation rec {
+  pname = "heimer";
+  version = "1.11.0";
+
+  src = fetchFromGitHub {
+    owner = "juzzlin";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    sha256 = "0k1p92viwj2p357rp2ypfljkzxrcvrq3lc76f0872c55zrf253wp";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ qttools qtbase ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19229,6 +19229,8 @@ in
 
   hashit = callPackage ../tools/misc/hashit { };
 
+  heimer = libsForQt5.callPackage ../applications/misc/heimer { };
+
   hello = callPackage ../applications/misc/hello { };
   hello-unfree = callPackage ../applications/misc/hello-unfree { };
 


### PR DESCRIPTION
###### Motivation for this change

"Simple cross-platform mind map and note-taking tool written in Qt"

:innocent: meant to submit this earlier, but better later than never!
Enjoy!


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).