### PR TITLE
zsh-history: Add module and tests

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -169,6 +169,7 @@
   ./programs/zsh/zsh.nix
   ./programs/zsh/zsh-autoenv.nix
   ./programs/zsh/zsh-autosuggestions.nix
+  ./programs/zsh/zsh-history.nix
   ./programs/zsh/zsh-syntax-highlighting.nix
   ./rename.nix
   ./security/acme.nix

--- a/nixos/modules/programs/zsh/zsh-history.nix
+++ b/nixos/modules/programs/zsh/zsh-history.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.zsh-history;
+in
+{
+
+  options.programs.zsh-history = {
+    enable = lib.mkEnableOption "A CLI to provide enhanced history for your shell";
+  };
+
+  config = lib.mkIf cfg.enable {
+    meta.maintainers = with lib.maintainers; [ kampka ];
+
+    environment.systemPackages = [ pkgs.zsh-history ];
+
+    programs.zsh.interactiveShellInit = ''
+      source ${pkgs.zsh-history.out}/share/zsh/init.zsh
+    '';
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -294,5 +294,6 @@ in
   xss-lock = handleTest ./xss-lock.nix {};
   yabar = handleTest ./yabar.nix {};
   yggdrasil = handleTest ./yggdrasil.nix {};
+  zsh-history = handleTest ./zsh-history.nix {};
   zookeeper = handleTest ./zookeeper.nix {};
 }

--- a/nixos/tests/zsh-history.nix
+++ b/nixos/tests/zsh-history.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "zsh-history";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ kampka ];
+  };
+
+  nodes.default = { ... }: {
+    programs = {
+      zsh.enable = true;
+      zsh-history.enable = true;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    default.wait_for_unit("multi-user.target")
+    default.wait_until_succeeds("pgrep -f 'agetty.*tty1'")
+
+    # Login
+    default.wait_until_tty_matches(1, "login: ")
+    default.send_chars("root\n")
+    default.wait_until_tty_matches(1, "login: root")
+
+    # Launch a zsh shell. This should also load the zsh history code
+    default.send_chars("zsh\n")
+    default.wait_until_tty_matches(1, "root@default>")
+
+    # Generate some history
+    default.send_chars("echo foobar\n")
+    default.wait_until_tty_matches(1, "foobar")
+
+    # Ensure that command was recorded in history
+    default.succeed("/run/current-system/sw/bin/history list | grep -q foobar")
+  '';
+})

--- a/pkgs/shells/zsh/zsh-history/default.nix
+++ b/pkgs/shells/zsh/zsh-history/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildGoModule, installShellFiles }:
+{ lib, fetchFromGitHub, buildGoModule, installShellFiles, nixosTests }:
 
 buildGoModule rec {
   pname = "zsh-history";
@@ -28,5 +28,9 @@ buildGoModule rec {
     homepage = https://github.com/b4b4r07/history;
     platforms = platforms.unix;
     maintainers = with maintainers; [ kampka ];
+  };
+
+  passthru.tests = {
+    installed-tests = nixosTests.zsh-history;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Adds a module to configure the `zsh-history` software on zsh startup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace 
