### PR TITLE
python3Packages.odo: disable due to dask incompatibility

### DIFF
--- a/pkgs/development/python-modules/odo/default.nix
+++ b/pkgs/development/python-modules/odo/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "odo";
-  version= "unstable-2019-07-16";
+  version= "unstable-2018-09-21";
 
   src = fetchFromGitHub {
     owner = "blaze";
@@ -54,5 +54,6 @@ buildPythonPackage rec {
     description = "Data migration utilities";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ fridh costrouc ];
+    broken = true; # no longer compatible with dask>=2.0
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The dask backend is no longer compatible with the version of dask we have in nixpkgs.

Also did:
 - fix commit date https://github.com/blaze/odo/commits/master

noticed it was broken when reviewing  #75739

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
Nothing changed
https://github.com/NixOS/nixpkgs/pull/75742
$ nix-shell /home/jon/.cache/nix-review/pr-75742/shell.nix
```