### PR TITLE
[RFC] mkDerivation: support version suffix, which is part of derivation nam…

### DIFF
--- a/pkgs/applications/audio/amarok/default.nix
+++ b/pkgs/applications/audio/amarok/default.nix
@@ -8,7 +8,8 @@
 
 mkDerivation rec {
   pname = "amarok";
-  version = "2.9.0-20190824";
+  version = "2.9.1pre";
+  versionSuffix = "20190824";
 
   src = fetchgit {
     # master has the Qt5 version as of April 2018 but a formal release has not

--- a/pkgs/applications/graphics/sane/backends/dsseries/default.nix
+++ b/pkgs/applications/graphics/sane/backends/dsseries/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libsane-dsseries";
-  version = "1.0.5-1";
+  version = "1.0.5-1"; # '-1' is not suffix, but part of version
 
   src = fetchurl {
     url = "https://download.brother.com/welcome/dlf100974/${pname}-${version}.x86_64.rpm";

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-discord/default.nix
@@ -1,8 +1,9 @@
 { stdenv, fetchFromGitHub, pkgconfig, pidgin, json-glib }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "purple-discord";
-  version = "unstable-2018-04-10";
+  version = "2018.04.10";
+  versionSuffix = "_" + builtins.substring 0 7 src.rev;
 
   src = fetchFromGitHub {
     owner = "EionRobb";

--- a/pkgs/development/libraries/science/math/QuadProgpp/default.nix
+++ b/pkgs/development/libraries/science/math/QuadProgpp/default.nix
@@ -2,12 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "QuadProgpp";
-  version = "4b6bd65f09fbff99c172a86d6e96ca74449b323f";
+  version = "1.2.2pre";
+  versionSuffix = "_" + builtins.substring 0 7 src.rev;
 
   src = fetchFromGitHub {
     owner = "liuq";
     repo = "QuadProgpp";
-    rev = version;
+    rev = "4b6bd65f09fbff99c172a86d6e96ca74449b323f";
     sha256 = "02r0dlk2yjpafknvm945vbgs4sl26w2i1gw3pllar9hi364y8hnx";
   };
 

--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -6,18 +6,11 @@
 let
   # Release notes and download URLs are here:
   # https://registrationcenter.intel.com/en/products/
-  version = "${year}.${spot}.${rel}";
-  year = "2019";
-
-  # Darwin is pinned to 2019.3 because the DMG does not unpack; see here for details:
-  # https://github.com/matthewbauer/undmg/issues/4
-  spot = if stdenvNoCC.isDarwin then "3" else "5";
-  rel = if stdenvNoCC.isDarwin then "199" else "281";
-
-  rpm-ver = "${year}.${spot}-${rel}-${year}.${spot}-${rel}";
-
-  # Intel openmp uses its own versioning, but shares the spot release patch.
-  openmp-ver = "19.0.${spot}-${rel}-19.0.${spot}-${rel}";
+  version = if stdenvNoCC.isDarwin
+    # Darwin is pinned to 2019.3 because the DMG does not unpack; see here for details:
+    # https://github.com/matthewbauer/undmg/issues/4
+    then "2019.3.199"
+    else "2019.5.281";
 
 in stdenvNoCC.mkDerivation {
   pname = "mkl";
@@ -46,11 +39,11 @@ in stdenvNoCC.mkDerivation {
       tar xzvf $f
     done
   '' else ''
-    rpmextract rpm/intel-mkl-cluster-rt-${rpm-ver}.x86_64.rpm
-    rpmextract rpm/intel-mkl-common-c-${rpm-ver}.noarch.rpm
-    rpmextract rpm/intel-mkl-core-${rpm-ver}.x86_64.rpm
-    rpmextract rpm/intel-mkl-core-rt-${rpm-ver}.x86_64.rpm
-    rpmextract rpm/intel-openmp-${openmp-ver}.x86_64.rpm
+    rpmextract rpm/intel-mkl-cluster-rt-*.x86_64.rpm
+    rpmextract rpm/intel-mkl-common-c-*.noarch.rpm
+    rpmextract rpm/intel-mkl-core-20*.x86_64.rpm
+    rpmextract rpm/intel-mkl-core-rt-*.x86_64.rpm
+    rpmextract rpm/intel-openmp-*.x86_64.rpm
   '';
 
   installPhase = ''

--- a/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel-remote/default.nix
@@ -8,7 +8,7 @@
 
 buildBazelPackage rec {
   name = "bazel-remote-${version}";
-  version = "2019-01-12";
+  version = "2019.01.12";
 
   src = fetchFromGitHub {
     owner = "buchgr";

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -22,6 +22,7 @@ let
   in stdenv.mkDerivation rec {
     pname = "postgresql";
     inherit version;
+    versionSuffix = ".p" + toString (lib.length patches);
 
     src = fetchurl {
       url = "mirror://postgresql/source/v${version}/${pname}-${version}.tar.bz2";

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -19,18 +19,20 @@ common =
   , withLibseccomp ? lib.any (lib.meta.platformMatch stdenv.hostPlatform) libseccomp.meta.platforms, libseccomp
   , withAWS ? stdenv.isLinux || stdenv.isDarwin, aws-sdk-cpp
 
-  , name, suffix ? "", src, includesPerl ? false, fromGit ? false
+  , version, suffix ? "", src, includesPerl ? false, fromGit ? false
 
-  }:
+  }@attrs:
   let
      sh = busybox-sandbox-shell;
      nix = stdenv.mkDerivation rec {
-      inherit name src;
-      version = lib.getVersion name;
+      pname = "nix";
+      version = attrs.version;
+      versionSuffix = suffix;
+      VERSION_SUFFIX = suffix;
+
+      inherit src;
 
       is20 = lib.versionAtLeast version "2.0pre";
-
-      VERSION_SUFFIX = lib.optionalString fromGit suffix;
 
       outputs = [ "out" "dev" "man" "doc" ];
 
@@ -161,9 +163,9 @@ in rec {
   nix = nixStable;
 
   nix1 = callPackage common rec {
-    name = "nix-1.11.16";
+    version = "1.11.16";
     src = fetchurl {
-      url = "http://nixos.org/releases/nix/${name}/${name}.tar.xz";
+      url = "http://nixos.org/releases/nix/nix-${version}/nix-${version}.tar.xz";
       sha256 = "0ca5782fc37d62238d13a620a7b4bff6a200bab1bd63003709249a776162357c";
     };
 
@@ -174,9 +176,9 @@ in rec {
   };
 
   nixStable = callPackage common (rec {
-    name = "nix-2.3.1";
+    version = "2.3.1";
     src = fetchurl {
-      url = "http://nixos.org/releases/nix/${name}/${name}.tar.xz";
+      url = "http://nixos.org/releases/nix/nix-${version}/nix-${version}.tar.xz";
       sha256 = "bb6578e9f20eebab6d78469ecc59c450ac54f276e5a86a882015d98fecb1bc7b";
     };
 
@@ -186,8 +188,8 @@ in rec {
   });
 
   nixUnstable = lib.lowPrio (callPackage common rec {
-    name = "nix-2.3${suffix}";
-    suffix = "pre6895_84de821";
+    version = "2.3pre";
+    suffix = "6895_84de821";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
@@ -200,8 +202,8 @@ in rec {
   });
 
   nixFlakes = lib.lowPrio (callPackage common rec {
-    name = "nix-2.4${suffix}";
-    suffix = "pre20191022_9cac895";
+    version = "2.4pre";
+    suffix = "20191022_9cac895";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";


### PR DESCRIPTION
mkDerivation: support version suffix, which is part of derivation name but is not part of meta.name.

Inspired by https://github.com/NixOS/nixpkgs/issues/73228
Helps with https://github.com/NixOS/nixpkgs/issues/74494
cc @AMDmi3 if this makes life easier for Repology.

cc @davidak 
```
$ for x in \
     amarok dsseries purple-discord QuadProgpp mkl bazel-remote postgresql nix nixFlakes\
  ; do nix eval -f. $x.meta.name; done
```

Previous `meta.name` (published to Repology):
```
"amarok-2.9.0-20190824"
"libsane-dsseries-1.0.5-1"
"purple-discord-unstable-2018-04-10"
"QuadProgpp-4b6bd65f09fbff99c172a86d6e96ca74449b323f"
"mkl-2019.5.281"
"bazel-remote-2019-01-12"
"postgresql-11.6"
"nix-2.3.1"
"nix-2.4pre20191022_9cac895"
```
New `meta.name`:
```
"amarok-2.9.1pre"
"libsane-dsseries-1.0.5-1"
"purple-discord-2018.04.10"
"QuadProgpp-1.2.2pre"
"mkl-2019.5.281"
"bazel-remote-2019.01.12"
"postgresql-11.6"
"nix-2.3.1"
"nix-2.4pre"
```
----


Previous names:
```
"amarok-2.9.0-20190824"
"libsane-dsseries-1.0.5-1"
"purple-discord-unstable-2018-04-10"
"QuadProgpp-4b6bd65f09fbff99c172a86d6e96ca74449b323f"
"mkl-2019.5.281"
"bazel-remote-2019-01-12"
"postgresql-11.6"
"nix-2.3.1"
"nix-2.4pre20191022_9cac895"
```

New names:
```
"amarok-2.9.1pre20190824"
"libsane-dsseries-1.0.5-1"
"purple-discord-2018.04.10_9a97886"
"QuadProgpp-1.2.2pre_4b6bd65"
"mkl-2019.5.281"
"bazel-remote-2019.01.12"
"postgresql-11.6.p6"
"nix-2.3.1"
"nix-2.4pre20191022_9cac895"
```
