### PR TITLE
Make python interpreters manylinux aware

### DIFF
--- a/pkgs/development/interpreters/python/manylinux/default.nix
+++ b/pkgs/development/interpreters/python/manylinux/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs }:
+{ makeSetupHook, lib, pkgs }:
 
 let
   # Create a derivation that links all desired manylinux libraries
@@ -68,14 +68,19 @@ let
     "libcrypt.so.1" = glibc;
     }));
 
+  createManyLinuxSetupHook = manylinuxVersion: makeSetupHook {
+    name = "manylinux${toString manylinuxVersion}-setup-hook";
+    substitutions = { inherit manylinuxVersion; };
+  } ./setup-hook.sh;
+
 in {
   # List of libraries that are needed for manylinux compatibility.
   # When using a wheel that is manylinux1 compatible, just extend
   # the `buildInputs` with one of these `manylinux` lists.
   # Additionally, add `autoPatchelfHook` to `nativeBuildInputs`.
-  manylinux1 = lib.unique (lib.attrValues manylinux1Libs);
-  manylinux2010 = lib.unique (lib.attrValues manylinux2010Libs);
-  manylinux2014 = lib.unique (lib.attrValues manylinux2014Libs);
+  manylinux1 = lib.unique (lib.attrValues manylinux1Libs) ++ [ (createManyLinuxSetupHook "1") ];
+  manylinux2010 = lib.unique (lib.attrValues manylinux2010Libs) ++ [ (createManyLinuxSetupHook "2010") ];
+  manylinux2014 = lib.unique (lib.attrValues manylinux2014Libs) ++ [ (createManyLinuxSetupHook "2014") ];
 
   # These are symlink trees to the relevant libs and are typically not needed
   # These exist so as to quickly test whether all required libraries are provided

--- a/pkgs/development/interpreters/python/manylinux/setup-hook.sh
+++ b/pkgs/development/interpreters/python/manylinux/setup-hook.sh
@@ -1,0 +1,1 @@
+export NIX_PYTHON_MANYLINUX="@manylinuxVersion@"


### PR DESCRIPTION
###### Motivation for this change
Following up on https://github.com/NixOS/nixpkgs/pull/73866 this PR makes python interpreters announce manylinux compatibility when actually necessary (ie when a manylinux package is a build input). The way this works is:

- manylinux packages set `NIX_PYTHON_MANYLINUX` in a setupHook
- Python interepreters have a `_manylinux.py` file that checks the presence of the environment variable and its value and set the support level accordingly

###### Things done
- Tested in combination with current work on https://github.com/nix-community/poetry2nix

----

Abandoned in favor of  #75763

@FRidh @andir and me had a short chat on irc and agreed that the easiest way forward is to drop the `_manylinux.py` files completely. With the file gone pip will instead assume compatibility by default. It is now up to the user to select an appropriate manylinux package and add it to the respective derivation to ensure that all libraries required by the standard are available.