### PR TITLE
teams: init at 1.2.00.32451

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, wrapGAppsHook
+, dpkg
+, atomEnv
+, libuuid
+, pulseaudio
+, at-spi2-atk
+, coreutils
+, gawk
+, xdg_utils
+, systemd }:
+
+stdenv.mkDerivation rec {
+  pname = "teams";
+  version = "1.2.00.32451";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/repos/ms-teams/pool/main/t/teams/teams_${version}_amd64.deb";
+    sha256 = "1p053kg5qksr78v2h7cxia5mb9kzgfwm6n99x579vfx48kka1n18";
+  };
+
+  nativeBuildInputs = [ dpkg autoPatchelfHook wrapGAppsHook ];
+
+  unpackCmd = "dpkg -x $curSrc .";
+
+  buildInputs = atomEnv.packages ++ [
+    libuuid
+    at-spi2-atk
+  ];
+
+  runtimeDependencies = [
+    systemd.lib
+    pulseaudio
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix PATH : "${coreutils}/bin:${gawk}/bin:${xdg_utils}/bin")
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{opt,bin}
+
+    mv share/teams $out/opt/
+    mv share $out/share
+
+    substituteInPlace $out/share/applications/teams.desktop \
+      --replace /usr/bin/ $out/bin/
+
+    ln -s $out/opt/teams/teams $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Microsoft Teams";
+    homepage = "https://teams.microsoft.com";
+    downloadPage = "https://teams.microsoft.com/downloads";
+    license = licenses.unfree;
+    maintainers = [ maintainers.liff ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21360,6 +21360,8 @@ in
 
   tambura = callPackage ../applications/audio/tambura { };
 
+  teams = callPackage ../applications/networking/instant-messengers/teams { };
+
   teamspeak_client = libsForQt512.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };
   teamspeak_server = callPackage ../applications/networking/instant-messengers/teamspeak/server.nix { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A Linux version of Microsoft Teams [was released](https://aka.ms/get-teams-linux).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notes

It’s somewhat similar to Slack so I was using the slack derivation as a reference.