### PR TITLE
weechat: Fix build on Darwin (TCL fix also)

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, lib
-, ncurses, openssl, aspell, gnutls
+, ncurses, openssl, aspell, gnutls, gettext
 , zlib, curl, pkgconfig, libgcrypt
 , cmake, makeWrapper, libobjc, libresolv, libiconv
 , asciidoctor # manpages
@@ -49,7 +49,7 @@ let
         ;
 
       buildInputs = with stdenv.lib; [
-          ncurses openssl aspell gnutls zlib curl pkgconfig
+          ncurses openssl aspell gnutls gettext zlib curl pkgconfig
           libgcrypt makeWrapper cmake asciidoctor
           ]
         ++ optionals stdenv.isDarwin [ libobjc libresolv ]

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -34,7 +34,12 @@ stdenv.mkDerivation {
   postInstall = ''
     make install-private-headers
     ln -s $out/bin/tclsh${release} $out/bin/tclsh
-    ln -s $out/lib/libtcl${release}.so $out/lib/libtcl.so
+    if [[ -e "$out/lib/libtcl${release}.so" ]]; then
+      ln -s $out/lib/libtcl${release}.so $out/lib/libtcl.so
+    fi
+    if [[ -e "$out/lib/libtcl${release}.dylib" ]]; then
+      ln -s $out/lib/libtcl${release}.dylib $out/lib/libtcl.dylib
+    fi
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Darwin weechat needs `gettext`.

Also, the TCL derivation assumes dlls end with `.so` even on Darwin, which causes it to create a dangling symlink.  The weechat changelog indicates that the mechanism for detecting the library location has changed in this version, and the new version tries to link against the dangling symlink, causing it to fail.

The TCL bit causes a lot of rebuilds, so this PR is to `staging`.

###### Motivation for this change

Update of weechat derivation broke building on Darwin.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

weechat cc @lovek323 @the-kenny @lheckemann @ma27
tcl cc @vrthra