### PR TITLE
hostapd: 2.8 -> 2.9

### DIFF
--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "hostapd";
-  version = "2.8";
+  version = "2.9";
 
   src = fetchurl {
     url = "https://w1.fi/releases/${pname}-${version}.tar.gz";
-    sha256 = "1c74rrazkhy4lr7pwgwa2igzca7h9l4brrs7672kiv7fwqmm57wj";
+    sha256 = "1mrbvg4v7vm7mknf0n29mf88k3s4a4qj6r4d51wq8hmjj1m7s7c8";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
Associated release note:
https://w1.fi/security/2019-6/sae-eap-pwd-side-channel-attack-update.txt

###### Motivation for this change

Our current hostapd setup might be vulnerable to a side-channel attack on `EAP-pwd` in a particular setup.

Relevant release note part:

> All wpa_supplicant and hostapd versions with EAP-pwd support
(CONFIG_EAP_PWD=y in the build configuration and EAP-pwd being enabled
in the runtime configuration). Note that EAP-pwd server implementation
in hostapd enables only a single group at the time (pwd_group parameter)
and by default, group 19 is used. As such, this would be applicable only
if the pwd_group parameter is set to use one of the groups 28-30. The
EAP-pwd peer implementation wpa_supplicant, follows the group selected
by the server and as such, it would be vulnerable for the case where an
attacker controls the authentication server (e.g., through a rogue AP)
if the crypto library supports groups 28-30.

No reason to freak about that, but better be safe than sorry.

There's no breaking change regarding this release, updating `hostapd` should be safe and backward-compatible.

We probably want to backport this to 19.09 together with https://github.com/NixOS/nixpkgs/pull/75140 (not merged yet).

Tested on my test router setup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @flokli 
