### PR TITLE
gpxlab: init at 0.7.0

### DIFF
--- a/pkgs/applications/misc/gpxlab/default.nix
+++ b/pkgs/applications/misc/gpxlab/default.nix
@@ -1,0 +1,34 @@
+{ mkDerivation, lib, fetchFromGitHub, qmake, qttools, qttranslations }:
+
+mkDerivation rec {
+  pname = "gpxlab";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "BourgeoisLab";
+    repo = "GPXLab";
+    rev = "v${version}";
+    sha256 = "080vnwcciqblfrbfyz9gjhl2lqw1hkdpbgr5qfrlyglkd4ynjd84";
+  };
+
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [ qttools qttranslations ];
+
+  preConfigure = ''
+    lrelease GPXLab/locale/*.ts
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/BourgeoisLab/GPXLab";
+    description = "Program to show and manipulate GPS tracks";
+    longDescription = ''
+      GPXLab is an application to display and manage GPS tracks
+      previously recorded with a GPS tracker.
+    '';
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19188,6 +19188,8 @@ in
 
   gpsprune = callPackage ../applications/misc/gpsprune { };
 
+  gpxlab = libsForQt5.callPackage ../applications/misc/gpxlab { };
+
   gpxsee = libsForQt5.callPackage ../applications/misc/gpxsee { };
 
   gspell = callPackage ../development/libraries/gspell { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/sqir7hl9b4271sv717chy9va9k9z6045-gpxlab-0.7.0
/nix/store/sqir7hl9b4271sv717chy9va9k9z6045-gpxlab-0.7.0	 279.8M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
