### PR TITLE
gtk-server: 2.3.1 -> 2.4.5

### DIFF
--- a/pkgs/development/interpreters/gtk-server/default.nix
+++ b/pkgs/development/interpreters/gtk-server/default.nix
@@ -1,28 +1,34 @@
-{ stdenv, fetchurl, libffcall, gtk2, pkgconfig }:
+{ stdenv, fetchurl
+, glib
+, gtk3
+, libffcall
+, pkgconfig
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
-  v = "2.3.1";
-  name = "gtk-server-${v}";
+  pname = "gtk-server";
+  version = "2.4.5";
 
   src = fetchurl {
-    url = "mirror://sourceforge/gtk-server/${name}-sr.tar.gz";
-    sha256 = "0z8ng5rhxc7fpsj3d50h25wkgcnxjfy030jm8r9w9m729w2c9hxb";
+    url = "https://www.gtk-server.org/stable/gtk-server-${version}.tar.gz";
+    sha256 = "0vlx5ibvc7hyc8yipjgvrx1azvmh42i9fv1khg3dvn09nrdkrc7f";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libffcall gtk2 ];
+  preConfigure = ''
+    cd src
+  '';
 
-  configureOptions = [ "--with-gtk2" ];
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+  buildInputs = [ libffcall glib gtk3 ];
 
-  NIX_LDFLAGS = [
-    "-ldl"
-  ];
+  configureOptions = [ "--with-gtk3" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "gtk-server for interpreted GUI programming";
-    homepage = http://www.gtk-server.org/;
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = [stdenv.lib.maintainers.tohl];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = "http://www.gtk-server.org/";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.tohl ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
looking through @r-ryantm logs

Also bumped gtk version from gtk2 to gtk3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/75644
1 package were built:
gtk-server
```