### PR TITLE
home-assistant: add zha

### DIFF
--- a/pkgs/development/python-modules/crccheck/default.nix
+++ b/pkgs/development/python-modules/crccheck/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, nose }:
+
+buildPythonPackage rec {
+  pname = "crccheck";
+  version = "0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "0ckymm6s5kw08i1j35fy2cfha1hyq94pq1kc66brb552qgjs91jn";
+  };
+
+  propagatedBuildInputs = [ nose ];
+
+  meta = with stdenv.lib; {
+    description = "Calculation library for CRCs and checksums";
+    homepage = https://bitbucket.org/martin_scharrer/crccheck;
+    maintainers = with maintainers; [ elseym ];
+  };
+}

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, zigpy, pytest }:
+
+buildPythonPackage rec {
+  pname = "zha-quirks";
+  version = "0.0.28";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "021z5f5dm74amxkqnz4s1690ydprciqg23jz3n4mpjlxyxbdfj73";
+  };
+
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ zigpy ];
+
+  meta = with stdenv.lib; {
+    description = "Library implementing Zigpy quirks for ZHA in Home Assistant";
+    homepage = https://github.com/dmulcahey/zha-device-handlers;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ elseym ];
+  };
+}

--- a/pkgs/development/python-modules/zigpy-deconz/default.nix
+++ b/pkgs/development/python-modules/zigpy-deconz/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pyserial-asyncio, zigpy
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "zigpy-deconz";
+  version = "0.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "049k6lvgf6yjkinbbzm7gqrzqljk2ky9kfw8n53x8kjyfmfp71i2";
+  };
+
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [ pyserial-asyncio zigpy ];
+
+  meta = with stdenv.lib; {
+    description = "A library which communicates with Deconz radios for zigpy";
+    homepage = http://github.com/zigpy/zigpy-deconz;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ elseym ];
+  };
+}

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, aiohttp, crccheck, pycryptodome
+, asynctest, pytest, pytest-asyncio }:
+
+buildPythonPackage rec {
+  pname = "zigpy";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "zigpy";
+    repo = "zigpy";
+    rev = version;
+    sha256 = "14a6hwsx9k1k775mx0g64l0nq6c6nsnqis9v157l9lx9vdqdzm4v";
+  };
+
+  buildInputs = [ asynctest pytest pytest-asyncio ];
+
+  propagatedBuildInputs = [ aiohttp crccheck pycryptodome ];
+
+  meta = with stdenv.lib; {
+    description = "Library implementing a ZigBee stack";
+    homepage = https://github.com/zigpy/zigpy;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ elseym ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -873,7 +873,7 @@
     "zengge" = ps: with ps; [  ];
     "zeroconf" = ps: with ps; [ aiohttp-cors zeroconf ];
     "zestimate" = ps: with ps; [ xmltodict ];
-    "zha" = ps: with ps; [  ];
+    "zha" = ps: with ps; [ zigpy zigpy-deconz zha-quirks ];
     "zhong_hong" = ps: with ps; [  ];
     "zigbee" = ps: with ps; [  ];
     "ziggo_mediabox_xl" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6597,6 +6597,8 @@ in {
 
   crccheck = callPackage ../development/python-modules/crccheck { };
 
+  zigpy-deconz = callPackage ../development/python-modules/zigpy-deconz { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6597,6 +6597,8 @@ in {
 
   crccheck = callPackage ../development/python-modules/crccheck { };
 
+  zha-quirks = callPackage ../development/python-modules/zha-quirks { };
+
   zigpy-deconz = callPackage ../development/python-modules/zigpy-deconz { };
 
 });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6593,6 +6593,8 @@ in {
 
   pony = callPackage ../development/python-modules/pony { };
 
+  zigpy = callPackage ../development/python-modules/zigpy { };
+
   crccheck = callPackage ../development/python-modules/crccheck { };
 
 });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6593,6 +6593,8 @@ in {
 
   pony = callPackage ../development/python-modules/pony { };
 
+  crccheck = callPackage ../development/python-modules/crccheck { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

adds the home-assistant zha-component with support for deconz hardware. tested with the ConBee II.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
