### PR TITLE
rustup: add helper to bring dev pkgs in for compilition

### DIFF
--- a/pkgs/development/tools/rust/rustup/with-dev.nix
+++ b/pkgs/development/tools/rust/rustup/with-dev.nix
@@ -1,0 +1,19 @@
+{ rustup, runCommand, makeWrapper, pkgsHostTarget
+, name ? (let p = builtins.parseDrvName rustup.name; in "${p.name}-with-dev-${p.version}")
+, devPkgs }:
+
+runCommand name {
+  inherit (rustup) version;
+
+  nativeBuildInputs = [ makeWrapper ];
+  # Setup hook of pkg-config will set `$PKG_CONFIG_PATH`
+  buildInputs = [ rustup pkgsHostTarget.pkg-config ] ++ devPkgs;
+  preferLocalBuild = true;
+
+} ''
+  cp -r ${rustup} $out
+  chmod -R +w $out
+  wrapProgram $out/bin/rustup \
+    --prefix PKG_CONFIG_PATH ":" "$PKG_CONFIG_PATH" \
+    --prefix PATH ":" "${pkgsHostTarget.pkg-config}/bin"
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8708,6 +8708,7 @@ in
   rustup = callPackage ../development/tools/rust/rustup {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };
+  rustup-with-dev = { devPkgs }: callPackage ../development/tools/rust/rustup/with-dev.nix { inherit devPkgs; };
 
   sagittarius-scheme = callPackage ../development/compilers/sagittarius-scheme {};
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
When compiling `-sys` crates, some dependent libraries will be found using `pkg-config` and get linked. Since our `pkg-config` use setup-hook to locate pkgs, that means we need to compile always in `nix-shell -p pkg-config <other-deps>`. Installing these packages globally does not work.

This PR introduces a helper function providing a customized `rustup` wrapper to make some often-used developing packages available for compiling, without the requirement of `nix-shell` every time.

###### Usage:
- `nix-env -iE 'with import <nixpkgs> {}; rustup-with-dev { devPkgs = [ openssl.dev ]; }'`
- `cargo build some_crate_using_openssl_sys # Feel free`

###### More concerns:
- Should we name it to `rustup_configurable` just like `vim_configurable`? (With maybe future extension?)
- More documentation?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Mic92 
