### PR TITLE
python3Packages.gym: disable due to missing dependencies

### DIFF
--- a/pkgs/development/python-modules/gym/default.nix
+++ b/pkgs/development/python-modules/gym/default.nix
@@ -29,5 +29,6 @@ buildPythonPackage rec {
     homepage = https://gym.openai.com/;
     license = licenses.mit;
     maintainers = with maintainers; [ hyphon81 ];
+    broken = true; # now requires opencv-python, but it's unavailable
   };
 }


### PR DESCRIPTION
###### Motivation for this change
tired of seeing the broken noise when reviewing other packages for the past few weeks. It's broken, and unless someone wants to package opencv-python, I'm disabling this

```
ERROR: Could not find a version that satisfies the requirement opencv-python (from gym==0.15.4) (from versions: none)
  ERROR: No matching distribution found for opencv-python (from gym==0.15.4)
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
