### PR TITLE
ettercap: fix pango not finding hb.h from harfbuzz

### DIFF
--- a/pkgs/applications/networking/sniffers/ettercap/default.nix
+++ b/pkgs/applications/networking/sniffers/ettercap/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, libpcap, libnet, zlib, curl, pcre
-, openssl, ncurses, glib, gtk3, atk, pango, flex, bison, geoip
+, openssl, ncurses, glib, gtk3, atk, pango, flex, bison, geoip, harfbuzz
 , pkgconfig }:
 
 stdenv.mkDerivation rec {
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libpcap libnet zlib curl pcre openssl ncurses
     glib gtk3 atk pango geoip
+    harfbuzz
   ];
 
   preConfigure = ''
@@ -29,6 +30,8 @@ stdenv.mkDerivation rec {
     "-DBUNDLED_LIBS=Off"
     "-DGTK3_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
   ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${harfbuzz.dev}/include/harfbuzz" ];
 
   meta = with stdenv.lib; {
     description = "Comprehensive suite for man in the middle attacks";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It's broken, fixed it

The error message

```
In file included from /nix/store/6n6icd9pmmzdl7k39mdksv3k8y2z1bfn-pango-1.44.7-dev/include/pango-1.0/pango/pango-font.h:25,
                 from /nix/store/6n6icd9pmmzdl7k39mdksv3k8y2z1bfn-pango-1.44.7-dev/include/pango-1.0/pango/pango-attributes.h:25,
                 from /nix/store/6n6icd9pmmzdl7k39mdksv3k8y2z1bfn-pango-1.44.7-dev/include/pango-1.0/pango/pango.h:25,
                 from /nix/store/i1akaw2n7ryr3gms1yap6i463j9819xw-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdktypes.h:35,
                 from /nix/store/i1akaw2n7ryr3gms1yap6i463j9819xw-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdkapplaunchcontext.h:30,
                 from /nix/store/i1akaw2n7ryr3gms1yap6i463j9819xw-gtk+3-3.24.12-dev/include/gtk-3.0/gdk/gdk.h:32,
                 from /nix/store/i1akaw2n7ryr3gms1yap6i463j9819xw-gtk+3-3.24.12-dev/include/gtk-3.0/gtk/gtk.h:30,
                 from /build/source/src/interfaces/gtk3/ec_gtk3.h:4,
                 from /build/source/src/ec_interfaces.c:31:
/nix/store/6n6icd9pmmzdl7k39mdksv3k8y2z1bfn-pango-1.44.7-dev/include/pango-1.0/pango/pango-coverage.h:28:10: fatal error: hb.h: No such file or directory
 #include <hb.h>
          ^~~~~~
compilation terminated.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @pSub 
