### PR TITLE
postgresql: Add ensureExtensions option to service setup

### DIFF
--- a/nixos/tests/postgresql.nix
+++ b/nixos/tests/postgresql.nix
@@ -31,6 +31,7 @@ let
       {
         services.postgresql.enable = true;
         services.postgresql.package = postgresql-package;
+        services.postgresql.ensureExtensions = [ "hstore" ];
 
         services.postgresqlBackup.enable = true;
         services.postgresqlBackup.databases = optional (!backup-all) "postgres";
@@ -61,6 +62,12 @@ let
       machine.succeed(check_count("SELECT * FROM sth;", 5))
       machine.fail(check_count("SELECT * FROM sth;", 4))
       machine.succeed(check_count("SELECT xpath('/test/text()', doc) FROM xmltest;", 1))
+      machine.succeed(
+          check_count(
+              "SELECT * FROM pg_available_extensions WHERE name = 'hstore' AND installed_version is not null",
+              1,
+          )
+      )
 
       # Check backup service
       machine.succeed("systemctl start ${backupService}.service")


### PR DESCRIPTION
###### Motivation for this change

There are still a couple of services that create postgres extensions and databases in preStart,
usually relying on privilege escalation to do it. This change will allow us to simplify extension creation and unify these modules.

Heads up for potential reviewers: The postgresql tests suite currently fails because it also tests the pgbackup service. This service uses command line options that was removed in recent postgres versions. I'll try to address that issue in a separate PR.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice 
