### PR TITLE
ark: Add package description

### DIFF
--- a/pkgs/applications/kde/ark/default.nix
+++ b/pkgs/applications/kde/ark/default.nix
@@ -22,6 +22,7 @@ in
 mkDerivation {
   name = "ark";
   meta = {
+    description = "Graphical file compression/decompression utility";
     license = with lib.licenses;
       [ gpl2 lgpl3 ] ++ lib.optional unfreeEnableUnrar unfree;
     maintainers = [ lib.maintainers.ttuegel ];


### PR DESCRIPTION
###### Motivation for this change
The KDE utility ark has no description

###### Things done
Trivial change: added meta.description with a copy of the first line of description from the upstream website

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ttuegel 
