### PR TITLE
emacsMacport: Rename emacsVersion attribute to version

### DIFF
--- a/pkgs/applications/editors/emacs/macport.nix
+++ b/pkgs/applications/editors/emacs/macport.nix
@@ -4,10 +4,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  emacsVersion = "26.3";
-  emacsName = "emacs-${emacsVersion}";
+  pname = "emacs";
+  version = "26.3";
+
+  emacsName = "emacs-${version}";
   macportVersion = "7.7";
-  name = "emacs-mac-${emacsVersion}-${macportVersion}";
+  name = "emacs-mac-${version}-${macportVersion}";
 
   src = fetchurl {
     url = "mirror://gnu/emacs/${emacsName}.tar.xz";


### PR DESCRIPTION
Changes in https://github.com/NixOS/nixpkgs/pull/74936 depend on emacs
derivations to have a version attribute.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
change in https://github.com/NixOS/nixpkgs/pull/74936 reference "version" attribute in emacs derivations. emacsMacport used "emacsVersion". I found no other references to "emacsVersion" throughout nixpkgs and chose to change the derivation to use version which is in line with the reference found in elpa-packages.nix. 

Bug can be reproduced/tested in the repl like so:

```
nix-repl> :l <nixpkgs>
nix-repl> (emacsPackagesFor emacsMacport).emacsWithPackages(ps: [ ps.seq ])
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jwiegley @matthewbauer