### PR TITLE
Fix pythonPackages.sentry-sdk build

### DIFF
--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -1,4 +1,22 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k, urllib3, certifi, django, flask, tornado, bottle, rq, falcon, celery, pyramid, sanic, aiohttp }:
+{ aiohttp
+, bottle
+, buildPythonPackage
+, celery
+, certifi
+, django
+, falcon
+, fetchPypi
+, flask
+, iana-etc
+, isPy3k
+, libredirect
+, pyramid
+, rq
+, sanic
+, stdenv
+, tornado
+, urllib3
+}:
 
 buildPythonPackage rec {
   pname = "sentry-sdk";
@@ -20,4 +38,14 @@ buildPythonPackage rec {
     license = licenses.bsd2;
     maintainers = with maintainers; [ gebner ];
   };
+
+  # The Sentry tests need access to `/etc/protocols` (the tests call
+  # `socket.getprotobyname('tcp')`, which reads from this file). Normally
+  # this path isn't available in the sandbox. Therefore, use libredirect
+  # to make on eavailable from `iana-etc`. This is a test-only operation.
+  preCheck = ''
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols
+    export LD_PRELOAD=${libredirect}/lib/libredirect.so
+  '';
+  postCheck = "unset NIX_REDIRECTS LD_PRELOAD";
 }


### PR DESCRIPTION
###### Motivation for this change

The following command fails on Nixpkgs `master`:

```
nix-build -A python37Packages.sentry-sdk
```

<details>

<summary>Build output before</summary>

```
sentry_sdk (unittest.loader._FailedTest) ... ERROR

======================================================================
ERROR: sentry_sdk (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: sentry_sdk
Traceback (most recent call last):
  File "/nix/store/drr8qcgiccfc5by09r5zc30flgwh1mbx-python3-3.7.5/lib/python3.7/unittest/loader.py", line 470, in _find_test_path
    package = self._get_module_from_name(name)
  File "/nix/store/drr8qcgiccfc5by09r5zc30flgwh1mbx-python3-3.7.5/lib/python3.7/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/build/sentry-sdk-0.13.2/sentry_sdk/__init__.py", line 1, in <module>
    from sentry_sdk.hub import Hub, init
  File "/build/sentry-sdk-0.13.2/sentry_sdk/hub.py", line 9, in <module>
    from sentry_sdk.scope import Scope
  File "/build/sentry-sdk-0.13.2/sentry_sdk/scope.py", line 6, in <module>
    from sentry_sdk.utils import logger, capture_internal_exceptions
  File "/build/sentry-sdk-0.13.2/sentry_sdk/utils.py", line 772, in <module>
    HAS_REAL_CONTEXTVARS, ContextVar = _get_contextvars()
  File "/build/sentry-sdk-0.13.2/sentry_sdk/utils.py", line 740, in _get_contextvars
    if not _is_threading_local_monkey_patched():
  File "/build/sentry-sdk-0.13.2/sentry_sdk/utils.py", line 721, in _is_threading_local_monkey_patched
    from eventlet.patcher import is_monkey_patched  # type: ignore
  File "/nix/store/c7gzwdfhpq2a9ix6xy15fv4fjn1s57fs-python3.7-eventlet-0.25.1/lib/python3.7/site-packages/eventlet/__init__.py", line 10, in <module>
    from eventlet import convenience
  File "/nix/store/c7gzwdfhpq2a9ix6xy15fv4fjn1s57fs-python3.7-eventlet-0.25.1/lib/python3.7/site-packages/eventlet/convenience.py", line 7, in <module>
    from eventlet.green import socket
  File "/nix/store/c7gzwdfhpq2a9ix6xy15fv4fjn1s57fs-python3.7-eventlet-0.25.1/lib/python3.7/site-packages/eventlet/green/socket.py", line 21, in <module>
    from eventlet.support import greendns
  File "/nix/store/c7gzwdfhpq2a9ix6xy15fv4fjn1s57fs-python3.7-eventlet-0.25.1/lib/python3.7/site-packages/eventlet/support/greendns.py", line 69, in <module>
    setattr(dns.rdtypes.IN, pkg, import_patched('dns.rdtypes.IN.' + pkg))
  File "/nix/store/c7gzwdfhpq2a9ix6xy15fv4fjn1s57fs-python3.7-eventlet-0.25.1/lib/python3.7/site-packages/eventlet/support/greendns.py", line 59, in import_patched
    return patcher.import_patched(module_name, **modules)
  File "/nix/store/c7gzwdfhpq2a9ix6xy15fv4fjn1s57fs-python3.7-eventlet-0.25.1/lib/python3.7/site-packages/eventlet/patcher.py", line 126, in import_patched
    *additional_modules + tuple(kw_additional_modules.items()))
  File "/nix/store/c7gzwdfhpq2a9ix6xy15fv4fjn1s57fs-python3.7-eventlet-0.25.1/lib/python3.7/site-packages/eventlet/patcher.py", line 100, in inject
    module = __import__(module_name, {}, {}, module_name.split('.')[:-1])
  File "/nix/store/grdm0zv2b7blma4ykb11nvb6g7xw8jcz-python3.7-dnspython-1.16.0/lib/python3.7/site-packages/dns/rdtypes/IN/WKS.py", line 25, in <module>
    _proto_tcp = socket.getprotobyname('tcp')
OSError: protocol not found


----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (errors=1)
Test failed: <unittest.runner.TextTestResult run=1 errors=1 failures=0>
error: Test failed: <unittest.runner.TextTestResult run=1 errors=1 failures=0>
builder for '/nix/store/aq3bs2hpacj0jaj0zgpjlkajgxvpxhm0-python3.7-sentry-sdk-0.13.2.drv' failed with exit code 1
error: build of '/nix/store/aq3bs2hpacj0jaj0zgpjlkajgxvpxhm0-python3.7-sentry-sdk-0.13.2.drv' failed
```
</details>

The test suite wants to read `/etc/protocols`, but this file isn't available in the sandbox by default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date (Could not find docs)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @gebner 