### PR TITLE
mavproxy: init at 1.8.17

### DIFF
--- a/pkgs/applications/science/robotics/mavproxy/default.nix
+++ b/pkgs/applications/science/robotics/mavproxy/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonApplication, fetchPypi, matplotlib, numpy, pymavlink, pyserial
+, setuptools, wxPython_4_0 }:
+
+buildPythonApplication rec {
+  pname = "MAVProxy";
+  version = "1.8.17";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "193hjilsmbljbgj7v6icy3b4hzm14l0z6v05v7ycx6larij5xj2r";
+  };
+
+  propagatedBuildInputs = [
+    matplotlib
+    numpy
+    pymavlink
+    pyserial
+    setuptools
+    wxPython_4_0
+  ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "MAVLink proxy and command line ground station";
+    homepage = "https://github.com/ArduPilot/MAVProxy";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/development/python-modules/pymavlink/default.nix
+++ b/pkgs/development/python-modules/pymavlink/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, future, lxml }:
+
+buildPythonPackage rec {
+  pname = "pymavlink";
+  version = "2.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0y9rz3piddzdjpp7d5w9xi6lc9v9b4p4375a5hrfiphrmhds85i3";
+  };
+
+  propagatedBuildInputs = [ future lxml ];
+
+  # No tests included in PyPI tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python MAVLink interface and utilities";
+    homepage = "https://github.com/ArduPilot/pymavlink";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10160,6 +10160,8 @@ in
   maven = maven3;
   maven3 = callPackage ../development/tools/build-managers/apache-maven { };
 
+  mavproxy = python3Packages.callPackage ../applications/science/robotics/mavproxy { };
+
   go-md2man = callPackage ../development/tools/misc/md2man {};
 
   mage = callPackage ../development/tools/build-managers/mage { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1063,6 +1063,8 @@ in {
 
   pymatgen-lammps = callPackage ../development/python-modules/pymatgen-lammps { };
 
+  pymavlink = callPackage ../development/python-modules/pymavlink { };
+
   pymsgbox = callPackage ../development/python-modules/pymsgbox { };
 
   pynisher = callPackage ../development/python-modules/pynisher { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

MAVProxy is a command line ground control station (GCS) for drones using the standard MAVLink protocol (ie. ArduPilot, PX4). Some GUI GCSs are already included in nixpkgs (QGroundControl, apmplanner2), but MAVProxy includes move development focused functionality that is required for certain use-cases, such as performing software-in-the-loop simulation with ArduPilot.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @wucke13 because you have worked on apmplanner2 and QGroundControl, so might be interested in this package