### PR TITLE
clojure: 1.10.1.489 -> 1.10.1.492

### DIFF
--- a/pkgs/development/interpreters/clojure/default.nix
+++ b/pkgs/development/interpreters/clojure/default.nix
@@ -2,30 +2,30 @@
 
 stdenv.mkDerivation rec {
   pname = "clojure";
-  version = "1.10.1.489";
+  version = "1.10.1.492";
 
   src = fetchurl {
     url = "https://download.clojure.org/install/clojure-tools-${version}.tar.gz";
-    sha256 = "12ks7adh5cx99l5vydppkqknk5nvv9vsj2k0afcwwxd897m794kz";
+    sha256 = "09mhy5xw9kdr10a1xpbn5v97qyyhngw5s1n1alrs45a4m3l11iky";
   };
 
   buildInputs = [ makeWrapper ];
 
-  outputs = [ "out" "prefix" ];
-
   installPhase = let
     binPath = stdenv.lib.makeBinPath [ rlwrap jdk11 ];
-  in ''
-    mkdir -p $prefix/libexec
-    cp clojure-tools-${version}.jar $prefix/libexec
-    cp example-deps.edn $prefix
+  in
+    ''
+      mkdir -p $out/libexec
+      cp clojure-tools-${version}.jar $out/libexec
+      cp example-deps.edn $out
+      cp deps.edn $out
 
-    substituteInPlace clojure --replace PREFIX $prefix
+      substituteInPlace clojure --replace PREFIX $out
 
-    install -Dt $out/bin clj clojure
-    wrapProgram $out/bin/clj --prefix PATH : $out/bin:${binPath}
-    wrapProgram $out/bin/clojure --prefix PATH : $out/bin:${binPath}
-  '';
+      install -Dt $out/bin clj clojure
+      wrapProgram $out/bin/clj --prefix PATH : $out/bin:${binPath}
+      wrapProgram $out/bin/clojure --prefix PATH : $out/bin:${binPath}
+    '';
 
   meta = with stdenv.lib; {
     description = "A Lisp dialect for the JVM";


### PR DESCRIPTION
Install again default `deps.edn`. `deps.edn` was embedded in clojure jar,
but that change was reverted, see
https://github.com/clojure/brew-install/commit/a34969513fb8f95e541fa4f4b65296c005d76320

Update derivation to produce only one output. Multiple outputs was
introduced by #35140, but I don't think is necessary anymore.

Code was automatically formatted with nixpkgs-fmt

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bendlas @yegortimoshenko 
