### PR TITLE
python3Packages.jaraco_text: 3.1 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/jaraco_text/default.nix
+++ b/pkgs/development/python-modules/jaraco_text/default.nix
@@ -1,15 +1,31 @@
-{ buildPythonPackage, fetchPypi, setuptools_scm
+{ lib, buildPythonPackage, fetchPypi, pythonOlder
+, importlib-resources
 , jaraco_functools
+, setuptools_scm
 }:
 
 buildPythonPackage rec {
   pname = "jaraco.text";
-  version = "3.1";
+  version = "3.2.0";
+
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0c7effed0f269e8bdae3374a7545763e84c1e7f9777cf2dd2d49eef92eb0d7b7";
+    sha256 = "1v0hz3h74m31jlbc5bxwkvrx1h2n7887bajrg1n1c3yc4q8qn1z5";
   };
+
+  nativeBuildInputs =[ setuptools_scm ];
+  propagatedBuildInputs = [
+    jaraco_functools
+  ] ++ lib.optional (pythonOlder "3.7") [ importlib-resources ];
+
+  # no tests in pypi package
   doCheck = false;
-  buildInputs =[ setuptools_scm ];
-  propagatedBuildInputs = [ jaraco_functools ];
+
+  meta = with lib; {
+    description = "Module for text manipulation";
+    homepage = "https://github.com/jaraco/jaraco.text";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+
 }


### PR DESCRIPTION
###### Motivation for this change
going through @r-ryantm logs

cleaned up the expression a lot as well

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/75740
9 package were built:
errbot python27Packages.jaraco_collections python27Packages.jaraco_text python37Packages.irc python37Packages.jaraco_collections python37Packages.jaraco_text python38Packages.irc python38Packages.jaraco_collections python38Packages.jaraco_text
```