### PR TITLE
python3Packages.gcovr: 4.1 -> 4.2

### DIFF
--- a/pkgs/development/python-modules/gcovr/default.nix
+++ b/pkgs/development/python-modules/gcovr/default.nix
@@ -2,25 +2,33 @@
 , buildPythonPackage
 , fetchPypi
 , jinja2
+, lxml
 }:
 
 buildPythonPackage rec {
   pname = "gcovr";
-  version = "4.1";
+  version = "4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ca94c337f2d9a70db177ec4330534fad7b2b772beda625c1ec071fbcf1361e22";
+    sha256 = "0gyady7x3v3l9fm1zan0idaggqqcm31y7g5vxk7h05p5h7f39bjs";
   };
 
   propagatedBuildInputs = [
     jinja2
+    lxml
   ];
 
   # There are no unit tests in the pypi tarball. Most of the unit tests on the
   # github repository currently only work with gcc5, so we just disable them.
   # See also: https://github.com/gcovr/gcovr/issues/206
   doCheck = false;
+
+  pythonImportsCheck = [
+    "gcovr"
+    "gcovr.workers"
+    "gcovr.configuration"
+  ];
 
   meta = with stdenv.lib; {
     description = "A Python script for summarizing gcov data";


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date in @r-ryantm logs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 3 copied (6.0 MiB), 1.5 MiB DL]
https://github.com/NixOS/nixpkgs/pull/75092
3 package were built:
gcovr python27Packages.gcovr python38Packages.gcovr
```