### PR TITLE
[r19.09] libofx: add patch for CVE-2019-9656

### DIFF
--- a/pkgs/development/libraries/libofx/default.nix
+++ b/pkgs/development/libraries/libofx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, opensp, pkgconfig, libxml2, curl }:
+{ stdenv, fetchurl, opensp, pkgconfig, libxml2, curl, fetchpatch }:
         
 stdenv.mkDerivation rec {
   name = "libofx-0.9.14";
@@ -7,6 +7,14 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/libofx/${name}.tar.gz";
     sha256 = "02i9zxkp66yxjpjay5dscfh53bz5vxy03zcxncpw09svl6zmf9xq";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-9656.patch";
+      url = "https://github.com/libofx/libofx/commit/15d0511253d7a8011ab7fa8d1e74c265d17d1b44.patch";
+      sha256 = "13lmn8izjdxsi8yvwqn635kc8qcr0cazzhz16lj4fdwwa645z2ca";
+    })
+  ];
 
   configureFlags = [ "--with-opensp-includes=${opensp}/include/OpenSP" ];
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-9656

See #75155 for master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
