### PR TITLE
openorienteering-mapper: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/applications/gis/openorienteering-mapper/default.nix
+++ b/pkgs/applications/gis/openorienteering-mapper/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "OpenOrienteering-Mapper";
-  version = "0.9.0";
+  version = "0.9.1";
 
   buildInputs = [ gdal qtbase qttools qtlocation qtimageformats
                   qtsensors clipper zlib proj doxygen cups];
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "OpenOrienteering";
     repo = "mapper";
     rev = "v${version}";
-    sha256 = "0wnxj2xf529941dwss6ygb1krfx18lzl6rf67060b0zndc7n6l8f";
+    sha256 = "1fyhvf2y89hj7wj89kxccx3dqcja6ndy3w4rx1vmzrp246jpz7wb";
   };
 
   cmakeFlags =


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/OpenOrienteering/mapper/releases/tag/v0.9.1)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/9ggwghaaxisd3cjk4iniwrmjdkq1paxj-OpenOrienteering-Mapper-0.9.0
/nix/store/9ggwghaaxisd3cjk4iniwrmjdkq1paxj-OpenOrienteering-Mapper-0.9.0	 663.9M
$ nix path-info -Sh /nix/store/kdx140kwf9xx7hkzd1502sqk025y69if-OpenOrienteering-Mapper-0.9.1
/nix/store/kdx140kwf9xx7hkzd1502sqk025y69if-OpenOrienteering-Mapper-0.9.1	 664.4M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mpickering
