### PR TITLE
libofx: 0.9.14 -> 0.9.15, addressing CVE-2019-9656

### DIFF
--- a/pkgs/development/libraries/libofx/default.nix
+++ b/pkgs/development/libraries/libofx/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, opensp, pkgconfig, libxml2, curl
-, autoconf, automake, libtool, gengetopt }:
+, autoconf, automake, libtool, gengetopt, libiconv }:
 
 stdenv.mkDerivation rec {
   pname = "libofx";
@@ -15,13 +15,13 @@ stdenv.mkDerivation rec {
   preConfigure = "./autogen.sh";
   configureFlags = [ "--with-opensp-includes=${opensp}/include/OpenSP" ];
   nativeBuildInputs = [ pkgconfig libtool autoconf automake gengetopt ];
-  buildInputs = [ opensp libxml2 curl ];
+  buildInputs = [ opensp libxml2 curl ] ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
   meta = { 
     description = "Opensource implementation of the Open Financial eXchange specification";
     homepage = http://libofx.sourceforge.net/;
     license = "LGPL";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/libraries/libofx/default.nix
+++ b/pkgs/development/libraries/libofx/default.nix
@@ -1,15 +1,20 @@
-{ stdenv, fetchurl, opensp, pkgconfig, libxml2, curl }:
-        
-stdenv.mkDerivation rec {
-  name = "libofx-0.9.14";
+{ stdenv, fetchFromGitHub, opensp, pkgconfig, libxml2, curl
+, autoconf, automake, libtool, gengetopt }:
 
-  src = fetchurl {
-    url = "mirror://sourceforge/libofx/${name}.tar.gz";
-    sha256 = "02i9zxkp66yxjpjay5dscfh53bz5vxy03zcxncpw09svl6zmf9xq";
+stdenv.mkDerivation rec {
+  pname = "libofx";
+  version = "0.9.15";
+
+  src = fetchFromGitHub {
+    owner = "LibOFX";
+    repo = pname;
+    rev = version;
+    sha256 = "1jx56ma351p8af8dvavygjwf6ipa7qbgq7bpdsymwj27apdnixfy";
   };
 
+  preConfigure = "./autogen.sh";
   configureFlags = [ "--with-opensp-includes=${opensp}/include/OpenSP" ];
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig libtool autoconf automake gengetopt ];
   buildInputs = [ opensp libxml2 curl ];
 
   meta = { 
@@ -20,4 +25,3 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-9656

Also included a commit to enable for darwin - tested macos 10.14. Unsure as to whether, longterm, we should be changing the homepage to the github repo - so I opened an issue upstream asking https://github.com/libofx/libofx/issues/31

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
