### PR TITLE
cinnamon.cjs: init at 4.4.0

### DIFF
--- a/pkgs/desktops/cinnamon/cjs/default.nix
+++ b/pkgs/desktops/cinnamon/cjs/default.nix
@@ -1,0 +1,82 @@
+{ autoconf-archive
+, autoreconfHook
+, dbus-glib
+, fetchFromGitHub
+, gobject-introspection
+, pkgconfig
+, stdenv
+, wrapGAppsHook
+, python3
+, cairo
+, gnome3
+, xapps
+, keybinder3
+, upower
+, callPackage
+, glib
+, libffi
+, gtk3
+, readline
+}:
+
+let
+
+  # https://github.com/linuxmint/cjs/issues/80
+  spidermonkey_52 = callPackage ./spidermonkey_52.nix {};
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "cjs";
+  version = "4.4.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "0q5h2pbwysc6hwq5js3lwi6zn7i5qjjy070ynfhfn3z69lw5iz2d";
+  };
+
+  propagatedBuildInputs = [
+    glib
+
+    # bindings
+    gnome3.caribou
+    keybinder3
+    upower
+    xapps
+  ];
+
+  nativeBuildInputs = [
+    autoconf-archive
+    autoreconfHook
+    wrapGAppsHook
+    pkgconfig
+  ];
+
+  buildInputs = [
+    # from .pc
+    gobject-introspection
+    libffi
+    spidermonkey_52 # mozjs-52
+    cairo # +cairo-gobject
+    gtk3
+
+    # other
+
+    dbus-glib
+    readline
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/cjs";
+    description = "JavaScript bindings for Cinnamon";
+
+    longDescription = ''
+      This module contains JavaScript bindings based on gobject-introspection.
+    '';
+
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/desktops/cinnamon/cjs/fix-werror.patch
+++ b/pkgs/desktops/cinnamon/cjs/fix-werror.patch
@@ -1,0 +1,39 @@
+From 1b802175914418f5675047c34f1ab1593dd35b18 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Maciej=20Kr=C3=BCger?= <mkg20001@gmail.com>
+Date: Wed, 8 Jan 2020 11:04:27 +0100
+Subject: [PATCH] fix werror
+
+---
+ js/src/moz.build       | 2 +-
+ js/src/shell/moz.build | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/js/src/moz.build b/js/src/moz.build
+index 1162cb70c..595ea9842 100644
+--- a/js/src/moz.build
++++ b/js/src/moz.build
+@@ -785,7 +785,7 @@ if CONFIG['JS_HAS_CTYPES']:
+         DEFINES['FFI_BUILDING'] = True
+ 
+ if CONFIG['GNU_CXX']:
+-    CXXFLAGS += ['-Wno-shadow', '-Werror=format']
++    CXXFLAGS += ['-Wno-shadow']
+ 
+ # Suppress warnings in third-party code.
+ if CONFIG['CLANG_CXX']:
+diff --git a/js/src/shell/moz.build b/js/src/shell/moz.build
+index 72ea8145c..77475b241 100644
+--- a/js/src/shell/moz.build
++++ b/js/src/shell/moz.build
+@@ -51,7 +51,7 @@ shellmoduleloader.inputs = [
+ ]
+ 
+ if CONFIG['GNU_CXX']:
+-    CXXFLAGS += ['-Wno-shadow', '-Werror=format']
++    CXXFLAGS += ['-Wno-shadow']
+ 
+ # This is intended as a temporary workaround to enable VS2015.
+ if CONFIG['_MSC_VER']:
+-- 
+2.17.1
+

--- a/pkgs/desktops/cinnamon/cjs/spidermonkey_52.nix
+++ b/pkgs/desktops/cinnamon/cjs/spidermonkey_52.nix
@@ -1,0 +1,95 @@
+{ stdenv, fetchurl, fetchpatch, autoconf213, pkgconfig, perl, zip, which, readline, icu, zlib, nspr, buildPackages }:
+
+let
+  version = "52.9.0";
+in stdenv.mkDerivation {
+  pname = "spidermonkey";
+  inherit version;
+
+  src = fetchurl {
+    url = "mirror://mozilla/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz";
+    sha256 = "1mlx34fgh1kaqamrkl5isf0npch3mm6s4lz3jsjb7hakiijhj7f0";
+  };
+
+  outputs = [ "out" "dev" ];
+  setOutputFlags = false; # Configure script only understands --includedir
+
+  buildInputs = [ readline icu zlib nspr ];
+  nativeBuildInputs = [ autoconf213 pkgconfig perl which buildPackages.python2 zip ];
+
+  # Apparently this package fails to build correctly with modern compilers, which at least
+  # on ARMv6 causes polkit testsuite to break with an assertion failure in spidermonkey.
+  # These flags were stolen from:
+  # https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/js52
+  NIX_CFLAGS_COMPILE = "-fno-delete-null-pointer-checks -fno-strict-aliasing -fno-tree-vrp";
+
+  patches = [
+    # needed to build gnome3.gjs
+    (fetchpatch {
+      name = "mozjs52-disable-mozglue.patch";
+      url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/mozjs52-disable-mozglue.patch?h=packages/js52&id=4279d2e18d9a44f6375f584911f63d13de7704be;
+      sha256 = "18wkss0agdyff107p5lfflk72qiz350xqw2yqc353alkx4fsfpz0";
+    })
+    (fetchpatch {
+      url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/no-error.diff?h=packages/js52;
+      sha256 = "1vsw6558lxiy0r1mg6y49cgddan1mfqvqlkyv734bgxyg6n3pb9i";
+    })
+    ./fix-werror.patch
+  ];
+
+  configurePlatforms = [ ];
+
+  preConfigure = ''
+    export CXXFLAGS="-fpermissive"
+    export LIBXUL_DIST=$out
+    export PYTHON="${buildPackages.python2.interpreter}"
+    configureFlagsArray+=("--includedir=$dev/include")
+
+    cd js/src
+
+    autoconf
+  '';
+
+  configureFlags = [
+    "--with-nspr-prefix=${nspr}"
+    "--with-system-zlib"
+    "--with-system-icu"
+    "--with-intl-api"
+    "--enable-readline"
+    "--enable-shared-js"
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-jemalloc"
+    ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "--host=${stdenv.buildPlatform.config}"
+    "--target=${stdenv.hostPlatform.config}"
+  ];
+
+  makeFlags = [
+    "HOST_CC=${buildPackages.stdenv.cc}/bin/cc"
+  ];
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    moveToOutput bin/js52-config "$dev"
+    # Nuke a static lib.
+    rm $out/lib/libjs_static.ajs
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Mozilla's JavaScript engine written in C/C++";
+    homepage = https://developer.mozilla.org/en/SpiderMonkey;
+    license = licenses.gpl2; # TODO: MPL/GPL/LGPL tri-license.
+    maintainers = [ maintainers.abbradar ];
+    platforms = platforms.linux;
+
+    # Commented out so hydra builds the package
+    # (I know what you're thinking now, but cjs won't be pulling anything from the network
+    #  and modules are allowed to execute commands anyways, so an RCE is basically irrelevant)
+    #
+    # knownVulnerabilities = [
+    #   "The runtime was extracted from Firefox 52, which EOL’d on September 5, 2018."
+    # ];
+  };
+}

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -1,5 +1,6 @@
 { pkgs, lib }:
 
 lib.makeScope pkgs.newScope (self: with self; {
-  xapps = callPackage ./xapps {};
+  cjs = callPackage ./cjs { };
+  xapps = callPackage ./xapps { };
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Needed for porting the cinnamon desktop environment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
