### PR TITLE
phoronix-test-suite: add tests

### DIFF
--- a/pkgs/tools/misc/phoronix-test-suite/default.nix
+++ b/pkgs/tools/misc/phoronix-test-suite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, php, which, gnused, makeWrapper, gnumake, gcc }:
+{ stdenv, fetchurl, php, which, gnused, makeWrapper, gnumake, gcc, callPackage }:
 
 stdenv.mkDerivation rec {
   pname = "phoronix-test-suite";
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
     --set PHP_BIN ${php}/bin/php \
     --prefix PATH : ${stdenv.lib.makeBinPath [ gnumake gcc ]}
   '';
+
+  passthru.tests = {
+    simple-execution = callPackage ./tests.nix { };
+  };
 
   meta = with stdenv.lib; {
     description = "Open-Source, Automated Benchmarking";

--- a/pkgs/tools/misc/phoronix-test-suite/tests.nix
+++ b/pkgs/tools/misc/phoronix-test-suite/tests.nix
@@ -1,0 +1,20 @@
+{ runCommand, phoronix-test-suite }:
+
+let
+  inherit (phoronix-test-suite) pname version;
+in
+
+runCommand "${pname}-tests" { meta.timeout = 3; }
+  ''
+    # automatic initial setup to prevent interactive questions
+    ${phoronix-test-suite}/bin/phoronix-test-suite enterprise-setup >/dev/null
+    # get version of installed program and compare with package version
+    if [[ `${phoronix-test-suite}/bin/phoronix-test-suite version` != *"${version}"*  ]]; then
+      echo "Error: program version does not match package version"
+      exit 1
+    fi
+    # run dummy command
+    ${phoronix-test-suite}/bin/phoronix-test-suite dummy_module.dummy-command >/dev/null
+    # needed for Nix to register the command as successful
+    touch $out
+  ''


### PR DESCRIPTION
###### Motivation for this change

Add tests to make reviews easier and the package more stable.

This is my attempt to implement package testing like discussed in https://github.com/NixOS/nixpkgs/issues/73076#issuecomment-552046457.

Please provide feedback!

Some aspects might be controversial like `with phoronix-test-suite;`. It allows to simply use `"${version}"` in the tests, but using `with` was discouraged for some reason.

Also what about naming?

```
  passthru.tests = {
    tests = callPackage ./tests.nix { };
  };
```

tests tests tests don't read nicely. should we call it "simple" or "basic"?

When it is approved i would like to add tests to more packages and document it.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jtojnar @worldofpeace @Profpatsch @7c6f434c
