### PR TITLE
Port NixOs tests to python

### DIFF
--- a/nixos/tests/haproxy.nix
+++ b/nixos/tests/haproxy.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...}: {
+import ./make-test-python.nix ({ pkgs, ...}: {
   name = "haproxy";
   nodes = {
     machine = { ... }: {
@@ -33,11 +33,13 @@ import ./make-test.nix ({ pkgs, ...}: {
     };
   };
   testScript = ''
-    startAll;
-    $machine->waitForUnit('multi-user.target');
-    $machine->waitForUnit('haproxy.service');
-    $machine->waitForUnit('httpd.service');
-    $machine->succeed('curl -k http://localhost:80/index.txt | grep "We are all good!"');
-    $machine->succeed('curl -k http://localhost:80/metrics | grep haproxy_process_pool_allocated_bytes');
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("haproxy.service")
+    machine.wait_for_unit("httpd.service")
+    assert "We are all good!" in machine.succeed("curl -k http://localhost:80/index.txt")
+    assert "haproxy_process_pool_allocated_bytes" in machine.succeed(
+        "curl -k http://localhost:80/metrics"
+    )
   '';
 })

--- a/nixos/tests/initrd-network.nix
+++ b/nixos/tests/initrd-network.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "initrd-network";
 
   meta.maintainers = [ pkgs.stdenv.lib.maintainers.eelco ];
@@ -15,8 +15,8 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   testScript =
     ''
-      startAll;
-      $machine->waitForUnit("multi-user.target");
-      $machine->succeed("ip link >&2");
+      start_all()
+      machine.wait_for_unit("multi-user.target")
+      machine.succeed("ip link >&2")
     '';
 })

--- a/nixos/tests/leaps.nix
+++ b/nixos/tests/leaps.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs,  ... }:
+import ./make-test-python.nix ({ pkgs,  ... }:
 
 {
   name = "leaps";
@@ -22,9 +22,11 @@ import ./make-test.nix ({ pkgs,  ... }:
 
   testScript =
     ''
-      startAll;
-      $server->waitForOpenPort(6666);
-      $client->waitForUnit("network.target");
-      $client->succeed("${pkgs.curl}/bin/curl http://server:6666/leaps/ | grep -i 'leaps'");
+      start_all()
+      server.wait_for_open_port(6666)
+      client.wait_for_unit("network.target")
+      assert "leaps" in client.succeed(
+          "${pkgs.curl}/bin/curl http://server:6666/leaps/"
+      )
     '';
 })

--- a/nixos/tests/lidarr.nix
+++ b/nixos/tests/lidarr.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test-python.nix ({ lib, ... }:
 
 with lib;
 
@@ -11,8 +11,10 @@ with lib;
     { services.lidarr.enable = true; };
 
   testScript = ''
-    $machine->waitForUnit('lidarr.service');
-    $machine->waitForOpenPort('8686');
-    $machine->succeed("curl --fail http://localhost:8686/");
+    start_all()
+
+    machine.wait_for_unit("lidarr.service")
+    machine.wait_for_open_port("8686")
+    machine.succeed("curl --fail http://localhost:8686/")
   '';
 })

--- a/nixos/tests/mailcatcher.nix
+++ b/nixos/tests/mailcatcher.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test-python.nix ({ lib, ... }:
 
 {
   name = "mailcatcher";
@@ -16,11 +16,15 @@ import ./make-test.nix ({ lib, ... }:
     };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $machine->waitForUnit('mailcatcher.service');
-    $machine->waitForOpenPort('1025');
-    $machine->succeed('echo "this is the body of the email" | mail -s "subject" root@example.org');
-    $machine->succeed('curl http://localhost:1080/messages/1.source') =~ /this is the body of the email/ or die;
+    machine.wait_for_unit("mailcatcher.service")
+    machine.wait_for_open_port("1025")
+    machine.succeed(
+        'echo "this is the body of the email" | mail -s "subject" root@example.org'
+    )
+    assert "this is the body of the email" in machine.succeed(
+        "curl http://localhost:1080/messages/1.source"
+    )
   '';
 })

--- a/nixos/tests/wireguard/namespaces.nix
+++ b/nixos/tests/wireguard/namespaces.nix
@@ -13,7 +13,7 @@ let
 
 in
 
-import ../make-test.nix ({ pkgs, ...} : {
+import ../make-test-python.nix ({ pkgs, ...} : {
   name = "wireguard-with-namespaces";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ asymmetric ];
@@ -65,16 +65,14 @@ import ../make-test.nix ({ pkgs, ...} : {
   };
 
   testScript = ''
-    startAll();
+    start_all()
 
-    $peer0->waitForUnit("wireguard-wg0.service");
-    $peer1->waitForUnit("wireguard-wg0.service");
-    $peer2->waitForUnit("wireguard-wg0.service");
-    $peer3->waitForUnit("wireguard-wg0.service");
+    for machine in peer0, peer1, peer2, peer3:
+        machine.wait_for_unit("wireguard-wg0.service")
 
-    $peer0->succeed("ip -n ${socketNamespace} link show wg0");
-    $peer1->succeed("ip -n ${interfaceNamespace} link show wg0");
-    $peer2->succeed("ip -n ${interfaceNamespace} link show wg0");
-    $peer3->succeed("ip link show wg0");
+    peer0.succeed("ip -n ${socketNamespace} link show wg0")
+    peer1.succeed("ip -n ${interfaceNamespace} link show wg0")
+    peer2.succeed("ip -n ${interfaceNamespace} link show wg0")
+    peer3.succeed("ip link show wg0")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc 
