### PR TITLE
sqlite-sqldiff: init at 3.30.0

### DIFF
--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   pname = "sqlite";
   version = "3.30.0";
 
-  # NB! Make sure to update analyzer.nix src (in the same directory).
+  # NB! Make sure to update analyzer.nix and sqldiff.nix src (in the same directory).
   src = fetchurl {
     url = "https://sqlite.org/2019/sqlite-autoconf-${archiveVersion version}.tar.gz";
     sha256 = "0n7w839y55dc3qqf2zv8xk6238cc6mpx24q4w5amwic7g96cza70";

--- a/pkgs/development/libraries/sqlite/sqldiff.nix
+++ b/pkgs/development/libraries/sqlite/sqldiff.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, unzip, sqlite, tcl }:
+
+let
+  archiveVersion = import ./archive-version.nix stdenv.lib;
+in
+
+stdenv.mkDerivation rec {
+  pname = "sqlite-sqldiff";
+  version = "3.30.0";
+
+  src = assert version == sqlite.version; fetchurl {
+    url = "https://sqlite.org/2019/sqlite-src-${archiveVersion version}.zip";
+    sha256 = "0d4i87q0f618pmrgax0mr5x7m8bywikrwjvixag3biyhgl5rx7fd";
+  };
+
+  nativeBuildInputs = [ unzip tcl ];
+
+  makeFlags = [ "sqldiff" ];
+
+  installPhase = "install -Dt $out/bin sqldiff";
+
+  meta = with stdenv.lib; {
+    description = "A tool that compares SQLite databases";
+    downloadPage = http://sqlite.org/download.html;
+    homepage = https://www.sqlite.org;
+    license = licenses.publicDomain;
+    maintainers = with maintainers; [ chaduffy ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14134,6 +14134,8 @@ in
 
   sqlite-analyzer = lowPrio (callPackage ../development/libraries/sqlite/analyzer.nix { });
 
+  sqlite-sqldiff = lowPrio (callPackage ../development/libraries/sqlite/sqldiff.nix { });
+
   sqlar = callPackage ../development/libraries/sqlite/sqlar.nix { };
 
   sqlite-interactive = appendToName "interactive" (sqlite.override { interactive = true; }).bin;


### PR DESCRIPTION
Tool for comparing sqlite databases, included in sqlite source.

Following same packaging conventions as sqlite-analyzer.

###### Motivation for this change

Useful tool included with sqlite distribution, not otherwise available in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
