### PR TITLE
Update php build configuration

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -61,6 +61,7 @@ let
   , xmlrpcSupport ? (config.php.xmlrpc or false) && (libxml2Support)
   , cgotoSupport ? config.php.cgoto or false
   , valgrindSupport ? (config.php.valgrind or true) && (versionAtLeast version "7.2")
+  , ipv6Support ? config.php.ipv6 or true
   }:
 
     let
@@ -193,7 +194,8 @@ let
       ++ optional (!pharSupport) "--disable-phar"
       ++ optional xmlrpcSupport "--with-xmlrpc"
       ++ optional cgotoSupport "--enable-re2c-cgoto"
-      ++ optional valgrindSupport "--with-valgrind=${valgrind.dev}";
+      ++ optional valgrindSupport "--with-valgrind=${valgrind.dev}"
+      ++ optional (!ipv6Support) "--disable-ipv6";
 
       hardeningDisable = [ "bindnow" ];
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -211,9 +211,6 @@ let
 
         export EXTENSION_DIR=$out/lib/php/extensions
 
-        configureFlags+=(--with-config-file-path=$out/etc \
-          --includedir=$dev/include)
-
         ./buildconf --force
       '';
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,9 +1,10 @@
 # pcre functionality is tested in nixos/tests/php-pcre.nix
 { lib, stdenv, fetchurl, autoconf, bison, libtool, pkgconfig, re2c
 , libxml2, readline, zlib, curl, postgresql, gettext
-, openssl, pcre, pcre2, sqlite, config, libjpeg, libpng, freetype
+, openssl, pcre, pcre2, sqlite, config
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, unixODBC
 , uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium, html-tidy, libargon2
+, gd, freetype, libXpm, libjpeg, libpng, libwebp
 , libzip, valgrind, oniguruma
 }:
 
@@ -84,7 +85,7 @@ let
         ++ optionals imapSupport [ uwimap openssl pam ]
         ++ optionals curlSupport [ curl openssl ]
         ++ optionals ldapSupport [ openldap openssl ]
-        ++ optionals gdSupport [ libpng libjpeg freetype ]
+        ++ optionals gdSupport [ gd freetype libXpm libjpeg libpng libwebp ]
         ++ optionals opensslSupport [ openssl openssl.dev ]
         ++ optional apxs2Support apacheHttpd
         ++ optional (ldapSupport && stdenv.isLinux) cyrus_sasl
@@ -155,17 +156,22 @@ let
       ++ optional (mysqliSupport && mysqlndSupport) "--with-mysqli=mysqlnd"
       ++ optional (pdo_mysqlSupport || mysqliSupport) "--with-mysql-sock=/run/mysqld/mysqld.sock"
       ++ optional bcmathSupport "--enable-bcmath"
-      # FIXME: Our own gd package doesn't work, see https://bugs.php.net/bug.php?id=60108.
       ++ optionals (gdSupport && versionAtLeast version "7.4") [
         "--enable-gd"
+        "--with-external-gd=${gd.dev}"
+        "--with-webp=${libwebp}"
         "--with-jpeg=${libjpeg.dev}"
+        "--with-xpm=${libXpm.dev}"
         "--with-freetype=${freetype.dev}"
         "--enable-gd-jis-conv"
       ] ++ optionals (gdSupport && versionOlder version "7.4") [
-        "--with-gd"
-        "--with-freetype-dir=${freetype.dev}"
-        "--with-png-dir=${libpng.dev}"
+        "--with-gd=${gd.dev}"
+        "--with-webp-dir=${libwebp}"
         "--with-jpeg-dir=${libjpeg.dev}"
+        "--with-png-dir=${libpng.dev}"
+        "--with-freetype-dir=${freetype.dev}"
+        "--with-xpm-dir=${libXpm.dev}"
+        "--enable-gd-jis-conv"
       ]
       ++ optional gmpSupport "--with-gmp=${gmp.dev}"
       ++ optional soapSupport "--enable-soap"

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,7 +1,8 @@
 # pcre functionality is tested in nixos/tests/php-pcre.nix
-{ lib, stdenv, fetchurl, autoconf, bison, libtool, pkgconfig, re2c
+{ config, lib, stdenv, fetchurl
+, autoconf, automake, bison, file, flex, libtool, pkgconfig, re2c
 , libxml2, readline, zlib, curl, postgresql, gettext
-, openssl, pcre, pcre2, sqlite, config
+, openssl, pcre, pcre2, sqlite
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, unixODBC
 , uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium, html-tidy, libargon2
 , gd, freetype, libXpm, libjpeg, libpng, libwebp
@@ -72,11 +73,14 @@ let
 
       inherit version;
 
-      name = "php-${version}";
+      pname = "php";
 
       enableParallelBuilding = true;
 
-      nativeBuildInputs = [ autoconf bison libtool pkgconfig re2c ];
+      nativeBuildInputs = [
+        autoconf automake bison file flex libtool pkgconfig re2c
+      ];
+
       buildInputs = [ ]
         ++ optional (versionOlder version "7.3") pcre
         ++ optional (versionAtLeast version "7.3") pcre2
@@ -138,7 +142,6 @@ let
       ++ optional (libxml2Support && (versionOlder version "7.4")) "--with-libxml-dir=${libxml2.dev}"
       ++ optional (!libxml2Support) [
         "--disable-dom"
-        "--disable-libxml"
         (if (versionOlder version "7.4") then "--disable-libxml" else "--without-libxml")
         "--disable-simplexml"
         "--disable-xml"
@@ -217,11 +220,17 @@ let
             --replace '@PHP_LDFLAGS@' ""
         done
 
-        #[[ -z "$libxml2" ]] || addToSearchPath PATH $libxml2/bin
+        substituteInPlace ./build/libtool.m4 --replace /usr/bin/file ${file}/bin/file
 
         export EXTENSION_DIR=$out/lib/php/extensions
 
-        ./buildconf --force
+        ./buildconf --copy --force
+
+        if test -f $src/genfiles; then
+          ./genfiles
+        fi
+      '' + optionalString stdenv.isDarwin ''
+        substituteInPlace configure --replace "-lstdc++" "-lc++"
       '';
 
       postInstall = ''
@@ -233,8 +242,8 @@ let
         mkdir -p $dev/bin $dev/share/man/man1
         mv $out/bin/phpize $out/bin/php-config $dev/bin/
         mv $out/share/man/man1/phpize.1.gz \
-          $out/share/man/man1/php-config.1.gz \
-          $dev/share/man/man1/
+           $out/share/man/man1/php-config.1.gz \
+           $dev/share/man/man1/
       '';
 
       src = fetchurl {
@@ -252,10 +261,6 @@ let
       };
 
       patches = [ ./fix-paths-php7.patch ] ++ extraPatches;
-
-      postPatch = optional stdenv.isDarwin ''
-        substituteInPlace configure --replace "-lstdc++" "-lc++"
-      '';
 
       stripDebugList = "bin sbin lib modules";
 

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -62,6 +62,7 @@ let
   , cgotoSupport ? config.php.cgoto or false
   , valgrindSupport ? (config.php.valgrind or true) && (versionAtLeast version "7.2")
   , ipv6Support ? config.php.ipv6 or true
+  , pearSupport ? (config.php.pear or true) && (libxml2Support)
   }:
 
     let
@@ -195,7 +196,8 @@ let
       ++ optional xmlrpcSupport "--with-xmlrpc"
       ++ optional cgotoSupport "--enable-re2c-cgoto"
       ++ optional valgrindSupport "--with-valgrind=${valgrind.dev}"
-      ++ optional (!ipv6Support) "--disable-ipv6";
+      ++ optional (!ipv6Support) "--disable-ipv6"
+      ++ optional (pearSupport && libxml2Support) "--with-pear=$(out)/lib/php/pear";
 
       hardeningDisable = [ "bindnow" ];
 


### PR DESCRIPTION
###### Motivation for this change
Changes in this PR:
- Drop support build php wint maraidb connector-c. Php not support version 3.1.
- Remove unused configure flags. The `configureFlags+` option is not applied during build.
- Add option `config.php.pear`
- Add option `config.php.ipv6`
- Build PHP with an external GD library
- Update `preConfigure` phase. Needed for a correct build from git-source.

cc @etu @aanderse 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
