### PR TITLE
pythonPackages.wsnsimpy: init at 0.2.5

### DIFF
--- a/pkgs/development/python-modules/wsnsimpy/default.nix
+++ b/pkgs/development/python-modules/wsnsimpy/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage, fetchPypi, isPy27, lib, setuptools, simpy, tkinter
+# GUI-based visualization of the simulation is optional
+, enableVisualization ? true }:
+
+buildPythonPackage rec {
+  pname = "wsnsimpy";
+  version = "0.2.5";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b7fdqwc2v9alfwf2fr0aqr8rf2pb5lpm4anpilmvrh2lhjar4i2";
+  };
+
+  propagatedBuildInputs = [ setuptools simpy ]
+    ++ lib.optional enableVisualization tkinter;
+
+  # No test cases are included, thus unittest tries to run the examples, which
+  # fail because no DISPLAYs are available.
+  doCheck = false;
+
+  pythonImportsCheck = [ "wsnsimpy" ]
+    ++ lib.optional enableVisualization "wsnsimpy.wsnsimpy_tk";
+
+  meta = with lib; {
+    description = "SimPy-based WSN Simulator";
+    homepage = "https://pypi.org/project/wsnsimpy/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dmrauh ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7633,6 +7633,8 @@ in {
 
   WSME = callPackage ../development/python-modules/WSME { };
 
+  wsnsimpy = callPackage ../development/python-modules/wsnsimpy { };
+
   wsproto = if (pythonAtLeast "3.6") then
     callPackage ../development/python-modules/wsproto { }
   else


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I needed a Python-based simulation library for wireless sensor networks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
