### PR TITLE
gohufont: generate opentype files

### DIFF
--- a/pkgs/data/fonts/gohufont/default.nix
+++ b/pkgs/data/fonts/gohufont/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchFromGitHub
 , mkfontdir, mkfontscale, bdf2psf, bdftopcf
-, fonttosfnt
+, fonttosfnt, libfaketime
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs =
-    [ mkfontdir mkfontscale bdf2psf bdftopcf fonttosfnt ];
+    [ mkfontdir mkfontscale bdf2psf bdftopcf
+      fonttosfnt libfaketime
+    ];
 
   buildPhase = ''
     # convert bdf fonts to psf
@@ -35,7 +37,7 @@ stdenv.mkDerivation rec {
     for i in *.bdf $src/hidpi/*.bdf; do
         name=$(basename $i .bdf)
         bdftopcf -o "$name.pcf" "$i"
-        fonttosfnt -v -o "$name.otb" "$i" || true
+        faketime -f "1970-01-01 00:00:01" fonttosfnt -v -o "$name.otb" "$i" || true
     done
   '';
 
@@ -57,7 +59,7 @@ stdenv.mkDerivation rec {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  outputHash     = "0j9fhvzkascpb5y8lc1pmmmgd74apgw9mimbj0bk2chcbfsi852p";
+  outputHash     = "028mq0j6w76isv4ycj1jzx7ih9d9cz5012np7f1pf3bvnvw3ajw2";
 
   meta = with stdenv.lib; {
     description = ''

--- a/pkgs/servers/x11/xorg/fix-uninitialised-memory.patch
+++ b/pkgs/servers/x11/xorg/fix-uninitialised-memory.patch
@@ -1,0 +1,61 @@
+From 51e8117654fb092ae5412d7aa184bfc6b498c954 Mon Sep 17 00:00:00 2001
+From: rnhmjoj <rnhmjoj@inventati.org>
+Date: Fri, 7 Feb 2020 17:46:54 +0100
+Subject: [PATCH 1/2] Fix incorrect error handling in macTime()
+
+mktime() and time() return (time_t -1) to signal an error.
+Checking for negative values will incorrectly assume an error
+happened for any calendar date before the unix epoch.
+---
+ util.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/util.c b/util.c
+index bcbfa2f..4482c9a 100644
+--- a/util.c
++++ b/util.c
+@@ -213,10 +213,10 @@ macTime(int *hi, unsigned *lo)
+     tm.tm_isdst = -1;
+ 
+     macEpoch = mktime_gmt(&tm);
+-    if(macEpoch < 0) return -1;
++    if(macEpoch == -1) return -1;
+ 
+     current = time(NULL);
+-    if(current < 0)
++    if(current == -1)
+         return -1;
+ 
+     if(current < macEpoch) {
+-- 
+2.23.0
+
+From 81a61c049e6de80120531f0770b22e7637c9acb9 Mon Sep 17 00:00:00 2001
+From: rnhmjoj <rnhmjoj@inventati.org>
+Date: Fri, 7 Feb 2020 17:47:52 +0100
+Subject: [PATCH 2/2] Fix uninitialised memory write
+
+If macTime() fails write zeros instead of unitialized memory to
+the date fields.
+---
+ write.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/write.c b/write.c
+index 318adef..c8a86e4 100644
+--- a/write.c
++++ b/write.c
+@@ -434,8 +434,8 @@ fixupChecksum(FILE *out, int full_length, int head_position)
+ static int 
+ writehead(FILE* out, FontPtr font)
+ {
+-    int time_hi;
+-    unsigned time_lo;
++    int time_hi = 0;
++    unsigned time_lo = 0;
+ 
+     macTime(&time_hi, &time_lo);
+ 
+-- 
+2.23.0
+

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -22,6 +22,11 @@ self: super:
     buildInputs = attrs.buildInputs ++ [ self.xorgproto ];
   });
 
+  fonttosfnt = super.fonttosfnt.overrideAttrs (attrs: {
+    # https://gitlab.freedesktop.org/xorg/app/fonttosfnt/merge_requests/6
+    patches = [ ./fix-uninitialised-memory.patch ];
+  });
+
   bitmap = super.bitmap.overrideAttrs (attrs: {
     nativeBuildInputs = attrs.nativeBuildInputs ++ [ makeWrapper ];
     postInstall = ''

--- a/pkgs/tools/misc/bdf2psf/default.nix
+++ b/pkgs/tools/misc/bdf2psf/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "10c0rbhqscizfa063m6mms31i0knh25bxr35s008b6mp5pxr33mc";
   };
 
-  buildInputs = [ dpkg ];
+  nativeBuildInputs = [ dpkg ];
 
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17493,7 +17493,7 @@ in
 
   geolite-legacy = callPackage ../data/misc/geolite-legacy { };
 
-  gohufont = callPackage ../data/fonts/gohufont { };
+  gohufont = callPackage ../data/fonts/gohufont { inherit (xorg) fonttosfnt mkfontdir; };
 
   gnome-user-docs = callPackage ../data/documentation/gnome-user-docs { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17494,7 +17494,7 @@ in
   geolite-legacy = callPackage ../data/misc/geolite-legacy { };
 
   gohufont = callPackage ../data/fonts/gohufont
-    { inherit (buildPackages.xorg) fonttosfnt mkfontdir; };
+    { inherit (buildPackages.xorg) fonttosfnt mkfontscale; };
 
   gnome-user-docs = callPackage ../data/documentation/gnome-user-docs { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17493,7 +17493,8 @@ in
 
   geolite-legacy = callPackage ../data/misc/geolite-legacy { };
 
-  gohufont = callPackage ../data/fonts/gohufont { inherit (xorg) fonttosfnt mkfontdir; };
+  gohufont = callPackage ../data/fonts/gohufont
+    { inherit (buildPackages.xorg) fonttosfnt mkfontdir; };
 
   gnome-user-docs = callPackage ../data/documentation/gnome-user-docs { };
 


### PR DESCRIPTION
###### Motivation for this change
See #75160 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested in xterm, xfontsel and dunst
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

