### PR TITLE
perlPackages.XMLParser: Work around cross-compilation regression

### DIFF
--- a/pkgs/development/perl-modules/xml-parser-0001-HACK-Assumes-Expat-paths-are-good.patch
+++ b/pkgs/development/perl-modules/xml-parser-0001-HACK-Assumes-Expat-paths-are-good.patch
@@ -1,0 +1,45 @@
+From e996904128653c67b04ddbdb1e10cef158098957 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Fri, 6 Dec 2019 23:00:51 -0500
+Subject: [PATCH] [HACK]: Assumes Expat paths are good.
+
+The `check_lib` check fails with the cross-compilation build platform's
+Perl, since apparently `mktemp` is missing...
+
+Even then, side-stepping the issue, it seems it is not actually enough
+to work, as the compilation fails.
+---
+ Makefile.PL | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile.PL b/Makefile.PL
+index 505d1df..fc38b76 100644
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -29,12 +29,17 @@ foreach (@ARGV) {
+ @ARGV = @replacement_args;
+ 
+ unless (
+-    check_lib(    # fill in what you prompted the user for here
+-        lib     => [qw(expat)],
+-        header  => ['expat.h'],
+-        incpath => $expat_incpath,
+-        ( $expat_libpath ? ( libpath => $expat_libpath ) : () ),
+-    )
++    #check_lib(    # fill in what you prompted the user for here
++    #    lib     => [qw(expat)],
++    #    header  => ['expat.h'],
++    #    incpath => $expat_incpath,
++    #    ( $expat_libpath ? ( libpath => $expat_libpath ) : () ),
++    #)
++    # The check_lib implementation fails horribly with cross-compilation.
++    # We are giving known good paths to expat.
++    # And in all cases, the previous behaviour of not actually failing
++    # seemed to work just fine :/.
++    false
+ ) {
+     warn <<'Expat_Not_Installed;';
+ 
+-- 
+2.23.0
+

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20404,7 +20404,8 @@ let
       url = mirror://cpan/authors/id/T/TO/TODDR/XML-Parser-2.46.tar.gz;
       sha256 = "0pai3ik47q7rgnix9644c673fwydz52gqkxr9kxwq765j4j36cfk";
     };
-    patchPhase = stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    patches = [ ../development/perl-modules/xml-parser-0001-HACK-Assumes-Expat-paths-are-good.patch ];
+    postPatch = stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
       substituteInPlace Expat/Makefile.PL --replace 'use English;' '#'
     '' + stdenv.lib.optionalString stdenv.isCygwin ''
       sed -i"" -e "s@my \$compiler = File::Spec->catfile(\$path, \$cc\[0\]) \. \$Config{_exe};@my \$compiler = File::Spec->catfile(\$path, \$cc\[0\]) \. (\$^O eq 'cygwin' ? \"\" : \$Config{_exe});@" inc/Devel/CheckLib.pm


### PR DESCRIPTION
Since 2.44_01, the behaviour for `check_lib` in their `Makefile.PL` has
been "fixed" to fail when the `assert_lib` function fails to build the
test.

 * https://github.com/toddr/XML-Parser/commit/2bc1e90c04220a04a0b40d1047d464bc55f56210

Now, this wouldn't be so bad, since it's good to actually test what
stuff is being compiled against.

Except that *something* is wonky with the cross-compilation build-time
Perl.

```
Undefined subroutine &File::Temp::mktemp called at inc/Devel/CheckLib.pm line 236.
```

As far as I know, this is a built-in function from Perl.

 * https://perldoc.perl.org/File/Temp.html

Though, something *else* is wrong with `Checklib.pm`. Side-stepping the
issue by (eww) shelling out to `mktemp`, we get these errors:

```

/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-armv7l-unknown-linux-gnueabihf-binutils-2.31.1/bin/armv7l-unknown-linux-gnueabihf-ld: assertlib_src1_0.553056903257133: file not recognized: file truncated
collect2: error: ld returned 1 exit status
 -I/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.2.8-armv7l-unknown-linux-gnueabihf-dev/include -L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.2.8-armv7l-unknown-linux-gnueabihf/lib -lexpat
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-armv7l-unknown-linux-gnueabihf-binutils-2.31.1/bin/armv7l-unknown-linux-gnueabihf-ld: assertlib_src2_0.262169388446154: file not recognized: file truncated
collect2: error: ld returned 1 exit status
Can't link/include C library 'expat.h', 'expat', aborting.
```

Meanwhile, the actual build, while building the library, seemingly has
no issues building using those paths. `¯\_(ツ)_/¯`

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @volth as de facto perl peep
cc anyone handy enough with perl :(
cc @matthewbauer @Ericson2314  who could have insight with cross-compilation
cc @flokli as he was doing cross-compilation and maybe had the same issue.