### PR TITLE
hasura: init at 1.2.1

### DIFF
--- a/pkgs/servers/hasura/ci-info.nix
+++ b/pkgs/servers/hasura/ci-info.nix
@@ -1,0 +1,22 @@
+{ mkDerivation, aeson, aeson-casing, base, fetchgit, hashable
+, hpack, stdenv, template-haskell, text, th-lift-instances
+, unordered-containers
+}:
+mkDerivation {
+  pname = "ci-info";
+  version = "0.1.0.0";
+  src = fetchgit {
+    url = "https://github.com/hasura/ci-info-hs.git";
+    sha256 = "0rn1799z4y7z1c6ijrr0gscarg25zmnfq0z9rrmk4ad727vf1ppc";
+    rev = "6af5a68450347a02295a9cd050d05a8b2f5c06ab";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    aeson aeson-casing base hashable template-haskell text
+    th-lift-instances unordered-containers
+  ];
+  libraryToolDepends = [ hpack ];
+  prePatch = "hpack";
+  homepage = "https://github.com/hasura/ci-info-hs#readme";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/servers/hasura/cli.nix
+++ b/pkgs/servers/hasura/cli.nix
@@ -1,0 +1,33 @@
+{ buildGoModule, hasura-graphql-engine }:
+
+buildGoModule rec {
+  name = "hasura-${version}";
+  version = hasura-graphql-engine.version;
+
+  src = hasura-graphql-engine.src;
+  modRoot = "./cli";
+
+  goPackagePath = "github.com/hasura/graphql-engine/cli";
+  subPackages = [ "cmd/hasura" ];
+
+  modSha256 = "0bpb9r0n8n8c1p8sas3qanhvqw45rq8kygb4dmkfhj3d9vlgn6d2";
+
+  buildFlagsArray = [''-ldflags=
+    -X github.com/hasura/graphql-engine/cli/version.BuildVersion=${version}
+    -s
+    -w
+  ''];
+
+  postInstall = ''
+    mkdir -p $out/share/{bash-completion/completions,zsh/site-functions}
+
+    export HOME=$PWD
+    $out/bin/hasura completion bash > $out/share/bash-completion/completions/hasura
+    $out/bin/hasura completion zsh > $out/share/zsh/site-functions/_hasura
+  '';
+
+  meta = {
+    inherit (hasura-graphql-engine.meta) license homepage maintainers;
+    description = "Hasura GraphQL Engine CLI";
+  };
+}

--- a/pkgs/servers/hasura/default.nix
+++ b/pkgs/servers/hasura/default.nix
@@ -1,0 +1,63 @@
+{ haskell }:
+
+with haskell.lib;
+
+let
+  # version in cabal file is invalid
+  version = "1.2.1";
+
+  pkgs = haskell.packages.ghc865.override {
+    overrides = self: super: {
+      # cabal2nix  --subpath server --maintainer offline --no-check --revision 1.2.1 https://github.com/hasura/graphql-engine.git
+      hasura-graphql-engine = justStaticExecutables
+        ((self.callPackage ./graphql-engine.nix { }).overrideDerivation (d: {
+          name = "graphql-engine-${version}";
+
+          inherit version;
+
+          # hasura needs VERSION env exported during build
+          preBuild = "export VERSION=${version}";
+        }));
+
+      hasura-cli = self.callPackage ./cli.nix {
+        hasura-graphql-engine = self.hasura-graphql-engine // {
+          inherit version;
+        };
+      };
+
+      # internal dependencies, non published on hackage (find revisions in cabal.project file)
+      # cabal2nix --revision <rev> https://github.com/hasura/ci-info-hs.git
+      ci-info = self.callPackage ./ci-info.nix { };
+      # cabal2nix --revision <rev> https://github.com/hasura/graphql-parser-hs.git
+      graphql-parser = self.callPackage ./graphql-parser.nix { };
+      # cabal2nix --revision <rev> https://github.com/hasura/pg-client-hs.git
+      pg-client = self.callPackage ./pg-client.nix { };
+
+      # version constrained dependencies, without these hasura will not build,
+      # find versions in graphql-engine.cabal
+      # cabal2nix cabal://dependent-map-0.2.4.0
+      dependent-map = self.callPackage ./dependent-map.nix { };
+      # cabal2nix cabal://dependent-sum-0.4
+      dependent-sum = self.callPackage ./dependent-sum.nix { };
+      # cabal2nix cabal://these-0.7.6
+      these = doJailbreak (self.callPackage ./these.nix { });
+      # cabal2nix cabal://immortal-0.2.2.1
+      immortal = self.callPackage ./immortal.nix { };
+      # cabal2nix cabal://network-uri-2.6.1.0
+      network-uri = self.callPackage ./network-uri.nix { };
+      # cabal2nix cabal://ghc-heap-view-0.6.0
+      ghc-heap-view = disableLibraryProfiling (self.callPackage ./ghc-heap-view.nix { });
+
+      # unmark broewn packages and do required modifications
+      stm-hamt = doJailbreak (unmarkBroken super.stm-hamt);
+      superbuffer = dontCheck (doJailbreak (unmarkBroken super.superbuffer));
+      Spock-core = dontCheck (unmarkBroken super.Spock-core);
+      stm-containers = dontCheck (unmarkBroken super.stm-containers);
+      ekg-json = unmarkBroken super.ekg-json;
+      list-t = dontCheck (unmarkBroken super.list-t);
+      primitive-extras = unmarkBroken super.primitive-extras;
+    };
+  };
+in {
+  inherit (pkgs) hasura-graphql-engine hasura-cli;
+}

--- a/pkgs/servers/hasura/dependent-map.nix
+++ b/pkgs/servers/hasura/dependent-map.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, containers, dependent-sum, stdenv }:
+mkDerivation {
+  pname = "dependent-map";
+  version = "0.2.4.0";
+  sha256 = "5db396bdb5d156434af920c074316c3b84b4d39ba8e1cd349c7bb6679cb28246";
+  revision = "1";
+  editedCabalFile = "0a5f35d1sgfq1cl1r5bgb5pwfjniiycxiif4ycxglaizp8g5rlr1";
+  libraryHaskellDepends = [ base containers dependent-sum ];
+  homepage = "https://github.com/mokus0/dependent-map";
+  description = "Dependent finite maps (partial dependent products)";
+  license = "unknown";
+  hydraPlatforms = stdenv.lib.platforms.none;
+}

--- a/pkgs/servers/hasura/dependent-sum.nix
+++ b/pkgs/servers/hasura/dependent-sum.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, stdenv }:
+mkDerivation {
+  pname = "dependent-sum";
+  version = "0.4";
+  sha256 = "a8deecb4153a1878173f8d0a18de0378ab068bc15e5035b9e4cb478e8e4e1a1e";
+  libraryHaskellDepends = [ base ];
+  homepage = "https://github.com/mokus0/dependent-sum";
+  description = "Dependent sum type";
+  license = stdenv.lib.licenses.publicDomain;
+}

--- a/pkgs/servers/hasura/ghc-heap-view.nix
+++ b/pkgs/servers/hasura/ghc-heap-view.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, binary, bytestring, Cabal, containers
+, deepseq, filepath, ghc-heap, stdenv, template-haskell
+, transformers
+}:
+mkDerivation {
+  pname = "ghc-heap-view";
+  version = "0.6.0";
+  sha256 = "99ed6034d02a7a942e1b6ed970e9f7028dcdfd5b5d29fd8a0fb89f1a5e7c5ec8";
+  enableSeparateDataOutput = true;
+  setupHaskellDepends = [ base Cabal filepath ];
+  libraryHaskellDepends = [
+    base binary bytestring containers ghc-heap template-haskell
+    transformers
+  ];
+  testHaskellDepends = [ base deepseq ];
+  description = "Extract the heap representation of Haskell values and thunks";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/servers/hasura/graphql-engine.nix
+++ b/pkgs/servers/hasura/graphql-engine.nix
@@ -1,0 +1,71 @@
+{ mkDerivation, aeson, aeson-casing, ansi-wl-pprint, asn1-encoding
+, asn1-types, async, attoparsec, attoparsec-iso8601, auto-update
+, base, base64-bytestring, byteorder, bytestring, case-insensitive
+, ci-info, containers, criterion, cryptonite, data-has, deepseq
+, dependent-map, dependent-sum, directory, ekg-core, ekg-json
+, fast-logger, fetchgit, file-embed, filepath, generic-arbitrary
+, ghc-heap-view, graphql-parser, hashable, hspec, hspec-core
+, hspec-expectations-lifted, http-client, http-client-tls
+, http-types, immortal, insert-ordered-containers, jose, lens
+, lifted-async, lifted-base, list-t, mime-types, monad-control
+, monad-time, monad-validate, mtl, mustache, mwc-probability
+, mwc-random, natural-transformation, network, network-uri
+, optparse-applicative, pem, pg-client, postgresql-binary
+, postgresql-libpq, process, profunctors, psqueues, QuickCheck
+, regex-tdfa, safe, scientific, semver, shakespeare, split
+, Spock-core, stdenv, stm, stm-containers, template-haskell, text
+, text-builder, text-conversions, th-lift-instances, these, time
+, transformers, transformers-base, unix, unordered-containers
+, uri-encode, uuid, vector, wai, wai-websockets, warp, websockets
+, wreq, x509, yaml, zlib
+}:
+mkDerivation {
+  pname = "graphql-engine";
+  version = "1.0.0";
+  src = fetchgit {
+    url = "https://github.com/hasura/graphql-engine.git";
+    sha256 = "0hg44zl3gqa8lq7kggwgmgbsgdc7zrv5cxs507vilg11xklsbz4l";
+    rev = "27b0b59361cebecd074bd59123f602e7b013bac1";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/server; echo source root reset to $sourceRoot";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson aeson-casing ansi-wl-pprint asn1-encoding asn1-types async
+    attoparsec attoparsec-iso8601 auto-update base base64-bytestring
+    byteorder bytestring case-insensitive ci-info containers cryptonite
+    data-has deepseq dependent-map dependent-sum directory ekg-core
+    ekg-json fast-logger file-embed filepath generic-arbitrary
+    ghc-heap-view graphql-parser hashable http-client http-client-tls
+    http-types immortal insert-ordered-containers jose lens
+    lifted-async lifted-base list-t mime-types monad-control monad-time
+    monad-validate mtl mustache network network-uri
+    optparse-applicative pem pg-client postgresql-binary
+    postgresql-libpq process profunctors psqueues QuickCheck regex-tdfa
+    scientific semver shakespeare split Spock-core stm stm-containers
+    template-haskell text text-builder text-conversions
+    th-lift-instances these time transformers transformers-base unix
+    unordered-containers uri-encode uuid vector wai wai-websockets warp
+    websockets wreq x509 yaml zlib
+  ];
+  executableHaskellDepends = [
+    base bytestring pg-client text text-conversions
+  ];
+  testHaskellDepends = [
+    aeson base bytestring hspec hspec-core hspec-expectations-lifted
+    http-client http-client-tls lifted-base monad-control mtl
+    natural-transformation optparse-applicative pg-client process
+    QuickCheck safe split text time transformers-base
+    unordered-containers
+  ];
+  benchmarkHaskellDepends = [
+    async base bytestring criterion deepseq mwc-probability mwc-random
+    split text vector
+  ];
+  doCheck = false;
+  homepage = "https://www.hasura.io";
+  description = "GraphQL API over Postgres";
+  license = stdenv.lib.licenses.asl20;
+  maintainers = with stdenv.lib.maintainers; [ offline ];
+}

--- a/pkgs/servers/hasura/graphql-parser.nix
+++ b/pkgs/servers/hasura/graphql-parser.nix
@@ -1,0 +1,35 @@
+{ mkDerivation, aeson, attoparsec, base, bytestring, containers
+, criterion, fetchgit, filepath, hedgehog, hpack, prettyprinter
+, protolude, regex-tdfa, scientific, stdenv, template-haskell, text
+, text-builder, th-lift-instances, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "graphql-parser";
+  version = "0.1.0.0";
+  src = fetchgit {
+    url = "https://github.com/hasura/graphql-parser-hs.git";
+    sha256 = "0vz0sqqmr1l02d3f1pc5k7rm7vpxmg5d5ijvdcwdm34yw6x5lz1v";
+    rev = "623ad78aa46e7ba2ef1aa58134ad6136b0a85071";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    aeson attoparsec base bytestring containers filepath hedgehog
+    prettyprinter protolude regex-tdfa scientific template-haskell text
+    text-builder th-lift-instances unordered-containers vector
+  ];
+  libraryToolDepends = [ hpack ];
+  testHaskellDepends = [
+    aeson attoparsec base bytestring containers filepath hedgehog
+    prettyprinter protolude regex-tdfa scientific template-haskell text
+    text-builder th-lift-instances unordered-containers vector
+  ];
+  benchmarkHaskellDepends = [
+    aeson attoparsec base bytestring containers criterion filepath
+    hedgehog prettyprinter protolude regex-tdfa scientific
+    template-haskell text text-builder th-lift-instances
+    unordered-containers vector
+  ];
+  prePatch = "hpack";
+  homepage = "https://github.com/hasura/graphql-parser-hs#readme";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/servers/hasura/immortal.nix
+++ b/pkgs/servers/hasura/immortal.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, lifted-base, monad-control, stdenv, stm
+, tasty, tasty-hunit, transformers, transformers-base
+}:
+mkDerivation {
+  pname = "immortal";
+  version = "0.2.2.1";
+  sha256 = "ed4aa1a2883a693a73fec47c8c2d5332d61a0626a2013403e1a8fb25cc6c8d8e";
+  libraryHaskellDepends = [
+    base lifted-base monad-control stm transformers-base
+  ];
+  testHaskellDepends = [
+    base lifted-base stm tasty tasty-hunit transformers
+  ];
+  homepage = "https://github.com/feuerbach/immortal";
+  description = "Spawn threads that never die (unless told to do so)";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/servers/hasura/network-uri.nix
+++ b/pkgs/servers/hasura/network-uri.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, deepseq, HUnit, parsec, stdenv
+, test-framework, test-framework-hunit, test-framework-quickcheck2
+}:
+mkDerivation {
+  pname = "network-uri";
+  version = "2.6.1.0";
+  sha256 = "423e0a2351236f3fcfd24e39cdbc38050ec2910f82245e69ca72a661f7fc47f0";
+  revision = "1";
+  editedCabalFile = "141nj7q0p9wkn5gr41ayc63cgaanr9m59yym47wpxqr3c334bk32";
+  libraryHaskellDepends = [ base deepseq parsec ];
+  testHaskellDepends = [
+    base HUnit test-framework test-framework-hunit
+    test-framework-quickcheck2
+  ];
+  homepage = "https://github.com/haskell/network-uri";
+  description = "URI manipulation";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/servers/hasura/pg-client.nix
+++ b/pkgs/servers/hasura/pg-client.nix
@@ -1,0 +1,30 @@
+{ mkDerivation, aeson, aeson-casing, attoparsec, base, bytestring
+, criterion, fetchgit, file-embed, hashable, hashtables, hasql
+, hasql-pool, hasql-transaction, monad-control, mtl
+, postgresql-binary, postgresql-libpq, resource-pool, retry
+, scientific, stdenv, template-haskell, text, text-builder, th-lift
+, th-lift-instances, time, transformers-base, uuid, vector
+}:
+mkDerivation {
+  pname = "pg-client";
+  version = "0.1.0";
+  src = fetchgit {
+    url = "https://github.com/hasura/pg-client-hs.git";
+    sha256 = "1941gj5yp24kx0xb1nd774nwp5vnpsp6m83isqkwpyz9spl4sq7l";
+    rev = "70a849d09bea9461e72c5a5bbde06df65aab61c0";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    aeson aeson-casing attoparsec base bytestring hashable hashtables
+    monad-control mtl postgresql-binary postgresql-libpq resource-pool
+    retry scientific template-haskell text text-builder th-lift
+    th-lift-instances time transformers-base uuid vector
+  ];
+  testHaskellDepends = [ base ];
+  benchmarkHaskellDepends = [
+    base bytestring criterion file-embed hashable hasql hasql-pool
+    hasql-transaction mtl postgresql-libpq text text-builder
+  ];
+  homepage = "https://github.com/hasura/platform";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/servers/hasura/these.nix
+++ b/pkgs/servers/hasura/these.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, aeson, base, base-compat, bifunctors, binary
+, containers, data-default-class, deepseq, hashable, keys, lens
+, mtl, QuickCheck, quickcheck-instances, semigroupoids, stdenv
+, tasty, tasty-quickcheck, transformers, transformers-compat
+, unordered-containers, vector, vector-instances
+}:
+mkDerivation {
+  pname = "these";
+  version = "0.7.6";
+  sha256 = "9464b83d98e626360a8ad9836ba77e5201cd1e9c89b95b1b11a28ef3c23ac746";
+  libraryHaskellDepends = [
+    aeson base base-compat bifunctors binary containers
+    data-default-class deepseq hashable keys lens mtl QuickCheck
+    semigroupoids transformers transformers-compat unordered-containers
+    vector vector-instances
+  ];
+  testHaskellDepends = [
+    aeson base base-compat bifunctors binary containers hashable lens
+    QuickCheck quickcheck-instances tasty tasty-quickcheck transformers
+    unordered-containers vector
+  ];
+  homepage = "https://github.com/isomorphism/these";
+  description = "An either-or-both data type & a generalized 'zip with padding' typeclass";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15532,6 +15532,10 @@ in
 
   hashi-ui = callPackage ../servers/hashi-ui {};
 
+  inherit (callPackage ../servers/hasura { })
+    hasura-cli
+    hasura-graphql-engine;
+
   heapster = callPackage ../servers/monitoring/heapster { };
 
   hbase = callPackage ../servers/hbase {};
@@ -23619,7 +23623,7 @@ in
   };
 
   nethack-x11 = callPackage ../games/nethack { x11Mode = true; };
-  
+
   netris = callPackage ../games/netris { };
 
   neverball = callPackage ../games/neverball { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### About

This package is based on https://github.com/input-output-hk/cardano-explorer/tree/master/nix/nixos/graphql-engine who should also get most of the credit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ivan @domenkozar 