### PR TITLE
Thunderbird: Wayland support and version bump

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -9,6 +9,7 @@
 , runtimeShell
 , cargo, rustc, rust-cbindgen, llvmPackages, nasm
 , enableGTK3 ? false, gtk3, gnome3, wrapGAppsHook, makeWrapper
+, waylandSupport ? true, libxkbcommon
 , enableCalendar ? true
 , debugBuild ? false
 , # If you want the resulting program to call itself "Thunderbird" instead
@@ -43,7 +44,8 @@ in stdenv.mkDerivation rec {
       libevent libstartup_notification /* cairo */
       icu libpng jemalloc nasm
     ]
-    ++ lib.optionals enableGTK3 [ gtk3 gnome3.adwaita-icon-theme ];
+    ++ lib.optionals enableGTK3 [ gtk3 gnome3.adwaita-icon-theme ]
+    ++ lib.optional waylandSupport libxkbcommon;
 
   # from firefox + m4 + wrapperTool
   # llvm is for llvm-objdump
@@ -86,7 +88,7 @@ in stdenv.mkDerivation rec {
       "--disable-updater"
       "--enable-jemalloc"
       "--disable-gconf"
-      "--enable-default-toolkit=cairo-gtk${if enableGTK3 then "3" else "2"}"
+      "--enable-default-toolkit=cairo-gtk${if enableGTK3 then "3${lib.optionalString waylandSupport "-wayland"}" else "2"}"
       "--enable-js-shell"
     ]
       ++ lib.optional enableCalendar "--enable-calendar"

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -26,11 +26,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.2.2";
+  version = "68.3.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "3mvanjfc35f14lsfa4zjlhsvwij1n9dz9xmisd5s376r5wp9y33sva5ly914b2hmdl85ypdwv90zyi6whj7jb2f2xmqk480havxgjcn";
+    sha512 = "3aqr3dj5laws516k6jf8f35a1964p0s75sp682yy87xnzgd8m1iha55z79dcavis2ma9hiyacjnznjz04qhqd4q8swjgfg7lj8lyiwl";
   };
 
   # from firefox, but without sound libraries
@@ -54,13 +54,7 @@ in stdenv.mkDerivation rec {
   patches = [
     # Remove buildconfig.html to prevent a dependency on clang etc.
     ./no-buildconfig.patch
-  ]
-  ++ lib.optional (lib.versionOlder version "69")
-    (fetchpatch { # https://bugzilla.mozilla.org/show_bug.cgi?id=1500436#c29
-      name = "write_error-parallel_make.diff";
-      url = "https://hg.mozilla.org/mozilla-central/raw-diff/562655fe/python/mozbuild/mozbuild/action/node.py";
-      sha256 = "11d7rgzinb4mwl7yzhidjkajynmxgmffr4l9isgskfapyax9p88y";
-    });
+  ];
 
   configureFlags =
     [ # from firefox, but without sound libraries (alsa, libvpx, pulseaudio)
@@ -76,7 +70,7 @@ in stdenv.mkDerivation rec {
       "--with-system-libevent"
       "--with-system-png" # needs APNG support
       "--with-system-icu"
-      #"--enable-rust-simd" # not supported since rustc 1.32.0 -> 1.33.0; TODO: probably OK since 68.0.0
+      "--enable-rust-simd"
       "--enable-system-ffi"
       "--enable-system-pixman"
       "--enable-system-sqlite"
@@ -84,7 +78,7 @@ in stdenv.mkDerivation rec {
       "--enable-startup-notification"
       "--disable-crashreporter"
       "--disable-tests"
-      "--disable-necko-wifi" # maybe we want to enable this at some point
+      "--disable-necko-wifi"
       "--disable-updater"
       "--enable-jemalloc"
       "--disable-gconf"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I noticed wayland support wasn't available, so I copied the implementation from Firefox and verified that it works. There was a version bump available, so I did that too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nbp  @edolstra (cc. @andir since he maintains FF which is a similar build)
