### PR TITLE
hivemind: 1.0.4 -> 1.0.6

### DIFF
--- a/pkgs/applications/misc/hivemind/default.nix
+++ b/pkgs/applications/misc/hivemind/default.nix
@@ -2,14 +2,14 @@
 
 buildGoPackage rec {
   pname = "hivemind";
-  version = "1.0.4";
+  version = "1.0.6";
   goPackagePath = "github.com/DarthSim/hivemind";
 
   src = fetchFromGitHub {
     owner = "DarthSim";
     repo = "hivemind";
     rev = "v${version}";
-    sha256 = "1z2izvyf0j3gi0cas5v22kkmkls03sg67182k8v3p6kwhzn0jw67";
+    sha256 = "0afcnd03wsdphbbpha65rv5pnv0x6ldnnm6rnv1m6xkkywgnzx95";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The `hivemind` application has a new version. [Changelog](https://github.com/DarthSim/hivemind/releases) excerpt:

Build the new version with: `nix-build -A hivemind`

```
v1.0.6
Critical fix for Linux

v1.0.5
Loading environment variables from .env file;
Hivemind options can be set with environment variables;
--no-prefix flag.
```

Build the new version with: `nix-build -A hivemind`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @sveitser
