### PR TITLE
codeql: init at 2.0.0

### DIFF
--- a/pkgs/development/tools/analysis/codeql/default.nix
+++ b/pkgs/development/tools/analysis/codeql/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, fetchzip
+, zlib
+, xorg
+, freetype
+, alsaLib
+, jdk11
+, curl
+, lttng-ust
+, autoPatchelfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "codeql";
+  version = "2.0.0";
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  src = fetchzip {
+    url = "https://github.com/github/codeql-cli-binaries/releases/download/v${version}/codeql.zip";
+    sha256 = "1v6wzjdhfws77fr5r15s03f1ipzc1gh7sl8gvw1fb4pplpa2d08s";
+  };
+
+  nativeBuildInputs = [
+    zlib
+    xorg.libX11
+    xorg.libXext
+    xorg.libXi
+    xorg.libXtst
+    xorg.libXrender
+    freetype
+    alsaLib
+    jdk11
+    stdenv.cc.cc.lib
+    curl
+    lttng-ust
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    # codeql directory should not be top-level, otherwise,
+    # it'll include /nix/store to resolve extractors.
+    mkdir -p $out/{codeql,bin}
+    cp -R * $out/codeql/
+
+    ln -sf $out/codeql/tools/linux64/lib64trace.so $out/codeql/tools/linux64/libtrace.so
+
+    sed -i 's;"$CODEQL_DIST/tools/$CODEQL_PLATFORM/java/bin/java";"${jdk11}/bin/java";' $out/codeql/codeql
+
+    ln -s $out/codeql/codeql $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Semantic code analysis engine";
+    homepage = "https://semmle.com/codeql";
+    maintainers = [ maintainers.dump_stack ];
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -807,6 +807,8 @@ in
 
   cloudflare-wrangler = callPackage ../development/tools/cloudflare-wrangler { };
 
+  codeql = callPackage ../development/tools/analysis/codeql { };
+
   container-linux-config-transpiler = callPackage ../development/tools/container-linux-config-transpiler { };
 
   ccextractor = callPackage ../applications/video/ccextractor { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Adds codeql ― semantic code analysis engine.

https://securitylab.github.com/tools/codeql

https://semmle.com/codeql

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
