### PR TITLE
 brial: 1.2.5 -> 1.2.6, pybrial: use brial src

### DIFF
--- a/pkgs/applications/science/math/sage/pybrial.nix
+++ b/pkgs/applications/science/math/sage/pybrial.nix
@@ -1,6 +1,7 @@
 { stdenv
 , fetchFromGitHub
 , buildPythonPackage
+, brial
 }:
 # This has a cyclic dependency with sage. I don't include sage in the
 # buildInputs and let python figure it out at runtime. Because of this,
@@ -9,15 +10,10 @@
 # it).
 buildPythonPackage rec {
     pname = "pyBRiAl";
-    version = "1.2.3";
+    version = brial.version;
 
     # included with BRiAl source
-    src = fetchFromGitHub {
-      owner = "BRiAl";
-      repo = "BRiAl";
-      rev = version;
-      sha256 = "0qy4cwy7qrk4zg151cmws5cglaa866z461cnj9wdnalabs7v7qbg";
-    };
+    src = brial.src;
 
     sourceRoot = "source/sage-brial";
 

--- a/pkgs/development/libraries/science/math/brial/default.nix
+++ b/pkgs/development/libraries/science/math/brial/default.nix
@@ -8,14 +8,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.2.5";
+  version = "1.2.6";
   pname = "brial";
 
   src = fetchFromGitHub {
     owner = "BRiAl";
     repo = "BRiAl";
     rev = version;
-    sha256 = "1nv56fp3brpzanxj7vwvxqdafqfsfhdgq5imr3m94psw5gdfqwja";
+    sha256 = "1mc1zjr3mxcx6bg0js5k9jx65japg7644b0aj1al75m4nwh2ygab";
   };
 
   # FIXME package boost-test and enable checks


### PR DESCRIPTION
###### Motivation for this change

Motivation for the update is mostly BRiAl/BRiAl#37, which is a
pre-requiste for getting the sage tests to pass with python3.

The pybrial package is a bit awkward. It doesn't have its own top-level
attribute, since it has a cyclic dependency with sage. That's one of the
reasons why it rarely gets updated. Its distributed along with brial, so
its best to keep the versions synchronized. The easiest way to do this
is to just re-use the source of brial.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
