### PR TITLE
python3Packages.mesa: 0.8.6 -> unstable-2019-12-09

### DIFF
--- a/pkgs/development/python-modules/mesa/default.nix
+++ b/pkgs/development/python-modules/mesa/default.nix
@@ -4,7 +4,8 @@
 
 buildPythonPackage rec {
   pname = "mesa";
-  version = "0.8.6";
+  # contains several fixes for networkx 2.4 bump
+  version = "unstable-2019-12-09";
 
   # According to their docs, this library is for Python 3+.
   disabled = isPy27;
@@ -12,8 +13,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "projectmesa";
     repo = "mesa";
-    rev = "v${version}";
-    sha256 = "0d8c636zhswxd91ldlmdxxlyym2fj3bk1iqmpc1jp3hg7vvc7w03";
+    rev = "86b343b42630e94d939029ff2cc609ff04ed40e9";
+    sha256 = "1y41s1vd89vcsm4aia18ayfff4w2af98lwn5l9fcwp157li985vw";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
##### Motivation for this change
networkx 2.4 broke their api https://github.com/networkx/networkx/issues/3750

the last official mesa release was so long ago that patches no longer cleanly apply

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
https://github.com/NixOS/nixpkgs/pull/75750
1 package were built:
python37Packages.mesa
```