### PR TITLE
fuse-overlayfs: 0.7 -> 0.7.2

### DIFF
--- a/pkgs/tools/filesystems/fuse-overlayfs/default.nix
+++ b/pkgs/tools/filesystems/fuse-overlayfs/default.nix
@@ -2,24 +2,25 @@
 
 stdenv.mkDerivation rec {
   pname = "fuse-overlayfs";
-  version = "0.7";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1nhqy1fdzhkjhqs54nq66zj5bf85n3gr4k6zl0hswdvhg6flkg75";
+    sha256 = "1ybrki63ixrkraynms5i4jiil9901whwxs6p61h2c2ild8w2ir8n";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
   buildInputs = [ fuse3 ];
 
   meta = with lib; {
-    homepage = https://github.com/containers/fuse-overlayfs;
     description = "FUSE implementation for overlayfs";
     longDescription = "An implementation of overlay+shiftfs in FUSE for rootless containers.";
     license = licenses.gpl3;
+    maintainers = with maintainers; [ ma9e ];
     platforms = platforms.unix;
-    maintainers = [ maintainers.ma9e ];
+    inherit (src.meta) homepage;
   };
 }


### PR DESCRIPTION

###### Motivation for this change

upstream update - works here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @furrycatherder 
