### PR TITLE
rambox-pro: fix missing icons, autostart and clean up dir layout

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/pro.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/pro.nix
@@ -20,6 +20,9 @@ stdenv.mkDerivation rec {
 
     asar e resources/app.asar $out/resources
 
+    substituteInPlace "$out/resources/dist/electron/main.js" \
+      --replace ",isHidden:" ",path:\"$out/bin/ramboxpro\",isHidden:"
+
     cp $desktopItem/share/applications/* $out/share/applications
     cp $out/resources/dist/electron/imgs/256x256.png $out/share/icons/hicolor/256x256/apps/ramboxpro.png
     cp $out/resources/dist/electron/imgs/256x256.png $out/resources/dist/renderer/assets/images/app/icon.png

--- a/pkgs/applications/networking/instant-messengers/rambox/pro.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/pro.nix
@@ -16,22 +16,28 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir -p $out/bin $out/opt/RamboxPro $out/share/applications
-    asar e resources/app.asar $out/opt/RamboxPro/resources/app.asar.unpacked   
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
+    mkdir -p $out/{bin,resources/dist/renderer/assets/images/app,share/applications,share/icons/hicolor/256x256/apps}
+
+    asar e resources/app.asar $out/resources
+
+    cp $desktopItem/share/applications/* $out/share/applications
+    cp $out/resources/dist/electron/imgs/256x256.png $out/share/icons/hicolor/256x256/apps/ramboxpro.png
+    cp $out/resources/dist/electron/imgs/256x256.png $out/resources/dist/renderer/assets/images/app/icon.png
   '';
 
   postFixup = ''
     makeWrapper ${electron}/bin/electron $out/bin/ramboxpro \
-      --add-flags "$out/opt/RamboxPro/resources/app.asar.unpacked --without-update" \
+      --add-flags "$out/resources --without-update" \
       --prefix PATH : ${xdg_utils}/bin
   '';
 
   desktopItem = makeDesktopItem {
     name = "rambox-pro";
     exec = "ramboxpro";
+    icon = "ramboxpro";
     type = "Application";
     desktopName = "Rambox Pro";
+    categories = "Network;";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The main motivation for this change was to add actual icons to Rambox Pro since the lack of any icons was bugging me and no doubt any other users of the package.

I have also resolved an issue where the Electron application itself was autostarted at login instead of Rambox Pro like it should be.

I also decided to clean up the directory structure in-line with other similar packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
