### PR TITLE
makeDesktopItem: add desktop file validation

### DIFF
--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -1,4 +1,5 @@
-{ lib, runCommandLocal }:
+{ lib, runCommandLocal, desktop-file-utils }:
+
 { name
 , type ? "Application"
 , exec
@@ -11,6 +12,7 @@
 , categories ? "Application;Other;"
 , startupNotify ? null
 , extraEntries ? null
+, fileValidation ? true # whether to validate resulting desktop file.
 }:
 
 let
@@ -28,8 +30,8 @@ let
 in
 runCommandLocal "${name}.desktop" {}
   ''
-    mkdir -p $out/share/applications
-    cat > $out/share/applications/${name}.desktop <<EOF
+    mkdir -p "$out/share/applications"
+    cat > "$out/share/applications/${name}.desktop" <<EOF
     [Desktop Entry]
     Type=${type}
     Exec=${exec}
@@ -40,4 +42,9 @@ runCommandLocal "${name}.desktop" {}
     ${if extraEntries == null then ''EOF'' else ''
     ${extraEntries}
     EOF''}
+
+    ${lib.optionalString fileValidation ''
+      echo "Running desktop-file validation"
+      ${desktop-file-utils}/bin/desktop-file-validate "$out/share/applications/${name}.desktop"
+    ''}
   ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This uses desktop-file-validate in desktop-file-utils.
It can be turned off if wanted.

Errant entries according to the specification will now fail the build, and enforce properly created desktop files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
