### PR TITLE
nixos containers: disable NixOS manual in container config.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -235,6 +235,14 @@
      choices (whether to perform the action as themselves with wheel permissions, or as the root user).
     </para>
    </listitem>
+   <listitem>
+    <para>
+     NixOS containers no longer build NixOS manual by default. This saves evaluation time,
+     especially if there are many declarative containers defined. Note that this is already done
+     when <literal>&lt;nixos/modules/profiles/minimal.nix&gt;</literal> module is included
+     in container config.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/virtualisation/container-config.nix
+++ b/nixos/modules/virtualisation/container-config.nix
@@ -10,6 +10,7 @@ with lib;
     nix.optimise.automatic = mkDefault false; # the store is host managed
     services.udisks2.enable = mkDefault false;
     powerManagement.enable = mkDefault false;
+    documentation.nixos.enable = mkDefault false;
 
     networking.useHostResolvConf = mkDefault true;
 


### PR DESCRIPTION
This makes ~2.5x speed up of an empty container instantiate, hence reduces
rebuild time of system with many declarative containers.

Note that this doesn't affect production systems much, because those most
likely already include `minimal.nix` profile.

Based on https://github.com/NixOS/nixpkgs/pull/75031#issuecomment-565206179