### PR TITLE
pdftk: reinit at 3.0.8

### DIFF
--- a/pkgs/tools/typesetting/pdftk/default.nix
+++ b/pkgs/tools/typesetting/pdftk/default.nix
@@ -1,42 +1,95 @@
-{ fetchurl, stdenv, gcj, unzip }:
+{ stdenv, fetchFromGitLab, gradle_5, jre, perl, writeText, runtimeShell }:
 
-stdenv.mkDerivation {
-  name = "pdftk-2.02";
+let
+  pname = "pdftk";
+  version = "3.0.8";
 
-  src = fetchurl {
-    url = "https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk-2.02-src.zip";
-    sha256 = "1hdq6zm2dx2f9h7bjrp6a1hfa1ywgkwydp14i2sszjiszljnm3qi";
+  src = fetchFromGitLab {
+    owner = "pdftk-java";
+    repo = "pdftk";
+    rev = "v${version}";
+    sha256 = "1bj4a9g5mbxd859mmawzs0mpm0jw7ap4n1imcwkwz142r9x1g6rk";
   };
 
-  nativeBuildInputs = [ gcj unzip ];
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit src version;
 
-  hardeningDisable = [ "fortify" "format" ];
+    nativeBuildInputs = [ gradle_5 perl ];
 
-  preBuild = ''
-    cd pdftk
-    sed -e 's@/usr/bin/@@g' -i Makefile.*
-    NIX_ENFORCE_PURITY= \
-      make \
-      LIBGCJ="${gcj.cc}/share/java/libgcj-${gcj.cc.version}.jar" \
-      GCJ=gcj GCJH=gcjh GJAR=gjar \
-      -iC ../java all
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d)
+      gradle -Dfile.encoding=utf-8 shadowJar;
+    '';
+
+    # Mavenize dependency paths
+    # e.g. org.codehaus.groovy/groovy/2.4.0/{hash}/groovy-2.4.0.jar -> org/codehaus/groovy/groovy/2.4.0/groovy-2.4.0.jar
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "12b7lw1zpj69pv4bpbrm6pi0ip02ay3dfj3vcy2jyikfbwdb3qcz";
+  };
+
+  # Point to our local deps repo
+  gradleInit = writeText "init.gradle" ''
+    logger.lifecycle 'Replacing Maven repositories with ${deps}...'
+    gradle.projectsLoaded {
+      rootProject.allprojects {
+        buildscript {
+          repositories {
+            clear()
+            maven { url '${deps}' }
+          }
+        }
+        repositories {
+          clear()
+          maven { url '${deps}' }
+        }
+      }
+    }
+
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
+        repositories {
+          maven { url '${deps}' }
+        }
+      }
+  }
   '';
 
-  # Makefile.Debian has almost fitting defaults
-  makeFlags = [ "-f" "Makefile.Debian" "VERSUFF=" ];
+in stdenv.mkDerivation rec {
+  inherit pname version src;
+
+  nativeBuildInputs = [ gradle_5 ];
+
+  buildPhase = ''
+    export GRADLE_USER_HOME=$(mktemp -d)
+    gradle --offline --no-daemon --info --init-script ${gradleInit} shadowJar
+  '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/man/man1
-    cp pdftk $out/bin
-    cp ../pdftk.1 $out/share/man/man1
+    mkdir -p $out/{bin,share/pdftk,share/man/man1}
+    cp build/libs/pdftk.jar $out/share/pdftk
+
+    cat  << EOF > $out/bin/pdftk
+    #!${runtimeShell}
+    exec ${jre}/bin/java -jar "$out/share/pdftk/pdftk.jar" "\$@"
+    EOF
+    chmod a+x "$out/bin/pdftk"
+
+    cp ${src}/pdftk.1 $out/share/man/man1
   '';
 
-
   meta = {
-    description = "Simple tool for doing everyday things with PDF documents";
-    homepage = https://www.pdflabs.com/tools/pdftk-server/;
+    description = "Command-line tool for working with PDFs";
+    homepage = "https://gitlab.com/pdftk-java/pdftk";
     license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [raskin];
-    platforms = with stdenv.lib.platforms; linux;
+    maintainers = with stdenv.lib.maintainers; [ raskin averelld ];
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/tools/typesetting/pdftk/legacy.nix
+++ b/pkgs/tools/typesetting/pdftk/legacy.nix
@@ -1,0 +1,42 @@
+{ fetchurl, stdenv, gcj, unzip }:
+
+stdenv.mkDerivation {
+  name = "pdftk-2.02";
+
+  src = fetchurl {
+    url = "https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk-2.02-src.zip";
+    sha256 = "1hdq6zm2dx2f9h7bjrp6a1hfa1ywgkwydp14i2sszjiszljnm3qi";
+  };
+
+  nativeBuildInputs = [ gcj unzip ];
+
+  hardeningDisable = [ "fortify" "format" ];
+
+  preBuild = ''
+    cd pdftk
+    sed -e 's@/usr/bin/@@g' -i Makefile.*
+    NIX_ENFORCE_PURITY= \
+      make \
+      LIBGCJ="${gcj.cc}/share/java/libgcj-${gcj.cc.version}.jar" \
+      GCJ=gcj GCJH=gcjh GJAR=gjar \
+      -iC ../java all
+  '';
+
+  # Makefile.Debian has almost fitting defaults
+  makeFlags = [ "-f" "Makefile.Debian" "VERSUFF=" ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man/man1
+    cp pdftk $out/bin
+    cp ../pdftk.1 $out/share/man/man1
+  '';
+
+
+  meta = {
+    description = "Simple tool for doing everyday things with PDF documents";
+    homepage = https://www.pdflabs.com/tools/pdftk-server/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [raskin];
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20554,6 +20554,7 @@ in
 
   pdfcpu = callPackage ../applications/graphics/pdfcpu { };
   pdftk = callPackage ../tools/typesetting/pdftk { };
+  pdftk-legacy = lowPrio (callPackage ../tools/typesetting/pdftk/legacy.nix { });
   pdfgrep  = callPackage ../tools/typesetting/pdfgrep { };
 
   pdfpc = callPackage ../applications/misc/pdfpc {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I think this is basically a maintained rewrite of the previous package. See also https://gitlab.com/pdftk-java/pdftk#known-differences-with-pdftk

Independent testing would be good. I'm keeping maintainers as is, I hope that's ok. Also, supported platforms are a guess.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
