### PR TITLE
kotatogram-desktop: init at 1.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2910,6 +2910,12 @@
     githubId = 4401220;
     name = "Michael Eden";
   };
+  ilya-fedin = {
+    email = "fedin-ilja2010@ya.ru";
+    github = "ilya-fedin";
+    githubId = 17829319;
+    name = "Ilya Fedin";
+  };
   ilya-kolpakov = {
     email = "ilya.kolpakov@gmail.com";
     github = "ilya-kolpakov";

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -1,0 +1,54 @@
+{ mkDerivation, lib, fetchFromGitHub, pkg-config, python3, cmake, ninja
+, qtbase, qtimageformats, enchant, xdg_utils, ffmpeg, openalSoft, lzma
+, lz4, xxHash, zlib, minizip, openssl, libtgvoip, range-v3
+}:
+
+with lib;
+
+mkDerivation rec {
+  pname = "kotatogram-desktop";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "kotatogram";
+    repo = "kotatogram-desktop";
+    rev = "k${version}";
+    sha256 = "1j5wn3k1mr2c39szmyzm0pf720jmbllcaj40p2ydx0p3lir1s760";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp \
+      --replace '"libenchant-2.so.2"' '"${enchant}/lib/libenchant-2.so.2"'
+  '';
+
+  nativeBuildInputs = [ pkg-config python3 cmake ninja ];
+
+  buildInputs = [
+    qtbase qtimageformats ffmpeg openalSoft lzma lz4 xxHash
+    zlib minizip openssl enchant libtgvoip range-v3
+  ];
+
+  qtWrapperArgs = [
+    "--prefix PATH : ${xdg_utils}/bin"
+  ];
+
+  cmakeFlags = [
+    "-DTDESKTOP_API_TEST=ON"
+    "-DTDESKTOP_DISABLE_GTK_INTEGRATION=ON"
+    "-DDESKTOP_APP_USE_PACKAGED_RLOTTIE=OFF"
+  ];
+
+  meta = {
+    description = "Kotatogram – experimental Telegram Desktop fork";
+    longDescription = ''
+      Unofficial desktop client for the Telegram messenger, based on Telegram Desktop.
+
+      It contains some useful (or purely cosmetic) features, but they could be unstable. A detailed list is available here: https://kotatogram.github.io/changes
+    '';
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    homepage = https://kotatogram.github.io;
+    maintainers = with maintainers; [ ilya-fedin ];
+  };
+}

--- a/pkgs/development/libraries/libtgvoip/default.nix
+++ b/pkgs/development/libraries/libtgvoip/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, pkg-config, autoreconfHook
+, openssl, libopus, alsaLib, libpulseaudio
+}:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  pname = "libtgvoip";
+  version = "unstable-2020-01-21";
+
+  src = fetchFromGitHub {
+    owner = "telegramdesktop";
+    repo = "libtgvoip";
+    rev = "ade4434f1c6efabecc3b548ca1f692f8d103d22a";
+    sha256 = "1bhnx3sknadx7a4qk9flh356kffb02xx32grj7cj7ik4rarccgp0";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  buildInputs = [ openssl libopus alsaLib libpulseaudio ];
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "VoIP library for Telegram clients";
+    license = licenses.unlicense;
+    platforms = platforms.linux;
+    homepage = https://github.com/telegramdesktop/libtgvoip;
+    maintainers = with maintainers; [ ilya-fedin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12868,6 +12868,8 @@ in
 
   libtap = callPackage ../development/libraries/libtap { };
 
+  libtgvoip = callPackage ../development/libraries/libtgvoip { };
+
   libtsm = callPackage ../development/libraries/libtsm { };
 
   libtxc_dxtn = callPackage ../development/libraries/libtxc_dxtn { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19676,6 +19676,8 @@ in
 
   konversation = libsForQt5.callPackage ../applications/networking/irc/konversation { };
 
+  kotatogram-desktop = qt5.callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop { };
+
   krita = libsForQt5.callPackage ../applications/graphics/krita {
     openjpeg = openjpeg_1;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
