### PR TITLE
step-ca: init at 0.13.3

### DIFF
--- a/pkgs/tools/security/step-ca/default.nix
+++ b/pkgs/tools/security/step-ca/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "step-ca";
+  version = "0.13.3";
+
+  goPackagePath = "github.com/smallstep/certificates";
+
+  src = fetchFromGitHub {
+    owner = "smallstep";
+    repo = "certificates";
+    rev = "v${version}";
+    sha256 = "1i42j7v5a5qqqb9ng8irblfyzykhyws0394q3zac290ymjijxbnq";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "A private certificate authority (X.509 & SSH) & ACME server for secure automated certificate management, so you can use TLS everywhere & SSO for SSH";
+    homepage = "https://smallstep.com/certificates/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cmcdragonkai ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/tools/security/step-ca/deps.nix
+++ b/pkgs/tools/security/step-ca/deps.nix
@@ -1,0 +1,291 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/AndreasBriese/bbloom";
+    fetch = {
+      type = "git";
+      url = "https://github.com/AndreasBriese/bbloom";
+      rev =  "e2d15f34fcf99d5dbb871c820ec73f710fca9815";
+      sha256 = "05kkrsmpragy69bj6s80pxlm3pbwxrkkx7wgk0xigs6y2n6ylpds";
+    };
+  }
+  {
+    goPackagePath  = "github.com/chzyer/readline";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chzyer/readline";
+      rev =  "2972be24d48e78746da79ba8e24e8b488c9880de";
+      sha256 = "104q8dazj8yf6b089jjr82fy9h1g80zyyzvp3g8b44a7d8ngjj6r";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dgraph-io/badger";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgraph-io/badger";
+      rev =  "391b6d3b93e6014fe8c2971fcc0c1266e47dbbd9";
+      sha256 = "13zyd6irxagwfv4azgmpk2qg8f80plhxrcjl8x89jzsjkl0a0pkx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dgryski/go-farm";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgryski/go-farm";
+      rev =  "6a90982ecee230ff6cba02d5bd386acc030be9d3";
+      sha256 = "1x3l4jgps0v1bjvd446kj4dp0ckswjckxgrng9afm275ixnf83ix";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-chi/chi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-chi/chi";
+      rev =  "0ebf7795c516423a110473652e9ba3a59a504863";
+      sha256 = "18hwj6vni19ykp3bsmg9ggnl6y2hawym0vbsigdgx8craqbp7jb1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-sql-driver/mysql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-sql-driver/mysql";
+      rev =  "72cd26f257d44c1114970e19afddcd812016007e";
+      sha256 = "1fvsvwc1v2i0gqn01mynvi1shp5xm0xaym6xng09fcbqb56lbjx1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "aa810b61a9c79d51363740d207bb46cf8e620ed5";
+      sha256 = "0kf4b59rcbb1cchfny2dm9jyznp8ri2hsb14n8iak1q8986xa0ab";
+    };
+  }
+  {
+    goPackagePath  = "github.com/juju/ansiterm";
+    fetch = {
+      type = "git";
+      url = "https://github.com/juju/ansiterm";
+      rev =  "720a0952cc2ac777afc295d9861263e2a4cf96a1";
+      sha256 = "0n6j0y7xhashp8gdkdl0r7vlbkdrkymrzxn9hxrx522k2isggs7h";
+    };
+  }
+  {
+    goPackagePath  = "github.com/konsorten/go-windows-terminal-sequences";
+    fetch = {
+      type = "git";
+      url = "https://github.com/konsorten/go-windows-terminal-sequences";
+      rev =  "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242";
+      sha256 = "1lchgf27n276vma6iyxa0v1xds68n2g8lih5lavqnx5x6q5pw2ip";
+    };
+  }
+  {
+    goPackagePath  = "github.com/lunixbochs/vtclean";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lunixbochs/vtclean";
+      rev =  "2d01aacdc34a083dca635ba869909f5fc0cd4f41";
+      sha256 = "1ss88dyx5hr4imvpg5lixvp0cf7c2qm4x9m8mdgshjpm92g5rqmf";
+    };
+  }
+  {
+    goPackagePath  = "github.com/manifoldco/promptui";
+    fetch = {
+      type = "git";
+      url = "https://github.com/manifoldco/promptui";
+      rev =  "157c96fb638a14d268b305cf2012582431fcc410";
+      sha256 = "0zha48i5f529q4j1qycybdzza4l9706hijiqws36ikd5jzg8i7wz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev =  "167de6bfdfba052fa6b2d3664c8f5272e23c9072";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c";
+      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mmcloughlin/avo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mmcloughlin/avo";
+      rev =  "2e7d06bc7ada2979f17ccf8ebf486dba23b84fc7";
+      sha256 = "0fna1hhg193zy428lkj24a8853g3qviqs2c9xi96mji6ldprna5d";
+    };
+  }
+  {
+    goPackagePath  = "github.com/newrelic/go-agent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/newrelic/go-agent";
+      rev =  "f5bce3387232559bcbe6a5f8227c4bf508dac1ba";
+      sha256 = "1zbp1cqhxp0sz3faymam6h1f91r1gl8dnnjx7qg8r06bd5fbzllb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "ba968bfe8b2f7e042a574c888954fccecfa385b4";
+      sha256 = "0g5qcb4d4fd96midz0zdk8b9kz8xkzwfa8kr1cliqbg8sxsy5vd1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/rs/xid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rs/xid";
+      rev =  "15d26544def341f036c5f8dca987a4cbe575032c";
+      sha256 = "1vgw1dikqw273awcci6pzifs7shkl5ah4l88j1zjbnpgbiwzlx9j";
+    };
+  }
+  {
+    goPackagePath  = "github.com/samfoo/ansi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/samfoo/ansi";
+      rev =  "b6bd2ded7189ce35bc02233b554eb56a5146af73";
+      sha256 = "0sw2d7c6l2ry34x0n4j37ydr8s7hxnax76yh6n35gb2g6f1h46sz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/shurcooL/sanitized_anchor_name";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/sanitized_anchor_name";
+      rev =  "86672fcb3f950f35f2e675df2240550f2a50762f";
+      sha256 = "142m507s9971cl8qdmbcw7sqxnkgi3xqd8wzvfq15p0w7w8i4a3h";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev =  "ad15b42461921f1fb3529b058c6786c6a45d5162";
+      sha256 = "02xdfcp4f6dqvpavwf1vvr794qgz2fx8929paam7wnvcxy7ib606";
+    };
+  }
+  {
+    goPackagePath  = "github.com/smallstep/assert";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smallstep/assert";
+      rev =  "de77670473b5492f5d0bce155b5c01534c2d13f7";
+      sha256 = "15z2b4qyylnwgq2pzlaxsdabqxh8dbna4ddprk9rzmsvnfkpds16";
+    };
+  }
+  {
+    goPackagePath  = "github.com/smallstep/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smallstep/cli";
+      rev =  "eeecaac062cb548ee2ab7c7563bc3c2f2160f019";
+      sha256 = "1khhd1vgwqb08vki1nh0k4i2yk6jjdqmnq4f8anqn125zsj7hvdk";
+    };
+  }
+  {
+    goPackagePath  = "github.com/smallstep/nosql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smallstep/nosql";
+      rev =  "f80b3f432de0662f07ebd58fe52b0a119fe5dcd9";
+      sha256 = "155blxdgaprl1py5g8p52gipp0ckz3k6v41hgsp83nay01yynafb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/urfave/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/cli";
+      rev =  "b67dcf995b6a7b7f14fad5fcb7cc5441b05e814b";
+      sha256 = "0n5vq4nydlhb7w12jiwphvxqdy4jwpxc3zwlxyhf05lq1nxfb56h";
+    };
+  }
+  {
+    goPackagePath  = "go.etcd.io/bbolt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/etcd-io/bbolt";
+      rev =  "63597a96ec0ad9e6d43c3fc81e809909e0237461";
+      sha256 = "13d5l6p6c5wvkr6vn9hkhz9c593qifn7fgx0hg4d6jcvg1y0bnm2";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "4d3f4d9ffa16a13f451c3b2999e9c49e9750bf06";
+      sha256 = "0sbsgjm6wqa162ssrf1gnpv62ak5wjn1bn8v7sxwwfg8a93z1028";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "c44066c5c816ec500d459a2a324a753f78531ae0";
+      sha256 = "0mgww74bl15d0jvsh4f3qr1ckjzb8icb8hn0mgs5ppa0b2fgpc4f";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "9b800f95dbbc54abff0acf7ee32d88ba4e328c89";
+      sha256 = "07v3l7q7y59cwvw0mc85i39v7qjcc1jh4svwi789rmrqqm5nq7q6";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev =  "3a10b9bf0a52df7e992a8c3eb712a86d3c896c75";
+      sha256 = "19f3dijcc54jnd7458jab2dgpd0gzccmv2qympd9wi8cc8jpnhws";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "54a98f90d1c46b7731eb8fb305d2a321c30ef610";
+      sha256 = "0l7mkdnwhidv8m686x432vmx8z5nqcrr9f46ddgvrxbh4wvyfcll";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/square/go-jose.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/square/go-jose";
+      rev =  "730df5f748271903322feb182be83b43ebbbe27d";
+      sha256 = "11r93g9xrcjqj7qvq8sbd5hy5rnbpmim0vdsp6rbav8gl7wimaa3";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2023,6 +2023,8 @@ in
 
   stagit = callPackage ../development/tools/stagit { };
 
+  step-ca = callPackage ../tools/security/step-ca { };
+
   step-cli = callPackage ../tools/security/step-cli { };
 
   bash-supergenpass = callPackage ../tools/security/bash-supergenpass { };


### PR DESCRIPTION
##### Motivation for this change

This adds step-ca, a certificate server that goes along with `step-cli`. This is already available in nixpkgs: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/security/step-cli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @xfix 
