### PR TITLE
thunderbird: rewrite (68.2.2 -> 68.3.0)

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -25,11 +25,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   pname = "thunderbird";
-  version = "68.2.2";
+  version = "68.3.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "3mvanjfc35f14lsfa4zjlhsvwij1n9dz9xmisd5s376r5wp9y33sva5ly914b2hmdl85ypdwv90zyi6whj7jb2f2xmqk480havxgjcn";
+    sha512 = "3aqr3dj5laws516k6jf8f35a1964p0s75sp682yy87xnzgd8m1iha55z79dcavis2ma9hiyacjnznjz04qhqd4q8swjgfg7lj8lyiwl";
   };
 
   # from firefox, but without sound libraries

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -1,213 +1,339 @@
-{ lib, stdenv, fetchurl, pkgconfig, gtk2, pango, perl, python2, python3, nodejs
-, libIDL, libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
-, freetype, fontconfig, file, nspr, nss, libnotify
-, yasm, libGLU, libGL, sqlite, zip, unzip
-, libevent, libstartup_notification
-, icu, libpng, jemalloc
-, autoconf213, which, m4, fetchpatch
-, writeScript, xidel, common-updater-scripts, coreutils, gnused, gnugrep, curl
-, runtimeShell
-, cargo, rustc, rust-cbindgen, llvmPackages, nasm
-, enableGTK3 ? false, gtk3, gnome3, wrapGAppsHook, makeWrapper
-, enableCalendar ? true
-, debugBuild ? false
-, # If you want the resulting program to call itself "Thunderbird" instead
-  # of "Earlybird" or whatever, enable this option.  However, those
-  # binaries may not be distributed without permission from the
-  # Mozilla Foundation, see
-  # http://www.mozilla.org/foundation/trademarks/.
-  enableOfficialBranding ? false
+{ autoconf213
+, bzip2
+, cargo
+, common-updater-scripts
+, coreutils
+, curl
+, dbus
+, dbus-glib
+, fetchurl
+, file
+, fontconfig
+, freetype
+, glib
+, gnugrep
+, gnused
+, icu
+, jemalloc
+, lib
+, libGL
+, libGLU
+, libIDL
+, libevent
+, libjpeg
+, libnotify
+, libpng
+, libstartup_notification
+, libvpx
+, libwebp
+, llvmPackages
+, m4
 , makeDesktopItem
+, nasm
+, nodejs
+, nspr
+, nss
+, pango
+, perl
+, pkgconfig
+, python2
+, python3
+, runtimeShell
+, rust-cbindgen
+, rustc
+, sqlite
+, stdenv
+, unzip
+, which
+, writeScript
+, xidel
+, xorg
+, yasm
+, zip
+, zlib
+
+, debugBuild ? false
+
+, alsaSupport ? stdenv.isLinux, alsaLib
+, pulseaudioSupport ? stdenv.isLinux, libpulseaudio
+, gtk3Support ? true, gtk2, gtk3, wrapGAppsHook
+, waylandSupport ? true
+, libxkbcommon, calendarSupport ? true
+
+, # If you want the resulting program to call itself "Thunderbird" instead
+# of "Earlybird" or whatever, enable this option.  However, those
+# binaries may not be distributed without permission from the
+# Mozilla Foundation, see
+# http://www.mozilla.org/foundation/trademarks/.
+enableOfficialBranding ? false
 }:
 
-let
-  wrapperTool = if enableGTK3 then wrapGAppsHook else makeWrapper;
-  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
-in stdenv.mkDerivation rec {
+assert waylandSupport -> gtk3Support == true;
+
+stdenv.mkDerivation rec {
   pname = "thunderbird";
   version = "68.3.0";
 
   src = fetchurl {
-    url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "3aqr3dj5laws516k6jf8f35a1964p0s75sp682yy87xnzgd8m1iha55z79dcavis2ma9hiyacjnznjz04qhqd4q8swjgfg7lj8lyiwl";
+    url =
+      "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
+    sha512 =
+      "3aqr3dj5laws516k6jf8f35a1964p0s75sp682yy87xnzgd8m1iha55z79dcavis2ma9hiyacjnznjz04qhqd4q8swjgfg7lj8lyiwl";
   };
 
-  # from firefox, but without sound libraries
-  buildInputs =
-    [ gtk2 zip libIDL libjpeg zlib bzip2
-      dbus dbus-glib pango freetype fontconfig xorg.libXi
-      xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
-      nspr nss libnotify xorg.pixman yasm libGLU libGL
-      xorg.libXScrnSaver xorg.xorgproto
-      xorg.libXext sqlite unzip
-      libevent libstartup_notification /* cairo */
-      icu libpng jemalloc nasm
-    ]
-    ++ lib.optionals enableGTK3 [ gtk3 gnome3.adwaita-icon-theme ];
+  nativeBuildInputs = [
+    autoconf213
+    cargo
+    gnused
+    llvmPackages.llvm
+    m4
+    nasm
+    nodejs
+    perl
+    pkgconfig
+    python2
+    python3
+    rust-cbindgen
+    rustc
+    which
+    yasm
+  ] ++ lib.optional gtk3Support wrapGAppsHook;
 
-  # from firefox + m4 + wrapperTool
-  # llvm is for llvm-objdump
-  nativeBuildInputs = [ m4 autoconf213 which gnused pkgconfig perl python2 python3 nodejs wrapperTool cargo rustc rust-cbindgen llvmPackages.llvm ];
+  buildInputs = [
+    bzip2
+    dbus
+    dbus-glib
+    file
+    fontconfig
+    freetype
+    glib
+    gtk2
+    icu
+    jemalloc
+    libGL
+    libGLU
+    libIDL
+    libevent
+    libjpeg
+    libnotify
+    libpng
+    libstartup_notification
+    libvpx
+    libwebp
+    nspr
+    nss
+    pango
+    perl
+    sqlite
+    unzip
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcursor
+    xorg.libXext
+    xorg.libXft
+    xorg.libXi
+    xorg.libXrender
+    xorg.libXt
+    xorg.pixman
+    xorg.xorgproto
+    zip
+    zlib
+  ] ++ lib.optional alsaSupport alsaLib
+    ++ lib.optional gtk3Support gtk3
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional waylandSupport libxkbcommon;
+
+  NIX_CFLAGS_COMPILE =[
+    "-I${glib.dev}/include/gio-unix-2.0"
+    "-I${nss.dev}/include/nss"
+  ];
 
   patches = [
-    # Remove buildconfig.html to prevent a dependency on clang etc.
     ./no-buildconfig.patch
-  ]
-  ++ lib.optional (lib.versionOlder version "69")
-    (fetchpatch { # https://bugzilla.mozilla.org/show_bug.cgi?id=1500436#c29
-      name = "write_error-parallel_make.diff";
-      url = "https://hg.mozilla.org/mozilla-central/raw-diff/562655fe/python/mozbuild/mozbuild/action/node.py";
-      sha256 = "11d7rgzinb4mwl7yzhidjkajynmxgmffr4l9isgskfapyax9p88y";
-    });
+  ];
 
-  configureFlags =
-    [ # from firefox, but without sound libraries (alsa, libvpx, pulseaudio)
-      "--enable-application=comm/mail"
-      "--disable-alsa"
-      "--disable-pulseaudio"
+  postPatch = ''
+    rm -rf obj-x86_64-pc-linux-gnu
+  '';
 
-      "--with-system-jpeg"
-      "--with-system-zlib"
-      "--with-system-bz2"
-      "--with-system-nspr"
-      "--with-system-nss"
-      "--with-system-libevent"
-      "--with-system-png" # needs APNG support
-      "--with-system-icu"
-      #"--enable-rust-simd" # not supported since rustc 1.32.0 -> 1.33.0; TODO: probably OK since 68.0.0
-      "--enable-system-ffi"
-      "--enable-system-pixman"
-      "--enable-system-sqlite"
-      #"--enable-system-cairo"
-      "--enable-startup-notification"
-      "--disable-crashreporter"
-      "--disable-tests"
-      "--disable-necko-wifi" # maybe we want to enable this at some point
-      "--disable-updater"
-      "--enable-jemalloc"
-      "--disable-gconf"
-      "--enable-default-toolkit=cairo-gtk${if enableGTK3 then "3" else "2"}"
-      "--enable-js-shell"
-    ]
-      ++ lib.optional enableCalendar "--enable-calendar"
-      ++ (if debugBuild then [ "--enable-debug" "--enable-profiling"]
-                        else [ "--disable-debug" "--enable-release"
-                               "--disable-debug-symbols"
-                               "--enable-optimize" "--enable-strip" ])
-      ++ lib.optional enableOfficialBranding "--enable-official-branding"
-      ++ lib.optionals (lib.versionAtLeast version "56" && !stdenv.hostPlatform.isi686) [
-        # on i686-linux: --with-libclang-path is not available in this configuration
-        "--with-libclang-path=${llvmPackages.libclang}/lib"
-        "--with-clang-path=${llvmPackages.clang}/bin/clang"
-      ];
+  preConfigure = ''
+    # remove distributed configuration files
+    rm -f configure
+    rm -f js/src/configure
+    rm -f .mozconfig*
+
+    configureScript="$(realpath ./mach) configure"
+    # AS=as in the environment causes build failure https://bugzilla.mozilla.org/show_bug.cgi?id=1497286
+    unset AS
+
+    export MOZCONFIG=$(pwd)/mozconfig
+
+    # Set C flags for Rust's bindgen program. Unlike ordinary C
+    # compilation, bindgen does not invoke $CC directly. Instead it
+    # uses LLVM's libclang. To make sure all necessary flags are
+    # included we need to look in a few places.
+    # TODO: generalize this process for other use-cases.
+
+    BINDGEN_CFLAGS="$(< ${stdenv.cc}/nix-support/libc-cflags) \
+      $(< ${stdenv.cc}/nix-support/cc-cflags) \
+      ${stdenv.cc.default_cxx_stdlib_compile} \
+      ${
+        lib.optionalString stdenv.cc.isClang
+        "-idirafter ${stdenv.cc.cc}/lib/clang/${
+          lib.getVersion stdenv.cc.cc
+        }/include"
+      } \
+      ${
+        lib.optionalString stdenv.cc.isGNU
+        "-isystem ${stdenv.cc.cc}/include/c++/${
+          lib.getVersion stdenv.cc.cc
+        } -isystem ${stdenv.cc.cc}/include/c++/${
+          lib.getVersion stdenv.cc.cc
+        }/$(cc -dumpmachine)"
+      } \
+      $NIX_CFLAGS_COMPILE"
+
+    echo "ac_add_options BINDGEN_CFLAGS='$BINDGEN_CFLAGS'" >> $MOZCONFIG
+  '';
+
+  configureFlags = let
+    toolkitSlug = if gtk3Support then
+      "3${lib.optionalString waylandSupport "-wayland"}"
+    else
+      "2";
+    toolkitValue = "cairo-gtk${toolkitSlug}";
+  in [
+    "--enable-application=comm/mail"
+
+    "--with-system-bz2"
+    "--with-system-icu"
+    "--with-system-jpeg"
+    "--with-system-libevent"
+    "--with-system-nspr"
+    "--with-system-nss"
+    "--with-system-png" # needs APNG support
+    "--with-system-icu"
+    "--with-system-zlib"
+    "--with-system-webp"
+    "--with-system-libvpx"
+
+    "--enable-rust-simd"
+    "--enable-crashreporter"
+    "--enable-default-toolkit=${toolkitValue}"
+    "--enable-js-shell"
+    "--enable-necko-wifi"
+    "--enable-startup-notification"
+    "--enable-system-ffi"
+    "--enable-system-pixman"
+    "--enable-system-sqlite"
+
+    "--disable-gconf"
+    "--disable-tests"
+    "--disable-updater"
+    "--enable-jemalloc"
+  ] ++ (if debugBuild then [
+    "--enable-debug"
+    "--enable-profiling"
+  ] else [
+    "--disable-debug"
+    "--enable-release"
+    "--disable-debug-symbols"
+    "--enable-optimize"
+    "--enable-strip"
+  ]) ++ lib.optionals (!stdenv.hostPlatform.isi686) [
+    # on i686-linux: --with-libclang-path is not available in this configuration
+    "--with-libclang-path=${llvmPackages.libclang}/lib"
+    "--with-clang-path=${llvmPackages.clang}/bin/clang"
+  ] ++ lib.optional alsaSupport "--enable-alsa"
+  ++ lib.optional calendarSupport "--enable-calendar"
+  ++ lib.optional enableOfficialBranding "--enable-official-branding"
+  ++ lib.optional pulseaudioSupport "--enable-pulseaudio";
 
   enableParallelBuilding = true;
 
-  preConfigure =
-    ''
-      cxxLib=$( echo -n ${gcc}/include/c++/* )
-      archLib=$cxxLib/$( ${gcc}/bin/gcc -dumpmachine )
+  postConfigure = ''
+    cd obj-*
+  '';
 
-      test -f layout/style/ServoBindings.toml && sed -i -e '/"-DRUST_BINDGEN"/ a , "-cxx-isystem", "'$cxxLib'", "-isystem", "'$archLib'"' layout/style/ServoBindings.toml
+  makeFlags = lib.optionals enableOfficialBranding [
+    "MOZILLA_OFFICIAL=1"
+    "BUILD_OFFICIAL=1"
+  ];
 
-      configureScript="$(realpath ./configure)"
-      mkdir ../objdir
-      cd ../objdir
+  doCheck = false;
 
-      # AS=as in the environment causes build failure https://bugzilla.mozilla.org/show_bug.cgi?id=1497286
-      unset AS
-    '';
+  postInstall = let
+    desktopItem = makeDesktopItem {
+      categories = lib.concatStringsSep ";" [ "Application" "Network" ];
+      desktopName = "Thunderbird";
+      genericName = "Mail Reader";
+      name = "thunderbird";
+      exec = "thunderbird %U";
+      icon = "$out/lib/thunderbird/chrome/icons/default/default256.png";
+      mimeType = lib.concatStringsSep ";" [
+        # Email
+        "x-scheme-handler/mailto"
+        "message/rfc822"
+        # Feeds
+        "x-scheme-handler/feed"
+        "application/rss+xml"
+        "application/x-extension-rss"
+        # Newsgroups
+        "x-scheme-handler/news"
+        "x-scheme-handler/snews"
+        "x-scheme-handler/nntp"
+      ];
+    };
+  in ''
+    # TODO: Move to a dev output?
+    rm -rf $out/include $out/lib/thunderbird-devel-* $out/share/idl
 
-  dontWrapGApps = true; # we do it ourselves
-  postInstall =
-    ''
-      # TODO: Move to a dev output?
-      rm -rf $out/include $out/lib/thunderbird-devel-* $out/share/idl
+    ${desktopItem.buildCommand}
+  '';
 
-      # $binary is a symlink to $target.
-      # We wrap $target by replacing the $binary symlink.
-      local target="$out/lib/thunderbird/thunderbird"
-      local binary="$out/bin/thunderbird"
+  preFixup = ''
+    # Needed to find Mozilla runtime
+    gappsWrapperArgs+=(
+      --argv0 "$out/bin/thunderbird"
+      --set MOZ_APP_LAUNCHER thunderbird
+      # https://github.com/NixOS/nixpkgs/pull/61980
+      --set SNAP_NAME "thunderbird"
+      --set MOZ_LEGACY_PROFILES 1
+      --set MOZ_ALLOW_DOWNGRADE 1
+    )
+  '';
 
-      # Wrap correctly, this is needed to
-      # 1) find Mozilla runtime, because argv0 must be the real thing,
-      #    or a symlink thereto. It cannot be the wrapper itself
-      # 2) detect itself as the default mailreader across builds
-      gappsWrapperArgs+=(
-        --argv0 "$target"
-        --set MOZ_APP_LAUNCHER thunderbird
-        # See commit 87e261843c4236c541ee0113988286f77d2fa1ee
-        --set MOZ_LEGACY_PROFILES 1
-        --set MOZ_ALLOW_DOWNGRADE 1
-        # https://github.com/NixOS/nixpkgs/pull/61980
-        --set SNAP_NAME "thunderbird"
-      )
-      ${
-        # We wrap manually because wrapGAppsHook does not detect the symlink
-        # To mimic wrapGAppsHook, we run it with dontWrapGApps, so
-        # gappsWrapperArgs gets defined correctly
-        lib.optionalString enableGTK3 "wrapGAppsHook"
-      }
-
-      # "$binary" is a symlink, replace it by the wrapper
-      rm "$binary"
-      makeWrapper "$target" "$binary" "''${gappsWrapperArgs[@]}"
-
-      ${ let desktopItem = makeDesktopItem {
-          name = "thunderbird";
-          exec = "thunderbird %U";
-          desktopName = "Thunderbird";
-          icon = "$out/lib/thunderbird/chrome/icons/default/default256.png";
-          genericName = "Mail Reader";
-          categories = "Application;Network";
-          mimeType = stdenv.lib.concatStringsSep ";" [
-            # Email
-            "x-scheme-handler/mailto"
-            "message/rfc822"
-            # Newsgroup
-            "x-scheme-handler/news"
-            "x-scheme-handler/snews"
-            "x-scheme-handler/nntp"
-            # Feed
-            "x-scheme-handler/feed"
-            "application/rss+xml"
-            "application/x-extension-rss"
-          ];
-        }; in desktopItem.buildCommand
-      }
-    '';
-
-  postFixup =
-    # Fix notifications. LibXUL uses dlopen for this, unfortunately; see #18712.
-    ''
-      patchelf --set-rpath "${lib.getLib libnotify
-        }/lib:$(patchelf --print-rpath "$out"/lib/thunderbird*/libxul.so)" \
-          "$out"/lib/thunderbird*/libxul.so
-    '';
+  # FIXME: This can probably be removed as soon as we package a
+  # Thunderbird >=71.0 since XUL shouldn't be anymore (in use)?
+  postFixup = ''
+    local xul="$out/lib/thunderbird/libxul.so"
+    patchelf --set-rpath "${libnotify}/lib:$(patchelf --print-rpath $xul)" $xul
+  '';
 
   doInstallCheck = true;
-  installCheckPhase =
-    ''
-      # Some basic testing
-      "$out/bin/thunderbird" --version
-    '';
+  installCheckPhase = ''
+    "$out/bin/thunderbird" --version
+  '';
 
-  disallowedRequisites = [ stdenv.cc ];
-
-  meta = with stdenv.lib; {
-    description = "A full-featured e-mail client";
-    homepage = http://www.mozilla.org/thunderbird/;
-    license =
-      # Official branding implies thunderbird name and logo cannot be reuse,
-      # see http://www.mozilla.org/foundation/licensing.html
-      if enableOfficialBranding then licenses.proprietary else licenses.mpl11;
-    maintainers = [ maintainers.pierron maintainers.eelco ];
-    platforms = platforms.linux;
-  };
+  disallowedRequisites = [
+    stdenv.cc
+  ];
 
   passthru.updateScript = import ./../../browsers/firefox/update.nix {
     attrPath = "thunderbird";
     baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
-    inherit writeScript lib common-updater-scripts xidel coreutils gnused gnugrep curl runtimeShell;
+    inherit writeScript lib common-updater-scripts xidel coreutils gnused
+      gnugrep curl runtimeShell;
+  };
+
+  meta = with stdenv.lib; {
+    description = "A full-featured e-mail client";
+    homepage = "https://www.thunderbird.net";
+    maintainers = with maintainers; [
+      eelco
+      lovesegfault
+      pierron
+    ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21491,7 +21491,7 @@ in
     inherit (gnome2) libIDL;
     inherit (rustPackages_1_38_0) cargo rustc;
     libpng = libpng_apng;
-    enableGTK3 = true;
+    gtk3Support = true;
   };
 
   thunderbolt = callPackage ../os-specific/linux/thunderbolt {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This supersedes #75143, adding Wayland support, bumping to 68.3.0, and also reworking the build a bit.

The reason for reworking is I noticed the Firefox and Thunderbird builds had gone astray, and since they are almost identical, we ought to try and keep them as much in sync as possible.

I would appreciate @andir taking a look at this since he maintains Firefox and probably has some insights into it.

I've also added myself as a maintainer of the package. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edolstra @nbp 
