### PR TITLE
Cleanup buildRustCrate expression

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, echo_build_heading, noisily, makeDeps, rust }:
+{ lib, stdenv, echo_build_heading, noisily, mkRustcDepArgs, rust }:
 { crateName,
   dependencies,
   crateFeatures, crateRenames, libName, release, libPath,
@@ -7,7 +7,7 @@
 
   let
 
-    deps = makeDeps dependencies crateRenames;
+    deps = mkRustcDepArgs dependencies crateRenames;
     rustcOpts =
       lib.foldl' (opts: opt: opts + " " + opt)
         (if release then "-C opt-level=3" else "-C debuginfo=2")

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -36,7 +36,7 @@
 
     build_bin() {
       crate_name=$1
-      crate_name_=$(echo $crate_name | sed -e "s/-/_/g")
+      crate_name_=$(echo $crate_name | tr '-' '_')
       main_file=""
       if [[ ! -z $2 ]]; then
         main_file=$2
@@ -54,7 +54,7 @@
 
 
     EXTRA_LIB=""
-    CRATE_NAME=$(echo ${libName} | sed -e "s/-/_/g")
+    CRATE_NAME=$(echo ${libName} | tr '-' '_')
 
     if [[ -e target/link_ ]]; then
       EXTRA_BUILD="$(cat target/link_) $EXTRA_BUILD"
@@ -108,7 +108,7 @@
         # https://github.com/rust-lang/cargo/blob/90fc9f620190d5fa3c80b0c8c65a1e1361e6b8ae/src/cargo/util/toml/targets.rs#L308-L325
 
         # the first two cases are the "new" default IIRC
-        BIN_NAME_=$(echo $BIN_NAME | sed -e 's/-/_/g')
+        BIN_NAME_=$(echo $BIN_NAME | tr '-' '_')
         FILES=( "src/bin/$BIN_NAME.rs" "src/bin/$BIN_NAME/main.rs" "src/bin/$BIN_NAME_.rs" "src/bin/$BIN_NAME_/main.rs" "src/bin/main.rs" "src/main.rs" )
 
         if ! [ -e "${libPath}" -o -e src/lib.rs -o -e "src/${libName}.rs" ]; then

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -9,7 +9,7 @@
 
     deps = makeDeps dependencies crateRenames;
     rustcOpts =
-      lib.lists.foldl' (opts: opt: opts + " " + opt)
+      lib.foldl' (opts: opt: opts + " " + opt)
         (if release then "-C opt-level=3" else "-C debuginfo=2")
         (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOpts);
     rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -3,128 +3,65 @@
   dependencies,
   crateFeatures, crateRenames, libName, release, libPath,
   crateType, metadata, crateBin, hasCrateBin,
-  extraRustcOpts, verbose, colors }:
+  extraRustcOpts, verbose, colors,
+}:
 
   let
-    deps = mkRustcDepArgs dependencies crateRenames;
-    rustcOpts =
-      lib.foldl' (opts: opt: opts + " " + opt)
-        (if release then "-C opt-level=3" else "-C debuginfo=2")
-        (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOpts);
+    baseRustcOpts =
+      [(if release then "-C opt-level=3" else "-C debuginfo=2")]
+      ++ ["-C codegen-units=$NIX_BUILD_CORES"]
+      ++ [(mkRustcDepArgs dependencies crateRenames)]
+      ++ [crateFeatures]
+      ++ extraRustcOpts
+      ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--target ${rust.toRustTarget stdenv.hostPlatform} -C linker=${stdenv.hostPlatform.config}-gcc"
+    ;
     rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";
+
+
+    # build the final rustc arguments that can be different between different
+    # crates
+    libRustcOpts = lib.concatStringsSep " " (
+      baseRustcOpts
+      ++ [rustcMeta]
+      ++ (map (x: "--crate-type ${x}") crateType)
+    );
+
+    binRustcOpts = lib.concatStringsSep " " (
+      baseRustcOpts
+    );
+
   in ''
     runHook preBuild
     ${echo_build_heading colors}
     ${noisily colors verbose}
 
-    build_lib() {
-       lib_src=$1
-       echo_build_heading $lib_src ${libName}
+    # configure & source common build functions
+    LIB_RUSTC_OPTS="${libRustcOpts}"
+    BIN_RUSTC_OPTS="${binRustcOpts}"
+    LIB_EXT="${stdenv.hostPlatform.extensions.sharedLibrary}"
+    LIB_PATH="${libPath}"
+    LIB_NAME="${libName}"
+    source ${./lib.sh}
 
-       noisily rustc --crate-name $CRATE_NAME $lib_src \
-         ${lib.strings.concatStrings (map (x: " --crate-type ${x}") crateType)}  \
-         ${rustcOpts} ${rustcMeta} ${crateFeatures} --out-dir target/lib \
-         --emit=dep-info,link -L dependency=target/deps ${deps} --cap-lints allow \
-         $BUILD_OUT_DIR $EXTRA_BUILD $EXTRA_FEATURES --color ${colors}
-
-       EXTRA_LIB=" --extern $CRATE_NAME=target/lib/lib$CRATE_NAME-${metadata}.rlib"
-       if [ -e target/deps/lib$CRATE_NAME-${metadata}${stdenv.hostPlatform.extensions.sharedLibrary} ]; then
-          EXTRA_LIB="$EXTRA_LIB --extern $CRATE_NAME=target/lib/lib$CRATE_NAME-${metadata}${stdenv.hostPlatform.extensions.sharedLibrary}"
-       fi
-    }
-
-    build_bin() {
-      crate_name=$1
-      crate_name_=$(echo $crate_name | tr '-' '_')
-      main_file=""
-      if [[ ! -z $2 ]]; then
-        main_file=$2
-      fi
-      echo_build_heading $@
-      noisily rustc --crate-name $crate_name_ $main_file --crate-type bin ${rustcOpts}\
-        ${crateFeatures} --out-dir target/bin --emit=dep-info,link -L dependency=target/deps \
-        $LINK ${deps}$EXTRA_LIB --cap-lints allow \
-        $BUILD_OUT_DIR $EXTRA_BUILD $EXTRA_FEATURES --color ${colors} \
-        ${if stdenv.hostPlatform != stdenv.buildPlatform then "--target ${rust.toRustTarget stdenv.hostPlatform} -C linker=${stdenv.hostPlatform.config}-gcc" else ""}
-      if [ "$crate_name_" != "$crate_name" ]; then
-        mv target/bin/$crate_name_ target/bin/$crate_name
-      fi
-    }
-
-
-    EXTRA_LIB=""
     CRATE_NAME='${lib.replaceStrings ["-"] ["_"] libName}'
 
-    if [[ -e target/link_ ]]; then
-      EXTRA_BUILD="$(cat target/link_) $EXTRA_BUILD"
-    fi
+    setup_link_paths
 
-    if [[ -e "${libPath}" ]]; then
-       build_lib ${libPath}
+    if [[ -e "$LIB_PATH" ]]; then
+       build_lib $LIB_PATH
     elif [[ -e src/lib.rs ]]; then
        build_lib src/lib.rs
-    elif [[ -e src/${libName}.rs ]]; then
-       build_lib src/${libName}.rs
+    elif [[ -e "src/$LIB_NAME.rs" ]]; then
+       build_lib src/$LIB_NAME.rs
     fi
 
-    echo "$EXTRA_LINK_SEARCH" | while read i; do
-       if [[ ! -z "$i" ]]; then
-         for library in $i; do
-           echo "-L $library" >> target/link
-           L=$(echo $library | sed -e "s#$(pwd)/target/build#$lib/lib#")
-           echo "-L $L" >> target/link.final
-         done
-       fi
-    done
-    echo "$EXTRA_LINK" | while read i; do
-       if [[ ! -z "$i" ]]; then
-         for library in $i; do
-           echo "-l $library" >> target/link
-           echo "-l $library" >> target/link.final
-         done
-       fi
-    done
-
-    if [[ -e target/link ]]; then
-       sort -u target/link.final > target/link.final.sorted
-       mv target/link.final.sorted target/link.final
-       sort -u target/link > target/link.sorted
-       mv target/link.sorted target/link
-
-       tr '\n' ' ' < target/link > target/link_
-       LINK=$(cat target/link_)
-    fi
 
     ${lib.optionalString (lib.length crateBin > 0) (lib.concatMapStringsSep "\n" (bin: ''
       mkdir -p target/bin
       BIN_NAME='${bin.name or crateName}'
       ${if !bin ? path then ''
-        # heuristic to "guess" the correct source file as found in cargo:
-        # https://github.com/rust-lang/cargo/blob/90fc9f620190d5fa3c80b0c8c65a1e1361e6b8ae/src/cargo/util/toml/targets.rs#L308-L325
-
-        # the first two cases are the "new" default IIRC
-        BIN_NAME_='${lib.replaceStrings ["-"] ["_"] bin.name}'
-        FILES=( "src/bin/$BIN_NAME.rs" "src/bin/$BIN_NAME/main.rs" "src/bin/$BIN_NAME_.rs" "src/bin/$BIN_NAME_/main.rs" "src/bin/main.rs" "src/main.rs" )
-
-        if ! [ -e "${libPath}" -o -e src/lib.rs -o -e "src/${libName}.rs" ]; then
-          # if this is not a library the following path is also valid
-          FILES=( "src/$BIN_NAME.rs" "src/$BIN_NAME_.rs" "''${FILES[@]}" )
-        fi
-
-        for file in "''${FILES[@]}";
-        do
-          echo "checking file $file"
-          # first file that exists wins
-          if [[ -e "$file" ]]; then
-                  BIN_PATH="$file"
-                  break
-          fi
-        done
-
-        if [[ -z "$BIN_PATH" ]]; then
-          echo "failed to find file for binary target: $BIN_NAME" >&2
-          exit 1
-        fi
+        BIN_PATH=""
+        search_for_bin_path "$BIN_NAME"
       '' else ''
         BIN_PATH='${bin.path}'
       ''}

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -15,16 +15,6 @@
     rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";
   in ''
     runHook preBuild
-    norm=""
-    bold=""
-    green=""
-    boldgreen=""
-    if [[ "${colors}" == "always" ]]; then
-      norm="$(printf '\033[0m')" #returns to "normal"
-      bold="$(printf '\033[0;1m')" #set bold
-      green="$(printf '\033[0;32m')" #set green
-      boldgreen="$(printf '\033[0;1;32m')" #set bold, and set green.
-    fi
     ${echo_build_heading colors}
     ${noisily colors verbose}
 

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -20,9 +20,9 @@
 , verbose
 , workspace_member }:
 let version_ = lib.splitString "-" crateVersion;
-    versionPre = if lib.tail version_ == [] then "" else builtins.elemAt version_ 1;
+    versionPre = if lib.tail version_ == [] then "" else lib.elemAt version_ 1;
     version = lib.splitVersion (lib.head version_);
-    rustcOpts = lib.lists.foldl' (opts: opt: opts + " " + opt)
+    rustcOpts = lib.foldl' (opts: opt: opts + " " + opt)
         (if release then "-C opt-level=3" else "-C debuginfo=2")
         (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOpts);
     buildDeps = makeDeps buildDependencies crateRenames;
@@ -90,9 +90,9 @@ in ''
   export HOST="${stdenv.hostPlatform.config}"
   export PROFILE=${if release then "release" else "debug"}
   export OUT_DIR=$(pwd)/target/build/${crateName}.out
-  export CARGO_PKG_VERSION_MAJOR=${builtins.elemAt version 0}
-  export CARGO_PKG_VERSION_MINOR=${builtins.elemAt version 1}
-  export CARGO_PKG_VERSION_PATCH=${builtins.elemAt version 2}
+  export CARGO_PKG_VERSION_MAJOR=${lib.elemAt version 0}
+  export CARGO_PKG_VERSION_MINOR=${lib.elemAt version 1}
+  export CARGO_PKG_VERSION_PATCH=${lib.elemAt version 2}
   export CARGO_PKG_VERSION_PRE="${versionPre}"
   export CARGO_PKG_HOMEPAGE="${crateHomepage}"
   export NUM_JOBS=1

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, echo_build_heading, noisily, makeDeps }:
+{ lib, stdenv, echo_build_heading, noisily, mkRustcDepArgs }:
 { build
 , buildDependencies
 , colors
@@ -25,7 +25,7 @@ let version_ = lib.splitString "-" crateVersion;
     rustcOpts = lib.foldl' (opts: opt: opts + " " + opt)
         (if release then "-C opt-level=3" else "-C debuginfo=2")
         (["-C codegen-units=$NIX_BUILD_CORES"] ++ extraRustcOpts);
-    buildDeps = makeDeps buildDependencies crateRenames;
+    buildDeps = mkRustcDepArgs buildDependencies crateRenames;
     authors = lib.concatStringsSep ":" crateAuthors;
     optLevel = if release then 3 else 0;
     completeDepsDir = lib.concatStringsSep " " completeDeps;

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -13,7 +13,9 @@ let
       then "macos"
       else stdenv.hostPlatform.parsed.kernel.name;
 
-    makeDeps = dependencies: crateRenames:
+    # Create rustc arguments to link against the given list of dependencies and
+    # renames
+    mkRustcDepArgs = dependencies: crateRenames:
       lib.concatMapStringsSep " " (dep:
         let
           extern = lib.replaceStrings ["-"] ["_"] dep.libName;
@@ -27,15 +29,14 @@ let
            " --extern ${name}=${dep.lib}/lib/lib${extern}-${dep.metadata}${stdenv.hostPlatform.extensions.sharedLibrary}")
       ) dependencies;
 
-
    inherit (import ./log.nix { inherit lib; }) noisily echo_build_heading;
 
    configureCrate = import ./configure-crate.nix {
-     inherit lib stdenv echo_build_heading noisily makeDeps;
+     inherit lib stdenv echo_build_heading noisily mkRustcDepArgs;
    };
 
    buildCrate = import ./build-crate.nix {
-     inherit lib stdenv echo_build_heading noisily makeDeps rust;
+     inherit lib stdenv echo_build_heading noisily mkRustcDepArgs rust;
    };
 
    installCrate = import ./install-crate.nix;

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -81,15 +81,8 @@ stdenv.mkDerivation (rec {
     name = "rust_${crate.crateName}-${crate.version}";
     depsBuildBuild = [ rust stdenv.cc ];
     buildInputs = (crate.buildInputs or []) ++ buildInputs_;
-    dependencies =
-      map
-        (dep: lib.getLib (dep.override { rust = rust; release = release; verbose = verbose; crateOverrides = crateOverrides; }))
-        dependencies_;
-
-    buildDependencies =
-      map
-        (dep: lib.getLib (dep.override { rust = rust; release = release; verbose = verbose; crateOverrides = crateOverrides; }))
-        buildDependencies_;
+    dependencies = makeDependencies dependencies_;
+    buildDependencies = makeDependencies buildDependencies_;
 
     completeDeps = lib.unique (dependencies ++ lib.concatMap (dep: dep.completeDeps) dependencies);
     completeBuildDeps = lib.unique (

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -126,7 +126,10 @@ stdenv.mkDerivation (rec {
     colors = lib.attrByPath [ "colors" ] "always" crate;
     extraLinkFlags = lib.concatStringsSep " " (crate.extraLinkFlags or []);
     edition = crate.edition or null;
-    extraRustcOpts = lib.optionals (crate ? extraRustcOpts) crate.extraRustcOpts ++ extraRustcOpts_ ++ (lib.optional (edition != null) "--edition ${edition}");
+    extraRustcOpts =
+      lib.optionals (crate ? extraRustcOpts) crate.extraRustcOpts
+      ++ extraRustcOpts_
+      ++ (lib.optional (edition != null) "--edition ${edition}");
 
     configurePhase = configureCrate {
       inherit crateName buildDependencies completeDeps completeBuildDeps crateDescription

--- a/pkgs/build-support/rust/build-rust-crate/helpers.nix
+++ b/pkgs/build-support/rust/build-rust-crate/helpers.nix
@@ -3,23 +3,23 @@
   kernel = stdenv.hostPlatform.parsed.kernel.name;
   abi = stdenv.hostPlatform.parsed.abi.name;
   cpu = stdenv.hostPlatform.parsed.cpu.name;
-   updateFeatures = f: up: functions: builtins.deepSeq f (lib.lists.foldl' (features: fun: fun features) (lib.attrsets.recursiveUpdate f up) functions);
+   updateFeatures = f: up: functions: lib.deepSeq f (lib.foldl' (features: fun: fun features) (lib.attrsets.recursiveUpdate f up) functions);
    mapFeatures = features: map (fun: fun { features = features; });
-   mkFeatures = feat: lib.lists.foldl (features: featureName:
+   mkFeatures = feat: lib.foldl (features: featureName:
      if feat.${featureName} or false then
        [ featureName ] ++ features
      else
        features
-   ) [] (builtins.attrNames feat);
-  include = includedFiles: src: builtins.filterSource (path: type:
-     lib.lists.any (f:
+   ) [] (lib.attrNames feat);
+  include = includedFiles: src: lib.filterSource (path: type:
+     lib.any (f:
        let p = toString (src + ("/" + f));
        in
        p == path || (lib.strings.hasPrefix (p + "/") path)
      ) includedFiles
   ) src;
-  exclude = excludedFiles: src: builtins.filterSource (path: type:
-    lib.lists.all (f:
+  exclude = excludedFiles: src: lib.filterSource (path: type:
+    lib.all (f:
        !lib.strings.hasPrefix (toString (src + ("/" + f))) path
     ) excludedFiles
   ) src;

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -1,0 +1,117 @@
+build_lib() {
+  lib_src=$1
+  echo_build_heading $lib_src ${libName}
+
+  noisily rustc \
+    --crate-name $CRATE_NAME \
+    $lib_src \
+    --out-dir target/lib \
+    --emit=dep-info,link \
+    -L dependency=target/deps \
+    --cap-lints allow \
+    $LIB_RUSTC_OPTS \
+    $BUILD_OUT_DIR \
+    $EXTRA_BUILD \
+    $EXTRA_FEATURES \
+    --color $colors
+
+  EXTRA_LIB=" --extern $CRATE_NAME=target/lib/lib$CRATE_NAME-$metadata.rlib"
+  if [ -e target/deps/lib$CRATE_NAME-$metadata$LIB_EXT ]; then
+     EXTRA_LIB="$EXTRA_LIB --extern $CRATE_NAME=target/lib/lib$CRATE_NAME-$metadata$LIB_EXT"
+  fi
+}
+
+build_bin() {
+  crate_name=$1
+  crate_name_=$(echo $crate_name | tr '-' '_')
+  main_file=""
+  if [[ ! -z $2 ]]; then
+    main_file=$2
+  fi
+  echo_build_heading $@
+  noisily rustc \
+    --crate-name $crate_name_ \
+    $main_file \
+    --crate-type bin \
+    $BIN_RUSTC_OPTS \
+    --out-dir target/bin \
+    --emit=dep-info,link \
+    -L dependency=target/deps \
+    $LINK \
+    $EXTRA_LIB \
+    --cap-lints allow \
+    $BUILD_OUT_DIR \
+    $EXTRA_BUILD \
+    $EXTRA_FEATURES \
+    --color ${colors} \
+
+  if [ "$crate_name_" != "$crate_name" ]; then
+    mv target/bin/$crate_name_ target/bin/$crate_name
+  fi
+}
+
+setup_link_paths() {
+  EXTRA_LIB=""
+  if [[ -e target/link_ ]]; then
+    EXTRA_BUILD="$(cat target/link_) $EXTRA_BUILD"
+  fi
+
+  echo "$EXTRA_LINK_SEARCH" | while read i; do
+     if [[ ! -z "$i" ]]; then
+       for library in $i; do
+         echo "-L $library" >> target/link
+         L=$(echo $library | sed -e "s#$(pwd)/target/build#$lib/lib#")
+         echo "-L $L" >> target/link.final
+       done
+     fi
+  done
+  echo "$EXTRA_LINK" | while read i; do
+     if [[ ! -z "$i" ]]; then
+       for library in $i; do
+         echo "-l $library" >> target/link
+         echo "-l $library" >> target/link.final
+       done
+     fi
+  done
+
+  if [[ -e target/link ]]; then
+     sort -u target/link.final > target/link.final.sorted
+     mv target/link.final.sorted target/link.final
+     sort -u target/link > target/link.sorted
+     mv target/link.sorted target/link
+
+     tr '\n' ' ' < target/link > target/link_
+     LINK=$(cat target/link_)
+  fi
+}
+
+search_for_bin_path() {
+  # heuristic to "guess" the correct source file as found in cargo:
+  # https://github.com/rust-lang/cargo/blob/90fc9f620190d5fa3c80b0c8c65a1e1361e6b8ae/src/cargo/util/toml/targets.rs#L308-L325
+
+  BIN_NAME=$1
+  BIN_NAME_=$(echo $BIN_NAME | tr '-' '_')
+
+  # the first two cases are the "new" default IIRC
+  FILES=( "src/bin/$BIN_NAME.rs" "src/bin/$BIN_NAME/main.rs" "src/bin/$BIN_NAME_.rs" "src/bin/$BIN_NAME_/main.rs" "src/bin/main.rs" "src/main.rs" )
+
+  if ! [ -e "$LIB_PATH" -o -e src/lib.rs -o -e "src/$LIB_NAME.rs" ]; then
+    # if this is not a library the following path is also valid
+    FILES=( "src/$BIN_NAME.rs" "src/$BIN_NAME_.rs" "${FILES[@]}" )
+  fi
+
+  for file in "${FILES[@]}";
+  do
+    echo "checking file $file"
+    # first file that exists wins
+    if [[ -e "$file" ]]; then
+            BIN_PATH="$file"
+            break
+    fi
+  done
+
+  if [[ -z "$BIN_PATH" ]]; then
+    echo "failed to find file for binary target: $BIN_NAME" >&2
+    exit 1
+  fi
+}

--- a/pkgs/build-support/rust/build-rust-crate/log.nix
+++ b/pkgs/build-support/rust/build-rust-crate/log.nix
@@ -1,0 +1,33 @@
+{ lib }:
+{
+  echo_build_heading = colors: ''
+    echo_build_heading() {
+     start=""
+     end=""
+     ${lib.optionalString (colors == "always") ''
+       start="$(printf '\033[0;1;32m')" #set bold, and set green.
+       end="$(printf '\033[0m')" #returns to "normal"
+     ''}
+     if (( $# == 1 )); then
+       echo "$start""Building $1""$end"
+     else
+       echo "$start""Building $1 ($2)""$end"
+     fi
+    }
+  '';
+  noisily = colors: verbose: ''
+    noisily() {
+      start=""
+      end=""
+      ${lib.optionalString (colors == "always") ''
+        start="$(printf '\033[0;1;32m')" #set bold, and set green.
+        end="$(printf '\033[0m')" #returns to "normal"
+      ''}
+  	  ${lib.optionalString verbose ''
+        echo -n "$start"Running "$end"
+        echo $@
+  	  ''}
+  	  $@
+    }
+  '';
+}


### PR DESCRIPTION

###### Motivation for this change

I am working on test support for `buildRustCrate` and as a prerequisite I started cleaning up the expression so it gets easier to grasp what is actually going on. Some reformatting, minor code changes, moved stuff around. The main part is probably the "simpler" `buildPhase` were we are no longer constructing a huge script from a huge file but have a file with common primitives that we are driving based on the current crate.

There is probably more stuff that we can cleanup and rework here but before this gets too big I'd like to land this.

I did successfully rebuild two of my larger private projects, carnix,  toml2nix & the entire `buildRustCrateTests` set.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
