### PR TITLE
ocamlPackages.rpclib: 5.9.0 → 6.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
@@ -1,11 +1,11 @@
-{ lib, buildDunePackage, rpclib, ppxfind, ppx_deriving, cppo }:
+{ lib, buildDunePackage, rpclib, ppxlib, ppx_deriving }:
 
 buildDunePackage rec {
   pname = "ppx_deriving_rpc";
 
   inherit (rpclib) version src;
 
-  buildInputs = [ ppxfind cppo ];
+  buildInputs = [ ppxlib ];
 
   propagatedBuildInputs = [ rpclib ppx_deriving ];
 

--- a/pkgs/development/ocaml-modules/rpclib/default.nix
+++ b/pkgs/development/ocaml-modules/rpclib/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, alcotest, cmdliner, rresult, result, xmlm, yojson }:
+{ lib, fetchFromGitHub, buildDunePackage, alcotest, cmdliner, rresult, result, xmlm, yojson }:
 
 buildDunePackage rec {
   pname = "rpclib";
-  version = "5.9.0";
+  version = "6.0.0";
 
   minimumOCamlVersion = "4.04";
 
@@ -10,7 +10,7 @@ buildDunePackage rec {
     owner = "mirage";
     repo = "ocaml-rpc";
     rev = "v${version}";
-    sha256 = "1swnnmmnkn53mxqpckdnd1j8bz0wksqznjbv0zamspxyqybmancq";
+    sha256 = "0bmr20sj7kybjjlwd42irj0f5zlnxcw7mxa1mdgxkki9bmhsqr51";
   };
 
   buildInputs = [ alcotest cmdliner yojson ];
@@ -18,7 +18,7 @@ buildDunePackage rec {
 
   doCheck = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/mirage/ocaml-rpc";
     description = "Light library to deal with RPCs in OCaml";
     license = licenses.isc;


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.09

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vyorkin
