### PR TITLE
firefox: fix indexedDB for 71.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -110,7 +110,8 @@ let
       url = "https://raw.githubusercontent.com/archlinuxarm/PKGBUILDs/09c7fa0dc1d87922e3b464c0fa084df1227fca79/extra/firefox/build-arm-libopus.patch";
       sha256 = "1zg56v3lc346fkzcjjx21vjip2s9hb2xw4pvza1dsfdnhsnzppfp";
     })
-  ] ++ patches;
+  ] ++ lib.optional (lib.versionAtLeast ffversion "71") ./fix-ff71-lto.patch
+  ++ patches;
 
 in
 

--- a/pkgs/applications/networking/browsers/firefox/fix-ff71-lto.patch
+++ b/pkgs/applications/networking/browsers/firefox/fix-ff71-lto.patch
@@ -1,0 +1,100 @@
+Original Patch: https://bugzilla.mozilla.org/show_bug.cgi?id=1601707#c6
+
+Also fixes the issues with dom localstorage.
+
+--- a/dom/indexedDB/ActorsParent.cpp
++++ b/dom/indexedDB/ActorsParent.cpp
+@@ -24311,11 +24311,11 @@ nsresult ObjectStoreAddOrPutRequestOp::DoDatabaseWork(
+   // if we allow overwrite or not. By not allowing overwrite we raise
+   // detectable errors rather than corrupting data.
+   DatabaseConnection::CachedStatement stmt;
+-  const auto& optReplaceDirective = (!mOverwrite || keyUnset)
+-                                        ? NS_LITERAL_CSTRING("")
+-                                        : NS_LITERAL_CSTRING("OR REPLACE ");
+   rv = aConnection->GetCachedStatement(
+-      NS_LITERAL_CSTRING("INSERT ") + optReplaceDirective +
++      NS_LITERAL_CSTRING("INSERT ") +
++	  ((!mOverwrite || keyUnset)
++           ? NS_LITERAL_CSTRING("")
++           : NS_LITERAL_CSTRING("OR REPLACE ")) +
+           NS_LITERAL_CSTRING("INTO object_data "
+                              "(object_store_id, key, file_ids, data) "
+                              "VALUES (:") +
+@@ -26076,9 +26076,6 @@ nsresult Cursor::OpenOp::DoIndexDatabaseWork(DatabaseConnection* aConnection) {
+ 
+   const bool usingKeyRange = mOptionalKeyRange.isSome();
+ 
+-  const auto& indexTable = mCursor->mUniqueIndex
+-                               ? NS_LITERAL_CSTRING("unique_index_data")
+-                               : NS_LITERAL_CSTRING("index_data");
+ 
+   NS_NAMED_LITERAL_CSTRING(sortColumn, "sort_column");
+ 
+@@ -26099,7 +26096,9 @@ nsresult Cursor::OpenOp::DoIndexDatabaseWork(DatabaseConnection* aConnection) {
+                                  "object_data.file_ids, "
+                                  "object_data.data "
+                                  "FROM ") +
+-                             indexTable +
++                             (mCursor->mUniqueIndex
++                                 ? NS_LITERAL_CSTRING("unique_index_data")
++                                 : NS_LITERAL_CSTRING("index_data")) +
+                              NS_LITERAL_CSTRING(
+                                  " AS index_table "
+                                  "JOIN object_data "
+@@ -26198,9 +26197,6 @@ nsresult Cursor::OpenOp::DoIndexKeyDatabaseWork(
+ 
+   const bool usingKeyRange = mOptionalKeyRange.isSome();
+ 
+-  const auto& table = mCursor->mUniqueIndex
+-                          ? NS_LITERAL_CSTRING("unique_index_data")
+-                          : NS_LITERAL_CSTRING("index_data");
+ 
+   NS_NAMED_LITERAL_CSTRING(sortColumn, "sort_column");
+ 
+@@ -26218,7 +26214,10 @@ nsresult Cursor::OpenOp::DoIndexKeyDatabaseWork(
+                              NS_LITERAL_CSTRING(
+                                  "object_data_key "
+                                  " FROM ") +
+-                             table + NS_LITERAL_CSTRING(" WHERE index_id = :") +
++                             (mCursor->mUniqueIndex
++                                 ? NS_LITERAL_CSTRING("unique_index_data")
++                                 : NS_LITERAL_CSTRING("index_data")) +
++                             NS_LITERAL_CSTRING(" WHERE index_id = :") +
+                              kStmtParamNameId;
+ 
+   const auto keyRangeClause =
+diff --git a/dom/localstorage/ActorsParent.cpp b/dom/localstorage/ActorsParent.cpp
+index 9c46c20670..642cef1701 100644
+--- a/dom/localstorage/ActorsParent.cpp
++++ b/dom/localstorage/ActorsParent.cpp
+@@ -6959,13 +6959,10 @@ nsresult PrepareDatastoreOp::Start() {
+   MOZ_ASSERT(!QuotaClient::IsShuttingDownOnBackgroundThread());
+   MOZ_ASSERT(MayProceed());
+ 
+-  const LSRequestCommonParams& commonParams =
+-      mForPreload
+-          ? mParams.get_LSRequestPreloadDatastoreParams().commonParams()
+-          : mParams.get_LSRequestPrepareDatastoreParams().commonParams();
+-
+   const PrincipalInfo& storagePrincipalInfo =
+-      commonParams.storagePrincipalInfo();
++      mForPreload
++          ? mParams.get_LSRequestPreloadDatastoreParams().commonParams().storagePrincipalInfo()
++          : mParams.get_LSRequestPrepareDatastoreParams().commonParams().storagePrincipalInfo();
+ 
+   if (storagePrincipalInfo.type() == PrincipalInfo::TSystemPrincipalInfo) {
+     QuotaManager::GetInfoForChrome(&mSuffix, &mGroup, &mOrigin);
+@@ -6996,10 +6993,9 @@ nsresult PrepareDatastoreOp::CheckExistingOperations() {
+     return NS_ERROR_FAILURE;
+   }
+ 
+-  const LSRequestCommonParams& commonParams =
+-      mForPreload
+-          ? mParams.get_LSRequestPreloadDatastoreParams().commonParams()
+-          : mParams.get_LSRequestPrepareDatastoreParams().commonParams();
++  const LSRequestCommonParams& preloadCommonParams = mParams.get_LSRequestPreloadDatastoreParams().commonParams();
++  const LSRequestCommonParams& prepareCommonParams = mParams.get_LSRequestPrepareDatastoreParams().commonParams();
++  const LSRequestCommonParams& commonParams = mForPreload ? preloadCommonParams : prepareCommonParams;
+ 
+   const PrincipalInfo& storagePrincipalInfo =
+       commonParams.storagePrincipalInfo();


### PR DESCRIPTION
Adapted [original patch](https://bugzilla.mozilla.org/show_bug.cgi?id=1601707#c6) to also fix dom localstorage.

###### Motivation for this change

See discussion in https://github.com/NixOS/nixpkgs/pull/74905#issuecomment-562847578.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

