### PR TITLE
netdata: 1.18.1 -> 1.19.0

### DIFF
--- a/nixos/tests/netdata.nix
+++ b/nixos/tests/netdata.nix
@@ -25,6 +25,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
     # check if the netdata main page loads.
     netdata.succeed("curl --fail http://localhost:19999/")
+    netdata.succeed("sleep 4")
 
     # check if netdata can read disk ops for root owned processes.
     # if > 0, successful. verifies both netdata working and

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
 , CoreFoundation, IOKit, libossp_uuid
 , curl, libcap,  libuuid, lm_sensors, zlib
 , withCups ? false, cups
@@ -12,12 +12,14 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "1.18.1";
+  version = "1.19.0";
   pname = "netdata";
 
-  src = fetchurl {
-    url = "https://github.com/netdata/netdata/releases/download/v${version}/netdata-v${version}.tar.gz";
-    sha256 = "08g5jp63k8y5gbg8v9hxj75q0533c6cyzpjml9z1g5h2h4zaik1r";
+  src = fetchFromGitHub {
+    owner = "netdata";
+    repo = "netdata";
+    rev = "v${version}";
+    sha256 = "1s6kzx4xh8b6v7ki8h2mfzprj5rxvlgx2md20cr8c0v81qpz3q3q";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];

--- a/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
+++ b/pkgs/tools/system/netdata/no-files-in-etc-and-var.patch
@@ -1,9 +1,9 @@
 diff --git a/Makefile.am b/Makefile.am
-index f2087bb..7a70cfb 100644
+index 2625dcc..1fdd645 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -116,10 +116,10 @@ AM_CFLAGS = \
- 	$(NULL)
+@@ -113,10 +113,10 @@ AM_CFLAGS = \
+     $(NULL)
  
  sbin_PROGRAMS =
 -dist_cache_DATA = packaging/installer/.keep
@@ -17,70 +17,113 @@ index f2087bb..7a70cfb 100644
  plugins_PROGRAMS =
  
  LIBNETDATA_FILES = \
+diff --git a/collectors/Makefile.am b/collectors/Makefile.am
+index 7431025..f62f8ac 100644
+--- a/collectors/Makefile.am
++++ b/collectors/Makefile.am
+@@ -30,11 +30,6 @@ SUBDIRS = \
+ usercustompluginsconfigdir=$(configdir)/custom-plugins.d
+ usergoconfigdir=$(configdir)/go.d
+ 
+-# Explicitly install directories to avoid permission issues due to umask
+-install-exec-local:
+-	$(INSTALL) -d $(DESTDIR)$(usercustompluginsconfigdir)
+-	$(INSTALL) -d $(DESTDIR)$(usergoconfigdir)
+-
+ dist_noinst_DATA = \
+     README.md \
+     $(NULL)
 diff --git a/collectors/charts.d.plugin/Makefile.am b/collectors/charts.d.plugin/Makefile.am
-index 2989b4b..64de7d6 100644
+index b3b2fb9..68b768e 100644
 --- a/collectors/charts.d.plugin/Makefile.am
 +++ b/collectors/charts.d.plugin/Makefile.am
-@@ -32,7 +32,6 @@ dist_charts_DATA = \
+@@ -31,13 +31,8 @@ dist_charts_DATA = \
  
  userchartsconfigdir=$(configdir)/charts.d
  dist_userchartsconfig_DATA = \
 -    .keep \
      $(NULL)
  
+-# Explicitly install directories to avoid permission issues due to umask
+-install-exec-local:
+-	$(INSTALL) -d $(DESTDIR)$(userchartsconfigdir)
+-
  chartsconfigdir=$(libconfigdir)/charts.d
+ dist_chartsconfig_DATA = \
+     $(NULL)
 diff --git a/collectors/node.d.plugin/Makefile.am b/collectors/node.d.plugin/Makefile.am
-index 3b5a0a5..b7abe01 100644
+index 411bce9..ba60276 100644
 --- a/collectors/node.d.plugin/Makefile.am
 +++ b/collectors/node.d.plugin/Makefile.am
-@@ -23,7 +23,6 @@ dist_noinst_DATA = \
+@@ -23,13 +23,8 @@ dist_noinst_DATA = \
  
  usernodeconfigdir=$(configdir)/node.d
  dist_usernodeconfig_DATA = \
 -    .keep \
      $(NULL)
  
+-# Explicitly install directories to avoid permission issues due to umask
+-install-exec-local:
+-	$(INSTALL) -d $(DESTDIR)$(usernodeconfigdir)
+-
  nodeconfigdir=$(libconfigdir)/node.d
+ dist_nodeconfig_DATA = \
+     $(NULL)
 diff --git a/collectors/python.d.plugin/Makefile.am b/collectors/python.d.plugin/Makefile.am
-index 652a35d..cf4b2cc 100644
+index cb14e35..8a6c5a7 100644
 --- a/collectors/python.d.plugin/Makefile.am
 +++ b/collectors/python.d.plugin/Makefile.am
-@@ -29,7 +29,6 @@ dist_python_DATA = \
+@@ -29,13 +29,8 @@ dist_python_DATA = \
  
  userpythonconfigdir=$(configdir)/python.d
  dist_userpythonconfig_DATA = \
 -    .keep \
      $(NULL)
  
+-# Explicitly install directories to avoid permission issues due to umask
+-install-exec-local:
+-	$(INSTALL) -d $(DESTDIR)$(userpythonconfigdir)
+-
  pythonconfigdir=$(libconfigdir)/python.d
+ dist_pythonconfig_DATA = \
+     $(NULL)
 diff --git a/collectors/statsd.plugin/Makefile.am b/collectors/statsd.plugin/Makefile.am
-index e63bf98..0f59782 100644
+index 87b6ca7..9d010c7 100644
 --- a/collectors/statsd.plugin/Makefile.am
 +++ b/collectors/statsd.plugin/Makefile.am
-@@ -14,6 +14,5 @@ dist_statsdconfig_DATA = \
+@@ -14,9 +14,4 @@ dist_statsdconfig_DATA = \
  
  userstatsdconfigdir=$(configdir)/statsd.d
  dist_userstatsdconfig_DATA = \
 -    .keep \
      $(NULL)
- 
+-
+-# Explicitly install directories to avoid permission issues due to umask
+-install-exec-local:
+-	$(INSTALL) -d $(DESTDIR)$(userstatsdconfigdir)
 diff --git a/health/Makefile.am b/health/Makefile.am
-index 62a4c6d..4d651df 100644
+index f63faa8..8912ef2 100644
 --- a/health/Makefile.am
 +++ b/health/Makefile.am
-@@ -16,7 +16,6 @@ dist_noinst_DATA = \
+@@ -16,13 +16,8 @@ dist_noinst_DATA = \
  
  userhealthconfigdir=$(configdir)/health.d
  dist_userhealthconfig_DATA = \
 -    .keep \
      $(NULL)
  
+-# Explicitly install directories to avoid permission issues due to umask
+-install-exec-local:
+-	$(INSTALL) -d $(DESTDIR)$(userhealthconfigdir)
+-
  healthconfigdir=$(libconfigdir)/health.d
+ dist_healthconfig_DATA = \
+     health.d/adaptec_raid.conf \
 diff --git a/system/Makefile.am b/system/Makefile.am
-index b085dca..ccfa588 100644
+index ad68c65..bf6a840 100644
 --- a/system/Makefile.am
 +++ b/system/Makefile.am
-@@ -17,10 +17,6 @@ CLEANFILES = \
+@@ -16,14 +16,6 @@ CLEANFILES = \
  include $(top_srcdir)/build/subst.inc
  SUFFIXES = .in
  
@@ -88,6 +131,25 @@ index b085dca..ccfa588 100644
 -    edit-config \
 -    $(NULL)
 -
+-# Explicitly install directories to avoid permission issues due to umask
+-install-exec-local:
+-	$(INSTALL) -d $(DESTDIR)$(configdir)
+-
  nodist_noinst_DATA = \
- 	netdata-openrc \
- 	netdata.logrotate \
+     netdata-openrc \
+     netdata.logrotate \
+diff --git a/web/Makefile.am b/web/Makefile.am
+index ccaccd7..f2fed50 100644
+--- a/web/Makefile.am
++++ b/web/Makefile.am
+@@ -11,10 +11,6 @@ SUBDIRS = \
+ 
+ usersslconfigdir=$(configdir)/ssl
+ 
+-# Explicitly install directories to avoid permission issues due to umask
+-install-exec-local:
+-	$(INSTALL) -d $(DESTDIR)$(usersslconfigdir)
+-
+ dist_noinst_DATA = \
+     README.md \
+     gui/confluence/README.md \


### PR DESCRIPTION
###### Motivation for this change
Update netdata to version 1.19.0.
Changelog - https://docs.netdata.cloud/changelog/#v1190-2019-11-27

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
