### PR TITLE
Add trilium server and module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -813,6 +813,7 @@
   ./services/web-apps/restya-board.nix
   ./services/web-apps/tt-rss.nix
   ./services/web-apps/trac.nix
+  ./services/web-apps/trilium.nix
   ./services/web-apps/selfoss.nix
   ./services/web-apps/shiori.nix
   ./services/web-apps/virtlyst.nix

--- a/nixos/modules/services/web-apps/trilium.nix
+++ b/nixos/modules/services/web-apps/trilium.nix
@@ -1,0 +1,87 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.trilium-server;
+  configIni = pkgs.writeText "trilium-config.ini" ''
+    [General]
+    # Instance name can be used to distinguish between different instances
+    instanceName=${cfg.instanceName}
+
+    # Disable automatically generating desktop icon
+    noDesktopIcon=true
+
+    [Network]
+    # host setting is relevant only for web deployments - set the host on which the server will listen
+    host=${cfg.host}
+    # port setting is relevant only for web deployments, desktop builds run on random free port
+    port=${toString cfg.port}
+    # true for TLS/SSL/HTTPS (secure), false for HTTP (unsecure).
+    https=false
+  '';
+in
+{
+
+  options.services.trilium-server = with lib; {
+    enable = mkEnableOption "trilium-server";
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/var/lib/trilium";
+      description = ''
+        The directory storing the nodes database and the configuration.
+      '';
+    };
+
+    instanceName = mkOption {
+      type = types.str;
+      default = "Trilium";
+      description = ''
+        Instance name used to distinguish between different instances
+      '';
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = ''
+        The host address to bind to (defaults to localhost).
+      '';
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 8080;
+      description = ''
+        The port number to bind to.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    meta.maintainers = with lib.maintainers; [ kampka ];
+
+    users.groups.trilium = {};
+    users.users.trilium = {
+      description = "Trilium User";
+      group = "trilium";
+      home = cfg.dataDir;
+      isSystemUser = true;
+    };
+
+    systemd.services.trilium-server = {
+      wantedBy = [ "multi-user.target" ];
+      environment.TRILIUM_DATA_DIR = cfg.dataDir;
+      serviceConfig = {
+        ExecStart = "${pkgs.trilium-server}/bin/trilium-server";
+        User = "trilium";
+        Group = "trilium";
+        PrivateTmp = "true";
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d  ${cfg.dataDir}            0750 trilium trilium - -"
+      "L+ ${cfg.dataDir}/config.ini -    -       -       - ${configIni}"
+    ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -277,7 +277,7 @@ in
   tor = handleTest ./tor.nix {};
   transmission = handleTest ./transmission.nix {};
   trac = handleTest ./trac.nix {};
-  trilium-server = handleTest ./trilium-server.nix {};
+  trilium-server = handleTestOn ["x86_64-linux"] ./trilium-server.nix {};
   trezord = handleTest ./trezord.nix {};
   trickster = handleTest ./trickster.nix {};
   udisks2 = handleTest ./udisks2.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -277,6 +277,7 @@ in
   tor = handleTest ./tor.nix {};
   transmission = handleTest ./transmission.nix {};
   trac = handleTest ./trac.nix {};
+  trilium-server = handleTest ./trilium-server.nix {};
   trezord = handleTest ./trezord.nix {};
   trickster = handleTest ./trickster.nix {};
   udisks2 = handleTest ./udisks2.nix {};

--- a/nixos/tests/trilium-server.nix
+++ b/nixos/tests/trilium-server.nix
@@ -1,0 +1,37 @@
+import ./make-test-python.nix ({ ... }: {
+  name = "trilium-server";
+  nodes = {
+    default = {
+      services.trilium-server.enable = true;
+    };
+    configured = {
+      services.trilium-server = {
+        enable = true;
+        dataDir = "/data/trilium";
+      };
+    };
+  };
+
+  testScript =
+    ''
+      start_all()
+
+      with subtest("by default works without configuration"):
+          default.wait_for_unit("trilium-server.service")
+
+      with subtest("by default available on port 8080"):
+          default.wait_for_unit("trilium-server.service")
+          default.wait_for_open_port(8080)
+          # we output to /dev/null here to avoid a python UTF-8 decode error
+          # but the check will still fail if the service doesn't respond
+          default.succeed("curl --fail -o /dev/null 127.0.0.1:8080")
+
+      with subtest("by default creates empty document"):
+          default.wait_for_unit("trilium-server.service")
+          default.succeed("test -f /var/lib/trilium/document.db")
+
+      with subtest("configured with custom data store"):
+          configured.wait_for_unit("trilium-server.service")
+          configured.succeed("test -f /data/trilium/document.db")
+    '';
+})

--- a/nixos/tests/trilium-server.nix
+++ b/nixos/tests/trilium-server.nix
@@ -10,6 +10,14 @@ import ./make-test-python.nix ({ ... }: {
         dataDir = "/data/trilium";
       };
     };
+
+    nginx = {
+      services.trilium-server = {
+        enable = true;
+        nginx.enable = true;
+        nginx.hostName = "trilium.example.com";
+      };
+    };
   };
 
   testScript =
@@ -33,5 +41,13 @@ import ./make-test-python.nix ({ ... }: {
       with subtest("configured with custom data store"):
           configured.wait_for_unit("trilium-server.service")
           configured.succeed("test -f /data/trilium/document.db")
+
+      with subtest("nginx with custom host name"):
+          nginx.wait_for_unit("trilium-server.service")
+          nginx.wait_for_unit("nginx.service")
+
+          nginx.succeed(
+              "curl --resolve 'trilium.example.com:80:127.0.0.1' http://trilium.example.com/"
+          )
     '';
 })

--- a/pkgs/applications/office/trilium/0001-Use-console-logger-instead-of-rolling-files.patch
+++ b/pkgs/applications/office/trilium/0001-Use-console-logger-instead-of-rolling-files.patch
@@ -1,0 +1,69 @@
+From 5be803a1171855f976a5b607970fa3949db72181 Mon Sep 17 00:00:00 2001
+From: Christian Kampka <christian@kampka.net>
+Date: Mon, 9 Dec 2019 19:40:27 +0100
+Subject: [PATCH] Use console logger instead of rolling files
+
+---
+ src/services/log.js | 26 +++-----------------------
+ 1 file changed, 3 insertions(+), 23 deletions(-)
+
+diff --git a/src/services/log.js b/src/services/log.js
+index 1514c209..456c3749 100644
+--- a/src/services/log.js
++++ b/src/services/log.js
+@@ -1,35 +1,15 @@
+ "use strict";
+ 
+-const fs = require('fs');
+-const dataDir = require('./data_dir');
+-
+-if (!fs.existsSync(dataDir.LOG_DIR)) {
+-    fs.mkdirSync(dataDir.LOG_DIR, 0o700);
+-}
+-
+-const logger = require('simple-node-logger').createRollingFileLogger({
+-    errorEventName: 'error',
+-    logDirectory: dataDir.LOG_DIR,
+-    fileNamePattern: 'trilium-<DATE>.log',
+-    dateFormat:'YYYY-MM-DD'
+-});
+-
+ function info(message) {
+     // info messages are logged asynchronously
+     setTimeout(() => {
+         console.log(message);
+-
+-        logger.info(message);
+     }, 0);
+ }
+ 
+ function error(message) {
+     message = "ERROR: " + message;
+ 
+-    // we're using .info() instead of .error() because simple-node-logger emits weird error for showError()
+-    // errors are logged synchronously to make sure it doesn't get lost in case of crash
+-    logger.info(message);
+-
+     console.trace(message);
+ }
+ 
+@@ -45,12 +25,12 @@ function request(req) {
+     if (req.url.includes(".js.map") || req.url.includes(".css.map")) {
+         return;
+     }
+-
+-    logger.info(req.method + " " + req.url);
++    if(process.env.DEBUG)
++        console.log(req.method + " " + req.url);
+ }
+ 
+ module.exports = {
+     info,
+     error,
+     request
+-};
+\ No newline at end of file
++};
+-- 
+2.23.0
+

--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -11,56 +11,60 @@ let
     categories = "Office";
   };
 
-in stdenv.mkDerivation rec {
-  pname = "trilium";
   version = "0.37.8";
+in {
+  
+  trilium-desktop = stdenv.mkDerivation rec {
+    pname = "trilium-desktop";
+    inherit version;
 
-  src = fetchurl {
-    url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
-    sha256 = "06d88waxxjdnrn0y8qr6p9rf5xkvl5lbabb0xyk0dgy3wg70zlxz";
-  };
-
-  # Fetch from source repo, no longer included in release.
-  # (they did special-case icon.png but we want the scalable svg)
-  # Use the version here to ensure we get any changes.
-  trilium_svg = fetchurl {
-    url = "https://raw.githubusercontent.com/zadam/trilium/v${version}/src/public/images/trilium.svg";
-    sha256 = "1rgj7pza20yndfp8n12k93jyprym02hqah36fkk2b3if3kcmwnfg";
-  };
-
-
-  nativeBuildInputs = [
-    autoPatchelfHook
-    makeWrapper
-    wrapGAppsHook
-  ];
-
-  buildInputs = [ atomEnv.packages gtk3 ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/trilium
-    mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
-
-    cp -r ./* $out/share/trilium
-    ln -s $out/share/trilium/trilium $out/bin/trilium
-
-    ln -s ${trilium_svg} $out/share/icons/hicolor/scalable/apps/trilium.svg
-    cp ${desktopItem}/share/applications/* $out/share/applications
-  '';
-
-  # LD_LIBRARY_PATH "shouldn't" be needed, remove when possible :)
-  preFixup = ''
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : ${atomEnv.libPath})
-  '';
-
-  dontStrip = true;
-
-  meta = with stdenv.lib; {
-    inherit description;
-    homepage = https://github.com/zadam/trilium;
-    license = licenses.agpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ emmanuelrosa dtzWill ];
+    src = fetchurl {
+      url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
+      sha256 = "06d88waxxjdnrn0y8qr6p9rf5xkvl5lbabb0xyk0dgy3wg70zlxz";
+    };
+  
+    # Fetch from source repo, no longer included in release.
+    # (they did special-case icon.png but we want the scalable svg)
+    # Use the version here to ensure we get any changes.
+    trilium_svg = fetchurl {
+      url = "https://raw.githubusercontent.com/zadam/trilium/v${version}/src/public/images/trilium.svg";
+      sha256 = "1rgj7pza20yndfp8n12k93jyprym02hqah36fkk2b3if3kcmwnfg";
+    };
+  
+  
+    nativeBuildInputs = [
+      autoPatchelfHook
+      makeWrapper
+      wrapGAppsHook
+    ];
+  
+    buildInputs = [ atomEnv.packages gtk3 ];
+  
+    installPhase = ''
+      mkdir -p $out/bin
+      mkdir -p $out/share/trilium
+      mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
+  
+      cp -r ./* $out/share/trilium
+      ln -s $out/share/trilium/trilium $out/bin/trilium
+  
+      ln -s ${trilium_svg} $out/share/icons/hicolor/scalable/apps/trilium.svg
+      cp ${desktopItem}/share/applications/* $out/share/applications
+    '';
+  
+    # LD_LIBRARY_PATH "shouldn't" be needed, remove when possible :)
+    preFixup = ''
+      gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : ${atomEnv.libPath})
+    '';
+  
+    dontStrip = true;
+  
+    meta = with stdenv.lib; {
+      inherit description;
+      homepage = https://github.com/zadam/trilium;
+      license = licenses.agpl3;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ emmanuelrosa dtzWill ];
+    };
   };
 }

--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -15,7 +15,7 @@ let
     inherit description;
     homepage = https://github.com/zadam/trilium;
     license = licenses.agpl3;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ emmanuelrosa dtzWill kampka ];
   };
 

--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -19,7 +19,7 @@ let
     maintainers = with maintainers; [ emmanuelrosa dtzWill kampka ];
   };
 
-  version = "0.37.8";
+  version = "0.38.2";
 
 in {
   
@@ -30,7 +30,7 @@ in {
 
     src = fetchurl {
       url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
-      sha256 = "06d88waxxjdnrn0y8qr6p9rf5xkvl5lbabb0xyk0dgy3wg70zlxz";
+      sha256 = "10f5zfqcfcjynw04d5xzrfmkbqpk85i4mq7njhkibx2f1m0br2qa";
     };
   
     # Fetch from source repo, no longer included in release.
@@ -78,7 +78,7 @@ in {
 
     src = fetchurl {
       url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-server-${version}.tar.xz";
-      sha256 = "04xhmc60fwvv8ip8mj112z7a9x5ahp51f1hvi20sffs0685mfaj3";
+      sha256 = "1df0cx9gpzk0086lgha0qm1g03l8f4rz7y2xzgpzng5rrxjkgz61";
     };
 
     nativeBuildInputs = [

--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -20,6 +20,7 @@ let
   };
 
   version = "0.37.8";
+
 in {
   
   trilium-desktop = stdenv.mkDerivation rec {
@@ -90,6 +91,7 @@ in {
       libxkbfile
     ];
 
+    patches = [ ./0001-Use-console-logger-instead-of-rolling-files.patch ] ;
     installPhase = ''
       mkdir -p $out/bin
       mkdir -p $out/share/trilium-server

--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -13,11 +13,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "trilium";
-  version = "0.33.6";
+  version = "0.37.8";
 
   src = fetchurl {
     url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
-    sha256 = "1sg6iqhpgyr8zr6w6dgs0ha0indb9vyp8vh2clj2fds5ahhlvf91";
+    sha256 = "06d88waxxjdnrn0y8qr6p9rf5xkvl5lbabb0xyk0dgy3wg70zlxz";
   };
 
   # Fetch from source repo, no longer included in release.

--- a/pkgs/applications/office/trilium/default.nix
+++ b/pkgs/applications/office/trilium/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoPatchelfHook, atomEnv, makeWrapper, makeDesktopItem, gtk3, wrapGAppsHook, zlib, libxkbfile }:
+{ stdenv, nixosTests, fetchurl, autoPatchelfHook, atomEnv, makeWrapper, makeDesktopItem, gtk3, wrapGAppsHook, zlib, libxkbfile }:
 
 let
   description = "Trilium Notes is a hierarchical note taking application with focus on building large personal knowledge bases.";
@@ -107,5 +107,9 @@ in {
       EOF
       chmod a+x $out/bin/trilium-server
     '';
+
+    passthru.tests = {
+      trilium-server = nixosTests.trilium-server;
+    };
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6810,6 +6810,7 @@ in
 
   inherit (callPackage ../applications/office/trilium {})
     trilium-desktop
+    trilium-server
     ;
   trilium = trilium-desktop;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6808,7 +6808,10 @@ in
 
   triggerhappy = callPackage ../tools/inputmethods/triggerhappy {};
 
-  trilium = callPackage ../applications/office/trilium { };
+  inherit (callPackage ../applications/office/trilium {})
+    trilium-desktop
+    ;
+  trilium = trilium-desktop;
 
   trousers = callPackage ../tools/security/trousers { };
 


### PR DESCRIPTION
###### Motivation for this change

This change adds the trilium server package and a module to run it.
It also refactors the trilium package as such so its easier to keep the metadata and version of both packages in sync.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill @emmanuelrosa 
