### PR TITLE
ocamlPackages.irmin: init at 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/alcotest/lwt.nix
+++ b/pkgs/development/ocaml-modules/alcotest/lwt.nix
@@ -1,0 +1,16 @@
+{ lib, buildDunePackage, alcotest, logs, ocaml_lwt }:
+
+buildDunePackage {
+  pname = "alcotest-lwt";
+
+  inherit (alcotest) version src;
+
+  propagatedBuildInputs = [ alcotest logs ocaml_lwt ];
+
+  doCheck = true;
+
+  meta = alcotest.meta // {
+    description = "Lwt-based helpers for Alcotest";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/index/default.nix
+++ b/pkgs/development/ocaml-modules/index/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchurl, buildDunePackage, fmt, logs }:
+
+buildDunePackage rec {
+  pname = "index";
+  version = "1.0.1";
+
+  minimumOCamlVersion = "4.07";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/index/releases/download/${version}/index-${version}.tbz";
+    sha256 = "1006wr3g21s4j2vsd73gphhkrh1fy4swh6gqvlsa9c6q7vz9wbvz";
+  };
+
+  propagatedBuildInputs = [ fmt logs ];
+
+  meta = {
+    homepage = "https://github.com/mirage/index";
+    description = "A platform-agnostic multi-level index";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/irmin-watcher/default.nix
+++ b/pkgs/development/ocaml-modules/irmin-watcher/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchurl, buildDunePackage
+, astring, fmt, logs, ocaml_lwt
+}:
+
+buildDunePackage rec {
+  pname = "irmin-watcher";
+  version = "0.4.1";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/irmin-watcher/releases/download/${version}/irmin-watcher-${version}.tbz";
+    sha256 = "00d4ph4jbsw6adp3zqdrwi099hfcf7p1xzi0685qr7bgcmandjfv";
+  };
+
+  propagatedBuildInputs = [ astring fmt logs ocaml_lwt ];
+
+  meta = {
+    homepage = "https://github.com/mirage/irmin-watcher";
+    description = "Portable Irmin watch backends using FSevents or Inotify";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/irmin/default.nix
+++ b/pkgs/development/ocaml-modules/irmin/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchurl, buildDunePackage
+, astring, base64, digestif, fmt, jsonm, logs, ocaml_lwt, ocamlgraph, uri
+, alcotest, hex
+}:
+
+buildDunePackage rec {
+
+  pname = "irmin";
+  version = "2.0.0";
+
+  minimumOCamlVersion = "4.06";
+
+  src = fetchurl {
+    url = "https://github.com/mirage/irmin/releases/download/${version}/irmin-${version}.tbz";
+    sha256 = "09qffvgi5yrm3ghiywlbdhjly8xb5x5njnan213q8j033fzmf2dr";
+  };
+
+  propagatedBuildInputs = [ astring base64 digestif fmt jsonm logs ocaml_lwt ocamlgraph uri ];
+
+  checkInputs = lib.optionals doCheck [ alcotest hex ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://irmin.org/";
+    description = "A distributed database built on the same principles as Git";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/irmin/fs.nix
+++ b/pkgs/development/ocaml-modules/irmin/fs.nix
@@ -1,0 +1,21 @@
+{ lib, buildDunePackage, irmin, irmin-test }:
+
+buildDunePackage rec {
+
+  pname = "irmin-fs";
+
+  inherit (irmin) version src;
+
+  propagatedBuildInputs = [ irmin ];
+
+  checkInputs = lib.optional doCheck irmin-test;
+
+  doCheck = true;
+
+  meta = irmin.meta // {
+    description = "Generic file-system backend for Irmin";
+  };
+
+}
+
+

--- a/pkgs/development/ocaml-modules/irmin/git.nix
+++ b/pkgs/development/ocaml-modules/irmin/git.nix
@@ -1,0 +1,20 @@
+{ lib, buildDunePackage, git, irmin, irmin-mem, irmin-test, git-unix }:
+
+buildDunePackage rec {
+
+  pname = "irmin-git";
+
+  inherit (irmin) version src;
+
+  propagatedBuildInputs = [ git irmin ];
+
+  checkInputs = lib.optionals doCheck [ git-unix irmin-mem irmin-test ];
+
+  doCheck = true;
+
+  meta = irmin.meta // {
+    description = "Git backend for Irmin";
+  };
+
+}
+

--- a/pkgs/development/ocaml-modules/irmin/graphql.nix
+++ b/pkgs/development/ocaml-modules/irmin/graphql.nix
@@ -1,0 +1,20 @@
+{ lib, buildDunePackage, cohttp-lwt, graphql-cohttp, graphql-lwt, irmin }:
+
+buildDunePackage rec {
+
+  pname = "irmin-graphql";
+
+  inherit (irmin) version src;
+
+  propagatedBuildInputs = [ cohttp-lwt graphql-cohttp graphql-lwt irmin ];
+
+  doCheck = true;
+
+  meta = irmin.meta // {
+    description = "GraphQL server for Irmin";
+  };
+
+}
+
+
+

--- a/pkgs/development/ocaml-modules/irmin/http.nix
+++ b/pkgs/development/ocaml-modules/irmin/http.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, cohttp-lwt, irmin, webmachine
+, checkseum, git-unix, irmin-git, irmin-mem, irmin-test
+}:
+
+buildDunePackage rec {
+
+  pname = "irmin-http";
+
+  inherit (irmin) version src;
+
+  propagatedBuildInputs = [ cohttp-lwt irmin webmachine ];
+
+  checkInputs = lib.optionals doCheck [ checkseum git-unix irmin-git irmin-mem irmin-test ];
+
+  doCheck = true;
+
+  meta = irmin.meta // {
+    description = "HTTP client and server for Irmin";
+  };
+
+}
+
+

--- a/pkgs/development/ocaml-modules/irmin/mem.nix
+++ b/pkgs/development/ocaml-modules/irmin/mem.nix
@@ -1,0 +1,19 @@
+{ lib, buildDunePackage, irmin, irmin-test }:
+
+buildDunePackage rec {
+
+  pname = "irmin-mem";
+
+  inherit (irmin) version src;
+
+  propagatedBuildInputs = [ irmin ];
+
+  checkInputs = lib.optional doCheck irmin-test;
+
+  doCheck = true;
+
+  meta = irmin.meta // {
+    description = "Generic in-memory Irmin stores";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/irmin/pack.nix
+++ b/pkgs/development/ocaml-modules/irmin/pack.nix
@@ -1,0 +1,19 @@
+{ lib, buildDunePackage, alcotest-lwt, index, irmin, irmin-test }:
+
+buildDunePackage rec {
+
+  pname = "irmin-pack";
+
+  inherit (irmin) version src;
+
+  propagatedBuildInputs = [ index irmin ];
+
+  checkInputs = lib.optionals doCheck [ alcotest-lwt irmin-test ];
+
+  doCheck = true;
+
+  meta = irmin.meta // {
+    description = "Irmin backend which stores values in a pack file";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/irmin/test.nix
+++ b/pkgs/development/ocaml-modules/irmin/test.nix
@@ -1,0 +1,15 @@
+{ buildDunePackage, alcotest, cmdliner, irmin, metrics-unix, mtime }:
+
+buildDunePackage {
+
+  pname = "irmin-test";
+
+  inherit (irmin) version src;
+
+  propagatedBuildInputs = [ alcotest cmdliner irmin metrics-unix mtime ];
+
+  meta = irmin.meta // {
+    description = "Irmin test suite";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/irmin/unix.nix
+++ b/pkgs/development/ocaml-modules/irmin/unix.nix
@@ -1,0 +1,26 @@
+{ lib, buildDunePackage
+, checkseum, cmdliner, git-unix, yaml
+, irmin, irmin-fs, irmin-git, irmin-graphql, irmin-http, irmin-mem, irmin-pack, irmin-watcher
+, irmin-test
+}:
+
+buildDunePackage rec {
+
+  pname = "irmin-unix";
+
+  inherit (irmin) version src;
+
+  propagatedBuildInputs = [ checkseum cmdliner git-unix yaml
+    irmin irmin-fs irmin-git irmin-graphql irmin-http irmin-mem irmin-pack irmin-watcher
+  ];
+
+  checkInputs = lib.optional doCheck irmin-test;
+
+  doCheck = true;
+
+  meta = irmin.meta // {
+    description = "Unix backends for Irmin";
+  };
+
+}
+

--- a/pkgs/development/ocaml-modules/yaml/default.nix
+++ b/pkgs/development/ocaml-modules/yaml/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchurl, buildDunePackage
+, ppx_sexp_conv
+, bos, ctypes, fmt, logs, rresult, sexplib
+}:
+
+buildDunePackage rec {
+  pname = "yaml";
+  version = "2.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/avsm/ocaml-yaml/releases/download/v${version}/yaml-v${version}.tbz";
+    sha256 = "1r8jj572h416g2zliwmxj2j9hkv73nxnpfb9gmbj9gixg24lskx0";
+  };
+
+  propagatedBuildInputs = [ bos ctypes fmt logs ppx_sexp_conv rresult sexplib ];
+
+  meta = {
+    description = "Parse and generate YAML 1.1 files";
+    homepage = "https://github.com/avsm/ocaml-yaml";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -887,6 +887,8 @@ let
 
     xtmpl = callPackage ../development/ocaml-modules/xtmpl { };
 
+    yaml = callPackage ../development/ocaml-modules/yaml { };
+
     yojson = callPackage ../development/ocaml-modules/yojson { };
 
     zarith = callPackage ../development/ocaml-modules/zarith { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -372,6 +372,8 @@ let
 
     irmin = callPackage ../development/ocaml-modules/irmin { };
 
+    irmin-test = callPackage ../development/ocaml-modules/irmin/test.nix { };
+
     jingoo = callPackage ../development/ocaml-modules/jingoo {
       pcre = ocaml_pcre;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -386,6 +386,8 @@ let
 
     irmin-test = callPackage ../development/ocaml-modules/irmin/test.nix { };
 
+    irmin-unix = callPackage ../development/ocaml-modules/irmin/unix.nix { };
+
     irmin-watcher = callPackage ../development/ocaml-modules/irmin-watcher { };
 
     jingoo = callPackage ../development/ocaml-modules/jingoo {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -374,6 +374,8 @@ let
 
     irmin-git = callPackage ../development/ocaml-modules/irmin/git.nix { };
 
+    irmin-http = callPackage ../development/ocaml-modules/irmin/http.nix { };
+
     irmin-mem = callPackage ../development/ocaml-modules/irmin/mem.nix { };
 
     irmin-test = callPackage ../development/ocaml-modules/irmin/test.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -372,6 +372,8 @@ let
 
     irmin = callPackage ../development/ocaml-modules/irmin { };
 
+    irmin-git = callPackage ../development/ocaml-modules/irmin/git.nix { };
+
     irmin-mem = callPackage ../development/ocaml-modules/irmin/mem.nix { };
 
     irmin-test = callPackage ../development/ocaml-modules/irmin/test.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -386,6 +386,8 @@ let
 
     irmin-test = callPackage ../development/ocaml-modules/irmin/test.nix { };
 
+    irmin-watcher = callPackage ../development/ocaml-modules/irmin-watcher { };
+
     jingoo = callPackage ../development/ocaml-modules/jingoo {
       pcre = ocaml_pcre;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -376,6 +376,8 @@ let
 
     irmin-git = callPackage ../development/ocaml-modules/irmin/git.nix { };
 
+    irmin-graphql = callPackage ../development/ocaml-modules/irmin/graphql.nix { };
+
     irmin-http = callPackage ../development/ocaml-modules/irmin/http.nix { };
 
     irmin-mem = callPackage ../development/ocaml-modules/irmin/mem.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -372,6 +372,8 @@ let
 
     irmin = callPackage ../development/ocaml-modules/irmin { };
 
+    irmin-fs = callPackage ../development/ocaml-modules/irmin/fs.nix { };
+
     irmin-git = callPackage ../development/ocaml-modules/irmin/git.nix { };
 
     irmin-http = callPackage ../development/ocaml-modules/irmin/http.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -382,6 +382,8 @@ let
 
     irmin-mem = callPackage ../development/ocaml-modules/irmin/mem.nix { };
 
+    irmin-pack = callPackage ../development/ocaml-modules/irmin/pack.nix { };
+
     irmin-test = callPackage ../development/ocaml-modules/irmin/test.nix { };
 
     jingoo = callPackage ../development/ocaml-modules/jingoo {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -18,6 +18,8 @@ let
 
     alcotest = callPackage ../development/ocaml-modules/alcotest {};
 
+    alcotest-lwt = callPackage ../development/ocaml-modules/alcotest/lwt.nix {};
+
     angstrom = callPackage ../development/ocaml-modules/angstrom { };
 
     angstrom-async = callPackage ../development/ocaml-modules/angstrom-async { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -362,6 +362,8 @@ let
 
     httpaf = callPackage ../development/ocaml-modules/httpaf { };
 
+    index = callPackage ../development/ocaml-modules/index { };
+
     inifiles = callPackage ../development/ocaml-modules/inifiles { };
 
     iri = callPackage ../development/ocaml-modules/iri { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -370,6 +370,8 @@ let
 
     iri = callPackage ../development/ocaml-modules/iri { };
 
+    irmin = callPackage ../development/ocaml-modules/irmin { };
+
     jingoo = callPackage ../development/ocaml-modules/jingoo {
       pcre = ocaml_pcre;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -372,6 +372,8 @@ let
 
     irmin = callPackage ../development/ocaml-modules/irmin { };
 
+    irmin-mem = callPackage ../development/ocaml-modules/irmin/mem.nix { };
+
     irmin-test = callPackage ../development/ocaml-modules/irmin/test.nix { };
 
     jingoo = callPackage ../development/ocaml-modules/jingoo {


### PR DESCRIPTION
###### Motivation for this change

https://tarides.com/blog/2019-11-21-irmin-v2

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
