### PR TITLE
herwig: 7.1.6 -> 7.2.0

### DIFF
--- a/pkgs/development/libraries/physics/herwig/default.nix
+++ b/pkgs/development/libraries/physics/herwig/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "herwig";
-  version = "7.1.6";
+  version = "7.2.0";
 
   src = fetchurl {
     url = "https://www.hepforge.org/archive/herwig/Herwig-${version}.tar.bz2";
-    sha256 = "0h4gcmwnk4iyd31agzcq3p8bvlrgc8svm4ymzqgvvhizwflqf3yr";
+    sha256 = "0r5iyai2j99pk9p36g4rp98bxm55zd1ik9kgm2zf5zgpvxfm8csr";
   };
 
   nativeBuildInputs = [ autoconf automake libtool ];
 
   buildInputs = [ boost fastjet gfortran gsl thepeg zlib ]
-    # There is a bug that requires for MMHT PDF's to be presend during the build
-    ++ (with lhapdf.pdf_sets; [ MMHT2014lo68cl MMHT2014nlo68cl ]);
+    # There is a bug that requires for default PDF's to be present during the build
+    ++ (with lhapdf.pdf_sets; [ CT14lo CT14nlo ]);
 
   postPatch = ''
     patchShebangs ./
@@ -25,12 +25,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A multi-purpose particle physics event generator";
-    license     = stdenv.lib.licenses.gpl2;
-    homepage    = https://herwig.hepforge.org/;
-    platforms   = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ veprbl ];
-    broken      = stdenv.isAarch64; # doesn't compile: ignoring return value of 'FILE* freopen...
+    homepage = https://herwig.hepforge.org/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ veprbl ];
+    platforms = platforms.unix;
+    broken = stdenv.isAarch64; # doesn't compile: ignoring return value of 'FILE* freopen...
   };
 }

--- a/pkgs/development/libraries/physics/thepeg/default.nix
+++ b/pkgs/development/libraries/physics/thepeg/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "thepeg";
-  version = "2.1.6";
+  version = "2.2.0";
 
   src = fetchurl {
     url = "https://www.hepforge.org/archive/thepeg/ThePEG-${version}.tar.bz2";
-    sha256 = "0krz6psr69kn48xkgr0mjadmzvq572mzn02inlasiz3bf61izrf1";
+    sha256 = "1y7vwsc4zk629np4rpjh7a8qzvyqc2fixnwq98dgdndp2544gqfk";
   };
 
   buildInputs = [ boost fastjet gsl hepmc2 lhapdf rivet zlib ];
@@ -19,11 +19,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Toolkit for High Energy Physics Event Generation";
-    license     = stdenv.lib.licenses.gpl2;
-    homepage    = https://herwig.hepforge.org/;
-    platforms   = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ veprbl ];
+    homepage = https://herwig.hepforge.org/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ veprbl ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
thepeg: 2.1.6 -> 2.2.0

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `herwig` to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
