### PR TITLE
vim-vint: 0.3.20 -> 0.3.21

### DIFF
--- a/pkgs/development/tools/vim-vint/default.nix
+++ b/pkgs/development/tools/vim-vint/default.nix
@@ -1,31 +1,26 @@
-{ fetchFromGitHub, lib, python3Packages }:
+{ lib, python3Packages }:
 
 with python3Packages;
 
 buildPythonApplication rec {
   pname = "vim-vint";
-  version = "0.3.20";
+  version = "0.3.21";
 
-  src = fetchFromGitHub {
-    owner = "kuniwak";
-    repo = "vint";
-    rev = "v${version}";
-    sha256 = "0ij9br4z9h8qay6l41sicr4lbjc38hxsn3lgjrj9zpn2b3585syx";
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "15qdh8fby9xgfjxidcfv1xmrqqrxxapky7zmyn46qx1abhp9piax";
   };
 
   # For python 3.5 > version > 2.7 , a nested dependency (pythonPackages.hypothesis) fails.
   disabled = ! pythonAtLeast "3.5";
 
-  # Prevent setup.py from adding dependencies in run-time and insisting on specific package versions
-  postPatch = ''
-    substituteInPlace setup.py --replace "return requires" "return []"
-  '';
-  checkInputs = [ pytest ];
-  propagatedBuildInputs = [ ansicolor chardet pyyaml  setuptools] ;
+  checkInputs = [ pytest pytestcov ];
+  propagatedBuildInputs = [ ansicolor chardet pyyaml setuptools ];
 
-  # The acceptance tests check for stdout and location of binary files, which fails in nix-build.
-  checkPhase = ''
-    py.test -k "not acceptance"
+  # Unpin test dependency versions. This is fixed in master but not yet released.
+  preCheck = ''
+    sed -i 's/==.*//g' test-requirements.txt
+    sed -i 's/mock == 1.0.1/mock/g' setup.py
   '';
 
   meta = with lib; {


### PR DESCRIPTION
The runtime dependencies are no longer pinned but the test dependencies
still are.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andsild