### PR TITLE
libnotify: propagate glib and gdk-pixbuf

### DIFF
--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -1,5 +1,14 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, fetchpatch
-, glib, gdk-pixbuf, gobject-introspection, gnome3 }:
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, fetchpatch
+, glib
+, gdk-pixbuf
+, gobject-introspection
+, gnome3
+}:
 
 stdenv.mkDerivation rec {
   pname = "libnotify";
@@ -26,8 +35,17 @@ stdenv.mkDerivation rec {
     "-Dgtk_doc=false"
   ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ];
-  propagatedBuildInputs = [ glib gdk-pixbuf ];
+  nativeBuildInputs = [
+    gobject-introspection
+    meson
+    ninja
+    pkgconfig
+  ];
+
+  propagatedBuildInputs = [
+    gdk-pixbuf
+    glib
+  ];
 
   passthru = {
     updateScript = gnome3.updateScript {
@@ -40,6 +58,7 @@ stdenv.mkDerivation rec {
     homepage = https://developer.gnome.org/notification-spec/;
     description = "A library that sends desktop notifications to a notification daemon";
     platforms = platforms.unix;
+    maintainers = gnome3.maintainers;
     license = licenses.lgpl21;
   };
 }

--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ];
-  buildInputs = [ glib gdk-pixbuf ];
+  propagatedBuildInputs = [ glib gdk-pixbuf ];
 
   passthru = {
     updateScript = gnome3.updateScript {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
They're in Requires:
Requires: gdk-pixbuf-2.0, gio-2.0 >=  2.26.0, glib-2.0 >=  2.26.0

This has caused one issue so far https://github.com/NixOS/nixpkgs/pull/75321.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).