### PR TITLE
ruby-modules: parse build_flags correctly

### DIFF
--- a/pkgs/development/ruby-modules/gem/nix-bundle-install.rb
+++ b/pkgs/development/ruby-modules/gem/nix-bundle-install.rb
@@ -5,6 +5,7 @@ require 'rubygems/command'
 require 'fileutils'
 require 'pathname'
 require 'tmpdir'
+require 'shellwords'
 
 if defined?(Encoding.default_internal)
   Encoding.default_internal = Encoding::UTF_8
@@ -31,7 +32,7 @@ bin_dir = File.join(ENV["out"], "bin")
 type        = ARGV[0]
 name        = ARGV[1]
 version     = ARGV[2]
-build_flags = ARGV[3]
+build_flags = Shellwords.split(ARGV[3])
 if type == "git"
   uri         = ARGV[4]
   REPO        = ARGV[5]
@@ -117,7 +118,7 @@ else
   source = Bundler::Source::Path.new(options)
 end
 spec = source.specs.search_all(name).first
-Bundler.rubygems.with_build_args [build_flags] do
+Bundler.rubygems.with_build_args build_flags do
   source.install(spec)
 end
 


### PR DESCRIPTION
In building a gem whose native extension is a Rakefile, the previous version of this code will call essentially `rake ""`, when it means to call `rake`. This breaks the intent to call the default task.

This change converts `""` into `[]` rather than `[""]`, and probably un-breaks conditions where we're trying to pass multiple flags, since bundler/rubygems seems to want them as an array of flags.

cc @aneeshusa @zimbatm 