### PR TITLE
openafs_1_8: 1.8.3 -> 1.8.5

### DIFF
--- a/pkgs/servers/openafs/1.8/cross-build.patch
+++ b/pkgs/servers/openafs/1.8/cross-build.patch
@@ -2,9 +2,9 @@ diff -Nur --unidirectional-new-file openafs-1.8.2/configure.ac openafs-1.8.2.new
 --- openafs-1.8.2/configure.ac	2018-09-11 17:52:48.000000000 +0200
 +++ openafs-1.8.2.new/configure.ac	2018-10-16 15:56:36.512277860 +0200
 @@ -23,6 +23,7 @@
+ AFS_LT_INIT
  
  AC_PROG_CC
- AC_PROG_LIBTOOL
 +AX_PROG_CC_FOR_BUILD
  
  AC_PATH_PROGS([PATH_CPP], [cpp], [${CC-cc} -E], [$PATH:/lib:/usr/ccs/lib])

--- a/pkgs/servers/openafs/1.8/default.nix
+++ b/pkgs/servers/openafs/1.8/default.nix
@@ -28,9 +28,6 @@ stdenv.mkDerivation {
   # Makefiles don't include install targets for all new shared libs, yet.
   dontDisableStatic = true;
 
-  # Fixes broken format string in 1.8.2
-  hardeningDisable=[ "format" ];
-
   preConfigure = ''
     patchShebangs .
     for i in `grep -l -R '/usr/\(include\|src\)' .`; do

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -11,20 +11,6 @@ in stdenv.mkDerivation {
   name = "openafs-${version}-${kernel.modDirVersion}";
   inherit version src;
 
-  patches = [
-    # Linux 5.3
-    (fetchpatch {
-      name = "openafs_1_8-recurse-keyring_search.patch";
-      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=02d82275c17284d04629282aa374bb39f511c989";
-      sha256 = "03pkldwf6i67yf6i1705qp18rx5b0b342ryda8vfjw9lnvpinygs";
-    })
-    (fetchpatch {
-      name = "openafs_1_8-send-sig.patch";
-      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=2b7af1243f46496c0b5973b3fa2a6396243f7613";
-      sha256 = "13gyh5ncpp15dl7056gdzl5xhp2bmafc557bd2a4bwx9nyj53bag";
-    })
-  ];
-
   nativeBuildInputs = [ autoconf automake flex libtool_2 perl which yacc ]
     ++ kernel.moduleBuildDependencies;
 

--- a/pkgs/servers/openafs/1.8/srcs.nix
+++ b/pkgs/servers/openafs/1.8/srcs.nix
@@ -1,14 +1,14 @@
 { fetchurl }:
 rec {
-  version = "1.8.3";
+  version = "1.8.5";
   src = fetchurl {
     url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "19ffchxwgqg4wl98l456jdpgq2w8b5izn8hxdsq9hjs0a1nc3nga";
+    sha256 = "08w5n803xm75j7daa3mr2ncfmcg0wpm7yasj6zyddqlb4f7xdppf";
   };
 
   srcs = [ src
     (fetchurl {
       url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      sha256 = "14smdhn1f6f3cbvvwxgjjld0m4b17vqh3rzkxf5apmjsdda21njq";
+      sha256 = "08mg3n0q2igfas1khj18r9apyrkpbp1jick0ix5nfaal90jbifis";
     })];
 }


### PR DESCRIPTION
##### Motivation for this change

Addresses security advisories OPENAFS-SA-2019-001, OPENAFS-SA-2019-002, OPENAFS-SA-2019-003.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @maggesi @spacefrogg
