### PR TITLE
Port NixOS tests to python

### DIFF
--- a/nixos/tests/mutable-users.nix
+++ b/nixos/tests/mutable-users.nix
@@ -1,6 +1,6 @@
 # Mutable users tests.
 
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "mutable-users";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ gleber ];
@@ -19,21 +19,27 @@ import ./make-test.nix ({ pkgs, ...} : {
     immutableSystem = nodes.machine.config.system.build.toplevel;
     mutableSystem = nodes.mutable.config.system.build.toplevel;
   in ''
-    $machine->start();
-    $machine->waitForUnit("default.target");
+    machine.start()
+    machine.wait_for_unit("default.target")
 
     # Machine starts in immutable mode. Add a user and test if reactivating
     # configuration removes the user.
-    $machine->fail("cat /etc/passwd | grep ^foobar:");
-    $machine->succeed("sudo useradd foobar");
-    $machine->succeed("cat /etc/passwd | grep ^foobar:");
-    $machine->succeed("${immutableSystem}/bin/switch-to-configuration test");
-    $machine->fail("cat /etc/passwd | grep ^foobar:");
+    with subtest("Machine in immutable mode"):
+        assert "foobar" not in machine.succeed("cat /etc/passwd")
+        machine.succeed("sudo useradd foobar")
+        assert "foobar" in machine.succeed("cat /etc/passwd")
+        machine.succeed(
+            "${immutableSystem}/bin/switch-to-configuration test"
+        )
+        assert "foobar" not in machine.succeed("cat /etc/passwd")
 
     # In immutable mode passwd is not wrapped, while in mutable mode it is
     # wrapped.
-    $machine->succeed('which passwd | grep /run/current-system/');
-    $machine->succeed("${mutableSystem}/bin/switch-to-configuration test");
-    $machine->succeed('which passwd | grep /run/wrappers/');
+    with subtest("Password is wrapped in mutable mode"):
+        assert "/run/current-system/" in machine.succeed("which passwd")
+        machine.succeed(
+            "${mutableSystem}/bin/switch-to-configuration test"
+        )
+        assert "/run/wrappers/" in machine.succeed("which passwd")
   '';
 })

--- a/nixos/tests/mxisd.nix
+++ b/nixos/tests/mxisd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... } : {
+import ./make-test-python.nix ({ pkgs, ... } : {
 
   name = "mxisd";
   meta = with pkgs.stdenv.lib.maintainers; {
@@ -19,13 +19,12 @@ import ./make-test.nix ({ pkgs, ... } : {
   };
 
   testScript = ''
-    startAll;
-    $server_mxisd->waitForUnit("mxisd.service");
-    $server_mxisd->waitForOpenPort(8090);
-    $server_mxisd->succeed("curl -Ssf \"http://127.0.0.1:8090/_matrix/identity/api/v1\"");
-    $server_ma1sd->waitForUnit("mxisd.service");
-    $server_ma1sd->waitForOpenPort(8090);
-    $server_ma1sd->succeed("curl -Ssf \"http://127.0.0.1:8090/_matrix/identity/api/v1\"")
-
+    start_all()
+    server_mxisd.wait_for_unit("mxisd.service")
+    server_mxisd.wait_for_open_port(8090)
+    server_mxisd.succeed("curl -Ssf 'http://127.0.0.1:8090/_matrix/identity/api/v1'")
+    server_ma1sd.wait_for_unit("mxisd.service")
+    server_ma1sd.wait_for_open_port(8090)
+    server_ma1sd.succeed("curl -Ssf 'http://127.0.0.1:8090/_matrix/identity/api/v1'")
   '';
 })

--- a/nixos/tests/nesting.nix
+++ b/nixos/tests/nesting.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix {
+import ./make-test-python.nix {
   name = "nesting";
   nodes =  {
     clone = { pkgs, ... }: {
@@ -19,24 +19,26 @@ import ./make-test.nix {
     };
   };
   testScript = ''
-    $clone->waitForUnit("default.target");
-    $clone->succeed("cowsay hey");
-    $clone->fail("hello");
+    clone.wait_for_unit("default.target")
+    clone.succeed("cowsay hey")
+    clone.fail("hello")
 
-    # Nested clones do inherit from parent
-    $clone->succeed("/run/current-system/fine-tune/child-1/bin/switch-to-configuration test");
-    $clone->succeed("cowsay hey");
-    $clone->succeed("hello");
+    with subtest("Nested clones do inherit from parent"):
+        clone.succeed(
+            "/run/current-system/fine-tune/child-1/bin/switch-to-configuration test"
+        )
+        clone.succeed("cowsay hey")
+        clone.succeed("hello")
     
+        children.wait_for_unit("default.target")
+        children.succeed("cowsay hey")
+        children.fail("hello")
 
-    $children->waitForUnit("default.target");
-    $children->succeed("cowsay hey");
-    $children->fail("hello");
-
-    # Nested children do not inherit from parent
-    $children->succeed("/run/current-system/fine-tune/child-1/bin/switch-to-configuration test");
-    $children->fail("cowsay hey");
-    $children->succeed("hello");
-
+    with subtest("Nested children do not inherit from parent"):
+        children.succeed(
+            "/run/current-system/fine-tune/child-1/bin/switch-to-configuration test"
+        )
+        children.fail("cowsay hey")
+        children.succeed("hello")
   '';
 }

--- a/nixos/tests/nghttpx.nix
+++ b/nixos/tests/nghttpx.nix
@@ -1,7 +1,7 @@
 let
   nginxRoot = "/run/nginx";
 in
-  import ./make-test.nix ({...}: {
+  import ./make-test-python.nix ({...}: {
     name  = "nghttpx";
     nodes = {
       webserver = {
@@ -52,10 +52,10 @@ in
     };
 
     testScript = ''
-      startAll;
+      start_all()
 
-      $webserver->waitForOpenPort("80");
-      $proxy->waitForOpenPort("80");
-      $client->waitUntilSucceeds("curl -s --fail http://proxy/hello-world.txt");
+      webserver.wait_for_open_port("80")
+      proxy.wait_for_open_port("80")
+      client.wait_until_succeeds("curl -s --fail http://proxy/hello-world.txt")
     '';
   })

--- a/nixos/tests/novacomd.nix
+++ b/nixos/tests/novacomd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "novacomd";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ dtzWill ];
@@ -9,26 +9,20 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   testScript = ''
-    $machine->waitForUnit("multi-user.target");
+    machine.wait_for_unit("novacomd.service")
 
-    # multi-user.target wants novacomd.service, but let's make sure
-    $machine->waitForUnit("novacomd.service");
+    with subtest("Make sure the daemon is really listening"):
+        machine.wait_for_open_port(6968)
+        machine.succeed("novacom -l")
 
-    # Check status and try connecting with novacom
-    $machine->succeed("systemctl status novacomd.service >&2");
-    # to prevent non-deterministic failure,
-    # make sure the daemon is really listening
-    $machine->waitForOpenPort(6968);
-    $machine->succeed("novacom -l");
+    with subtest("Stop the daemon, double-check novacom fails if daemon isn't working"):
+        machine.stop_job("novacomd")
+        machine.fail("novacom -l")
 
-    # Stop the daemon, double-check novacom fails if daemon isn't working
-    $machine->stopJob("novacomd");
-    $machine->fail("novacom -l");
-
-    # And back again for good measure
-    $machine->startJob("novacomd");
-    # make sure the daemon is really listening
-    $machine->waitForOpenPort(6968);
-    $machine->succeed("novacom -l");
+    with subtest("Make sure the daemon starts back up again"):
+        machine.start_job("novacomd")
+        # make sure the daemon is really listening
+        machine.wait_for_open_port(6968)
+        machine.succeed("novacom -l")
   '';
 })

--- a/nixos/tests/nzbget.nix
+++ b/nixos/tests/nzbget.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : {
+import ./make-test-python.nix ({ pkgs, ...} : {
   name = "nzbget";
   meta = with pkgs.stdenv.lib.maintainers; {
     maintainers = [ aanderse flokli ];
@@ -15,12 +15,16 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $server->waitForUnit("nzbget.service");
-    $server->waitForUnit("network.target");
-    $server->waitForOpenPort(6789);
-    $server->succeed("curl -s -u nzbget:tegbzn6789 http://127.0.0.1:6789 | grep -q 'This file is part of nzbget'");
-    $server->succeed("${pkgs.nzbget}/bin/nzbget -n -o ControlIP=127.0.0.1 -o ControlPort=6789 -o ControlPassword=tegbzn6789 -V");
+    server.wait_for_unit("nzbget.service")
+    server.wait_for_unit("network.target")
+    server.wait_for_open_port(6789)
+    assert "This file is part of nzbget" in server.succeed(
+        "curl -s -u nzbget:tegbzn6789 http://127.0.0.1:6789"
+    )
+    server.succeed(
+        "${pkgs.nzbget}/bin/nzbget -n -o Control_iP=127.0.0.1 -o Control_port=6789 -o Control_password=tegbzn6789 -V"
+    )
   '';
 })

--- a/nixos/tests/osrm-backend.nix
+++ b/nixos/tests/osrm-backend.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+import ./make-test-python.nix ({ pkgs, lib, ... }:
 let
   port = 5000;
 in {
@@ -45,9 +45,13 @@ in {
   testScript = let
     query = "http://localhost:${toString port}/route/v1/driving/7.41720,43.73304;7.42463,43.73886?steps=true";
   in ''
-    $machine->waitForUnit("osrm.service");
-    $machine->waitForOpenPort(${toString port});
-    $machine->succeed("curl --silent '${query}' | jq .waypoints[0].name | grep -F 'Boulevard Rainier III'");
-    $machine->succeed("curl --silent '${query}' | jq .waypoints[1].name | grep -F 'Avenue de la Costa'");
+    machine.wait_for_unit("osrm.service")
+    machine.wait_for_open_port(${toString port})
+    assert "Boulevard Rainier III" in machine.succeed(
+        "curl --silent '${query}' | jq .waypoints[0].name"
+    )
+    assert "Avenue de la Costa" in machine.succeed(
+        "curl --silent '${query}' | jq .waypoints[1].name"
+    )
   '';
 })

--- a/nixos/tests/overlayfs.nix
+++ b/nixos/tests/overlayfs.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ... }: {
+import ./make-test-python.nix ({ pkgs, ... }: {
   name = "overlayfs";
   meta.maintainers = with pkgs.stdenv.lib.maintainers; [ bachp ];
 
@@ -9,49 +9,42 @@ import ./make-test.nix ({ pkgs, ... }: {
   };
 
   testScript = ''
-    $machine->succeed("ls /dev");
+    machine.succeed("ls /dev")
 
-    $machine->succeed("mkdir -p /tmp/mnt");
+    machine.succeed("mkdir -p /tmp/mnt")
 
     # Test ext4 + overlayfs
-    $machine->succeed(
-
-      "mkfs.ext4 -F -L overlay-ext4 /dev/vdb",
-      "mount -t ext4 /dev/vdb /tmp/mnt",
-
-      "mkdir -p /tmp/mnt/upper /tmp/mnt/lower /tmp/mnt/work /tmp/mnt/merged",
-
-      # Setup some existing files
-      "echo 'Replace' > /tmp/mnt/lower/replace.txt",
-      "echo 'Append' > /tmp/mnt/lower/append.txt",
-      "echo 'Overwrite' > /tmp/mnt/lower/overwrite.txt",
-
-      "mount -t overlay overlay -o lowerdir=/tmp/mnt/lower,upperdir=/tmp/mnt/upper,workdir=/tmp/mnt/work /tmp/mnt/merged",
-
-      # Test new
-      "echo 'New' > /tmp/mnt/merged/new.txt",
-      "[[ \"\$(cat /tmp/mnt/merged/new.txt)\" == \"New\" ]]",
-
-      # Test replace
-      "[[ \"\$(cat /tmp/mnt/merged/replace.txt)\" == \"Replace\" ]]",
-      "echo 'Replaced' > /tmp/mnt/merged/replace-tmp.txt",
-      "mv /tmp/mnt/merged/replace-tmp.txt /tmp/mnt/merged/replace.txt",
-      "[[ \"\$(cat /tmp/mnt/merged/replace.txt)\" == \"Replaced\" ]]",
-
-      # Overwrite
-      "[[ \"\$(cat /tmp/mnt/merged/overwrite.txt)\" == \"Overwrite\" ]]",
-      "echo 'Overwritten' > /tmp/mnt/merged/overwrite.txt",
-      "[[ \"\$(cat /tmp/mnt/merged/overwrite.txt)\" == \"Overwritten\" ]]",
-
-      # Test append
-      "[[ \"\$(cat /tmp/mnt/merged/append.txt)\" == \"Append\" ]]",
-      "echo 'ed' >> /tmp/mnt/merged/append.txt",
-      #"cat /tmp/mnt/merged/append.txt && exit 1",
-      "[[ \"\$(cat /tmp/mnt/merged/append.txt)\" == \"Append\ned\" ]]",
-
-      "umount /tmp/mnt/merged",
-      "umount /tmp/mnt",
-      "udevadm settle"
-    );
+    machine.succeed(
+        """
+          mkfs.ext4 -F -L overlay-ext4 /dev/vdb
+          mount -t ext4 /dev/vdb /tmp/mnt
+          mkdir -p /tmp/mnt/upper /tmp/mnt/lower /tmp/mnt/work /tmp/mnt/merged
+          # Setup some existing files
+          echo 'Replace' > /tmp/mnt/lower/replace.txt
+          echo 'Append' > /tmp/mnt/lower/append.txt
+          echo 'Overwrite' > /tmp/mnt/lower/overwrite.txt
+          mount -t overlay overlay -o lowerdir=/tmp/mnt/lower,upperdir=/tmp/mnt/upper,workdir=/tmp/mnt/work /tmp/mnt/merged
+          # Test new
+          echo 'New' > /tmp/mnt/merged/new.txt
+          [[ "\$(cat /tmp/mnt/merged/new.txt)" == "New" ]]
+          # Test replace
+          [[ "\$(cat /tmp/mnt/merged/replace.txt)" == "Replace" ]]
+          echo 'Replaced' > /tmp/mnt/merged/replace-tmp.txt
+          mv /tmp/mnt/merged/replace-tmp.txt /tmp/mnt/merged/replace.txt
+          [[ "\$(cat /tmp/mnt/merged/replace.txt)" == "Replaced" ]]
+          # Overwrite
+          [[ "\$(cat /tmp/mnt/merged/overwrite.txt)" == "Overwrite" ]]
+          echo 'Overwritten' > /tmp/mnt/merged/overwrite.txt
+          [[ "\$(cat /tmp/mnt/merged/overwrite.txt)" == "Overwritten" ]]
+          # Test append
+          [[ "\$(cat /tmp/mnt/merged/append.txt)" == "Append" ]]
+          echo 'ed' >> /tmp/mnt/merged/append.txt
+          #"cat /tmp/mnt/merged/append.txt && exit 1
+          [[ "\$(cat /tmp/mnt/merged/append.txt)" == "Append\ned" ]]
+          umount /tmp/mnt/merged
+          umount /tmp/mnt
+          udevadm settle
+      """
+    )
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc
