### PR TITLE
wt: 3.4.2 -> 3.5.0, 4.1.2 -> 4.2.0

### DIFF
--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -49,8 +49,8 @@ let
     };
 in {
   wt3 = generic {
-    version = "3.4.2";
-    sha256 = "03mwr4yv3705y74pdh19lmh8szad6gk2x2m23f4pr0wrmqg73307";
+    version = "3.5.0";
+    sha256 = "1xcwzldbval5zrf7f3n2gkpscagg51cw2jp6p3q1yh6bi59haida";
   };
 
   wt4 = generic {

--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -54,7 +54,7 @@ in {
   };
 
   wt4 = generic {
-    version = "4.1.2";
-    sha256 = "06bnadpgflg8inikzynnz4l4r6w1bphjwlva4pzf51w648vpkknl";
+    version = "4.2.0";
+    sha256 = "0zrrdjz0sa8hrmybjp4aap1lcqcqvsicd7dj49zj1m5k8gnfpm4v";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
minor updates:
https://github.com/emweb/wt/releases/tag/4.2.0
https://github.com/emweb/wt/releases/tag/3.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).