### PR TITLE
pentobi: init at 17.3

### DIFF
--- a/pkgs/games/pentobi/default.nix
+++ b/pkgs/games/pentobi/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, appstream, fetchurl, cmake, gettext, libxslt, librsvg, itstool
+  , qtbase, qtquickcontrols2, qtsvg, qttools, qtwebview, docbook_xsl
+  , wrapQtAppsHook
+}:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  version = "17.3";
+  pname = "pentobi";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/pentobi/${pname}-${version}.tar.xz";
+    sha256 = "00c495i4vrji9hs7v8xr9gm8yqs97bfk2wzsayhps11hmbqzllx9";
+  };
+
+  nativeBuildInputs = [ cmake docbook_xsl wrapQtAppsHook ];
+  buildInputs = [ appstream qtbase qtsvg qtquickcontrols2 qttools qtwebview itstool librsvg ];
+
+  patchPhase = ''
+    substituteInPlace pentobi_thumbnailer/CMakeLists.txt --replace "/manpages" "/share/xml/docbook-xsl/manpages/"
+    substituteInPlace pentobi/unix/CMakeLists.txt --replace "/manpages" "/share/xml/docbook-xsl/manpages/"
+    substituteInPlace pentobi/docbook/CMakeLists.txt --replace "/html" "/share/xml/docbook-xsl/html"
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_VERBOSE_MAKEFILE=1"
+    "-DDOCBOOKXSL_DIR=${docbook_xsl}"
+    "-DMETAINFO_ITS=${appstream}/share/gettext/its/metainfo.its"
+  ];
+
+  meta = {
+    description = "A computer opponent for the board game Blokus";
+    homepage = https://pentobi.sourceforge.io;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22984,6 +22984,8 @@ in
 
   pacvim = callPackage ../games/pacvim { };
 
+  pentobi = libsForQt5.callPackage ../games/pentobi { };
+
   performous = callPackage ../games/performous {
     boost = boost166;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
