### PR TITLE
pythonPackages.transformers: init at 2.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5187,6 +5187,12 @@
     githubId = 20792;
     name = "Sebastian Galkin";
   };
+  pashashocky = {
+    email = "pashashocky@gmail.com";
+    github = "pashashocky";
+    githubId = 673857;
+    name = "Pash Shocky";
+  };
   pashev = {
     email = "pashev.igor@gmail.com";
     github = "ip1981";

--- a/pkgs/development/libraries/sentencepiece/default.nix
+++ b/pkgs/development/libraries/sentencepiece/default.nix
@@ -1,0 +1,31 @@
+{ config
+, fetchFromGitHub
+, stdenv
+, lib
+, cmake
+, gperftools
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sentencepiece";
+  version = "0.1.84";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "144y25nj4rwxmgvzqbr7al9fjwh3539ssjswvzrx4gsgfk62lsm0";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ cmake gperftools ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/google/sentencepiece;
+    description = "Unsupervised text tokenizer for Neural Network-based text generation";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ pashashocky ];
+  };
+}

--- a/pkgs/development/python-modules/sacremoses/default.nix
+++ b/pkgs/development/python-modules/sacremoses/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage
+, stdenv
+, fetchFromGitHub
+, click
+, six
+, tqdm
+, joblib
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "sacremoses";
+  version = "0.0.35";
+
+  src = fetchFromGitHub {
+    owner = "alvations";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "1gzr56w8yx82mn08wax5m0xyg15ym4ri5l80gmagp8r53443j770";
+  };
+
+  propagatedBuildInputs = [ click six tqdm joblib ];
+
+  checkInputs = [ pytest ];
+  # ignore tests which call to remote host
+  checkPhase = ''
+    pytest -k 'not truecase'
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/alvations/sacremoses";
+    description = "Python port of Moses tokenizer, truecaser and normalizer";
+    license = licenses.lgpl21Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ pashashocky ];
+  };
+}

--- a/pkgs/development/python-modules/sentencepiece/default.nix
+++ b/pkgs/development/python-modules/sentencepiece/default.nix
@@ -1,0 +1,15 @@
+{ buildPythonPackage
+, stdenv
+, sentencepiece
+, pkgconfig
+}:
+
+buildPythonPackage rec {
+  pname = "sentencepiece";
+  inherit (sentencepiece) version src meta;
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ sentencepiece ];
+
+  sourceRoot = "source/python";
+}

--- a/pkgs/development/python-modules/transformers/default.nix
+++ b/pkgs/development/python-modules/transformers/default.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage
+, stdenv
+, fetchFromGitHub
+, sacremoses
+, requests
+, sentencepiece
+, boto3
+, tqdm
+, regex
+, numpy
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "transformers";
+  version = "2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1p8p3lhhiyk1xl9gpgq4vbchyz57v3w7hhvsj1r90zs3cckindl8";
+  };
+
+  propagatedBuildInputs = [ numpy sacremoses requests sentencepiece boto3 tqdm regex ];
+
+  checkInputs = [ pytest ];
+  # pretrained tries to download from s3
+  checkPhase = ''
+    cd transformers # avoid importing local files
+    HOME=$TMPDIR pytest -k 'not pretrained_tokenizers'
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/huggingface/transformers";
+    description = "State-of-the-art Natural Language Processing for TensorFlow 2.0 and PyTorch";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ pashashocky ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25607,4 +25607,6 @@ in
 
   gortr = callPackage ../servers/gortr {};
 
+  sentencepiece = callPackage ../development/libraries/sentencepiece {};
+
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1268,6 +1268,8 @@ in {
 
   selectors2 = callPackage ../development/python-modules/selectors2 { };
 
+  sacremoses = callPackage ../development/python-modules/sacremoses { };
+
   sentencepiece = callPackage ../development/python-modules/sentencepiece {
     inherit (pkgs) sentencepiece pkgconfig;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1268,6 +1268,10 @@ in {
 
   selectors2 = callPackage ../development/python-modules/selectors2 { };
 
+  sentencepiece = callPackage ../development/python-modules/sentencepiece {
+    inherit (pkgs) sentencepiece pkgconfig;
+  };
+
   sentinel = callPackage ../development/python-modules/sentinel { };
 
   sentry-sdk = callPackage ../development/python-modules/sentry-sdk {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1274,6 +1274,8 @@ in {
     inherit (pkgs) sentencepiece pkgconfig;
   };
 
+  transformers = callPackage ../development/python-modules/transformers { };
+
   sentinel = callPackage ../development/python-modules/sentinel { };
 
   sentry-sdk = callPackage ../development/python-modules/sentry-sdk {};


### PR DESCRIPTION
Adding the [transformers](https://github.com/huggingface/transformers) library for DeepLearning along side the dependencies to build it.

###### Motivation for this change
Wanted to build the transformers library for ML work.

This is my first PR into NixOS, so please let me know if I am doing something wrong and I will try to rectify this in the future, but I struggled quite a bit through this - so happy that it builds. This builds on my system and made sure this builds with Sandboxing. 

Wasn't sure if I had to create multiple PR's for each separate package that transformers depends on, but it's all in here. 

Tests for transformers exist, but i don't think they will work in sandboxing because they require downloading packages from s3, and also require to have tensorflow or pytorch installed... I will try to get them to work one more time, but failed on first try.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jonringer @teh @FRidh - Not sure who I am supposed to be tagging for PR's that don't have any maintainers. 
