### PR TITLE
beets.externalPlugins.check: init at 0.12.0 

### DIFF
--- a/pkgs/tools/audio/beets/beet-check-tests.patch
+++ b/pkgs/tools/audio/beets/beet-check-tests.patch
@@ -1,0 +1,17 @@
+diff --git a/test/cli_test.py b/test/cli_test.py
+index 26df140..2eb913c 100644
+--- a/test/cli_test.py
++++ b/test/cli_test.py
+@@ -372,12 +372,6 @@ class ToolListTest(TestHelper, TestCase):
+         self.assertIn('flac', stdout.getvalue())
+         self.assertIn('oggz-validate', stdout.getvalue())
+ 
+-    def test_found_mp3val(self):
+-        shutil.copy('/bin/echo', os.path.join(self.temp_dir, 'mp3val'))
+-        with captureStdout() as stdout:
+-            beets.ui._raw_main(['check', '--list-tools'])
+-        self.assertRegexpMatches(stdout.getvalue(), r'mp3val *found')
+-
+     def test_oggz_validate_not_found(self):
+         with captureStdout() as stdout:
+             beets.ui._raw_main(['check', '--list-tools'])

--- a/pkgs/tools/audio/beets/check-plugin.nix
+++ b/pkgs/tools/audio/beets/check-plugin.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, beets, pythonPackages, flac, liboggz, mp3val }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "beets-check";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    repo = "beets-check";
+    owner = "geigerzaehler";
+    rev = "v${version}";
+    sha256 = "0b2ijjf0gycs6b40sm33ida3sjygjiv4spb5mba52vysc7iwmnjn";
+  };
+
+  nativeBuildInputs = [ beets ];
+  checkInputs = [ pythonPackages.nose flac liboggz mp3val ];
+  propagatedBuildInputs = [ flac liboggz mp3val ];
+
+  # patch out broken tests
+  patches = [ ./beet-check-tests.patch ];
+
+  # patch out futures dependency, it is only needed for Python2 which we don't
+  # support.
+  prePatch = ''
+    sed -i "/futures/d" setup.py
+  '';
+
+  checkPhase = "nosetests";
+
+  meta = with stdenv.lib; {
+    description = "Beets plugin to Verify and store checksums in your library";
+    homepage = https://github.com/geigerzaehler/beets-check;
+    license = licenses.mit;
+    maintainers = with maintainers; [ lovesegfault ];
+  };
+}

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -29,6 +29,7 @@
 
 # External plugins
 , enableAlternatives   ? false
+, enableCheck          ? false, liboggz ? null
 , enableCopyArtifacts  ? false
 
 , bashInteractive, bash-completion
@@ -37,6 +38,7 @@
 assert enableAbsubmit    -> essentia-extractor            != null;
 assert enableAcoustid    -> pythonPackages.pyacoustid     != null;
 assert enableBadfiles    -> flac != null && mp3val != null;
+assert enableCheck       -> flac != null && mp3val != null && liboggz != null;
 assert enableConvert     -> ffmpeg != null;
 assert enableDiscogs     -> pythonPackages.discogs_client != null;
 assert enableFetchart    -> pythonPackages.responses      != null;
@@ -106,6 +108,7 @@ let
 
   plugins = {
     alternatives = callPackage ./alternatives-plugin.nix pluginArgs;
+    check = callPackage ./check-plugin.nix pluginArgs;
     copyartifacts = callPackage ./copyartifacts-plugin.nix pluginArgs;
   };
 
@@ -142,6 +145,7 @@ in pythonPackages.buildPythonApplication rec {
               || enableSubsonicupdate
               || enableAcousticbrainz)
                                     pythonPackages.requests
+    ++ optional enableCheck         plugins.check
     ++ optional enableConvert       ffmpeg
     ++ optional enableDiscogs       pythonPackages.discogs_client
     ++ optional enableGmusic        pythonPackages.gmusicapi
@@ -245,6 +249,10 @@ in pythonPackages.buildPythonApplication rec {
   '';
 
   makeWrapperArgs = [ "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\"" "--set GST_PLUGIN_SYSTEM_PATH_1_0 \"$GST_PLUGIN_SYSTEM_PATH_1_0\"" ];
+
+  passthru = {
+    externalPlugins = plugins;
+  };
 
   meta = {
     description = "Music tagger and library organizer";


### PR DESCRIPTION
###### Motivation for this change
I need this plugin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @aszlig @domenkozar @pjones 
