### PR TITLE
darwin.CF: fix retry condition

### DIFF
--- a/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
+++ b/pkgs/os-specific/darwin/swift-corelibs/corefoundation.nix
@@ -76,8 +76,8 @@ stdenv.mkDerivation {
   # later.
   buildPhase = stdenv.lib.optionalString true ''
     for i in {1..512}; do
-        if ninjaBuildPhase; then
-          break
+        if ninja -j $NIX_BUILD_CORES; then
+            break
         fi
 
         echo >&2


### PR DESCRIPTION
###### Motivation for this change

Using a function in an if condition when set -e is set doesn't seem to
break out or return false which means the workaround from 41ca86129fa18278758e177d1821351dc608d24c
never gets triggered.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
