### PR TITLE
nixos/make-test: don't pick up impure overlays

### DIFF
--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };

--- a/nixos/tests/buildbot.nix
+++ b/nixos/tests/buildbot.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/certmgr.nix
+++ b/nixos/tests/certmgr.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };

--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem
 , config ? {}
-, pkgs ? import ../.. { inherit system config; }
+, overlays ? []
+, pkgs ? import ../.. { inherit system config overlays; }
 , channelMap ? {
     stable = pkgs.chromium;
     beta   = pkgs.chromiumBeta;

--- a/nixos/tests/cloud-init.nix
+++ b/nixos/tests/cloud-init.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };

--- a/nixos/tests/common/letsencrypt/mkcerts.nix
+++ b/nixos/tests/common/letsencrypt/mkcerts.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {}
+{ pkgs ? import ../../../.. { config = {}; overlays = []; }
 , lib ? pkgs.lib
 
 , domains ? [ "acme-v02.api.letsencrypt.org" "letsencrypt.org" ]

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/elk.nix
+++ b/nixos/tests/elk.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; },
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
   enableUnfree ? false
   # To run the test on the unfree ELK use the folllowing command:
   # NIXPKGS_ALLOW_UNFREE=1 nix-build nixos/tests/elk.nix -A ELK-6 --arg enableUnfree true

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };

--- a/nixos/tests/hydra/default.nix
+++ b/nixos/tests/hydra/default.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem
 , config ? { }
-, pkgs ? import ../../.. { inherit system config; }
+, overlays ? []
+, pkgs ? import ../../.. { inherit system config overlays; }
 }:
 
 let

--- a/nixos/tests/installed-tests/default.nix
+++ b/nixos/tests/installed-tests/default.nix
@@ -3,7 +3,8 @@
 
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../../.. { inherit system config overlays; }
 }:
 
 with import ../../lib/testing-python.nix { inherit system pkgs; };

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/kafka.nix
+++ b/nixos/tests/kafka.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/kerberos/default.nix
+++ b/nixos/tests/kerberos/default.nix
@@ -1,5 +1,5 @@
 { system ? builtins.currentSystem
-, pkgs ? import ../../.. { inherit system; }
+, pkgs ? import ../../.. { inherit system; config = {}; overlays = []; }
 }:
 {
   mit = import ./mit.nix { inherit system pkgs; };

--- a/nixos/tests/keymap.nix
+++ b/nixos/tests/keymap.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/kubernetes/base.nix
+++ b/nixos/tests/kubernetes/base.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../../.. { inherit system config overlays; }
 }:
 
 with import ../../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/kubernetes/dns.nix
+++ b/nixos/tests/kubernetes/dns.nix
@@ -1,4 +1,7 @@
-{ system ? builtins.currentSystem, pkgs ? import <nixpkgs> { inherit system; } }:
+{ system ? builtins.currentSystem
+, pkgs ? import ../../.. { inherit system; config = {}; overlays = []; }
+}:
+
 with import ./base.nix { inherit system; };
 let
   domain = "my.zyx";

--- a/nixos/tests/kubernetes/e2e.nix
+++ b/nixos/tests/kubernetes/e2e.nix
@@ -1,4 +1,7 @@
-{ system ? builtins.currentSystem, pkgs ? import <nixpkgs> { inherit system; } }:
+{ system ? builtins.currentSystem
+, pkgs ? import ../../.. { inherit system; config = {}; overlays = []; }
+}:
+
 with import ./base.nix { inherit system; };
 let
   domain = "my.zyx";

--- a/nixos/tests/kubernetes/rbac.nix
+++ b/nixos/tests/kubernetes/rbac.nix
@@ -1,4 +1,7 @@
-{ system ? builtins.currentSystem, pkgs ? import <nixpkgs> { inherit system; } }:
+{ system ? builtins.currentSystem
+, pkgs ? import ../../.. { inherit system; config = {}; overlays = []; }
+}:
+
 with import ./base.nix { inherit system; };
 let
 

--- a/nixos/tests/make-test-python.nix
+++ b/nixos/tests/make-test-python.nix
@@ -1,6 +1,6 @@
 f: {
   system ? builtins.currentSystem,
-  pkgs ? import ../.. { inherit system; config = {}; },
+  pkgs ? import ../.. { inherit system; config = {}; overlays = []; },
   ...
 } @ args:
 

--- a/nixos/tests/make-test.nix
+++ b/nixos/tests/make-test.nix
@@ -1,6 +1,6 @@
 f: {
   system ? builtins.currentSystem,
-  pkgs ? import ../.. { inherit system; config = {}; },
+  pkgs ? import ../.. { inherit system; config = {}; overlays = []; },
   ...
 } @ args:
 

--- a/nixos/tests/matomo.nix
+++ b/nixos/tests/matomo.nix
@@ -1,5 +1,7 @@
-{ system ? builtins.currentSystem, config ? { }
-, pkgs ? import ../.. { inherit system config; } }:
+{ system ? builtins.currentSystem
+, config ? { }
+, overlays ? []
+, pkgs ? import ../.. { inherit system config overlays; } }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };
 with pkgs.lib;

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem
 , config ? {}
-, pkgs ? import ../.. { inherit system config; }
+, overlays ? []
+, pkgs ? import ../.. { inherit system config overlays; }
 # bool: whether to use networkd in the tests
 , networkd }:
 

--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../../.. { inherit system config overlays; }
 }:
 {
   basic = import ./basic.nix { inherit system pkgs; };

--- a/nixos/tests/openstack-image.nix
+++ b/nixos/tests/openstack-image.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/postgresql-wal-receiver.nix
+++ b/nixos/tests/postgresql-wal-receiver.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem
 , config ? { }
-, pkgs ? import ../.. { inherit system config; } }:
+, overlays ? []
+, pkgs ? import ../.. { inherit system config overlays; } }:
 
 with import ../lib/testing.nix { inherit system pkgs; };
 with pkgs.lib;

--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };

--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 let

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem
 , config ? {}
-, pkgs ? import ../.. { inherit system config; }
+, overlays ? []
+, pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 let

--- a/nixos/tests/redmine.nix
+++ b/nixos/tests/redmine.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/rspamd.nix
+++ b/nixos/tests/rspamd.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/rsyslogd.nix
+++ b/nixos/tests/rsyslogd.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/run-in-machine.nix
+++ b/nixos/tests/run-in-machine.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config config; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };

--- a/nixos/tests/solr.nix
+++ b/nixos/tests/solr.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; },
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; },
   debug ? false,
   enableUnfree ? false,
   # Nested KVM virtualization (https://www.linux-kvm.org/page/Nested_Guests)

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  overlays ? [],
+  pkgs ? import ../.. { inherit system config overlays; }
 }:
 
 with import ../lib/testing.nix { inherit system pkgs; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Specify overlays = [] to prevent nixpkgs from evaluating overlays from
$HOME etc.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc @Ekleog @aszlig 
