### PR TITLE
spamassassin: 3.4.2 -> 3.4.3

### DIFF
--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -2,11 +2,11 @@
 
 perlPackages.buildPerlPackage rec {
   pname = "SpamAssassin";
-  version = "3.4.2";
+  version = "3.4.3";
 
   src = fetchurl {
     url = "mirror://apache/spamassassin/source/Mail-${pname}-${version}.tar.bz2";
-    sha256 = "1np8h293bzg33i0xn9gj9krwgr7k6xbyf1yhxr2j2xci95d080yg";
+    sha256 = "1380cmrgjsyidnznr844c5yr9snz36dw7xchdfryi2s61vjzvf55";
   };
 
   # https://bz.apache.org/SpamAssassin/show_bug.cgi?id=7434


### PR DESCRIPTION
###### Motivation for this change

Two security issues have been fixed in this release:
  * CVE-2019-12420 for Multipart Denial of Service Vulnerability
  * CVE-2018-11805 for nefarious CF files can be configured to
    run system commands without any output or errors.

https://svn.apache.org/repos/asf/spamassassin/branches/3.4/build/announcements/3.4.3.txt


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I only "compiled" the package locally since there are no tests that I could execute :/


###### Notify maintainers

cc @peti
