### PR TITLE
whipper: update to 0.9.0

### DIFF
--- a/pkgs/applications/audio/whipper/default.nix
+++ b/pkgs/applications/audio/whipper/default.nix
@@ -1,24 +1,26 @@
-{ stdenv, fetchFromGitHub, python2, cdparanoia, cdrdao, flac
-, sox, accuraterip-checksum, utillinux, substituteAll }:
+{ stdenv, fetchFromGitHub, python3, cdparanoia, cdrdao, flac
+, sox, accuraterip-checksum, libsndfile, utillinux, substituteAll }:
 
-python2.pkgs.buildPythonApplication rec {
-  name = "whipper-${version}";
-  version = "0.7.3";
+python3.pkgs.buildPythonApplication rec {
+  pname = "whipper";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "whipper-team";
     repo = "whipper";
     rev = "v${version}";
-    sha256 = "0ypbgc458i7yvbyvg6wg6agz5yzlwm1v6zw7fmyq9h59xsv27mpr";
+    sha256 = "0x1qsp021i0l5sdcm2kcv9zfwp696k4izhw898v6marf8phll7xc";
   };
 
-  pythonPath = with python2.pkgs; [
+  pythonPath = with python3.pkgs; [
     pygobject3 musicbrainzngs urllib3 chardet
-    pycdio setuptools mutagen CDDB
+    pycdio setuptools setuptools_scm mutagen
     requests
   ];
 
-  checkInputs = with python2.pkgs; [
+  buildInputs = [ libsndfile ];
+
+  checkInputs = with python3.pkgs; [
     twisted
   ];
 
@@ -33,6 +35,10 @@ python2.pkgs.buildPythonApplication rec {
     "--prefix" "PATH" ":" (stdenv.lib.makeBinPath [ accuraterip-checksum cdrdao utillinux flac sox ])
   ];
 
+  preBuild = ''
+    export SETUPTOOLS_SCM_PRETEND_VERSION="v${version}"
+  '';
+
   # some tests require internet access
   # https://github.com/JoeLametta/whipper/issues/291
   doCheck = false;
@@ -44,7 +50,7 @@ python2.pkgs.buildPythonApplication rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/whipper-team/whipper;
     description = "A CD ripper aiming for accuracy over speed";
-    maintainers = with maintainers; [ rycee ];
+    maintainers = with maintainers; [ rycee emily ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/development/python-modules/pycdio/default.nix
+++ b/pkgs/development/python-modules/pycdio/default.nix
@@ -4,20 +4,23 @@
 , setuptools
 , nose
 , pkgs
-, isPy27
 }:
 
 buildPythonPackage rec {
   pname = "pycdio";
   version = "2.1.0";
-  disabled = !isPy27;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "01b7vqqfry071p60sabydym7r3m3rxszyqpdbs1qi5rk2sfyblnn";
   };
 
-  prePatch = "sed -i -e '/DRIVER_BSDI/d' pycdio.py";
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace 'library_dirs=library_dirs' 'library_dirs=[dir.decode("utf-8") for dir in library_dirs]' \
+      --replace 'include_dirs=include_dirs' 'include_dirs=[dir.decode("utf-8") for dir in include_dirs]' \
+      --replace 'runtime_library_dirs=runtime_lib_dirs' 'runtime_library_dirs=[dir.decode("utf-8") for dir in runtime_lib_dirs]'
+  '';
 
   preConfigure = ''
     patchShebangs .


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New upstream release, plus with the fix to `pycdio` this now works on Python 3. Yay!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).