### PR TITLE
gopher: 3.0.11 -> 3.0.17

### DIFF
--- a/pkgs/applications/networking/gopher/gopher/default.nix
+++ b/pkgs/applications/networking/gopher/gopher/default.nix
@@ -1,23 +1,25 @@
-{stdenv, fetchurl, ncurses}:
+{ stdenv, fetchFromGitHub, ncurses }:
 
 stdenv.mkDerivation rec {
   pname = "gopher";
-  version = "3.0.11";
+  version = "3.0.17";
 
-  src = fetchurl {
-    url = "http://gopher.quux.org:70/devel/gopher/Downloads/gopher_${version}.tar.gz";
-    sha256 = "15r7x518wlpfqpd6z0hbdwm8rw8ll8hbpskdqgxxhrmy00aa7w9c";
+  src = fetchFromGitHub {
+    owner = "jgoerzen";
+    repo = pname;
+    rev = "release/${version}";
+    sha256 = "1j6xh5l8v231d4mwl9gj1c34dc0jmazz6zg1qqfxmqr9y609jq3h";
   };
 
   buildInputs = [ ncurses ];
 
   preConfigure = "export LIBS=-lncurses";
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://gopher.quux.org:70/devel/gopher;
     description = "A ncurses gopher client";
-    platforms = stdenv.lib.platforms.unix;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+    platforms = platforms.linux; # clang doesn't like local regex.h
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ sternenseemann ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date in @r-ryantm logs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/75090
1 package were built:
gopher
```