### PR TITLE
pam_gnupg: init at unstable-2019-10-25

### DIFF
--- a/pkgs/os-specific/linux/pam_gnupg/default.nix
+++ b/pkgs/os-specific/linux/pam_gnupg/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkgconfig
+, gnupg
+, autoconf
+, automake
+, libtool
+, pam
+, libHX
+, libxml2
+, pcre
+, perl
+, openssl
+, cryptsetup}:
+
+stdenv.mkDerivation rec {
+  pname = "pam_gnupg";
+  version = "unstable-2019-10-25";
+
+  src = fetchFromGitHub {
+    owner = "cruegge";
+    repo = "pam-gnupg";
+    rev = "363a50820fc00d6af6f6c01b87bacab51b67cda7";
+    sha256 = "1qf3vsb7na49cgsvr03an5s7bnhj88c2g391rsd53qaxji2ni9mg";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ gnupg autoconf automake libtool pam libHX libxml2 pcre perl openssl cryptsetup ];
+
+  preConfigure = ''
+    ./autogen.sh --prefix=$out
+    ./configure
+    '';
+
+  makeFlags = "DESTDIR=$(out)";
+
+  meta = with lib; {
+    description = "Unlock GnuPG keys on login";
+    homepage = "https://github.com/cruegge/pam-gnupg";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dawidsowa ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16739,6 +16739,8 @@ in
   # pam_bioapi ( see http://www.thinkwiki.org/wiki/How_to_enable_the_fingerprint_reader )
 
   pam_ccreds = callPackage ../os-specific/linux/pam_ccreds { };
+  
+  pam_gnupg = callPackage ../os-specific/linux/pam_gnupg { };
 
   pam_krb5 = callPackage ../os-specific/linux/pam_krb5 { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This pull request adds [pam_gnupg](https://github.com/cruegge/pam-gnupg), which allows unlocking GnuPG keys at login.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
