### PR TITLE
reptyr: add patch to fix tests

### DIFF
--- a/pkgs/os-specific/linux/reptyr/default.nix
+++ b/pkgs/os-specific/linux/reptyr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, python2 }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, python2 }:
 
 stdenv.mkDerivation rec {
   version = "0.7.0";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev = "reptyr-${version}";
     sha256 = "1hnijfz1ab34j2h2cxc3f43rmbclyihgn9x9wxa7jqqgb2xm71hj";
   };
+
+  patches = [
+    # Fix tests hanging
+    (fetchpatch {
+      url = "https://github.com/nelhage/reptyr/commit/bca3070ac0f3888b5d37ee162505be81b3b496ff.patch";
+      sha256 = "0w6rpv9k4a80q0ijzdq5hlpr37ncr284piqjv5agy8diniwlilab";
+    })
+  ];
 
   makeFlags = [ "PREFIX=" "DESTDIR=$(out)" ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes #75076

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tbenst @7c6f434c 
