### PR TITLE
xsecurelock: Remove obsolete path fix

### DIFF
--- a/pkgs/tools/X11/xsecurelock/default.nix
+++ b/pkgs/tools/X11/xsecurelock/default.nix
@@ -32,11 +32,6 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
-  preInstall = ''
-    substituteInPlace helpers/saver_blank \
-      --replace 'protect xset' 'protect ${xset}/bin/xset'
-  '';
-
   meta = with lib; {
     description = "X11 screen lock utility with security in mind";
     homepage = https://github.com/google/xsecurelock;


### PR DESCRIPTION
###### Motivation for this change
This fix is no longer needed.

`helpers/saver_blank` became [trivial](https://github.com/google/xsecurelock/blob/master/helpers/saver_blank) in xsecurelock commit [d4a817ae5e071540a1b11825908dd91a8697591a](https://github.com/google/xsecurelock/commit/d4a817ae5e071540a1b11825908dd91a8697591a), which first appeared in release 1.4.0.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @fpletz 
