### PR TITLE
gegl_0_4: add patch for test timeouts

### DIFF
--- a/pkgs/development/libraries/gegl/4.0.nix
+++ b/pkgs/development/libraries/gegl/4.0.nix
@@ -57,6 +57,12 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/gegl/commit/2bc06bfedee4fb25f6a966c8235b75292e24e55f.patch";
       sha256 = "1psls61wsrdq5pzpvj22mrm46lpzrw3wkx6li7dv6fyb65wz2n4d";
     })
+
+    # Fix test timeout. Downstream debian patch.
+    (fetchpatch {
+      url = "https://salsa.debian.org/gnome-team/gegl/raw/9b7520b38d87cd8ad4b39bf0b8c62d011da25169/debian/patches/increase_test_timeout.patch";
+      sha256 = "1prc1h1aipjd9db0i1j7nzga4zvk3vl8qsjpz1jzv1wwvz02isly";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
##### Commit message

This has failed at the checkPhase many times
on hydra due to a timeout in a particular testcase.
I'm unable to identify which testcase it is within the
source from the output, but I usually place winning
bets on debian patches.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Too many occasions has the gnome3 tests failed because of gegl job timing out on a test.
https://hydra.nixos.org/build/108422657
https://hydra.nixos.org/build/108162813
https://hydra.nixos.org/build/108162815
https://hydra.nixos.org/build/108095634

Other times it's `checking for references to /build/ in /nix/store/k4gy2675j79g72hlj5ch2sjgxjh23abc-gegl-0.4.18-devdoc...` which is annoying enough for me to notice at this point.

I'm not sure it fixes anything **in NixOS**, so please be critical.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
