### PR TITLE
glui: 2.36 -> 2.37

### DIFF
--- a/pkgs/development/libraries/glui/default.nix
+++ b/pkgs/development/libraries/glui/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, fetchurl
+, fetchFromGitHub
 , freeglut
 , libGL
 , libGLU
@@ -11,16 +11,16 @@
 
 stdenv.mkDerivation rec {
   pname = "glui";
-  version = "2.36";
+  version = "2.37";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/glui/Source/${version}/glui-${version}.tgz";
-    sha256 = "11r7f0k5jlbl825ibhm5c6bck0fn1hbliya9x1f253ikry1mxvy1";
+  src = fetchFromGitHub {
+    owner = "libglui";
+    repo = "glui";
+    rev = version;
+    sha256 = "0qg2y8w95s03zay1qsqs8pqxxlg6l9kwm7rrs1qmx0h22sxb360i";
   };
 
   buildInputs = [ freeglut libGLU libGL libXmu libXext libX11 libXi ];
-
-  preConfigure = ''cd src'';
 
   installPhase = ''
     mkdir -p "$out"/{bin,lib,share/glui/doc,include}


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date in @r-ryantm logs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/75089
1 package were built:
glui
```