### PR TITLE
netboot: docs: building netboot should specify an arch

### DIFF
--- a/nixos/doc/manual/installation/installing-pxe.xml
+++ b/nixos/doc/manual/installation/installing-pxe.xml
@@ -16,7 +16,7 @@
  </para>
 
 <programlisting>
-nix-build -A netboot nixos/release.nix
+nix-build -A netboot.x86_64-linux nixos/release.nix
 </programlisting>
 
  <para>


### PR DESCRIPTION
##### Motivation for this change
The command currently listed in the documentation does not work. It tries to build all architectures and fails on aarch64-linux.

###### Things done

- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
