### PR TITLE
installer/cd-dvd/iso-image: avoid leaking build timestamps

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -603,9 +603,6 @@ in
         { source = config.system.build.squashfsStore;
           target = "/nix-store.squashfs";
         }
-        { source = config.isoImage.efiSplashImage;
-          target = "/EFI/boot/efi-background.png";
-        }
         { source = config.isoImage.splashImage;
           target = "/isolinux/background.png";
         }
@@ -630,8 +627,8 @@ in
         { source = "${efiDir}/EFI";
           target = "/EFI";
         }
-        { source = pkgs.writeText "loopback.cfg" "source /EFI/boot/grub.cfg";
-          target = "/boot/grub/loopback.cfg";
+        { source = (pkgs.writeTextDir "grub/loopback.cfg" "source /EFI/boot/grub.cfg") + "/grub";
+          target = "/boot/grub";
         }
       ] ++ optionals (config.boot.loader.grub.memtest86.enable && canx86BiosBoot) [
         { source = "${pkgs.memtest86plus}/memtest.bin";
@@ -640,6 +637,10 @@ in
       ] ++ optionals (config.isoImage.grubTheme != null) [
         { source = config.isoImage.grubTheme;
           target = "/EFI/boot/grub-theme";
+        }
+      ] ++ [
+        { source = config.isoImage.efiSplashImage;
+          target = "/EFI/boot/efi-background.png";
         }
       ];
 


### PR DESCRIPTION
When 'grafting' '/nix/store/<hash>-loopback.cfg' from disk onto
'/boot/grub/loopback.cfg' on the iso, the parent 'grub' directory does not
exist yet. In this case it is automatically created and inherits its
attributes, including timestamp, from /nix/store.

This is correct/expected/intentional behavior of xorriso, but has the
undesired result of leaking the timestamps of /nix/store into the iso. For
this reason we put the loopback.cfg in a
'/nix/store/<hash>-loopback.cfg/grub/loopback.cfg' instead, so it will inherit
the attributes from the correctly-timestamped
'/nix/store/<hash>-loopback.cfg/grub' directory.

For the same reason we move '/EFI/boot/efi-background.png' down in the list
so it is grafted after its parent '/EFI/boot' directory is created with
the correct timestamp.

###### Motivation for this change

Making the installations ISO's bit-by-bit deterministic/reproducible for easier (security) checking, fixes #74944

###### Things done

Tested that together with #74174 `nix-build ./nixos/release-combined.nix -A nixos.iso_minimal.x86_64-linux --check` now succeeds

###### Notify maintainers

cc @bjornfor @veprbl 
