### PR TITLE
sonata: fix runtime error

### DIFF
--- a/pkgs/applications/audio/sonata/default.nix
+++ b/pkgs/applications/audio/sonata/default.nix
@@ -2,7 +2,7 @@
 , python3Packages, gnome3, gtk3, gsettings-desktop-schemas, gobject-introspection }:
 
 let
-  inherit (python3Packages) buildPythonApplication isPy3k dbus-python pygobject3 mpd2;
+  inherit (python3Packages) buildPythonApplication isPy3k dbus-python pygobject3 mpd2 setuptools;
 in buildPythonApplication rec {
   pname = "sonata";
   version = "1.7b1";
@@ -29,7 +29,7 @@ in buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = [
-    gobject-introspection gtk3 pygobject3
+    gobject-introspection gtk3 pygobject3 setuptools
   ];
 
   # The optional tagpy dependency (for editing metadata) is not yet


### PR DESCRIPTION
Currently sonata fails to run with this error:

```
$ sonata 
/nix/store/b1f3r3g9lpmn591fpk40syrh4m80y971-sonata-1.7b1/lib/python3.7/site-packages/sonata/launcher.py:159: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk, Gdk
Traceback (most recent call last):
  File "/nix/store/b1f3r3g9lpmn591fpk40syrh4m80y971-sonata-1.7b1/bin/..sonata-wrapped-wrapped", line 9, in <module>
    sys.exit(run())
  File "/nix/store/b1f3r3g9lpmn591fpk40syrh4m80y971-sonata-1.7b1/lib/python3.7/site-packages/sonata/launcher.py", line 186, in run
    from sonata import main
  File "/nix/store/b1f3r3g9lpmn591fpk40syrh4m80y971-sonata-1.7b1/lib/python3.7/site-packages/sonata/main.py", line 38, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Adding `setuptools` to propagatedBuildInputs fixes it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rvl
