### PR TITLE
dolt: init at 0.12.0

### DIFF
--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -26,7 +26,7 @@
    <title>buildGoModule</title>
 <programlisting>
 pet = buildGoModule rec {
-  name = "pet-${version}";
+  pname = "pet";
   version = "0.3.4";
 
   src = fetchFromGitHub {
@@ -79,7 +79,7 @@ pet = buildGoModule rec {
    <title>buildGoPackage</title>
 <programlisting>
 deis = buildGoPackage rec {
-  name = "deis-${version}";
+  pname = "deis";
   version = "1.13.0";
 
   goPackagePath = "github.com/deis/deis"; <co xml:id='ex-buildGoPackage-1' />

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -10,6 +10,9 @@
 # A function to override the go-modules derivation
 , overrideModAttrs ? (_oldAttrs : {})
 
+# path to go.mod and go.sum directory
+, modRoot ? "./"
+
 # modSha256 is the sha256 of the vendored dependencies
 , modSha256
 
@@ -58,7 +61,7 @@ let
       export GOCACHE=$TMPDIR/go-cache
       export GOPATH="$TMPDIR/go"
       mkdir -p "''${GOPATH}/pkg/mod/cache/download"
-
+      cd "${args.modRoot}"
       runHook postConfigure
     '';
 
@@ -100,6 +103,8 @@ let
       export GOPATH="$TMPDIR/go"
       export GOSUMDB=off
       export GOPROXY=file://${go-modules}
+
+      cd "$modRoot"
 
       runHook postConfigure
     '';

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -61,7 +61,7 @@ let
       export GOCACHE=$TMPDIR/go-cache
       export GOPATH="$TMPDIR/go"
       mkdir -p "''${GOPATH}/pkg/mod/cache/download"
-      cd "${args.modRoot}"
+      cd "${modRoot}"
       runHook postConfigure
     '';
 

--- a/pkgs/servers/sql/dolt/default.nix
+++ b/pkgs/servers/sql/dolt/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, lib, buildGoModule }:
+
+buildGoModule rec {
+    name = "dolt-${version}";
+    version = "0.12.0";
+
+    src = fetchFromGitHub {
+        owner = "liquidata-inc";
+        repo = "dolt";
+        rev = "v${version}";
+        sha256 = "1sy8ia9j5aymjpf3k86fc8yw6384iy9ryd8cl72fr9cp70l7sx1q";
+    };
+
+    modRoot = "./go";
+    subPackages = [ "cmd/dolt" "cmd/git-dolt" "cmd/git-dolt-smudge" ];
+    modSha256 = "0fagi529m1gf5jrqdlg9vxxq4yz9k9q8h92ch0gahp43kxfbgr4q";
+
+    meta = with lib; {
+        description = "Relational database with version control and CLI a-la Git.";
+        homepage = https://github.com/liquidata-inc/dolt;
+        license = licenses.asl20;
+        maintainers = with maintainers; [ danbst ];
+        platforms = platforms.linux ++ platforms.darwin;
+    };
+}

--- a/pkgs/servers/sql/dolt/default.nix
+++ b/pkgs/servers/sql/dolt/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
     meta = with lib; {
         description = "Relational database with version control and CLI a-la Git.";
-        homepage = https://github.com/liquidata-inc/dolt;
+        homepage = "https://github.com/liquidata-inc/dolt";
         license = licenses.asl20;
         maintainers = with maintainers; [ danbst ];
         platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/servers/sql/dolt/default.nix
+++ b/pkgs/servers/sql/dolt/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, lib, buildGoModule }:
 
 buildGoModule rec {
-    name = "dolt-${version}";
+    pname = "dolt";
     version = "0.12.0";
 
     src = fetchFromGitHub {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9876,6 +9876,8 @@ in
 
   doit = callPackage ../development/tools/build-managers/doit { };
 
+  dolt = callPackage ../servers/sql/dolt { };
+
   dot2tex = pythonPackages.dot2tex;
 
   doxygen = callPackage ../development/tools/documentation/doxygen {


### PR DESCRIPTION
###### Motivation for this change
Dolt is an alpha-quality, but actively developing RDBMS with Git-like CLI and data versioning.

To make it build I added a `modRoot` argument to go-modules, to configure path to `go.mod` file.
I could do this with extra overrides, like:
```
            modConfigurePhase = ''
                runHook preConfigure

                export GOCACHE=$TMPDIR/go-cache
                export GOPATH="$TMPDIR/go"
                cd go

                runHook postConfigure
            '';
            preConfigure = ''
                cd go
            '';
```
but this is cleaner. cc @kalbasit 

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
