### PR TITLE
[19.09] ansible fixes for CVE-2019-10156 CVE-2019-10206 CVE-2019-14846 CVE-2019-14856 CVE-2019-14858 CVE-2019-14864

### DIFF
--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -18,13 +18,13 @@
 
 buildPythonPackage rec {
   pname = "ansible";
-  version = "2.8.4";
+  version = "2.8.7";
 
   src = fetchFromGitHub {
     owner = "ansible";
     repo = "ansible";
     rev = "v${version}";
-    sha256 = "1fp7zz8awfv70nn8i6x0ggx4472377hm7787x16qv2kz4nb069ki";
+    sha256 = "08vqjk85j0g1x0iad03d7ysws433dikii8j2lr3a1mlx6d186vv8";
   };
 
   prePatch = ''

--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -17,11 +17,11 @@
 
   ansible_2_6 = with python3Packages; toPythonApplication (ansible.overridePythonAttrs(old: rec {
     pname = "ansible";
-    version = "2.6.17";
+    version = "2.6.20";
 
     src = fetchurl {
       url = "https://releases.ansible.com/ansible/${pname}-${version}.tar.gz";
-      sha256 = "0ixr3g1nb02xblqyk87bzag8sj8phy37m24xflabfl1k2zfh0313";
+      sha256 = "02ra9q2mifyawn0719y78wrbqzik73aymlzwi90fq71jgyfvkkqn";
     };
   }));
 }

--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -7,11 +7,11 @@
 
   ansible_2_7 = with python3Packages; toPythonApplication (ansible.overridePythonAttrs(old: rec {
     pname = "ansible";
-    version = "2.7.11";
+    version = "2.7.15";
 
     src = fetchurl {
       url = "https://releases.ansible.com/ansible/${pname}-${version}.tar.gz";
-      sha256 = "0zipzm9al6k74h88b6zkddpcbxqs4cms7lidid6wn1vx3d3dxrp7";
+      sha256 = "1kjqr35c11njyi3f2rjab6821bhqcrdykv4285q76gwv0qynigwr";
     };
   }));
 


### PR DESCRIPTION
###### Motivation for this change

This addresses the following issues in our Ansible packages:

CVE-2019-10156
CVE-2019-10206
CVE-2019-14846
CVE-2019-14856
CVE-2019-14858
CVE-2019-14864

Changelogs:
 - https://github.com/ansible/ansible/blob/9bdb89f740a87bcf760424577ce18a8f68d7a741/changelogs/CHANGELOG-v2.6.rst
 - https://github.com/ansible/ansible/blob/24220a618a6d5cd3b5c99f8c7f7771661ed08d33/changelogs/CHANGELOG-v2.8.rst
- https://github.com/ansible/ansible/blob/0623dedf2d9c4afc09e5be30d3ef249f9d1ebece/changelogs/CHANGELOG-v2.7.rst#v2-7-15

Backport of  #75715

###### Things done

I only build the packages. No further checks. I do not have any Ansible managed infra anymore...

###### Notify maintainers

cc @joamaki @costrouc 
