### PR TITLE
crystal: reduce closure size of compiled exes by splitting outputs

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -56,6 +56,8 @@ let
       inherit sha256;
     };
 
+    outputs = [ "out" "lib" "bin" ];
+
     # we are almost able to run the full test suite now
     postPatch = ''
       substituteInPlace src/crystal/system/unix/time.cr \
@@ -97,22 +99,22 @@ let
 
     # This makes sure we don't keep depending on the previous version of
     # crystal used to build this one.
-    CRYSTAL_LIBRARY_PATH = "${placeholder "out"}/lib/crystal";
+    CRYSTAL_LIBRARY_PATH = "${placeholder "lib"}/crystal";
 
     # We *have* to add `which` to the PATH or crystal is unable to build stuff
     # later if which is not available.
     installPhase = ''
       runHook preInstall
 
-      install -Dm755 .build/crystal $out/bin/crystal
-      wrapProgram $out/bin/crystal \
+      install -Dm755 .build/crystal $bin/bin/crystal
+      wrapProgram $bin/bin/crystal \
           --suffix PATH : ${lib.makeBinPath [ pkgconfig clang which ]} \
-          --suffix CRYSTAL_PATH : lib:$out/lib/crystal \
+          --suffix CRYSTAL_PATH : lib:$lib/crystal \
           --suffix CRYSTAL_LIBRARY_PATH : ${
             lib.makeLibraryPath (commonBuildInputs extraBuildInputs)
           }
-      install -dm755 $out/lib/crystal
-      cp -r src/* $out/lib/crystal/
+      install -dm755 $lib/crystal
+      cp -r src/* $lib/crystal/
 
       install -dm755 $out/share/doc/crystal/api
       cp -r docs/* $out/share/doc/crystal/api/
@@ -124,6 +126,10 @@ let
       install -Dm644 man/crystal.1 $out/share/man/man1/crystal.1
 
       install -Dm644 -t $out/share/licenses/crystal LICENSE README.md
+
+      mkdir -p $out
+      ln -s $bin/bin $out/bin
+      ln -s $lib $out/lib
 
       runHook postInstall
     '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

So far, compiled crystal programs retained a reference to `crystal`, which in turn depends on `llvm` and a ton of other things.
This makes sure that the output paths of crystal are  split up, so only `lib` is still referenced for runtime backtrace output.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @david50407 @peterhoeg 
