### PR TITLE
internetarchive: Provide setuptools at runtime

### DIFF
--- a/pkgs/development/python-modules/internetarchive/default.nix
+++ b/pkgs/development/python-modules/internetarchive/default.nix
@@ -1,6 +1,6 @@
 { buildPythonPackage, fetchFromGitHub, pytest, six, clint, pyyaml, docopt
 , requests, jsonpatch, args, schema, responses, backports_csv, isPy3k
-, lib, glibcLocales }:
+, lib, glibcLocales, setuptools }:
 
 buildPythonPackage rec {
   pname = "internetarchive";
@@ -23,6 +23,7 @@ buildPythonPackage rec {
     jsonpatch
     args
     schema
+    setuptools
   ] ++ lib.optional (!isPy3k) backports_csv;
 
   checkInputs = [ pytest responses glibcLocales ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Since commit f7e28bf5d8181926e600a222cb70180519d09726 ("Split buildPythonPackage into setup hooks"), the `ia` command provided by this package has crashed with the error:

    Traceback (most recent call last):
      File "/nix/store/7n1jf081h0qnj82m2s69mxzj02zf746f-python3.7-internetarchive-1.8.1/bin/.ia-wrapped", line 7, in <module>
        from internetarchive.cli.ia import main
      File "/nix/store/7n1jf081h0qnj82m2s69mxzj02zf746f-python3.7-internetarchive-1.8.1/lib/python3.7/site-packages/internetarchive/cli/__init__.py", line 27, in <module>
        from internetarchive.cli import ia, ia_configure, ia_delete, ia_download, ia_list, \
      File "/nix/store/7n1jf081h0qnj82m2s69mxzj02zf746f-python3.7-internetarchive-1.8.1/lib/python3.7/site-packages/internetarchive/cli/ia.py", line 60, in <module>
        from pkg_resources import iter_entry_points, DistributionNotFound
    ModuleNotFoundError: No module named 'pkg_resources'

This commit fixes that by adding `setuptools` (which contains the 'pkg_resources' module) to `propagatedBuildInputs`.

This can also be backported to 19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh 