### PR TITLE
uboot: add support for the ODROID-C2

### DIFF
--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchFromGitHub, pkgsCross, buildPackages }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, openssl, pkgsCross, buildPackages }:
 
 let
   buildArmTrustedFirmware = { filesToInstall
             , installDir ? "$out"
-            , platform
+            , platform ? null
             , extraMakeFlags ? []
             , extraMeta ? {}
             , version ? "2.1"
             , ... } @ args:
            stdenv.mkDerivation ({
 
-    name = "arm-trusted-firmware-${platform}-${version}";
+    name = "arm-trusted-firmware${lib.optionalString (platform != null) "-${platform}"}-${version}";
     inherit version;
 
     src = fetchFromGitHub {
@@ -25,16 +25,18 @@ let
     # For Cortex-M0 firmware in RK3399
     nativeBuildInputs = [ pkgsCross.arm-embedded.stdenv.cc ];
 
+    buildInputs = [ openssl ];
+
     makeFlags = [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-      "PLAT=${platform}"
-    ] ++ extraMakeFlags;
+    ] ++ (lib.optional (platform != null) "PLAT=${platform}")
+      ++ extraMakeFlags;
 
     installPhase = ''
       runHook preInstall
 
       mkdir -p ${installDir}
-      cp ${stdenv.lib.concatStringsSep " " filesToInstall} ${installDir}
+      cp ${lib.concatStringsSep " " filesToInstall} ${installDir}
 
       runHook postInstall
     '';
@@ -45,7 +47,7 @@ let
     # Fatal error: can't create build/sun50iw1p1/release/bl31/sunxi_clocks.o: No such file or directory
     enableParallelBuilding = false;
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage = https://github.com/ARM-software/arm-trusted-firmware;
       description = "A reference implementation of secure world software for ARMv8-A";
       license = licenses.bsd3;
@@ -55,6 +57,22 @@ let
 
 in {
   inherit buildArmTrustedFirmware;
+
+  armTrustedFirmwareTools = buildArmTrustedFirmware rec {
+    extraMakeFlags = [
+      "HOSTCC=${stdenv.cc.targetPrefix}gcc"
+      "fiptool" "certtool" "sptool"
+    ];
+    filesToInstall = [
+      "tools/fiptool/fiptool"
+      "tools/cert_create/cert_create"
+      "tools/sptool/sptool"
+    ];
+    postInstall = ''
+      mkdir -p "$out/bin"
+      find "$out" -type f -executable -exec mv -t "$out/bin" {} +
+    '';
+  };
 
   armTrustedFirmwareAllwinner = buildArmTrustedFirmware rec {
     platform = "sun50i_a64";

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -103,4 +103,11 @@ in {
     extraMeta.platforms = ["aarch64-linux"];
     filesToInstall = [ "build/${platform}/release/bl31/bl31.elf"];
   };
+
+  armTrustedFirmwareS905 = buildArmTrustedFirmware rec {
+    extraMakeFlags = [ "bl31" ];
+    platform = "gxbb";
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = [ "build/${platform}/release/bl31.bin"];
+  };
 }

--- a/pkgs/misc/meson-tools/default.nix
+++ b/pkgs/misc/meson-tools/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "meson-tools";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "afaerber";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1bvshfa9pa012yzdwapi3nalpgcwmfq7d3n3w3mlr357a6kq64qk";
+  };
+
+  buildInputs = [ openssl ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    mv amlbootsig unamlbootsig amlinfo "$out/bin"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/afaerber/meson-tools";
+    description = "Tools for Amlogic Meson ARM platforms";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -95,7 +95,7 @@ let
       homepage = http://www.denx.de/wiki/U-Boot/;
       description = "Boot loader for embedded systems";
       license = licenses.gpl2;
-      maintainers = with maintainers; [ dezgeg samueldr ];
+      maintainers = with maintainers; [ dezgeg samueldr lopsided98 ];
     } // extraMeta;
   } // removeAttrs args [ "extraMeta" ]);
 

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, fetchurl, fetchpatch, fetchFromGitHub, bc, bison, dtc, flex
-, openssl, swig, armTrustedFirmwareAllwinner, armTrustedFirmwareRK3328
-, armTrustedFirmwareRK3399
+, openssl, swig, meson-tools, armTrustedFirmwareAllwinner
+, armTrustedFirmwareRK3328, armTrustedFirmwareRK3399
+, armTrustedFirmwareS905
 , buildPackages
 }:
 
@@ -170,6 +171,52 @@ in {
     defconfig = "novena_defconfig";
     extraMeta.platforms = ["armv7l-linux"];
     filesToInstall = ["u-boot.bin" "SPL"];
+  };
+
+  # Flashing instructions:
+  # dd if=bl1.bin.hardkernel of=<device> conv=fsync bs=1 count=442
+  # dd if=bl1.bin.hardkernel of=<device> conv=fsync bs=512 skip=1 seek=1
+  # dd if=u-boot.gxbb of=<device> conv=fsync bs=512 seek=97
+  ubootOdroidC2 = let
+    firmwareBlobs = fetchFromGitHub {
+      owner = "armbian";
+      repo = "odroidc2-blobs";
+      rev = "47c5aac4bcac6f067cebe76e41fb9924d45b429c";
+      sha256 = "1ns0a130yxnxysia8c3q2fgyjp9k0nkr689dxk88qh2vnibgchnp";
+      meta.license = lib.licenses.unfreeRedistributableFirmware;
+    };
+  in buildUBoot {
+    defconfig = "odroid-c2_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = ["u-boot.bin" "u-boot.gxbb" "${firmwareBlobs}/bl1.bin.hardkernel"];
+    postBuild = ''
+      # BL301 image needs at least 64 bytes of padding after it to place
+      # signing headers (with amlbootsig)
+      truncate -s 64 bl301.padding.bin
+      cat '${firmwareBlobs}/gxb/bl301.bin' bl301.padding.bin > bl301.padded.bin
+      # The downstream fip_create tool adds a custom TOC entry with UUID
+      # AABBCCDD-ABCD-EFEF-ABCD-12345678ABCD for the BL301 image. It turns out
+      # that the firmware blob does not actually care about UUIDs, only the
+      # order the images appear in the file. Because fiptool does not know
+      # about the BL301 UUID, we would have to use the --blob option, which adds
+      # the image to the end of the file, causing the boot to fail. Instead, we
+      # take advantage of the fact that UUIDs are ignored and just put the
+      # images in the right order with the wrong UUIDs. In the command below,
+      # --tb-fw is really --scp-fw and --scp-fw is the BL301 image.
+      #
+      # See https://github.com/afaerber/meson-tools/issues/3 for more
+      # information.
+      '${buildPackages.armTrustedFirmwareTools}/bin/fiptool' create \
+        --align 0x4000 \
+        --tb-fw '${firmwareBlobs}/gxb/bl30.bin' \
+        --scp-fw bl301.padded.bin \
+        --soc-fw '${armTrustedFirmwareS905}/bl31.bin' \
+        --nt-fw u-boot.bin \
+        fip.bin
+      cat '${firmwareBlobs}/gxb/bl2.package' fip.bin > boot_new.bin
+      '${buildPackages.meson-tools}/bin/amlbootsig' boot_new.bin u-boot.img
+      dd if=u-boot.img of=u-boot.gxbb bs=512 skip=96
+    '';
   };
 
   ubootOdroidXU3 = buildUBoot {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15816,6 +15816,7 @@ in
     armTrustedFirmwareQemu
     armTrustedFirmwareRK3328
     armTrustedFirmwareRK3399
+    armTrustedFirmwareS905
     ;
 
   microcodeAmd = callPackage ../os-specific/linux/microcode/amd.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1899,6 +1899,8 @@ in
 
   meson = callPackage ../development/tools/build-managers/meson { };
 
+  meson-tools = callPackage ../misc/meson-tools { };
+
   metabase = callPackage ../servers/metabase { };
 
   mididings = callPackage ../tools/audio/mididings { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15811,6 +15811,7 @@ in
 
   inherit (callPackage ../misc/arm-trusted-firmware {})
     buildArmTrustedFirmware
+    armTrustedFirmwareTools
     armTrustedFirmwareAllwinner
     armTrustedFirmwareQemu
     armTrustedFirmwareRK3328

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16955,6 +16955,7 @@ in
     ubootGuruplug
     ubootJetsonTK1
     ubootNovena
+    ubootOdroidC2
     ubootOdroidXU3
     ubootOrangePiPc
     ubootOrangePiZeroPlus2H5


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This adds support for the ODROID-C2 to U-Boot in nixpkgs. It minimizes the use of binary blobs and vendor tools. It has been tested in combination with mainline Linux 5.4.1.

The Amlogic S905 uses 5 bootloader stages. The first (`bl1.bin.hardkernel`) is partially placed in the MBR bootstrap code area and partially in the sector after the MBR. The rest of the stages are stored in a FIP image placed at sector 97. `bl30.bin` and `bl301.bin` are binary blobs ([sources are technically available for `bl301.bin`](https://github.com/hardkernel/u-boot_firmware/tree/odroidc2-bl301), but building them is more trouble than it's worth). The other two images are ATF and U-Boot, both of which have upstream support for the SoC/board.

Hardkernel's U-Boot tree has a custom version of the `fip_create` tool taken from ATF. It was modified to add padding to the BL301 image (to make room for a signature) and place the BL301 image between BL30 and BL31 (ATF) with a custom UUID. BL301 needs to be signed by the `aml_encrypt_gxb` tool which is only provided as a binary for `x86_64-linux`.

Upstream ATF has replaced `fip_create` with `fiptool`. It is possible to add images with custom UUIDs using `fiptool`, but they are always added to the end of the file. This is a problem because the bootloader blob responsible for loading the FIP only looks at the order of the images, not their UUIDs. `fiptool` [can be patched to place the BL301 image at the right position](https://github.com/afaerber/arm-trusted-firmware/commit/3da46db507b23e6dfb1ffaa033fa3f7392f1437e), but it turns out that this is not really necessary. Since the bootloader doesn't care about UUIDs, we can simply put the images in the right order with the wrong UUIDs using an unmodified `fiptool`. See https://github.com/afaerber/meson-tools/issues/3 for more information.

The [meson-tools](https://github.com/afaerber/meson-tools) project contains a reverse engineered version of `aml_encrypt_gxb`, which can be used instead.

There is an opportunity for bikeshedding here: what should the ATF package be called?
* armTrustedFirmwareS905
* armTrustedFirmwareAmlogicS905
* armTrustedFirmwareMesonGxbb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @samueldr @dezgeg @grahamc