### PR TITLE
[19.09] apt: 1.4.6 -> 1.4.9 (CVE-2019-3462)

### DIFF
--- a/pkgs/tools/package-management/apt/default.nix
+++ b/pkgs/tools/package-management/apt/default.nix
@@ -16,11 +16,11 @@
 stdenv.mkDerivation rec {
   pname = "apt";
 
-  version = "1.4.6";
+  version = "1.4.9";
 
   src = fetchzip {
-    url = "https://launchpad.net/ubuntu/+archive/primary/+files/apt_${version}.tar.xz";
-    sha256 = "0ahwhmscrmnpvl1r732wg93dzkhv8c1sph2yrqgsrhr73c1616ix";
+    url = "mirror://debian/pool/main/a/apt/apt_${version}.tar.xz";
+    sha256 = "1xmgl7wj6gl1f8c2yxp5fcandxyg7jyigpsqr8kp76r06648dxv2";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Fixes on remote content injection issue (CVE-2019-3462).

Complete changelog:

 > apt (1.4.9) stretch-security; urgency=medium
 >
 >   * SECURITY UPDATE: content injection in http method (CVE-2019-3462)
 >     (LP: #1812353)
 >
 >  -- Julian Andres Klode <jak@debian.org>  Fri, 18 Jan 2019 11:42:07 +0100
 >
 > apt (1.4.8) stretch; urgency=medium
 >
 >   [ Balint Reczey ]
 >   * Gracefully terminate process when stopping apt-daily-upgrade (LP: #1690980)
 >
 >   [ David Kalnischkies ]
 >   * don't ask an uninit _system for supported archs, this
 >     crashes the mirror method (LP: #1613184)
 >
 >   [ Julian Andres Klode ]

 >   * Do not warn about duplicate "legacy" targets (Closes: #839259)
 >     (LP: #1697120)
 >   * apt-daily: Pull in network-online.target in service, not timer
 >     - this can cause a severe boot performance regression / hang
 >     (LP: #1716973)
 >
 >  -- Julian Andres Klode <jak@debian.org>  Wed, 13 Sep 2017 18:47:33 +0200
 >
 > apt (1.4.7) stretch; urgency=medium
 >
 >   * New release with important fixes up to 1.5~beta1; also see LP: #1702326
 >
 >   [ Robert Luberda ]
 >   * fix a "critical" typo in old changelog entry (Closes: 866358)
 >
 >   [ David Kalnischkies ]
 >   * test suite/travis CI: ignore profiling warning in progress lines
 >   * use port from SRV record instead of initial port
 >
 >   [ Julian Andres Klode ]
 >   * Reset failure reason when connection was successful, so later errors are
 >     reported as such and not as "connection failure" warnings.
 >   * debian/gbp.conf: Set debian-branch to 1.4.y
 >   * http: A response with Content-Length: 0 has no content, so don't try to
 >     read it - it will either timeout or the server closes the connection.
 >   * travis CI: Migrate to Docker
 >
 >  -- Julian Andres Klode <jak@debian.org>  Thu, 13 Jul 2017 23:45:39 +0200


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
