### PR TITLE
pythonPackages.{pandas,panel,pafy,ovh,opt-einsum,oauth,numpy}: fix homepage

### DIFF
--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -66,7 +66,7 @@ in buildPythonPackage rec {
 
   meta = {
     description = "Scientific tools for Python";
-    homepage = http://numpy.scipy.org/;
+    homepage = https://numpy.org/;
     maintainers = with lib.maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/oauth/default.nix
+++ b/pkgs/development/python-modules/oauth/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = http://code.google.com/p/oauth;
+    homepage = https://code.google.com/archive/p/oauth/;
     description = "Library for OAuth version 1.0a";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/opt-einsum/default.nix
+++ b/pkgs/development/python-modules/opt-einsum/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Optimizing NumPy's einsum function with order optimization and GPU support.";
-    homepage = http://optimized-einsum.readthedocs.io;
+    homepage = https://github.com/dgasmith/opt_einsum;
     license = licenses.mit;
     maintainers = with maintainers; [ teh ];
   };

--- a/pkgs/development/python-modules/ovh/default.nix
+++ b/pkgs/development/python-modules/ovh/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Thin wrapper around OVH's APIs";
-    homepage = http://api.ovh.com/;
+    homepage = https://github.com/ovh/python-ovh;
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.makefu ];
   };

--- a/pkgs/development/python-modules/pafy/default.nix
+++ b/pkgs/development/python-modules/pafy/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A library to download YouTube content and retrieve metadata";
-    homepage = http://np1.github.io/pafy/;
+    homepage = https://github.com/mps-youtube/pafy;
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ odi ];
   };

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -111,7 +111,7 @@ in buildPythonPackage rec {
     # https://github.com/pandas-dev/pandas/issues/14866
     # pandas devs are no longer testing i686 so safer to assume it's broken
     broken = stdenv.isi686;
-    homepage = http://pandas.pydata.org/;
+    homepage = https://pandas.pydata.org/;
     description = "Python Data Analysis Library";
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ raskin fridh knedlsepp ];

--- a/pkgs/development/python-modules/panel/default.nix
+++ b/pkgs/development/python-modules/panel/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A high level dashboarding library for python visualization libraries";
-    homepage = http://pyviz.org;
+    homepage = https://pyviz.org;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
###### Motivation for this change
noticed quite a bit of the repology errors coming from python packages, decided to bump the homepages of a few packages.

https://repology.org/repository/nix_unstable/problems

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
