### PR TITLE
soulseekqt: fix icons, change unpack method, update homepage, more generic appimage handling

### DIFF
--- a/pkgs/applications/networking/p2p/soulseekqt/default.nix
+++ b/pkgs/applications/networking/p2p/soulseekqt/default.nix
@@ -1,60 +1,51 @@
 { stdenv, lib, fetchzip, mkDerivation
+, appimageTools
 , autoPatchelfHook
-, dbus
 , desktop-file-utils
-, fontconfig
 , imagemagick
-, libjson
 , qtmultimedia
-, radare2
-, jq
-, squashfsTools
-, zlib
 }:
 
 mkDerivation rec {
   pname = "soulseekqt";
   version = "2018-1-30";
+  name="${pname}-${version}";
 
   src = fetchzip {
       url = "https://www.slsknet.org/SoulseekQt/Linux/SoulseekQt-${version}-64bit-appimage.tgz";
       sha256 = "16ncnvv8h33f161mgy7qc0wjvvqahsbwvby65qhgfh9pbbgb4xgg";
-    };
+  };
+
+  appextracted = appimageTools.extractType2 {
+    inherit name;
+    src="${src}/SoulseekQt-2018-1-30-64bit.AppImage";
+  };
 
   dontBuild = true;
-
-  nativeBuildInputs = [ imagemagick radare2 jq autoPatchelfHook squashfsTools
-    desktop-file-utils ];
+  dontConfigure = true;
+  
+  nativeBuildInputs = [ imagemagick autoPatchelfHook desktop-file-utils ];
   buildInputs = [ qtmultimedia stdenv.cc.cc ];
 
-  # avoid usage of appimage's runner option --appimage-extract
-  postUnpack = ''
-    cd $sourceRoot
-
-    # multiarch offset one-liner using same method as AppImage
-    offset=$(r2 *.AppImage -nn -Nqc "pfj.elf_header @ 0" |\
-      jq 'map({(.name): .value}) | add | .shoff + (.shnum * .shentsize)')
-
-    unsquashfs -o $offset *.AppImage
-    sourceRoot=squashfs-root
-  '';
-
   installPhase = ''
+      # directory in /nix/store so readonly
+      cd $appextracted
 
       binary="$(readlink AppRun)"
-      mv default.desktop $binary.desktop
       install -Dm755 $binary -t $out/bin
 
       # fixup and install desktop file
       desktop-file-install --dir $out/share/applications \
         --set-key Exec --set-value $binary \
         --set-key Comment --set-value "${meta.description}" \
-        --set-key Categories --set-value Network $binary.desktop
+        --set-key Categories --set-value Network default.desktop
+      mv $out/share/applications/default.desktop $out/share/applications/SoulseekQt.desktop
 
       #TODO: write generic code to read icon path from $binary.desktop
+      icon="$(readlink .DirIcon)"
       for size in 16 32 48 64 72 96 128 192 256 512 1024; do
         mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-        convert -resize "$size"x"$size" ./soulseek.png $out/share/icons/hicolor/"$size"x"$size"/apps/soulseek.png
+        convert -resize "$size"x"$size" $icon $out/share/icons/hicolor/"$size"x"$size"/apps/$icon
       done
     '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
