### PR TITLE
maestral: 0.4.2 -> 0.6.1

### DIFF
--- a/pkgs/applications/networking/maestral/default.nix
+++ b/pkgs/applications/networking/maestral/default.nix
@@ -1,24 +1,40 @@
-{ stdenv, lib, python3Packages, fetchFromGitHub
-, withGui ? false, wrapQtAppsHook ? null }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, python3
+, withGui ? false
+, wrapQtAppsHook ? null
+}:
 
-python3Packages.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "maestral${lib.optionalString withGui "-gui"}";
-  version = "0.4.2";
+  version = "0.6.1";
+
+  disabled = python3.pkgs.pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = "maestral-dropbox";
     rev = "v${version}";
-    sha256 = "0xis0cqfp3wgajwk44dmi2gbfirmz0a0zi25qxdzpdn0z19hp88m";
+    sha256 = "06i3c7i85x879np158156mba7kxz2cwh75390sc9gwwngc95d9h9";
   };
 
-  disabled = python3Packages.pythonOlder "3.6";
-
-  propagatedBuildInputs = (with python3Packages; [
-    blinker click dropbox keyring keyrings-alt Pyro4 requests u-msgpack-python watchdog
+  propagatedBuildInputs = with python3.pkgs; [
+    blinker
+    bugsnag
+    click
+    dropbox
+    keyring
+    keyrings-alt
+    lockfile
+    Pyro5
+    requests
+    u-msgpack-python
+    watchdog
   ] ++ lib.optionals stdenv.isLinux [
-    sdnotify systemd
-  ] ++ lib.optional withGui pyqt5);
+    sdnotify
+    systemd
+  ] ++ lib.optional withGui pyqt5;
 
   nativeBuildInputs = lib.optional withGui wrapQtAppsHook;
 

--- a/pkgs/development/python-modules/bugsnag/default.nix
+++ b/pkgs/development/python-modules/bugsnag/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, six
+, webob
+}:
+
+buildPythonPackage rec {
+  pname = "bugsnag";
+  version = "3.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17cjh7g8gbr0gb22nzybkw7vq9x5wfa5ln94hhzijbz934bw1f37";
+  };
+
+  propagatedBuildInputs = [ six webob ];
+
+  # no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Automatic error monitoring for django, flask, etc.";
+    homepage = "https://www.bugsnag.com";
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/pyro5/default.nix
+++ b/pkgs/development/python-modules/pyro5/default.nix
@@ -1,0 +1,33 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, serpent
+, pythonOlder
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "Pyro5";
+  version = "5.7";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08n9jqm81pjw9hvzk6kgxwqvh29q3glgccf77kxih5nn77pwdnni";
+  };
+
+  propagatedBuildInputs = [ serpent ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  # ignore network related tests, which fail in sandbox
+  disabledTests = [ "StartNSfunc" "Broadcast" "GetIP" ];
+
+  meta = with lib; {
+    description = "Distributed object middleware for Python (RPC)";
+    homepage = "https://github.com/irmen/Pyro5";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5444,6 +5444,8 @@ in {
 
   Pyro4 = callPackage ../development/python-modules/pyro4 { };
 
+  Pyro5 = callPackage ../development/python-modules/pyro5 { };
+
   rope = callPackage ../development/python-modules/rope { };
 
   ropper = callPackage ../development/python-modules/ropper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -522,6 +522,8 @@ in {
 
   bugseverywhere = throw "bugseverywhere has been removed: Abandoned by upstream."; # Added 2019-11-27
 
+  bugsnag = callPackage ../development/python-modules/bugsnag { };
+
   cachecontrol = callPackage ../development/python-modules/cachecontrol { };
 
   cachelib = callPackage ../development/python-modules/cachelib { };


### PR DESCRIPTION
###### Motivation for this change

Upstream is rapidly improving.

Daily driver.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
