### PR TITLE
pythonPackages.weboob: add futures dependency

### DIFF
--- a/pkgs/development/python-modules/weboob/default.nix
+++ b/pkgs/development/python-modules/weboob/default.nix
@@ -1,8 +1,24 @@
-{ buildPythonPackage, fetchPypi, stdenv
-, nose, pillow, prettytable, pyyaml, dateutil, gdata
-, requests, mechanize, feedparser, lxml, gnupg, pyqt5
-, libyaml, simplejson, cssselect, pdfminer
-, termcolor, google_api_python_client, html2text
+{ lib, buildPythonPackage, fetchPypi, isPy27
+, cssselect
+, dateutil
+, feedparser
+, futures
+, gdata
+, gnupg
+, google_api_python_client
+, html2text
+, libyaml
+, lxml
+, mechanize
+, nose
+, pdfminer
+, pillow
+, prettytable
+, pyqt5
+, pyyaml
+, requests
+, simplejson
+, termcolor
 , unidecode
 }:
 
@@ -34,10 +50,27 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pyqt5 ];
 
-  propagatedBuildInputs = [ pillow prettytable pyyaml dateutil
-    gdata requests mechanize feedparser lxml gnupg pyqt5 libyaml
-    simplejson cssselect pdfminer termcolor
-    google_api_python_client html2text unidecode ];
+  propagatedBuildInputs = [
+    cssselect
+    dateutil
+    feedparser
+    gdata
+    gnupg
+    google_api_python_client
+    html2text
+    libyaml
+    lxml
+    mechanize
+    pdfminer
+    pillow
+    prettytable
+    pyqt5
+    pyyaml
+    requests
+    simplejson
+    termcolor
+    unidecode
+  ] ++ lib.optionals isPy27 [ futures ];
 
   checkPhase = ''
     nosetests
@@ -46,6 +79,6 @@ buildPythonPackage rec {
   meta = {
     homepage = http://weboob.org;
     description = "Collection of applications and APIs to interact with websites without requiring the user to open a browser";
-    license = stdenv.lib.licenses.agpl3;
+    license = lib.licenses.agpl3;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken reviewing #75725

also formatted the file
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[5 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/75746
4 package were built:
kmymoney python27Packages.weboob python37Packages.weboob python38Packages.weboob
```