### PR TITLE
hostapd: use getrandom(2)

### DIFF
--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
     CONFIG_INTERNETWORKING=y
     CONFIG_HS20=y
     CONFIG_ACS=y
+    CONFIG_GETRANDOM=y
   '' + stdenv.lib.optionalString (sqlite != null) ''
     CONFIG_SQLITE=y
   '';


### PR DESCRIPTION
Motivation: Devices with few entropy sources on boot hang/block if many services try to
read from `/dev/random`.

https://w1.fi/cgit/hostap/commit/?id=89a7cdd690b48a0c56380cf4609442ed13527f44
states getrandom() is recommended, but not enabled by default since it
relies on:

* Linux kernel 3.17 (NixOS 19.09 has 4.19; master presumably later)
* glibc 2.25 (NixOS master has 2.27
  https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/glibc/common.nix#L37 )

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Phreedom  @NinjaTrappeur 
