### PR TITLE
hqemu: init at 2.5.2

### DIFF
--- a/pkgs/applications/virtualization/hqemu/9p-ignore-noatime.patch
+++ b/pkgs/applications/virtualization/hqemu/9p-ignore-noatime.patch
@@ -1,0 +1,14 @@
+context-adjusted adaptation of upstream commit cdc3e7eeafa9f683214d2c15d52ef384c3de6611
+
+diff --git a/hw/9pfs/9p.c b/hw/9pfs/9p.c
+index 55821343e5..0b8425fe18 100644
+--- a/hw/9pfs/virtio-9p.c
++++ b/hw/9pfs/virtio-9p.c
+@@ -100,7 +100,6 @@ static int dotl_to_open_flags(int flags)
+         { P9_DOTL_LARGEFILE, O_LARGEFILE },
+         { P9_DOTL_DIRECTORY, O_DIRECTORY },
+         { P9_DOTL_NOFOLLOW, O_NOFOLLOW },
+-        { P9_DOTL_NOATIME, O_NOATIME },
+         { P9_DOTL_SYNC, O_SYNC },
+     };
+ 

--- a/pkgs/applications/virtualization/hqemu/default.nix
+++ b/pkgs/applications/virtualization/hqemu/default.nix
@@ -1,0 +1,159 @@
+{ stdenv, fetchurl, python, zlib, pkgconfig, glib
+, ncurses, perl, pixman, vde2, alsaLib, texinfo, flex
+, bison, lzo, snappy, libaio, gnutls, nettle, curl, llvmPackages_6
+, makeWrapper
+, attr, libcap, libcap_ng
+, numaSupport ? stdenv.isLinux && !stdenv.isAarch32, numactl
+, seccompSupport ? false, libseccomp
+, pulseSupport ? true, libpulseaudio
+, sdlSupport ? true, SDL
+, gtkSupport ? true, gtk3, gettext, vte
+, vncSupport ? true, libjpeg, libpng
+, spiceSupport ? true, spice, spice-protocol
+, usbredirSupport ? spiceSupport, usbredir
+, cephSupport ? false, ceph
+, openGLSupport ? sdlSupport, mesa, epoxy, libdrm
+, virglSupport ? openGLSupport, virglrenderer
+, smbdSupport ? false, samba
+, hostCpuOnly ? false
+, hostCpuTargets ? (if hostCpuOnly
+                    then (stdenv.lib.optional stdenv.isx86_64 "i386-softmmu"
+                          ++ ["${stdenv.hostPlatform.qemuArch}-softmmu"])
+                    else null)
+}:
+
+with stdenv.lib;
+
+let
+  supportedTargets = crossLists (a: b: "${a}-${b}") [
+    [ "i386" "x86_64" "aarch64" "arm" ]
+    ([ "softmmu" ] ++ optional stdenv.isLinux "linux-user")
+  ];
+  # leaving the target list unspecified causes broken targets to be built too
+  hostCpuTargets_ = if hostCpuTargets != null then hostCpuTargets else supportedTargets;
+  unsupportedTargets = subtractLists supportedTargets hostCpuTargets_;
+in
+  assert unsupportedTargets == [];
+
+let
+  audio = optionalString (hasSuffix "linux" stdenv.hostPlatform.system) "alsa,"
+    + optionalString pulseSupport "pa,"
+    + optionalString sdlSupport "sdl,";
+
+  version = "2.5.2";
+  src = fetchurl {
+    name = "hqemu-${version}.tar.gz";
+    url = "http://csl.iis.sinica.edu.tw/hqemu/download.php?v=${version}";
+    sha256 = "1h92c9m1458drvkfpbgxxyvvpk7x99l021ls61j73cldhxnjmgpg";
+  };
+  llvmPatch = stdenv.mkDerivation {
+    inherit src;
+    name = "llvm-hqemu.patch";
+    installPhase = "cp patch/llvm/llvm-6.0.patch $out";
+    phases = ["unpackPhase" "installPhase"];
+  };
+  llvmTools = llvmPackages_6.tools.extend (self: super: {
+    llvm = super.llvm.overrideAttrs (super_: { patches = super_.patches ++ [ llvmPatch ]; });
+  });
+in
+
+stdenv.mkDerivation rec {
+  inherit src version;
+  pname = "hqemu";
+
+  nativeBuildInputs = [ python python.pkgs.sphinx pkgconfig flex bison ];
+  buildInputs =
+    [ zlib glib ncurses perl pixman
+      vde2 texinfo makeWrapper lzo snappy
+      gnutls nettle curl llvmTools.llvm llvmTools.clang
+    ]
+    ++ optionals seccompSupport [ libseccomp ]
+    ++ optionals numaSupport [ numactl ]
+    ++ optionals pulseSupport [ libpulseaudio ]
+    ++ optionals sdlSupport [ SDL ]
+    ++ optionals gtkSupport [ gtk3 gettext vte ]
+    ++ optionals vncSupport [ libjpeg libpng ]
+    ++ optionals spiceSupport [ spice-protocol spice ]
+    ++ optionals usbredirSupport [ usbredir ]
+    ++ optionals stdenv.isLinux [ alsaLib libaio libcap_ng libcap attr ]
+    ++ optionals cephSupport [ ceph ]
+    ++ optionals openGLSupport [ mesa epoxy libdrm ]
+    ++ optionals virglSupport [ virglrenderer ]
+    ++ optionals smbdSupport [ samba ];
+
+  enableParallelBuilding = true;
+
+  outputs = [ "out" "ga" ];
+
+  patches = [
+    ./no-etc-install.patch
+    ./fix-qemu-ga.patch
+    ./9p-ignore-noatime.patch
+  ];
+
+  # avoid an apparent collision in registered command-line parameters
+  postPatch = ''
+    substituteInPlace llvm/llvm.cpp --replace '"threads"' '"hthreads"'
+  '';
+
+  hardeningDisable = [ "stackprotector" ];
+
+  preConfigure = ''
+    unset CPP # intereferes with dependency calculation
+  '' + optionalString stdenv.hostPlatform.isMusl ''
+    NIX_CFLAGS_COMPILE+=" -D_LINUX_SYSINFO_H"
+  '';
+
+  configureFlags =
+    [ "--audio-drv-list=${audio}"
+      "--sysconfdir=/etc"
+      "--localstatedir=/var"
+      "--enable-docs"
+      "--enable-llvm"
+    ]
+    ++ optional numaSupport "--enable-numa"
+    ++ optional seccompSupport "--enable-seccomp"
+    ++ optional spiceSupport "--enable-spice"
+    ++ optional usbredirSupport "--enable-usb-redir"
+    ++ optional (hostCpuTargets_ != null) "--target-list=${stdenv.lib.concatStringsSep "," hostCpuTargets_}"
+    ++ optional stdenv.isLinux "--enable-linux-aio"
+    ++ optional gtkSupport "--enable-gtk"
+    ++ optional cephSupport "--enable-rbd"
+    ++ optional openGLSupport "--enable-opengl"
+    ++ optional virglSupport "--enable-virglrenderer"
+    ++ optional smbdSupport "--smbd=${samba}/bin/smbd";
+
+  doCheck = false; # tries to access /dev
+
+  postFixup =
+    ''
+      # copy qemu-ga (guest agent) to separate output
+      mkdir -p $ga/bin
+      cp $out/bin/qemu-ga $ga/bin/
+    '';
+
+  # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.
+  postInstall = ''
+    if [ -x $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} ]; then
+      makeWrapper $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} \
+                  $out/bin/qemu-kvm \
+                  --add-flags "\$([ -e /dev/kvm ] && echo -enable-kvm)"
+    fi
+  '';
+
+  passthru = {
+    qemu-system-i386 = "bin/qemu-system-i386";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = http://csl.iis.sinica.edu.tw/hqemu/;
+    description = "QEMU fork with LLVM optimizations for binary translation hot-spots";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ ris ];
+    platforms = platforms.linux;
+    knownVulnerabilities = [''
+      Being based on QEMU 2.5.0, this is presumably vulnerable to all QEMU weaknesses
+      discovered after that.
+    ''];
+  };
+}

--- a/pkgs/applications/virtualization/hqemu/fix-qemu-ga.patch
+++ b/pkgs/applications/virtualization/hqemu/fix-qemu-ga.patch
@@ -1,0 +1,22 @@
+diff --git a/qga/commands-posix.c b/qga/commands-posix.c
+index 0dc219d..9d020d3 100644
+--- a/qga/commands-posix.c
++++ b/qga/commands-posix.c
+@@ -102,6 +102,8 @@ void qmp_guest_shutdown(bool has_mode, const char *mode, Error **errp)
+         reopen_fd_to_null(1);
+         reopen_fd_to_null(2);
+
++        execle("/run/current-system/sw/bin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
++               "hypervisor initiated shutdown", (char*)NULL, environ);
+         execle("/sbin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
+                "hypervisor initiated shutdown", (char*)NULL, environ);
+         _exit(EXIT_FAILURE);
+@@ -189,6 +191,8 @@ void qmp_guest_set_time(bool has_time, int64_t time_ns, Error **errp)
+
+         /* Use '/sbin/hwclock -w' to set RTC from the system time,
+          * or '/sbin/hwclock -s' to set the system time from RTC. */
++        execle("/run/current-system/sw/bin/hwclock", "hwclock", has_time ? "-w" : "-s",
++               NULL, environ);
+         execle("/sbin/hwclock", "hwclock", has_time ? "-w" : "-s",
+                NULL, environ);
+         _exit(EXIT_FAILURE);

--- a/pkgs/applications/virtualization/hqemu/no-etc-install.patch
+++ b/pkgs/applications/virtualization/hqemu/no-etc-install.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 85862fb8..ed52c5ec 100644
+--- a/Makefile
++++ b/Makefile
+@@ -438,7 +438,7 @@ endif
+ 
+ 
+ install: all $(if $(BUILD_DOCS),install-doc) \
+-install-datadir install-localstatedir
++install-datadir
+ ifneq ($(TOOLS),)
+	$(call install-prog,$(subst qemu-ga,qemu-ga$(EXESUF),$(TOOLS)),$(DESTDIR)$(bindir))
+ endif

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20740,6 +20740,10 @@ in
 
   qdirstat = libsForQt5.callPackage ../applications/misc/qdirstat {};
 
+  hqemu = callPackage ../applications/virtualization/hqemu {
+    python = python2;
+  };
+
   qemu = callPackage ../applications/virtualization/qemu {
     inherit (darwin.apple_sdk.frameworks) CoreServices Cocoa Hypervisor;
     inherit (darwin.stubs) rez setfile;


### PR DESCRIPTION
###### Motivation for this change
hqemu (http://csl.iis.sinica.edu.tw/hqemu/) is an interesting research project that grafts LLVM on to qemu's TCG binary translation, allowing it to optimize hotspots. I've managed to get some pretty good results from it, tripling execution speeds in some of my tests.

Package is heavily based on the qemu one, with some features removed and disabled for darwin - I get the feeling linux is the only host that has ever seen any attention, and my brief attempts at getting it to build on macos yielded nothing but pain.

Also note it has `knownVulnerabilities` set because it's not as though this is a security-maintained application, so isn't really appropriate for production use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
