### PR TITLE
python3Packages.streamz: disable kafka tests

### DIFF
--- a/pkgs/development/python-modules/streamz/default.nix
+++ b/pkgs/development/python-modules/streamz/default.nix
@@ -1,11 +1,9 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
+{ lib, buildPythonPackage, fetchPypi, fetchpatch
 , tornado
 , toolz
 , zict
 , six
-, pytest_4
+, pytest
 , networkx
 , distributed
 , confluent-kafka
@@ -22,7 +20,21 @@ buildPythonPackage rec {
     sha256 = "127rpdjgkcyjifmkqbhmqfbzlgi32n54rybrdxja610qr906y40c";
   };
 
+  patches = [
+    # fix networkx rename issue of GiGraph.node -> DiGraph.nodes, remove on next bump
+    ( fetchpatch {
+      url = "https://github.com/python-streamz/streamz/commit/f8b7bdb6bcb9dd107677e82e755ff4695bf0c4be.patch";
+      sha256 = "1b2frp0j369gf55plxk2pigblhsc44m0rm9az01y83cjlcm26x2s";
+    })
+    # also, fix networkx rename issue of GiGraph.node -> DiGraph.nodes, remove on next bump
+    ( fetchpatch {
+      url = "https://github.com/python-streamz/streamz/commit/f7603f4cbea54f1548885881206a3ca9d6e52250.patch";
+      sha256 = "1125kqiaz6b3cifz0yk1zrkxj5804lfzl4kc58jhqajv8rsrbs45";
+    })
+  ];
+
   propagatedBuildInputs = [
+    networkx
     tornado
     toolz
     zict
@@ -33,20 +45,21 @@ buildPythonPackage rec {
     confluent-kafka
     distributed
     graphviz
-    networkx
-    pytest_4
+    pytest
     requests
   ];
 
   # Disable test_tcp_async because fails on sandbox build
+  # disable kafka tests
   checkPhase = ''
     pytest --deselect=streamz/tests/test_sources.py::test_tcp_async \
-      --deselect=streamz/tests/test_sources.py::test_tcp
+      --deselect=streamz/tests/test_sources.py::test_tcp \
+      --ignore=streamz/tests/test_kafka.py
   '';
 
   meta = with lib; {
     description = "Pipelines to manage continuous streams of data";
-    homepage = "https://github.com/mrocklin/streamz";
+    homepage = "https://github.com/python-streamz/streamz";
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
###### Motivation for this change
saw it was broken when reviewing #75743

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
