### PR TITLE
Unbreak ghcide and bump haskell-lsp version

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -308,6 +308,7 @@ self: super: {
   hgdbmi = dontCheck super.hgdbmi;
   hi = dontCheck super.hi;
   hierarchical-clustering = dontCheck super.hierarchical-clustering;
+  hie-bios = dontCheck super.hie-bios;                  # https://github.com/mpickering/hie-bios/issues/25#issuecomment-567011935
   hlibgit2 = disableHardening super.hlibgit2 [ "format" ];
   hmatrix-tests = dontCheck super.hmatrix-tests;
   hquery = dontCheck super.hquery;
@@ -1323,8 +1324,10 @@ self: super: {
   spacecookie = super.spacecookie.override { systemd = self.systemd_2_2_0; };
 
   # ghcide needs the latest versions of haskell-lsp.
-  ghcide = super.ghcide.override { haskell-lsp = self.haskell-lsp_0_18_0_0; lsp-test = self.lsp-test_0_8_2_0; };
-  haskell-lsp_0_18_0_0 = super.haskell-lsp_0_18_0_0.override { haskell-lsp-types = self.haskell-lsp-types_0_18_0_0; };
-  lsp-test_0_8_2_0 = (dontCheck super.lsp-test_0_8_2_0).override { haskell-lsp = self.haskell-lsp_0_18_0_0; };
-
+  ghcide = doJailbreak (super.ghcide.override {
+    haskell-lsp = super.haskell-lsp_0_19_0_0.override { # This is in fact a version too new.
+      haskell-lsp-types = super.haskell-lsp-types_0_19_0_0;
+    };
+    hie-bios = self.hie-bios;
+  });
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -308,7 +308,6 @@ self: super: {
   hgdbmi = dontCheck super.hgdbmi;
   hi = dontCheck super.hi;
   hierarchical-clustering = dontCheck super.hierarchical-clustering;
-  hie-bios = dontCheck super.hie-bios;                  # https://github.com/mpickering/hie-bios/issues/25#issuecomment-567011935
   hlibgit2 = disableHardening super.hlibgit2 [ "format" ];
   hmatrix-tests = dontCheck super.hmatrix-tests;
   hquery = dontCheck super.hquery;
@@ -1323,11 +1322,19 @@ self: super: {
   # needs newer version of the systemd package
   spacecookie = super.spacecookie.override { systemd = self.systemd_2_2_0; };
 
-  # ghcide needs the latest versions of haskell-lsp.
-  ghcide = doJailbreak (super.ghcide.override {
-    haskell-lsp = super.haskell-lsp_0_19_0_0.override { # This is in fact a version too new.
+  # https://github.com/NixOS/nixpkgs/pull/75869
+  hie-bios = dontCheck super.hie-bios;
+
+  # ghcide needs version 0.18 of haskell-lsp.
+  # 0.19 is in fact a version too new, but it compiles.
+  # This override should be removed as soon as versions have stabilized again.
+  ghcide = allowInconsistentDependencies (doJailbreak (super.ghcide.override {
+    haskell-lsp = super.haskell-lsp_0_19_0_0.override {
       haskell-lsp-types = super.haskell-lsp-types_0_19_0_0;
     };
+    lsp-test = doJailbreak (super.lsp-test.override {
+      haskell-lsp = self.haskell-lsp;
+    });
     hie-bios = self.hie-bios;
-  });
+  }));
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9199,7 +9199,6 @@ broken-packages:
   - stack-run-auto
   - stack-type
   - stack-wrapper
-  - stack2cabal
   - stack2nix
   - stackage
   - stackage-build-plan


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
