### PR TITLE
buildSkawarePackage: pass through extra args

### DIFF
--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -18,12 +18,15 @@ in {
 , configureFlags
   # mostly for moving and deleting files from the build directory
   # : lines
-, postInstall
+, postInstall ? ""
+  # : lines
+, postFixup ? ""
   # : list Maintainer
 , maintainers ? []
-
-
-}:
+  # : attrs
+, meta ? {}
+, ...
+} @ args:
 
 let
 
@@ -50,15 +53,11 @@ let
     "README.*"
   ];
 
-in stdenv.mkDerivation {
-  name = "${pname}-${version}";
-
+in stdenv.mkDerivation ({
   src = fetchurl {
     url = "https://skarnet.org/software/${pname}/${pname}-${version}.tar.gz";
     inherit sha256;
   };
-
-  inherit outputs;
 
   dontDisableStatic = true;
   enableParallelBuilding = true;
@@ -84,13 +83,11 @@ in stdenv.mkDerivation {
        noiseFiles = commonNoiseFiles;
        docFiles = commonMetaFiles;
      }} $doc/share/doc/${pname}
-
-    ${postInstall}
-  '';
+  '' + postInstall;
 
   postFixup = ''
     ${cleanPackaging.checkForRemainingFiles}
-  '';
+  '' + postFixup;
 
   meta = {
     homepage = "https://skarnet.org/software/${pname}/";
@@ -98,6 +95,9 @@ in stdenv.mkDerivation {
     license = stdenv.lib.licenses.isc;
     maintainers = with lib.maintainers;
       [ pmahoney Profpatsch ] ++ maintainers;
-  };
+  } // meta;
 
-}
+} // builtins.removeAttrs args [
+  "sha256" "configureFlags" "postInstall" "postFixup"
+  "meta" "description" "platforms"  "maintainers"
+])


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This allows things like hooks other than postInstall to be passed
through to mkDerivation, which is very useful when customising or
debugging a package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @pmahoney
