### PR TITLE
defaultGemConfig: change 'infocmp' reference from 'ncurses.dev' to 'ncurses'

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -536,7 +536,7 @@ in
     dontBuild = false;
     postPatch = ''
       substituteInPlace lib/rbreadline.rb \
-        --replace 'infocmp' '${ncurses.dev}/bin/infocmp'
+        --replace 'infocmp' '${ncurses}/bin/infocmp'
     '';
   };
 


### PR DESCRIPTION
###### Motivation for this change
The "infocmp" binary no longer exists in "${ncurses.dev}/bin/".
It now exists in "${ncurses}/bin/".

This may have changed at https://github.com/NixOS/nixpkgs/commit/c7fbf93ecc8d009c0b1598fb443fb3088b6489a8

My test case is "msfconsole" from the package "metasploit". The tool does not launch without this patch.

I have tested my system with this patch applied, but do not know what other software may be affected.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
