### PR TITLE
python3Packages.nipype: fix build, add missing dependencies

### DIFF
--- a/pkgs/development/python-modules/etelemetry/default.nix
+++ b/pkgs/development/python-modules/etelemetry/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, requests, pytest }:
+
+buildPythonPackage rec {
+  version = "0.1.2";
+  pname = "etelemetry";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0m3dqvs3xbckmjiwppy366qmgzx0z917j1d7dadfl3bprgipy51j";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # all 2 of the tests both try to pull down from a url
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "etelemetry"
+    "etelemetry.client"
+    "etelemetry.config"
+  ];
+
+  meta = with lib; {
+    description = "Lightweight python client to communicate with the etelemetry server";
+    homepage = "https://github.com/mgxd/etelemetry-client";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -6,6 +6,8 @@
 , click
 , configparser ? null
 , dateutil
+, etelemetry
+, filelock
 , funcsigs
 , future
 , futures
@@ -14,6 +16,7 @@
 , nibabel
 , numpy
 , packaging
+, pathlib2
 , prov
 , psutil
 , pybids
@@ -60,6 +63,8 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     click
     dateutil
+    etelemetry
+    filelock
     funcsigs
     future
     networkx
@@ -77,6 +82,7 @@ buildPythonPackage rec {
   ] ++ stdenv.lib.optional (!isPy3k) [
     configparser
     futures
+    pathlib2 # darwin doesn't receive this transitively, but it is in install_requires
   ];
 
   checkInputs = [
@@ -91,6 +97,8 @@ buildPythonPackage rec {
     which
   ];
 
+  # checks on darwin inspect memory which doesn't work in build environment
+  doCheck = !stdenv.isDarwin;
   # ignore tests which incorrect fail to detect xvfb
   checkPhase = ''
     LC_ALL="en_US.UTF-8" pytest -v nipype -k 'not display'

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2034,6 +2034,8 @@ in {
 
   envs = callPackage ../development/python-modules/envs { };
 
+  etelemetry = callPackage ../development/python-modules/etelemetry { };
+
   eth-hash = callPackage ../development/python-modules/eth-hash { };
 
   eth-typing = callPackage ../development/python-modules/eth-typing { };


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken when reviewing a different PR a few days ago, got back around to fixing it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[5 built, 1 copied (0.0 MiB), 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/75642
5 package were built:
python27Packages.etelemetry python27Packages.nipype python37Packages.etelemetry python37Packages.nipype python38Packages.etelemetry
```