### PR TITLE
podman-compose: init at 0.1.5

### DIFF
--- a/pkgs/applications/virtualization/podman-compose/default.nix
+++ b/pkgs/applications/virtualization/podman-compose/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonApplication, fetchPypi, podman, pyyaml }:
+
+buildPythonApplication rec {
+  version = "0.1.5";
+  pname = "podman-compose";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sgbc889zq127qhxa9frhswa1mid19fs5qnyzfihx648y5i968pv";
+  };
+
+  propagatedBuildInputs = [ pyyaml podman ];
+
+  meta = with lib; {
+    description = "An implementation of docker-compose with podman backend";
+    homepage = "https://github.com/containers/podman-compose";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5721,6 +5721,8 @@ in
 
   podman = callPackage ../applications/virtualization/podman { };
 
+  podman-compose = python3Packages.callPackage ../applications/virtualization/podman-compose {};
+
   pod2mdoc = callPackage ../tools/misc/pod2mdoc { };
 
   poedit = callPackage ../tools/text/poedit { };


### PR DESCRIPTION
###### Motivation for this change
[README](https://github.com/containers/podman-compose/blob/master/README.md)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/rjxw9zakrqlpj9fmdwljzwg12y04q0n5-podman-compose-0.1.5
/nix/store/rjxw9zakrqlpj9fmdwljzwg12y04q0n5-podman-compose-0.1.5	 188.6M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
