### PR TITLE
mmh: init at 0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3698,6 +3698,16 @@
     githubId = 66669;
     name = "Jeff Zellner";
   };
+  kaction = {
+    name  = "Dmitry Bogatov";
+    email = "KAction@disroot.org";
+    github = "kaction";
+    githubId = 44864956;
+    key = [{
+      longkeyid = "ed25519/0x749FD4DFA2E94236";
+      fingerprint = "3F87 0A7C A7B4 3731 2F13  6083 749F D4DF A2E9 4236";
+    }];
+  };
   kaiha = {
     email = "kai.harries@gmail.com";
     github = "kaiha";

--- a/pkgs/applications/networking/mailreaders/mmh/default.nix
+++ b/pkgs/applications/networking/mailreaders/mmh/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, ncurses, autoreconfHook, flex }:
+let rev = "431604647f89d5aac7b199a7883e98e56e4ccf9e";
+in stdenv.mkDerivation rec {
+  pname = "mmh-unstable";
+  version = "2019-09-08";
+
+  src = fetchurl {
+    url = "http://git.marmaro.de/?p=mmh;a=snapshot;h=${rev};sf=tgz";
+    name = "mmh-${rev}.tgz";
+    sha256 = "1q97p4g3f1q2m567i2dbx7mm7ixw3g91ww2rymwj42cxk9iyizhv";
+  };
+
+  buildInputs = [ ncurses ];
+  nativeBuildInputs = [ autoreconfHook flex ];
+
+  meta = with stdenv.lib; {
+    description = "Set of electronic mail handling programs";
+    homepage = "http://marmaro.de/prog/mmh";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20588,6 +20588,7 @@ in
     else
       libsForQt5.callPackage ../applications/audio/musescore { };
 
+  mmh = callPackage ../applications/networking/mailreaders/mmh { };
   mutt = callPackage ../applications/networking/mailreaders/mutt { };
   mutt-with-sidebar = mutt.override {
     withSidebar = true;


### PR DESCRIPTION
New package for mail reader I use for long time. Patches are ported from
Debian package (also mine).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).