### PR TITLE
postgresql-backup: Use saner defaults for pg_dump

### DIFF
--- a/nixos/modules/services/backup/postgresql-backup.nix
+++ b/nixos/modules/services/backup/postgresql-backup.nix
@@ -89,7 +89,7 @@ in {
 
       pgdumpOptions = mkOption {
         type = types.separatedString " ";
-        default = "-Cbo";
+        default = "-C";
         description = ''
           Command line options for pg_dump. This options is not used
           if <literal>config.services.postgresqlBackup.backupAll</literal> is enabled.


### PR DESCRIPTION
###### Motivation for this change

This change removes defaults from the pg_dump options.
Rational:

- -b : Include large objects in the dump. This is the default behavior except when --schema, --table, or --schema-only is specified. Since this is the case here, the option is simply redundant.
- -o : This option has two issues
  - It is documented as 
    > Dump object identifiers (OIDs) as part of the data for every table. Use this option if your application references the OID columns in some way (e.g., in a foreign key constraint). Otherwise, this option should not be used.
    This option is highly specific to application behavior that requires it and *should not be used otherwise*, making it a poor choice for a default value.
   - It is no longer supported in [recent versions](https://github.com/postgres/postgres/commit/578b229718e8f15fa779e20f086c4b6bb3776106)

Removing these settings seems a saner default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @markuskowa 
