### PR TITLE
pythonPackages.caiman: init at 1.6.4

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -100,6 +100,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = ''BSD 3-clause "New" or "Revised" License'';
   };
 
+  bsd3-lbnl = spdx {
+    spdxId = "BSD-3-Clause-LBNL";
+    fullName = ''Lawrence Berkeley National Labs BSD variant license'';
+  };
+
   bsdOriginal = spdx {
     spdxId = "BSD-4-Clause";
     fullName = ''BSD 4-clause "Original" or "Old" License'';

--- a/pkgs/development/python-modules/caiman/default.nix
+++ b/pkgs/development/python-modules/caiman/default.nix
@@ -1,0 +1,107 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, bokeh
+, coverage
+, cython
+, ffmpeg
+, future
+, h5py
+, holoviews
+, imageio
+, ipykernel
+, ipython
+, ipyparallel
+, jupyter
+, matplotlib
+, mypy
+, nose
+, numpy
+, numpydoc
+, opencv3
+, peakutils
+, pims
+, pynwb
+, pyqt5
+, pyqtgraph
+, qt5
+, scikitimage
+, scikitlearn
+, scipy
+, tensorflow
+, tifffile
+, tk
+, tqdm
+, yapf
+}:
+
+qt5.mkDerivationWith buildPythonPackage rec {
+  pname = "caiman";
+  version = "1.6.4";
+
+  src = fetchFromGitHub {
+      owner = "flatironinstitute";
+      repo = pname;
+      rev = "v"+version;
+      sha256 = "12q5awr890pzpgpxfrf85034axwshv5bq9mxacrdc79278q4ghcc";
+  };
+
+  buildInputs = [
+    ffmpeg
+    qt5.qtbase
+  ];
+
+  separateDebugInfo = true;
+
+
+  # for some reason, in default check phase, gcc and g++ are called a 2nd time and recompile
+  # same programs. Tests fail as wrapQtAppsHook is not called
+
+  # both checkPhases below result in segmentation fault
+  # likewise, disabling tests and trying to `import caiman` in nix-shell also
+  # segfaults
+  # checkPhase = ''nosetests'';
+  checkPhase = ''python caimanmanager.py test'';
+
+  checkInputs = [
+    nose
+  ];
+
+  propagatedBuildInputs = [
+    bokeh
+    coverage
+    cython
+    future
+    h5py
+    holoviews
+    imageio
+    ipykernel
+    ipython
+    ipyparallel
+    jupyter
+    matplotlib
+    mypy
+    nose
+    numpy
+    numpydoc
+    opencv3
+    peakutils
+    pims
+    pynwb
+    pyqt5
+    pyqtgraph
+    scikitimage
+    scikitlearn
+    scipy
+    tensorflow
+    tifffile
+    tk
+    tqdm
+    yapf
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/flatironinstitute/caiman";
+    description = "Computational toolbox for large scale Calcium Imaging Analysis.";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/hdmf/default.nix
+++ b/pkgs/development/python-modules/hdmf/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, chardet
+, h5py
+, numpy
+, scipy
+, pandas
+, ruamel_yaml
+, six
+, unittest2
+}:
+
+buildPythonPackage rec {
+  pname = "hdmf";
+  version = "1.3.3";
+  # pynwb depends on 1.3.3. 1.4 does not work
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0r3wj5pifhzfa773lnkl7garc18svfvpk5y5p0d0ww4xc2hab1k1";
+  };
+
+  checkInputs = [ unittest2 ];
+
+  propagatedBuildInputs = [
+    chardet
+    h5py
+    numpy
+    scipy
+    pandas
+    ruamel_yaml
+    six
+  ];
+
+  meta = with lib; {
+    description = "A package for standardizing hierarchical object data";
+    homepage = "https://github.com/hdmf-dev/hdmf";
+    license = licenses.bsd3-lbnl;
+    maintainers = [ maintainers.tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/peakutils/default.nix
+++ b/pkgs/development/python-modules/peakutils/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi
+, numpy
+, scipy
+, pandas
+}:
+
+buildPythonPackage rec {
+  pname = "peakutils";
+  version = "1.3.2";
+
+  src = fetchPypi {
+    pname = "PeakUtils";
+    inherit version;
+    sha256 = "2cf1f609132f0219e2fc9c7e221b62d1c82c9a502ec9a4c1195823423275c954";
+  };
+
+    propagatedBuildInputs = [
+      numpy
+      scipy
+      pandas
+    ];
+
+  # https://bitbucket.org/lucashnegri/peakutils/issues/36/exp-not-found
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Peak detection utilities for 1D data";
+    homepage = https://bitbucket.org/lucashnegri/peakutils;
+    license = licenses.mit;
+    maintainers = [ maintainers.tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/pynwb/default.nix
+++ b/pkgs/development/python-modules/pynwb/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, chardet
+, h5py
+, hdmf
+, numpy
+, pandas
+, python-dateutil
+, ruamel_yaml
+, six
+, unittest2
+}:
+
+buildPythonPackage rec {
+  pname = "pynwb";
+  version = "1.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "35955986ab44849776809bcbb65880d5baed44aebaff5f0eb85eabc7b1c3a1f0";
+  };
+
+
+  # # Package conditions to handle
+  # # might have to sed setup.py and egg.info in patchPhase
+  # # sed -i "s/<package>.../<package>/"
+  # hdmf (==1.3.3)
+  patchPhase = ''
+    substituteInPlace requirements.txt \
+      --replace "chardet==3.0.4" "chardet" \
+      --replace "h5py==2.10.0" "h5py" \
+      --replace "hdmf==1.3.3" "hdmf" \
+      --replace "numpy==1.17.2" "numpy" \
+      --replace "pandas==0.25.1" "pandas" \
+      --replace "python-dateutil==2.8.0" "python-dateutil" \
+      --replace "ruamel.yaml==0.16.5" "ruamel.yaml" \
+      --replace "six==1.12.0" "six"
+    rm tests/build_fake_data.py
+    rm tests/build_fake_extension.py
+  '';
+
+  # doCheck = false;
+
+  checkInputs = [ unittest2 ];
+
+  propagatedBuildInputs = [
+    chardet
+    h5py
+    hdmf
+    numpy
+    pandas
+    python-dateutil
+    ruamel_yaml
+    six
+  ];
+
+  meta = with lib; {
+    description = "Package for working with Neurodata stored in the NWB format";
+    homepage = https://github.com/NeurodataWithoutBorders/pynwb;
+    license = licenses.bsd3-lbnl;
+    maintainers = [ maintainers.tbenst ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -499,6 +499,8 @@ in {
 
   cadquery = callPackage ../development/python-modules/cadquery { };
 
+  caiman = callPackage ../development/python-modules/caiman { };
+
   catalogue = callPackage ../development/python-modules/catalogue { };
 
   cdecimal = callPackage ../development/python-modules/cdecimal { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -898,6 +898,8 @@ in {
 
   pdfx = callPackage ../development/python-modules/pdfx { };
 
+  peakutils = callPackage ../development/python-modules/peakutils { };
+
   pynwb = callPackage ../development/python-modules/pynwb { };
 
   pyperf = callPackage ../development/python-modules/pyperf { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -896,6 +896,8 @@ in {
 
   pdfx = callPackage ../development/python-modules/pdfx { };
 
+  pynwb = callPackage ../development/python-modules/pynwb { };
+
   pyperf = callPackage ../development/python-modules/pyperf { };
 
   pefile = callPackage ../development/python-modules/pefile { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -595,6 +595,8 @@ in {
 
   parver = callPackage ../development/python-modules/parver { };
   arpeggio = callPackage ../development/python-modules/arpeggio { };
+  hdmf = callPackage ../development/python-modules/hdmf { };
+
   invoke = callPackage ../development/python-modules/invoke { };
 
   distorm3 = callPackage ../development/python-modules/distorm3 { };


### PR DESCRIPTION
###### Motivation for this change
Add CaImAn, a Python toolbox for large scale Calcium Imaging data Analysis and behavioral analysis.

The current derivation segfaults, possibly due to improper use of `qt5.mkDerivationWith`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @