### PR TITLE
pythonPackages.Babel: Fix use of glibcLocales, skip musl tests

### DIFF
--- a/pkgs/development/python-modules/Babel/default.nix
+++ b/pkgs/development/python-modules/Babel/default.nix
@@ -22,6 +22,15 @@ buildPythonPackage rec {
     # https://github.com/NixOS/nixpkgs/issues/74904 (like above).
     && !(stdenv.hostPlatform.isMusl && !isPy3k);
 
+  # Without this, the build oddly fails on ofborg CI (but not on nh2's NixOS)
+  # when Python M 3 is used.
+  # Even more oddly, using `export LC_ALL="C.UTF-8"` (with quotes) makes it
+  # fail as well.
+  # See https://github.com/NixOS/nixpkgs/pull/75676#issuecomment-567289105
+  preCheck = if isPy3k then null else ''
+    export LC_ALL=C.UTF-8
+  '';
+
   meta = with lib; {
     homepage = http://babel.edgewall.org;
     description = "A collection of tools for internationalizing Python applications";


### PR DESCRIPTION
Fixes #74904.

The test failure:

    File "/build/Babel-2.7.0/babel/messages/pofile.py", line 325, in _invalid_pofile
      print(u"WARNING: Problem on line {0}: {1}".format(lineno + 1, line))
    UnicodeEncodeError: 'ascii' codec can't encode character u'\xe0' in position 84: ordinal not in range(128)

occurs in either of these cases:

* glibc is used and `glibcLocales` is not a `buildInput`
* musl is used and tests are run

`python3Packages.Babel` does not have this problem, on either glibc
or musl.

I also found that the `preCheck` `export LC_ALL="en_US.UTF-8"` is not
necessary in any case.

With this commit,

    python27Packages.Babel
    python3Packages.Babel
    pkgsMusl.python27Packages.Babel
    pkgsMusl.python3Packages.Babel

all build.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

No maintainers listed.

FYI @dtzWill  from #74904.