### PR TITLE
kitty: replace library path using patch instead of substituteInPlace

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -70,16 +70,13 @@ buildPythonApplication rec {
       src = ./library-paths.patch;
       libstartup_notification = "${libstartup_notification}/lib/libstartup-notification-1.so";
       libcanberra = "${libcanberra}/lib/libcanberra.so";
+      libEGL = "${stdenv.lib.getLib libGL}/lib/libEGL.so.1";
     })
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
     ./no-lto.patch
     ./no-werror.patch
     ./png2icns.patch
   ];
-
-  preConfigure  = stdenv.lib.optional (!stdenv.isDarwin) ''
-    substituteInPlace glfw/egl_context.c --replace "libEGL.so.1" "${stdenv.lib.getLib libGL}/lib/libEGL.so.1"
-  '';
 
   buildPhase = if stdenv.isDarwin then ''
     ${python.interpreter} setup.py kitty.app --update-check-interval=0

--- a/pkgs/applications/misc/kitty/library-paths.patch
+++ b/pkgs/applications/misc/kitty/library-paths.patch
@@ -1,3 +1,15 @@
+--- a/glfw/egl_context.c
++++ b/glfw/egl_context.c
+@@ -314,7 +314,7 @@ bool _glfwInitEGL(void)
+ #elif defined(__CYGWIN__)
+         "libEGL-1.so",
+ #else
+-        "libEGL.so.1",
++        "@libEGL@",
+ #endif
+         NULL
+     };
+
 --- a/kitty/desktop.c
 +++ b/kitty/desktop.c
 @@ -30,7 +30,7 @@


### PR DESCRIPTION
This makes patching the path for `libEGL` consistent with `libstartup-notification` and `libcanberra`.
It should also prevent silently doing nothing in case the code in kitty is changed, similar to what was described in 1842c4aaa409e4731d355aa1f77ed817dd3939a2.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tex @rvolosatovs @Ma27
