### PR TITLE
cups-dymo: fix build

### DIFF
--- a/pkgs/misc/cups/drivers/dymo/fix-includes.patch
+++ b/pkgs/misc/cups/drivers/dymo/fix-includes.patch
@@ -65,3 +65,16 @@ diff -rp dymo-cups-drivers-1.4.0.5/src/lw/CupsFilterLabelWriter.h dymo-cups-driv
   #include <cups/raster.h>
   #include "LabelWriterDriver.h"
   #include "LabelWriterLanguageMonitor.h"
+diff -rp dymo-cups-drivers-1.4.0.5/src/common/CupsPrintEnvironment.cpp dymo-cups-drivers-1.4.0.5-fix/src/common/CupsPrintEnvironment.cpp
+*** dymo-cups-drivers-1.4.0.5/src/common/CupsPrintEnvironment.cpp	2019-12-16 19:37:23.429662838 +0000
+--- dymo-cups-drivers-1.4.0.5-fix/src/common/CupsPrintEnvironment.cpp	2019-12-16 19:41:48.506991614 +0000
+***************
+*** 23,28 ****
+--- 23,29 ----
+  #include "CupsPrintEnvironment.h"
+  #include <errno.h>
+  #include <cups/cups.h>
++ #include <cups/sidechannel.h>
+  #include <cassert>
+
+  namespace DymoPrinterDriver


### PR DESCRIPTION
###### Motivation for this change
Compilation broke, this fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @makefu
