### PR TITLE
quartus: init at 19.1.0.670

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3844,6 +3844,12 @@
     githubId = 449813;
     name = "Roman Kuznetsov";
   };
+  kwohlfahrt = {
+    email = "kai.wohlfahrt@gmail.com";
+    github = "kwohlfahrt";
+    githubId = 2422454;
+    name = "Kai Wohlfahrt";
+  };
   kylesferrazza = {
     name = "Kyle Sferrazza";
     email = "kyle.sferrazza@gmail.com";

--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -1,0 +1,119 @@
+{ buildFHSUserEnv, makeDesktopItem, stdenv, lib, requireFile, unstick, cycloneVSupport ? true }:
+
+let
+  quartus = stdenv.mkDerivation rec {
+    version = "19.1.0.670";
+    pname = "quartus-prime-lite";
+
+    src = let
+      require = {name, sha256}: requireFile {
+        inherit name sha256;
+        url = "${meta.homepage}/${lib.versions.majorMinor version}/?edition=lite&platform=linux";
+      };
+    in map require ([{
+      name = "QuartusLiteSetup-${version}-linux.run";
+      sha256 = "15vxvqxqdk29ahlw3lkm1nzxyhzy4626wb9s5f2h6sjgq64r8m7f";
+    } {
+      name = "ModelSimSetup-${version}-linux.run";
+      sha256 = "0j1vfr91jclv88nam2plx68arxmz4g50sqb840i60wqd5b0l3y6r";
+    }] ++ lib.optional cycloneVSupport {
+      name = "cyclonev-${version}.qdz";
+      sha256 = "0bqxpvjgph0y6slk0jq75mcqzglmqkm0jsx10y9xz5llm6zxzqab";
+    });
+
+    nativeBuildInputs = [ unstick ];
+
+    buildCommand = let
+      installers = lib.sublist 0 2 src;
+      components = lib.sublist 2 ((lib.length src) - 2) src;
+      copyInstaller = installer: ''
+        # `$(cat $NIX_CC/nix-support/dynamic-linker) $src[0]` often segfaults, so cp + patchelf
+        cp ${installer} $TEMP/${installer.name}
+        chmod u+w,+x $TEMP/${installer.name}
+        patchelf --interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $TEMP/${installer.name}
+      '';
+      copyComponent = component: "cp ${component} $TEMP/${component.name}";
+      # leaves enabled: quartus, modelsim_ase, devinfo
+      disabledComponents = [
+        "quartus_help"
+        "quartus_update"
+        "modelsim_ae"
+        # Devices
+        "arria_lite"
+        "cyclone"
+        "cyclone10lp"
+        "max"
+        "max10"
+      ] ++ lib.optional (!cycloneVSupport) "cyclonev";
+    in ''
+    ${lib.concatMapStringsSep "\n" copyInstaller installers}
+    ${lib.concatMapStringsSep "\n" copyComponent components}
+
+    unstick $TEMP/${(builtins.head installers).name} \
+      --disable-components ${lib.concatStringsSep "," disabledComponents} \
+      --mode unattended --installdir $out --accept_eula 1
+
+    # This patch is from https://wiki.archlinux.org/index.php/Altera_Design_Software
+    patch --force --strip 0 --directory $out < ${./vsim.patch}
+
+    rm -r $out/uninstall $out/logs
+  '';
+
+    meta = {
+      homepage = "https://fpgasoftware.intel.com";
+      description = "FPGA design and simulation software";
+      license = lib.licenses.unfree;
+      platforms = lib.platforms.linux;
+      maintainers = with lib.maintainers; [ kwohlfahrt ];
+    };
+  };
+
+  desktopItem = makeDesktopItem {
+    name = quartus.name;
+    exec = "quartus";
+    icon = "quartus";
+    desktopName = "Quartus";
+    genericName = "Quartus FPGA IDE";
+    categories = "Development;";
+  };
+
+# I think modelsim_ase/linux/vlm checksums itself, so use FHSUserEnv instead of `patchelf`
+in buildFHSUserEnv {
+  name = "quartus-prime-lite";
+
+  targetPkgs = pkgs: with pkgs; [
+    # quartus requirements
+    glib
+    xorg.libICE
+    xorg.libSM
+    zlib
+    # qsys requirements
+    xorg.libXtst
+    xorg.libXi
+  ];
+  multiPkgs = pkgs: with pkgs; let
+    # This seems ugly - can we override `libpng = libpng12` for all `pkgs`?
+    freetype = pkgs.freetype.override { libpng = libpng12; };
+    fontconfig = pkgs.fontconfig.override { inherit freetype; };
+    libXft = pkgs.xorg.libXft.override { inherit freetype fontconfig; };
+  in [
+    # modelsim requirements
+    libxml2
+    ncurses5
+    unixODBC
+    libXft
+    # common requirements
+    freetype
+    fontconfig
+    xorg.libX11
+    xorg.libXext
+    xorg.libXrender
+  ];
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+  runScript = "${quartus}/quartus/bin/quartus";
+}

--- a/pkgs/applications/editors/quartus-prime/vsim.patch
+++ b/pkgs/applications/editors/quartus-prime/vsim.patch
@@ -1,0 +1,11 @@
+--- modelsim_ase/vco     	1970-01-01 01:00:01.000000000 +0100
++++ modelsim_ase/vco      	1970-01-01 01:00:01.000000000 +0100
+@@ -207,7 +207,7 @@
+           2.[5-9]*)         vco="linux" ;;
+           2.[1-9][0-9]*)    vco="linux" ;;
+           3.[0-9]*)    		vco="linux" ;;
+-          *)                vco="linux_rh60" ;;
++          *)                vco="linux" ;;
+         esac
+         if [ ! -x "$dir/$vco/vsim" ]; then
+           if [ -x "$dir/linuxle/vsim" ]; then

--- a/pkgs/os-specific/linux/unstick/default.nix
+++ b/pkgs/os-specific/linux/unstick/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, meson, ninja, pkgconfig, libseccomp }:
+
+stdenv.mkDerivation rec {
+  name = "unstick";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "kwohlfahrt";
+    repo = name;
+    rev = "effee9aa242ca12dc94cc6e96bc073f4cc9e8657";
+    sha256 = "08la3jmmzlf4pm48bf9zx4cqj9gbqalpqy0s57bh5vfsdk74nnhv";
+  };
+
+  sourceRoot = "source/src";
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [ libseccomp ];
+
+  meta = {
+    homepage = "https://github.com/kwohlfahrt/unstick";
+    description = "Silently eats chmod commands forbidden by Nix";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ kwohlfahrt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25810,4 +25810,6 @@ in
   kcli = callPackage ../development/tools/kcli {};
 
   unstick = callPackage ../os-specific/linux/unstick {};
+
+  quartus-prime-lite = callPackage ../applications/editors/quartus-prime {};
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25808,4 +25808,6 @@ in
   sentencepiece = callPackage ../development/libraries/sentencepiece {};
 
   kcli = callPackage ../development/tools/kcli {};
+
+  unstick = callPackage ../os-specific/linux/unstick {};
 }


### PR DESCRIPTION
###### Motivation for this change

Add Quartus Prime software for programming Intel FPGAs. There are unfortunately no open-source alternatives.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

This is a new package - should i add myself as a maintainer, even though I don't have commit access to nixpkgs?