### PR TITLE
Add `pkgs.lib.encodeGNUCommandLine`

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -1,0 +1,33 @@
+{ lib }:
+
+{ /* Automatically convert an attribute set to command-line options.
+
+     This helps protect against malformed command lines and also to reduce
+     boilerplate related to command-line construction for simple use cases.
+
+     Example:
+       renderOptions { foo = "A"; bar = 1; baz = null; qux = true; v = true; }
+       => " --bar '1' --foo 'A' --qux -v"
+  */
+  renderOptions =
+    options:
+      let
+        render = key: value:
+          let
+            hyphenate =
+              k: if builtins.stringLength k == 1 then "-${k}" else "--${k}";
+
+            renderOption = v: if v == null then "" else " ${hyphenate key} ${lib.escapeShellArg v}";
+
+            renderSwitch = if value then " ${hyphenate key}" else "";
+
+          in
+                 if builtins.isBool value
+            then renderSwitch
+            else if builtins.isList value
+            then lib.concatMapStrings renderOption value
+            else renderOption value;
+
+      in
+        lib.concatStrings (lib.mapAttrsToList render options);
+}

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -6,10 +6,10 @@
      boilerplate related to command-line construction for simple use cases.
 
      Example:
-       renderOptions { foo = "A"; bar = 1; baz = null; qux = true; v = true; }
+       encodeGNUCommandLine { foo = "A"; bar = 1; baz = null; qux = true; v = true; }
        => " --bar '1' --foo 'A' --qux -v"
   */
-  renderOptions =
+  encodeGNUCommandLine =
     options:
       let
         render = key: value:

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -6,8 +6,23 @@
      boilerplate related to command-line construction for simple use cases.
 
      Example:
-       encodeGNUCommandLine { } { foo = "A"; bar = 1; baz = null; qux = true; v = true; }
-       => " --bar '1' --foo 'A' --qux -v"
+       encodeGNUCommandLine
+         { }
+         { data = builtins.toJSON { id = 0; };
+
+           X = "PUT";
+
+           retry = 3;
+
+           retry-delay = null;
+
+           url = [ "https://example.com/foo" "https://example.com/bar" ];
+
+           silent = false;
+
+           verbose = true;
+         };
+       => " -X 'PUT' --data '{\"id\":0}' --retry '3' --url 'https://example.com/foo' --url 'https://example.com/bar' --verbose"
   */
   encodeGNUCommandLine =
     { renderKey ?
@@ -21,7 +36,7 @@
 
     , renderBool ? key: value: if value then " ${renderKey key}" else ""
 
-    , renderList ? key: value: lib.concatMapStrings renderOption value
+    , renderList ? key: value: lib.concatMapStrings (renderOption key) value
     }:
     options:
       let

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -121,7 +121,7 @@ let
       isOptionType mkOptionType;
     inherit (asserts)
       assertMsg assertOneOf;
-    inherit (cli) encodeGNUCommandLine;
+    inherit (cli) encodeGNUCommandLine toGNUCommandLine;
     inherit (debug) addErrorContextToAttrs traceIf traceVal traceValFn
       traceXMLVal traceXMLValMarked traceSeq traceSeqN traceValSeq
       traceValSeqFn traceValSeqN traceValSeqNFn traceShowVal

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -121,7 +121,7 @@ let
       isOptionType mkOptionType;
     inherit (asserts)
       assertMsg assertOneOf;
-    inherit (cli) renderOptions;
+    inherit (cli) encodeGNUCommandLine;
     inherit (debug) addErrorContextToAttrs traceIf traceVal traceValFn
       traceXMLVal traceXMLValMarked traceSeq traceSeqN traceValSeq
       traceValSeqFn traceValSeqN traceValSeqNFn traceShowVal

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -39,6 +39,7 @@ let
 
     # misc
     asserts = callLibs ./asserts.nix;
+    cli = callLibs ./cli.nix;
     debug = callLibs ./debug.nix;
     generators = callLibs ./generators.nix;
     misc = callLibs ./deprecated.nix;
@@ -120,6 +121,7 @@ let
       isOptionType mkOptionType;
     inherit (asserts)
       assertMsg assertOneOf;
+    inherit (cli) renderOptions;
     inherit (debug) addErrorContextToAttrs traceIf traceVal traceValFn
       traceXMLVal traceXMLValMarked traceSeq traceSeqN traceValSeq
       traceValSeqFn traceValSeqN traceValSeqNFn traceShowVal

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -443,7 +443,7 @@ runTests {
 
   testRenderOptions = {
     expr =
-       renderOptions
+       encodeGNUCommandLine
          { foo = "A";
 
            bar = 1;

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -441,4 +441,20 @@ runTests {
     expected  = "«foo»";
   };
 
+  testRenderOptions = {
+    expr =
+       renderOptions
+         { foo = "A";
+
+           bar = 1;
+
+           baz = null;
+
+           qux = true;
+
+           v = true;
+         };
+
+    expected = " --bar '1' --foo 'A' --qux -v";
+  };
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -445,17 +445,21 @@ runTests {
     expr =
        encodeGNUCommandLine
          { }
-         { foo = "A";
+         { data = builtins.toJSON { id = 0; };
 
-           bar = 1;
+           X = "PUT";
 
-           baz = null;
+           retry = 3;
 
-           qux = true;
+           retry-delay = null;
 
-           v = true;
+           url = [ "https://example.com/foo" "https://example.com/bar" ];
+
+           silent = false;
+
+           verbose = true;
          };
 
-    expected = " --bar '1' --foo 'A' --qux -v";
+    expected = " -X 'PUT' --data '{\"id\":0}' --retry '3' --url 'https://example.com/foo' --url 'https://example.com/bar' --verbose";
   };
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -444,6 +444,7 @@ runTests {
   testRenderOptions = {
     expr =
        encodeGNUCommandLine
+         { }
          { foo = "A";
 
            bar = 1;

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -460,6 +460,6 @@ runTests {
            verbose = true;
          };
 
-    expected = " -X 'PUT' --data '{\"id\":0}' --retry '3' --url 'https://example.com/foo' --url 'https://example.com/bar' --verbose";
+    expected = "'-X' 'PUT' '--data' '{\"id\":0}' '--retry' '3' '--url' 'https://example.com/foo' '--url' 'https://example.com/bar' '--verbose'";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This adds a new utility to intelligently convert Nix records to
command line options to reduce boilerplate for simple use cases and to
also reduce the likelihood of malformed command lines

###### Things done

I ran `nix-instantiate --eval --strict lib/tests/misc.nix`