### PR TITLE
vaapiIntel: unstable-20190211 -> 2.4.0

### DIFF
--- a/pkgs/development/libraries/vaapi-intel/default.nix
+++ b/pkgs/development/libraries/vaapi-intel/default.nix
@@ -5,16 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "intel-vaapi-driver";
-  # TODO: go back to stable releases with the next stable release after 2.3.0.
-  #       see: https://github.com/NixOS/nixpkgs/issues/55975 (and the libva comment v)
-  rev = "329975c63123610fc750241654a3bd18add75beb"; # generally try to match libva version, but not required
-  version = "git-20190211";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner  = "intel";
     repo   = "intel-vaapi-driver";
-    rev    = rev;
-    sha256 = "10333wh2d0hvz5lxl3gjvqs71s7v9ajb0269b3bj5kbflj03v3n5";
+    rev    = version;
+    sha256 = "019w0hvjc9l85yqhy01z2bvvljq208nkb43ai2v377l02krgcrbl";
   };
 
   patchPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
After 10+ months, Intel cut a new release of `intel-vaapi-driver` so we can get back to a stable release in nixpkgs.

See: https://github.com/intel/intel-vaapi-driver/issues/449

BTW: Why are this and other related packaged named so weirdly? `vaapiIntel` vs `intel-vaapi-driver`? I'm more accustomed to seeing package names in nixpkgs follow their upstream package names?

NOTE: As much as I want to trust Intel, I haven't tested this myself so I can't vouch for this yet. I'll move this out of Draft when I get a chance to test it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
