### PR TITLE
xandikos: init at 0.1.0

### DIFF
--- a/pkgs/servers/xandikos/default.nix
+++ b/pkgs/servers/xandikos/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, fetchFromGitHub
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "xandikos";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jelmer";
+    repo = "xandikos";
+    rev = "v${version}";
+    sha256 = "12r8fciid2qpqf054584ywwh49yddyhhpkpcm6jihzyr5y2r4kn1";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    dulwich
+    defusedxml
+    icalendar
+    jinja2
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Lightweight CalDAV/CardDAV server";
+    homepage = "https://github.com/jelmer/xandikos";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers."0x4A6F" ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14530,6 +14530,8 @@ in
 
   x265 = callPackage ../development/libraries/x265 { };
 
+  xandikos = callPackage ../servers/xandikos { };
+
   inherit (callPackages ../development/libraries/xapian { })
     xapian_1_4;
   xapian = xapian_1_4;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [xandikos](https://xandikos.org/) package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matthiasbeyer taking over xandikos from #31096
