### PR TITLE
xilinx-bootgen: init at 2019-10-23

### DIFF
--- a/pkgs/tools/misc/xilinx-bootgen/default.nix
+++ b/pkgs/tools/misc/xilinx-bootgen/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, openssl }:
+
+stdenv.mkDerivation {
+  pname = "xilinx-bootgen";
+  version = "unstable-2019-10-23";
+
+  src = fetchFromGitHub {
+    owner = "xilinx";
+    repo = "bootgen";
+    rev = "f9f477adf243fa40bc8c7316a7aac37a0efd426d";
+    sha256 = "1qciz3jkzy0z0lcgqnhch9pqj0202mk5ghzp2m9as5pzk8n8hrbz";
+  };
+
+  buildInputs = [ openssl ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    install -Dm755 bootgen $out/bin/bootgen
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Generate Boot Images for Xilinx Zynq and ZU+ SoCs";
+    longDescription = ''
+      Bootgen for Xilinx Zynq and ZU+ SoCs, without code related to generating
+      obfuscated key and without code to support FPGA encryption and
+      authentication. These features are only available as part of Bootgen
+      shipped with Vivado tools.
+
+      For more details about Bootgen, please refer to Xilinx UG1283.
+    '';
+    homepage = "https://github.com/Xilinx/bootgen";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.flokli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17036,6 +17036,8 @@ in
 
   xf86_video_nested = callPackage ../os-specific/linux/xf86-video-nested { };
 
+  xilinx-bootgen = callPackage ../tools/misc/xilinx-bootgen { };
+
   xorg_sys_opengl = callPackage ../os-specific/linux/opengl/xorg-sys { };
 
   zd1211fw = callPackage ../os-specific/linux/firmware/zd1211 { };


### PR DESCRIPTION
###### Motivation for this change
Being able to assemble `boot.img` files for XIlinx Zynq and ZU+ SoCs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).