### PR TITLE
open-vm-tools: 10.3.10 -> 11.0.1

### DIFF
--- a/pkgs/applications/virtualization/open-vm-tools/default.nix
+++ b/pkgs/applications/virtualization/open-vm-tools/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "open-vm-tools";
-  version = "10.3.10";
+  version = "11.0.1";
 
   src = fetchFromGitHub {
     owner  = "vmware";
     repo   = "open-vm-tools";
     rev    = "stable-${version}";
-    sha256 = "0x2cyccnb4sycrw7r5mzby2d196f9jiph8vyqi0x8v8r2b4vi4yj";
+    sha256 = "1p499ilb2j1s0d7qf19b8nig8ggdq7b60xcgb7bc18g8kp5g82lv";
   };
 
   sourceRoot = "${src.name}/open-vm-tools";
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
      mkdir -p common-agent/etc/config
      sed -i 's|.*common-agent/etc/config/Makefile.*|\\|' configure.ac
 
+     sed -i 's,etc/vmware-tools,''${prefix}/etc/vmware-tools,' Makefile.am
      sed -i 's,^confdir = ,confdir = ''${prefix},' scripts/Makefile.am
      sed -i 's,etc/vmware-tools,''${prefix}/etc/vmware-tools,' services/vmtoolsd/Makefile.am
      sed -i 's,$(PAM_PREFIX),''${prefix}/$(PAM_PREFIX),' services/vmtoolsd/Makefile.am

--- a/pkgs/applications/virtualization/open-vm-tools/recognize_nixos.patch
+++ b/pkgs/applications/virtualization/open-vm-tools/recognize_nixos.patch
@@ -1,8 +1,8 @@
-diff --git a/lib/include/guest_os.h b/open-vm-tools/lib/include/guest_os.h
-index ef202e3..c7a105d 100644
+diff --git a/lib/include/guest_os.h b/lib/include/guest_os.h
+index 868dec68..0b9a2ad7 100644
 --- a/lib/include/guest_os.h
 +++ b/lib/include/guest_os.h
-@@ -238,6 +238,7 @@ Bool Gos_InSetArray(uint32 gos, const uint32 *set);
+@@ -278,6 +278,7 @@ Bool Gos_InSetArray(uint32 gos, const uint32 *set);
  #define STR_OS_MANDRAKE_FULL      "Mandrake Linux"
  #define STR_OS_MANDRIVA           "mandriva"
  #define STR_OS_MKLINUX            "MkLinux"
@@ -10,19 +10,19 @@ index ef202e3..c7a105d 100644
  #define STR_OS_NOVELL             "nld9"
  #define STR_OS_NOVELL_FULL        "Novell Linux Desktop 9"
  #define STR_OS_ORACLE6            "oraclelinux6"
-diff --git a/lib/misc/hostinfoPosix.c b/open-vm-tools/lib/misc/hostinfoPosix.c
-index 0f55070..2d8467c 100644
+diff --git a/lib/misc/hostinfoPosix.c b/lib/misc/hostinfoPosix.c
+index 348a67ec..5f8beb2b 100644
 --- a/lib/misc/hostinfoPosix.c
 +++ b/lib/misc/hostinfoPosix.c
-@@ -195,6 +195,7 @@ static const DistroInfo distroArray[] = {
-    {"Mandrake",           "/etc/mandrake-release"},
-    {"Mandriva",           "/etc/mandriva-release"},
-    {"MkLinux",            "/etc/mklinux-release"},
-+   {"NixOS",              "/etc/os-release"},
-    {"Novell",             "/etc/nld-release"},
-    {"OracleLinux",        "/etc/oracle-release"},
-    {"Photon",             "/etc/lsb-release"},
-@@ -554,6 +555,8 @@ HostinfoGetOSShortName(char *distro,         // IN: full distro name
+@@ -203,6 +203,7 @@ static const DistroInfo distroArray[] = {
+    { "Mandrake",           "/etc/mandrake-release"      },
+    { "Mandriva",           "/etc/mandriva-release"      },
+    { "MkLinux",            "/etc/mklinux-release"       },
++   { "NixOS",              "/etc/os-release"            },
+    { "Novell",             "/etc/nld-release"           },
+    { "OracleLinux",        "/etc/oracle-release"        },
+    { "Photon",             "/etc/lsb-release"           },
+@@ -865,6 +866,8 @@ HostinfoGetOSShortName(const char *distro,      // IN: full distro name
        }
     } else if (strstr(distroLower, "mandrake")) {
        Str_Strcpy(distroShort, STR_OS_MANDRAKE, distroShortSize);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @joamaki
