### PR TITLE
Another batch of Python 2 removals

### DIFF
--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -24,8 +24,7 @@ assert nlSupport     -> ! iwSupport && libnl         != null;
 assert i3Support     -> ! i3GapsSupport && jsoncpp != null && i3      != null;
 assert i3GapsSupport -> ! i3Support     && jsoncpp != null && i3-gaps != null;
 
-let xcbproto-py3 = xcbproto.override { python = python3; };
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
     pname = "polybar";
     version = "3.4.1";
 
@@ -51,7 +50,7 @@ in stdenv.mkDerivation rec {
     };
 
     buildInputs = [
-      cairo libXdmcp libpthreadstubs libxcb pcre python3 xcbproto-py3 xcbutil
+      cairo libXdmcp libpthreadstubs libxcb pcre python3 xcbproto xcbutil
       xcbutilcursor xcbutilimage xcbutilrenderutil xcbutilwm xcbutilxrm
 
       (if alsaSupport   then alsaLib       else null)

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, nss, python
+{ stdenv, fetchurl, nss, python3
 , blacklist ? []
 , includeEmail ? false
 }:
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "unbundled" ];
 
-  nativeBuildInputs = [ python ];
+  nativeBuildInputs = [ python3 ];
 
   configurePhase = ''
     ln -s nss/lib/ckfw/builtins/certdata.txt

--- a/pkgs/desktops/gnome-3/core/zenity/default.nix
+++ b/pkgs/desktops/gnome-3/core/zenity/default.nix
@@ -1,5 +1,15 @@
-{ stdenv, fetchurl, pkgconfig, libxml2, libxslt, gnome3, gtk3
-, gnome-doc-utils, intltool, libX11, which, itstool, wrapGAppsHook }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, libxml2
+, gnome3
+, gtk3
+, yelp-tools
+, gettext
+, libX11
+, itstool
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "zenity";
@@ -10,13 +20,19 @@ stdenv.mkDerivation rec {
     sha256 = "15fdh8xfdhnwcynyh4byx3mrjxbyprqnwxzi7qn3g5wwaqryg1p7";
   };
 
-  preBuild = ''
-    mkdir -p $out/include
-  '';
+  nativeBuildInputs = [
+    pkgconfig
+    gettext
+    yelp-tools
+    itstool
+    libxml2
+    wrapGAppsHook
+  ];
 
-  buildInputs = [ gtk3 libxml2 libxslt libX11 itstool ];
-
-  nativeBuildInputs = [ pkgconfig intltool gnome-doc-utils which wrapGAppsHook ];
+  buildInputs = [
+    gtk3
+    libX11
+  ];
 
   passthru = {
     updateScript = gnome3.updateScript {
@@ -26,6 +42,8 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
+    description = "Tool to display dialogs from the commandline and shell scripts";
+    homepage = "https://wiki.gnome.org/Projects/Zenity";
     platforms = platforms.linux;
     maintainers = gnome3.maintainers;
   };

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -1,4 +1,4 @@
-{ stdenv, file, curl, pkgconfig, python, openssl, cmake, zlib
+{ stdenv, file, curl, pkgconfig, python3, openssl, cmake, zlib
 , makeWrapper, libiconv, cacert, rustPlatform, rustc, libgit2
 , CoreFoundation, Security
 }:
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage {
   dontUpdateAutotoolsGnuConfigScripts = true;
 
   nativeBuildInputs = [ pkgconfig cmake makeWrapper ];
-  buildInputs = [ cacert file curl python openssl zlib libgit2 ]
+  buildInputs = [ cacert file curl python3 openssl zlib libgit2 ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation Security libiconv ];
 
   LIBGIT2_SYS_USE_PKG_CONFIG = 1;

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -1,5 +1,5 @@
 { stdenv, removeReferencesTo, pkgsBuildBuild, pkgsBuildHost, pkgsBuildTarget
-, fetchurl, file, python2
+, fetchurl, file, python3
 , llvm_9, darwin, git, cmake, rust, rustPlatform
 , pkgconfig, openssl
 , which, libffi
@@ -121,7 +121,7 @@ in stdenv.mkDerivation rec {
   dontUseCmakeConfigure = true;
 
   nativeBuildInputs = [
-    file python2 rustPlatform.rust.rustc git cmake
+    file python3 rustPlatform.rust.rustc git cmake
     which libffi removeReferencesTo pkgconfig
   ];
 

--- a/pkgs/development/libraries/audio/lilv/default.nix
+++ b/pkgs/development/libraries/audio/lilv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lv2, pkgconfig, python, serd, sord, sratom, wafHook }:
+{ stdenv, fetchurl, lv2, pkgconfig, python3, serd, sord, sratom, wafHook }:
 
 stdenv.mkDerivation rec {
   pname = "lilv";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0f24cd7wkk5l969857g2ydz2kjjrkvvddg1g87xzzs78lsvq8fy3";
   };
 
-  nativeBuildInputs = [ pkgconfig wafHook ];
-  buildInputs = [ lv2 python serd sord sratom ];
+  nativeBuildInputs = [ pkgconfig python3 wafHook ];
+  buildInputs = [ lv2 serd sord sratom ];
 
   meta = with stdenv.lib; {
     homepage = http://drobilla.net/software/lilv;

--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk2, libsndfile, pkgconfig, python, wafHook }:
+{ stdenv, fetchurl, gtk2, libsndfile, pkgconfig, python3, wafHook }:
 
 stdenv.mkDerivation rec {
   pname = "lv2";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig wafHook ];
-  buildInputs = [ gtk2 libsndfile python ];
+  buildInputs = [ gtk2 libsndfile python3 ];
 
   meta = with stdenv.lib; {
     homepage = http://lv2plug.in;

--- a/pkgs/development/libraries/audio/sratom/default.nix
+++ b/pkgs/development/libraries/audio/sratom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lv2, pkgconfig, python, serd, sord, wafHook }:
+{ stdenv, fetchurl, lv2, pkgconfig, python3, serd, sord, wafHook }:
 
 stdenv.mkDerivation rec {
   pname = "sratom";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0lz883ravxjf7r9wwbx2gx9m8vhyiavxrl9jdxfppjxnsralll8a";
   };
 
-  nativeBuildInputs = [ pkgconfig wafHook ];
-  buildInputs = [ lv2 python serd sord ];
+  nativeBuildInputs = [ pkgconfig wafHook python3 ];
+  buildInputs = [ lv2 serd sord ];
 
   meta = with stdenv.lib; {
     homepage = http://drobilla.net/software/sratom;

--- a/pkgs/development/libraries/epoxy/default.nix
+++ b/pkgs/development/libraries/epoxy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, utilmacros, python
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, utilmacros, python3
 , libGL, libX11
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig utilmacros python ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig utilmacros python3 ];
   buildInputs = [ libGL libX11 ];
 
   preConfigure = optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/farstream/default.nix
+++ b/pkgs/development/libraries/farstream/default.nix
@@ -1,11 +1,11 @@
 { stdenv
 , fetchurl
+, fetchpatch
 , libnice
 , pkgconfig
-, pythonPackages
+, autoreconfHook
 , gstreamer
 , gst-plugins-base
-, gst-python
 , gupnp-igd
 , gobject-introspection
 , gst-plugins-good
@@ -13,9 +13,7 @@
 , gst-libav
 }:
 
-let
-  inherit (pythonPackages) python pygobject2;
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "farstream-0.2.8";
 
   outputs = [ "out" "dev" ];
@@ -25,23 +23,29 @@ in stdenv.mkDerivation rec {
     sha256 = "0249ncd20x5mf884fd8bw75c3118b9fdml837v4fib349xmrqfrb";
   };
 
+  patches = [
+    # Python has not been used for ages
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/farstream/farstream/commit/73891c28fa27d5e65a71762e826f13747d743588.patch";
+      sha256 = "19pw1m8xhxyf5yhl6k898w240ra2k0m28gfv858x70c4wl786lrn";
+    })
+  ];
+
   buildInputs = [
     libnice
-    python
-    pygobject2
     gupnp-igd
     libnice
   ];
 
   nativeBuildInputs = [
     pkgconfig
+    autoreconfHook
     gobject-introspection
   ];
 
   propagatedBuildInputs = [
     gstreamer
     gst-plugins-base
-    gst-python
     gst-plugins-good
     gst-plugins-bad
     gst-libav

--- a/pkgs/development/libraries/farstream/default.nix
+++ b/pkgs/development/libraries/farstream/default.nix
@@ -1,6 +1,16 @@
-{ stdenv, fetchurl, libnice, pkgconfig, pythonPackages, gstreamer, gst-plugins-base
-, gst-python, gupnp-igd, gobject-introspection
-, gst-plugins-good, gst-plugins-bad, gst-libav
+{ stdenv
+, fetchurl
+, libnice
+, pkgconfig
+, pythonPackages
+, gstreamer
+, gst-plugins-base
+, gst-python
+, gupnp-igd
+, gobject-introspection
+, gst-plugins-good
+, gst-plugins-bad
+, gst-libav
 }:
 
 let
@@ -15,17 +25,30 @@ in stdenv.mkDerivation rec {
     sha256 = "0249ncd20x5mf884fd8bw75c3118b9fdml837v4fib349xmrqfrb";
   };
 
-  buildInputs = [ libnice python pygobject2 gupnp-igd libnice ];
+  buildInputs = [
+    libnice
+    python
+    pygobject2
+    gupnp-igd
+    libnice
+  ];
 
-  nativeBuildInputs = [ pkgconfig gobject-introspection ];
+  nativeBuildInputs = [
+    pkgconfig
+    gobject-introspection
+  ];
 
   propagatedBuildInputs = [
-    gstreamer gst-plugins-base gst-python
-    gst-plugins-good gst-plugins-bad gst-libav
+    gstreamer
+    gst-plugins-base
+    gst-python
+    gst-plugins-good
+    gst-plugins-bad
+    gst-libav
   ];
 
   meta = with stdenv.lib; {
-    homepage = https://www.freedesktop.org/wiki/Software/Farstream;
+    homepage = "https://www.freedesktop.org/wiki/Software/Farstream";
     description = "Audio/Video Communications Framework formely known as farsight";
     platforms = platforms.linux;
     license = licenses.lgpl21;

--- a/pkgs/development/libraries/gamin/default.nix
+++ b/pkgs/development/libraries/gamin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, python, pkgconfig, glib }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, glib }:
 
 stdenv.mkDerivation (rec {
   name = "gamin-0.1.10";
@@ -10,13 +10,13 @@ stdenv.mkDerivation (rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ python glib ];
+  buildInputs = [ glib ];
 
   # `_GNU_SOURCE' is needed, e.g., to get `struct ucred' from
   # <sys/socket.h> with Glibc 2.9.
   configureFlags = [
     "--disable-debug"
-    "--with-python=${python}"
+    "--without-python" # python3 not supported
     "CPPFLAGS=-D_GNU_SOURCE"
   ];
 
@@ -44,4 +44,3 @@ stdenv.mkDerivation (rec {
     sed -i 's/,--version-script=.*$/\\/' libgamin/Makefile
   '';
 })
-

--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, python
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, python3
 , zlib, libssh2, openssl, http-parser, curl
 , libiconv, Security
 }:
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DTHREADSAFE=ON" ];
 
-  nativeBuildInputs = [ cmake python pkgconfig ];
+  nativeBuildInputs = [ cmake python3 pkgconfig ];
 
   buildInputs = [ zlib libssh2 openssl http-parser curl ]
     ++ stdenv.lib.optional stdenv.isDarwin Security;

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -3,7 +3,7 @@
 , meson
 , ninja
 , pkgconfig
-, python
+, python3
 , gst-plugins-base
 , orc
 , bzip2
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkgconfig
-    python
+    python3
     meson
     ninja
     gettext

--- a/pkgs/development/libraries/jbig2dec/default.nix
+++ b/pkgs/development/libraries/jbig2dec/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, autoconf }:
+{ stdenv, fetchurl, python3, autoconf }:
 
 stdenv.mkDerivation rec {
   name = "jbig2dec-0.17";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ autoconf ];
 
-  checkInputs = [ python ];
+  checkInputs = [ python3 ];
   doCheck = true;
 
   meta = {

--- a/pkgs/development/libraries/libdbusmenu/default.nix
+++ b/pkgs/development/libraries/libdbusmenu/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, lib, file
 , pkgconfig, intltool
 , glib, dbus-glib, json-glib
-, gobject-introspection, vala, gnome-doc-utils
+, gobject-introspection, vala
 , gtkVersion ? null, gtk2 ? null, gtk3 ? null }:
 
 with lib;
@@ -18,11 +18,10 @@ stdenv.mkDerivation rec {
     sha256 = "12l7z8dhl917iy9h02sxmpclnhkdjryn08r8i4sr8l3lrlm4mk5r";
   };
 
-  nativeBuildInputs = [ vala pkgconfig intltool ];
+  nativeBuildInputs = [ vala pkgconfig intltool gobject-introspection ];
 
   buildInputs = [
     glib dbus-glib json-glib
-    gobject-introspection gnome-doc-utils
   ] ++ optional (gtkVersion != null) (if gtkVersion == "2" then gtk2 else gtk3);
 
   postPatch = ''

--- a/pkgs/development/libraries/libevdev/default.nix
+++ b/pkgs/development/libraries/libevdev/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python }:
+{ stdenv, fetchurl, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "libevdev";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "04a2klvii0in9ln8r85mk2cm73jq8ry2m3yzmf2z8xyjxzjcmlr0";
   };
 
-  buildInputs = [ python ];
+  buildInputs = [ python3 ];
 
   meta = with stdenv.lib; {
     description = "Wrapper library for evdev devices";

--- a/pkgs/development/libraries/libglvnd/default.nix
+++ b/pkgs/development/libraries/libglvnd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, autoreconfHook, python2, pkgconfig, libX11, libXext, xorgproto, addOpenGLRunpath }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, autoreconfHook, python3, pkgconfig, libX11, libXext, xorgproto, addOpenGLRunpath }:
 
 stdenv.mkDerivation rec {
   pname = "libglvnd";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1hyywwjsmvsd7di603f7iznjlccqlc7yvz0j59gax7bljm9wb6ni";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig python2 addOpenGLRunpath ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig python3 addOpenGLRunpath ];
   buildInputs = [ libX11 libXext xorgproto ];
 
   # The following 3 patches should be removed once libglvnd >1.2.0 is released

--- a/pkgs/development/libraries/libgsf/default.nix
+++ b/pkgs/development/libraries/libgsf/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, intltool, gettext, glib, libxml2, zlib, bzip2
-, python, perl, gdk-pixbuf, libiconv, libintl, gnome3 }:
+, perl, gdk-pixbuf, libiconv, libintl, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "libgsf";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool libintl ];
 
-  buildInputs = [ gettext bzip2 zlib python ];
+  buildInputs = [ gettext bzip2 zlib ];
   checkInputs = [ perl ];
 
   propagatedBuildInputs = [ libxml2 glib gdk-pixbuf libiconv ];

--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -11,7 +11,6 @@
 , gsettings-desktop-schemas
 , glib
 , makeWrapper
-, python2
 , python3
 , SystemConfiguration
 , CoreFoundation
@@ -29,7 +28,7 @@ stdenv.mkDerivation rec {
     sha256 = "10swd3x576pinx33iwsbd4h15fbh2snmfxzcmab4c56nb08qlbrs";
   };
 
-  outputs = [ "out" "dev" "py2" "py3" ];
+  outputs = [ "out" "dev" "py3" ];
 
   nativeBuildInputs = [
     pkgconfig
@@ -39,7 +38,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pcre
-    python2
     python3
     zlib
   ] ++ (if stdenv.hostPlatform.isDarwin then [
@@ -55,7 +53,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DWITH_MOZJS=ON"
-    "-DPYTHON2_SITEPKG_DIR=${placeholder "py2"}/${python2.sitePackages}"
+    "-DWITH_PYTHON2=OFF"
     "-DPYTHON3_SITEPKG_DIR=${placeholder "py3"}/${python3.sitePackages}"
   ];
 

--- a/pkgs/development/libraries/serd/default.nix
+++ b/pkgs/development/libraries/serd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, python, wafHook }:
+{ stdenv, fetchurl, pkgconfig, python3, wafHook }:
 
 stdenv.mkDerivation rec {
   pname = "serd";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1yyfyvc6kwagi5w43ljp1bbjdvdpmgpds74lmjxycm91bkx0xyvf";
   };
 
-  nativeBuildInputs = [ pkgconfig python wafHook ];
+  nativeBuildInputs = [ pkgconfig python3 wafHook ];
 
   meta = with stdenv.lib; {
     homepage = http://drobilla.net/software/serd;

--- a/pkgs/development/libraries/sord/default.nix
+++ b/pkgs/development/libraries/sord/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, python, serd, pcre, wafHook }:
+{ stdenv, fetchurl, pkgconfig, python3, serd, pcre, wafHook }:
 
 stdenv.mkDerivation rec {
   pname = "sord";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "13fshxwpipjrvsah1m2jw1kf022z2q5vpw24bzcznglgvms13x89";
   };
 
-  nativeBuildInputs = [ pkgconfig wafHook ];
-  buildInputs = [ python serd pcre ];
+  nativeBuildInputs = [ pkgconfig python3 wafHook ];
+  buildInputs = [ serd pcre ];
 
   meta = with stdenv.lib; {
     homepage = http://drobilla.net/software/sord;

--- a/pkgs/development/python-modules/anytree/default.nix
+++ b/pkgs/development/python-modules/anytree/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , substituteAll
 , fetchpatch
 , nose
@@ -11,13 +11,11 @@
 
 buildPythonPackage rec {
   pname = "anytree";
-  version = "2.7.2";
+  version = "2.7.3";
 
-  src = fetchFromGitHub {
-    owner = "c0fec0de";
-    repo = pname;
-    rev = version;
-    sha256 = "0ag5ir9h5p7rbm2pmpxlkflwigrm7z4afh24jvbhqj7pyrbjmk9w";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05736hamjv4f38jw6z9y4wckc7mz18ivbizm1s3pb0n6fp1sy4zk";
   };
 
   patches = [

--- a/pkgs/development/python-modules/anytree/default.nix
+++ b/pkgs/development/python-modules/anytree/default.nix
@@ -5,6 +5,7 @@
 , fetchpatch
 , nose
 , six
+, withGraphviz ? true
 , graphviz
 , fontconfig
 }:
@@ -18,7 +19,7 @@ buildPythonPackage rec {
     sha256 = "05736hamjv4f38jw6z9y4wckc7mz18ivbizm1s3pb0n6fp1sy4zk";
   };
 
-  patches = [
+  patches = lib.optionals withGraphviz [
     (substituteAll {
       src = ./graphviz.patch;
       inherit graphviz;
@@ -33,10 +34,13 @@ buildPythonPackage rec {
     six
   ];
 
-  # Fontconfig error: Cannot load default config file
-  preCheck = ''
+  # tests print “Fontconfig error: Cannot load default config file”
+  preCheck = lib.optionalString withGraphviz ''
     export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
   '';
+
+  # circular dependency anytree → graphviz → pango → glib → gtk-doc → anytree
+  doCheck = withGraphviz;
 
   checkPhase = ''
     runHook preCheck

--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, fetchurl, perl, python, flex, bison, qt4, CoreServices, libiconv }:
+{ stdenv, cmake, fetchurl, python3, flex, bison, qt4, CoreServices, libiconv }:
 
 stdenv.mkDerivation rec {
 
@@ -12,11 +12,15 @@ stdenv.mkDerivation rec {
     sha256 = "bd9c0ec462b6a9b5b41ede97bede5458e0d7bb40d4cfa27f6f622eb33c59245d";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    python3
+    flex
+    bison
+  ];
 
   buildInputs =
-    [ perl python flex bison ]
-    ++ stdenv.lib.optional (qt4 != null) qt4
+       stdenv.lib.optional (qt4 != null) qt4
     ++ stdenv.lib.optional stdenv.isSunOS libiconv
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices libiconv ];
 

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -2,9 +2,8 @@
 , fetchFromGitLab
 , meson
 , ninja
-, pkgconfig
+, pkg-config
 , python3
-, libxml2Python
 , docbook_xml_dtd_43
 , docbook_xsl
 , libxslt
@@ -13,9 +12,11 @@
 , withDblatex ? false, dblatex
 }:
 
-stdenv.mkDerivation rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "gtk-doc";
   version = "1.32";
+
+  format = "other";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -32,36 +33,40 @@ stdenv.mkDerivation rec {
   outputDevdoc = "out";
 
   nativeBuildInputs = [
+    pkg-config
     gettext
     meson
     ninja
+    libxslt # for xsltproc
   ];
 
   buildInputs = [
     docbook_xml_dtd_43
     docbook_xsl
     libxslt
-    pkgconfig
-    python3
-    python3.pkgs.pygments # Needed for https://gitlab.gnome.org/GNOME/gtk-doc/blob/GTK_DOC_1_32/meson.build#L42
-    libxml2Python
-  ]
-  ++ stdenv.lib.optional withDblatex dblatex
-  ;
+  ] ++ stdenv.lib.optionals withDblatex [
+    dblatex
+  ];
+
+  pythonPath = with python3.pkgs; [
+    pygments # Needed for https://gitlab.gnome.org/GNOME/gtk-doc/blob/GTK_DOC_1_32/meson.build#L42
+    (anytree.override { withGraphviz = false; })
+    lxml
+  ];
 
   mesonFlags = [
     "-Dtests=false"
     "-Dyelp_manual=false"
   ];
 
-  # Make pygments available for binaries, python.withPackages creates a wrapper
-  # but scripts are not allowed in shebangs so we link it into sys.path.
-  postInstall = ''
-    ln -s ${python3.pkgs.pygments}/${python3.sitePackages}/* $out/share/gtk-doc/python/
-  '';
-
   doCheck = false; # requires a lot of stuff
   doInstallCheck = false; # fails
+
+  postFixup = ''
+    # Do not propagate Python
+    substituteInPlace $out/nix-support/propagated-build-inputs \
+      --replace "${python3}" ""
+  '';
 
   passthru = {
     # Consumers are expected to copy the m4 files to their source tree, let them reuse the patch

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -4,7 +4,7 @@
   freetype, tradcpp, fontconfig, meson, ninja, ed,
   libGL, spice-protocol, zlib, libGLU, dbus, libunwind, libdrm,
   mesa, udev, bootstrap_cmds, bison, flex, clangStdenv, autoreconfHook,
-  mcpp, epoxy, openssl, pkgconfig, llvm_6,
+  mcpp, epoxy, openssl, pkgconfig, llvm_6, python3,
   ApplicationServices, Carbon, Cocoa, Xplugin
 }:
 
@@ -307,6 +307,10 @@ self: super:
   x11perf = super.x11perf.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [ freetype fontconfig ];
   });
+
+  xcbproto = super.xcbproto.override {
+    python = python3;
+  };
 
   xcbutil = super.xcbutil.overrideAttrs (attrs: {
     outputs = [ "out" "dev" ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -72,7 +72,9 @@ self: super:
 
   mkfontdir = self.mkfontscale;
 
-  libxcb = super.libxcb.overrideAttrs (attrs: {
+  libxcb = (super.libxcb.override {
+    python = python3;
+  }).overrideAttrs (attrs: {
     configureFlags = [ "--enable-xkb" "--enable-xinput" ];
     outputs = [ "out" "dev" "man" "doc" ];
   });

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, python, pythonPackages, gamin }:
+{ stdenv, fetchFromGitHub, fetchpatch, python3, gamin }:
 
 let version = "0.10.4"; in
 
-pythonPackages.buildPythonApplication {
+python3.pkgs.buildPythonApplication {
   pname = "fail2ban";
   inherit version;
 
@@ -13,8 +13,19 @@ pythonPackages.buildPythonApplication {
     sha256 = "07ik6rm856q0ic2r7vbg6j3hsdcdgkv44hh5ck0c2y21fqwrck3l";
   };
 
-  propagatedBuildInputs = [ gamin ]
-    ++ (stdenv.lib.optional stdenv.isLinux pythonPackages.systemd);
+  patches = [
+    # 0.10.3 supports Python 3 but somehow this got into the way
+    # https://github.com/fail2ban/fail2ban/issues/2255
+    (fetchpatch {
+      url = "https://github.com/fail2ban/fail2ban/commit/657b147c0d7830f3600f3dc7feaa4815a7e19fde.patch";
+      sha256 = "1hrk2x7ssrfhab1wrjk5xw1sxhiv2735glfcp6qcj8x4dss3q7f7";
+    })
+  ];
+
+  pythonPath = with python3.pkgs;
+    stdenv.lib.optionals stdenv.isLinux [
+      systemd
+    ];
 
   preConfigure = ''
     for i in config/action.d/sendmail*.conf; do
@@ -33,11 +44,11 @@ pythonPackages.buildPythonApplication {
     substituteInPlace setup.py --replace /usr/share/doc/ share/doc/
 
     # see https://github.com/NixOS/nixpkgs/issues/4968
-    ${python}/bin/${python.executable} setup.py install_data --install-dir=$out --root=$out
+    ${python3.interpreter} setup.py install_data --install-dir=$out --root=$out
   '';
 
   postInstall = let
-    sitePackages = "$out/lib/${python.libPrefix}/site-packages";
+    sitePackages = "$out/${python3.sitePackages}";
   in ''
     # see https://github.com/NixOS/nixpkgs/issues/4968
     rm -rf ${sitePackages}/etc ${sitePackages}/usr ${sitePackages}/var;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3280,6 +3280,7 @@ in
 
   fontforge = lowPrio (callPackage ../tools/misc/fontforge {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+    python = python3;
   });
   fontforge-gtk = fontforge.override {
     withSpiro = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16541,7 +16541,9 @@ in
 
   keyutils = callPackage ../os-specific/linux/keyutils { };
 
-  libselinux = callPackage ../os-specific/linux/libselinux { };
+  libselinux = callPackage ../os-specific/linux/libselinux {
+    python = python3;
+  };
 
   libsemanage = callPackage ../os-specific/linux/libsemanage { };
 
@@ -25034,7 +25036,6 @@ in
   serviio = callPackage ../servers/serviio {};
   selinux-python = callPackage ../os-specific/linux/selinux-python {
     # needs python3 bindings
-    libselinux = libselinux.override { python = python3; };
     libsemanage = libsemanage.override { python = python3; };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16545,7 +16545,9 @@ in
     python = python3;
   };
 
-  libsemanage = callPackage ../os-specific/linux/libsemanage { };
+  libsemanage = callPackage ../os-specific/linux/libsemanage {
+    python = python3;
+  };
 
   libraw = callPackage ../development/libraries/libraw { };
 
@@ -25034,10 +25036,7 @@ in
   seafile-shared = callPackage ../misc/seafile-shared { };
 
   serviio = callPackage ../servers/serviio {};
-  selinux-python = callPackage ../os-specific/linux/selinux-python {
-    # needs python3 bindings
-    libsemanage = libsemanage.override { python = python3; };
-  };
+  selinux-python = callPackage ../os-specific/linux/selinux-python { };
 
   slock = callPackage ../misc/screensavers/slock {
     conf = config.slock.conf or null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11133,7 +11133,6 @@ in
     inherit (gst_all_1)
       gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad
       gst-libav;
-    inherit (pythonPackages) gst-python;
   };
 
   fcgi = callPackage ../development/libraries/fcgi { };


### PR DESCRIPTION
I was digging through `gnome3.gnome-shell`’s build-time closure using `nix-store -q --graph $(nix-instantiate '<nixpkgs>' -A gnome3.gnome-shell) | dijkstra -da $(nix-instantiate '<nixpkgs>' -A python2) | gvpr -c 'N[dist>1000.0]{delete(NULL, $)}' | xdot -` and eliminating Python 2 from derivations referencing it by replacing it with Python 3 whenever possible.

#### Testing

- [x] Built individual packages based against unstable:
    - [x] `farstream`
    - [x] `libevdev`
    - [x] `ninja`
    - [x] `python3.pkgs.anytree`
    - [x] `zenity`
    - [x] `libdbusmenu-gtk3`
    - [x] `xorg.xcbproto`
    - [x] `cacert`
    - [x] `libselinux`
    - [x] `epoxy`
    - [x] `anytree` + `gtk-doc`
        - [x] Build `glib` to test `gtk-doc` working
    - [x] `xorg.libxcb`
    - [x] `fontforge`
    - [x] `libglvnd`
    - [x] `libgit2`
    - [x] `serd`
    - [x] `sord`
    - [x] `sratom`
    - [x] `lv2`
    - [x] `lilv`
    - [x] `fail2ban`
    - [x] `gamin`
    - [x] `gst_all_1.gst-plugins-good`
    - [x] `libgsf`
    - [x] `doxygen`
    - [x] `jbig2dec`
    - [x] `libproxy`
    - [x] `rustc`
    - [x] `cargo`


Some packages were not handled:

* `asciidoc` (`asciidoctor` in Ruby is the new upstream, switch to https://github.com/asciidoc/asciidoc-py3/releases)
* `llvm_7`, `llvm_9` (not sure about bootstrapping)
* `ninja` (Darwin bootstrapping issue https://gist.github.com/GrahamcOfBorg/130aa188dad522a3e0df7ce27006565e)
* `parted` (two tests are failing)
* `spidermonkey_60` (takes too long to build)
* `qtbase` (takes too long to build)
* `libplist` (does not build with Python 3)
* `telepathy-glib` (`telepathy-logger` depends on Python 2)