### PR TITLE
errbot: fix darwin tests

### DIFF
--- a/pkgs/applications/networking/errbot/default.nix
+++ b/pkgs/applications/networking/errbot/default.nix
@@ -37,6 +37,7 @@ py.pkgs.buildPythonApplication rec {
     sleekxmpp pyasn1 pyasn1-modules hypchat
   ];
 
+  __darwinAllowLocalNetworking = true;
   checkInputs = with py.pkgs; [ mock pytest ];
   # avoid tests that do network calls
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing in another PR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
