### PR TITLE
js_of_ocaml: 3.4.0 -> 3.5.2

### DIFF
--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchurl, stdenv
+{ callPackage, fetchurl, fetchpatch, stdenv
 , ocamlPackages, coqPackages, rubber, hevea, emacs }:
 
 stdenv.mkDerivation {
@@ -30,7 +30,13 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   # Remove unnecessary call to which
-  patches = [ ./configure.patch ];
+  patches = [ ./configure.patch
+    # Compatibility with js_of_ocaml 3.5
+    (fetchpatch {
+      url = "https://gitlab.inria.fr/why3/why3/commit/269ab313382fe3e64ef224813937314748bf7cf0.diff";
+      sha256 = "0i92wdnbh8pihvl93ac0ma1m5g95jgqqqj4kw6qqvbbjjqdgvzwa";
+    })
+  ];
 
   configureFlags = [ "--enable-verbose-make" ];
 

--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,7 +1,6 @@
 { stdenv, fetchzip, which, ocsigen_server, ocaml,
   lwt_react,
-  opaline, ppx_tools, ppx_deriving, findlib
-, ppx_tools_versioned
+  opaline, ppx_deriving, findlib
 , js_of_ocaml-ocamlbuild, js_of_ocaml-ppx, js_of_ocaml-ppx_deriving_json
 , js_of_ocaml-lwt
 , js_of_ocaml-tyxml
@@ -15,15 +14,14 @@ else
 stdenv.mkDerivation rec
 {
   pname = "eliom";
-  version = "6.8.0";
+  version = "6.10.1";
 
   src = fetchzip {
     url = "https://github.com/ocsigen/eliom/archive/${version}.tar.gz";
-    sha256 = "0di4q0wzbnk9sxlaj97ivghzh8qvjb8n17h80y4nmqhys97pldif";
+    sha256 = "006722wcmhsfhyzv3qbgrrn53fbv9v4i31z52a0pznb6cll45nkm";
   };
 
-  buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild js_of_ocaml-ppx_deriving_json opaline ppx_tools
-    ppx_tools_versioned
+  buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild js_of_ocaml-ppx_deriving_json opaline
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,15 +1,14 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, camlp4, ocsigen-toolkit, pgocaml, macaque, safepass, yojson
-, js_of_ocaml-camlp4, lwt_camlp4
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocsigen-toolkit, pgocaml_ppx, macaque, safepass, yojson
 , cohttp-lwt-unix
 , resource-pooling
 }:
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-ocsigen-start-${version}";
-  version = "2.7.0";
+  version = "2.16.1";
 
-  buildInputs = [ ocaml findlib js_of_ocaml-camlp4 lwt_camlp4 ];
-  propagatedBuildInputs = [ pgocaml macaque safepass ocsigen-toolkit yojson resource-pooling cohttp-lwt-unix camlp4 ];
+  buildInputs = [ ocaml findlib ];
+  propagatedBuildInputs = [ pgocaml_ppx safepass ocsigen-toolkit yojson resource-pooling cohttp-lwt-unix ];
 
   patches = [ ./templates-dir.patch ];
 
@@ -23,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "ocsigen";
     repo = "ocsigen-start";
     rev = version;
-    sha256 = "1kp9g679xnff2ybwsicnc9c203hi9ri1ijbpp6221b2sj6zxf2wc";
+    sha256 = "1pzpyrd3vbhc7zvzh6bv44793ikx5bglpd5p4wk5jj65v1w39jwd";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -5,9 +5,9 @@
 stdenv.mkDerivation rec {
  pname = "ocsigen-toolkit";
  name = "ocaml${ocaml.version}-${pname}-${version}";
- version = "2.2.0";
+ version = "2.5.0";
 
- propagatedBuildInputs = [ calendar eliom js_of_ocaml-ppx_deriving_json ];
+ propagatedBuildInputs = [ calendar js_of_ocaml-ppx_deriving_json eliom ];
  buildInputs = [ ocaml findlib opaline ];
 
  installPhase =
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     owner = "ocsigen";
     repo = pname;
     rev = version;
-    sha256 = "0qy6501jf81qcmkbicgrb1x4pxsjkhr40plwdn09w37d8vx9va3s";
+    sha256 = "0hll8qr363pbb65jnr2w36zcbplbwn08xb7826ayiwigakj783p9";
   };
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -1,16 +1,23 @@
 { stdenv, fetchFromGitHub, buildDunePackage
+, version ? "0.8.1"
 , ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
 }:
 
+let sha256 =
+  { "0.8.1" = "0vm0jajmg8135scbg0x60ivyy5gzv4abwnl7zls2mrw23ac6kml6";
+    "0.12.0" = "1cg0is23c05k1rc94zcdz452p9zn11dpqxm1pnifwx5iygz3w0a1";
+  }."${version}"
+; in
+
 buildDunePackage rec {
   pname = "ppxlib";
-  version = "0.8.1";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
     repo = pname;
     rev = version;
-    sha256 = "0vm0jajmg8135scbg0x60ivyy5gzv4abwnl7zls2mrw23ac6kml6";
+    inherit sha256;
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -1,23 +1,23 @@
 { lib, fetchFromGitHub, buildDunePackage
-, ocaml, findlib, cmdliner, dune, cppo, yojson
+, ocaml, findlib, cmdliner, dune, cppo, yojson, ocaml-migrate-parsetree
 }:
 
 buildDunePackage rec {
 	pname = "js_of_ocaml-compiler";
-	version = "3.4.0";
+	version = "3.5.2";
 
 	src = fetchFromGitHub {
 		owner = "ocsigen";
 		repo = "js_of_ocaml";
 		rev = version;
-		sha256 = "0c537say0f3197zn8d83nrihabrxyn28xc6d7c9c3l0vvrv6qvfj";
+		sha256 = "1fm855iavljx7rf9hii2qb7ky920zv082d9zlcl504by1bxp1yg8";
 	};
 
 	nativeBuildInputs = [ ocaml findlib dune cppo ];
   buildInputs = [ cmdliner ];
 
   configurePlatforms = [];
-	propagatedBuildInputs = [ yojson ];
+	propagatedBuildInputs = [ yojson ocaml-migrate-parsetree ];
 
 	meta = {
 		description = "Compiler from OCaml bytecode to Javascript";

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix
@@ -1,5 +1,5 @@
 { stdenv, ocaml, findlib, dune, js_of_ocaml-compiler
-, js_of_ocaml, ppx_deriving
+, js_of_ocaml, ppxlib
 }:
 
 stdenv.mkDerivation {
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
 	buildInputs = [ ocaml findlib dune ];
 
-	propagatedBuildInputs = [ js_of_ocaml ppx_deriving ];
+	propagatedBuildInputs = [ js_of_ocaml ppxlib ];
 
 	buildPhase = "dune build -p js_of_ocaml-ppx_deriving_json";
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -428,7 +428,9 @@ let
 
     js_of_ocaml-ppx = callPackage ../development/tools/ocaml/js_of_ocaml/ppx.nix {};
 
-    js_of_ocaml-ppx_deriving_json = callPackage ../development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix {};
+    js_of_ocaml-ppx_deriving_json = callPackage ../development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix {
+      ppxlib = ppxlib.override { version = "0.12.0"; };
+    };
 
     js_of_ocaml-tyxml = callPackage ../development/tools/ocaml/js_of_ocaml/tyxml.nix {};
 


### PR DESCRIPTION
a  drive-by contribution, as I was playing around with this (it has better
support for the `num` library, it seems.)