### PR TITLE
nixos/nixos-option: "See also configuration.nix manpage" in nixos-option manpage

### DIFF
--- a/nixos/doc/manual/man-nixos-option.xml
+++ b/nixos/doc/manual/man-nixos-option.xml
@@ -119,4 +119,13 @@ Defined by:
    bug, please report to Nicolas Pierron.
   </para>
  </refsection>
+ <refsection>
+  <title>See also</title>
+  <para>
+   <citerefentry>
+    <refentrytitle>configuration.nix</refentrytitle>
+    <manvolnum>5</manvolnum>
+   </citerefentry>
+  </para>
+ </refsection>
 </refentry>


### PR DESCRIPTION
##### Motivation for this change

`man configuration.nix` is of interest to anyone reading `man nixos-option`


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
