### PR TITLE
crystal: 0.31.1 -> 0.32.1

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -198,6 +198,15 @@ in rec {
     };
   };
 
+  binaryCrystal_0_31 = genericBinary {
+    version = "0.31.1";
+    sha256s = {
+      x86_64-linux  = "0r8salf572xrnr4m6ll9q5hz6jj8q7ff1rljlhmqb1r26a8mi2ih";
+      i686-linux    = "0hridnis5vvrswflx0q67xfg5hryhz6ivlwrb9n4pryj5d1gwjrr";
+      x86_64-darwin = "1dgxgv0s3swkc5cwawzgpbc6bcd2nx4hjxc7iw2h907y1vgmbipz";
+    };
+  };
+
   crystal_0_25 = generic {
     version = "0.25.1";
     sha256  = "15xmbkalsdk9qpc6wfpkly3sifgw6a4ai5jzlv78dh3jp7glmgyl";
@@ -241,14 +250,13 @@ in rec {
   };
 
   crystal_0_32 = generic {
-    version = "255bfc5fa925b95b72e34b26ad997fb2b3f83059";
-    sha256  = "1dgk36cj5lwhs1c4zp0s1c9hjk0h3vljq6zwhlnzkl1xs7cgzim1";
+    version = "0.32.0";
+    sha256  = "0cmhsg54rm00f1ismpzz0aafj7s5c9k1gxh168q1y2pp5v8llkvv";
     doCheck = false; # 5 checks are failing now
-    binary = crystal_0_31;
-    extraBuildInputs = [ readline ];
+    binary = binaryCrystal_0_31;
   };
 
-  crystal = crystal_0_31;
+  crystal = crystal_0_32;
 
   crystal2nix = callPackage ./crystal2nix.nix {};
 }

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -189,6 +189,15 @@ in rec {
     };
   };
 
+  binaryCrystal_0_30 = genericBinary {
+    version = "0.30.1";
+    sha256s = {
+      x86_64-linux  = "1k2mb74jh3ns3m7y73j4wpf571sayn73zbn6d7q81d09r280zrma";
+      i686-linux    = "0vsq1ayf922spydp2g2mmimc797jmm7nl5nljhfppcclrwygdyk2";
+      x86_64-darwin = "1p3s4lwdgykb7h7aysjhrs7vm0zhinzw5d7rfv6jsyin4j8yxhzz";
+    };
+  };
+
   crystal_0_25 = generic {
     version = "0.25.1";
     sha256  = "15xmbkalsdk9qpc6wfpkly3sifgw6a4ai5jzlv78dh3jp7glmgyl";
@@ -228,7 +237,7 @@ in rec {
     version = "0.31.1";
     sha256  = "1dswxa32w16gnc6yjym12xj7ibg0g6zk3ngvl76lwdjqb1h6lwz8";
     doCheck = false; # 5 checks are failing now
-    binary = crystal_0_30;
+    binary = binaryCrystal_0_30;
   };
 
   crystal_0_32 = generic {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7887,6 +7887,7 @@ in
     crystal_0_29
     crystal_0_30
     crystal_0_31
+    crystal_0_32
     crystal
     crystal2nix;
 


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @manveru @david50407 @peterhoeg 

Note: it may be worth switching building inputs across to use `llvm_8` so that it's matched to the official builds.