### PR TITLE
wireguard-tools: 0.0.20191127 -> 0.0.20191212

### DIFF
--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -14,11 +14,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "wireguard-tools";
-  version = "0.0.20191127";
+  version = "0.0.20191212";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "1n1x5858c32p0a13rrhn9a491174k5z4wd0gsy8qn546k1a8qj99";
+    sha256 = "1vyin3i4nqc4syri49jhjc4qm0qshpvgw7k4d3g5vlyskhdfv5q0";
   };
 
   sourceRoot = "source/src/tools";


### PR DESCRIPTION
###### Motivation for this change

new snapshot: https://lists.zx2c4.com/pipermail/wireguard/2019-December/004764.html

This snapshot includes support for (and prefers) nftables as part of `wg-quck`'s [CVE-2019-14899](https://seclists.org/oss-sec/2019/q4/122) mitigations. I stuck with the existing `iptables` integration for the nix package because that's what we use in `nixos`, but I'm wondering how that interacts with `nix` installed on other distributions (e.g Fedora defaults to nftables now)?

`nix-review wip` passes for all kernels exept `linux-libre-latest`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @elseym @ericsagnes @mic92 @zx2c4 @globin @ma27 
