### PR TITLE
Port NixOS tests to python

### DIFF
--- a/nixos/tests/hadoop/hdfs.nix
+++ b/nixos/tests/hadoop/hdfs.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({...}: {
+import ../make-test-python.nix ({...}: {
   nodes = {
     namenode = {pkgs, ...}: {
       services.hadoop = {
@@ -35,20 +35,20 @@ import ../make-test.nix ({...}: {
   };
 
   testScript = ''
-    startAll
+    start_all()
 
-    $namenode->waitForUnit("hdfs-namenode");
-    $namenode->waitForUnit("network.target");
-    $namenode->waitForOpenPort(8020);
-    $namenode->waitForOpenPort(9870);
+    namenode.wait_for_unit("hdfs-namenode")
+    namenode.wait_for_unit("network.target")
+    namenode.wait_for_open_port(8020)
+    namenode.wait_for_open_port(9870)
 
-    $datanode->waitForUnit("hdfs-datanode");
-    $datanode->waitForUnit("network.target");
-    $datanode->waitForOpenPort(9864);
-    $datanode->waitForOpenPort(9866);
-    $datanode->waitForOpenPort(9867);
+    datanode.wait_for_unit("hdfs-datanode")
+    datanode.wait_for_unit("network.target")
+    datanode.wait_for_open_port(9864)
+    datanode.wait_for_open_port(9866)
+    datanode.wait_for_open_port(9867)
 
-    $namenode->succeed("curl http://namenode:9870");
-    $datanode->succeed("curl http://datanode:9864");
+    namenode.succeed("curl http://namenode:9870")
+    datanode.succeed("curl http://datanode:9864")
   '';
 })

--- a/nixos/tests/hadoop/yarn.nix
+++ b/nixos/tests/hadoop/yarn.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({...}: {
+import ../make-test-python.nix ({...}: {
   nodes = {
     resourcemanager = {pkgs, ...}: {
       services.hadoop.package = pkgs.hadoop_3_1;
@@ -28,19 +28,19 @@ import ../make-test.nix ({...}: {
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $resourcemanager->waitForUnit("yarn-resourcemanager");
-    $resourcemanager->waitForUnit("network.target");
-    $resourcemanager->waitForOpenPort(8031);
-    $resourcemanager->waitForOpenPort(8088);
+    resourcemanager.wait_for_unit("yarn-resourcemanager")
+    resourcemanager.wait_for_unit("network.target")
+    resourcemanager.wait_for_open_port(8031)
+    resourcemanager.wait_for_open_port(8088)
 
-    $nodemanager->waitForUnit("yarn-nodemanager");
-    $nodemanager->waitForUnit("network.target");
-    $nodemanager->waitForOpenPort(8042);
-    $nodemanager->waitForOpenPort(8041);
+    nodemanager.wait_for_unit("yarn-nodemanager")
+    nodemanager.wait_for_unit("network.target")
+    nodemanager.wait_for_open_port(8042)
+    nodemanager.wait_for_open_port(8041)
 
-    $resourcemanager->succeed("curl http://localhost:8088");
-    $nodemanager->succeed("curl http://localhost:8042");
+    resourcemanager.succeed("curl http://localhost:8088")
+    nodemanager.succeed("curl http://localhost:8042")
   '';
 })

--- a/nixos/tests/hitch/default.nix
+++ b/nixos/tests/hitch/default.nix
@@ -1,4 +1,4 @@
-import ../make-test.nix ({ pkgs, ... }:
+import ../make-test-python.nix ({ pkgs, ... }:
 {
   name = "hitch";
   meta = with pkgs.stdenv.lib.maintainers; {
@@ -23,11 +23,11 @@ import ../make-test.nix ({ pkgs, ... }:
 
   testScript =
     ''
-      startAll;
+      start_all()
 
-      $machine->waitForUnit('multi-user.target');
-      $machine->waitForUnit('hitch.service');
-      $machine->waitForOpenPort(443);
-      $machine->succeed('curl -k https://localhost:443/index.txt | grep "We are all good!"');
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_for_unit("hitch.service")
+      machine.wait_for_open_port(443)
+      assert "We are all good!" in machine.succeed("curl -k https://localhost:443/index.txt")
     '';
 })


### PR DESCRIPTION
###### Motivation for this change

#72828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tfc 