### PR TITLE
arp-scan: 1.9.5 -> 1.9.7

### DIFF
--- a/pkgs/tools/misc/arp-scan/default.nix
+++ b/pkgs/tools/misc/arp-scan/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "arp-scan";
-  version = "1.9.5";
+  version = "1.9.7";
 
   src = fetchFromGitHub {
     owner = "royhills";
     repo = "arp-scan";
-    rev = "4de863c2627a05177eda7159692a588f9f520cd1";
-    sha256 = "15zpfdybk2kh98shqs8qqd0f9nyi2ch2wcyv729rfj7yp0hif5mb";
+    rev = version;
+    sha256 = "1mf7a4f9vzvnkiavc87aqyciswggsb4fpy7j05jxnvjyyxv3l7gp";
   };
 
   perlModules = with perlPackages; [
@@ -19,11 +19,11 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ libpcap makeWrapper ];
+  buildInputs = [ perlPackages.perl libpcap makeWrapper ];
 
   postInstall = ''
     for name in get-{oui,iab}; do
-      wrapProgram "$out/bin/$name" --set PERL5LIB "${perlPackages.makePerlPath perlModules }"
+      wrapProgram "$out/bin/$name" --set PERL5LIB "${perlPackages.makeFullPerlPath perlModules}"
     done;
   '';
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       Arp-scan is a command-line tool that uses the ARP protocol to discover
       and fingerprint IP hosts on the local network.
     '';
-    homepage = http://www.nta-monitor.com/wiki/index.php/Arp-scan_Documentation;
+    homepage = "http://www.nta-monitor.com/wiki/index.php/Arp-scan_Documentation";
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ bjornfor mikoim ];


### PR DESCRIPTION
- 1.9.5 -> 1.9.7
- Fixes perl shebang and PERL5LIB for get-{oui,iab} scripts
- Quoted meta.homepage

###### Motivation for this change

1.9.5 did not seem to work, it didn't give any host list when scanning a local network. upgrading to 1.9.7 fixed the issue for me. 

Also fixed PERL5LIB and shebang for helper scripts `get-oui` and `get-iab`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bjornfor @mikoim 
