### PR TITLE
[r19.09] boolector: add patch for CVE-2019-7560

### DIFF
--- a/pkgs/applications/science/logic/boolector/default.nix
+++ b/pkgs/applications/science/logic/boolector/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchFromGitHub, fetchpatch
 , cmake, lingeling, btor2tools
 }:
 
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
     rev    = "refs/tags/${version}";
     sha256 = "15i3ni5klss423m57wcy1gx0m5wfrjmglapwg85pm7fb3jj1y7sz";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-7560.patch";
+      url = "https://github.com/Boolector/boolector/commit/8d979d02e0482c7137c9f3a34e6d430dbfd1f5c5.patch";
+      sha256 = "1a1g02mk8b0azzjcigdn5zpshn0dn05fciwi8sd5q38yxvnvpbbi";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ lingeling btor2tools ];

--- a/pkgs/applications/science/logic/btor2tools/default.nix
+++ b/pkgs/applications/science/logic/btor2tools/default.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation {
   outputs = [ "out" "dev" "lib" ];
 
   meta = with stdenv.lib; {
-    description = "Fast SAT solver";
-    homepage    = http://fmv.jku.at/lingeling/;
+    description = "A generic parser and tool package for the BTOR2 format";
+    homepage    = "https://github.com/Boolector/btor2tools";
     license     = licenses.mit;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ thoughtpolice ];


### PR DESCRIPTION
###### Motivation for this change
Backport of #75279

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice 
