### PR TITLE
docker examples: Drop unneeded contents list

### DIFF
--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -236,7 +236,6 @@ rec {
     name = "another-layered-image";
     tag = "latest";
     config.Cmd = [ "${pkgs.hello}/bin/hello" ];
-    contents = [ pkgs.hello ];
   };
 
 }


### PR DESCRIPTION
##### Motivation for this change

The command being in the configuration is sufficient for the hello package to be included.

```
[nix-shell:~/projects/github.com/NixOS/nixpkgs]$ nix-build . -A dockerTools.examples.another-layered-image
these derivations will be built:
  /nix/store/9fnl8l0k8y1sg9mz49a67aivl8qhbba1-another-layered-image-granular-docker-layers.drv
  /nix/store/4iynqb80j30ciqhckv9yhh6rhh6ymfa6-docker-image-another-layered-image.tar.gz.drv
building '/nix/store/9fnl8l0k8y1sg9mz49a67aivl8qhbba1-another-layered-image-granular-docker-layers.drv'...
Creating layer #1 for /nix/store/xhpwab5kavygbr1fswawmdyqvmn3wa4i-glibc-2.27
Creating layer #2 for /nix/store/234v87nsmj70i1592h713i6xidfkqyjw-hello-2.10
Creating layer #3 for /nix/store/s37hdf10l0bwd9ik6fnpp4ppsgxmkp8p-another-layered-image-config.json
Creating layer #4 for /nix/store/8h4ab7990pv3yzrfv3q6kpgnx92iv7s3-bulk-layers
Creating layer #5 for /nix/store/mx2zl07020rw7j120p4bkpi5fi3ca4cy-closure
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
tar: Removing leading `/' from member names
Finished building layer 'another-layered-image-granular-docker-layers'
building '/nix/store/4iynqb80j30ciqhckv9yhh6rhh6ymfa6-docker-image-another-layered-image.tar.gz.drv'...
Cooking the image...
Finished.
/nix/store/hzq9n2343gl2f92ndpd4nwq972rr04mr-docker-image-another-layered-image.tar.gz

[nix-shell:~/projects/github.com/NixOS/nixpkgs]$  sudo docker load< ./result
[sudo] password for grahamc:
bbfe743ad63d: Loading layer [==================================================>]  10.24kB/10.24kB
f3b058e3822c: Loading layer [==================================================>]  71.68kB/71.68kB
1789b98d50f6: Loading layer [==================================================>]  10.24kB/10.24kB
f5cf65691c2f: Loading layer [==================================================>]  71.68kB/71.68kB
Loaded image: another-layered-image:latest

[nix-shell:~/projects/github.com/NixOS/nixpkgs]$ sudo docker run another-layered-image:latest
Hello, world!
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
