### PR TITLE
pgcli: 2.1.1 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/pgspecial/default.nix
+++ b/pkgs/development/python-modules/pgspecial/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pgspecial";
-  version = "1.11.7";
+  version = "1.11.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0wy1zmd44y0vl0kxx2y53g6lpipmixbwwrg6c2r7rc3nwa0icl7p";
+    sha256 = "8c53fa2b2490fa9ec34ede4eafff8ddbe8bce5cba3dcae96509be36ec8c75575";
   };
 
   checkInputs = [ pytest ];

--- a/pkgs/development/tools/database/pgcli/default.nix
+++ b/pkgs/development/tools/database/pgcli/default.nix
@@ -1,17 +1,17 @@
-{ buildPythonApplication, lib, fetchPypi, isPy3k, fetchpatch
+{ buildPythonApplication, lib, fetchPypi, isPy3k
 , cli-helpers, click, configobj, humanize, prompt_toolkit, psycopg2
 , pygments, sqlparse, pgspecial, setproctitle, keyring, pytest, mock
 }:
 
 buildPythonApplication rec {
   pname = "pgcli";
-  version = "2.1.1";
+  version = "2.2.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1jmnb8izsdjmq9cgajhfapr31wlhvcml4lakz2mcmjn355x83q44";
+    sha256 = "54138a31e6736a34c63b84a6d134c9292c9a73543cc0f66e80a0aaf79259d39b";
   };
 
   propagatedBuildInputs = [
@@ -21,9 +21,10 @@ buildPythonApplication rec {
 
   checkInputs = [ pytest mock ];
 
-  # One test fails: https://github.com/dbcli/pgcli/issues/1104
-  doCheck = false;
-  checkPhase = "pytest";
+  # `test_application_name_db_uri` fails: https://github.com/dbcli/pgcli/issues/1104
+  checkPhase = ''
+    pytest --deselect=tests/test_main.py::test_application_name_db_uri
+  '';
 
   meta = with lib; {
     description = "Command-line interface for PostgreSQL";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/dbcli/pgcli/blob/v2.2.0/changelog.rst#220

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
