### PR TITLE
teensyduino: add missing dependencies for teensy-loader

### DIFF
--- a/pkgs/development/arduino/arduino-core/default.nix
+++ b/pkgs/development/arduino/arduino-core/default.nix
@@ -32,6 +32,7 @@ let
 
   teensy_libpath = stdenv.lib.makeLibraryPath [
     atk
+    cairo
     expat
     fontconfig
     freetype
@@ -42,11 +43,13 @@ let
     libpng12
     libusb
     pango
+    udev
     xorg.libSM
     xorg.libX11
     xorg.libXext
     xorg.libXft
     xorg.libXinerama
+    xorg.libXxf86vm
     zlib
   ];
   teensy_architecture =


### PR DESCRIPTION
###### Motivation for this change
The teensy-loader (./share/arduino/hardware/tools/teensy) was not linked with the full list of dependencies that it needs. Thus it didn't start when called by the Arduino (Teensyduino) UI to actually push code to the device.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @antono @auntie @robberer @bjornfor @bergey