### PR TITLE
ocamlPackages.mdx: 1.4.0 → 1.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/containers/default.nix
+++ b/pkgs/development/ocaml-modules/containers/default.nix
@@ -16,7 +16,7 @@ buildDunePackage rec {
 
   buildInputs = [ iter ];
 
-  checkInputs = lib.optionals doCheck [ gen mdx ounit qcheck uutf ];
+  checkInputs = lib.optionals doCheck [ gen mdx.bin ounit qcheck uutf ];
 
   propagatedBuildInputs = [ result uchar ];
 

--- a/pkgs/development/ocaml-modules/iter/default.nix
+++ b/pkgs/development/ocaml-modules/iter/default.nix
@@ -11,7 +11,7 @@ buildDunePackage rec {
     sha256 = "0j2sg50byn0ppmf6l36ksip7zx1d3gv7sc4hbbxs2rmx39jr7vxh";
   };
 
-  buildInputs = lib.optionals doCheck [ mdx qtest ];
+  buildInputs = lib.optionals doCheck [ mdx.bin qtest ];
   propagatedBuildInputs = [ result ];
 
   doCheck = lib.versionAtLeast ocaml.version "4.04";

--- a/pkgs/development/ocaml-modules/mdx/default.nix
+++ b/pkgs/development/ocaml-modules/mdx/default.nix
@@ -1,23 +1,29 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, astring, cmdliner, cppo, fmt, logs, ocaml-migrate-parsetree, ocaml_lwt, pandoc, re }:
+{ lib, fetchurl, buildDunePackage, opaline, ocaml
+, astring, cmdliner, cppo, fmt, logs, ocaml-migrate-parsetree, ocaml-version, ocaml_lwt, pandoc, re }:
 
 buildDunePackage rec {
   pname = "mdx";
-  version = "1.4.0";
+  version = "1.5.0";
 
-  src = fetchFromGitHub {
-    owner = "realworldocaml";
-    repo = pname;
-    rev = version;
-    sha256 = "0ljd00d261s2wf7cab086asqi39icf9zs4nylni6dldaqb027d4w";
+  src = fetchurl {
+    url = "https://github.com/realworldocaml/mdx/releases/download/1.5.0/mdx-1.5.0.tbz";
+    sha256 = "0g45plf4z7d178gp0bx7842fwbd3m19679yfph3s95da6mrfm3xn";
   };
 
   nativeBuildInputs = [ cppo ];
-  buildInputs = [ astring cmdliner fmt logs ocaml-migrate-parsetree re ];
+  buildInputs = [ cmdliner ];
+  propagatedBuildInputs = [ astring fmt logs ocaml-migrate-parsetree ocaml-version re ];
   checkInputs = lib.optionals doCheck [ ocaml_lwt pandoc ];
 
-  doCheck = !lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
 
   dontStrip = lib.versions.majorMinor ocaml.version == "4.04";
+
+  outputs = [ "bin" "lib" "out" ];
+
+  installPhase = ''
+    ${opaline}/bin/opaline -prefix $bin -libdir $lib/lib/ocaml/${ocaml.version}/site-lib
+  '';
 
   meta = {
     homepage = https://github.com/realworldocaml/mdx;

--- a/pkgs/development/ocaml-modules/ocaml-version/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-version/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchurl, buildDunePackage, result }:
+
+buildDunePackage rec {
+
+  pname = "ocaml-version";
+  version = "2.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/ocurrent/ocaml-version/releases/download/v${version}/ocaml-version-v${version}.tbz";
+    sha256 = "0c711lifl35xila9k0rvhijy9zm3shd37q3jgw7xf01hn1swg0hn";
+  };
+
+  propagatedBuildInputs = [ result ];
+
+  meta = {
+    description = "Manipulate, parse and generate OCaml compiler version strings";
+    homepage = "https://github.com/ocurrent/ocaml-version";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/printbox/default.nix
+++ b/pkgs/development/ocaml-modules/printbox/default.nix
@@ -13,7 +13,7 @@ buildDunePackage rec {
     sha256 = "16nwwpp13hzlcm9xqfxc558afm3i5s802dkj69l9s2vp04lgms5n";
   };
 
-  checkInputs = lib.optional doCheck mdx;
+  checkInputs = lib.optional doCheck mdx.bin;
 
   doCheck = !lib.versionAtLeast ocaml.version "4.08";
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -575,6 +575,8 @@ let
 
     ocaml_text = callPackage ../development/ocaml-modules/ocaml-text { };
 
+    ocaml-version = callPackage ../development/ocaml-modules/ocaml-version { };
+
     ocf = callPackage ../development/ocaml-modules/ocf { };
 
     ocp-build = callPackage ../development/tools/ocaml/ocp-build { };


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.09

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @romildo
