### PR TITLE
Port NixOS tests to python

### DIFF
--- a/nixos/tests/pdns-recursor.nix
+++ b/nixos/tests/pdns-recursor.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test-python.nix ({ pkgs, ... }: {
   name = "powerdns";
 
   nodes.server = { ... }: {
@@ -6,7 +6,7 @@ import ./make-test.nix ({ pkgs, ... }: {
   };
 
   testScript = ''
-    $server->waitForUnit("pdns-recursor");
-    $server->waitForOpenPort("53");
+    server.wait_for_unit("pdns-recursor")
+    server.wait_for_open_port("53")
   '';
 })

--- a/nixos/tests/peerflix.nix
+++ b/nixos/tests/peerflix.nix
@@ -1,6 +1,6 @@
 # This test runs peerflix and checks if peerflix starts
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "peerflix";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ offline ];
@@ -15,9 +15,9 @@ import ./make-test.nix ({ pkgs, ...} : {
     };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $peerflix->waitForUnit("peerflix.service");
-    $peerflix->waitUntilSucceeds("curl localhost:9000");
+    peerflix.wait_for_unit("peerflix.service")
+    peerflix.wait_until_succeeds("curl localhost:9000")
   '';
 })

--- a/nixos/tests/pgmanage.nix
+++ b/nixos/tests/pgmanage.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... } :
+import ./make-test-python.nix ({ pkgs, ... } :
 let
   role     = "test";
   password = "secret";
@@ -29,11 +29,13 @@ in
   };
 
   testScript = ''
-    startAll;
-    $one->waitForUnit("default.target");
-    $one->requireActiveUnit("pgmanage.service");
+    start_all()
+    one.wait_for_unit("default.target")
+    one.require_unit_state("pgmanage.service", "active")
 
     # Test if we can log in.
-    $one->waitUntilSucceeds("curl 'http://localhost:8080/pgmanage/auth' --data 'action=login&connname=${conn}&username=${role}&password=${password}' --fail");
+    one.wait_until_succeeds(
+        "curl 'http://localhost:8080/pgmanage/auth' --data 'action=login&connname=${conn}&username=${role}&password=${password}' --fail"
+    )
   '';
 })

--- a/nixos/tests/php-pcre.nix
+++ b/nixos/tests/php-pcre.nix
@@ -1,7 +1,7 @@
 
 let testString = "can-use-subgroups"; in
 
-import ./make-test.nix ({ ...}: {
+import ./make-test-python.nix ({ ...}: {
   name = "php-httpd-pcre-jit-test";
   machine = { lib, pkgs, ... }: {
     time.timeZone = "UTC";
@@ -31,9 +31,10 @@ import ./make-test.nix ({ ...}: {
   };
   testScript = { ... }:
   ''
-    $machine->waitForUnit('httpd.service');
+    machine.wait_for_unit("httpd.service")
     # Ensure php evaluation by matching on the var_dump syntax
-    $machine->succeed('curl -vvv -s http://127.0.0.1:80/index.php \
-      | grep "string(${toString (builtins.stringLength testString)}) \"${testString}\""');
+    assert 'string(${toString (builtins.stringLength testString)}) "${testString}"' in machine.succeed(
+        "curl -vvv -s http://127.0.0.1:80/index.php"
+    )
   '';
 })

--- a/nixos/tests/postgis.nix
+++ b/nixos/tests/postgis.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "postgis";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ lsix ];
@@ -20,10 +20,10 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   testScript = ''
-    startAll;
-    $master->waitForUnit("postgresql");
-    $master->sleep(10); # Hopefully this is long enough!!
-    $master->succeed("sudo -u postgres psql -c 'CREATE EXTENSION postgis;'");
-    $master->succeed("sudo -u postgres psql -c 'CREATE EXTENSION postgis_topology;'");
+    start_all()
+    master.wait_for_unit("postgresql")
+    master.sleep(10)  # Hopefully this is long enough!!
+    master.succeed("sudo -u postgres psql -c 'CREATE EXTENSION postgis;'")
+    master.succeed("sudo -u postgres psql -c 'CREATE EXTENSION postgis_topology;'")
   '';
 })

--- a/nixos/tests/sonarr.nix
+++ b/nixos/tests/sonarr.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }:
+import ./make-test-python.nix ({ lib, ... }:
 
 with lib;
 
@@ -11,8 +11,8 @@ with lib;
     { services.sonarr.enable = true; };
 
   testScript = ''
-    $machine->waitForUnit('sonarr.service');
-    $machine->waitForOpenPort('8989');
-    $machine->succeed("curl --fail http://localhost:8989/");
+    machine.wait_for_unit("sonarr.service")
+    machine.wait_for_open_port("8989")
+    machine.succeed("curl --fail http://localhost:8989/")
   '';
 })

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -1,6 +1,6 @@
 # Test configuration switching.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "switch-test";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ gleber ];
@@ -28,7 +28,11 @@ import ./make-test.nix ({ pkgs, ...} : {
       exec env -i "$@" | tee /dev/stderr
     '';
   in ''
-    $machine->succeed("${stderrRunner} ${originalSystem}/bin/switch-to-configuration test");
-    $machine->succeed("${stderrRunner} ${otherSystem}/bin/switch-to-configuration test");
+    machine.succeed(
+        "${stderrRunner} ${originalSystem}/bin/switch-to-configuration test"
+    )
+    machine.succeed(
+        "${stderrRunner} ${otherSystem}/bin/switch-to-configuration test"
+    )
   '';
 })

--- a/nixos/tests/systemd-timesyncd.nix
+++ b/nixos/tests/systemd-timesyncd.nix
@@ -1,7 +1,7 @@
 # Regression test for systemd-timesync having moved the state directory without
 # upstream providing a migration path. https://github.com/systemd/systemd/issues/12131
 
-import ./make-test.nix (let
+import ./make-test-python.nix (let
   common = { lib, ... }: {
     # override the `false` value from the qemu-vm base profile
     services.timesyncd.enable = lib.mkForce true;
@@ -25,28 +25,28 @@ in {
   };
 
   testScript = ''
-    startAll;
-    $current->succeed('systemctl status systemd-timesyncd.service');
+    start_all()
+    current.succeed("systemctl status systemd-timesyncd.service")
     # on a new install with a recent systemd there should not be any
     # leftovers from the dynamic user mess
-    $current->succeed('test -e /var/lib/systemd/timesync');
-    $current->succeed('test ! -L /var/lib/systemd/timesync');
+    current.succeed("test -e /var/lib/systemd/timesync")
+    current.succeed("test ! -L /var/lib/systemd/timesync")
 
     # timesyncd should be running on the upgrading system since we fixed the
     # file bits in the activation script
-    $pre1909->succeed('systemctl status systemd-timesyncd.service');
+    pre1909.succeed("systemctl status systemd-timesyncd.service")
 
     # the path should be gone after the migration
-    $pre1909->succeed('test ! -e /var/lib/private/systemd/timesync');
+    pre1909.succeed("test ! -e /var/lib/private/systemd/timesync")
 
     # and the new path should no longer be a symlink
-    $pre1909->succeed('test -e /var/lib/systemd/timesync');
-    $pre1909->succeed('test ! -L /var/lib/systemd/timesync');
+    pre1909.succeed("test -e /var/lib/systemd/timesync")
+    pre1909.succeed("test ! -L /var/lib/systemd/timesync")
 
     # after a restart things should still work and not fail in the activation
     # scripts and cause the boot to fail..
-    $pre1909->shutdown;
-    $pre1909->start;
-    $pre1909->succeed('systemctl status systemd-timesyncd.service');
+    pre1909.shutdown()
+    pre1909.start()
+    pre1909.succeed("systemctl status systemd-timesyncd.service")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc
