### PR TITLE
tintin: added ssl support via gnutls

### DIFF
--- a/pkgs/games/tintin/default.nix
+++ b/pkgs/games/tintin/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchurl, zlib, pcre }:
+{ stdenv, fetchurl, lib, zlib, pcre
+, tlsSupport ? true, gnutls ? null
+# ^ set { tlsSupport = false; } to reduce closure size by ~= 18.6 MB
+}:
+
+assert tlsSupport -> gnutls != null;
 
 stdenv.mkDerivation rec {
   name = "tintin-2.01.92";
@@ -8,7 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "0id8rd2yhh6ccjnlwyixflsay1rq3sw6pwlhz1ic3nzj22cd91ik";
   };
 
-  buildInputs = [ zlib pcre ];
+  nativeBuildInputs = lib.optional tlsSupport gnutls.dev;
+  buildInputs = [ zlib pcre ] ++ lib.optional tlsSupport gnutls;
 
   preConfigure = ''
     cd src


### PR DESCRIPTION




<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Now passwords can be sent encrypted via tls.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
  *(no pkgs)*
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  *Closure size difference is +18.36 MB (+161.38%). Therefore there is a switch `tlsSupport ? true` to turn off tls.*
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lovek323
