### PR TITLE
pythonPackages.pdfminer: 20181108 -> 20191020

### DIFF
--- a/pkgs/development/python-modules/pdfminer_six/default.nix
+++ b/pkgs/development/python-modules/pdfminer_six/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     description = "fork of PDFMiner using six for Python 2+3 compatibility";
     homepage = https://github.com/pdfminer/pdfminer.six;
     license = licenses.mit;
-    maintainers = with maintainers; [ psyanticy ];
+    maintainers = with maintainers; [ psyanticy marsam ];
   };
 }
 

--- a/pkgs/development/python-modules/pdfminer_six/default.nix
+++ b/pkgs/development/python-modules/pdfminer_six/default.nix
@@ -1,21 +1,23 @@
-{ stdenv, buildPythonPackage, python, fetchFromGitHub, six, pycryptodome, chardet, nose, pytest, sortedcontainers }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy3k, six, pycryptodome, chardet, nose, sortedcontainers }:
 
 buildPythonPackage rec {
   pname = "pdfminer_six";
-  version = "20181108";
+  version = "20191020";
 
+  # No tests in PyPi Tarball
   src = fetchFromGitHub {
     owner = "pdfminer";
     repo = "pdfminer.six";
     rev = version;
-    sha256 = "1v8pcx43fgidv1g54s92k85anvcss08blkhm4yi1hn1ybl0mmw6c";
+    sha256 = "1fqn4ilcscvw6ws9a1yqiprha9d3rgw3d0280clkbk6s4l26wm9h";
   };
 
-  propagatedBuildInputs = [ six pycryptodome chardet sortedcontainers ];
+  propagatedBuildInputs = [ six pycryptodome sortedcontainers ]
+    ++ stdenv.lib.optionals isPy3k [ chardet ];
 
-  checkInputs = [ nose pytest ];
+  checkInputs = [ nose ];
   checkPhase = ''
-    ${python.interpreter} -m pytest
+    nosetests
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -22,12 +22,12 @@
 
 buildPythonPackage rec {
   pname = "pikepdf";
-  version = "1.8.0";
+  version = "1.8.1";
   disabled = ! isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0pxcx3xc6c0plgxa4w9sjdf4rs1sxpx152b1vqvad2i3392n77ga";
+    sha256 = "a57a295296820087e66a3c62569d288958f29d1a354701ace6639a7692cc3022";
   };
 
   buildInputs = [

--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "tqdm";
-  version = "4.36.1";
+  version = "4.40.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "abc25d0ce2397d070ef07d8c7e706aede7920da163c64997585d42d3537ece3d";
+    sha256 = "f0ab01cf3ae5673d18f918700c0165e5fad0f26b5ebe4b34f62ead92686b5340";
   };
 
-  buildInputs = [ nose coverage glibcLocales flake8 ];
+  checkInputs = [ nose coverage glibcLocales flake8 ];
 
   postPatch = ''
     # Remove performance testing.

--- a/pkgs/tools/text/ocrmypdf/default.nix
+++ b/pkgs/tools/text/ocrmypdf/default.nix
@@ -28,14 +28,14 @@ let
 
 in buildPythonApplication rec {
   pname = "ocrmypdf";
-  version = "9.0.3";
+  version = "9.2.0";
   disabled = ! python3Packages.isPy3k;
 
   src = fetchFromGitHub {
     owner = "jbarlow83";
     repo = "OCRmyPDF";
     rev = "v${version}";
-    sha256 = "1qnjdcbwkxxqfahylzl0wj1gk51yi9m8akd4d1rrq37vg2vwdkjy";
+    sha256 = "1mvc6x5nn242z65pxv39ch71vaikgi89bb0sjbfy2jbw91vk41xa";
   };
 
   nativeBuildInputs = with python3Packages; [
@@ -53,7 +53,6 @@ in buildPythonApplication rec {
     pikepdf
     pillow
     reportlab
-    ruffus
     setuptools
     tqdm
   ];
@@ -71,8 +70,8 @@ in buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace src/ocrmypdf/leptonica.py \
-      --replace "ffi.dlopen(find_library('lept'))" \
-      'ffi.dlopen("${stdenv.lib.makeLibraryPath [leptonica]}/liblept${stdenv.hostPlatform.extensions.sharedLibrary}")'
+      --replace "lept = ffi.dlopen(_libpath)" \
+      'lept = ffi.dlopen("${stdenv.lib.makeLibraryPath [leptonica]}/liblept${stdenv.hostPlatform.extensions.sharedLibrary}")'
   '';
 
   # The tests take potentially 20+ minutes, depending on machine


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/pdfminer/pdfminer.six/releases/tag/20191020

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
