### PR TITLE
skrooge: 2.20.0 -> 2.21.0

### DIFF
--- a/pkgs/applications/office/skrooge/default.nix
+++ b/pkgs/applications/office/skrooge/default.nix
@@ -7,20 +7,12 @@
 
 mkDerivation rec {
   pname = "skrooge";
-  version = "2.20.0";
+  version = "2.21.0";
 
   src = fetchurl {
     url = "http://download.kde.org/stable/skrooge/${pname}-${version}.tar.xz";
-    sha256 = "0rakfngp7j2x7h1isg6lbc5kva6k1kg99dz0zl43dc28s15can1w";
+    sha256 = "1aqn0367q7mdg728r5085aqzc4mgfz1bgqqlhgdjjp7r192yq7r2";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "skrooge-2.20.0-missing-header.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-office/skrooge/files/skrooge-2.20.0-missing-header.patch?id=cb8c91474b0ae2f9e889f89afe2d9114dbd1784f";
-      sha256 = "154zsidx45h6qrcqjh6czjxrcwrcmbyv3yh2k1s40v8pzvjwzrld";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake extra-cmake-modules kdoctools shared-mime-info


### PR DESCRIPTION
###### Motivation for this change

Update to new upstream version

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).