### PR TITLE
cinnamon.xapps: init at 1.6.8

### DIFF
--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -1,0 +1,5 @@
+{ pkgs, lib }:
+
+lib.makeScope pkgs.newScope (self: with self; {
+  xapps = callPackage ./xapps {};
+})

--- a/pkgs/desktops/cinnamon/xapps/default.nix
+++ b/pkgs/desktops/cinnamon/xapps/default.nix
@@ -1,0 +1,104 @@
+{ fetchFromGitHub
+, fetchpatch
+, glib
+, gobject-introspection
+, gtk3
+, libgnomekbd
+, gdk-pixbuf
+, cairo
+, xorg
+, meson
+, ninja
+, pkgconfig
+, python3
+, stdenv
+, vala
+, wrapGAppsHook
+, inxi
+, mate
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xapps";
+  version = "1.6.8";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "09f77vsydv8r6r43py8hrpq7pb4a1pfivy19zgijjy2241i7059v";
+  };
+
+  # TODO: https://github.com/NixOS/nixpkgs/issues/36468
+  NIX_CFLAGS_COMPILE = [
+    "-I${glib.dev}/include/gio-unix-2.0"
+  ];
+
+  patches = [
+    (fetchpatch { # details see https://github.com/linuxmint/xapps/pull/65
+      url = "https://github.com/linuxmint/xapps/compare/d361d9cf357fade59b4bb68df2dcb2c0c39f90e1...2dfe82ec68981ea046345b2be349bd56293579f7.diff";
+      sha256 = "0sffclamvjas8ad57kxrg0vrgrd95xsk0xdl53dc3yivpxkfxrnk";
+    })
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    (python3.withPackages(ps: with ps; [
+      pygobject3
+      setproctitle # mate applet
+    ]))
+    libgnomekbd
+    gdk-pixbuf
+    xorg.libxkbfile
+    python3.pkgs.pygobject3 # for .pc file
+    mate.mate-panel # for gobject-introspection
+  ];
+
+  # Requires in xapp.pc
+  propagatedBuildInputs = [
+    gtk3
+    cairo
+    glib
+  ];
+
+  mesonFlags = [
+    "-Dpy-overrides-dir=${placeholder "out"}/${python3.sitePackages}/gi/overrides"
+  ];
+
+  postPatch = ''
+    chmod +x schemas/meson_install_schemas.py # patchShebangs requires executable file
+
+    # The fetchpatch hook removes the renames, so postPatch has to rename those files, remove once PR merged
+    mv files/usr/bin/pastebin scripts/pastebin
+    mv files/usr/bin/upload-system-info scripts/upload-system-info
+    mv files/usr/bin/xfce4-set-wallpaper scripts/xfce4-set-wallpaper
+    mv files/usr/share/icons/hicolor icons
+
+    patchShebangs \
+      libxapp/g-codegen.py \
+      schemas/meson_install_schemas.py
+
+    # Patch pastebin & inxi location
+    sed "s|/usr/bin/pastebin|$out/bin/pastebin|" -i scripts/upload-system-info
+    sed "s|'inxi'|'${inxi}/bin/inxi'|" -i scripts/upload-system-info
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/xapps";
+    description = "Cross-desktop libraries and common resources";
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/development/libraries/libgnomekbd/default.nix
+++ b/pkgs/development/libraries/libgnomekbd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, file, intltool, glib, gtk3, libxklavier, makeWrapper, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, file, intltool, glib, gtk3, libxklavier, wrapGAppsHook, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "libgnomekbd";
@@ -13,13 +13,19 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript { packageName = pname; };
   };
 
-  nativeBuildInputs = [ pkgconfig file intltool makeWrapper ];
-  buildInputs = [ glib gtk3 libxklavier ];
+  nativeBuildInputs = [
+    file
+    intltool
+    pkgconfig
+    wrapGAppsHook
+  ];
 
-  preFixup = ''
-    wrapProgram $out/bin/gkbd-keyboard-display \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-  '';
+  # Requires in libgnomekbd.pc
+  propagatedBuildInputs = [
+    gtk3
+    libxklavier
+    glib
+  ];
 
   meta = with stdenv.lib; {
     description = "Keyboard management library";

--- a/pkgs/development/python-modules/xapp/default.nix
+++ b/pkgs/development/python-modules/xapp/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, psutil
+, pygobject3
+, gtk3
+, gobject-introspection
+, xapps
+, polkit
+}:
+
+buildPythonPackage rec {
+  pname = "xapp";
+  version = "1.8.1";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "python-xapp";
+    rev = version;
+    sha256 = "0vw3cn09nx75lv4d9idp5fdhd81xs279zhbyyilynq29cxxs2zil";
+  };
+
+  propagatedBuildInputs = [
+    psutil
+    pygobject3
+    gtk3
+    gobject-introspection
+    xapps
+    polkit
+  ];
+
+  postPatch = ''
+    substituteInPlace "xapp/os.py" --replace "/usr/bin/pkexec" "${polkit}/bin/pkexec"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/python-xapp";
+    description = "Cross-desktop libraries and common resources for python";
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23345,6 +23345,8 @@ in
 
   ### DESKTOP ENVIRONMENTS
 
+  cinnamon = recurseIntoAttrs (callPackage ../desktops/cinnamon { });
+
   deepin = recurseIntoAttrs (import ../desktops/deepin {
     inherit pkgs libsForQt5;
     inherit (lib) makeScope;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -182,7 +182,7 @@ in {
   aresponses = callPackage ../development/python-modules/aresponses { };
 
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
-  
+
   arviz = callPackage ../development/python-modules/arviz { };
 
   asana = callPackage ../development/python-modules/asana { };
@@ -1148,7 +1148,7 @@ in {
   pytesseract = callPackage ../development/python-modules/pytesseract { };
 
   pytest-bdd = callPackage ../development/python-modules/pytest-bdd { };
-  
+
   pytest-black = callPackage ../development/python-modules/pytest-black { };
 
   pytest-click = callPackage ../development/python-modules/pytest-click { };
@@ -5421,6 +5421,11 @@ in {
   xarray = callPackage ../development/python-modules/xarray { };
 
   xapian = callPackage ../development/python-modules/xapian { xapian = pkgs.xapian; };
+
+  xapp = callPackage ../development/python-modules/xapp {
+    inherit (pkgs) gtk3 gobject-introspection polkit;
+    inherit (pkgs.cinnamon) xapps;
+  };
 
   xlwt = callPackage ../development/python-modules/xlwt { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This adds the xapps package and it's python module to nixpkgs, to allow for the cinnamon desktop to be ported


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
