### PR TITLE
kramdown-rfc2629: init at 1.2.13

### DIFF
--- a/pkgs/tools/text/kramdown-rfc2629/Gemfile
+++ b/pkgs/tools/text/kramdown-rfc2629/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'kramdown-rfc2629'

--- a/pkgs/tools/text/kramdown-rfc2629/Gemfile.lock
+++ b/pkgs/tools/text/kramdown-rfc2629/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    certified (1.0.0)
+    kramdown (1.17.0)
+    kramdown-rfc2629 (1.2.13)
+      certified (~> 1.0)
+      kramdown (~> 1.17.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  kramdown-rfc2629
+
+BUNDLED WITH
+   1.17.3

--- a/pkgs/tools/text/kramdown-rfc2629/default.nix
+++ b/pkgs/tools/text/kramdown-rfc2629/default.nix
@@ -1,0 +1,18 @@
+{ lib, bundlerApp }:
+
+# Not in the default ../../../development/ruby-modules/with-packages/Gemfile
+# because of version clash on the "kramdown" dependency.
+bundlerApp rec {
+  pname = "kramdown-rfc2629";
+  gemdir = ./.;
+  exes = [ "kramdown-rfc2629" ];
+
+  meta = with lib; {
+    description = "A markdown parser with multiple backends";
+    homepage    = "https://github.com/cabo/kramdown-rfc2629";
+    license     = with licenses; mit;
+    maintainers = with maintainers; [
+      vcunat # not really, but I expect to use it occasionally around IETF
+    ];
+  };
+}

--- a/pkgs/tools/text/kramdown-rfc2629/gemset.nix
+++ b/pkgs/tools/text/kramdown-rfc2629/gemset.nix
@@ -1,0 +1,33 @@
+{
+  certified = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1706p6p0a8adyvd943af2a3093xakvislgffw3v9dvp7j07dyk5a";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  kramdown = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n1c4jmrh5ig8iv1rw81s4mw4xsp4v97hvf8zkigv4hn5h542qjq";
+      type = "gem";
+    };
+    version = "1.17.0";
+  };
+  kramdown-rfc2629 = {
+    dependencies = ["certified" "kramdown"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0s53m46qlcdakik0czvx0p41mk46l9l36331cps8gpf364wf3l9d";
+      type = "gem";
+    };
+    version = "1.2.13";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1853,6 +1853,8 @@ in
 
   klaus = with python3Packages; toPythonApplication klaus;
 
+  kramdown-rfc2629 = callPackage ../tools/text/kramdown-rfc2629 { };
+
   lcdproc = callPackage ../servers/monitoring/lcdproc { };
 
   languagetool = callPackage ../tools/text/languagetool {  };


### PR DESCRIPTION
###### Motivation for this change

Missing package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] N/A Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] N/A Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] N/A? Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

I hope I'm not doing some non-sense wrt. our ruby packaging, so I'll leave this open for a few days before merging.  I quickly saw changes and docs from #61114.
