### PR TITLE
tdb: 1.3.16 -> 1.3.18

### DIFF
--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "tdb-1.3.16";
+  name = "tdb-1.3.18";
 
   src = fetchurl {
     url = "mirror://samba/tdb/${name}.tar.gz";
-    sha256 = "1ibcz466xwk1x6xvzlgzd5va4lyrjzm3rnjak29kkwk7cmhw4gva";
+    sha256 = "1drnsdh1w0px35r0y7l7g59yvyr67mvcsdrli4wab0mwi07b8mn1";
   };
 
   nativeBuildInputs = [ pkgconfig wafHook ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
sssd requires it when using Active Directory, otherwise we get:
```
[   52.702464] sssd_be[804]: Unable to load module [ad] with path [/nix/store/kcaid7ypwfk896awy5qwyvamdpqfzwd9-sssd-1.16.4/lib/sssd/libsss_ad.so]: /nix/store/7cslafmwm9qiar8yn5q227r61ycifqpi-tdb-1.3.16/lib/libtdb.so.1: version `TDB_1.3.17' not found (required by /nix/store/sm41fp80ilnshgwjj8yzs9s4v4bkpcki-samba-4.10.10/lib/libsmbconf.so.0)
```

Note that is not the latest version. The new one is more complex to update. It requires some python stuff. At least with 1.3.18 I can play with sssd.

I'm working on a nixos test to catch if sssd doesn't start but it will be for later.

#58380 will bring tdb to >= 1.4.0 if merged eventually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I only tested nixos/tests/samba.nix as I wasn't able to find out other tests depending on tdb.

I did join a samba active directory (that I set up for testing) with this.

/nix/store/7cslafmwm9qiar8yn5q227r61ycifqpi-tdb-1.3.16	  94.1M
/nix/store/kac47wii2ml0x62wpzcr35x40mwrfvjg-tdb-1.3.18	  94.1M

###### Notify maintainers

cc @
