### PR TITLE
pythonPackages.testresources: Move pbr to propagatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/testresources/default.nix
+++ b/pkgs/development/python-modules/testresources/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "ee9d1982154a1e212d4e4bac6b610800bfb558e4fb853572a827bc14a96e4417";
   };
 
-  buildInputs = [ pbr ];
+  propagatedBuildInputs = [ pbr ];
 
   checkInputs = [ fixtures testtools ];
 


### PR DESCRIPTION
###### Motivation for this change

Since testresources declares `Requires-Dist: pbr (>=1.8)` and imports `pbr.version`, any user of testresources also needs to have pbr.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
  - `python38Packages.zeep` fails to build, but that’s not a regression
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dotlambda
