### PR TITLE
muse: Use wrapQtAppsHook

### DIFF
--- a/pkgs/applications/audio/muse/default.nix
+++ b/pkgs/applications/audio/muse/default.nix
@@ -1,7 +1,9 @@
 { stdenv
 , fetchFromGitHub
 , libjack2
-, qt5
+, wrapQtAppsHook
+, qtsvg
+, qttools
 , cmake
 , libsndfile
 , libsamplerate
@@ -13,7 +15,6 @@
 , dssi
 , liblo
 , pkgconfig
-, gitAndTools
 }:
 
 stdenv.mkDerivation {
@@ -45,14 +46,14 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     pkgconfig
-    gitAndTools.gitFull
+    wrapQtAppsHook
+    qttools
+    cmake
   ];
 
   buildInputs = [
     libjack2
-    qt5.qtsvg
-    qt5.qttools
-    cmake
+    qtsvg
     libsndfile
     libsamplerate
     ladspaH
@@ -65,15 +66,4 @@ stdenv.mkDerivation {
   ];
 
   sourceRoot = "source/muse3";
-
-  buildPhase = ''
-    cd ..
-    bash compile_muse.sh
-  '';
-
-  installPhase = ''
-    mkdir $out
-    cd build
-    make install
-  '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24754,7 +24754,7 @@ in
 
   mupen64plus = callPackage ../misc/emulators/mupen64plus { };
 
-  muse = callPackage ../applications/audio/muse { };
+  muse = libsForQt5.callPackage ../applications/audio/muse { };
 
   musly = callPackage ../applications/audio/musly { };
 


### PR DESCRIPTION
###### Motivation for this change

Fixes this error:

```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could
be initialized. Reinstalling the application may fix this problem.

Aborted (core dumped)
```

Also, remove the unnecessary build input `gitFull`, and enable parallel building.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @volth
