### PR TITLE
cura suite: 4.3.0 -> 4.4.0

### DIFF
--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "cura";
-  version = "4.3.0";
+  version = "4.4.0";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "Cura";
-    rev = version;
-    sha256 = "1wf60qr0wqsci5skp55qr8h56s3x5s2icxbn58ia9s4a5hhvnsmf";
+    rev = "v${version}";
+    sha256 = "131n36qhdfky584wr3zv73ckjjprwaqb5fih8yln2syf8b7ziwlz";
   };
 
   materials = fetchFromGitHub {

--- a/pkgs/applications/misc/curaengine/default.nix
+++ b/pkgs/applications/misc/curaengine/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "curaengine";
-  version = "4.3.0";
+  version = "4.4.0";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "CuraEngine";
     rev = version;
-    sha256 = "074qcaj1v2ri9wppx9lr066nlidkrsp9m1rrrk2hs2b61x0340ff";
+    sha256 = "1m89bp4g0dldh7vv1clj110m29ajiaghdq7b49mb3y8ifgrf8rdi";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/python-modules/libarcus/default.nix
+++ b/pkgs/development/python-modules/libarcus/default.nix
@@ -3,14 +3,14 @@
 
 buildPythonPackage rec {
   pname = "libarcus";
-  version = "4.3.0";
+  version = "4.4.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "libArcus";
     rev = version;
-    sha256 = "1x06daijxbrqj0dlxmi2zn7ap74zf6hih3krmkwhvarm2nr052g4";
+    sha256 = "16m7m6ak5fqw3djn4azwiamkizcc1dv7brv11kv99n3b43zzgn6d";
   };
 
   disabled = pythonOlder "3.4.0";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   buildInputs = [ protobuf ];
 
   postPatch = ''
-    sed -i 's#''${Python3_SITELIB}#${placeholder "out"}/${python.sitePackages}#' cmake/SIPMacros.cmake
+    sed -i 's#''${Python3_SITEARCH}#${placeholder "out"}/${python.sitePackages}#' cmake/SIPMacros.cmake
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/libsavitar/default.nix
+++ b/pkgs/development/python-modules/libsavitar/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "libsavitar";
-  version = "4.3.0";
+  version = "4.4.0";
   format = "other";
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/uranium/default.nix
+++ b/pkgs/development/python-modules/uranium/default.nix
@@ -2,7 +2,7 @@
 , pyqt5, numpy, scipy, shapely, libarcus, doxygen, gettext, pythonOlder }:
 
 buildPythonPackage rec {
-  version = "4.3.0";
+  version = "4.4.0";
   pname = "uranium";
   format = "other";
 
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     owner = "Ultimaker";
     repo = "Uranium";
     rev = version;
-    sha256 = "13dk6hkwrzljp1dyb40cyfnfbnl7dvlqsm0ncnmxhwizxr31jb8c";
+    sha256 = "1hy7lhn48mfrmfx6mbqxzc6bfh9ndnvcwjlsb6a71mw62xg6w7c2";
   };
 
   disabled = pythonOlder "3.5.0";


### PR DESCRIPTION
Replaces #74134.

###### Motivation for this change

Changelog: https://github.com/Ultimaker/Cura/releases/tag/v4.4.0

Note the `cura.materials` hash is not updated because apparently
its contents stay the same, despite version update.

Implements comment about libarcus from:
https://github.com/NixOS/nixpkgs/pull/69435#issuecomment-535465040

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] Tested `cura` GUI, it slices successfully.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar @gebner 
