### PR TITLE
whipper: 0.9.0 -> 0.9.1.dev7+g9e95f06

### DIFF
--- a/pkgs/applications/audio/whipper/default.nix
+++ b/pkgs/applications/audio/whipper/default.nix
@@ -3,19 +3,24 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "whipper";
-  version = "0.9.0";
+  version = "0.9.1.dev7+g${stdenv.lib.substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "whipper-team";
     repo = "whipper";
-    rev = "v${version}";
-    sha256 = "0x1qsp021i0l5sdcm2kcv9zfwp696k4izhw898v6marf8phll7xc";
+    rev = "9e95f0604fa30ab06445fe46e3bc93bba6092a05";
+    sha256 = "1c2qldw9vxpvdfh5wl6mfcd7zzz3v8r86ffqll311lcp2zin33dg";
   };
 
   pythonPath = with python3.pkgs; [
-    pygobject3 musicbrainzngs urllib3 chardet
-    pycdio setuptools setuptools_scm mutagen
+    musicbrainzngs
+    mutagen
+    pycdio
+    pygobject3
     requests
+    ruamel_yaml
+    setuptools
+    setuptools_scm
   ];
 
   buildInputs = [ libsndfile ];
@@ -36,7 +41,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   preBuild = ''
-    export SETUPTOOLS_SCM_PRETEND_VERSION="v${version}"
+    export SETUPTOOLS_SCM_PRETEND_VERSION="${version}"
   '';
 
   # some tests require internet access


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I jumped the gun a little on #75635; missing dependencies and an upstream issue (whipper-team/whipper#431) meant that the `whipper` package was currently broken. This bumps it to a git revision with the issue fixed, and as a result I have successfully ripped several CDs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Ma27, if you don't mind merging this one :)