### PR TITLE
`lib.strings.intersperse` -> `lib.lists.intersperse`.

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -71,14 +71,14 @@ let
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin
       getLib getDev chooseDevOutputs zipWithNames zip;
-    inherit (lists) singleton forEach foldr fold foldl foldl' imap0 imap1
+    inherit (lists) intersperse singleton forEach foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range partition zipListsWith zipLists
       reverseList listDfs toposort sort naturalSort compareLists take
       drop sublist last init crossLists unique intersectLists
       subtractLists mutuallyExclusive groupBy groupBy';
     inherit (strings) concatStrings concatMapStrings concatImapStrings
-      intersperse concatStringsSep concatMapStringsSep
+      concatStringsSep concatMapStringsSep
       concatImapStringsSep makeSearchPath makeSearchPathOutput
       makeLibraryPath makeBinPath optionalString
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -393,6 +393,23 @@ rec {
   reverseList = xs:
     let l = length xs; in genList (n: elemAt xs (l - n - 1)) l;
 
+  /* Place an element between each element of a list
+
+     Type: intersperse :: a -> [a] -> [a]
+
+     Example:
+       intersperse "/" ["usr" "local" "bin"]
+       => ["usr" "/" "local" "/" "bin"].
+  */
+  intersperse =
+    # Separator to add between elements
+    separator:
+    # Input list
+    list:
+    if list == [] || length list == 1
+    then list
+    else tail (lib.concatMap (x: [separator x]) list);
+
   /* Depth-First Search (DFS) for lists `list != []`.
 
      `before a b == true` means that `b` depends on `a` (there's an

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -54,9 +54,10 @@ rec {
     separator:
     # Input list
     list:
-    if list == [] || length list == 1
+    lib.warn "`lib.strings.intersperse' is deprecated and will be removed. Please use `lib.lists.intersperse'."
+    (if list == [] || length list == 1
     then list
-    else tail (lib.concatMap (x: [separator x]) list);
+    else tail (lib.concatMap (x: [separator x]) list));
 
   /* Concatenate a list of strings with a separator between each element
 
@@ -67,7 +68,7 @@ rec {
         => "usr/local/bin"
   */
   concatStringsSep = builtins.concatStringsSep or (separator: list:
-    concatStrings (intersperse separator list));
+    concatStrings (lib.lists.intersperse separator list));
 
   /* Maps a function over a list of strings and then concatenates the
      result with the specified separator interspersed between

--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -207,6 +207,11 @@
    </listitem>
    <listitem>
     <para>
+      <literal>lib.strings.intersperse</literal> has been moved to <literal> lib.lists.intersperse</literal>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      The packages <literal>openobex</literal> and <literal>obexftp</literal>
      are no loger installed when enabling bluetooth via
      <option>hardware.bluetooth.enable</option>.


### PR DESCRIPTION
`intersperse` is defined within `lib.strings` yet does not work for
strings, only lists. Furthermore, it only returns a list. There is no
sense in a function that only works with lists being in the strings
library.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
