### PR TITLE
libgpod: drop pygobject2

### DIFF
--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, python3, python3Packages, intltool
 , glibcLocales, gnome3, gtk3, wrapGAppsHook
-, ipodSupport ? false, libgpod, gobject-introspection
+, gobject-introspection
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -50,7 +50,7 @@ python3Packages.buildPythonApplication rec {
     podcastparser
     html5lib
     gtk3
-  ] ++ stdenv.lib.optional ipodSupport libgpod;
+  ];
 
   makeFlags = [
     "PREFIX=$(out)"

--- a/pkgs/development/libraries/libgpod/default.nix
+++ b/pkgs/development/libraries/libgpod/default.nix
@@ -1,17 +1,19 @@
-{stdenv, lib, fetchurl, gettext, perlPackages, intltool, pkgconfig, glib,
+{ stdenv, lib, fetchurl, gettext, perlPackages, intltool, pkgconfig, glib,
   libxml2, sqlite, zlib, sg3_utils, gdk-pixbuf, taglib,
-  libimobiledevice, python3Packages, mutagen,
+  libimobiledevice, mutagen,
   monoSupport ? false, mono, gtk-sharp-2_0
 }:
 
-let
-  inherit (python3Packages) python pygobject2;
-in stdenv.mkDerivation rec {
+
+stdenv.mkDerivation rec {
   name = "libgpod-0.8.3";
+
   src = fetchurl {
     url = "mirror://sourceforge/gtkpod/${name}.tar.bz2";
     sha256 = "0pcmgv1ra0ymv73mlj4qxzgyir026z9jpl5s5bkg35afs1cpk2k3";
   };
+
+  outputs = [ "out" "dev" ];
 
   preConfigure = "configureFlagsArray=( --with-udev-dir=$out/lib/udev )";
 
@@ -23,7 +25,7 @@ in stdenv.mkDerivation rec {
   dontStrip = true;
 
   propagatedBuildInputs = [ glib libxml2 sqlite zlib sg3_utils
-    gdk-pixbuf taglib libimobiledevice python pygobject2 mutagen ];
+    gdk-pixbuf taglib libimobiledevice  mutagen ];
 
   nativeBuildInputs = [ gettext intltool pkgconfig ]
     ++ (with perlPackages; [ perl XMLParser ])


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Let's drop libgpod using pygobject2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
