### PR TITLE
pythonPackages.mapbox: init at 0.18.0

### DIFF
--- a/pkgs/development/python-modules/mapbox/default.nix
+++ b/pkgs/development/python-modules/mapbox/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, boto3
+, cachecontrol
+, fetchFromGitHub
+, iso3166
+, python-dateutil
+, requests
+, responses
+, polyline
+, pytestCheckHook
+, uritemplate
+}:
+
+buildPythonPackage rec {
+  pname = "mapbox";
+  version = "0.18.0";
+
+  src = fetchFromGitHub {
+    owner = "mapbox";
+    repo = "mapbox-sdk-py";
+    rev = "0.18.0";
+    sha256 = "123wsa4j11ps5pkjgylbmw4gnzh2vi22swgmvy50w26glkszh075";
+  };
+
+  propagatedBuildInputs = [ boto3 cachecontrol iso3166 python-dateutil requests polyline uritemplate ];
+  checkInputs = [ pytestCheckHook responses ];
+
+  meta = with lib; {
+    homepage = https://github.com/mapbox/mapbox-sdk-py;
+    license = licenses.mit;
+    description = "Mapbox SDK for Python";
+    longDescription = "Low-level client API for Mapbox web services.";
+    maintainers = with maintainers; [ ersin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -792,6 +792,8 @@ in {
 
   manhole = callPackage ../development/python-modules/manhole { };
 
+  mapbox = callPackage ../development/python-modules/mapbox { };
+
   markerlib = callPackage ../development/python-modules/markerlib { };
 
   matchpy = callPackage ../development/python-modules/matchpy { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[Add the Mapbox for Python SDK](https://github.com/mapbox/mapbox-sdk-py).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

N/A
