### PR TITLE
k3s: init at 1.0.0

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "k3s";
+  version = "1.0.0";
+
+  src = let
+    throwError = throw "Unsupported system ${stdenv.hostPlatform.system}";
+  in {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/rancher/k3s/releases/download/v${version}/k3s";
+      sha256 = "1abj0vmnsgfa753r1yv7pkxp0s0ms703ma8sfr6cbqnhp256byik";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/rancher/k3s/releases/download/v${version}/k3s-arm64";
+      sha256 = "01q6dmf3gi6dvh812wmdqay2wrn831s04dm9ax63k47jjy6nbig3";
+    };
+    armv7l-linux = fetchurl {
+      url = "https://github.com/rancher/k3s/releases/download/v${version}/k3s-armhf";
+      sha256 = "1p8ji85igkhhhvhkx2c1i5ji6rysn6ym9nzmhs64rcy410b1mk1h";
+    };
+  }.${stdenv.hostPlatform.system} or throwError;
+
+  preferLocalBuild = true;
+  dontUnpack = true;
+  installPhase = "install -Dm755 $src $out/bin/k3s";
+
+  meta = with stdenv.lib; {
+    description = "Lightweight Kubernetes. 5 less than k8s.";
+    homepage = https://k3s.io/;
+    license = licenses.asl20;
+    maintainers = [ maintainers.offline ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19674,6 +19674,8 @@ in
 
   kubeless = callPackage ../applications/networking/cluster/kubeless { };
 
+  k3s = callPackage ../applications/networking/cluster/k3s { };
+
   k9s = callPackage ../applications/networking/cluster/k9s { };
 
   fluxctl = callPackage ../applications/networking/cluster/fluxctl { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Package k3s. I was not able to build it from source, as there are too many variables, and would probably need to fork a source, but statically linked binaries work just fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
