### PR TITLE
linux: fix amdgpu memory mapping with kernel >= 5.3

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -716,6 +716,9 @@ let
 
       # Enable AMD's ROCm GPU compute stack
       HSA_AMD = whenAtLeast "4.20" yes;
+      ZONE_DEVICE = whenAtLeast "5.3" yes;
+      HMM_MIRROR = whenAtLeast "5.3" yes;
+      DRM_AMDGPU_USERPTR = whenAtLeast "5.3" yes;
 
       PREEMPT = no;
       PREEMPT_VOLUNTARY = yes;


### PR DESCRIPTION
These configuration options are needed for the ROCm GPU compute stack
on kernels >= 5.3.

I first [discovered](https://github.com/RadeonOpenCompute/ROCm/issues/906#issuecomment-543397014) the need for these kernel options some time ago (probably when moving my main dev machine to kernel 5.3), and they were recently [rediscovered](https://github.com/nixos-rocm/nixos-rocm/issues/23#issuecomment-562771154) by another nixos-rocm user. Without them, ROCm software quickly crashes when attempting to communicate with the GPU. 

FWIW, these options are all enabled in the default [Arch kernel configuration](https://git.archlinux.org/svntogit/packages.git/tree/trunk/config?h=packages/linux), afaict.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
