### PR TITLE
gitlab: 12.5.3 -> 12.5.4

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,9 +1,9 @@
 {
-  "version": "12.5.3",
-  "repo_hash": "1q76yhg4ygs9w5hb8hbv1908d5pfqzr8idmjp06pa4dw5qqqkv97",
+  "version": "12.5.4",
+  "repo_hash": "08jngv83pvxjyw3iaqzv484v4mwgwnzg9am3iqfidl9ihbm7i4h2",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v12.5.3-ee",
+  "rev": "v12.5.4-ee",
   "passthru": {
     "GITALY_SERVER_VERSION": "1.72.1",
     "GITLAB_PAGES_VERSION": "1.12.0",


### PR DESCRIPTION
https://about.gitlab.com/blog/2019/12/10/critical-security-release-gitlab-12-5-4-released/

Insufficient parameter sanitization for Maven package registry could lead to privilege escalation and remote code execution vulnerabilities under certain conditions. The issue is now mitigated in the latest release and is assigned CVE-2019-19628.

When transferring a public project to a private group, private code would be disclosed via the Group Search API provided by Elasticsearch integration. The issue is now mitigated in the latest release and is assigned CVE-2019-19629.

The Git dependency has been upgraded to 2.22.2 in order to apply security fixes detailed here.

CVE-2019-19604 was identified by the GitLab Security Research team. For more information on that issue, please visit the GitLab Security Research Advisory

closes #75506.

Should be backported to 19.09, too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).