### PR TITLE
python3Packages.ipython: 7.8.0 -> 7.10.1

### DIFF
--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -22,12 +22,12 @@
 
 buildPythonPackage rec {
   pname = "ipython";
-  version = "7.8.0";
+  version = "7.10.1";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "dd76831f065f17bddd7eaa5c781f5ea32de5ef217592cf019e34043b56895aa1";
+    sha256 = "03h3m64k8jq0cc48i34g8xq0r68cx3w7wz721mfhr7k06qdv11pi";
   };
 
   prePatch = lib.optionalString stdenv.isDarwin ''
@@ -57,10 +57,14 @@ buildPythonPackage rec {
     nosetests
   '';
 
-  meta = {
+  pythonImportsCheck = [
+    "IPython"
+  ];
+
+  meta = with lib; {
     description = "IPython: Productive Interactive Computing";
     homepage = http://ipython.org/;
-    license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ bjornfor fridh ];
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bjornfor fridh ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed it failed up to update looking through @r-ryantm logs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

failures are broken on master:
```
[127 built (11 failed), 271 copied (3063.7 MiB), 603.3 MiB DL]
error: build of '/nix/store/73hhlga4nwzr2878avkalmm15gr1hh1b-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/75661
14 package failed to build:
python37Packages.google_cloud_bigquery python37Packages.optuna python37Packages.robotframework-tools python37Packages.runway-python python37Packages.starfish python37Packages.vega python38Packages.Nikola python38Packages.modeled python38Packages.moretools python38Packages.robotframework-tools python38Packages.runway-python python38Packages.scikit-tda python38Packages.spyder python38Packages.zetup

118 package were built:
adafruit-ampy cq-editor deeptools fdroidserver gnome3.accerciser jira-cli john jupyter paperless python37Packages.Nikola python37Packages.Pweave python37Packages.altair python37Packages.androguard python37Packages.ansible-kernel python37Packages.bash_kernel python37Packages.caffe python37Packages.chart-studio python37Packages.colorcet python37Packages.cufflinks python37Packages.datashader python37Packages.dftfit python37Packages.greatfet python37Packages.holoviews python37Packages.hvplot python37Packages.intake python37Packages.ipdb python37Packages.ipdbplugin python37Packages.ipykernel python37Packages.ipyparallel python37Packages.ipython python37Packages.ipywidgets python37Packages.jira python37Packages.jupyter python37Packages.jupyter_client python37Packages.jupyter_console python37Packages.jupyter_core python37Packages.jupyterhub python37Packages.jupyterhub-ldapauthenticator python37Packages.jupyterlab python37Packages.jupyterlab_launcher python37Packages.jupyterlab_server python37Packages.jupytext python37Packages.kmapper python37Packages.line_profiler python37Packages.modeled python37Packages.moretools python37Packages.nbconvert python37Packages.nbdime python37Packages.nbformat python37Packages.nbmerge python37Packages.nbsmoke python37Packages.nbsphinx python37Packages.nbval python37Packages.notebook python37Packages.oauthenticator python37Packages.papermill python37Packages.phik python37Packages.plotly python37Packages.pygmo python37Packages.python-dotenv python37Packages.qtconsole python37Packages.rpy2 python37Packages.scapy python37Packages.scikit-bio python37Packages.scikit-tda python37Packages.sopel spyder python37Packages.spyder-kernels python37Packages.widgetsnbextension python37Packages.zetup python38Packages.Pweave python38Packages.androguard python38Packages.ansible-kernel python38Packages.bash_kernel python38Packages.chart-studio python38Packages.colorcet python38Packages.greatfet python38Packages.ipdb python38Packages.ipdbplugin python38Packages.ipykernel python38Packages.ipyparallel python38Packages.ipython python38Packages.ipywidgets python38Packages.jira python38Packages.jupyter python38Packages.jupyter_client python38Packages.jupyter_console python38Packages.jupyter_core python38Packages.jupyterhub python38Packages.jupyterhub-ldapauthenticator python38Packages.jupyterlab python38Packages.jupyterlab_launcher python38Packages.jupyterlab_server python38Packages.jupytext python38Packages.kmapper python38Packages.line_profiler python38Packages.nbconvert python38Packages.nbdime python38Packages.nbformat python38Packages.nbmerge python38Packages.nbsmoke python38Packages.nbsphinx python38Packages.nbval python38Packages.notebook python38Packages.oauthenticator python38Packages.papermill python38Packages.plotly python38Packages.pygmo python38Packages.python-dotenv python38Packages.qtconsole python38Packages.scapy python38Packages.sopel python38Packages.spyder-kernels python38Packages.widgetsnbextension sage sageWithDoc streamlit theharvester
```