### PR TITLE
scryer-prolog: init at 0.8.127

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6254,6 +6254,12 @@
     githubId = 34393802;
     name = "Malte Voos";
   };
+  malbarbo = {
+    email = "malbarbo@gmail.com";
+    github = "malbarbo";
+    githubId = 1678126;
+    name = "Marco A L Barbosa";
+  };
   malyn = {
     email = "malyn@strangeGizmo.com";
     github = "malyn";

--- a/pkgs/development/compilers/scryer-prolog/cargo.patch
+++ b/pkgs/development/compilers/scryer-prolog/cargo.patch
@@ -1,0 +1,101 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index ef25833..d9de212 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -41,9 +41,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+ 
+ [[package]]
+ name = "az"
+-version = "0.3.1"
++version = "1.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "41a6b78289a33e09b00818ca8c90ab17c5dabb6e74f4b29a6de679c0e0886ade"
++checksum = "e9bcd47d94aa4eb8c076b50fc61a75020789394ffb9bd74a180b3379130f6569"
+ 
+ [[package]]
+ name = "base64"
+@@ -384,9 +384,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "gmp-mpfr-sys"
+-version = "1.2.2"
++version = "1.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "63d7f805cf9df081683d463f62864bda8b8e3ce7162a8e11cd0c49f27b8ce89b"
++checksum = "ad4e8e85ec9fb902b4564deeb17b1a263d3ba1334bef56154418aa045b159508"
+ dependencies = [
+  "libc",
+  "winapi 0.3.8",
+@@ -766,15 +766,6 @@ version = "0.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+ 
+-[[package]]
+-name = "openssl-src"
+-version = "111.9.0+1.1.1g"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a2dbe10ddd1eb335aba3780eb2eaa13e1b7b441d2562fd962398740927f39ec4"
+-dependencies = [
+- "cc",
+-]
+-
+ [[package]]
+ name = "openssl-sys"
+ version = "0.9.58"
+@@ -784,7 +775,6 @@ dependencies = [
+  "autocfg 1.0.0",
+  "cc",
+  "libc",
+- "openssl-src",
+  "pkg-config",
+  "vcpkg",
+ ]
+@@ -1159,9 +1149,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rug"
+-version = "1.8.0"
++version = "1.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "72315b6d9cb7d886fb99724330c47ceb29e923df657c31da3849fe88c0ded710"
++checksum = "e538d00da450a8e48aac7e6322e67b2dc86ec71a1feeac0e3954c4f07f01bc45"
+ dependencies = [
+  "az",
+  "gmp-mpfr-sys",
+@@ -1232,7 +1222,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+ 
+ [[package]]
+ name = "scryer-prolog"
+-version = "0.8.126"
++version = "0.8.127"
+ dependencies = [
+  "base64 0.12.3",
+  "blake2",
+@@ -1243,6 +1233,7 @@ dependencies = [
+  "divrem",
+  "downcast",
+  "git-version",
++ "gmp-mpfr-sys",
+  "hostname",
+  "indexmap",
+  "lazy_static",
+diff --git a/Cargo.toml b/Cargo.toml
+index c359e1b..75c4325 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -41,10 +41,14 @@ ring = "0.16.13"
+ ripemd160 = "0.8.0"
+ sha3 = "0.8.2"
+ blake2 = "0.8.1"
+-openssl = { version = "0.10.29", features = ["vendored"] }
++openssl = { version = "0.10.29" }
+ native-tls = "0.2.4"
+ chrono = "0.4.11"
+ select = "0.4.3"
+ roxmltree = "0.11.0"
+ base64 = "0.12.3"
+ sodiumoxide = "0.2.6"
++
++[dependencies.gmp-mpfr-sys]
++version = "1.4"
++features = ["use-system-libs"]

--- a/pkgs/development/compilers/scryer-prolog/default.nix
+++ b/pkgs/development/compilers/scryer-prolog/default.nix
@@ -31,5 +31,6 @@ rustPlatform.buildRustPackage rec {
     description = "A modern Prolog implementation written mostly in Rust.";
     homepage = "https://github.com/mthom/scryer-prolog";
     license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ malbarbo ];
   };
 }

--- a/pkgs/development/compilers/scryer-prolog/default.nix
+++ b/pkgs/development/compilers/scryer-prolog/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, gmp
+, libmpc
+, mpfr
+, openssl
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "scryer-prolog";
+  version = "0.8.127";
+
+  src = fetchFromGitHub {
+    owner = "mthom";
+    repo = "scryer-prolog";
+    rev = "v${version}";
+    sha256 = "0307yclslkdx6f0h0101a3da47rhz6qizf4i8q8rjh4id8wpdsn8";
+  };
+
+  # Use system openssl, gmp, mpc and mpfr.
+  cargoPatches = [ ./cargo.patch ];
+
+  cargoSha256 = "0gb0l2wwf8079jwggn9zxk8pz8pxg3b7pin1d7dsbd4ij52lzyi2";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl gmp libmpc mpfr ];
+
+  meta = with lib; {
+    description = "A modern Prolog implementation written mostly in Rust.";
+    homepage = "https://github.com/mthom/scryer-prolog";
+    license = with licenses; [ bsd3 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11981,6 +11981,8 @@ in
   };
   scalafmt = callPackage ../development/tools/scalafmt { };
 
+  scryer-prolog = callPackage ../development/compilers/scryer-prolog { };
+
   sdcc = callPackage ../development/compilers/sdcc {
     gputils = null;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A modern prolog interpreter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
