### PR TITLE
precice: init at 1.6.1

### DIFF
--- a/pkgs/development/libraries/precice/default.nix
+++ b/pkgs/development/libraries/precice/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, cmake, gcc, boost, eigen, libxml2, openmpi, python2, python2Packages }:
+
+stdenv.mkDerivation rec {
+  pname = "precice";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "precice";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "00631zw6cpm67j35cwad04nwgfcvlxa8p660fwz30pgj2hzdx3d2";
+  };
+
+  preConfigure = ''
+    cmakeFlags="-DBUILD_SHARED_LIBS=ON -DPETSC=off"
+  '';
+
+  nativeBuildInputs = [ cmake gcc ];
+  buildInputs = [ boost eigen libxml2 openmpi python2 python2Packages.numpy ];
+  installPhase = ''
+    mkdir -p $out/lib
+    cp libprecice.so libprecice.so.1.6.1 $out/lib/
+  '';
+
+  meta = {
+    description = "preCICE stands for Precise Code Interaction Coupling Environment";
+    license = with lib.licenses; [ gpl3 ];
+    homepage = "https://www.precice.org/";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ Scriptkiddi ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1984,6 +1984,8 @@ in
 
   psstop = callPackage ../tools/system/psstop { };
 
+  precice = callPackage ../development/libraries/precice { };
+
   parallel-rust = callPackage ../tools/misc/parallel-rust { };
 
   pyCA = python3Packages.callPackage ../applications/video/pyca {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Need this for a course

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
