### PR TITLE
aiger, lingeling: enable for darwin

### DIFF
--- a/pkgs/applications/science/logic/aiger/default.nix
+++ b/pkgs/applications/science/logic/aiger/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage    = http://fmv.jku.at/aiger/;
     license     = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ thoughtpolice ];
-    platforms   = stdenv.lib.platforms.linux;
+    platforms   = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/applications/science/logic/lingeling/default.nix
+++ b/pkgs/applications/science/logic/lingeling/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
     description = "Fast SAT solver";
     homepage    = http://fmv.jku.at/lingeling/;
     license     = licenses.mit;
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
While working on #75279 I noticed that two of its dependencies do actually appear to build & work fine on darwin (tested macos 10.14).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
