### PR TITLE
python3Packages.jupyter-repo2docker: fix build

### DIFF
--- a/pkgs/development/python-modules/jupyter-repo2docker/default.nix
+++ b/pkgs/development/python-modules/jupyter-repo2docker/default.nix
@@ -1,18 +1,14 @@
-{ stdenv
-, buildPythonPackage
-, fetchPypi
-, pkgs-docker
+{ stdenv, buildPythonPackage, fetchPypi, pythonAtLeast
 , docker
-, traitlets
-, python-json-logger
 , escapism
 , jinja2
-, ruamel_yaml
+, pkgs-docker
+, python-json-logger
 , pyyaml
-, pytest
-, wheel
-, pytestcov
-, pythonAtLeast
+, ruamel_yaml
+, semver
+, toml
+, traitlets
 }:
 
 buildPythonPackage rec {
@@ -25,11 +21,27 @@ buildPythonPackage rec {
     sha256 = "7965262913be6be60e64c8016f5f3d4bf93701f2787209215859d73b2adbc05a";
   };
 
-  checkInputs = [ pytest pyyaml wheel pytestcov ];
-  propagatedBuildInputs = [ pkgs-docker docker traitlets python-json-logger escapism jinja2 ruamel_yaml ];
+  propagatedBuildInputs = [
+    docker
+    escapism
+    jinja2
+    pkgs-docker
+    python-json-logger
+    ruamel_yaml
+    semver
+    toml
+    traitlets
+  ];
 
   # tests not packaged with pypi release
   doCheck = false;
+
+  pythonImportsCheck = [
+    "repo2docker"
+    "repo2docker.app"
+    "repo2docker.utils"
+    "repo2docker.contentproviders.base"
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://repo2docker.readthedocs.io/en/latest/;


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing #75420

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[3 built, 3 copied (1.0 MiB), 0.2 MiB DL]
https://github.com/NixOS/nixpkgs/pull/75421
2 package were built:
python37Packages.jupyter-repo2docker python38Packages.jupyter-repo2docker
```