### PR TITLE
pythonPackages.root_numpy: add setuptools dependency

### DIFF
--- a/pkgs/development/python-modules/root_numpy/default.nix
+++ b/pkgs/development/python-modules/root_numpy/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, isPy3k, buildPythonPackage, numpy, root, nose }:
+{ lib, fetchPypi, isPy3k, buildPythonPackage, numpy, root, nose, setuptools }:
 
 buildPythonPackage rec {
   pname = "root_numpy";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     nosetests -s -v root_numpy
   '';
 
-  propagatedBuildInputs = [ numpy root ];
+  propagatedBuildInputs = [ numpy root setuptools ];
 
   meta = with lib; {
     homepage = http://scikit-hep.org/root_numpy;


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken in #75569

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/75641
2 package were built:
python27Packages.root_numpy python27Packages.rootpy
```