### PR TITLE
arrow-cpp: add pkgsStatic support

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub, fixDarwinDylibNames, autoconf, boost
+{ stdenv, lib, fetchurl, fetchFromGitHub, fixDarwinDylibNames, autoconf, boost
 , brotli, cmake, double-conversion, flatbuffers, gflags, glog, gtest, lz4, perl
 , python, rapidjson, snappy, thrift, uriparser, which, zlib, zstd
 , enableShared ? true }:
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
   patches = [
     # patch to fix python-test
     ./darwin.patch
-  ] ++ stdenv.lib.optionals (!enableShared) [
+  ] ++ lib.optionals (!enableShared) [
     # The shared jemalloc lib is unused and breaks in static mode due to missing -fpic.
     ./jemalloc-disable-shared.patch
   ];
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
     cmake
     autoconf # for vendored jemalloc
     flatbuffers
-  ] ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
   buildInputs = [
     boost
     brotli
@@ -78,23 +78,23 @@ in stdenv.mkDerivation rec {
     # Disable Python for static mode because openblas is currently broken there.
     "-DARROW_PYTHON=${if enableShared then "ON" else "OFF"}"
     "-Duriparser_SOURCE=SYSTEM"
-  ] ++ stdenv.lib.optionals (!enableShared) [
+  ] ++ lib.optionals (!enableShared) [
     "-DARROW_BUILD_SHARED=OFF"
     "-DARROW_TEST_LINKAGE=static"
     "-DOPENSSL_USE_STATIC_LIBS=ON"
-  ] ++ stdenv.lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF";
+  ] ++ lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF";
 
   doInstallCheck = true;
   PARQUET_TEST_DATA =
     if doInstallCheck then "${parquet-testing}/data" else null;
   installCheckInputs = [ perl which ];
-  installCheckPhase = (stdenv.lib.optionalString stdenv.isDarwin ''
+  installCheckPhase = (lib.optionalString stdenv.isDarwin ''
     for f in release/*test{,s}; do
       install_name_tool -add_rpath "$out"/lib  "$f"
     done
   '')
   + (let
-    excludedTests = stdenv.lib.optionals stdenv.isDarwin [
+    excludedTests = lib.optionals stdenv.isDarwin [
       # Some plasma tests need to be patched to use a shorter AF_UNIX socket
       # path on Darwin. See https://github.com/NixOS/nix/pull/1085
       "plasma-external-store-tests"
@@ -108,8 +108,8 @@ in stdenv.mkDerivation rec {
   meta = {
     description = "A  cross-language development platform for in-memory data";
     homepage = "https://arrow.apache.org/";
-    license = stdenv.lib.licenses.asl20;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = with stdenv.lib.maintainers; [ tobim veprbl ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ tobim veprbl ];
   };
 }

--- a/pkgs/development/libraries/arrow-cpp/jemalloc-disable-shared.patch
+++ b/pkgs/development/libraries/arrow-cpp/jemalloc-disable-shared.patch
@@ -1,0 +1,11 @@
+diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
+--- a/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cmake_modules/ThirdpartyToolchain.cmake
+@@ -1428,6 +1428,7 @@ if(ARROW_JEMALLOC)
+                       "--with-jemalloc-prefix=je_arrow_"
+                       "--with-private-namespace=je_arrow_private_"
+                       "--without-export"
++                      "--disable-shared"
+                       # Don't override operator new()
+                       "--disable-cxx" "--disable-libdl"
+                       # See https://github.com/jemalloc/jemalloc/issues/1237

--- a/pkgs/development/libraries/double-conversion/default.nix
+++ b/pkgs/development/libraries/double-conversion/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake }:
+{ stdenv, lib, fetchFromGitHub, cmake, static ? false }:
 
 stdenv.mkDerivation rec {
   pname = "double-conversion";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}" ];
 
   # Case sensitivity issue
   preConfigure = lib.optionalString stdenv.isDarwin ''
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Binary-decimal and decimal-binary routines for IEEE doubles";
-    homepage = https://github.com/google/double-conversion;
+    homepage = "https://github.com/google/double-conversion";
     license = licenses.bsd3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ abbradar ];

--- a/pkgs/development/libraries/gflags/default.nix
+++ b/pkgs/development/libraries/gflags/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchFromGitHub, cmake, enableShared ? true}:
 
 stdenv.mkDerivation rec {
   pname = "gflags";
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
   preConfigure = "rm BUILD";
 
   cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_STATIC_LIBS=ON"
+    "-DGFLAGS_BUILD_SHARED_LIBS=${if enableShared then "ON" else "OFF"}"
+    "-DGFLAGS_BUILD_STATIC_LIBS=ON"
   ];
 
   doCheck = false;

--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, autoreconfHook, perl }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, perl, static ? false }:
 
 stdenv.mkDerivation rec {
   pname = "glog";
@@ -20,13 +20,15 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}" ];
 
   checkInputs = [ perl ];
   doCheck = false; # fails with "Mangled symbols (28 out of 380) found in demangle.dm"
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/google/glog;
+    homepage = "https://github.com/google/glog";
     license = licenses.bsd3;
     description = "Library for application-level logging";
     platforms = platforms.unix;

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -115,6 +115,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     perl
     which
+  ];
+
+  depsBuildBuild = [
     buildPackages.gfortran
     buildPackages.stdenv.cc
   ];

--- a/pkgs/development/libraries/snappy/default.nix
+++ b/pkgs/development/libraries/snappy/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchFromGitHub, cmake, static ? false }:
 
 stdenv.mkDerivation rec {
   pname = "snappy";
@@ -17,7 +17,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" "-DCMAKE_SKIP_BUILD_RPATH=OFF" ];
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+  ];
 
   postInstall = ''
     substituteInPlace "$out"/lib/cmake/Snappy/SnappyTargets.cmake \
@@ -29,7 +32,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with stdenv.lib; {
-    homepage = https://google.github.io/snappy/;
+    homepage = "https://google.github.io/snappy/";
     license = licenses.bsd3;
     description = "Compression/decompression library for very high speeds";
     platforms = platforms.all;

--- a/pkgs/development/web/woff2/brotli-static.patch
+++ b/pkgs/development/web/woff2/brotli-static.patch
@@ -1,0 +1,36 @@
+diff a/cmake/FindBrotliDec.cmake b/cmake/FindBrotliDec.cmake
+--- a/cmake/FindBrotliDec.cmake
++++ b/cmake/FindBrotliDec.cmake
+@@ -18,10 +18,10 @@ find_path(BROTLIDEC_INCLUDE_DIRS
+     HINTS ${PC_BROTLIDEC_INCLUDEDIR}
+ )
+ 
+-find_library(BROTLIDEC_LIBRARIES
+-    NAMES brotlidec
+-    HINTS ${PC_BROTLIDEC_LIBDIR}
+-)
++if(NOT BUILD_SHARED_LIBS)
++  set(_S "STATIC_")
++endif()
++set(BROTLIDEC_LIBRARIES ${PC_BROTLIDEC_${_S}LIBRARIES})
+ 
+ include(FindPackageHandleStandardArgs)
+ find_package_handle_standard_args(BrotliDec
+diff a/cmake/FindBrotliEnc.cmake b/cmake/FindBrotliEnc.cmake
+--- a/cmake/FindBrotliEnc.cmake
++++ b/cmake/FindBrotliEnc.cmake
+@@ -18,10 +18,10 @@ find_path(BROTLIENC_INCLUDE_DIRS
+     HINTS ${PC_BROTLIENC_INCLUDEDIR}
+ )
+ 
+-find_library(BROTLIENC_LIBRARIES
+-    NAMES brotlienc
+-    HINTS ${PC_BROTLIENC_LIBDIR}
+-)
++if(NOT BUILD_SHARED_LIBS)
++  set(_S "STATIC_")
++endif()
++set(BROTLIENC_LIBRARIES ${PC_BROTLIENC_${_S}LIBRARIES})
+ 
+ include(FindPackageHandleStandardArgs)
+ find_package_handle_standard_args(BrotliEnc

--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchFromGitHub, fetchpatch, gnugrep
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, gnugrep
 , fixDarwinDylibNames
 , file
-, legacySupport ? false }:
+, legacySupport ? false
+, enableShared ? true }:
 
 stdenv.mkDerivation rec {
   pname = "zstd";
@@ -14,55 +15,45 @@ stdenv.mkDerivation rec {
     owner = "facebook";
   };
 
+  nativeBuildInputs = [ cmake ]
+   ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
   patches = [
-    # All 3 from https://github.com/facebook/zstd/pull/1883
+    # From https://github.com/facebook/zstd/pull/1883
     (fetchpatch {
       url = "https://github.com/facebook/zstd/commit/106278e7e5fafaea3b7deb4147bdc8071562d2f0.diff";
       sha256 = "13z7id1qbc05cv1rmak7c8xrchp7jh1i623bq5pwcihg57wzcyr8";
-    })
-    (fetchpatch {
-      url = "https://github.com/facebook/zstd/commit/0ede342acc2c26f87ae962fa88e158904d4198c4.diff";
-      sha256 = "12l5xbvnzkvr76mvl1ls767paqfwbd9q1pzq44ckacfpz4f6iaap";
-      excludes = [
-        # I think line endings are causing problems, or something like that
-        "programs/windres/generate_res.bat"
-      ];
-    })
-    (fetchpatch {
-      url = "https://github.com/facebook/zstd/commit/10552eaffef84c011f67af0e04f0780b50a5ab26.diff";
-      sha256 = "1s27ravar3rn7q8abybp9733jhpsfcaci51k04da94ahahvxwiqw";
     })
   ] # This I didn't upstream because if you use posix threads with MinGW it will
     # work find, and I'm not sure how to write the condition.
     ++ stdenv.lib.optional stdenv.hostPlatform.isWindows ./mcfgthreads-no-pthread.patch;
 
-  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
-
-  makeFlags = [
-    "ZSTD_LEGACY_SUPPORT=${if legacySupport then "1" else "0"}"
-  ] ++ stdenv.lib.optional stdenv.hostPlatform.isWindows "OS=Windows";
+  cmakeFlags = [
+    "-DZSTD_BUILD_SHARED:BOOL=${if enableShared then "ON" else "OFF"}"
+    "-DZSTD_LEGACY_SUPPORT:BOOL=${if legacySupport then "ON" else "OFF"}"
+    "-DZSTD_BUILD_TESTS:BOOL=ON"
+  ];
+  cmakeDir = "../build/cmake";
+  dontUseCmakeBuildDir = true;
+  preConfigure = ''
+    mkdir -p build_ && cd $_
+  '';
 
   checkInputs = [ file ];
   doCheck = true;
   preCheck = ''
-    substituteInPlace tests/playTests.sh \
+    substituteInPlace ../tests/playTests.sh \
       --replace 'MD5SUM="md5 -r"' 'MD5SUM="md5sum"'
   '';
 
-  installFlags = [
-    "PREFIX=$(out)"
-  ];
-
-  preInstall = ''
-    substituteInPlace programs/zstdgrep \
+  preInstall = stdenv.lib.optionalString enableShared ''
+    substituteInPlace ../programs/zstdgrep \
       --replace ":-grep" ":-${gnugrep}/bin/grep" \
       --replace ":-zstdcat" ":-$out/bin/zstdcat"
 
-    substituteInPlace programs/zstdless \
+    substituteInPlace ../programs/zstdless \
       --replace "zstdcat" "$out/bin/zstdcat"
   '';
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Zstandard real-time compression algorithm";

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -223,6 +223,10 @@ in {
     staticOnly = true;
   };
 
+  zstd = super.zstd.override {
+    enableShared = false;
+  };
+
   llvmPackages_8 = super.llvmPackages_8 // {
     libraries = super.llvmPackages_8.libraries // rec {
       libcxxabi = super.llvmPackages_8.libraries.libcxxabi.override {

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -162,6 +162,10 @@ in {
     # --disable-shared flag
     stdenv = super.stdenv;
   };
+  arrow-cpp = super.arrow-cpp.override {
+    enableShared = false;
+    python = { pkgs = { python = null; numpy = null; }; };
+  };
   boost = super.boost.override {
     enableStatic = true;
     enableShared = false;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -203,6 +203,9 @@ in {
     # it doesn’t like the --disable-shared flag
     stdenv = super.stdenv;
   };
+  woff2 = super.woff2.override {
+    static = true;
+  };
   lz4 = super.lz4.override {
     enableShared = false;
     enableStatic = true;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -176,6 +176,9 @@ in {
   gmp = super.gmp.override {
     withStatic = true;
   };
+  gflags = super.gflags.override {
+    enableShared = false;
+  };
   glog = super.glog.override {
     static = true;
   };

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -170,6 +170,9 @@ in {
     # --disable-shared flag
     stdenv = super.stdenv;
   };
+  double-conversion = super.double-conversion.override {
+    static = true;
+  };
   gmp = super.gmp.override {
     withStatic = true;
   };

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -206,6 +206,9 @@ in {
   woff2 = super.woff2.override {
     static = true;
   };
+  snappy = super.snappy.override {
+    static = true;
+  };
   lz4 = super.lz4.override {
     enableShared = false;
     enableStatic = true;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -176,6 +176,9 @@ in {
   gmp = super.gmp.override {
     withStatic = true;
   };
+  glog = super.glog.override {
+    static = true;
+  };
   cdo = super.cdo.override {
     enable_all_static = true;
   };

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -55,7 +55,7 @@ self: super: let
   removeUnknownConfigureFlags = f: with self.lib;
     remove "--disable-shared"
     (remove "--enable-static" f);
-  
+
   ocamlFixPackage = b:
     b.overrideAttrs (o: {
       configurePlatforms = [ ];
@@ -63,7 +63,7 @@ self: super: let
       buildInputs = o.buildInputs ++ o.nativeBuildInputs or [ ];
       propagatedNativeBuildInputs = o.propagatedBuildInputs or [ ];
     });
-  
+
   ocamlStaticAdapter = _: super:
     self.lib.mapAttrs
       (_: p: if p ? overrideAttrs then ocamlFixPackage p else p)
@@ -170,6 +170,10 @@ in {
     # --disable-shared flag
     stdenv = super.stdenv;
   };
+  thrift = super.thrift.override {
+    static = true;
+    twisted = null;
+  };
   double-conversion = super.double-conversion.override {
     static = true;
   };
@@ -227,7 +231,7 @@ in {
   kmod = super.kmod.override {
     withStatic = true;
   };
-  
+
   curl = super.curl.override {
     # a very sad story: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=439039
     gssSupport = false;
@@ -263,6 +267,6 @@ in {
   ocaml-ng = self.lib.mapAttrs (_: set:
     if set ? overrideScope' then set.overrideScope' ocamlStaticAdapter else set
   ) super.ocaml-ng;
-  
+
   python27 = super.python27.override { static = true; };
 }

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -182,6 +182,9 @@ in {
   glog = super.glog.override {
     static = true;
   };
+  gtest = super.gtest.override {
+    static = true;
+  };
   cdo = super.cdo.override {
     enable_all_static = true;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done
Added a static option to _zstd_, _double-conversion_, _gflags_, _glog_, _gtest_, _woff2_, _snappy_, _thrift_, and finally _arrow-cpp_.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
