### PR TITLE
anydesk: Provide alternative URL

### DIFF
--- a/pkgs/applications/networking/remote/anydesk/default.nix
+++ b/pkgs/applications/networking/remote/anydesk/default.nix
@@ -31,7 +31,10 @@ in stdenv.mkDerivation rec {
   version = "5.5.1";
 
   src = fetchurl {
-    url = "https://download.anydesk.com/linux/${pname}-${version}-${arch}.tar.gz";
+    urls = [
+      "https://download.anydesk.com/linux/${pname}-${version}-${arch}.tar.gz"
+      "https://download.anydesk.com/linux/generic-linux/${pname}-${version}-${arch}.tar.gz"
+    ];
     inherit sha256;
   };
 


### PR DESCRIPTION
anydesk moves tar archives of older versions into a sub folder linux-generic, which breaks this package.  Use two URLs to take care of both recent and older versions.

###### Motivation for this change
When there's a new upstream version of anydesk, then the current package breaks.  This is because anydesk moves the tar archive of the old version into a sub folder.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @shyim 
