### PR TITLE
ecl: fix build with libffi 3.3

### DIFF
--- a/pkgs/development/compilers/ecl/16.1.2.nix
+++ b/pkgs/development/compilers/ecl/16.1.2.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation {
       url = "https://git.sagemath.org/sage.git/plain/build/pkgs/ecl/patches/16.1.2-getcwd.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
       sha256 = "1fbi8gn7rv8nqff5mpaijsrch3k3z7qc5cn4h1vl8qrr8xwqlqhb";
     })
+    ./ecl-1.16.2-libffi-3.3-abi.patch
   ];
 
   hardeningDisable = [ "format" ];

--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -35,6 +35,10 @@ stdenv.mkDerivation {
     inherit (s) url sha256;
   };
 
+  patches = [
+    ./libffi-3.3-abi.patch
+  ];
+
   configureFlags = [
     (if threadSupport then "--enable-threads" else "--disable-threads")
     "--with-gmp-prefix=${gmp.dev}"

--- a/pkgs/development/compilers/ecl/ecl-1.16.2-libffi-3.3-abi.patch
+++ b/pkgs/development/compilers/ecl/ecl-1.16.2-libffi-3.3-abi.patch
@@ -1,0 +1,15 @@
+diff --git a/src/c/ffi.d b/src/c/ffi.d
+index 8861303e..8a959c23 100644
+--- a/src/c/ffi.d
++++ b/src/c/ffi.d
+@@ -145,8 +145,8 @@ static struct {
+ #elif defined(X86_WIN64)
+         {@':win64', FFI_WIN64},
+ #elif defined(X86_ANY) || defined(X86) || defined(X86_64)
+-        {@':cdecl', FFI_SYSV},
+-        {@':sysv', FFI_SYSV},
++        {@':cdecl', FFI_UNIX64},
++        {@':sysv', FFI_UNIX64},
+         {@':unix64', FFI_UNIX64},
+ #endif
+ };

--- a/pkgs/development/compilers/ecl/libffi-3.3-abi.patch
+++ b/pkgs/development/compilers/ecl/libffi-3.3-abi.patch
@@ -1,0 +1,15 @@
+diff --git a/src/c/ffi.d b/src/c/ffi.d
+index 8174977a..caa69f39 100644
+--- a/src/c/ffi.d
++++ b/src/c/ffi.d
+@@ -133,8 +133,8 @@ static struct {
+ #elif defined(X86_WIN64)
+   {@':win64', FFI_WIN64},
+ #elif defined(X86_ANY) || defined(X86) || defined(X86_64)
+-  {@':cdecl', FFI_SYSV},
+-  {@':sysv', FFI_SYSV},
++  {@':cdecl', FFI_UNIX64},
++  {@':sysv', FFI_UNIX64},
+   {@':unix64', FFI_UNIX64},
+ #endif
+ };


### PR DESCRIPTION
###### Motivation for this change

The build was broken by the recent libffi update
(53a04a2df0c0812fd983364184d519dc3356e7d2) because of this upstream
change:

https://github.com/libffi/libffi/commit/ef76205647bca77796882d31f6ab5e889f461f07

I have changed the usage of FFI_SYSV as gentoo suggests:

https://wiki.gentoo.org/wiki/Libffi_3.3_porting_notes/FFI_SYSV

I'm not entirely sure if that is the right call here, but I haven't
noticed any regressions in my testing and its definitely better than a
broken build.

Upstream: https://gitlab.com/embeddable-common-lisp/ecl/issues/302


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
