### PR TITLE
[19.09] advancecomp: fix CVE-2019-9210

### DIFF
--- a/pkgs/tools/compression/advancecomp/default.nix
+++ b/pkgs/tools/compression/advancecomp/default.nix
@@ -1,5 +1,9 @@
-{ stdenv, fetchFromGitHub
-, autoreconfHook, zlib }:
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "advancecomp";
@@ -14,6 +18,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ zlib ];
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-9210.patch";
+      url = "https://github.com/amadvance/advancecomp/commit/fcf71a89265c78fc26243574dda3a872574a5c02.patch";
+      sha256 = "0cdv9g87c1y8zwhqkd9ba2zjw4slcvg7yzcqv43idvnwb5fl29n7";
+      excludes = [ "doc/history.d" ];
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = ''A set of tools to optimize deflate-compressed files'';


### PR DESCRIPTION
###### Motivation for this change

Fixes an out of bounds write in the library.

Stable backport of #75723 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

