### PR TITLE
sonic: 2016-03-01 -> 2018-07-06

### DIFF
--- a/pkgs/development/libraries/sonic/default.nix
+++ b/pkgs/development/libraries/sonic/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, fftw }:
 
 stdenv.mkDerivation {
   pname = "sonic";
-  version = "2016-03-01";
+  version = "2018-07-06";
 
   src = fetchFromGitHub {
     owner = "waywardgeek";
     repo = "sonic";
-    rev = "71bdf26c55716a45af50c667c0335a9519e952dd";
-    sha256 = "1kcl8fdf92kafmfhvyjal5gvkn99brkjyzbi9gw3rd5b30m3xz2b";
+    rev = "71c51195de71627d7443d05378c680ba756545e8";
+    sha256 = "1z9qdk3pk507hdg39v2z1hanlw2wv7mhn8br4cb8qry9z9qwi87i";
   };
 
   postPatch = ''
     sed -i "s,^PREFIX=.*,PREFIX=$out," Makefile
   '';
+
+  buildInputs = [ fftw ];
 
   meta = with stdenv.lib; {
     description = "Simple library to speed up or slow down speech";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update a `speechd` dependency.
Tested with `mumble.override { speechdSupport = true; }`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
