### PR TITLE
python3Packages.fpylll: fix arch tests

### DIFF
--- a/pkgs/development/python-modules/fpylll/default.nix
+++ b/pkgs/development/python-modules/fpylll/default.nix
@@ -45,11 +45,9 @@ buildPythonPackage rec {
   ];
 
   checkPhase = ''
-    # Since upstream introduced --doctest-modules in
-    # https://github.com/fplll/fpylll/commit/9732fdb40cf1bd43ad1f60762ec0a8401743fc79,
-    # it is necessary to ignore import mismatches. Not sure why, but the files
-    # should be identical anyway.
-    PY_IGNORE_IMPORTMISMATCH=1 pytest
+    # avoid importing local files, and doing doc tests
+    cd tests
+    pytest
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
related: https://github.com/NixOS/nixpkgs/pull/74372#issuecomment-566233686

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
