### PR TITLE
swt: 4.5 -> 4.14

### DIFF
--- a/pkgs/development/libraries/java/swt/default.nix
+++ b/pkgs/development/libraries/java/swt/default.nix
@@ -1,26 +1,25 @@
-{ stdenv, lib, fetchurl, unzip, jdk, pkgconfig, gtk2
+{ stdenv, lib, fetchurl, unzip, jdk, pkgconfig, gtk2, gtk3
 , libXt, libXtst, libXi, libGLU, libGL, webkitgtk, libsoup, xorg
 , pango, gdk-pixbuf, glib
 }:
 
 let
   platformMap = {
-    x86_64-linux =
-      { platform = "gtk-linux-x86_64";
-        sha256 = "1qq0pjll6030v4ml0hifcaaik7sx3fl7ghybfdw95vsvxafwp2ff"; };
-    i686-linux =
-      { platform = "gtk-linux-x86";
-        sha256 = "03mhzraikcs4fsz7d3h5af9pw1bbcfd6dglsvbk2ciwimy9zj30q"; };
-    x86_64-darwin =
-      { platform = "cocoa-macosx-x86_64";
-        sha256 = "00k1mfbncvyh8klgmk0891w8jwnd5niqb16j1j8yacrm2smmlb05"; };
+    x86_64-linux = {
+      platform = "gtk-linux-x86_64";
+      sha256 = "12y0x9yf3bc35blr08yda1h7cc1n26a37zakszizyx8adglxlbs4";
+    };
+    x86_64-darwin = {
+      platform = "cocoa-macosx-x86_64";
+      sha256 = "1mwra5a2x9k6gqa8azwybc813ngxcjg80jncpn083xspkxmmmv47";
+    };
   };
 
   metadata = assert platformMap ? ${stdenv.hostPlatform.system}; platformMap.${stdenv.hostPlatform.system};
 
 in stdenv.mkDerivation rec {
-  version = "4.5";
-  fullVersion = "${version}-201506032000";
+  version = "4.14";
+  fullVersion = "${version}-201912100610";
   pname = "swt";
 
   hardeningDisable = [ "format" ];
@@ -36,7 +35,7 @@ in stdenv.mkDerivation rec {
   sourceRoot = ".";
 
   nativeBuildInputs = [ unzip pkgconfig ];
-  buildInputs = [ jdk gtk2 libXt libXtst libXi libGLU libGL webkitgtk libsoup ];
+  buildInputs = [ jdk gtk2 gtk3 libXt libXtst libXi libGLU libGL webkitgtk libsoup ];
 
   NIX_LFLAGS = (map (x: "-L${lib.getLib x}/lib") [ xorg.libX11 pango gdk-pixbuf glib ]) ++
     [ "-lX11" "-lpango-1.0" "-lgdk_pixbuf-2.0" "-lglib-2.0" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

swt 4.5 is outdated since 2015 (!). Moreover, it's GTK2 compatibility is with gtk 2.18, meaning running something depending on our swt with gtk 2.24.32 will spit out errors such as:

```
***WARNING: GTK+ version too new (major mismatch)
***WARNING: SWT requires GTK 2.18.0
***WARNING: Detected: 2.24.32
```

See also: https://bugs.eclipse.org/bugs/show_bug.cgi?id=476644

Related PR: https://github.com/NixOS/nixpkgs/pull/59999 .

BTW https://github.com/NixOS/nixpkgs/issues/30826 should be closed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've tried switching over to the source tarball upstream provides (see the bottom link [here](http://archive.eclipse.org/eclipse/downloads/drops4/R-4.9-201809060745/)) but the build failed because what's in `src.zip` is completely different then what's in that tarball, download the source table and see for your self.

EDIT:

Maintainers: cc @pSub 