### PR TITLE
mojave-gtk-theme: 2019-09-09 -> 2019-12-12

### DIFF
--- a/pkgs/data/themes/mojave/default.nix
+++ b/pkgs/data/themes/mojave/default.nix
@@ -1,15 +1,23 @@
-{ stdenv, fetchFromGitHub, gtk_engines, gtk-engine-murrine }:
+{ stdenv, fetchFromGitHub, fetchurl, gtk_engines, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
   pname = "mojave-gtk-theme";
   version = "2019-12-12";
 
-  src = fetchFromGitHub {
-    owner = "vinceliuice";
-    repo = pname;
-    rev = version;
-    sha256 = "0d5m9gh97db01ygqlp2sv9v1m183d9fgid9n9wms9r5rrrw6bs8m";
-  };
+  srcs = [
+    (fetchFromGitHub {
+      owner = "vinceliuice";
+      repo = pname;
+      rev = version;
+      sha256 = "0d5m9gh97db01ygqlp2sv9v1m183d9fgid9n9wms9r5rrrw6bs8m";
+    })
+    (fetchurl {
+      url = "https://github.com/vinceliuice/Mojave-gtk-theme/raw/11741a99d96953daf9c27e44c94ae50a7247c0ed/macOS_Mojave_Wallpapers.tar.xz";
+      sha256 = "18zzkwm1kqzsdaj8swf0xby1n65gxnyslpw4lnxcx1rphip0rwf7";
+    })
+  ];
+
+  sourceRoot = "source";
 
   buildInputs = [ gtk_engines ];
 
@@ -18,6 +26,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     patchShebangs .
     name= ./install.sh -d $out/share/themes
+    install -D -t $out/share/wallpapers ../"macOS Mojave Wallpapers"/*
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/data/themes/mojave/default.nix
+++ b/pkgs/data/themes/mojave/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mojave-gtk-theme";
-  version = "2019-09-09";
+  version = "2019-12-12";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
     rev = version;
-    sha256 = "1qffh6jsvy61f29ymw1v9hpjnsvhqin19mp05cys1lnwc7y810zr";
+    sha256 = "0d5m9gh97db01ygqlp2sv9v1m183d9fgid9n9wms9r5rrrw6bs8m";
   };
 
   buildInputs = [ gtk_engines ];
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     patchShebangs .
-    mkdir -p $out/share/themes
     name= ./install.sh -d $out/share/themes
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Update to version [2019-12-12](https://github.com/vinceliuice/Mojave-gtk-theme/releases/tag/2019-12-12)
- Add wallpapers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).