### PR TITLE
bingrep: 0.7.0 -> 0.8.1

### DIFF
--- a/pkgs/development/tools/analysis/bingrep/default.nix
+++ b/pkgs/development/tools/analysis/bingrep/default.nix
@@ -2,17 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "bingrep";
-  version = "0.7.0";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "m4b";
     repo = pname;
-    # Currently doesn't tag versions so we're using the raw revision
-    rev = "33d56a4b020c4a3c111294fe41c613d5e8e9c7af";
-    sha256 = "0lg92wqknr584b44i5v4f97js56j89z7n8p2zpm8j1pfhjmgcigs";
+    rev = "v${version}";
+    sha256 = "1xig3lrw0jdaxibzirqnm50l8nj4si9pa9w0jypmyhf1lr6yzd0g";
   };
 
-  cargoSha256 = "1yxm7waldhilx7wh1ag79rkp8kypb9k1px4ynmzq11r72yl2p4m7";
+  cargoSha256 = "1fsp1ycfswrzldwnjw5cdwi809fd37pwshvrpf7sp0wmzx2bqhgm";
 
   meta = with stdenv.lib; {
     description = "Greps through binaries from various OSs and architectures, and colors them";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Pkg update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @minijackson 
