### PR TITLE
pythonPackages.python-twitter: init at 3.5

### DIFF
--- a/pkgs/development/python-modules/python-twitter/default.nix
+++ b/pkgs/development/python-modules/python-twitter/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pytestrunner
+, future
+, requests
+, responses
+, requests_oauthlib
+, pytest
+, hypothesis
+}:
+
+buildPythonPackage rec {
+  pname = "python-twitter";
+  version = "3.5";
+
+  # No tests in PyPi Tarball
+  src = fetchFromGitHub {
+    owner = "bear";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "08ydmf6dcd416cvw6xq1wxsz6b9s21f2mf9fh3y4qz9swj6n9h8z";
+  };
+
+  patches = [
+    # Fix tests. Remove with the next release
+    (fetchpatch {
+      url = "https://github.com/bear/python-twitter/commit/f7eb83d9dca3ba0ee93e629ba5322732f99a3a30.patch";
+      sha256 = "008b1bd03wwngs554qb136lsasihql3yi7vlcacmk4s5fmr6klqw";
+    })
+  ];
+
+  nativeBuildInputs = [ pytestrunner ];
+  propagatedBuildInputs = [ future requests requests_oauthlib ];
+  checkInputs = [ pytest responses hypothesis ];
+
+  meta = with stdenv.lib; {
+    description = "A Python wrapper around the Twitter API";
+    homepage = "https://github.com/bear/python-twitter";
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5716,6 +5716,8 @@ in {
 
   twitter-common-options = callPackage ../development/python-modules/twitter-common-options { };
 
+  python-twitter = callPackage ../development/python-modules/python-twitter { };
+
   umalqurra = callPackage ../development/python-modules/umalqurra { };
 
   unicodecsv = callPackage ../development/python-modules/unicodecsv { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/bear/python-twitter

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
