### PR TITLE
doc/python: improve description of community tools

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -865,11 +865,15 @@ Note: There is a boolean value `lib.inNixShell` set to `true` if nix-shell is in
 
 ### Tools
 
-Packages inside nixpkgs are written by hand. However many tools exist in
-community to help save time. No tool is preferred at the moment.
+Packages inside nixpkgs are written by hand. However the Nix community has created many tools
+to help save time. No tool is preferred at the moment, but the following may be of interest:
 
-- [pypi2nix](https://github.com/nix-community/pypi2nix): Generate Nix expressions for your Python project. Note that [sharing derivations from pypi2nix with nixpkgs is possible but not encouraged](https://github.com/nix-community/pypi2nix/issues/222#issuecomment-443497376).
-- [python2nix](https://github.com/proger/python2nix) by Vladimir Kirillov.
+- [pypi2nix](https://github.com/nix-community/pypi2nix): generate Nix expressions for Python packages.
+- [pip2nix](https://github.com/nix-community/pip2nix): generate Nix expressions for Python packages.
+- [nixpkgs-pytools](https://github.com/nix-community/nixpkgs-pytools): tools for removing the tedious nature of creating nixpkgs derivations.
+- [poetry2nix](https://github.com/nix-community/poetry2nix): turn Poetry projects into Nix derivations without the need to actually write Nix expressions.
+
+Note that pypi2nix maintains a separate package tree from nixpkgs, so Python package derivations from pypi2nix and nixpkgs [should not be used together](https://github.com/nix-community/pypi2nix/issues/222#issuecomment-443497376). But Python package derivations from pip2nix or nixpkgs-pytools can be used together with those from nixpkgs.
 
 ### Deterministic builds
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Added pip2nix, nixpkgs-pytools and poetry2nix, because they are actively maintained and in  [nix-community](https://github.com/nix-community). Removed [python2nix](https://github.com/proger/python2nix), because it's been broken [since 2017](https://github.com/NixOS/nixpkgs/issues/30887) and is [still broken](https://github.com/proger/python2nix/issues/6).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
