### PR TITLE
ocamlPackages.lua-ml: init at 0.9

### DIFF
--- a/pkgs/development/ocaml-modules/lua-ml/default.nix
+++ b/pkgs/development/ocaml-modules/lua-ml/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, dune }:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.07"
+then throw "lua-ml is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  pname = "lua-ml";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "lindig";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "09lj6qykg15fdf65in7xdry0jcifcr8vqbvz85v12gwfckmmxjir";
+  };
+
+  buildInputs = [ ocaml findlib ocamlbuild ];
+
+  buildFlags = [ "lib" ];
+
+  inherit (dune) installPhase;
+
+  meta = {
+    description = "An embeddable Lua 2.5 interpreter implemented in OCaml";
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+    license = stdenv.lib.licenses.bsd2;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -436,6 +436,8 @@ let
 
     lru = callPackage ../development/ocaml-modules/lru { };
 
+    lua-ml = callPackage ../development/ocaml-modules/lua-ml { };
+
     lwt2 = callPackage ../development/ocaml-modules/lwt/legacy.nix { };
 
     lwt4 = callPackage ../development/ocaml-modules/lwt/4.x.nix { };


### PR DESCRIPTION
###### Motivation for this change

Dependency of [soupault](https://soupault.neocities.org/)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
