### PR TITLE
aws-adfs: 1.19.1 -> 1.20.0; fix build

### DIFF
--- a/pkgs/development/python-modules/aws-adfs/default.nix
+++ b/pkgs/development/python-modules/aws-adfs/default.nix
@@ -1,13 +1,15 @@
 { lib, buildPythonPackage, fetchPypi
-, pytest, pytestrunner, pytestcov, mock, glibcLocales, lxml, boto3, requests, click, configparser }:
+, pytest, pytestrunner, pytestcov, mock, glibcLocales, lxml, boto3
+, requests, click, configparser, fido2, isPy27 }:
 
 buildPythonPackage rec {
   pname = "aws-adfs";
-  version = "1.19.1";
+  version = "1.20.0";
+  disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "20b2ad44d19aa494fa11cb2d1290359b3a7a0c6c8908179b4af0c9367d83e370";
+    sha256 = "1j18ffq5z8bcajavnlpbfhxrcadld5iv5gsfxg543yvdsp6hn2dg";
   };
 
   # Relax version constraint
@@ -22,7 +24,7 @@ buildPythonPackage rec {
   LC_ALL = "en_US.UTF-8";
 
   checkInputs = [ glibcLocales pytest pytestrunner pytestcov mock ];
-  propagatedBuildInputs = [ lxml boto3 requests click configparser ];
+  propagatedBuildInputs = [ lxml boto3 requests click configparser fido2 ];
 
   meta = with lib; {
     description = "Command line tool to ease aws cli authentication against ADFS";


### PR DESCRIPTION
#### Motivation for this change 
* Build is broken on Hydra for quite some time (https://hydra.nixos.org/build/107872384)
* update available

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bhipple
