### PR TITLE
python3Packages.bottleneck: 1.2.1 -> 1.3.1

### DIFF
--- a/pkgs/development/python-modules/bottleneck/default.nix
+++ b/pkgs/development/python-modules/bottleneck/default.nix
@@ -1,26 +1,34 @@
-{ buildPythonPackage
-, fetchPypi
+{ lib, buildPythonPackage, fetchPypi
 , nose
-, pytest
 , numpy
+, pytest
 , python
 }:
 
 buildPythonPackage rec {
   pname = "Bottleneck";
-  version = "1.2.1";
+  version = "1.3.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6efcde5f830aed64feafca0359b51db0e184c72af8ba6675b4a99f263922eb36";
+    sha256 = "0a2a94zahl3kqld2n9dm58fvazz9s52sa16nd8yn5jv20hvqc5a5";
   };
 
-  checkInputs = [ pytest nose ];
   propagatedBuildInputs = [ numpy ];
-  checkPhase = ''
-    py.test -p no:warnings $out/${python.sitePackages}
-  '';
+
   postPatch = ''
     substituteInPlace setup.py --replace "__builtins__.__NUMPY_SETUP__ = False" ""
   '';
+
+  checkInputs = [ pytest nose ];
+  checkPhase = ''
+    py.test -p no:warnings $out/${python.sitePackages}
+  '';
+
+  meta = with lib; {
+    description = "Fast NumPy array functions written in C";
+    homepage = "https://github.com/pydata/bottleneck";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ ];
+  };
 }


### PR DESCRIPTION
###### Motivation for this change
was looking through @r-ryantm logs

Also gave the expression some love

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[108 built (12 failed), 839 copied (5188.5 MiB), 1029.2 MiB DL]
error: build of '/nix/store/q3s2m9hvwzrs50dk5ga20gxa5wqsvxjb-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/75739
15 package failed to build:
python27Packages.geopandas python27Packages.pymatgen python27Packages.sumo python37Packages.blaze python37Packages.geopandas python37Packages.google_cloud_bigquery python37Packages.ibis-framework python37Packages.mesa python37Packages.odo python37Packages.optuna python37Packages.osmnx python37Packages.rl-coach python37Packages.starfish python37Packages.streamz python37Packages.vega

103 package were built:
apache-airflow csvs-to-sqlite paperwork poretools python27Packages.Quandl python27Packages.altair python27Packages.awkward python27Packages.bkcharts python27Packages.bottleneck python27Packages.cnvkit python27Packages.cufflinks python27Packages.drms python27Packages.fastparquet python27Packages.flammkuchen python27Packages.histbook python27Packages.holoviews python27Packages.hvplot python27Packages.imbalanced-learn python27Packages.mapsplotlib python27Packages.nipype python27Packages.pandas python27Packages.partd python27Packages.pyarrow python27Packages.pybids python27Packages.pytrends python27Packages.seaborn python27Packages.statsmodels python27Packages.tablib python27Packages.trackpy python27Packages.uproot python27Packages.uproot-methods python27Packages.vega python27Packages.vega_datasets python27Packages.vidstab python37Packages.Quandl python37Packages.acoustics python37Packages.altair python37Packages.aplpy python37Packages.arviz python37Packages.atomman python37Packages.awkward python37Packages.bkcharts python37Packages.bottleneck python37Packages.caffe python37Packages.cnvkit python37Packages.cufflinks python37Packages.dask python37Packages.dask-glm python37Packages.dask-image python37Packages.dask-jobqueue python37Packages.dask-ml python37Packages.dask-mpi python37Packages.dask-xgboost python37Packages.datashader python37Packages.dftfit python37Packages.distributed python37Packages.drms python37Packages.fastparquet python37Packages.flammkuchen python37Packages.glymur python37Packages.google_cloud_monitoring python37Packages.histbook python37Packages.holoviews python37Packages.hvplot python37Packages.image-match python37Packages.imbalanced-learn python37Packages.intake python37Packages.lammps-cython python37Packages.nipype python37Packages.pandas python37Packages.partd python37Packages.phik python37Packages.pims python37Packages.pvlib python37Packages.pyarrow python37Packages.pybids python37Packages.pyfftw python37Packages.pymatgen python37Packages.pymatgen-lammps python37Packages.pymc3 python37Packages.pytrends python37Packages.rpy2 python37Packages.scikit-bio python37Packages.scikitimage python37Packages.seaborn python37Packages.slicedimage python37Packages.statsmodels python37Packages.stumpy python37Packages.stytra python37Packages.sumo python37Packages.sunpy python37Packages.tablib python37Packages.trackpy python37Packages.uproot python37Packages.uproot-methods python37Packages.vega_datasets python37Packages.vidstab python37Packages.wrf-python python37Packages.xarray python37Packages.xgboost python38Packages.bottleneck streamlit visidata
```