### PR TITLE
ocamlPackages.graphql: init at 0.13.0

### DIFF
--- a/pkgs/development/ocaml-modules/graphql/cohttp.nix
+++ b/pkgs/development/ocaml-modules/graphql/cohttp.nix
@@ -1,0 +1,24 @@
+{ lib, buildDunePackage, ocaml-crunch
+, astring, cohttp, digestif, graphql, ocplib-endian
+, alcotest, cohttp-lwt-unix, graphql-lwt
+}:
+
+buildDunePackage rec {
+  pname = "graphql-cohttp";
+
+  inherit (graphql) version src;
+
+  nativeBuildInputs = [ ocaml-crunch ];
+  propagatedBuildInputs = [ astring cohttp digestif graphql ocplib-endian ];
+
+  checkInputs = lib.optionals doCheck [ alcotest cohttp-lwt-unix graphql-lwt ];
+
+  doCheck = true;
+
+  meta = graphql.meta // {
+    description = "Run GraphQL servers with “cohttp”";
+  };
+
+}
+
+

--- a/pkgs/development/ocaml-modules/graphql/default.nix
+++ b/pkgs/development/ocaml-modules/graphql/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildDunePackage, alcotest, graphql_parser, rresult, yojson }:
+
+buildDunePackage rec {
+  pname = "graphql";
+
+  inherit (graphql_parser) version src;
+
+  propagatedBuildInputs = [ graphql_parser rresult yojson ];
+
+  checkInputs = lib.optional doCheck alcotest;
+
+  doCheck = true;
+
+  meta = graphql_parser.meta // {
+    description = "Build GraphQL schemas and execute queries against them";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/graphql/lwt.nix
+++ b/pkgs/development/ocaml-modules/graphql/lwt.nix
@@ -1,0 +1,19 @@
+{ lib, buildDunePackage, alcotest, graphql, ocaml_lwt }:
+
+buildDunePackage rec {
+  pname = "graphql-lwt";
+
+  inherit (graphql) version src;
+
+  propagatedBuildInputs = [ graphql ocaml_lwt ];
+
+  checkInputs = lib.optional doCheck alcotest;
+
+  doCheck = true;
+
+  meta = graphql.meta // {
+    description = "Build GraphQL schemas with Lwt support";
+  };
+
+}
+

--- a/pkgs/development/ocaml-modules/graphql/parser.nix
+++ b/pkgs/development/ocaml-modules/graphql/parser.nix
@@ -1,0 +1,28 @@
+{ lib, buildDunePackage, fetchurl, alcotest, fmt, menhir, re }:
+
+buildDunePackage rec {
+  pname = "graphql_parser";
+  version = "0.13.0";
+
+  minimumOCamlVersion = "4.03";
+
+  src = fetchurl {
+    url = "https://github.com/andreas/ocaml-graphql-server/releases/download/${version}/graphql-${version}.tbz";
+    sha256 = "0gb5y99ph0nz5y3pc1gxq1py4wji2hyf2ydbp0hv23v00n50hpsm";
+  };
+
+  nativeBuildInputs = [ menhir ];
+  propagatedBuildInputs = [ fmt re ];
+
+  checkInputs = lib.optional doCheck alcotest;
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://github.com/andreas/ocaml-graphql-server";
+    description = "Library for parsing GraphQL queries";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -338,6 +338,8 @@ let
 
     gmetadom = callPackage ../development/ocaml-modules/gmetadom { };
 
+    graphql_parser = callPackage ../development/ocaml-modules/graphql/parser.nix { };
+
     gtktop = callPackage ../development/ocaml-modules/gtktop { };
 
     hex = callPackage ../development/ocaml-modules/hex { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -340,6 +340,8 @@ let
 
     graphql = callPackage ../development/ocaml-modules/graphql { };
 
+    graphql-lwt = callPackage ../development/ocaml-modules/graphql/lwt.nix { };
+
     graphql_parser = callPackage ../development/ocaml-modules/graphql/parser.nix { };
 
     gtktop = callPackage ../development/ocaml-modules/gtktop { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -340,6 +340,8 @@ let
 
     graphql = callPackage ../development/ocaml-modules/graphql { };
 
+    graphql-cohttp = callPackage ../development/ocaml-modules/graphql/cohttp.nix { };
+
     graphql-lwt = callPackage ../development/ocaml-modules/graphql/lwt.nix { };
 
     graphql_parser = callPackage ../development/ocaml-modules/graphql/parser.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -338,6 +338,8 @@ let
 
     gmetadom = callPackage ../development/ocaml-modules/gmetadom { };
 
+    graphql = callPackage ../development/ocaml-modules/graphql { };
+
     graphql_parser = callPackage ../development/ocaml-modules/graphql/parser.nix { };
 
     gtktop = callPackage ../development/ocaml-modules/gtktop { };


### PR DESCRIPTION
###### Motivation for this change

Dependency of irmin.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

