### PR TITLE
python3Packages.starfish: disable due to incompatible dependencies

### DIFF
--- a/pkgs/development/python-modules/starfish/default.nix
+++ b/pkgs/development/python-modules/starfish/default.nix
@@ -85,5 +85,6 @@ buildPythonPackage rec {
     homepage = https://spacetx-starfish.readthedocs.io/en/latest/;
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];
+    broken = true; # incompatible with latest python-dateutil, scikit-image
   };
 }


### PR DESCRIPTION
###### Motivation for this change
isn't compatible with latest python-dateutil or scikit-image

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
