### PR TITLE
python3Packages.docker: fix darwin tests

### DIFF
--- a/pkgs/development/python-modules/docker/default.nix
+++ b/pkgs/development/python-modules/docker/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy27
+{ lib, stdenv, buildPythonPackage, fetchPypi, isPy27
 , backports_ssl_match_hostname
 , mock
 , paramiko
 , pytest
+, pytestCheckHook
 , requests
 , six
 , websocket_client
@@ -17,25 +18,25 @@ buildPythonPackage rec {
     sha256 = "1hdgics03fz2fbhalzys7a7kjj54jnl5a37h6lzdgym41gkwa1kf";
   };
 
+  nativeBuildInputs = [
+    pytestCheckHook
+  ] ++ lib.optional isPy27 mock;
+
   propagatedBuildInputs = [
     paramiko
     requests
     six
     websocket_client
-  ] ++ stdenv.lib.optional isPy27 backports_ssl_match_hostname;
+  ] ++ lib.optional isPy27 backports_ssl_match_hostname;
 
-  checkInputs = [
-    mock
-    pytest
-  ];
-
-  # Other tests touch network
+  pytestFlagsArray = [ "tests/unit" ];
   # Deselect socket tests on Darwin because it hits the path length limit for a Unix domain socket
-  checkPhase = ''
-    ${pytest}/bin/pytest tests/unit/ ${stdenv.lib.optionalString stdenv.isDarwin "--deselect=tests/unit/api_test.py::TCPSocketStreamTest"}
-  '';
+  disabledTests = lib.optionals stdenv.isDarwin [ "stream_response" "socket_file" ];
 
-  meta = with stdenv.lib; {
+  # skip setuptoolsCheckPhase
+  doCheck = false;
+
+  meta = with lib; {
     description = "An API client for docker written in Python";
     homepage = "https://github.com/docker/docker-py";
     license = licenses.asl20;


### PR DESCRIPTION
###### Motivation for this change
closes: #75355

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[126 built (18 failed), 932 copied (6393.0 MiB), 1721.7 MiB DL]
error: build of '/nix/store/m2gpmqag4gs921qak64w6zjciw2cb8pv-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/75420
21 package failed to build:
aws-sam-cli python27Packages.geopandas python27Packages.nipype python27Packages.pymatgen python27Packages.sumo python37Packages.blaze python37Packages.dask-ml python37Packages.geopandas python37Packages.google_cloud_bigquery python37Packages.ibis-framework python37Packages.jupyter-repo2docker python37Packages.mesa python37Packages.nipype python37Packages.odo python37Packages.optuna python37Packages.osmnx python37Packages.rl-coach python37Packages.starfish python37Packages.streamz python37Packages.vega python38Packages.jupyter-repo2docker

118 package were built:
apache-airflow arion buildbot buildbot-full buildbot-ui csvs-to-sqlite docker-compose fdroidserver paperwork poretools python27Packages.Quandl python27Packages.altair python27Packages.awkward python27Packages.bkcharts python27Packages.celery python27Packages.cnvkit python27Packages.cufflinks python27Packages.djmail python27Packages.docker python27Packages.drms python27Packages.fastparquet python27Packages.histbook python27Packages.holoviews python27Packages.hvplot python27Packages.imbalanced-learn python27Packages.mapsplotlib python27Packages.moto python27Packages.pandas python27Packages.partd python27Packages.pyarrow python27Packages.pybids python27Packages.pytrends python27Packages.seaborn python27Packages.statsmodels python27Packages.tablib python27Packages.trackpy python27Packages.uproot python27Packages.uproot-methods python27Packages.vega python27Packages.vega_datasets python27Packages.vidstab python37Packages.Quandl python37Packages.acoustics python37Packages.altair python37Packages.aplpy python37Packages.atomman python37Packages.awkward python37Packages.bkcharts python37Packages.caffe python37Packages.celery python37Packages.cnvkit python37Packages.cufflinks python37Packages.dask python37Packages.dask-glm python37Packages.dask-image python37Packages.dask-jobqueue python37Packages.dask-mpi python37Packages.dask-xgboost python37Packages.datashader python37Packages.dftfit python37Packages.distributed python37Packages.djmail python37Packages.docker python37Packages.drms python37Packages.fastparquet python37Packages.glymur python37Packages.google_cloud_monitoring python37Packages.histbook python37Packages.holoviews python37Packages.hvplot python37Packages.image-match python37Packages.imbalanced-learn python37Packages.intake python37Packages.lammps-cython python37Packages.moto python37Packages.pandas python37Packages.partd python37Packages.phik python37Packages.pims python37Packages.pvlib python37Packages.pyarrow python37Packages.pybids python37Packages.pyfftw python37Packages.pymatgen python37Packages.pymatgen-lammps python37Packages.pymc3 python37Packages.pytrends python37Packages.rpy2 python37Packages.scikit-bio python37Packages.scikitimage python37Packages.seaborn python37Packages.sentry-sdk python37Packages.slicedimage python37Packages.statsmodels python37Packages.stumpy python37Packages.sumo python37Packages.sunpy python37Packages.tablib python37Packages.trackpy python37Packages.uproot python37Packages.uproot-methods python37Packages.vega_datasets python37Packages.vidstab python37Packages.wrf-python python37Packages.xarray python37Packages.xgboost python38Packages.docker sourcehut.buildsrht sourcehut.dispatchsrht sourcehut.gitsrht sourcehut.hgsrht sourcehut.listssrht sourcehut.mansrht sourcehut.metasrht sourcehut.pastesrht sourcehut.todosrht streamlit visidata
```