### PR TITLE
Disable native tests for john the ripper

### DIFF
--- a/pkgs/tools/security/john/default.nix
+++ b/pkgs/tools/security/john/default.nix
@@ -31,7 +31,10 @@ stdenv.mkDerivation rec {
     export AS=$CC
     export LD=$CC
   '';
-  configureFlags = [ "--disable-native-macro" ];
+  configureFlags = [
+    "--disable-native-tests"
+    "--with-systemwide"
+  ];
 
   buildInputs = [ openssl nss nspr kerberos gmp zlib libpcap re2 ];
   nativeBuildInputs = [ gcc python3Packages.wrapPython perl makeWrapper ];
@@ -43,8 +46,6 @@ stdenv.mkDerivation rec {
   # gcc -DAC_BUILT -Wall vncpcap2john.o memdbg.o -g    -lpcap -fopenmp -o ../run/vncpcap2john
   # gcc: error: memdbg.o: No such file or directory
   enableParallelBuilding = false;
-
-  NIX_CFLAGS_COMPILE = [ "-DJOHN_SYSTEMWIDE=1" ];
 
   postInstall = ''
     mkdir -p "$out/bin" "$out/etc/john" "$out/share/john" "$out/share/doc/john"

--- a/pkgs/tools/security/john/default.nix
+++ b/pkgs/tools/security/john/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     description = "John the Ripper password cracker";
     license = licenses.gpl2;
     homepage = https://github.com/magnumripper/JohnTheRipper/;
-    maintainers = with maintainers; [ offline ];
-    platforms = [ "x86_64-linux" "x86_64-darwin"];
+    maintainers = with maintainers; [ offline matthewbauer ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
