### PR TITLE
[staging] python3Packages.astor: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/astor/default.nix
+++ b/pkgs/development/python-modules/astor/default.nix
@@ -1,21 +1,13 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy27, pytest, fetchpatch }:
+{ lib, buildPythonPackage, fetchPypi, isPy27, pytest, fetchpatch }:
 
 buildPythonPackage rec {
   pname = "astor";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0qkq5bf13fqcwablg0nk7rx83izxdizysd42n26j5wbingcfx9ip";
+    sha256 = "0ppscdzzvxpznclkmhhj53iz314x3pfv4yc7c6gwxqgljgdgyvka";
   };
-
-  # fix packaging for setuptools>=41.4
-  patches = [
-    ( fetchpatch {
-        url = "https://github.com/berkerpeksag/astor/pull/163/commits/bd697678674aafcf3f7b1c06af67df181ed584e2.patch";
-        sha256 = "1m4szdyzalngd5klanmpjx5smgpc7rl5klky0lc0yhwbx210mla6";
-    })
-  ];
 
   # disable tests broken with python3.6: https://github.com/berkerpeksag/astor/issues/89
   checkInputs = [ pytest ];
@@ -28,7 +20,7 @@ buildPythonPackage rec {
                 and not test_codegen_from_root'
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Library for reading, writing and rewriting python AST";
     homepage = https://github.com/berkerpeksag/astor;
     license = licenses.bsd3;


### PR DESCRIPTION
###### Motivation for this change
#75425 but on staging

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
