### PR TITLE
python3Packages.aiorun: init at 2019.11.1

### DIFF
--- a/pkgs/development/python-modules/aiorun/default.nix
+++ b/pkgs/development/python-modules/aiorun/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, pytest
+, pytestcov
+, uvloop
+}:
+
+buildPythonPackage rec {
+  pname = "aiorun";
+  version = "2019.11.1";
+  format = "flit";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "cjrh";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04p3sci6af6qqfkcqamsqhmqqrigcwvl4bmx8yv5ppvkyq39pxi7";
+  };
+
+  checkInputs = [
+    pytest
+    pytestcov
+    uvloop
+  ];
+
+  # allow for writable directory for darwin
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkPhase = ''
+     pytest
+  '';
+
+  meta = with lib; {
+    description = "Boilerplate for asyncio applications";
+    homepage = https://github.com/cjrh/aiorun;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -165,6 +165,8 @@ in {
 
   aioredis = callPackage ../development/python-modules/aioredis { };
 
+  aiorun = callPackage ../development/python-modules/aiorun { };
+
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
   ansiwrap =  callPackage ../development/python-modules/ansiwrap { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Full test suite runs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
