### PR TITLE
docker-credential-helpers: init at 0.6.3

### DIFF
--- a/pkgs/tools/admin/docker-credential-helpers/default.nix
+++ b/pkgs/tools/admin/docker-credential-helpers/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, pkg-config, libsecret }:
+
+buildGoPackage rec {
+  pname = "docker-credential-helpers";
+  version = "0.6.3";
+
+  goPackagePath = "github.com/docker/docker-credential-helpers";
+
+  src = fetchFromGitHub {
+    owner = "docker";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0xgmwjva3j1s0cqkbajbamj13bgzh5jkf2ir54m9a7w8gjnsh6dx";
+  };
+
+  nativeBuildInputs = stdenv.lib.optionals stdenv.isLinux [ pkg-config ];
+
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ libsecret ];
+
+  buildPhase =
+    if stdenv.isDarwin
+    then ''
+      cd go/src/${goPackagePath}
+      go build -ldflags -s -o bin/docker-credential-osxkeychain osxkeychain/cmd/main_darwin.go
+    ''
+    else ''
+      cd go/src/${goPackagePath}
+      go build -o bin/docker-credential-secretservice secretservice/cmd/main_linux.go
+      go build -o bin/docker-credential-pass pass/cmd/main_linux.go
+    '';
+
+  installPhase =
+    if stdenv.isDarwin
+    then ''
+      install -Dm755 -t $bin/bin bin/docker-credential-osxkeychain
+    ''
+    else ''
+      install -Dm755 -t $bin/bin bin/docker-credential-pass
+      install -Dm755 -t $bin/bin bin/docker-credential-secretservice
+    '';
+
+  meta = with stdenv.lib; {
+    description = "Suite of programs to use native stores to keep Docker credentials safe";
+    homepage = "https://github.com/docker/docker-credential-helpers";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18420,6 +18420,8 @@ in
 
   docker-credential-gcr = callPackage ../tools/admin/docker-credential-gcr { };
 
+  docker-credential-helpers = callPackage ../tools/admin/docker-credential-helpers { };
+
   doodle = callPackage ../applications/search/doodle { };
 
   dr14_tmeter = callPackage ../applications/audio/dr14_tmeter { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/75726

I could not build docker-credential-pass on darwin, I'll try again once https://github.com/docker/docker-credential-helpers/pull/169 is merged
cc: @NilsIrl 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
