### PR TITLE
ocamlformat: 0.11.0 -> 0.12

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlformat/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/default.nix
@@ -1,16 +1,14 @@
-{ lib, fetchFromGitHub, ocamlPackages }:
+{ lib, fetchurl, ocamlPackages }:
 
 with ocamlPackages; buildDunePackage rec {
   pname = "ocamlformat";
-  version = "0.11.0";
+  version = "0.12";
 
   minimumOCamlVersion = "4.06";
 
-  src = fetchFromGitHub {
-    owner = "ocaml-ppx";
-    repo = pname;
-    rev = version;
-    sha256 = "0zvjn71jd4d3znnpgh0yphb2w8ggs457b6bl6cg1fmpdgxnds6yx";
+  src = fetchurl {
+    url = "https://github.com/ocaml-ppx/ocamlformat/releases/download/${version}/ocamlformat-${version}.tbz";
+    sha256 = "1zi8x597dhp2822j6j28s84yyiqppl7kykpwqqclx6ybypvlzdpj";
   };
 
   buildInputs = [
@@ -25,7 +23,7 @@ with ocamlPackages; buildDunePackage rec {
   ];
 
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/ocaml-ppx/ocamlformat";
     description = "Auto-formatter for OCaml code";
     maintainers = [ lib.maintainers.Zimmi48 ];
     license = lib.licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

New version. Also fix the source location so that `ocamlformat --version` works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vbgl
