### PR TITLE
Revert "python: gym: 0.15.3 -> 0.15.4"

### DIFF
--- a/pkgs/development/python-modules/gym/default.nix
+++ b/pkgs/development/python-modules/gym/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "gym";
-  version = "0.15.4";
+  version = "0.15.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3b930cbe1c76bbd30455b5e82ba723dea94159a5f988e927f443324bf7cc7ddd";
+    sha256 = "18381e13bbd1e2f206a1b88a2af4fb87affd7d06ee7955a6e5e6a79478a9adfc";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
This package was prematurely updated as part of updating the package set for python3.8

```
0.15.4 requires python-opencv, which isn't packaged yet,
and is not trival to package

This reverts commit 8ee4062480e78f17f47c0e9893c6e16fdff35b73.
```
closes: #75749
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

technically, these are all broken on master :)
```
8 built (2 failed), 258 copied (2260.6 MiB), 783.3 MiB DL]
error: build of '/nix/store/jpn71f3m0l5wk6zfs6sya83vh25bw64x-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/75802
2 package failed to build:
python37Packages.rl-coach python38Packages.baselines

6 package were built:
python27Packages.gym python37Packages.baselines python37Packages.gym python37Packages.roboschool python38Packages.gym python38Packages.roboschool
```