### PR TITLE
botocore,boto3,awscli: 1.13.2->1.13.37,1.10.1->1.10.37,1.16.266->1.16…

### DIFF
--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname =  "boto3";
-  version = "1.10.1"; # N.B: if you change this, change botocore too
+  version = "1.10.37"; # N.B: if you change this, change botocore too
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2904bfb928116fea3a83247de6c3687eb9bf942d764e361f5574d5ac11be2ad3";
+    sha256 = "078rb1pkxkpxr1pi7jff88h07z841xh00g7fagbk47n8zgx1ihbx";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -12,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.13.2"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.13.37"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8223485841ef4731a5d4943a733295ba69d0005c4ae64c468308cc07f6960d39";
+    sha256 = "1c0czyxx2a8h03r7psir00ifwdkapldrk3wd27b88dw2b1dv5v6d";
   };
 
   outputs = [ "out" "dev" ];
@@ -31,6 +31,12 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [ mock nose ];
+
+  # current nixpkgs come with python-dateutil 2.8.1
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "python-dateutil>=2.1,<2.8.1" "python-dateutil>=2.1" \
+  '';
 
   checkPhase = ''
     nosetests -v

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -19,11 +19,11 @@ let
 
 in py.pkgs.buildPythonApplication rec {
   pname = "awscli";
-  version = "1.16.266"; # N.B: if you change this, change botocore to a matching version too
+  version = "1.16.301"; # N.B: if you change this, change botocore to a matching version too
 
   src = py.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "9c59a5ca805f467669d471b29550ecafafb9b380a4a6926a9f8866f71cd4f7be";
+    sha256 = "1bpjgf2ln9pj9f3mfr2pv2qvi9vkbljw43pz3c4qxdkgh3n8l496";
   };
 
   # No tests included


### PR DESCRIPTION
….301

###### Motivation for this change

Keep the tool up to date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @FRidh
