### PR TITLE
python3Packages.mypy: 0.740 -> 0.750

### DIFF
--- a/pkgs/development/python-modules/ics/default.nix
+++ b/pkgs/development/python-modules/ics/default.nix
@@ -6,6 +6,7 @@
 buildPythonPackage rec {
   pname = "ics";
   version = "0.6";
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "C4ptainCrunch";
@@ -15,9 +16,16 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ tatsu arrow ];
-  checkInputs = [ pytest-sugar pytestpep8 pytest-flakes pytestcov ];
 
-  disabled = pythonOlder "3.6";
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "arrow>=0.11,<0.15" "arrow"
+  '';
+
+  checkInputs = [ pytest-sugar pytestpep8 pytest-flakes pytestcov ];
+  checkPhase = ''
+    pytest
+  '';
 
   meta = with stdenv.lib; {
     description = "Pythonic and easy iCalendar library (RFC 5545)";

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -5,19 +5,26 @@
 
 buildPythonPackage rec {
   pname = "mypy";
-  version = "0.740";
+  version = "0.750";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0k0l74g3jcq7ppzn234sffsaacn6qaq242famckk0cviwgld1jvf";
+  };
+
+  propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];
 
   # Tests not included in pip package.
   doCheck = false;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "48c8bc99380575deb39f5d3400ebb6a8a1cb5cc669bbba4d3bb30f904e0a0e7d";
-  };
-
-  disabled = !isPy3k;
-
-  propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];
+  pythonImportsCheck = [
+    "mypy"
+    "mypy.types"
+    "mypy.api"
+    "mypy.fastparse"
+    "mypy.report"
+  ];
 
   meta = with stdenv.lib; {
     description = "Optional static typing for Python";


### PR DESCRIPTION
###### Motivation for this change
looking through @r-ryantm logs

Also refactored expression to follow ordering of most other python packages
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

python38Packages.pyls-mypy is failing due to upstream python3.8 issue, unrelated to PR
```
https://github.com/NixOS/nixpkgs/pull/75738
1 package failed to build:
python38Packages.pyls-mypy

18 package were built:
git-revise mypy nix-pin python37Packages.algebraic-data-types python37Packages.ics python37Packages.pyls-mypy python37Packages.pynamodb python37Packages.pytest-mypy python37Packages.tatsu python38Packages.algebraic-data-types python38Packages.git-revise python38Packages.ics python38Packages.mypy python38Packages.pynamodb python38Packages.pytest-mypy python38Packages.tatsu thonny zfs-replicate
```