### PR TITLE
[r19.03] ghostscript: catch up with many CVE patches

### DIFF
--- a/pkgs/misc/ghostscript/9.26-CVE-2019-10216.patch
+++ b/pkgs/misc/ghostscript/9.26-CVE-2019-10216.patch
@@ -1,9 +1,21 @@
-Based on upstream commit 5b85ddd19a8420a1bd2d5529325be35d78e94234
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Fri, 2 Aug 2019 15:18:26 +0100
+Subject: Bug 701394: protect use of .forceput with executeonly
+Origin: http://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=5b85ddd19a8420a1bd2d5529325be35d78e94234
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2019-10216
+Bug: https://bugs.ghostscript.com/show_bug.cgi?id=701394
+
+---
+ Resource/Init/gs_type1.ps | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/Resource/Init/gs_type1.ps b/Resource/Init/gs_type1.ps
+index 6c7735bc0cc3..a039ccee3590 100644
 --- a/Resource/Init/gs_type1.ps
 +++ b/Resource/Init/gs_type1.ps
 @@ -118,25 +118,25 @@
                           ( to be the same as glyph: ) print 1 index //== exec } if
-                    3 index exch 3 index //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
+                    3 index exch 3 index .forceput
                                                                   % scratch(string) RAGL(dict) AGL(dict) CharStrings(dict) cstring gname
 -                 }
 +                 }executeonly
@@ -28,9 +40,12 @@ Based on upstream commit 5b85ddd19a8420a1bd2d5529325be35d78e94234
 -     } if
 +     } executeonly if
       pop
-      dup /.AGLprocessed~GS //true //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
+      dup /.AGLprocessed~GS //true .forceput
 -   } if
 +   } executeonly if
  
     %% We need to excute the C .buildfont1 in a stopped context so that, if there
     %% are errors we can put the stack back sanely and exit. Otherwise callers won't
+-- 
+2.20.1
+

--- a/pkgs/misc/ghostscript/9.26-CVE-2019-10216.patch
+++ b/pkgs/misc/ghostscript/9.26-CVE-2019-10216.patch
@@ -1,0 +1,36 @@
+Based on upstream commit 5b85ddd19a8420a1bd2d5529325be35d78e94234
+--- a/Resource/Init/gs_type1.ps
++++ b/Resource/Init/gs_type1.ps
+@@ -118,25 +118,25 @@
+                          ( to be the same as glyph: ) print 1 index //== exec } if
+                    3 index exch 3 index //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
+                                                                  % scratch(string) RAGL(dict) AGL(dict) CharStrings(dict) cstring gname
+-                 }
++                 }executeonly
+                  {pop} ifelse
+-               } forall
++               } executeonly forall
+                pop pop
+-             }
++             } executeonly
+              {
+                pop pop pop
+              } ifelse
+-           }
++           } executeonly
+            {
+                                                                % scratch(string) RAGL(dict) AGL(dict) CharStrings(dict) cstring gname
+              pop pop
+            } ifelse
+-         } forall
++         } executeonly forall
+          3 1 roll pop pop
+-     } if
++     } executeonly if
+      pop
+      dup /.AGLprocessed~GS //true //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
+-   } if
++   } executeonly if
+ 
+    %% We need to excute the C .buildfont1 in a stopped context so that, if there
+    %% are errors we can put the stack back sanely and exit. Otherwise callers won't

--- a/pkgs/misc/ghostscript/9.26-CVE-2019-14869.patch
+++ b/pkgs/misc/ghostscript/9.26-CVE-2019-14869.patch
@@ -1,0 +1,58 @@
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Tue, 5 Nov 2019 09:45:27 +0000
+Subject: Bug 701841: remove .forceput from /.charkeys
+Origin: https://git.ghostscript.com/?p=ghostpdl.git;a=commit;h=485904772c5f0aa1140032746e5a0abfc40f4cef
+Bug: https://bugs.ghostscript.com/show_bug.cgi?id=701841
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2019-14869
+
+When loading Type 1 or Truetype fonts from disk, we attempt to extend the glyph
+name table to include all identifiable glyph names from the Adobe Glyph List.
+
+In the case of Type 1 fonts, the font itself (almost always) marks the
+CharStrings dictionary as read-only, hence we have to use .forceput for that
+case.
+
+But for Truetype fonts, the CharStrings dictionary is created internally and is
+not read-only until *after* we have fully populated it (including the extended
+glyph names from the AGL), hence there is no need for .forceput, and no need to
+carry the security risk of using it.
+
+Replace with regular put.
+[Salvatore Bonaccorso: Backport to 9.26a: Drop last hunck removing
+'executeonly' (hiding .forceput) as this was never added back in 9.26a. Thanks
+to Marc Deslauriers for pointing this out]
+---
+ Resource/Init/gs_ttf.ps | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Resource/Init/gs_ttf.ps b/Resource/Init/gs_ttf.ps
+index 74043d16b0cf..6be8fe9955cd 100644
+--- a/Resource/Init/gs_ttf.ps
++++ b/Resource/Init/gs_ttf.ps
+@@ -1304,7 +1304,7 @@ currentdict /.pickcmap_with_no_xlatmap .undef
+           TTFDEBUG { (\n1 setting alias: ) print dup ==only
+                 ( to be the same as  ) print 2 index //== exec } if
+ 
+-          7 index 2 index 3 -1 roll exch .forceput
++          7 index 2 index 3 -1 roll exch put
+         } forall
+         pop pop pop
+       }
+@@ -1322,7 +1322,7 @@ currentdict /.pickcmap_with_no_xlatmap .undef
+           exch pop
+           TTFDEBUG { (\n2 setting alias: ) print 1 index ==only
+                      ( to use glyph index: ) print dup //== exec } if
+-          5 index 3 1 roll .forceput
++          5 index 3 1 roll put
+           //false
+         }
+         {
+@@ -1339,7 +1339,7 @@ currentdict /.pickcmap_with_no_xlatmap .undef
+         {                            %  CharStrings(dict) isunicode(boolean) cmap(dict) RAGL(dict) gname(name) codep(integer) gindex(integer)
+           TTFDEBUG { (\3 nsetting alias: ) print 1 index ==only
+                 ( to be index: ) print dup //== exec } if
+-          exch pop 5 index 3 1 roll .forceput
++          exch pop 5 index 3 1 roll put
+         }
+         {
+           pop pop

--- a/pkgs/misc/ghostscript/9.26-CVE-2019-3835-part-1.patch
+++ b/pkgs/misc/ghostscript/9.26-CVE-2019-3835-part-1.patch
@@ -1,0 +1,94 @@
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Mon, 26 Nov 2018 18:01:25 +0000
+Subject: Have gs_cet.ps run from gs_init.ps
+Origin: https://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=779664d79f0dca77dbdd66b753679bfd12dcbbad
+
+Previously gs_cet.ps was run on the command line, to set up the interpreter
+state so our output more closely matches the example output for the QL CET
+tests.
+
+Allow a -dCETMODE command line switch, which will cause gs_init.ps to run the
+file directly.
+
+This works better for gpdl as it means the changes are made in the intial
+interpreter state, rather than after initialisation is complete.
+
+This also means adding a definition of the default procedure for black
+generation and under color removal (rather it being defined in-line in
+.setdefaultbgucr
+
+Also, add a check so gs_cet.ps only runs once - if we try to run it a second
+time, we'll just skip over the file, flushing through to the end.
+---
+ Resource/Init/gs_cet.ps  | 11 ++++++++++-
+ Resource/Init/gs_init.ps | 13 ++++++++++++-
+ 2 files changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/Resource/Init/gs_cet.ps b/Resource/Init/gs_cet.ps
+index aff6aa9e6999..4261e795671c 100644
+--- a/Resource/Init/gs_cet.ps
++++ b/Resource/Init/gs_cet.ps
+@@ -1,6 +1,11 @@
+ %!PS
+ % Set defaults for Ghostscript to match Adobe CPSI behaviour for CET
+ 
++systemdict /product get (PhotoPRINT SE 5.0v2) readonly eq
++{
++  (%END GS_CET) .skipeof
++} if
++
+ % do this in the server level so it is persistent across jobs
+ //true 0 startjob not {
+   (*** Warning: CET startup is not in server default) = flush
+@@ -25,7 +30,9 @@ currentglobal //true setglobal
+ 
+ /UNROLLFORMS true def
+ 
+-{ } bind dup
++(%.defaultbgrucrproc) cvn { } bind def
++
++(%.defaultbgrucrproc) cvn load dup
+ setblackgeneration
+ setundercolorremoval
+ 0 array cvx readonly dup dup dup setcolortransfer
+@@ -114,3 +121,5 @@ userdict /.smoothness currentsmoothness put
+ % end of slightly nasty hack to give consistent cluster results
+ 
+ //false 0 startjob pop		% re-enter encapsulated mode
++
++%END GS_CET
+diff --git a/Resource/Init/gs_init.ps b/Resource/Init/gs_init.ps
+index 2fc46b127a46..780cb924ca57 100644
+--- a/Resource/Init/gs_init.ps
++++ b/Resource/Init/gs_init.ps
+@@ -1541,10 +1541,18 @@ setpacking
+   % any-part-of-pixel rule.
+   0.5 .setfilladjust
+ } bind def
++
+ % Set the default screen and BG/UCR.
++% We define the proc here, rather than inline in .setdefaultbgucr
++% for the benefit of gs_cet.ps so jobs that do anything that causes
++% .setdefaultbgucr to be called will still get the redefined proc
++% in gs_cet.ps
++(%.defaultbgrucrproc) cvn { pop 0 } def
++
+ /.setdefaultbgucr {
+   systemdict /setblackgeneration known {
+-    { pop 0 } dup setblackgeneration setundercolorremoval
++    (%.defaultbgrucrproc) cvn load dup
++    setblackgeneration setundercolorremoval
+   } if
+ } bind def
+ /.useloresscreen {	% - .useloresscreen <bool>
+@@ -2512,4 +2520,7 @@ WRITESYSTEMDICT {
+ % be 'true' in some cases.
+ userdict /AGM_preserve_spots //false put
+ 
++systemdict /CETMODE .knownget
++{ { (gs_cet.ps) runlibfile } if } if
++
+ % The interpreter will run the initial procedure (start).
+-- 
+2.11.0
+

--- a/pkgs/misc/ghostscript/9.26-CVE-2019-3835-part-2.patch
+++ b/pkgs/misc/ghostscript/9.26-CVE-2019-3835-part-2.patch
@@ -1,0 +1,60 @@
+From: Nancy Durgin <nancy.durgin@artifex.com>
+Date: Thu, 14 Feb 2019 10:09:00 -0800
+Subject: Undef /odef in gs_init.ps
+Origin: https://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=e8acf6d1aa1fc92f453175509bfdad6f2b12dc73
+
+Made a new temporary utility function in gs_cet.ps (.odef) to use instead
+of /odef.  This makes it fine to undef odef with all the other operators in
+gs_init.ps
+
+This punts the bigger question of what to do with .makeoperator, but it
+doesn't make the situation any worse than it already was.
+[Salvatore Bonaccorso: Backport for context in 9.26a]
+---
+ Resource/Init/gs_cet.ps  | 14 ++++++++++----
+ Resource/Init/gs_init.ps |  1 +
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+--- a/Resource/Init/gs_cet.ps
++++ b/Resource/Init/gs_cet.ps
+@@ -1,6 +1,10 @@
+ %!PS
+ % Set defaults for Ghostscript to match Adobe CPSI behaviour for CET
+ 
++/.odef {		% <name> <proc> odef -
++  1 index exch .makeoperator def
++} bind def
++
+ systemdict /product get (PhotoPRINT SE 5.0v2) readonly eq
+ {
+   (%END GS_CET) .skipeof
+@@ -93,8 +97,8 @@ userdict /.smoothness currentsmoothness
+    } {
+      /setsmoothness .systemvar /typecheck signalerror
+    } ifelse
+-} bind odef
+-/currentsmoothness { userdict /.smoothness get } bind odef % for 09-55.PS, 09-57.PS .
++} bind //.odef exec
++/currentsmoothness { userdict /.smoothness get } bind //.odef exec % for 09-55.PS, 09-57.PS .
+ 
+ % slightly nasty hack to give consistent cluster results
+ /ofnfa systemdict /filenameforall get def
+@@ -113,6 +117,8 @@ userdict /.smoothness currentsmoothness
+   } ifelse
+   ofnfa
+ } bind def
++
++currentdict /.odef undef
+ % end of slightly nasty hack to give consistent cluster results
+ 
+ //false 0 startjob pop		% re-enter encapsulated mode
+--- a/Resource/Init/gs_init.ps
++++ b/Resource/Init/gs_init.ps
+@@ -2263,6 +2263,7 @@ SAFER { .setsafeglobal } if
+   /.systemvmSFD /.settrapparams /.currentsystemparams /.currentuserparams /.getsystemparam /.getuserparam /.setsystemparams /.setuserparams
+   /.checkpassword /.locale_to_utf8 /.currentglobal /.gcheck /.imagepath /.currentoutputdevice
+   /.type /.writecvs /.setSMask /.currentSMask /.needinput /.countexecstack /.execstack /.applypolicies
++  /odef
+ 
+   % Used by a free user in the Library of Congress. Apparently this is used to
+   % draw a partial page, which is then filled in by the results of a barcode

--- a/pkgs/misc/ghostscript/9.26-CVE-2019-3835-part-3.patch
+++ b/pkgs/misc/ghostscript/9.26-CVE-2019-3835-part-3.patch
@@ -1,0 +1,269 @@
+From: Ray Johnston <ray.johnston@artifex.com>
+Date: Thu, 14 Feb 2019 10:20:03 -0800
+Subject: Fix bug 700585: Restrict superexec and remove it from internals and
+ gs_cet.ps
+Origin: https://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=205591753126802da850ada6511a0ff8411aa287
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2019-3835
+Bug-Debian: https://bugs.debian.org/925256
+Bug: https://bugs.ghostscript.com/show_bug.cgi?id=700585
+
+Also while changing things, restructure the CETMODE so that it will
+work with -dSAFER. The gs_cet.ps is now run when we are still at save
+level 0 with systemdict writeable. Allows us to undefine .makeoperator
+and .setCPSImode internal operators after CETMODE is handled.
+
+Change previous uses of superexec to using .forceput (with the usual
+.bind executeonly to hide it).
+[Salvatore Bonaccorso: Backport for context in 9.26a]
+---
+ Resource/Init/gs_cet.ps   | 37 ++++++++++++++-----------------------
+ Resource/Init/gs_dps1.ps  |  2 +-
+ Resource/Init/gs_fonts.ps |  8 ++++----
+ Resource/Init/gs_init.ps  | 38 +++++++++++++++++++++++++++-----------
+ Resource/Init/gs_ttf.ps   |  8 ++++----
+ Resource/Init/gs_type1.ps |  6 +++---
+ 6 files changed, 53 insertions(+), 46 deletions(-)
+
+--- a/Resource/Init/gs_cet.ps
++++ b/Resource/Init/gs_cet.ps
+@@ -1,36 +1,28 @@
+-%!PS
+ % Set defaults for Ghostscript to match Adobe CPSI behaviour for CET
+ 
+-/.odef {		% <name> <proc> odef -
+-  1 index exch .makeoperator def
+-} bind def
+-
++% skip if we've already run this -- based on fake "product"
+ systemdict /product get (PhotoPRINT SE 5.0v2) readonly eq
+ {
+   (%END GS_CET) .skipeof
+ } if
+ 
+-% do this in the server level so it is persistent across jobs
+-//true 0 startjob not {
+-  (*** Warning: CET startup is not in server default) = flush
+-} if
++% Note: this must be run at save level 0 and when systemdict is writeable
++currentglobal //true setglobal
++systemdict dup dup dup
++/version (3017.102) readonly .forceput		% match CPSI 3017.102
++/product (PhotoPRINT SE 5.0v2) readonly .forceput	% match CPSI 3017.102
++/revision 0 put			% match CPSI 3017.103 Tek shows revision 5
++/serialnumber dup {233640} readonly .makeoperator .forceput % match CPSI 3017.102 Tek shows serialnumber 1401788461
++
++systemdict /.odef {           % <name> <proc> odef -
++  1 index exch //.makeoperator def
++} .bind .forceput          % this will be undefined at the end
+ 
+ 300 .sethiresscreen	% needed for language switch build since it
+                         % processes gs_init.ps BEFORE setting the resolution
+ 
+ 0 array 0 setdash % CET 09-08 wants local setdash
+ 
+-currentglobal //true setglobal
+-
+-{
+-  systemdict dup dup dup
+-  /version (3017.102) readonly put		% match CPSI 3017.102
+-  /product (PhotoPRINT SE 5.0v2) readonly put	% match CPSI 3017.102
+-  /revision 0 put			% match CPSI 3017.103 Tek shows revision 5
+-  /serialnumber dup {233640} readonly .makeoperator put % match CPSI 3017.102 Tek shows serialnumber 1401788461
+-  systemdict /deviceinfo undef                  % for CET 20-23-1
+-%  /UNROLLFORMS true put                 % CET files do unreasonable things inside forms
+-} 1183615869 internaldict /superexec get exec
+ 
+ /UNROLLFORMS true def
+ 
+@@ -118,9 +110,7 @@ userdict /.smoothness currentsmoothness
+   ofnfa
+ } bind def
+ 
+-currentdict /.odef undef
+-% end of slightly nasty hack to give consistent cluster results
+-
+-//false 0 startjob pop		% re-enter encapsulated mode
++systemdict /.odef .undef
+ 
++% end of slightly nasty hack to give consistent cluster results
+ %END GS_CET
+--- a/Resource/Init/gs_dps1.ps
++++ b/Resource/Init/gs_dps1.ps
+@@ -85,7 +85,7 @@ level2dict begin
+                 % definition, copy it into the local directory.
+       //systemdict /SharedFontDirectory .knownget
+        { 1 index .knownget
+-          { //.FontDirectory 2 index 3 -1 roll { put } systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse } % readonly
++          { //.FontDirectory 2 index 3 -1 roll .forceput } % readonly
+          if
+        }
+       if
+--- a/Resource/Init/gs_fonts.ps
++++ b/Resource/Init/gs_fonts.ps
+@@ -512,11 +512,11 @@ buildfontdict 3 /.buildfont3 cvx put
+                 % the font in LocalFontDirectory.
+    .currentglobal
+     { //systemdict /LocalFontDirectory .knownget
+-       { 2 index 2 index { .growput } systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse }	% readonly
++       { 2 index 2 index .forceput }	% readonly
+       if
+     }
+    if
+-   dup //.FontDirectory 4 -2 roll { .growput } systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse	% readonly
++   dup //.FontDirectory 4 -2 roll .forceput % readonly
+                 % If the font originated as a resource, register it.
+    currentfile .currentresourcefile eq { dup .registerfont } if
+    readonly
+@@ -1179,13 +1179,13 @@ currentdict /.putgstringcopy .undef
+           //.FontDirectory 1 index known not {
+             2 dict dup /FontName 3 index put
+             dup /FontType 1 put
+-            //.FontDirectory 3 1 roll { put } systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse   % readonly
++            //.FontDirectory 3 1 roll //.forceput exec % readonly
+           } {
+             pop
+           } ifelse
+         } forall
+       } forall
+-    }
++    } executeonly	% hide .forceput
+ FAKEFONTS { exch } if pop def   % don't bind, .current/setglobal get redefined
+ 
+ % Install initial fonts from Fontmap.
+--- a/Resource/Init/gs_init.ps
++++ b/Resource/Init/gs_init.ps
+@@ -2194,9 +2194,6 @@ SAFER { .setsafeglobal } if
+   /.endtransparencygroup     % transparency-example.ps
+   /.setdotlength             % Bug687720.ps
+   /.sort /.setdebug /.mementolistnewblocks /getenv
+-
+-  /.makeoperator /.setCPSImode              % gs_cet.ps, this won't work on cluster with -dSAFER
+-
+   /unread
+   ]
+   {systemdict exch .forceundef} forall
+@@ -2276,7 +2273,6 @@ SAFER { .setsafeglobal } if
+ 
+   % Used by our own test suite files
+   %/.fileposition %image-qa.ps
+-  %/.makeoperator /.setCPSImode % gs_cet.ps
+ 
+   % Either our code uses these in ways which mean they can't be undefined, or they are used directly by
+   % test files/utilities, or engineers expressed a desire to keep them visible.
+@@ -2464,6 +2460,16 @@ end
+ /vmreclaim where
+  { pop NOGC not { 2 .vmreclaim 0 vmreclaim } if
+  } if
++
++% Do this before systemdict is locked (see below for additional CETMODE setup using gs_cet.ps)
++systemdict /CETMODE .knownget {
++  {
++    (gs_cet.ps) runlibfile
++  } if
++} if
++systemdict /.makeoperator .undef	% must be after gs_cet.ps
++systemdict /.setCPSImode .undef		% must be after gs_cet.ps
++
+ DELAYBIND not {
+   systemdict /.bindnow .undef       % We only need this for DELAYBIND
+   systemdict /.forcecopynew .undef	% remove temptation
+@@ -2472,16 +2478,29 @@ DELAYBIND not {
+   systemdict /.forceundef .undef	% ditto
+ } if
+ 
+-% Move superexec to internaldict if superexec is defined.
+-systemdict /superexec .knownget {
+-  1183615869 internaldict /superexec 3 -1 roll put
+-  systemdict /superexec .undef
++% Move superexec to internaldict if superexec is defined. (Level 2 or later)
++systemdict /superexec known {
++  % restrict superexec to single known use by PScript5.dll
++  % We could do this only for SAFER mode, but internaldict and superexec are
++  % not very well documented, and we don't want them to be used.
++  1183615869 internaldict /superexec {
++    2 index /Private eq		% first check for typical use in PScript5.dll
++    1 index length 1 eq and	% expected usage is: dict /Private <value> {put} superexec
++    1 index 0 get systemdict /put get eq and
++    {
++      //superexec exec		% the only usage we allow
++    } {
++      /superexec load /invalidaccess signalerror
++    } ifelse
++  } bind cvx executeonly put
++  systemdict /superexec .undef	% get rid of the dangerous (unrestricted) operator
+ } if
+ 
+ % Can't remove this one until the last minute :-)
+ DELAYBIND not {
+ systemdict /.undef .undef
+ } if
++
+ WRITESYSTEMDICT {
+    SAFER {
+        (\n *** WARNING - you have selected SAFER, indicating you want Ghostscript\n) print
+@@ -2508,7 +2527,4 @@ WRITESYSTEMDICT {
+ % be 'true' in some cases.
+ userdict /AGM_preserve_spots //false put
+ 
+-systemdict /CETMODE .knownget
+-{ { (gs_cet.ps) runlibfile } if } if
+-
+ % The interpreter will run the initial procedure (start).
+--- a/Resource/Init/gs_ttf.ps
++++ b/Resource/Init/gs_ttf.ps
+@@ -1421,7 +1421,7 @@ mark
+           TTFDEBUG { (\n1 setting alias: ) print dup ==only
+                 ( to be the same as  ) print 2 index //== exec } if
+ 
+-          7 index 2 index 3 -1 roll exch //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
++          7 index 2 index 3 -1 roll exch .forceput
+         } forall
+         pop pop pop
+       }
+@@ -1439,7 +1439,7 @@ mark
+           exch pop
+           TTFDEBUG { (\n2 setting alias: ) print 1 index ==only
+                      ( to use glyph index: ) print dup //== exec } if
+-          5 index 3 1 roll //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
++          5 index 3 1 roll .forceput
+           //false
+         }
+         {
+@@ -1456,7 +1456,7 @@ mark
+         {                            %  CharStrings(dict) isunicode(boolean) cmap(dict) RAGL(dict) gname(name) codep(integer) gindex(integer)
+           TTFDEBUG { (\3 nsetting alias: ) print 1 index ==only
+                 ( to be index: ) print dup //== exec } if
+-          exch pop 5 index 3 1 roll //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
++          exch pop 5 index 3 1 roll .forceput
+         }
+         {
+           pop pop
+--- a/Resource/Init/gs_type1.ps
++++ b/Resource/Init/gs_type1.ps
+@@ -116,7 +116,7 @@
+                  {                                               % scratch(string) RAGL(dict) AGL(dict) CharStrings(dict) cstring gname aglname
+                    CFFDEBUG { (\nsetting alias: ) print dup ==only
+                          ( to be the same as glyph: ) print 1 index //== exec } if
+-                   3 index exch 3 index //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
++                   3 index exch 3 index .forceput
+                                                                  % scratch(string) RAGL(dict) AGL(dict) CharStrings(dict) cstring gname
+                  }
+                  {pop} ifelse
+@@ -135,7 +135,7 @@
+          3 1 roll pop pop
+      } if
+      pop
+-     dup /.AGLprocessed~GS //true //.growput systemdict /superexec known {//superexec}{1183615869 internaldict /superexec get exec} ifelse
++     dup /.AGLprocessed~GS //true .forceput
+    } if
+ 
+    %% We need to excute the C .buildfont1 in a stopped context so that, if there
+@@ -148,7 +148,7 @@
+    {//.buildfont1} stopped
+    4 3 roll .setglobal
+    {//.buildfont1 $error /errorname get signalerror} if
+- } bind def
++ } .bind executeonly def	% hide .forceput
+ 
+ % If the diskfont feature isn't included, define a dummy .loadfontdict.
+ /.loadfontdict where

--- a/pkgs/misc/ghostscript/9.26-CVE-2019-3835-part-4.patch
+++ b/pkgs/misc/ghostscript/9.26-CVE-2019-3835-part-4.patch
@@ -1,0 +1,151 @@
+From: Ray Johnston <ray.johnston@artifex.com>
+Date: Sun, 24 Feb 2019 22:01:04 -0800
+Subject: Bug 700585: Obliterate "superexec". We don't need it, nor do any
+ known apps.
+Origin: https://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=d683d1e6450d74619e6277efeebfc222d9a5cb91
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2019-3835
+Bug-Debian: https://bugs.debian.org/925256
+Bug: https://bugs.ghostscript.com/show_bug.cgi?id=700585
+
+We were under the impression that the Windows driver 'PScript5.dll' used
+superexec, but after testing with our extensive suite of PostScript file,
+and analysis of the PScript5 "Adobe CoolType ProcSet, it does not appear
+that this operator is needed anymore. Get rid of superexec and all of the
+references to it, since it is a potential security hole.
+[Salvatore Bonaccorso: Backport for context in 9.26a]
+---
+ Resource/Init/gs_init.ps | 18 ------------------
+ psi/icontext.c           |  1 -
+ psi/icstate.h            |  1 -
+ psi/zcontrol.c           | 30 ------------------------------
+ psi/zdict.c              |  6 ++----
+ psi/zgeneric.c           |  3 +--
+ 6 files changed, 3 insertions(+), 56 deletions(-)
+
+--- a/Resource/Init/gs_init.ps
++++ b/Resource/Init/gs_init.ps
+@@ -2478,24 +2478,6 @@ DELAYBIND not {
+   systemdict /.forceundef .undef	% ditto
+ } if
+ 
+-% Move superexec to internaldict if superexec is defined. (Level 2 or later)
+-systemdict /superexec known {
+-  % restrict superexec to single known use by PScript5.dll
+-  % We could do this only for SAFER mode, but internaldict and superexec are
+-  % not very well documented, and we don't want them to be used.
+-  1183615869 internaldict /superexec {
+-    2 index /Private eq		% first check for typical use in PScript5.dll
+-    1 index length 1 eq and	% expected usage is: dict /Private <value> {put} superexec
+-    1 index 0 get systemdict /put get eq and
+-    {
+-      //superexec exec		% the only usage we allow
+-    } {
+-      /superexec load /invalidaccess signalerror
+-    } ifelse
+-  } bind cvx executeonly put
+-  systemdict /superexec .undef	% get rid of the dangerous (unrestricted) operator
+-} if
+-
+ % Can't remove this one until the last minute :-)
+ DELAYBIND not {
+ systemdict /.undef .undef
+--- a/psi/icontext.c
++++ b/psi/icontext.c
+@@ -151,7 +151,6 @@ context_state_alloc(gs_context_state_t *
+     pcst->rand_state = rand_state_initial;
+     pcst->usertime_total = 0;
+     pcst->keep_usertime = false;
+-    pcst->in_superexec = 0;
+     pcst->plugin_list = 0;
+     make_t(&pcst->error_object, t__invalid);
+     {	/*
+--- a/psi/icstate.h
++++ b/psi/icstate.h
+@@ -54,7 +54,6 @@ struct gs_context_state_s {
+     long usertime_total;	/* total accumulated usertime, */
+                                 /* not counting current time if running */
+     bool keep_usertime;		/* true if context ever executed usertime */
+-    int in_superexec;		/* # of levels of superexec */
+     /* View clipping is handled in the graphics state. */
+     ref error_object;		/* t__invalid or error object from operator */
+     ref userparams;		/* t_dictionary */
+--- a/psi/zcontrol.c
++++ b/psi/zcontrol.c
+@@ -158,34 +158,6 @@ zexecn(i_ctx_t *i_ctx_p)
+     return o_push_estack;
+ }
+ 
+-/* <obj> superexec - */
+-static int end_superexec(i_ctx_t *);
+-static int
+-zsuperexec(i_ctx_t *i_ctx_p)
+-{
+-    os_ptr op = osp;
+-    es_ptr ep;
+-
+-    check_op(1);
+-    if (!r_has_attr(op, a_executable))
+-        return 0;		/* literal object just gets pushed back */
+-    check_estack(2);
+-    ep = esp += 3;
+-    make_mark_estack(ep - 2, es_other, end_superexec); /* error case */
+-    make_op_estack(ep - 1,  end_superexec); /* normal case */
+-    ref_assign(ep, op);
+-    esfile_check_cache();
+-    pop(1);
+-    i_ctx_p->in_superexec++;
+-    return o_push_estack;
+-}
+-static int
+-end_superexec(i_ctx_t *i_ctx_p)
+-{
+-    i_ctx_p->in_superexec--;
+-    return 0;
+-}
+-
+ /* <array> <executable> .runandhide <obj>				*/
+ /* 	before executing  <executable>, <array> is been removed from	*/
+ /*	the operand stack and placed on the execstack with attributes	*/
+@@ -971,8 +943,6 @@ const op_def zcontrol3_op_defs[] = {
+     {"0%loop_continue", loop_continue},
+     {"0%repeat_continue", repeat_continue},
+     {"0%stopped_push", stopped_push},
+-    {"1superexec", zsuperexec},
+-    {"0%end_superexec", end_superexec},
+     {"2.runandhide", zrunandhide},
+     {"0%end_runandhide", end_runandhide},
+     op_def_end(0)
+--- a/psi/zdict.c
++++ b/psi/zdict.c
+@@ -212,8 +212,7 @@ zundef(i_ctx_t *i_ctx_p)
+     int code;
+ 
+     check_type(*op1, t_dictionary);
+-    if (i_ctx_p->in_superexec == 0)
+-        check_dict_write(*op1);
++    check_dict_write(*op1);
+     code = idict_undef(op1, op);
+     if (code < 0 && code != gs_error_undefined) /* ignore undefined error */
+         return code;
+@@ -504,8 +503,7 @@ zsetmaxlength(i_ctx_t *i_ctx_p)
+     int code;
+ 
+     check_type(*op1, t_dictionary);
+-    if (i_ctx_p->in_superexec == 0)
+-        check_dict_write(*op1);
++    check_dict_write(*op1);
+     check_type(*op, t_integer);
+     if (op->value.intval < 0)
+         return_error(gs_error_rangecheck);
+--- a/psi/zgeneric.c
++++ b/psi/zgeneric.c
+@@ -204,8 +204,7 @@ zput(i_ctx_t *i_ctx_p)
+ 
+     switch (r_type(op2)) {
+         case t_dictionary:
+-            if (i_ctx_p->in_superexec == 0)
+-                check_dict_write(*op2);
++            check_dict_write(*op2);
+             {
+                 int code = idict_put(op2, op1, op);
+ 

--- a/pkgs/misc/ghostscript/9.26-CVE-2019-3838-part-1.patch
+++ b/pkgs/misc/ghostscript/9.26-CVE-2019-3838-part-1.patch
@@ -1,0 +1,27 @@
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Wed, 20 Feb 2019 09:54:28 +0000
+Subject: Bug 700576: Make a transient proc executeonly (in DefineResource).
+Origin: https://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=ed9fcd95bb01f0768bf273b2526732e381202319
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2019-3838
+Bug-Debian: https://bugs.debian.org/925257
+Bug: https://bugs.ghostscript.com/show_bug.cgi?id=700576
+
+This prevents access to .forceput
+
+Solution originally suggested by cbuissar@redhat.com.
+[Salvatore Bonaccorso: Backport for context in 9.26a]
+---
+ Resource/Init/gs_res.ps | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/Resource/Init/gs_res.ps
++++ b/Resource/Init/gs_res.ps
+@@ -425,7 +425,7 @@ status {
+                         % so we have to use .forcedef here.
+                   /.Instances 1 index .forcedef	% Category dict is read-only
+                 } executeonly if
+-              }
++              } executeonly
+               { .LocalInstances dup //.emptydict eq
+                  { pop 3 dict localinstancedict Category 2 index put
+                  }

--- a/pkgs/misc/ghostscript/9.26-CVE-2019-3838-part-2.patch
+++ b/pkgs/misc/ghostscript/9.26-CVE-2019-3838-part-2.patch
@@ -1,0 +1,28 @@
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Fri, 22 Feb 2019 12:28:23 +0000
+Subject: Bug 700576(redux): an extra transient proc needs executeonly'ed.
+Origin: https://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=a82601e8f95a2f2147f3b3b9e44ec2b8f3a6be8b
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2019-3838
+Bug-Debian: https://bugs.debian.org/925257
+Bug: https://bugs.ghostscript.com/show_bug.cgi?id=700576
+
+---
+ Resource/Init/gs_res.ps | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Resource/Init/gs_res.ps b/Resource/Init/gs_res.ps
+index 82a1fdf3d5ee..1e28e25b1788 100644
+--- a/Resource/Init/gs_res.ps
++++ b/Resource/Init/gs_res.ps
+@@ -438,7 +438,7 @@ status {
+                         % Now make the resource value read-only.
+              0 2 copy get { readonly } .internalstopped pop
+              dup 4 1 roll put exch pop exch pop
+-           }
++           } executeonly
+            { /defineresource cvx /typecheck signaloperror
+            }
+         ifelse
+-- 
+2.11.0
+

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -51,6 +51,16 @@ stdenv.mkDerivation rec {
       url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=d3537a54740d78c5895ec83694a07b3e4f616f61";
       sha256 = "1hr8bpi87bbg1kvv28kflmfh1dhzxw66p9q0ddvbrj72qd86p3kx";
     })
+    (fetchpatch {
+      name = "CVE-2019-3839-part-1";
+      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=4ec9ca74bed49f2a82acb4bf430eae0d8b3b75c9";
+      sha256 = "0gn1n9fq5msrxxzspidcnmykp1iv3yvx5485fddmgrslr52ngcf9";
+    })
+    (fetchpatch {
+      name = "CVE-2019-3839-part-2";
+      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=db24f253409d5d085c2760c814c3e1d3fa2dac59";
+      sha256 = "1h6kpwc6ryr6jlxjr6bfnvmmf8x0kqmyjlx3hggqjs23n0wsr9p9";
+    })
   ];
 
   outputs = [ "out" "man" "doc" ];

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -61,6 +61,20 @@ stdenv.mkDerivation rec {
       url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=db24f253409d5d085c2760c814c3e1d3fa2dac59";
       sha256 = "1h6kpwc6ryr6jlxjr6bfnvmmf8x0kqmyjlx3hggqjs23n0wsr9p9";
     })
+    ./9.26-CVE-2019-10216.patch
+    (fetchpatch {
+        name = "CVE-2019-14811.CVE-2019-14812.CVE-2019-14813.patch";
+        url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=885444fcbe10dc42787ecb76686c8ee4dd33bf33";
+        sha256 = "19928sr7xpx7iibk9gn127g0r1yv2lcfpwgk2ipzz4wgrs3f5j70";
+    })
+    (fetchpatch {
+        name = "CVE-2019-14817-partial.patch";
+        url = "https://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=cd1b1cacadac2479e291efe611979bdc1b3bdb19";
+        # patch doesn't apply cleanly to all files, but at least partially applying it fixes
+        # *some* of the problematic sites.
+        excludes = ["Resource/Init/pdf_font.ps" "Resource/Init/pdf_draw.ps"];
+        sha256 = "04sy05svm3d2hyyzq41x5aqg3cgg2shaq08ivdqsys95nlihccpn";
+    })
   ];
 
   outputs = [ "out" "man" "doc" ];

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -81,6 +81,7 @@ stdenv.mkDerivation rec {
         excludes = ["Resource/Init/pdf_font.ps" "Resource/Init/pdf_draw.ps"];
         sha256 = "04sy05svm3d2hyyzq41x5aqg3cgg2shaq08ivdqsys95nlihccpn";
     })
+    ./9.26-CVE-2019-14869.patch
   ];
 
   outputs = [ "out" "man" "doc" ];

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -51,6 +51,10 @@ stdenv.mkDerivation rec {
       url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=d3537a54740d78c5895ec83694a07b3e4f616f61";
       sha256 = "1hr8bpi87bbg1kvv28kflmfh1dhzxw66p9q0ddvbrj72qd86p3kx";
     })
+    ./9.26-CVE-2019-3835-part-1.patch
+    ./9.26-CVE-2019-3835-part-2.patch
+    ./9.26-CVE-2019-3835-part-3.patch
+    ./9.26-CVE-2019-3835-part-4.patch
     (fetchpatch {
       name = "CVE-2019-3839-part-1";
       url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=4ec9ca74bed49f2a82acb4bf430eae0d8b3b75c9";

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation rec {
     ./9.26-CVE-2019-3835-part-2.patch
     ./9.26-CVE-2019-3835-part-3.patch
     ./9.26-CVE-2019-3835-part-4.patch
+    ./9.26-CVE-2019-3838-part-1.patch
+    ./9.26-CVE-2019-3838-part-2.patch
     (fetchpatch {
       name = "CVE-2019-3839-part-1";
       url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=4ec9ca74bed49f2a82acb4bf430eae0d8b3b75c9";


### PR DESCRIPTION
###### Motivation for this change
Having the same base version as 19.09, it's easy enough to bring all the relevant patches up to the level of #73590.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
