### PR TITLE
public-inbox: init at 1.2.0

### DIFF
--- a/pkgs/servers/mail/public-inbox/default.nix
+++ b/pkgs/servers/mail/public-inbox/default.nix
@@ -1,0 +1,66 @@
+{ buildPerlPackage, lib, fetchurl, makeWrapper
+, DBDSQLite, EmailMIME, IOSocketSSL, IPCRun, Plack, PlackMiddlewareReverseProxy
+, SearchXapian, TimeDate, URI
+, git, highlight, openssl, xapian
+}:
+
+let
+
+  # These tests would fail, and produce "Operation not permitted"
+  # errors from git, because they use git init --shared.  This tries
+  # to set the setgid bit, which isn't permitted inside build
+  # sandboxes.
+  #
+  # These tests were indentified with
+  #     grep -r shared t/
+  skippedTests = [ "convert-compact" "search" "v2writable" "www_listing" ];
+
+  testConditions = with lib;
+    concatMapStringsSep " " (n: "! -name ${escapeShellArg n}.t") skippedTests;
+
+in
+
+buildPerlPackage rec {
+  pname = "public-inbox";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://public-inbox.org/releases/public-inbox-${version}.tar.gz";
+    sha256 = "0sa2m4f2x7kfg3mi4im7maxqmqvawafma8f7g92nyfgybid77g6s";
+  };
+
+  outputs = [ "out" "devdoc" "sa_config" ];
+
+  postConfigure = ''
+    substituteInPlace Makefile --replace 'TEST_FILES = t/*.t' \
+        'TEST_FILES = $(shell find t -name *.t ${testConditions})'
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    DBDSQLite EmailMIME IOSocketSSL IPCRun Plack PlackMiddlewareReverseProxy
+    SearchXapian TimeDate URI highlight
+  ];
+
+  checkInputs = [ git openssl xapian ];
+  preCheck = ''
+    perl certs/create-certs.perl
+  '';
+
+  installTargets = [ "install" ];
+  postInstall = ''
+    for prog in $out/bin/*; do
+        wrapProgram $prog --prefix PATH : ${lib.makeBinPath [ git ]}
+    done
+
+    mv sa_config $sa_config
+  '';
+
+  meta = with lib; {
+    homepage = "https://public-inbox.org/";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ qyliss ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/text/highlight/default.nix
+++ b/pkgs/tools/text/highlight/default.nix
@@ -1,37 +1,58 @@
-{ stdenv, fetchFromGitLab, getopt, lua, boost, pkgconfig, gcc }:
+{ stdenv, fetchFromGitLab, getopt, lua, boost, pkgconfig, swig, perl, gcc }:
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
-  pname = "highlight";
-  version = "3.54";
+let
+  self = stdenv.mkDerivation rec {
+    pname = "highlight";
+    version = "3.54";
 
-  src = fetchFromGitLab {
-    owner = "saalen";
-    repo = "highlight";
-    rev = "v${version}";
-    sha256 = "1144qv3c02hd3qrnms9cxfprdmkvz06vy4zjq500wg4iz7r8654m";
+    src = fetchFromGitLab {
+      owner = "saalen";
+      repo = "highlight";
+      rev = "v${version}";
+      sha256 = "1144qv3c02hd3qrnms9cxfprdmkvz06vy4zjq500wg4iz7r8654m";
+    };
+
+    enableParallelBuilding = true;
+
+    nativeBuildInputs = [ pkgconfig swig perl ] ++ optional stdenv.isDarwin gcc;
+
+    buildInputs = [ getopt lua boost ];
+
+    prePatch = stdenv.lib.optionalString stdenv.cc.isClang ''
+      substituteInPlace src/makefile \
+          --replace 'CXX=g++' 'CXX=clang++'
+    '';
+
+    preConfigure = ''
+      makeFlags="PREFIX=$out conf_dir=$out/etc/highlight/ CXX=$CXX AR=$AR"
+    '';
+
+    # This has to happen _before_ the main build because it does a
+    # `make clean' for some reason.
+    preBuild = optionalString (!stdenv.isDarwin) ''
+      make -C extras/swig $makeFlags perl
+    '';
+
+    postCheck = optionalString (!stdenv.isDarwin) ''
+      perl -Iextras/swig extras/swig/testmod.pl
+    '';
+
+    preInstall = optionalString (!stdenv.isDarwin) ''
+      mkdir -p $out/${perl.libPrefix}
+      install -m644 extras/swig/highlight.{so,pm} $out/${perl.libPrefix}
+      make -C extras/swig clean # Clean up intermediate files.
+    '';
+
+    meta = with stdenv.lib; {
+      description = "Source code highlighting tool";
+      homepage = "http://www.andre-simon.de/doku/highlight/en/highlight.php";
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ ndowens willibutz ];
+    };
   };
 
-  enableParallelBuilding = true;
-
-  nativeBuildInputs = [ pkgconfig ] ++ optional stdenv.isDarwin  gcc ;
-
-  buildInputs = [ getopt lua boost ];
-
-  prePatch = stdenv.lib.optionalString stdenv.cc.isClang ''
-    substituteInPlace src/makefile \
-        --replace 'CXX=g++' 'CXX=clang++'
-  '';
-
-  preConfigure = ''
-    makeFlags="PREFIX=$out conf_dir=$out/etc/highlight/ CXX=$CXX AR=$AR"
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Source code highlighting tool";
-    homepage = "http://www.andre-simon.de/doku/highlight/en/highlight.php";
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ ndowens willibutz ];
-  };
-}
+in
+  if stdenv.isDarwin then self
+  else perl.pkgs.toPerlModule self

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15520,6 +15520,8 @@ in
 
   psqlodbc = callPackage ../development/libraries/psqlodbc { };
 
+  public-inbox = perlPackages.callPackage ../servers/mail/public-inbox { };
+
   pure-ftpd = callPackage ../servers/ftp/pure-ftpd { };
 
   pyIRCt = callPackage ../servers/xmpp/pyIRCt {};

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15725,6 +15725,28 @@ let
     };
   };
 
+  SearchXapian = buildPerlPackage rec {
+    pname = "Search-Xapian";
+    version = "1.2.25.2";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/O/OL/OLLY/Search-Xapian-${version}.tar.gz";
+      sha256 = "0hpa8gi38j0ibq8af6dy69lm1bl5jnq76nsa69dbrzbr88l5m594";
+    };
+    patches = [
+      (fetchpatch {
+        url = "https://git.xapian.org/?p=xapian;a=patch;h=69ad652b7ad7912801e686db2da55d73f79fbf75";
+        name = "fix-automated-testing-false-negative";
+        sha256 = "1241mpyf8mgx7szyl5sxa6wl388rzph3q51mn9v4yjbm0k5l0sxr";
+        stripLen = 1;
+      })
+    ];
+    buildInputs = [ pkgs.xapian ExtUtilsMakeMaker DevelLeak ];
+    meta = {
+      description = "Perl XS frontend to the Xapian C++ search library";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   SerealDecoder = buildPerlPackage {
     pname = "Sereal-Decoder";
     version = "4.007";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4721,6 +4721,20 @@ let
     propagatedBuildInputs = [ DataCompare ];
   };
 
+  DevelLeak = buildPerlPackage rec {
+    pname = "Devel-Leak";
+    version = "0.03";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/N/NI/NI-S/Devel-Leak-${version}.tar.gz";
+      sha256 = "0lkj2xwc3lhxv7scl43r8kfmls4am0b98sqf5vmf7d72257w6hkg";
+    };
+    meta = {
+      homepage = "https://metacpan.org/release/Devel-Leak";
+      description = "Utility for looking for perl objects that are not reclaimed";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ]; # According to Debian
+    };
+  };
+
   DevelPatchPerl = buildPerlPackage {
     pname = "Devel-PatchPerl";
     version = "1.80";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Supersedes #61158.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @catern
