### PR TITLE
aws-okta: fix build on darwin

### DIFF
--- a/pkgs/tools/security/aws-okta/default.nix
+++ b/pkgs/tools/security/aws-okta/default.nix
@@ -1,4 +1,4 @@
-{ buildGoPackage, fetchFromGitHub, libusb1, pkgconfig, stdenv }:
+{ buildGoPackage, fetchFromGitHub, libusb1, pkgconfig, stdenv, libiconv }:
 
 buildGoPackage rec {
   pname = "aws-okta";
@@ -18,14 +18,13 @@ buildGoPackage rec {
   buildFlags = "--tags release";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libusb1 ];
+  buildInputs = [ libusb1  libiconv ];
 
   meta = with stdenv.lib; {
     inherit version;
     description = "aws-vault like tool for Okta authentication";
     license = licenses.mit;
     maintainers = [maintainers.imalsogreg];
-    broken = stdenv.isDarwin;  # test with CoreFoundation 10.11
     platforms = platforms.all;
     homepage = https://github.com/segmentio/aws-okta;
     downloadPage = "https://github.com/segmentio/aws-okta";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
aws-okta build on darwin was broken. This PR fixes it on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @kalbasit 
