### PR TITLE
rav1e: init at 0.2.0

### DIFF
--- a/pkgs/tools/video/rav1e/default.nix
+++ b/pkgs/tools/video/rav1e/default.nix
@@ -1,0 +1,48 @@
+{ rustPlatform, fetchFromGitHub, fetchurl, stdenv, lib, unzip, nasm }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rav1e";
+  version = "0.2.0";
+
+  src = stdenv.mkDerivation rec {
+    name = "${pname}-${version}-source";
+
+    src = fetchFromGitHub {
+      owner = "xiph";
+      repo = "rav1e";
+      rev = "v${version}";
+      sha256 = "0sij9hwnar27gcwvfcjbhgyrhw99zjv8gr9s9gshqi766p5dy51a";
+    };
+    cargoLock = fetchurl {
+      url = "https://github.com/xiph/rav1e/releases/download/v${version}/rav1e-${version}.zip";
+      sha256 = "1i48c7mvc9q20d76p2rpxva551249m3p52q2z1g9sj4xzpyyk41m";
+    };
+
+    nativeBuildInputs = [ unzip ];
+
+    installPhase = ''
+      mkdir -p $out
+      cp -R ./* $out/
+      unzip ${cargoLock}
+      cp ./Cargo.lock $out/Cargo.lock
+    '';
+  };
+
+  cargoSha256 = "1z0xrcq4mx6gpjyqh1csa424sxmx54z3x7ij3w2063h6s2fv9jy3";
+
+  nativeBuildInputs = [ nasm ];
+
+  meta = with lib; {
+    description = "The fastest and safest AV1 encoder";
+    longDescription = ''
+      rav1e is an AV1 video encoder. It is designed to eventually cover all use
+      cases, though in its current form it is most suitable for cases where
+      libaom (the reference encoder) is too slow.
+      Features: https://github.com/xiph/rav1e#features
+    '';
+    inherit (src.src.meta) homepage;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.primeos ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2041,6 +2041,8 @@ in
     rainloop-community
     rainloop-standard;
 
+  rav1e = callPackage ../tools/video/rav1e { };
+
   ring-daemon = callPackage ../applications/networking/instant-messengers/ring-daemon { };
 
   riot-desktop = callPackage ../applications/networking/instant-messengers/riot/riot-desktop.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Get a good AV1 encoder into Nixpkgs (we already have dav1d for AV1 decoding).

~~TODO: Avoid having to add `Cargo.lock` to Nixpkgs. Upstream is probably open for this, see https://github.com/xiph/rav1e/issues/1434.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
