### PR TITLE
 kaidan: init at 0.4.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/kaidan/default.nix
+++ b/pkgs/applications/networking/instant-messengers/kaidan/default.nix
@@ -1,0 +1,37 @@
+{ mkDerivation, lib, fetchFromGitLab, extra-cmake-modules
+, kirigami2
+, knotifications
+, qtquickcontrols2
+, qxmpp }:
+
+mkDerivation rec {
+  pname = "kaidan";
+  version = "0.4.1";
+
+  src = fetchFromGitLab {
+    owner = "kde";
+    repo = pname;
+    domain = "invent.kde.org";
+    rev = "v${version}";
+    sha256 = "07ymypcs4whqx8c3s24rha4fkkddnfiqgli5irfkla09ifd12zfz";
+  };
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
+
+  propagatedBuildInputs = [
+    kirigami2
+    knotifications
+    qtquickcontrols2
+    qxmpp
+  ];
+
+  meta = with lib; {
+    description = "Simple and user-friendly Jabber/XMPP client for every device and platform";
+    homepage = "https://invent.kde.org/kde/kaidan/";
+    platforms = platforms.linux;
+    license = with licenses; [ gpl3Plus mit asl20 ];
+    maintainers = with maintainers; [ ajs124 ];
+  };
+}

--- a/pkgs/development/libraries/qxmpp/default.nix
+++ b/pkgs/development/libraries/qxmpp/default.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, lib, fetchFromGitHub, cmake }:
+
+mkDerivation rec {
+  pname = "qxmpp";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "${pname}-project";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1r6b2hgqd5s8ikc1w6x1a9dih1jkd456s691yjqafsqigcji2bp3";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with lib; {
+    description = "Cross-platform C++ XMPP client and server library";
+    homepage = "https://github.com/qxmpp-project/qxmpp";
+    platforms = platforms.linux;
+    license = with licenses; [ lgpl21Plus ];
+    maintainers = with maintainers; [ ajs124 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19611,6 +19611,8 @@ in
 
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };
 
+  kaidan = libsForQt5.callPackage ../applications/networking/instant-messengers/kaidan { };
+
   kdeconnect = libsForQt5.callPackage ../applications/misc/kdeconnect { };
 
   kdecoration-viewer = libsForQt5.callPackage ../tools/misc/kdecoration-viewer { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13763,6 +13763,8 @@ in
 
     qwt = callPackage ../development/libraries/qwt/6.nix { };
 
+    qxmpp = callPackage ../development/libraries/qxmpp { };
+
     telepathy = callPackage ../development/libraries/telepathy/qt { };
 
     vlc = callPackage ../applications/video/vlc {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Ticks off a box in #62168.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
cc @silverhook