### PR TITLE
linux-libre_latest: update automatically; fix build

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -33,6 +33,8 @@ in linux.override {
       '';
     };
 
+    passthru.updateScript = ./update-libre.sh;
+
     maintainers = [ lib.maintainers.qyliss ];
   };
 }

--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, fetchsvn, linux
 , scripts ? fetchsvn {
     url = "https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/branches/";
-    rev = "16794";
-    sha256 = "1lpaka4hs7yrpnrzfybd6radjylwvw2p4aly68pypykqs2srvm7j";
+    rev = "17112";
+    sha256 = "049vmi9q1vrcrq9p1zxj6bhhpkgy8fsyh955b54z3xlw7czng1s1";
   }
 , ...
 }:

--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -1,9 +1,6 @@
 { stdenv, lib, fetchsvn, linux
 , scripts ? fetchsvn {
     url = "https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/branches/";
-
-    # Update this if linux_latest-libre fails to build.
-    # $ curl https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/branches/ | grep -Eo 'Revision [0-9]+'
     rev = "16794";
     sha256 = "1lpaka4hs7yrpnrzfybd6radjylwvw2p4aly68pypykqs2srvm7j";
   }

--- a/pkgs/os-specific/linux/kernel/update-libre.sh
+++ b/pkgs/os-specific/linux/kernel/update-libre.sh
@@ -1,0 +1,26 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix-prefetch-svn git curl
+set -euo pipefail
+
+nixpkgs="$(git rev-parse --show-toplevel)"
+path="$nixpkgs/pkgs/os-specific/linux/kernel/linux-libre.nix"
+
+old_rev="$(grep -o 'rev = ".*"' "$path" | awk -F'"' '{print $2}')"
+
+svn_url=https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/branches/
+rev="$(curl -s "$svn_url" | grep -Em 1 -o 'Revision [0-9]+' | awk '{print $2}')"
+
+if [ "$old_rev" = "$rev" ]; then
+    echo "No updates for linux-libre"
+    exit 0
+fi
+
+sha256="$(QUIET=1 nix-prefetch-svn "$svn_url" "$rev" | tail -1)"
+
+sed -i -e "s/rev = \".*\"/rev = \"$rev\"/" \
+    -e "s/sha256 = \".*\"/sha256 = \"$sha256\"/" "$path"
+
+if [ -n "$COMMIT" ]; then
+    git commit -qm "linux-libre_latest: $old_rev -> $rev" "$path"
+    echo "Updated linux-libre_latest $old_rev -> $rev"
+fi

--- a/pkgs/os-specific/linux/kernel/update.sh
+++ b/pkgs/os-specific/linux/kernel/update.sh
@@ -57,3 +57,6 @@ ls $NIXPKGS/pkgs/os-specific/linux/kernel | while read FILE; do
 
   echo "Updated $OLDVER -> $V"
 done
+
+# Update linux-libre
+COMMIT=1 $NIXPKGS/pkgs/os-specific/linux/kernel/update-libre.sh


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Alternative to #74726.

This should mean that Linux-libre is updated whenever @NeQuissimus updates the kernel, AND whenever update scripts are run — I think r-ryantm does this?

Between these two scenarios, I’m hoping this should be run often enough that the libre kernels almost always build, even when new kernel series are added in Nixpkgs before Linux-libre supports them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).