### PR TITLE
haskellPackages.niv: 0.1.1 -> 0.2.6 (fix build under 19,09)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -7454,7 +7454,6 @@ broken-packages:
   - Ninjas
   - nirum
   - nitro
-  - niv
   - nixfromnpm
   - nkjp
   - nlp-scores


### PR DESCRIPTION
Fixes broken build in Nixpkgs 19.09.