### PR TITLE
mpdris2: add missing gdk-pixbuf to buildInputs

### DIFF
--- a/pkgs/tools/audio/mpdris2/default.nix
+++ b/pkgs/tools/audio/mpdris2/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , autoreconfHook
 , fetchFromGitHub
+, gdk-pixbuf
 , glib
 , gobject-introspection
 , intltool
@@ -34,6 +35,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   buildInputs = [
+    gdk-pixbuf
     glib
     libnotify
   ];


### PR DESCRIPTION
###### Motivation for this change
In order to properly import `Notify` from `libnotify`, `gobject-introspection` seemingly also needs `gdk-pixbuf`. Without this change the notification feature of `mpDris2` is impaired.

###### Things done
Added the missing `gdk-pixbuf` dependency to `buildInputs`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @eonpatapon
