### PR TITLE
hopper: fix libxml2 dynamic linking issue

### DIFF
--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -8,7 +8,6 @@
 , gmpxx
 , ncurses5
 , gnustep
-,
 }:
 stdenv.mkDerivation rec {
   pname = "hopper";

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -1,19 +1,17 @@
-{
-  stdenv, fetchurl, lib,
-
-  autoPatchelfHook,
-
-  wrapQtAppsHook,
-
-  libbsd,
-  python27,
-  gmpxx,
-
-  ncurses5,
-  gnustep,
+{ stdenv
+, fetchurl
+, lib
+, autoPatchelfHook
+, wrapQtAppsHook
+, libbsd
+, python27
+, gmpxx
+, ncurses5
+, gnustep
+,
 }:
 stdenv.mkDerivation rec {
-  pname    = "hopper";
+  pname = "hopper";
   version = "4.5.19";
   rev = "v${lib.versions.major version}";
 

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -1,21 +1,17 @@
-{ mkDerivation, stdenv, fetchurl, pkgs, lib, qtbase }:
+{
+  stdenv, fetchurl, lib,
+
+  autoPatchelfHook,
+
+  wrapQtAppsHook,
+
+  libbsd,
+  python27,
+  gmpxx,
+}:
 let
 
-  ldLibraryPath = with pkgs; stdenv.lib.makeLibraryPath  [
-    libbsd.out
-    libffi.out
-    gmpxx.out
-    python27Full.out
-    python27Packages.libxml2.out
-    qt5.qtbase
-    zlib
-    xlibs.libX11.out
-    xorg_sys_opengl.out
-    xlibs.libXrender.out
-    gcc-unwrapped.lib
-  ];
-
-in mkDerivation rec {
+in stdenv.mkDerivation rec {
   pname    = "hopper";
   version = "4.5.7";
   rev = "v${lib.versions.major version}";
@@ -27,31 +23,35 @@ in mkDerivation rec {
 
   sourceRoot = ".";
 
-  buildInputs = [
-    qtbase
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    autoPatchelfHook
   ];
 
-  qtWrapperArgs = [
-    ''--suffix LD_LIBRARY_PATH : ${ldLibraryPath}''
+  buildInputs = [
+    libbsd
+    python27
+    gmpxx
   ];
 
   installPhase = ''
     mkdir -p $out/bin
     mkdir -p $out/lib
     mkdir -p $out/share
+
     cp $sourceRoot/opt/hopper-${rev}/bin/Hopper $out/bin/hopper
     cp -r $sourceRoot/opt/hopper-${rev}/lib $out
     cp -r $sourceRoot/usr/share $out/share
-    patchelf \
-      --set-interpreter ${stdenv.glibc}/lib/ld-linux-x86-64.so.2 \
-      $out/bin/hopper
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = "https://www.hopperapp.com/index.html";
     description = "A macOS and Linux Disassembler";
-    license = stdenv.lib.licenses.unfree;
-    maintainers = [ stdenv.lib.maintainers.luis ];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.unfree;
+    maintainers = [
+      maintainers.luis
+      maintainers.Enteee
+    ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -13,12 +13,12 @@ let
 
 in stdenv.mkDerivation rec {
   pname    = "hopper";
-  version = "4.5.7";
+  version = "4.5.19";
   rev = "v${lib.versions.major version}";
 
   src = fetchurl {
     url = "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-${rev}-${version}-Linux.pkg.tar.xz";
-    sha256 = "1ce7a0f13126a940398aa8da4a74e250dff0401074f30446a8840ac3dbb902c0";
+    sha256 = "1c9wbjwz5xn0skz2a1wpxyx78hhrm8vcbpzagsg4wwnyblap59db";
   };
 
   sourceRoot = ".";

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -1,6 +1,21 @@
-{ stdenv, fetchurl, pkgs, lib }:
+{ mkDerivation, stdenv, fetchurl, pkgs, lib, qtbase }:
+let
 
-stdenv.mkDerivation rec {
+  ldLibraryPath = with pkgs; stdenv.lib.makeLibraryPath  [
+    libbsd.out
+    libffi.out
+    gmpxx.out
+    python27Full.out
+    python27Packages.libxml2.out
+    qt5.qtbase
+    zlib
+    xlibs.libX11.out
+    xorg_sys_opengl.out
+    xlibs.libXrender.out
+    gcc-unwrapped.lib
+  ];
+
+in mkDerivation rec {
   pname    = "hopper";
   version = "4.5.7";
   rev = "v${lib.versions.major version}";
@@ -12,13 +27,13 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
-  ldLibraryPath = with pkgs; stdenv.lib.makeLibraryPath  [
-libbsd.out libffi.out gmpxx.out python27Full.out python27Packages.libxml2 qt5.qtbase zlib  xlibs.libX11.out xorg_sys_opengl.out xlibs.libXrender.out gcc-unwrapped.lib
+  buildInputs = [
+    qtbase
   ];
 
-  nativeBuildInputs = [ pkgs.qt5.wrapQtAppsHook ];
-
-  qtWrapperArgs = [ ''--suffix LD_LIBRARY_PATH : ${ldLibraryPath}'' ];
+  qtWrapperArgs = [
+    ''--suffix LD_LIBRARY_PATH : ${ldLibraryPath}''
+  ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1831,7 +1831,7 @@ in
 
   hostsblock = callPackage ../tools/misc/hostsblock { };
 
-  hopper = callPackage ../development/tools/analysis/hopper {};
+  hopper = qt5.callPackage ../development/tools/analysis/hopper {};
 
   hr = callPackage ../applications/misc/hr { };
 


### PR DESCRIPTION
* port to qt5.callPackage / mkDerivation
* format derivation

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

On channel: `nixpkgs-20.03pre202154.58fb23f72ad` hopper currently fails to start:

```
$ hopper 
/etc/profiles/per-user/ente/bin/hopper: error while loading shared libraries: libxml2.so.2: cannot open shared object file: No such file or directory
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Luis-Hebendanz (Maintainer)
@ttuegel (Contributor)