### PR TITLE
[Draft] teams: init at 1.2.00.32451

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -1,0 +1,75 @@
+{ stdenv, fetchurl, makeDesktopItem, wrapGAppsHook
+, alsaLib, atk, at-spi2-atk, at-spi2-core, cairo, cups, dbus, expat, fontconfig, freetype, libgnome-keyring
+, gdk-pixbuf, glib, gtk3, libnotify, libX11, libXcomposite, libXcursor, libXdamage, libuuid, libsecret, libxkbfile
+, libXext, libXfixes, libXi, libXrandr, libXrender, libXtst, nspr, nss, libxcb
+, pango, systemd, libXScrnSaver, libcxx, pulseaudio, dpkg, tree, autoPatchelfHook }:
+
+let
+  binaryName = "teams";
+in stdenv.mkDerivation rec {
+  pname = "teams";
+  version = "1.2.00.32451";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/repos/ms-teams/pool/main/t/teams/teams_${version}_amd64.deb";
+    sha256 = "1p053kg5qksr78v2h7cxia5mb9kzgfwm6n99x579vfx48kka1n18";
+  };
+
+  nativeBuildInputs = [ dpkg wrapGAppsHook autoPatchelfHook ];
+
+  unpackPhase = ''
+    dpkg -x $src .
+  '';
+
+  dontWrapGApps = true;
+
+  buildInputs = [
+    libcxx systemd pulseaudio libsecret libxkbfile libgnome-keyring
+    stdenv.cc.cc alsaLib atk at-spi2-atk at-spi2-core cairo cups dbus expat fontconfig freetype
+    gdk-pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
+    libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
+    libXtst nspr nss libxcb pango systemd libXScrnSaver
+   ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r usr/bin $out/bin
+    cp -r usr/share $out/share
+
+    #mkdir -p $out/{bin,opt/${binaryName},share/pixmaps}
+    #mv * $out/opt/${binaryName}
+
+    #chmod +x $out/opt/${binaryName}/${binaryName}
+    #patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+    #    $out/opt/${binaryName}/${binaryName}
+
+    wrapProgram $out/share/${binaryName}/${binaryName} \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+
+    #ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
+    #ln -s $out/opt/${binaryName}/discord.png $out/share/pixmaps/${pname}.png
+
+    #ln -s "${desktopItem}/share/applications" $out/share/
+  '';
+
+  runtimeDependencies = [ pulseaudio ];
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = "teams";
+    icon = pname;
+    desktopName = "Teams";
+    genericName = meta.description;
+    categories = "Network;InstantMessaging;";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Unified communication and collaboration platform";
+    homepage = "https://teams.microsoft.com/start";
+    downloadPage = "https://teams.microsoft.com/downloads";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ jonringer ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2914,6 +2914,8 @@ in
 
   strawberry = libsForQt5.callPackage ../applications/audio/strawberry { };
 
+  teams = callPackage ../applications/networking/instant-messengers/teams { };
+
   tealdeer = callPackage ../tools/misc/tealdeer {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change
wanted to add the native teams app to nixpkgs

it's able to build, but currently i get this when running it:

```
strace ./result/share/teams/teams
...
connect(87, {sa_family=AF_UNIX, sun_path="/run/user/1000/pulse/native"}, 110) = 0
sendto(85, "W", 1, MSG_NOSIGNAL, NULL, 0) = -1 ENOTSOCK (Socket operation on non-socket)
write(85, "W", 1)                       = 1
write(85, "W", 1)                       = 1
mmap(NULL, 8392704, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_STACK, -1, 0) = 0x7f2fb17fb000
mprotect(0x7f2fb17fc000, 8388608, PROT_READ|PROT_WRITE) = 0
clone(child_stack=0x7f2fb1ffaa30, flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, parent_tid=[32182], tls=0x7f2fb1ffb700, child_tidptr=0x7f2fb1ffb9d0) = 32182
futex(0x55ecc13cd580, FUTEX_UNLOCK_PI_PRIVATE) = 0
futex(0x55ecc14422a8, FUTEX_WAIT_PRIVATE, 0, NULL) = 0
futex(0x55ecc13cd580, FUTEX_LOCK_PI_PRIVATE, NULL) = 0
futex(0x55ecc14422ac, FUTEX_WAIT_PRIVATE, 0, NULL) = 0
futex(0x55ecc13cd580, FUTEX_LOCK_PI_PRIVATE, NULL) = 0
read(58, "", 4)                         = 0
close(58)                               = 0
futex(0x55ecc13cd580, FUTEX_UNLOCK_PI_PRIVATE) = 0
futex(0x55ecc14422a8, FUTEX_WAIT_PRIVATE, 0, NULL) = 0
futex(0x55ecc13cd580, FUTEX_UNLOCK_PI_PRIVATE) = 0
gettid()                                = 32146
futex(0x7f2fb27fb7b8, FUTEX_WAKE_PRIVATE, 2147483647) = 1
futex(0x7f2fb27fb768, FUTEX_WAKE_PRIVATE, 1) = 1
futex(0x7f2f9c001c38, FUTEX_WAKE_PRIVATE, 1) = 1
read(41, "U\251m\377\34X\276\32", 8)    = 8
write(17, "\0", 1)                      = 1
write(17, "\0", 1)                      = 1
+++ killed by SIGTRAP (core dumped) +++
Trace/breakpoint trap (core dumped)
```
I'm just not really sure where to go from here, I'm assuming it's having some difficulty interacting with pulseaudio then dies, but I'm not really sure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
