### PR TITLE
weechat: 2.6 -> 2.7

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -27,12 +27,12 @@ let
   in
     assert lib.all (p: p.enabled -> ! (builtins.elem null p.buildInputs)) plugins;
     stdenv.mkDerivation rec {
-      version = "2.6";
+      version = "2.7";
       pname = "weechat";
 
       src = fetchurl {
         url = "https://weechat.org/files/src/weechat-${version}.tar.bz2";
-        sha256 = "1narazk28m7lmn1vqi7bhyvnr8apjrmaa4w1hbadn64hwr8ya1hb";
+        sha256 = "00hzchzw1w2181kczcrrnj8ngml3bwk7qciha3higxq3qynf0h8c";
       };
 
       outputs = [ "out" "man" ] ++ map (p: p.name) enabledPlugins;
@@ -41,6 +41,8 @@ let
       cmakeFlags = with stdenv.lib; [
         "-DENABLE_MAN=ON"
         "-DENABLE_DOC=ON"
+        "-DENABLE_JAVASCRIPT=OFF"  # Requires v8 <= 3.24.3, https://github.com/weechat/weechat/issues/360
+        "-DENABLE_PHP=OFF"
       ]
         ++ optionals stdenv.isDarwin ["-DICONV_LIBRARY=${libiconv}/lib/libiconv.dylib" "-DCMAKE_FIND_FRAMEWORK=LAST"]
         ++ map (p: "-D${p.cmakeFlag}=" + (if p.enabled then "ON" else "OFF")) plugins


### PR DESCRIPTION
##### Motivation for this change

New upstream release. https://weechat.org/files/changelog/ChangeLog-2.7.html

I disabled support for PHP and Javascript, both of which are now apparently enabled by default.

- Javascript depends on a v8 version <= 3.24.3, and while we have 3.14 in nixpkgs it is only used by a single package and probably on the way out. Upstream issue is here: https://github.com/weechat/weechat/issues/360
- PHP wants a bunch of additional dependencies, that would somewhat increase the footprint of the derivation
  ```
  [100%] Linking C shared module php.so
  [100%] Linking C shared module guile.so
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lc-client
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lzip
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lzip
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -largon2
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lsodium
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lreadline
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lpq
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lsqlite3
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lpq
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lldap
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -llber
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lpam
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -lpng
  /nix/store/a0kdlyvbj9j4l67a8kxjr494qx6g3q0v-binutils-2.31.1/bin/ld: cannot find -ljpeg
  collect2: error: ld returned 1 exit status
  make[2]: *** [src/plugins/php/CMakeFiles/php.dir/build.make:101: src/plugins/php/php.so] Error 1
  make[1]: *** [CMakeFiles/Makefile2:1239: src/plugins/php/CMakeFiles/php.dir/all] Error 2
  make[1]: *** Waiting for unfinished jobs....
  ```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc  @lovek323 @the-kenny @lheckemann @Ma27
