### PR TITLE
Nixos tests ports

### DIFF
--- a/nixos/tests/docker-tools-overlay.nix
+++ b/nixos/tests/docker-tools-overlay.nix
@@ -1,6 +1,6 @@
 # this test creates a simple GNU image with docker tools and sees if it executes
 
-import ./make-test.nix ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, ... }:
 {
   name = "docker-tools-overlay";
   meta = with pkgs.stdenv.lib.maintainers; {
@@ -16,17 +16,18 @@ import ./make-test.nix ({ pkgs, ... }:
       };
   };
 
-  testScript =
-    ''
-      $docker->waitForUnit("sockets.target");
+  testScript = ''
+      docker.wait_for_unit("sockets.target")
 
-      $docker->succeed("docker load --input='${pkgs.dockerTools.examples.bash}'");
-      $docker->succeed("docker run --rm ${pkgs.dockerTools.examples.bash.imageName} bash --version");
+      docker.succeed(
+          "docker load --input='${pkgs.dockerTools.examples.bash}'",
+          "docker run --rm ${pkgs.dockerTools.examples.bash.imageName} bash --version",
+      )
 
       # Check if the nix store has correct user permissions depending on what
       # storage driver is used, incorrectly built images can show up as readonly.
       # drw-------  3 0 0   3 Apr 14 11:36 /nix
       # drw------- 99 0 0 100 Apr 14 11:36 /nix/store
-      $docker->succeed("docker run --rm -u 1000:1000 ${pkgs.dockerTools.examples.bash.imageName} bash --version");
+      docker.succeed("docker run --rm -u 1000:1000 ${pkgs.dockerTools.examples.bash.imageName} bash --version")
     '';
 })

--- a/nixos/tests/ecryptfs.nix
+++ b/nixos/tests/ecryptfs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ ... }:
+import ./make-test-python.nix ({ ... }:
 {
   name = "ecryptfs";
 
@@ -10,75 +10,76 @@ import ./make-test.nix ({ ... }:
   };
 
   testScript = ''
-    $machine->waitForUnit("default.target");
+    def login_as_alice():
+        machine.wait_until_tty_matches(1, "login: ")
+        machine.send_chars("alice\n")
+        machine.wait_until_tty_matches(1, "Password: ")
+        machine.send_chars("foobar\n")
+        machine.wait_until_tty_matches(1, "alice\@machine")
 
-    # Set alice up with a password and a home
-    $machine->succeed("(echo foobar; echo foobar) | passwd alice");
-    $machine->succeed("chown -R alice.users ~alice");
 
-    # Migrate alice's home
-    my $out = $machine->succeed("echo foobar | ecryptfs-migrate-home -u alice");
-    $machine->log("ecryptfs-migrate-home said: $out");
+    def logout():
+        machine.send_chars("logout\n")
+        machine.wait_until_tty_matches(1, "login: ")
 
-    # Log alice in (ecryptfs passwhrase is wrapped during first login)
-    $machine->waitUntilTTYMatches(1, "login: ");
-    $machine->sendChars("alice\n");
-    $machine->waitUntilTTYMatches(1, "Password: ");
-    $machine->sendChars("foobar\n");
-    $machine->waitUntilTTYMatches(1, "alice\@machine");
-    $machine->sendChars("logout\n");
-    $machine->waitUntilTTYMatches(1, "login: ");
 
-    # Why do I need to do this??
-    $machine->succeed("su alice -c ecryptfs-umount-private || true");
-    $machine->sleep(1);
-    $machine->fail("mount | grep ecryptfs"); # check that encrypted home is not mounted
+    machine.wait_for_unit("default.target")
 
-    # Show contents of the user keyring
-    my $out = $machine->succeed("su - alice -c 'keyctl list \@u'");
-    $machine->log("keyctl unlink said: " . $out);
+    with subtest("Set alice up with a password and a home"):
+        machine.succeed("(echo foobar; echo foobar) | passwd alice")
+        machine.succeed("chown -R alice.users ~alice")
 
-    # Log alice again
-    $machine->waitUntilTTYMatches(1, "login: ");
-    $machine->sendChars("alice\n");
-    $machine->waitUntilTTYMatches(1, "Password: ");
-    $machine->sendChars("foobar\n");
-    $machine->waitUntilTTYMatches(1, "alice\@machine");
+    with subtest("Migrate alice's home"):
+        out = machine.succeed("echo foobar | ecryptfs-migrate-home -u alice")
+        machine.log(f"ecryptfs-migrate-home said: {out}")
 
-    # Create some files in encrypted home
-    $machine->succeed("su alice -c 'touch ~alice/a'");
-    $machine->succeed("su alice -c 'echo c > ~alice/b'");
-
-    # Logout
-    $machine->sendChars("logout\n");
-    $machine->waitUntilTTYMatches(1, "login: ");
+    with subtest("Log alice in (ecryptfs passwhrase is wrapped during first login)"):
+        login_as_alice()
+        machine.send_chars("logout\n")
+        machine.wait_until_tty_matches(1, "login: ")
 
     # Why do I need to do this??
-    $machine->succeed("su alice -c ecryptfs-umount-private || true");
-    $machine->sleep(1);
+    machine.succeed("su alice -c ecryptfs-umount-private || true")
+    machine.sleep(1)
 
-    # Check that the filesystem is not accessible
-    $machine->fail("mount | grep ecryptfs");
-    $machine->succeed("su alice -c 'test \! -f ~alice/a'");
-    $machine->succeed("su alice -c 'test \! -f ~alice/b'");
+    with subtest("check that encrypted home is not mounted"):
+        machine.fail("mount | grep ecryptfs")
 
-    # Log alice once more
-    $machine->waitUntilTTYMatches(1, "login: ");
-    $machine->sendChars("alice\n");
-    $machine->waitUntilTTYMatches(1, "Password: ");
-    $machine->sendChars("foobar\n");
-    $machine->waitUntilTTYMatches(1, "alice\@machine");
+    with subtest("Show contents of the user keyring"):
+        out = machine.succeed("su - alice -c 'keyctl list \@u'")
+        machine.log(f"keyctl unlink said: {out}")
 
-    # Check that the files are there
-    $machine->sleep(1);
-    $machine->succeed("su alice -c 'test -f ~alice/a'");
-    $machine->succeed("su alice -c 'test -f ~alice/b'");
-    $machine->succeed(qq%test "\$(cat ~alice/b)" = "c"%);
+    with subtest("Log alice again"):
+        login_as_alice()
 
-    # Catch https://github.com/NixOS/nixpkgs/issues/16766
-    $machine->succeed("su alice -c 'ls -lh ~alice/'");
+    with subtest("Create some files in encrypted home"):
+        machine.succeed("su alice -c 'touch ~alice/a'")
+        machine.succeed("su alice -c 'echo c > ~alice/b'")
 
-    $machine->sendChars("logout\n");
-    $machine->waitUntilTTYMatches(1, "login: ");
+    with subtest("Logout"):
+        logout()
+
+    # Why do I need to do this??
+    machine.succeed("su alice -c ecryptfs-umount-private || true")
+    machine.sleep(1)
+
+    with subtest("Check that the filesystem is not accessible"):
+        machine.fail("mount | grep ecryptfs")
+        machine.succeed("su alice -c 'test \! -f ~alice/a'")
+        machine.succeed("su alice -c 'test \! -f ~alice/b'")
+
+    with subtest("Log alice once more"):
+        login_as_alice()
+
+    with subtest("Check that the files are there"):
+        machine.sleep(1)
+        machine.succeed("su alice -c 'test -f ~alice/a'")
+        machine.succeed("su alice -c 'test -f ~alice/b'")
+        machine.succeed('test "$(cat ~alice/b)" = "c"')
+
+    with subtest("Catch https://github.com/NixOS/nixpkgs/issues/16766"):
+        machine.succeed("su alice -c 'ls -lh ~alice/'")
+
+    logout()
   '';
 })

--- a/nixos/tests/env.nix
+++ b/nixos/tests/env.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "environment";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ nequissimus ];
@@ -20,16 +20,17 @@ import ./make-test.nix ({ pkgs, ...} : {
       };
     };
 
-  testScript =
-    ''
-      $machine->succeed('[ -L "/etc/plainFile" ]');
-      $machine->succeed('cat "/etc/plainFile" | grep "Hello World"');
-      $machine->succeed('[ -d "/etc/folder" ]');
-      $machine->succeed('[ -d "/etc/folder/with" ]');
-      $machine->succeed('[ -L "/etc/folder/with/file" ]');
-      $machine->succeed('cat "/etc/plainFile" | grep "Hello World"');
+  testScript = ''
+    machine.succeed('[ -L "/etc/plainFile" ]')
+    assert "Hello World" in machine.succeed('cat "/etc/plainFile"')
+    machine.succeed('[ -d "/etc/folder" ]')
+    machine.succeed('[ -d "/etc/folder/with" ]')
+    machine.succeed('[ -L "/etc/folder/with/file" ]')
+    assert "Hello World" in machine.succeed('cat "/etc/plainFile"')
 
-      $machine->succeed('echo ''${TERMINFO_DIRS} | grep "/run/current-system/sw/share/terminfo"');
-      $machine->succeed('echo ''${NIXCON} | grep "awesome"');
-    '';
+    assert "/run/current-system/sw/share/terminfo" in machine.succeed(
+        "echo ''${TERMINFO_DIRS}"
+    )
+    assert "awesome" in machine.succeed("echo ''${NIXCON}")
+  '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace @flokli 
