### PR TITLE
python3Packages.casbin: init at 0.8.3

### DIFF
--- a/pkgs/development/python-modules/casbin/default.nix
+++ b/pkgs/development/python-modules/casbin/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, simpleeval
+, isPy27
+, coveralls
+}:
+
+buildPythonPackage rec {
+  pname = "casbin";
+  version = "0.8.3";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "pycasbin";
+    rev = "v${version}";
+    sha256 = "1s89m62933m4wprsknwhabgg7irykrcimv80hh2zkyyslz5vbq71";
+  };
+
+  propagatedBuildInputs = [
+    simpleeval
+  ];
+
+  checkInputs = [
+    coveralls
+  ];
+
+  checkPhase = ''
+    coverage run -m unittest discover -s tests -t tests
+  '';
+
+  meta = with lib; {
+    description = "An authorization library that supports access control models like ACL, RBAC, ABAC in Python";
+    homepage = https://github.com/casbin/pycasbin;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1906,6 +1906,8 @@ in {
 
   cartopy = callPackage ../development/python-modules/cartopy {};
 
+  casbin = callPackage ../development/python-modules/casbin { };
+
   case = callPackage ../development/python-modules/case {};
 
   cbor = callPackage ../development/python-modules/cbor {};


### PR DESCRIPTION
### Motivation for this change

Adding poplular authorization library for python. Full test suite runs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
