### PR TITLE
WriteHaskell: Strip binaries

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -148,6 +148,7 @@ rec {
         cp $contentPath tmp.hs
         ${ghc.withPackages (_: libraries )}/bin/ghc tmp.hs
         mv tmp $out
+        ${pkgs.binutils-unwrapped}/bin/strip --strip-unneeded "$out"
       '';
     } name;
 


### PR DESCRIPTION
###### Motivation for this change
Unstripped Haskell binaries are silly-large.  WriteC strips the C binaries it creates.  WriteHaskell oughta strip Haskell binaries too (they need it even more).

This reduces the size of Hello World [1] from 3.06 MiB to 678 KiB.

[1] As measured by `nix-shell -p 'writers.writeHaskellBin "hello" {} "main = putStrLn \"hello\""' --run 'ls -l $(which hello)'`


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Lassulus 
