### PR TITLE
ocaml-top: 1.1.5 → 1.2.0-rc

### DIFF
--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchzip, ncurses, ocamlPackages }:
+{ lib, fetchzip, ncurses, ocamlPackages }:
 
 with ocamlPackages; buildDunePackage rec {
   pname = "ocaml-top";
-  version = "1.1.5";
+  version = "1.2.0-rc";
 
   src = fetchzip {
     url = "https://github.com/OCamlPro/ocaml-top/archive/${version}.tar.gz";
-    sha256 = "1d4i6aanrafgrgk4mh154k6lkwk0b6mh66rykz33awlf5pfqd8yv";
+    sha256 = "1r290m9vvr25lgaanivz05h0kf4fd3h5j61wj4hpp669zffcyyb5";
   };
 
-  buildInputs = [ ncurses ocp-build lablgtk ocp-index ];
+  buildInputs = [ ncurses ocp-build lablgtk3-sourceview3 ocp-index ];
 
   configurePhase = ''
     export TERM=xterm
@@ -18,8 +18,8 @@ with ocamlPackages; buildDunePackage rec {
 
   meta = {
     homepage = https://www.typerex.org/ocaml-top.html;
-    license = stdenv.lib.licenses.gpl3;
+    license = lib.licenses.gpl3;
     description = "A simple cross-platform OCaml code editor built for top-level evaluation";
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Major update, port to GTK3

https://github.com/OCamlPro/ocaml-top/releases/tag/1.2.0-rc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

