### PR TITLE
texlive.bin.dvisvgm: fix

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -261,6 +261,21 @@ dvisvgm = stdenv.mkDerivation {
 
   inherit (common) src;
 
+  patches = [
+    # Fix for ghostscript>=9.27
+    # Backport of
+    # https://github.com/mgieseki/dvisvgm/commit/bc51951bc90b700c28ea018993bdb058e5271e9b
+    ./dvisvgm-fix.patch
+
+    # Needed for ghostscript>=9.50
+    (fetchpatch {
+      url = "https://github.com/mgieseki/dvisvgm/commit/7b93a9197b69305429183affd24fa40ee04a663a.patch";
+      sha256 = "1gmj76ja9xng39wxckhs9q140abixgb8rkrcfv2cdgq786wm3vag";
+      stripLen = 1;
+      extraPrefix = "texk/dvisvgm/dvisvgm-src/";
+    })
+  ];
+
   nativeBuildInputs = [ pkgconfig ];
   # TODO: dvisvgm still uses vendored dependencies
   buildInputs = [ core/*kpathsea*/ ghostscript zlib freetype potrace xxHash ];

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -278,7 +278,7 @@ dvisvgm = stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig ];
   # TODO: dvisvgm still uses vendored dependencies
-  buildInputs = [ core/*kpathsea*/ ghostscript zlib freetype potrace xxHash ];
+  buildInputs = [ core/*kpathsea*/ ghostscript zlib freetype /*potrace xxHash*/ ];
 
   preConfigure = "cd texk/dvisvgm";
 

--- a/pkgs/tools/typesetting/tex/texlive/dvisvgm-fix.patch
+++ b/pkgs/tools/typesetting/tex/texlive/dvisvgm-fix.patch
@@ -1,0 +1,16 @@
+diff a/texk/dvisvgm/dvisvgm-src/src/psdefs.cpp b/texk/dvisvgm/dvisvgm-src/src/psdefs.cpp
+--- a/texk/dvisvgm/dvisvgm-src/src/psdefs.cpp
++++ b/texk/dvisvgm/dvisvgm-src/src/psdefs.cpp
+@@ -107,8 +107,7 @@ const char *PSInterpreter::PSDEFS =
+ "dmode sysexec<</Normal 0/Compatible 0/Multiply 1/Screen 2/Overlay 3/SoftLight "
+ "4/HardLight 5/ColorDodge 6/ColorBurn 7/Darken 8/Lighten 9/Difference 10/Exclus"
+ "ion 11/Hue 12/Saturation 13/Color 14/Luminosity 15/CompatibleOverprint 16>>exc"
+-"h get 1(setblendmode)prcmd}def/@pdfpagecount{GS_PDF_ProcSet begin pdfdict begi"
+-"n(r)file pdfopen begin pdfpagecount currentdict pdfclose end end end}def/@pdfp"
+-"agebox{GS_PDF_ProcSet begin pdfdict begin(r)file pdfopen begin dup dup 1 lt ex"
+-"ch pdfpagecount gt or{pop}{pdfgetpage/MediaBox pget pop aload pop}ifelse curre"
+-"ntdict pdfclose end end end}def DELAYBIND{.bindnow}if ";
++"h get 1(setblendmode)prcmd}def/@pdfpagecount{(r)file runpdfbegin pdfpagecount "
++"runpdfend}def/@pdfpagebox{(r)file runpdfbegin dup dup 1 lt exch pdfpagecount g"
++"t or{pop}{pdfgetpage/MediaBox pget pop aload pop}ifelse runpdfend}def DELAYBIN"
++"D{.bindnow}if ";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes: #75070

###### Things done

Tested:
```bash
cat > mwe.tex <<EOF
\documentclass{article}
\begin{document}
  mwe
\end{document}
EOF
nix-shell -I nixpkgs=`pwd` -p 'texlive.combined.scheme-medium' --pure --run  'latex mwe.tex && dvisvgm mwe.dvi -n -b min -o mwe.svg'
nix-shell -I nixpkgs=`pwd` -p 'texlive.combined.scheme-medium' --pure --run  'pdflatex mwe.tex && dvisvgm -P mwe.pdf -n -b min -o mwe.svg'
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
