### PR TITLE
bless: init at 0.6.2

### DIFF
--- a/pkgs/applications/editors/bless/default.nix
+++ b/pkgs/applications/editors/bless/default.nix
@@ -1,0 +1,80 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, mono
+, gtk-sharp-2_0
+, gettext
+, makeWrapper
+, glib
+, gtk2-x11
+, gnome2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bless";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "afrantzis";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04ra2mcx3pkhzbhcz0zwfmbpqj6cwisrypi6xbc2d6pxd4hdafn1";
+  };
+
+  buildInputs = [
+    gtk-sharp-2_0
+    mono
+    # runtime only deps
+    glib
+    gtk2-x11
+    gnome2.libglade
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    autoreconfHook
+    gettext
+    makeWrapper
+  ];
+
+  configureFlags = [
+    # scrollkeeper is a gnome2 package, so it must be old and we shouldn't really support it
+    # NOTE: that sadly doesn't turn off the compilation of the manual with scrollkeeper, so we have to fake the binaries below
+    "--without-scrollkeeper"
+  ];
+
+  autoreconfPhase = ''
+    mkdir _bin
+
+    # this fakes the scrollkeeper commands, to keep the build happy
+    for f in scrollkeeper-preinstall scrollkeeper-update; do
+      echo "true" > ./_bin/$f
+      chmod +x ./_bin/$f
+    done
+
+    export PATH="$PWD/_bin:$PATH"
+
+    # and it also wants to install that file
+    touch ./doc/user/bless-manual.omf
+
+    # patch mono path
+    sed "s|^mono|${mono}/bin/mono|g" -i src/bless-script.in
+
+    ./autogen.sh
+    '';
+
+  preFixup = ''
+    MPATH="${gtk-sharp-2_0}/lib/mono/gtk-sharp-2.0:${glib.out}/lib:${gtk2-x11}/lib:${gnome2.libglade}/lib:${gtk-sharp-2_0}/lib"
+    wrapProgram $out/bin/bless --prefix MONO_PATH : "$MPATH" --prefix LD_LIBRARY_PATH : "$MPATH"
+    '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/afrantzis/bless";
+    description = "Gtk# Hex Editor";
+    maintainers = [ maintainers.mkg20001 ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    badPlatforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1215,6 +1215,8 @@ in
 
   behdad-fonts = callPackage ../data/fonts/behdad-fonts { };
 
+  bless = callPackage ../applications/editors/bless { };
+
   blink1-tool = callPackage ../tools/misc/blink1-tool { };
 
   bliss = callPackage ../applications/science/math/bliss { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Needed this for myself, might be useful for others, too

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
