### PR TITLE
python3Packages.dask: 2.6.0 -> 2.9.0

### DIFF
--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "dask";
-  version = "2.6.0";
+  version = "2.9.0";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "81c7891f0d2e7ac03d1f7fabf1f639360a1db52c03a7155ba9b08e9ee6280f2b";
+    sha256 = "1w1hqr8vyx6ygwflj2737dcy0mmgvrc0s602gnny8pzlcbs9m76b";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change
tried bumping this instead of disabling odo. Appears odo is just not compatible with dask>=2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

failures are broken on master
```
[18 built (6 failed), 5 copied (15.1 MiB), 6.4 MiB DL]
error: build of '/nix/store/zfyy2r88szks3zixwcvlbqjbljry54lz-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/75743
7 package failed to build:
python37Packages.blaze python37Packages.dask-ml python37Packages.datashader python37Packages.odo python37Packages.rl-coach python37Packages.starfish python37Packages.streamz

19 package were built:
python37Packages.aplpy python37Packages.caffe python37Packages.dask python37Packages.dask-glm python37Packages.dask-image python37Packages.dask-jobqueue python37Packages.dask-mpi python37Packages.dask-xgboost python37Packages.distributed python37Packages.glymur python37Packages.image-match python37Packages.intake python37Packages.pims python37Packages.pyfftw python37Packages.scikitimage python37Packages.slicedimage python37Packages.stumpy python37Packages.stytra python37Packages.sunpy
```