### PR TITLE
python3Packages.dask-ml: 1.0.0 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/dask-ml/default.nix
+++ b/pkgs/development/python-modules/dask-ml/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, pythonOlder
 , dask
 , numpy, toolz # dask[array]
 , numba
@@ -19,20 +20,40 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.0.0";
+  version = "1.1.1";
   pname = "dask-ml";
+  disabled = pythonOlder "3.6"; # >= 3.6
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "dde926478653bd03a3fbc501d3873a1534836608217b94d04320d1e1c07e59dc";
+    sha256 = "1yad9b9hd02rbdf6m1gfj74cjgcbyp7lxdj22d5h5rhv7xa3127x";
   };
 
-  checkInputs = [ pytest xgboost tensorflow joblib distributed ];
-  propagatedBuildInputs = [ dask numpy toolz numba pandas scikitlearn scipy dask-glm six multipledispatch packaging ];
+  propagatedBuildInputs = [
+    dask
+    dask-glm
+    distributed
+    multipledispatch
+    numba
+    numpy
+    packaging
+    pandas
+    scikitlearn
+    scipy
+    six
+    toolz
+  ];
 
-  # dask-ml has some heavy test requirements
-  # and requires some very new packages
+  # has non-standard build from source, and pypi doesn't include tests
   doCheck = false;
+
+  # in lieu of proper tests
+  pythonImportsCheck = [
+    "dask_ml"
+    "dask_ml.naive_bayes"
+    "dask_ml.wrappers"
+    "dask_ml.utils"
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/dask/dask-ml;


### PR DESCRIPTION
###### Motivation for this change

noticed it was broken reviewing #75420

bumped it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[1 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/75424
1 package were built:
python37Packages.dask-ml
```