### PR TITLE
dupeguru: init at 4.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4679,6 +4679,12 @@
     githubId = 2946283;
     name = "Brian Cohen";
   };
+  novoxudonoser = {
+    email = "radnovox@gmail.com";
+    github = "novoxudonoser";
+    githubId = 6052922;
+    name = "Kirill Struokov";
+  };
   np = {
     email = "np.nix@nicolaspouillard.fr";
     github = "np";

--- a/pkgs/applications/misc/dupeguru/default.nix
+++ b/pkgs/applications/misc/dupeguru/default.nix
@@ -1,0 +1,62 @@
+{stdenv, python3Packages, gettext, qt5, fetchFromGitHub}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "dupeguru";
+  version = "4.0.4";
+
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "arsenetar";
+    repo = "dupeguru";
+    rev = "${version}";
+    sha256 = "0ma4f1c6vmpz8gi4sdy43x1ik7wh42wayvk1iq520d3i714kfcpy";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    gettext
+    python3Packages.pyqt5
+    qt5.wrapQtAppsHook
+  ];
+
+  pythonPath = with python3Packages; [
+    pyqt5
+    send2trash
+    sphinx
+    polib
+    hsaudiotag3k
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder ''out''}"
+    "NO_VENV=1"
+  ];
+
+  # TODO: package pytest-monkeyplus for running tests
+  # https://github.com/NixOS/nixpkgs/pull/75054/files#r357690123
+  doCheck = false;
+
+  # Avoid double wrapping Python programs.
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    # TODO: A bug in python wrapper
+    # see https://github.com/NixOS/nixpkgs/pull/75054#discussion_r357656916
+    makeWrapperArgs="''${qtWrapperArgs[@]}"
+  '';
+
+  postFixup = ''
+    # Executable in $out/bin is a symlink to $out/share/dupeguru/run.py
+    # so wrapPythonPrograms hook does not handle it automatically.
+    wrapPythonProgramsIn "$out/share/dupeguru" "$out $pythonPath"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GUI tool to find duplicate files in a system";
+    homepage = "https://github.com/arsenetar/dupeguru";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.novoxudonoser ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -215,6 +215,8 @@ in
 
   dispad = callPackage ../tools/X11/dispad { };
 
+  dupeguru = callPackage ../applications/misc/dupeguru { };
+
   dump1090 = callPackage ../applications/radio/dump1090 { };
 
   ebook2cw = callPackage ../applications/radio/ebook2cw { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add dupeGuru programm https://dupeguru.voltaicideas.net .
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).