### PR TITLE
modules-shrunk: preserve module priorities from build

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -56,4 +56,12 @@ for module in $closure; do
     done
 done
 
+# copy module ordering hints for depmod
+cp $kernel/lib/modules/"$version"/modules.order $out/lib/modules/"$version"/.
+cp $kernel/lib/modules/"$version"/modules.builtin $out/lib/modules/"$version"/.
+
 depmod -b $out -a $version
+
+# remove original hints from final derivation
+rm $out/lib/modules/"$version"/modules.order
+rm $out/lib/modules/"$version"/modules.builtin


### PR DESCRIPTION
`depmod` looks for files modules.order and modules.builtin which are
generated at kernel build time but were previously not passed to
the `modules-shrunk` derivation.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

```
depmod: WARNING: could not open modules.order at /nix/store/fprfhcrkzbnqlivj146j57sjccm5kjpf-linux-4.19.87-modules-shrunk/lib/modules/4.19.87: No such file or directory
depmod: WARNING: could not open modules.builtin at /nix/store/fprfhcrkzbnqlivj146j57sjccm5kjpf-linux-4.19.87-modules-shrunk/lib/modules/4.19.87: No such file or directory
```

on `nixos-rebuild`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested in production
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
