### PR TITLE
nodePackages.dat :init at 13.13.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "nixEnvSelector.nixShellConfig": "NOT_MODIFIED_ENV"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "nixEnvSelector.nixShellConfig": "NOT_MODIFIED_ENV"
+}

--- a/pkgs/development/node-packages/composition-v13.nix
+++ b/pkgs/development/node-packages/composition-v13.nix
@@ -2,7 +2,7 @@
 
 {pkgs ? import <nixpkgs> {
     inherit system;
-  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-13_x"}:
+  }, system ? builtins.currentSystem, nodejs ? pkgs."nodejs-8_x"}:
 
 let
   nodeEnv = import ./node-env.nix {

--- a/pkgs/development/node-packages/default-v13.nix
+++ b/pkgs/development/node-packages/default-v13.nix
@@ -13,4 +13,7 @@ nodePackages // {
       wrapProgram "$out/bin/node2nix" --prefix PATH : ${stdenv.lib.makeBinPath [ pkgs.nix ]}
     '';
   };
+  dat = nodePackages.dat.override {
+    buildInputs = [ nodePackages.node-gyp-build pkgs.libtool ];
+  };
 }

--- a/pkgs/development/node-packages/default-v13.nix
+++ b/pkgs/development/node-packages/default-v13.nix
@@ -13,7 +13,7 @@ nodePackages // {
       wrapProgram "$out/bin/node2nix" --prefix PATH : ${stdenv.lib.makeBinPath [ pkgs.nix ]}
     '';
   };
-  dat = nodePackages.dat.override {
+  sodium-native = nodePackages.sodium-native.override {
     buildInputs = [ nodePackages.node-gyp-build pkgs.libtool ];
   };
 }

--- a/pkgs/development/node-packages/node-env.nix
+++ b/pkgs/development/node-packages/node-env.nix
@@ -363,7 +363,7 @@ let
 
         npm ${forceOfflineFlag} --nodedir=${nodeSources} ${npmFlags} ${stdenv.lib.optionalString production "--production"} rebuild
 
-        if [ "''${dontNpmInstall-}" != "1" ]
+        if [ "$dontNpmInstall" != "1" ]
         then
             # NPM tries to download packages even when they already exist if npm-shrinkwrap is used.
             rm -f npm-shrinkwrap.json

--- a/pkgs/development/node-packages/node-packages-v13.json
+++ b/pkgs/development/node-packages/node-packages-v13.json
@@ -1,4 +1,5 @@
 [
   "node2nix",
-  "dat"
+  "dat" ,
+  "sodium-native"
 ]

--- a/pkgs/development/node-packages/node-packages-v13.json
+++ b/pkgs/development/node-packages/node-packages-v13.json
@@ -1,3 +1,4 @@
 [
-  "node2nix"
+  "node2nix",
+  "dat"
 ]

--- a/pkgs/development/node-packages/node-packages-v13.nix
+++ b/pkgs/development/node-packages/node-packages-v13.nix
@@ -1957,13 +1957,13 @@ let
         sha1 = "12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44";
       };
     };
-    "is-string-1.0.4" = {
+    "is-string-1.0.5" = {
       name = "is-string";
       packageName = "is-string";
-      version = "1.0.4";
+      version = "1.0.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz";
-        sha1 = "cc3a9b69857d621e963725a24caeec873b826e64";
+        url = "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz";
+        sha512 = "buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==";
       };
     };
     "is-typedarray-1.0.0" = {
@@ -3289,13 +3289,13 @@ let
         sha512 = "NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==";
       };
     };
-    "resolve-1.13.1" = {
+    "resolve-1.14.1" = {
       name = "resolve";
       packageName = "resolve";
-      version = "1.13.1";
+      version = "1.14.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz";
-        sha512 = "CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==";
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz";
+        sha512 = "fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==";
       };
     };
     "resolve-url-0.2.1" = {
@@ -4552,7 +4552,7 @@ in
         ];
       })
       sources."request-2.88.0"
-      sources."resolve-1.13.1"
+      sources."resolve-1.14.1"
       sources."retry-0.10.1"
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.2.0"
@@ -4911,7 +4911,7 @@ in
       sources."is-redirect-1.0.0"
       sources."is-retry-allowed-1.2.0"
       sources."is-stream-1.1.0"
-      sources."is-string-1.0.4"
+      sources."is-string-1.0.5"
       sources."is-typedarray-1.0.0"
       sources."is-windows-1.0.2"
       sources."isarray-1.0.0"
@@ -5264,6 +5264,29 @@ in
       description = "Dat is the package manager for data. Easily share and version control data.";
       homepage = https://datproject.org/;
       license = "BSD-3-Clause";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
+  sodium-native = nodeEnv.buildNodePackage {
+    name = "sodium-native";
+    packageName = "sodium-native";
+    version = "2.4.6";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.6.tgz";
+      sha512 = "Ro9lhTjot8M01nwKLXiqLSmjR7B8o+Wg4HmJUjEShw/q6XPlNMzjPkA1VJKaMH8SO8fJ/sggAKVwreTaFszS2Q==";
+    };
+    dependencies = [
+      sources."ini-1.3.5"
+      sources."nan-2.14.0"
+      sources."node-gyp-build-4.2.0"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Low level bindings for libsodium";
+      homepage = https://github.com/sodium-friends/sodium-native;
+      license = "MIT";
     };
     production = true;
     bypassCache = true;

--- a/pkgs/development/node-packages/node-packages-v13.nix
+++ b/pkgs/development/node-packages/node-packages-v13.nix
@@ -13,6 +13,15 @@ let
         sha512 = "nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==";
       };
     };
+    "abstract-random-access-1.1.2" = {
+      name = "abstract-random-access";
+      packageName = "abstract-random-access";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/abstract-random-access/-/abstract-random-access-1.1.2.tgz";
+        sha1 = "9a8eac8ff79866f3f9b4bb1443ca778f1598aeda";
+      };
+    };
     "ajv-6.10.2" = {
       name = "ajv";
       packageName = "ajv";
@@ -22,6 +31,24 @@ let
         sha512 = "TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==";
       };
     };
+    "ansi-align-2.0.0" = {
+      name = "ansi-align";
+      packageName = "ansi-align";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz";
+        sha1 = "c36aeccba563b89ceb556f3690f0b1d9e3547f7f";
+      };
+    };
+    "ansi-diff-1.1.1" = {
+      name = "ansi-diff";
+      packageName = "ansi-diff";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-diff/-/ansi-diff-1.1.1.tgz";
+        sha512 = "XnTdFDQzbEewrDx8epWXdw7oqHMvv315vEtfqDiEhhWghIf4++h26c3/FMz7iTLhNrnj56DNIXpbxHZq+3s6qw==";
+      };
+    };
     "ansi-regex-2.1.1" = {
       name = "ansi-regex";
       packageName = "ansi-regex";
@@ -29,6 +56,60 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz";
         sha1 = "c3b33ab5ee360d86e0e628f0468ae7ef27d654df";
+      };
+    };
+    "ansi-regex-3.0.0" = {
+      name = "ansi-regex";
+      packageName = "ansi-regex";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz";
+        sha1 = "ed0317c322064f79466c02966bddb605ab37d998";
+      };
+    };
+    "ansi-split-1.0.1" = {
+      name = "ansi-split";
+      packageName = "ansi-split";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-split/-/ansi-split-1.0.1.tgz";
+        sha512 = "RRxQym4DFtDNmHIkW6aeFVvrXURb11lGAEPXNiryjCe8bK8RsANjzJ0M2aGOkvBYwP4Bl/xZ8ijtr6D3j1x/eg==";
+      };
+    };
+    "ansi-styles-3.2.1" = {
+      name = "ansi-styles";
+      packageName = "ansi-styles";
+      version = "3.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz";
+        sha512 = "VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==";
+      };
+    };
+    "anymatch-2.0.0" = {
+      name = "anymatch";
+      packageName = "anymatch";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz";
+        sha512 = "5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==";
+      };
+    };
+    "ap-0.1.0" = {
+      name = "ap";
+      packageName = "ap";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ap/-/ap-0.1.0.tgz";
+        sha1 = "d8a3f26615379398a1b53ca6cc1a666a0fbfe150";
+      };
+    };
+    "append-tree-2.4.4" = {
+      name = "append-tree";
+      packageName = "append-tree";
+      version = "2.4.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/append-tree/-/append-tree-2.4.4.tgz";
+        sha512 = "rPMUMkR8JjjPDDHHDZ/YeLO0KIbUGCrXgy921F6sBkEXBR9jYYxK8LUlwpZkUVi70cMR6r8uSmHZ/5HvtrntHg==";
       };
     };
     "aproba-1.2.0" = {
@@ -49,6 +130,51 @@ let
         sha512 = "5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==";
       };
     };
+    "arr-diff-4.0.0" = {
+      name = "arr-diff";
+      packageName = "arr-diff";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz";
+        sha1 = "d6461074febfec71e7e15235761a329a5dc7c520";
+      };
+    };
+    "arr-flatten-1.1.0" = {
+      name = "arr-flatten";
+      packageName = "arr-flatten";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz";
+        sha512 = "L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==";
+      };
+    };
+    "arr-union-3.1.0" = {
+      name = "arr-union";
+      packageName = "arr-union";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz";
+        sha1 = "e39b09aea9def866a8f206e288af63919bae39c4";
+      };
+    };
+    "array-lru-1.1.1" = {
+      name = "array-lru";
+      packageName = "array-lru";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/array-lru/-/array-lru-1.1.1.tgz";
+        sha1 = "0c7e1b4e022ae166ff1e8448c595f3181fcd3337";
+      };
+    };
+    "array-unique-0.3.2" = {
+      name = "array-unique";
+      packageName = "array-unique";
+      version = "0.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz";
+        sha1 = "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428";
+      };
+    };
     "asn1-0.2.4" = {
       name = "asn1";
       packageName = "asn1";
@@ -67,6 +193,33 @@ let
         sha1 = "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525";
       };
     };
+    "assign-symbols-1.0.0" = {
+      name = "assign-symbols";
+      packageName = "assign-symbols";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz";
+        sha1 = "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367";
+      };
+    };
+    "async-0.9.2" = {
+      name = "async";
+      packageName = "async";
+      version = "0.9.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async/-/async-0.9.2.tgz";
+        sha1 = "aea74d5e61c1f899613bf64bda66d4c78f2fd17d";
+      };
+    };
+    "async-1.0.0" = {
+      name = "async";
+      packageName = "async";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async/-/async-1.0.0.tgz";
+        sha1 = "f8fc04ca3a13784ade9e1641af98578cfbd647a9";
+      };
+    };
     "asynckit-0.4.0" = {
       name = "asynckit";
       packageName = "asynckit";
@@ -74,6 +227,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz";
         sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
+      };
+    };
+    "atob-2.1.2" = {
+      name = "atob";
+      packageName = "atob";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz";
+        sha512 = "Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==";
+      };
+    };
+    "atomic-batcher-1.0.2" = {
+      name = "atomic-batcher";
+      packageName = "atomic-batcher";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz";
+        sha1 = "d16901d10ccec59516c197b9ccd8930689b813b4";
       };
     };
     "aws-sign2-0.7.0" = {
@@ -85,13 +256,13 @@ let
         sha1 = "b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8";
       };
     };
-    "aws4-1.8.0" = {
+    "aws4-1.9.0" = {
       name = "aws4";
       packageName = "aws4";
-      version = "1.8.0";
+      version = "1.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz";
-        sha512 = "ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==";
+        url = "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz";
+        sha512 = "Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==";
       };
     };
     "balanced-match-1.0.0" = {
@@ -101,6 +272,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz";
         sha1 = "89b4d199ab2bee49de164ea02b89ce462d71b767";
+      };
+    };
+    "base-0.11.2" = {
+      name = "base";
+      packageName = "base";
+      version = "0.11.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/base/-/base-0.11.2.tgz";
+        sha512 = "5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==";
       };
     };
     "base64-js-1.3.1" = {
@@ -121,6 +301,78 @@ let
         sha1 = "a4301d389b6a43f9b67ff3ca11a3f6637e360e9e";
       };
     };
+    "bencode-1.0.0" = {
+      name = "bencode";
+      packageName = "bencode";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bencode/-/bencode-1.0.0.tgz";
+        sha512 = "N+VOSP5MkoX+xgnp6Y056iCY5TmCZg9rgPNPQe0bIiXchxYFP4vs/Tf0dTdQ+qQhP7HM2gvfFq+sUVjQsGy5Zw==";
+      };
+    };
+    "bencode-2.0.1" = {
+      name = "bencode";
+      packageName = "bencode";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bencode/-/bencode-2.0.1.tgz";
+        sha512 = "2uhEl8FdjSBUyb69qDTgOEeeqDTa+n3yMQzLW0cOzNf1Ow5bwcg3idf+qsWisIKRH8Bk8oC7UXL8irRcPA8ZEQ==";
+      };
+    };
+    "bitfield-rle-2.2.1" = {
+      name = "bitfield-rle";
+      packageName = "bitfield-rle";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bitfield-rle/-/bitfield-rle-2.2.1.tgz";
+        sha512 = "wrDhHe7LUkqaytxgbsFXoemzHRv6e8FrVNWWsQCgUfmuVYW6ke44hoGc9VdpjgfIsJ/ejmCFA8wDtDqACNAvyw==";
+      };
+    };
+    "bittorrent-dht-7.10.0" = {
+      name = "bittorrent-dht";
+      packageName = "bittorrent-dht";
+      version = "7.10.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-7.10.0.tgz";
+        sha512 = "fvb6M58Ceiv/S94nu6zeaiMoJvUYOeIqRbgaClm+kJTzCAqJPtAR/31pXNYB5iEReOoKqQB5zY33gY0W6ZRWQQ==";
+      };
+    };
+    "blake2b-2.1.3" = {
+      name = "blake2b";
+      packageName = "blake2b";
+      version = "2.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/blake2b/-/blake2b-2.1.3.tgz";
+        sha512 = "pkDss4xFVbMb4270aCyGD3qLv92314Et+FsKzilCLxDz5DuZ2/1g3w4nmBbu6nKApPspnjG7JcwTjGZnduB1yg==";
+      };
+    };
+    "blake2b-wasm-1.1.7" = {
+      name = "blake2b-wasm";
+      packageName = "blake2b-wasm";
+      version = "1.1.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz";
+        sha512 = "oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==";
+      };
+    };
+    "body-0.1.0" = {
+      name = "body";
+      packageName = "body";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/body/-/body-0.1.0.tgz";
+        sha1 = "e714fe28cd8848aa34cdf2c9f242bbe2e15d1cd8";
+      };
+    };
+    "boxen-1.3.0" = {
+      name = "boxen";
+      packageName = "boxen";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz";
+        sha512 = "TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==";
+      };
+    };
     "brace-expansion-1.1.11" = {
       name = "brace-expansion";
       packageName = "brace-expansion";
@@ -128,6 +380,51 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz";
         sha512 = "iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==";
+      };
+    };
+    "braces-2.3.2" = {
+      name = "braces";
+      packageName = "braces";
+      version = "2.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz";
+        sha512 = "aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==";
+      };
+    };
+    "buffer-alloc-1.2.0" = {
+      name = "buffer-alloc";
+      packageName = "buffer-alloc";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz";
+        sha512 = "CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==";
+      };
+    };
+    "buffer-alloc-unsafe-1.1.0" = {
+      name = "buffer-alloc-unsafe";
+      packageName = "buffer-alloc-unsafe";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz";
+        sha512 = "TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==";
+      };
+    };
+    "buffer-equals-1.0.4" = {
+      name = "buffer-equals";
+      packageName = "buffer-equals";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz";
+        sha1 = "0353b54fd07fd9564170671ae6f66b9cf10d27f5";
+      };
+    };
+    "buffer-fill-1.0.0" = {
+      name = "buffer-fill";
+      packageName = "buffer-fill";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz";
+        sha1 = "f8f78b76789888ef39f205cd637f68e702122b2c";
       };
     };
     "buffer-from-1.1.1" = {
@@ -148,6 +445,60 @@ let
         sha1 = "cb94faeb61c8696451db36534e1422f94f0aee88";
       };
     };
+    "bulk-write-stream-1.1.4" = {
+      name = "bulk-write-stream";
+      packageName = "bulk-write-stream";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bulk-write-stream/-/bulk-write-stream-1.1.4.tgz";
+        sha512 = "GtKwd/4etuk1hNeprXoESBO1RSeRYJMXKf+O0qHmWdUomLT8ysNEfX/4bZFXr3BK6eukpHiEnhY2uMtEHDM2ng==";
+      };
+    };
+    "bytes-3.1.0" = {
+      name = "bytes";
+      packageName = "bytes";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz";
+        sha512 = "zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==";
+      };
+    };
+    "cache-base-1.0.1" = {
+      name = "cache-base";
+      packageName = "cache-base";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz";
+        sha512 = "AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==";
+      };
+    };
+    "call-me-maybe-1.0.1" = {
+      name = "call-me-maybe";
+      packageName = "call-me-maybe";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz";
+        sha1 = "26d208ea89e37b5cbde60250a15f031c16a4d66b";
+      };
+    };
+    "camelcase-4.1.0" = {
+      name = "camelcase";
+      packageName = "camelcase";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz";
+        sha1 = "d545635be1e33c542649c69173e5de6acfae34dd";
+      };
+    };
+    "capture-stack-trace-1.0.1" = {
+      name = "capture-stack-trace";
+      packageName = "capture-stack-trace";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz";
+        sha512 = "mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==";
+      };
+    };
     "caseless-0.12.0" = {
       name = "caseless";
       packageName = "caseless";
@@ -155,6 +506,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz";
         sha1 = "1b681c21ff84033c826543090689420d187151dc";
+      };
+    };
+    "chalk-2.4.2" = {
+      name = "chalk";
+      packageName = "chalk";
+      version = "2.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz";
+        sha512 = "Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==";
       };
     };
     "chownr-1.1.3" = {
@@ -166,6 +526,96 @@ let
         sha512 = "i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==";
       };
     };
+    "chrome-dgram-3.0.4" = {
+      name = "chrome-dgram";
+      packageName = "chrome-dgram";
+      version = "3.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.4.tgz";
+        sha512 = "G8rOANSvSRC4hGny/K/ec1gXtNuZGzryFeoev49u0J4g/qws7H25vMKQlbD9izuedFVHwXFTdKQG62Tf/7Cmwg==";
+      };
+    };
+    "chrome-dns-1.0.1" = {
+      name = "chrome-dns";
+      packageName = "chrome-dns";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chrome-dns/-/chrome-dns-1.0.1.tgz";
+        sha512 = "HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==";
+      };
+    };
+    "chrome-net-3.3.3" = {
+      name = "chrome-net";
+      packageName = "chrome-net";
+      version = "3.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.3.tgz";
+        sha512 = "11jL8+Ogna8M5TEdyalE8IG6cpaFEU3YcaxAj3YjZKjRM/PeT70pZbrUY+xoGwqiEJZwJE4Td2CvGxUvS9ytKQ==";
+      };
+    };
+    "ci-info-1.6.0" = {
+      name = "ci-info";
+      packageName = "ci-info";
+      version = "1.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz";
+        sha512 = "vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==";
+      };
+    };
+    "circular-append-file-1.0.1" = {
+      name = "circular-append-file";
+      packageName = "circular-append-file";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/circular-append-file/-/circular-append-file-1.0.1.tgz";
+        sha512 = "BUDFvrBTCdeVhg9E05PX4XgMegk6xWB69uGwyuATEg7PMfa9lGU1mzFSK0xWNW2O0i9CAQHN0oIdXI/kI2hPkg==";
+      };
+    };
+    "class-utils-0.3.6" = {
+      name = "class-utils";
+      packageName = "class-utils";
+      version = "0.3.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz";
+        sha512 = "qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==";
+      };
+    };
+    "cli-boxes-1.0.0" = {
+      name = "cli-boxes";
+      packageName = "cli-boxes";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz";
+        sha1 = "4fa917c3e59c94a004cd61f8ee509da651687143";
+      };
+    };
+    "cli-spinners-1.3.1" = {
+      name = "cli-spinners";
+      packageName = "cli-spinners";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz";
+        sha512 = "1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==";
+      };
+    };
+    "cli-truncate-1.1.0" = {
+      name = "cli-truncate";
+      packageName = "cli-truncate";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz";
+        sha512 = "bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==";
+      };
+    };
+    "cliclopts-1.1.1" = {
+      name = "cliclopts";
+      packageName = "cliclopts";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz";
+        sha1 = "69431c7cb5af723774b0d3911b4c37512431910f";
+      };
+    };
     "code-point-at-1.1.0" = {
       name = "code-point-at";
       packageName = "code-point-at";
@@ -175,6 +625,69 @@ let
         sha1 = "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77";
       };
     };
+    "codecs-1.2.1" = {
+      name = "codecs";
+      packageName = "codecs";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/codecs/-/codecs-1.2.1.tgz";
+        sha512 = "SPnx+ZHXVJ0qTInRXmnxuyu8PDvSzvop5MXp1BOr/urFQI3yL2n5ewE755skTklF/hKVlWj8cinGxdR2gvLvTA==";
+      };
+    };
+    "codecs-2.0.0" = {
+      name = "codecs";
+      packageName = "codecs";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/codecs/-/codecs-2.0.0.tgz";
+        sha512 = "WXvpJRAgc693oqYvZte9uYEiL5YHtfrxyEq12uVny9oBJ1k37zSva5vVz7trsnt6R9Y15hEgOSC7VFZT2pfYnA==";
+      };
+    };
+    "collection-visit-1.0.0" = {
+      name = "collection-visit";
+      packageName = "collection-visit";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz";
+        sha1 = "4bc0373c164bc3291b4d368c829cf1a80a59dca0";
+      };
+    };
+    "color-convert-1.9.3" = {
+      name = "color-convert";
+      packageName = "color-convert";
+      version = "1.9.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz";
+        sha512 = "QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==";
+      };
+    };
+    "color-name-1.1.3" = {
+      name = "color-name";
+      packageName = "color-name";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz";
+        sha1 = "a7d0558bd89c42f795dd42328f740831ca53bc25";
+      };
+    };
+    "colors-1.0.3" = {
+      name = "colors";
+      packageName = "colors";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz";
+        sha1 = "0433f44d809680fdeb60ed260f1b0c262e82a40b";
+      };
+    };
+    "colors-1.4.0" = {
+      name = "colors";
+      packageName = "colors";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz";
+        sha512 = "a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==";
+      };
+    };
     "combined-stream-1.0.8" = {
       name = "combined-stream";
       packageName = "combined-stream";
@@ -182,6 +695,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz";
         sha512 = "FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==";
+      };
+    };
+    "component-emitter-1.3.0" = {
+      name = "component-emitter";
+      packageName = "component-emitter";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz";
+        sha512 = "Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==";
       };
     };
     "concat-map-0.0.1" = {
@@ -211,6 +733,24 @@ let
         sha512 = "a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==";
       };
     };
+    "configstore-3.1.2" = {
+      name = "configstore";
+      packageName = "configstore";
+      version = "3.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz";
+        sha512 = "vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==";
+      };
+    };
+    "connections-1.4.2" = {
+      name = "connections";
+      packageName = "connections";
+      version = "1.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/connections/-/connections-1.4.2.tgz";
+        sha1 = "7890482bf5c71af6c5ca192be3136aed74428aad";
+      };
+    };
     "console-control-strings-1.1.0" = {
       name = "console-control-strings";
       packageName = "console-control-strings";
@@ -218,6 +758,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz";
         sha1 = "3d7cf4464db6446ea644bf4b39507f9851008e8e";
+      };
+    };
+    "content-types-0.1.0" = {
+      name = "content-types";
+      packageName = "content-types";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/content-types/-/content-types-0.1.0.tgz";
+        sha1 = "0e790b3abfef90f6ecb77ae8585db9099caf7578";
+      };
+    };
+    "copy-descriptor-0.1.1" = {
+      name = "copy-descriptor";
+      packageName = "copy-descriptor";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz";
+        sha1 = "676f6eb3c39997c2ee1ac3a924fd6124748f578d";
       };
     };
     "core-util-is-1.0.2" = {
@@ -229,6 +787,60 @@ let
         sha1 = "b5fd54220aa2bc5ab57aab7140c940754503c1a7";
       };
     };
+    "corsify-2.1.0" = {
+      name = "corsify";
+      packageName = "corsify";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/corsify/-/corsify-2.1.0.tgz";
+        sha1 = "11a45bc47ab30c54d00bb869ea1802fbcd9a09d0";
+      };
+    };
+    "count-trailing-zeros-1.0.1" = {
+      name = "count-trailing-zeros";
+      packageName = "count-trailing-zeros";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/count-trailing-zeros/-/count-trailing-zeros-1.0.1.tgz";
+        sha1 = "aba6c5833be410d45b1eca3e6d583844ce682c77";
+      };
+    };
+    "create-error-class-3.0.2" = {
+      name = "create-error-class";
+      packageName = "create-error-class";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz";
+        sha1 = "06be7abef947a3f14a30fd610671d401bca8b7b6";
+      };
+    };
+    "cross-spawn-5.1.0" = {
+      name = "cross-spawn";
+      packageName = "cross-spawn";
+      version = "5.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz";
+        sha1 = "e8bd0efee58fcff6f8f94510a0a554bbfa235449";
+      };
+    };
+    "crypto-random-string-1.0.0" = {
+      name = "crypto-random-string";
+      packageName = "crypto-random-string";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz";
+        sha1 = "a230f64f568310e1498009940790ec99545bca7e";
+      };
+    };
+    "cycle-1.0.3" = {
+      name = "cycle";
+      packageName = "cycle";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz";
+        sha1 = "21e80b2be8580f98b468f379430662b046c34ad2";
+      };
+    };
     "dashdash-1.14.1" = {
       name = "dashdash";
       packageName = "dashdash";
@@ -236,6 +848,204 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz";
         sha1 = "853cfa0f7cbe2fed5de20326b8dd581035f6e2f0";
+      };
+    };
+    "dat-dns-3.2.1" = {
+      name = "dat-dns";
+      packageName = "dat-dns";
+      version = "3.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-dns/-/dat-dns-3.2.1.tgz";
+        sha512 = "gCfU2FBg41Qg7RgqYBRD3bjYWAaJFO6UvKfCU9SA1LBy6vZ3EoTZH5doCYdTTQmVEsAxMef18W0lnvr1Z7rx0g==";
+      };
+    };
+    "dat-doctor-2.1.2" = {
+      name = "dat-doctor";
+      packageName = "dat-doctor";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-doctor/-/dat-doctor-2.1.2.tgz";
+        sha512 = "h7JaXbgHDuTOA/HWxw77rEHSFE3zFp5BgORFOO0puTj9+Jr6ll8RuotLJQxx02EwUPPpSpE77juJ75Z9rvPXaA==";
+      };
+    };
+    "dat-encoding-5.0.1" = {
+      name = "dat-encoding";
+      packageName = "dat-encoding";
+      version = "5.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-encoding/-/dat-encoding-5.0.1.tgz";
+        sha512 = "PET9PlGt6ejgqU07hbPLx3tP2siDMMFumUe+xwmm4+5W+0cOlpzreCPoMVUBzxWeR4sPdxL+AS53odQTBtzEqA==";
+      };
+    };
+    "dat-ignore-2.1.2" = {
+      name = "dat-ignore";
+      packageName = "dat-ignore";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-ignore/-/dat-ignore-2.1.2.tgz";
+        sha512 = "27xyi8MzFCJ6qlB8AMGAjI/ec1q9AKT18Qe+8E8AxrG3Axpf4GHa+rWXBE9vTA5T1Mi4cPnhboiGLhiR4r0JAA==";
+      };
+    };
+    "dat-json-1.0.3" = {
+      name = "dat-json";
+      packageName = "dat-json";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-json/-/dat-json-1.0.3.tgz";
+        sha512 = "fppyz6O5htUleUClWXgJVyKVzRYCLiPwYKuBbpCcjXekBzuxU32Zyk4LwWs0yz9enV2GoXdCdtEvI2ffjzRhWw==";
+      };
+    };
+    "dat-link-resolve-2.3.0" = {
+      name = "dat-link-resolve";
+      packageName = "dat-link-resolve";
+      version = "2.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-link-resolve/-/dat-link-resolve-2.3.0.tgz";
+        sha512 = "k1wfcpUB65NQiSVg7vAyHhQlNawAwWvUmDghfCRDOEm68lvRZKyO+bf4mANRJfOV4Ah6GzGSKSKBKSHhYOyBiQ==";
+      };
+    };
+    "dat-log-1.2.0" = {
+      name = "dat-log";
+      packageName = "dat-log";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-log/-/dat-log-1.2.0.tgz";
+        sha512 = "oK6R74WV8TdhGR9VCLym7D/vlN8lXND5AyhJhrjtm1WNDrg/6Clx1Tk7k3Dt8quy2AmmGO7vbIk7iwFtzTAJfA==";
+      };
+    };
+    "dat-node-3.5.15" = {
+      name = "dat-node";
+      packageName = "dat-node";
+      version = "3.5.15";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-node/-/dat-node-3.5.15.tgz";
+        sha512 = "hL7JlZr17x25t+RHJN5saBEOn/fZFt6d8FyS2p+XxnVIQug9bGjnbAXdWbRVO9UJLfnZyKfB23wjvHND1015+g==";
+      };
+    };
+    "dat-registry-4.0.1" = {
+      name = "dat-registry";
+      packageName = "dat-registry";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-registry/-/dat-registry-4.0.1.tgz";
+        sha512 = "UjUZHdgVWL2YPQQzqbYoQaBZ+gbPvaaQcOaexfjR+kbON2av/H26zC4iUOrKWmbkqJZqAVt3Cj+GpNQie/GlUQ==";
+      };
+    };
+    "dat-secret-storage-4.0.1" = {
+      name = "dat-secret-storage";
+      packageName = "dat-secret-storage";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-secret-storage/-/dat-secret-storage-4.0.1.tgz";
+        sha512 = "BUhemnKpXUhKNl/1DuUwfFUyjzomlNF940uHPsOa3okmYu9z6mrp/EGQsLO3lO0YQomDUqS0G0DmHTse9vTU1A==";
+      };
+    };
+    "dat-storage-1.1.1" = {
+      name = "dat-storage";
+      packageName = "dat-storage";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-storage/-/dat-storage-1.1.1.tgz";
+        sha512 = "PjKjUatJN4ztBDI5nR94VuofyrVKOm6W3/DgqFO6U4ixdX351Jkuj+GiGScEmMOqn8vJgTmlUPTxJaBf38Fmkw==";
+      };
+    };
+    "dat-swarm-defaults-1.0.2" = {
+      name = "dat-swarm-defaults";
+      packageName = "dat-swarm-defaults";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dat-swarm-defaults/-/dat-swarm-defaults-1.0.2.tgz";
+        sha512 = "gz9RuhUxq3coYBrelzuFXCNyC579aO3Bm1Wlwa12/9tJr1NP0AAGxpHJYA1HZvt8X7ZdrtMzpFyNvs2Y9PFG6w==";
+      };
+    };
+    "debug-2.6.9" = {
+      name = "debug";
+      packageName = "debug";
+      version = "2.6.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz";
+        sha512 = "bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==";
+      };
+    };
+    "debug-3.2.6" = {
+      name = "debug";
+      packageName = "debug";
+      version = "3.2.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz";
+        sha512 = "mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==";
+      };
+    };
+    "debug-4.1.1" = {
+      name = "debug";
+      packageName = "debug";
+      version = "4.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz";
+        sha512 = "pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==";
+      };
+    };
+    "decode-uri-component-0.2.0" = {
+      name = "decode-uri-component";
+      packageName = "decode-uri-component";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz";
+        sha1 = "eb3913333458775cb84cd1a1fae062106bb87545";
+      };
+    };
+    "decompress-response-4.2.1" = {
+      name = "decompress-response";
+      packageName = "decompress-response";
+      version = "4.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz";
+        sha512 = "jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==";
+      };
+    };
+    "deep-equal-0.2.2" = {
+      name = "deep-equal";
+      packageName = "deep-equal";
+      version = "0.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz";
+        sha1 = "84b745896f34c684e98f2ce0e42abaf43bba017d";
+      };
+    };
+    "deep-extend-0.6.0" = {
+      name = "deep-extend";
+      packageName = "deep-extend";
+      version = "0.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz";
+        sha512 = "LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==";
+      };
+    };
+    "define-property-0.2.5" = {
+      name = "define-property";
+      packageName = "define-property";
+      version = "0.2.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz";
+        sha1 = "c35b1ef918ec3c990f9a5bc57be04aacec5c8116";
+      };
+    };
+    "define-property-1.0.0" = {
+      name = "define-property";
+      packageName = "define-property";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz";
+        sha1 = "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6";
+      };
+    };
+    "define-property-2.0.2" = {
+      name = "define-property";
+      packageName = "define-property";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz";
+        sha512 = "jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==";
       };
     };
     "delayed-stream-1.0.0" = {
@@ -256,6 +1066,105 @@ let
         sha1 = "84c6e159b81904fdca59a0ef44cd870d31250f9a";
       };
     };
+    "diffy-2.1.0" = {
+      name = "diffy";
+      packageName = "diffy";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/diffy/-/diffy-2.1.0.tgz";
+        sha512 = "BIo2fEAv3U0YmyuM1XTijwZ/OJjmXnlSvsguQy3LOaz5C2R/vrMy8SCRdQn1iz3KhBJYJzy+918xS/PKY/47lw==";
+      };
+    };
+    "directory-index-html-2.1.0" = {
+      name = "directory-index-html";
+      packageName = "directory-index-html";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/directory-index-html/-/directory-index-html-2.1.0.tgz";
+        sha1 = "4d5afc5187edba67ec6ab0e55f6422a0e2cb7338";
+      };
+    };
+    "discovery-channel-5.5.1" = {
+      name = "discovery-channel";
+      packageName = "discovery-channel";
+      version = "5.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/discovery-channel/-/discovery-channel-5.5.1.tgz";
+        sha512 = "EEmZQFE0PiOsJj7G3KVCwFGbYs4QchUvzA91iHtZ6HfkIqfBEDSTGLygJrUlY1Tr77WDV+qZVrZuNghHxSL/vw==";
+      };
+    };
+    "discovery-swarm-5.1.4" = {
+      name = "discovery-swarm";
+      packageName = "discovery-swarm";
+      version = "5.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/discovery-swarm/-/discovery-swarm-5.1.4.tgz";
+        sha512 = "vkg0bv+FUwSuPxBWzdNPQVNmXQlIbvz1Ygi+A1XefNUhEzfmM+RNndjtjlDgxD/ZUhFir9PX7Hw9iIDVujsOoA==";
+      };
+    };
+    "dns-discovery-6.2.3" = {
+      name = "dns-discovery";
+      packageName = "dns-discovery";
+      version = "6.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dns-discovery/-/dns-discovery-6.2.3.tgz";
+        sha512 = "ZULG1R5J9QHZfaXo5XFGVG22LIcnZorbEa7f83FYgCGDaQrVfyVmty3Z89OvBLpCPetwW+LzjCcT60ekhbQ+9g==";
+      };
+    };
+    "dns-packet-4.2.0" = {
+      name = "dns-packet";
+      packageName = "dns-packet";
+      version = "4.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz";
+        sha512 = "bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==";
+      };
+    };
+    "dns-socket-3.0.0" = {
+      name = "dns-socket";
+      packageName = "dns-socket";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dns-socket/-/dns-socket-3.0.0.tgz";
+        sha512 = "M0WkByoJ/mTm+HtwBQLsRJPe5uGIC/lYVOp+s6ZzhbZ5iq4GxjFyxYPQhB85dgCLvVb43aJQXHDC9aUgyKGc/Q==";
+      };
+    };
+    "dom-walk-0.1.1" = {
+      name = "dom-walk";
+      packageName = "dom-walk";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz";
+        sha1 = "672226dc74c8f799ad35307df936aba11acd6018";
+      };
+    };
+    "dot-prop-4.2.0" = {
+      name = "dot-prop";
+      packageName = "dot-prop";
+      version = "4.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz";
+        sha512 = "tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==";
+      };
+    };
+    "duplexer3-0.1.4" = {
+      name = "duplexer3";
+      packageName = "duplexer3";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz";
+        sha1 = "ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2";
+      };
+    };
+    "duplexify-3.7.1" = {
+      name = "duplexify";
+      packageName = "duplexify";
+      version = "3.7.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz";
+        sha512 = "07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==";
+      };
+    };
     "ecc-jsbn-0.1.2" = {
       name = "ecc-jsbn";
       packageName = "ecc-jsbn";
@@ -263,6 +1172,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz";
         sha1 = "3a83a904e54353287874c564b7549386849a98c9";
+      };
+    };
+    "end-of-stream-1.4.4" = {
+      name = "end-of-stream";
+      packageName = "end-of-stream";
+      version = "1.4.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz";
+        sha512 = "+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==";
+      };
+    };
+    "escape-string-regexp-1.0.5" = {
+      name = "escape-string-regexp";
+      packageName = "escape-string-regexp";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
+        sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
+      };
+    };
+    "execa-0.7.0" = {
+      name = "execa";
+      packageName = "execa";
+      version = "0.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz";
+        sha1 = "944becd34cc41ee32a63a9faf27ad5a65fc59777";
+      };
+    };
+    "expand-brackets-2.1.4" = {
+      name = "expand-brackets";
+      packageName = "expand-brackets";
+      version = "2.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz";
+        sha1 = "b77735e315ce30f6b6eff0f83b04151a22449622";
       };
     };
     "extend-3.0.2" = {
@@ -274,6 +1219,33 @@ let
         sha512 = "fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==";
       };
     };
+    "extend-shallow-2.0.1" = {
+      name = "extend-shallow";
+      packageName = "extend-shallow";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz";
+        sha1 = "51af7d614ad9a9f610ea1bafbb989d6b1c56890f";
+      };
+    };
+    "extend-shallow-3.0.2" = {
+      name = "extend-shallow";
+      packageName = "extend-shallow";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz";
+        sha1 = "26a71aaf073b39fb2127172746131c2704028db8";
+      };
+    };
+    "extglob-2.0.4" = {
+      name = "extglob";
+      packageName = "extglob";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz";
+        sha512 = "Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==";
+      };
+    };
     "extsprintf-1.3.0" = {
       name = "extsprintf";
       packageName = "extsprintf";
@@ -281,6 +1253,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz";
         sha1 = "96918440e3041a7a414f8c52e3c574eb3c3e1e05";
+      };
+    };
+    "eyes-0.1.8" = {
+      name = "eyes";
+      packageName = "eyes";
+      version = "0.1.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz";
+        sha1 = "62cf120234c683785d902348a800ef3e0cc20bc0";
+      };
+    };
+    "fast-bitfield-1.2.2" = {
+      name = "fast-bitfield";
+      packageName = "fast-bitfield";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fast-bitfield/-/fast-bitfield-1.2.2.tgz";
+        sha512 = "t8HYqkuE3YEqNcyWlAfh55479aTxO+GpYwvQvJppYqyBfSmRdNIhzY2m09FKN/MENTzq4wH6heHOIvsPyMAwvQ==";
       };
     };
     "fast-deep-equal-2.0.1" = {
@@ -292,13 +1282,49 @@ let
         sha1 = "7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49";
       };
     };
-    "fast-json-stable-stringify-2.0.0" = {
+    "fast-json-stable-stringify-2.1.0" = {
       name = "fast-json-stable-stringify";
       packageName = "fast-json-stable-stringify";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz";
+        sha512 = "lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==";
+      };
+    };
+    "fd-lock-1.0.2" = {
+      name = "fd-lock";
+      packageName = "fd-lock";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fd-lock/-/fd-lock-1.0.2.tgz";
+        sha512 = "8O4zSv6rlNNghVfzVkj/p7LUIeBm7Xxk6QnhfmR1WJm/W4kwS8IyShy4X1peRnFUYZUYLlcwEMKXF8QWxJCMvg==";
+      };
+    };
+    "fd-read-stream-1.1.0" = {
+      name = "fd-read-stream";
+      packageName = "fd-read-stream";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fd-read-stream/-/fd-read-stream-1.1.0.tgz";
+        sha1 = "d303ccbfee02a9a56a3493fb08bcb59691aa53b1";
+      };
+    };
+    "figures-2.0.0" = {
+      name = "figures";
+      packageName = "figures";
       version = "2.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz";
-        sha1 = "d5142c0caee6b1189f87d3a76111064f86c8bbf2";
+        url = "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz";
+        sha1 = "3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962";
+      };
+    };
+    "fill-range-4.0.0" = {
+      name = "fill-range";
+      packageName = "fill-range";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz";
+        sha1 = "d544811d428f98eb06a63dc402d2403c328c38f7";
       };
     };
     "findit-2.0.0" = {
@@ -308,6 +1334,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz";
         sha1 = "6509f0126af4c178551cfa99394e032e13a4d56e";
+      };
+    };
+    "flat-tree-1.6.0" = {
+      name = "flat-tree";
+      packageName = "flat-tree";
+      version = "1.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flat-tree/-/flat-tree-1.6.0.tgz";
+        sha1 = "fca30cddb9006fb656eb5ebc79aeb274e7fde9ed";
+      };
+    };
+    "for-in-1.0.2" = {
+      name = "for-in";
+      packageName = "for-in";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz";
+        sha1 = "81068d295a8142ec0ac726c6e2200c30fb6d5e80";
       };
     };
     "foreachasync-3.0.0" = {
@@ -335,6 +1379,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz";
         sha512 = "1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==";
+      };
+    };
+    "fragment-cache-0.2.1" = {
+      name = "fragment-cache";
+      packageName = "fragment-cache";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz";
+        sha1 = "4290fad27f13e89be7f33799c6bc5a0abfff0d19";
+      };
+    };
+    "from2-2.3.0" = {
+      name = "from2";
+      packageName = "from2";
+      version = "2.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz";
+        sha1 = "8bfb5502bde4a4d36cfdeea007fcca21d7e382af";
       };
     };
     "fs-extra-0.6.4" = {
@@ -382,6 +1444,24 @@ let
         sha1 = "2c03405c7538c39d7eb37b317022e325fb018bf7";
       };
     };
+    "get-stream-3.0.0" = {
+      name = "get-stream";
+      packageName = "get-stream";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz";
+        sha1 = "8e943d1358dc37555054ecbe2edb05aa174ede14";
+      };
+    };
+    "get-value-2.0.6" = {
+      name = "get-value";
+      packageName = "get-value";
+      version = "2.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz";
+        sha1 = "dc15ca1c672387ca76bd37ac0a395ba2042a2c28";
+      };
+    };
     "getpass-0.1.7" = {
       name = "getpass";
       packageName = "getpass";
@@ -398,6 +1478,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz";
         sha512 = "LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==";
+      };
+    };
+    "global-4.3.2" = {
+      name = "global";
+      packageName = "global";
+      version = "4.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/global/-/global-4.3.2.tgz";
+        sha1 = "e76989268a6c74c38908b1305b10fc0e394e9d0f";
+      };
+    };
+    "global-dirs-0.1.1" = {
+      name = "global-dirs";
+      packageName = "global-dirs";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz";
+        sha1 = "b319c0dd4607f353f3be9cca4c72fc148c49f445";
+      };
+    };
+    "got-6.7.1" = {
+      name = "got";
+      packageName = "got";
+      version = "6.7.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/got/-/got-6.7.1.tgz";
+        sha1 = "240cd05785a9a18e561dc1b44b41c763ef1e8db0";
       };
     };
     "graceful-fs-4.2.3" = {
@@ -427,6 +1534,15 @@ let
         sha512 = "sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==";
       };
     };
+    "has-flag-3.0.0" = {
+      name = "has-flag";
+      packageName = "has-flag";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz";
+        sha1 = "b5d454dc2199ae225699f3467e5a07f3b955bafd";
+      };
+    };
     "has-unicode-2.0.1" = {
       name = "has-unicode";
       packageName = "has-unicode";
@@ -434,6 +1550,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz";
         sha1 = "e0e6fe6a28cf51138855e086d1691e771de2a8b9";
+      };
+    };
+    "has-value-0.3.1" = {
+      name = "has-value";
+      packageName = "has-value";
+      version = "0.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz";
+        sha1 = "7b1f58bada62ca827ec0a2078025654845995e1f";
+      };
+    };
+    "has-value-1.0.0" = {
+      name = "has-value";
+      packageName = "has-value";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz";
+        sha1 = "18b281da585b1c5c51def24c930ed29a0be6b177";
+      };
+    };
+    "has-values-0.1.4" = {
+      name = "has-values";
+      packageName = "has-values";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz";
+        sha1 = "6d61de95d91dfca9b9a02089ad384bff8f62b771";
+      };
+    };
+    "has-values-1.0.0" = {
+      name = "has-values";
+      packageName = "has-values";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz";
+        sha1 = "95b0b63fec2146619a6fe57fe75628d5a39efe4f";
       };
     };
     "hosted-git-info-2.8.5" = {
@@ -445,6 +1597,15 @@ let
         sha512 = "kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==";
       };
     };
+    "http-methods-0.1.0" = {
+      name = "http-methods";
+      packageName = "http-methods";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/http-methods/-/http-methods-0.1.0.tgz";
+        sha1 = "29691b6fc58f4f7e81a3605dca82682b068e4430";
+      };
+    };
     "http-signature-1.2.0" = {
       name = "http-signature";
       packageName = "http-signature";
@@ -452,6 +1613,87 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz";
         sha1 = "9aecd925114772f3d95b65a60abb8f7c18fbace1";
+      };
+    };
+    "hypercore-7.7.1" = {
+      name = "hypercore";
+      packageName = "hypercore";
+      version = "7.7.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hypercore/-/hypercore-7.7.1.tgz";
+        sha512 = "boEiPCK848pNGACW1j111tJApu530e/UPpwbHytJZlrVf3YdgUIP1KL3aSi5xJFLUnuO8GLGl4lIsSeH8TaQQA==";
+      };
+    };
+    "hypercore-crypto-1.0.0" = {
+      name = "hypercore-crypto";
+      packageName = "hypercore-crypto";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-1.0.0.tgz";
+        sha512 = "xFwOnNlOt8L+SovC7dTNchKaNYJb5l8rKZZwpWQnCme1r7CU4Hlhp1RDqPES6b0OpS7DkTo9iU0GltQGkpsjMw==";
+      };
+    };
+    "hypercore-protocol-6.12.0" = {
+      name = "hypercore-protocol";
+      packageName = "hypercore-protocol";
+      version = "6.12.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.12.0.tgz";
+        sha512 = "T3oy9/7QFejqJX2RGcCUU1944e5/eKbLlSz9JPTNN1QbYFJgat/r7eTyOO8SMSLUimUmQx6YBMKhgYbdKzp7Bw==";
+      };
+    };
+    "hyperdrive-9.16.0" = {
+      name = "hyperdrive";
+      packageName = "hyperdrive";
+      version = "9.16.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hyperdrive/-/hyperdrive-9.16.0.tgz";
+        sha512 = "2iw4baOLmYEs8hWzGUmdgqLHIvjjhiM125kKhQv1aFaiwqDMLtZJ8JsxyeaRZZmMSaC9TuXwjUmU/rrPPgIoVA==";
+      };
+    };
+    "hyperdrive-http-4.4.0" = {
+      name = "hyperdrive-http";
+      packageName = "hyperdrive-http";
+      version = "4.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hyperdrive-http/-/hyperdrive-http-4.4.0.tgz";
+        sha512 = "utyYm6uIJ0AqSVLHVgk2VdEjy77f2X8YxAqnfLO/TqVfQDc44nI131mS4/mpmigYk24qwyelvg7y9CEPXfbVnA==";
+      };
+    };
+    "hyperdrive-network-speed-2.1.0" = {
+      name = "hyperdrive-network-speed";
+      packageName = "hyperdrive-network-speed";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hyperdrive-network-speed/-/hyperdrive-network-speed-2.1.0.tgz";
+        sha512 = "JolPS374h6oS1rmz1iebFfeDDvA2nAtiHbx9VJJGMgSDSx4Q77eeY09hDgZwY7KatSKUGWnnSyydSgVUb3+8Lw==";
+      };
+    };
+    "i-0.3.6" = {
+      name = "i";
+      packageName = "i";
+      version = "0.3.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/i/-/i-0.3.6.tgz";
+        sha1 = "d96c92732076f072711b6b10fd7d4f65ad8ee23d";
+      };
+    };
+    "import-lazy-2.1.0" = {
+      name = "import-lazy";
+      packageName = "import-lazy";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz";
+        sha1 = "05698e3d45c88e8d7e9d92cb0584e77f096f3e43";
+      };
+    };
+    "imurmurhash-0.1.4" = {
+      name = "imurmurhash";
+      packageName = "imurmurhash";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz";
+        sha1 = "9218b9b2b928a238b13dc4fb6b6d576f231453ea";
       };
     };
     "inflight-1.0.6" = {
@@ -481,6 +1723,114 @@ let
         sha512 = "RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==";
       };
     };
+    "inspect-custom-symbol-1.1.1" = {
+      name = "inspect-custom-symbol";
+      packageName = "inspect-custom-symbol";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/inspect-custom-symbol/-/inspect-custom-symbol-1.1.1.tgz";
+        sha512 = "GOucsp9EcdlLdhPUyOTvQDnbFJtp2WBWZV1Jqe+mVnkJQBL3w96+fB84C+JL+EKXOspMdB0eMDQPDp5w9fkfZA==";
+      };
+    };
+    "ip-1.1.5" = {
+      name = "ip";
+      packageName = "ip";
+      version = "1.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz";
+        sha1 = "bdded70114290828c0a039e72ef25f5aaec4354a";
+      };
+    };
+    "is-accessor-descriptor-0.1.6" = {
+      name = "is-accessor-descriptor";
+      packageName = "is-accessor-descriptor";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz";
+        sha1 = "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6";
+      };
+    };
+    "is-accessor-descriptor-1.0.0" = {
+      name = "is-accessor-descriptor";
+      packageName = "is-accessor-descriptor";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz";
+        sha512 = "m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==";
+      };
+    };
+    "is-buffer-1.1.6" = {
+      name = "is-buffer";
+      packageName = "is-buffer";
+      version = "1.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz";
+        sha512 = "NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==";
+      };
+    };
+    "is-ci-1.2.1" = {
+      name = "is-ci";
+      packageName = "is-ci";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz";
+        sha512 = "s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==";
+      };
+    };
+    "is-data-descriptor-0.1.4" = {
+      name = "is-data-descriptor";
+      packageName = "is-data-descriptor";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz";
+        sha1 = "0b5ee648388e2c860282e793f1856fec3f301b56";
+      };
+    };
+    "is-data-descriptor-1.0.0" = {
+      name = "is-data-descriptor";
+      packageName = "is-data-descriptor";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz";
+        sha512 = "jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==";
+      };
+    };
+    "is-descriptor-0.1.6" = {
+      name = "is-descriptor";
+      packageName = "is-descriptor";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz";
+        sha512 = "avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==";
+      };
+    };
+    "is-descriptor-1.0.2" = {
+      name = "is-descriptor";
+      packageName = "is-descriptor";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz";
+        sha512 = "2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==";
+      };
+    };
+    "is-extendable-0.1.1" = {
+      name = "is-extendable";
+      packageName = "is-extendable";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz";
+        sha1 = "62b110e289a471418e3ec36a617d472e301dfc89";
+      };
+    };
+    "is-extendable-1.0.1" = {
+      name = "is-extendable";
+      packageName = "is-extendable";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz";
+        sha512 = "arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==";
+      };
+    };
     "is-fullwidth-code-point-1.0.0" = {
       name = "is-fullwidth-code-point";
       packageName = "is-fullwidth-code-point";
@@ -488,6 +1838,132 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz";
         sha1 = "ef9e31386f031a7f0d643af82fde50c457ef00cb";
+      };
+    };
+    "is-fullwidth-code-point-2.0.0" = {
+      name = "is-fullwidth-code-point";
+      packageName = "is-fullwidth-code-point";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz";
+        sha1 = "a3b30a5c4f199183167aaab93beefae3ddfb654f";
+      };
+    };
+    "is-function-1.0.1" = {
+      name = "is-function";
+      packageName = "is-function";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz";
+        sha1 = "12cfb98b65b57dd3d193a3121f5f6e2f437602b5";
+      };
+    };
+    "is-installed-globally-0.1.0" = {
+      name = "is-installed-globally";
+      packageName = "is-installed-globally";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz";
+        sha1 = "0dfd98f5a9111716dd535dda6492f67bf3d25a80";
+      };
+    };
+    "is-npm-1.0.0" = {
+      name = "is-npm";
+      packageName = "is-npm";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz";
+        sha1 = "f2fb63a65e4905b406c86072765a1a4dc793b9f4";
+      };
+    };
+    "is-number-2.1.0" = {
+      name = "is-number";
+      packageName = "is-number";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz";
+        sha1 = "01fcbbb393463a548f2f466cce16dece49db908f";
+      };
+    };
+    "is-number-3.0.0" = {
+      name = "is-number";
+      packageName = "is-number";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz";
+        sha1 = "24fd6201a4782cf50561c810276afc7d12d71195";
+      };
+    };
+    "is-obj-1.0.1" = {
+      name = "is-obj";
+      packageName = "is-obj";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz";
+        sha1 = "3e4729ac1f5fde025cd7d83a896dab9f4f67db0f";
+      };
+    };
+    "is-options-1.0.1" = {
+      name = "is-options";
+      packageName = "is-options";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-options/-/is-options-1.0.1.tgz";
+        sha512 = "2Xj8sA0zDrAcaoWfBiNmc6VPWAgKDpim0T3J9Djq7vbm1UjwbUWzeuLu/FwC46g3cBbAn0E5R0xwVtOobM6Xxg==";
+      };
+    };
+    "is-path-inside-1.0.1" = {
+      name = "is-path-inside";
+      packageName = "is-path-inside";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz";
+        sha1 = "8ef5b7de50437a3fdca6b4e865ef7aa55cb48036";
+      };
+    };
+    "is-plain-object-2.0.4" = {
+      name = "is-plain-object";
+      packageName = "is-plain-object";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz";
+        sha512 = "h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==";
+      };
+    };
+    "is-redirect-1.0.0" = {
+      name = "is-redirect";
+      packageName = "is-redirect";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz";
+        sha1 = "1d03dded53bd8db0f30c26e4f95d36fc7c87dc24";
+      };
+    };
+    "is-retry-allowed-1.2.0" = {
+      name = "is-retry-allowed";
+      packageName = "is-retry-allowed";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz";
+        sha512 = "RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==";
+      };
+    };
+    "is-stream-1.1.0" = {
+      name = "is-stream";
+      packageName = "is-stream";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz";
+        sha1 = "12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44";
+      };
+    };
+    "is-string-1.0.4" = {
+      name = "is-string";
+      packageName = "is-string";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz";
+        sha1 = "cc3a9b69857d621e963725a24caeec873b826e64";
       };
     };
     "is-typedarray-1.0.0" = {
@@ -499,6 +1975,15 @@ let
         sha1 = "e479c80858df0c1b11ddda6940f96011fcda4a9a";
       };
     };
+    "is-windows-1.0.2" = {
+      name = "is-windows";
+      packageName = "is-windows";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz";
+        sha512 = "eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==";
+      };
+    };
     "isarray-1.0.0" = {
       name = "isarray";
       packageName = "isarray";
@@ -508,6 +1993,33 @@ let
         sha1 = "bb935d48582cba168c06834957a54a3e07124f11";
       };
     };
+    "isexe-2.0.0" = {
+      name = "isexe";
+      packageName = "isexe";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz";
+        sha1 = "e8fbf374dc556ff8947a10dcb0572d633f2cfa10";
+      };
+    };
+    "isobject-2.1.0" = {
+      name = "isobject";
+      packageName = "isobject";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz";
+        sha1 = "f065561096a3f1da2ef46272f815c840d87e0c89";
+      };
+    };
+    "isobject-3.0.1" = {
+      name = "isobject";
+      packageName = "isobject";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz";
+        sha1 = "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df";
+      };
+    };
     "isstream-0.1.2" = {
       name = "isstream";
       packageName = "isstream";
@@ -515,6 +2027,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz";
         sha1 = "47e63f7af55afa6f92e1500e690eb8b8529c099a";
+      };
+    };
+    "iterators-0.1.0" = {
+      name = "iterators";
+      packageName = "iterators";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/iterators/-/iterators-0.1.0.tgz";
+        sha1 = "d03f666ca4e6130138565997cacea54164203156";
       };
     };
     "jsbn-0.1.1" = {
@@ -571,22 +2092,265 @@ let
         sha1 = "313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2";
       };
     };
-    "mime-db-1.40.0" = {
-      name = "mime-db";
-      packageName = "mime-db";
-      version = "1.40.0";
+    "k-bucket-3.3.1" = {
+      name = "k-bucket";
+      packageName = "k-bucket";
+      version = "3.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz";
-        sha512 = "jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==";
+        url = "https://registry.npmjs.org/k-bucket/-/k-bucket-3.3.1.tgz";
+        sha512 = "kgwWqYT79rAahn4maIVTP8dIe+m1KulufWW+f1bB9DlZrRFiGpZ4iJOg2HUp4xJYBWONP3+rOPIWF/RXABU6mw==";
       };
     };
-    "mime-types-2.1.24" = {
+    "k-bucket-4.0.1" = {
+      name = "k-bucket";
+      packageName = "k-bucket";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/k-bucket/-/k-bucket-4.0.1.tgz";
+        sha512 = "YvDpmY3waI999h1zZoW1rJ04fZrgZ+5PAlVmvwDHT6YO/Q1AOhdel07xsKy9eAvJjQ9xZV1wz3rXKqEfaWvlcQ==";
+      };
+    };
+    "k-rpc-4.3.1" = {
+      name = "k-rpc";
+      packageName = "k-rpc";
+      version = "4.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/k-rpc/-/k-rpc-4.3.1.tgz";
+        sha512 = "mgAJZeFYbpP0xzJzmS0TQTYoFI0sjy3GnKFhg8wyboL+KvWg2WLaA2Oy9PthLPx2Rxz4WeBMk4y3MSOrDJ95FA==";
+      };
+    };
+    "k-rpc-socket-1.11.1" = {
+      name = "k-rpc-socket";
+      packageName = "k-rpc-socket";
+      version = "1.11.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.11.1.tgz";
+        sha512 = "8xtA8oqbZ6v1Niryp2/g4GxW16EQh5MvrUylQoOG+zcrDff5CKttON2XUXvMwlIHq4/2zfPVFiinAccJ+WhxoA==";
+      };
+    };
+    "keypress-0.2.1" = {
+      name = "keypress";
+      packageName = "keypress";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/keypress/-/keypress-0.2.1.tgz";
+        sha1 = "1e80454250018dbad4c3fe94497d6e67b6269c77";
+      };
+    };
+    "kind-of-3.2.2" = {
+      name = "kind-of";
+      packageName = "kind-of";
+      version = "3.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz";
+        sha1 = "31ea21a734bab9bbb0f32466d893aea51e4a3c64";
+      };
+    };
+    "kind-of-4.0.0" = {
+      name = "kind-of";
+      packageName = "kind-of";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz";
+        sha1 = "20813df3d712928b207378691a45066fae72dd57";
+      };
+    };
+    "kind-of-5.1.0" = {
+      name = "kind-of";
+      packageName = "kind-of";
+      version = "5.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz";
+        sha512 = "NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==";
+      };
+    };
+    "kind-of-6.0.2" = {
+      name = "kind-of";
+      packageName = "kind-of";
+      version = "6.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz";
+        sha512 = "s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==";
+      };
+    };
+    "last-one-wins-1.0.4" = {
+      name = "last-one-wins";
+      packageName = "last-one-wins";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz";
+        sha1 = "c1bfd0cbcb46790ec9156b8d1aee8fcb86cda22a";
+      };
+    };
+    "latest-version-3.1.0" = {
+      name = "latest-version";
+      packageName = "latest-version";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz";
+        sha1 = "a205383fea322b33b5ae3b18abee0dc2f356ee15";
+      };
+    };
+    "length-prefixed-message-3.0.4" = {
+      name = "length-prefixed-message";
+      packageName = "length-prefixed-message";
+      version = "3.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/length-prefixed-message/-/length-prefixed-message-3.0.4.tgz";
+        sha512 = "Tqyx4nggb9nkLD6p4hyIz7UiVNg5u3OnCP2h0hS/HXpheH88rsoNEgNB8xTnpPMw6zWXGZ7Cpg1zhWPlsJ0/TQ==";
+      };
+    };
+    "lodash.throttle-4.1.1" = {
+      name = "lodash.throttle";
+      packageName = "lodash.throttle";
+      version = "4.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz";
+        sha1 = "c23e91b710242ac70c37f1e1cda9274cc39bf2f4";
+      };
+    };
+    "lowercase-keys-1.0.1" = {
+      name = "lowercase-keys";
+      packageName = "lowercase-keys";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz";
+        sha512 = "G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==";
+      };
+    };
+    "lru-2.0.1" = {
+      name = "lru";
+      packageName = "lru";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lru/-/lru-2.0.1.tgz";
+        sha1 = "f979871e162e3f5ca254be46844c53d4c5364544";
+      };
+    };
+    "lru-3.1.0" = {
+      name = "lru";
+      packageName = "lru";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz";
+        sha1 = "ea7fb8546d83733396a13091d76cfeb4c06837d5";
+      };
+    };
+    "lru-cache-4.1.5" = {
+      name = "lru-cache";
+      packageName = "lru-cache";
+      version = "4.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz";
+        sha512 = "sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==";
+      };
+    };
+    "make-dir-1.3.0" = {
+      name = "make-dir";
+      packageName = "make-dir";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz";
+        sha512 = "2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==";
+      };
+    };
+    "map-cache-0.2.2" = {
+      name = "map-cache";
+      packageName = "map-cache";
+      version = "0.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz";
+        sha1 = "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf";
+      };
+    };
+    "map-visit-1.0.0" = {
+      name = "map-visit";
+      packageName = "map-visit";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz";
+        sha1 = "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f";
+      };
+    };
+    "memory-pager-1.5.0" = {
+      name = "memory-pager";
+      packageName = "memory-pager";
+      version = "1.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz";
+        sha512 = "ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==";
+      };
+    };
+    "menu-string-1.3.0" = {
+      name = "menu-string";
+      packageName = "menu-string";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/menu-string/-/menu-string-1.3.0.tgz";
+        sha512 = "ctDyraFPyJDXi6RWgWZ8SyDk2bAsFaBpobprCl7xbcfQamjtfuaN8+lcWUt8ARYfQKb1f8mcPVhQ+Q2ObeD/3A==";
+      };
+    };
+    "merkle-tree-stream-3.0.3" = {
+      name = "merkle-tree-stream";
+      packageName = "merkle-tree-stream";
+      version = "3.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/merkle-tree-stream/-/merkle-tree-stream-3.0.3.tgz";
+        sha1 = "f8a064760d37e7978ad5f9f6d3c119a494f57081";
+      };
+    };
+    "micromatch-3.1.10" = {
+      name = "micromatch";
+      packageName = "micromatch";
+      version = "3.1.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz";
+        sha512 = "MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==";
+      };
+    };
+    "mime-2.4.4" = {
+      name = "mime";
+      packageName = "mime";
+      version = "2.4.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz";
+        sha512 = "LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==";
+      };
+    };
+    "mime-db-1.42.0" = {
+      name = "mime-db";
+      packageName = "mime-db";
+      version = "1.42.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz";
+        sha512 = "UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==";
+      };
+    };
+    "mime-types-2.1.25" = {
       name = "mime-types";
       packageName = "mime-types";
-      version = "2.1.24";
+      version = "2.1.25";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz";
-        sha512 = "WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==";
+        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz";
+        sha512 = "5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==";
+      };
+    };
+    "mimic-response-2.0.0" = {
+      name = "mimic-response";
+      packageName = "mimic-response";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz";
+        sha512 = "8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==";
+      };
+    };
+    "min-document-2.19.0" = {
+      name = "min-document";
+      packageName = "min-document";
+      version = "2.19.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz";
+        sha1 = "7bd282e3f5842ed295bb748cdd9f1ffa2c824685";
       };
     };
     "minimatch-3.0.4" = {
@@ -607,6 +2371,15 @@ let
         sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
       };
     };
+    "minimist-1.2.0" = {
+      name = "minimist";
+      packageName = "minimist";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz";
+        sha1 = "a35008b20f41383eec1fb914f4cd5df79a264284";
+      };
+    };
     "minipass-2.9.0" = {
       name = "minipass";
       packageName = "minipass";
@@ -623,6 +2396,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz";
         sha512 = "6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==";
+      };
+    };
+    "mirror-folder-3.0.0" = {
+      name = "mirror-folder";
+      packageName = "mirror-folder";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mirror-folder/-/mirror-folder-3.0.0.tgz";
+        sha512 = "fh6wDXcSpFoKY7ZPHnEv1+xjLOS7tlkEpTvl4Y6ZsT0HNjIaYg6ktq9ng8MPthFruunS8D/3GnPeaWhoQD3X9g==";
+      };
+    };
+    "mixin-deep-1.3.2" = {
+      name = "mixin-deep";
+      packageName = "mixin-deep";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz";
+        sha512 = "WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==";
       };
     };
     "mkdirp-0.3.5" = {
@@ -643,6 +2434,150 @@ let
         sha1 = "30057438eac6cf7f8c4767f38648d6697d75c903";
       };
     };
+    "ms-2.0.0" = {
+      name = "ms";
+      packageName = "ms";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz";
+        sha1 = "5608aeadfc00be6c2901df5f9861788de0d597c8";
+      };
+    };
+    "ms-2.1.2" = {
+      name = "ms";
+      packageName = "ms";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz";
+        sha512 = "sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==";
+      };
+    };
+    "multi-random-access-2.1.1" = {
+      name = "multi-random-access";
+      packageName = "multi-random-access";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multi-random-access/-/multi-random-access-2.1.1.tgz";
+        sha1 = "6462f1b204109ccc644601650110a828443d66e2";
+      };
+    };
+    "multicast-dns-7.2.0" = {
+      name = "multicast-dns";
+      packageName = "multicast-dns";
+      version = "7.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.0.tgz";
+        sha512 = "Tu2QORGOFANB124NWQ/JTRhMf/ODouVLEuvu5Dz8YWEU55zQgRgFGnBHfIh5PbfNDAuaRl7yLB+pgWhSqVxi2Q==";
+      };
+    };
+    "multistream-2.1.1" = {
+      name = "multistream";
+      packageName = "multistream";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multistream/-/multistream-2.1.1.tgz";
+        sha512 = "xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==";
+      };
+    };
+    "mute-stream-0.0.8" = {
+      name = "mute-stream";
+      packageName = "mute-stream";
+      version = "0.0.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz";
+        sha512 = "nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==";
+      };
+    };
+    "mutexify-1.2.0" = {
+      name = "mutexify";
+      packageName = "mutexify";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mutexify/-/mutexify-1.2.0.tgz";
+        sha512 = "oprzxd2zhfrJqEuB98qc1dRMMonClBQ57UPDjnbcrah4orEMTq1jq3+AcdFe5ePzdbJXI7zmdhfftIdMnhYFoQ==";
+      };
+    };
+    "nan-2.14.0" = {
+      name = "nan";
+      packageName = "nan";
+      version = "2.14.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz";
+        sha512 = "INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==";
+      };
+    };
+    "nanoassert-1.1.0" = {
+      name = "nanoassert";
+      packageName = "nanoassert";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz";
+        sha1 = "4f3152e09540fde28c76f44b19bbcd1d5a42478d";
+      };
+    };
+    "nanobus-4.4.0" = {
+      name = "nanobus";
+      packageName = "nanobus";
+      version = "4.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz";
+        sha512 = "Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==";
+      };
+    };
+    "nanoguard-1.2.2" = {
+      name = "nanoguard";
+      packageName = "nanoguard";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nanoguard/-/nanoguard-1.2.2.tgz";
+        sha512 = "IMVIZkHP7Ep01foXurcJR59Hj/0yyApNK3JWpVHq2QVdLgo8wGU/ZsodlpL7jJ/m24+lxT0eyavrLCEuYQK2fg==";
+      };
+    };
+    "nanomatch-1.2.13" = {
+      name = "nanomatch";
+      packageName = "nanomatch";
+      version = "1.2.13";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz";
+        sha512 = "fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==";
+      };
+    };
+    "nanoscheduler-1.0.3" = {
+      name = "nanoscheduler";
+      packageName = "nanoscheduler";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz";
+        sha512 = "jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==";
+      };
+    };
+    "nanotiming-7.3.1" = {
+      name = "nanotiming";
+      packageName = "nanotiming";
+      version = "7.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz";
+        sha512 = "l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==";
+      };
+    };
+    "napi-macros-1.8.2" = {
+      name = "napi-macros";
+      packageName = "napi-macros";
+      version = "1.8.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/napi-macros/-/napi-macros-1.8.2.tgz";
+        sha512 = "Tr0DNY4RzTaBG2W2m3l7ZtFuJChTH6VZhXVhkGGjF/4cZTt+i8GcM9ozD+30Lmr4mDoZ5Xx34t2o4GJqYWDGcg==";
+      };
+    };
+    "napi-macros-2.0.0" = {
+      name = "napi-macros";
+      packageName = "napi-macros";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz";
+        sha512 = "A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==";
+      };
+    };
     "ncp-0.4.2" = {
       name = "ncp";
       packageName = "ncp";
@@ -652,6 +2587,78 @@ let
         sha1 = "abcc6cbd3ec2ed2a729ff6e7c1fa8f01784a8574";
       };
     };
+    "ncp-1.0.1" = {
+      name = "ncp";
+      packageName = "ncp";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz";
+        sha1 = "d15367e5cb87432ba117d2bf80fdf45aecfb4246";
+      };
+    };
+    "neat-input-1.10.0" = {
+      name = "neat-input";
+      packageName = "neat-input";
+      version = "1.10.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/neat-input/-/neat-input-1.10.0.tgz";
+        sha512 = "02JoPLCBocjslsujmMjNb12Fz2Ap4oCmCYWBSUmea4YN2EG7siBMZSQtpBjijpw65l3uR5NoSn/w7iumCjAONg==";
+      };
+    };
+    "neat-log-2.4.0" = {
+      name = "neat-log";
+      packageName = "neat-log";
+      version = "2.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/neat-log/-/neat-log-2.4.0.tgz";
+        sha512 = "5Gb0J17bqRxKBfgetrYCZav7kpFgunDhFq0i+kEq5Kn36Cuw4IskIl3yd+/P8jCcAzaKrQ7mrb+p6r/NP5esWA==";
+      };
+    };
+    "neat-log-3.1.0" = {
+      name = "neat-log";
+      packageName = "neat-log";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/neat-log/-/neat-log-3.1.0.tgz";
+        sha512 = "VarbsDsRN5C5pCdOskjJ7bOPvyjYeVduftgs1dYXqoFXwKFBPJq3VrmFRpbwjoW03Z80DSiiDbaPGX7ix+OFyA==";
+      };
+    };
+    "neat-spinner-1.0.0" = {
+      name = "neat-spinner";
+      packageName = "neat-spinner";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/neat-spinner/-/neat-spinner-1.0.0.tgz";
+        sha512 = "+T6UtYItDTE1L30g/nLRjP55dFlvldrzCRsn4CrcNHIbhg5JUe0hnOx1DHFViysUC7I1cevBQVjdGJ9ZftY9DA==";
+      };
+    };
+    "neat-tasks-1.1.1" = {
+      name = "neat-tasks";
+      packageName = "neat-tasks";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/neat-tasks/-/neat-tasks-1.1.1.tgz";
+        sha512 = "U8HkIv90/lrdNlHVp63PoF3FeuQUvJ6toMX6InqRqpBmQq9iukZRAnq/yCE4Ii6WHZRYa6DEiTH/EGFTZ0rIGg==";
+      };
+    };
+    "nets-3.2.0" = {
+      name = "nets";
+      packageName = "nets";
+      version = "3.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nets/-/nets-3.2.0.tgz";
+        sha1 = "d511fbab7af11da013f21b97ee91747d33852d38";
+      };
+    };
+    "network-address-1.1.2" = {
+      name = "network-address";
+      packageName = "network-address";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/network-address/-/network-address-1.1.2.tgz";
+        sha1 = "4aa7bfd43f03f0b81c9702b13d6a858ddb326f3e";
+      };
+    };
     "nijs-0.0.25" = {
       name = "nijs";
       packageName = "nijs";
@@ -659,6 +2666,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/nijs/-/nijs-0.0.25.tgz";
         sha1 = "04b035cb530d46859d1018839a518c029133f676";
+      };
+    };
+    "node-gyp-build-3.9.0" = {
+      name = "node-gyp-build";
+      packageName = "node-gyp-build";
+      version = "3.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz";
+        sha512 = "zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==";
+      };
+    };
+    "node-gyp-build-4.2.0" = {
+      name = "node-gyp-build";
+      packageName = "node-gyp-build";
+      version = "4.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.0.tgz";
+        sha512 = "4oiumOLhCDU9Rronz8PZ5S4IvT39H5+JEv/hps9V8s7RSLhsac0TCP78ulnHXOo8X1wdpPiTayGlM1jr4IbnaQ==";
       };
     };
     "nopt-3.0.6" = {
@@ -679,6 +2704,15 @@ let
         sha512 = "/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==";
       };
     };
+    "normalize-path-2.1.1" = {
+      name = "normalize-path";
+      packageName = "normalize-path";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz";
+        sha1 = "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9";
+      };
+    };
     "npm-package-arg-6.1.1" = {
       name = "npm-package-arg";
       packageName = "npm-package-arg";
@@ -695,6 +2729,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.6.0.tgz";
         sha512 = "Qs6P6nnopig+Y8gbzpeN/dkt+n7IyVd8f45NTMotGk6Qo7GfBmzwYx6jRLoOOgKiMnaQfYxsuyQlD8Mc3guBhg==";
+      };
+    };
+    "npm-run-path-2.0.2" = {
+      name = "npm-run-path";
+      packageName = "npm-run-path";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz";
+        sha1 = "35a9232dfa35d7067b4cb2ddf2357b1871536c5f";
       };
     };
     "npmconf-2.1.3" = {
@@ -740,6 +2783,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz";
         sha1 = "2109adc7965887cfc05cbbd442cac8bfbb360863";
+      };
+    };
+    "object-copy-0.1.0" = {
+      name = "object-copy";
+      packageName = "object-copy";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz";
+        sha1 = "7e7d858b781bd7c991a41ba975ed3812754e998c";
+      };
+    };
+    "object-visit-1.0.1" = {
+      name = "object-visit";
+      packageName = "object-visit";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz";
+        sha1 = "f79c4493af0c5377b59fe39d395e41042dd045bb";
+      };
+    };
+    "object.pick-1.3.0" = {
+      name = "object.pick";
+      packageName = "object.pick";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz";
+        sha1 = "87a10ac4c1694bd2e1cbf53591a66141fb5dd747";
       };
     };
     "once-1.3.3" = {
@@ -796,6 +2866,42 @@ let
         sha512 = "0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==";
       };
     };
+    "p-finally-1.0.0" = {
+      name = "p-finally";
+      packageName = "p-finally";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz";
+        sha1 = "3fbcfb15b899a44123b34b6dcc18b724336a2cae";
+      };
+    };
+    "package-json-4.0.1" = {
+      name = "package-json";
+      packageName = "package-json";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz";
+        sha1 = "8869a0401253661c4c4ca3da6c2121ed555f5eed";
+      };
+    };
+    "parse-headers-2.0.3" = {
+      name = "parse-headers";
+      packageName = "parse-headers";
+      version = "2.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz";
+        sha512 = "QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==";
+      };
+    };
+    "pascalcase-0.1.1" = {
+      name = "pascalcase";
+      packageName = "pascalcase";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz";
+        sha1 = "b363e55e8006ca6fe21784d2db22bd15d7917f14";
+      };
+    };
     "path-is-absolute-1.0.1" = {
       name = "path-is-absolute";
       packageName = "path-is-absolute";
@@ -803,6 +2909,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz";
         sha1 = "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f";
+      };
+    };
+    "path-is-inside-1.0.2" = {
+      name = "path-is-inside";
+      packageName = "path-is-inside";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz";
+        sha1 = "365417dede44430d1c11af61027facf074bdfc53";
+      };
+    };
+    "path-key-2.0.1" = {
+      name = "path-key";
+      packageName = "path-key";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz";
+        sha1 = "411cadb574c5a140d3a4b1910d40d80cc9f40b40";
       };
     };
     "path-parse-1.0.6" = {
@@ -823,6 +2947,87 @@ let
         sha1 = "6309f4e0e5fa913ec1c69307ae364b4b377c9e7b";
       };
     };
+    "pify-3.0.0" = {
+      name = "pify";
+      packageName = "pify";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz";
+        sha1 = "e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176";
+      };
+    };
+    "pkginfo-0.3.1" = {
+      name = "pkginfo";
+      packageName = "pkginfo";
+      version = "0.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz";
+        sha1 = "5b29f6a81f70717142e09e765bbeab97b4f81e21";
+      };
+    };
+    "pkginfo-0.4.1" = {
+      name = "pkginfo";
+      packageName = "pkginfo";
+      version = "0.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz";
+        sha1 = "b5418ef0439de5425fc4995042dced14fb2a84ff";
+      };
+    };
+    "posix-character-classes-0.1.1" = {
+      name = "posix-character-classes";
+      packageName = "posix-character-classes";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz";
+        sha1 = "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab";
+      };
+    };
+    "prepend-http-1.0.4" = {
+      name = "prepend-http";
+      packageName = "prepend-http";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz";
+        sha1 = "d4f4562b0ce3696e41ac52d0e002e57a635dc6dc";
+      };
+    };
+    "prettier-bytes-1.0.4" = {
+      name = "prettier-bytes";
+      packageName = "prettier-bytes";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prettier-bytes/-/prettier-bytes-1.0.4.tgz";
+        sha1 = "994b02aa46f699c50b6257b5faaa7fe2557e62d6";
+      };
+    };
+    "pretty-hash-1.0.1" = {
+      name = "pretty-hash";
+      packageName = "pretty-hash";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pretty-hash/-/pretty-hash-1.0.1.tgz";
+        sha1 = "16e0579188def56bdb565892bcd05a5d65324807";
+      };
+    };
+    "process-0.5.2" = {
+      name = "process";
+      packageName = "process";
+      version = "0.5.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/process/-/process-0.5.2.tgz";
+        sha1 = "1638d8a8e34c2f440a91db95ab9aeb677fc185cf";
+      };
+    };
+    "process-nextick-args-1.0.7" = {
+      name = "process-nextick-args";
+      packageName = "process-nextick-args";
+      version = "1.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz";
+        sha1 = "150e20b756590ad3f91093f25a4f2ad8bff30ba3";
+      };
+    };
     "process-nextick-args-2.0.1" = {
       name = "process-nextick-args";
       packageName = "process-nextick-args";
@@ -830,6 +3035,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz";
         sha512 = "3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==";
+      };
+    };
+    "progress-string-1.2.2" = {
+      name = "progress-string";
+      packageName = "progress-string";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/progress-string/-/progress-string-1.2.2.tgz";
+        sha512 = "JymvIR4IJ0qTyma7ExefBeJGp2IGaXYGWv8Z//Jq+AhrCd0uKlMPK9IWJ0LL6zbXbAN8fhLe1TL1hl1ZKOljDw==";
+      };
+    };
+    "prompt-1.0.0" = {
+      name = "prompt";
+      packageName = "prompt";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz";
+        sha1 = "8e57123c396ab988897fb327fd3aedc3e735e4fe";
       };
     };
     "proto-list-1.2.4" = {
@@ -841,13 +3064,40 @@ let
         sha1 = "212d5bfe1318306a420f6402b8e26ff39647a849";
       };
     };
-    "psl-1.4.0" = {
+    "protocol-buffers-encodings-1.1.0" = {
+      name = "protocol-buffers-encodings";
+      packageName = "protocol-buffers-encodings";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/protocol-buffers-encodings/-/protocol-buffers-encodings-1.1.0.tgz";
+        sha512 = "SmjEuAf3hc3h3rWZ6V1YaaQw2MNJWK848gLJgzx/sefOJdNLujKinJVXIS0q2cBQpQn2Q32TinawZyDZPzm4kQ==";
+      };
+    };
+    "pseudomap-1.0.2" = {
+      name = "pseudomap";
+      packageName = "pseudomap";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz";
+        sha1 = "f052a28da70e618917ef0a8ac34c1ae5a68286b3";
+      };
+    };
+    "psl-1.6.0" = {
       name = "psl";
       packageName = "psl";
-      version = "1.4.0";
+      version = "1.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz";
-        sha512 = "HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==";
+        url = "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz";
+        sha512 = "SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==";
+      };
+    };
+    "pump-3.0.0" = {
+      name = "pump";
+      packageName = "pump";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz";
+        sha512 = "LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==";
       };
     };
     "punycode-1.4.1" = {
@@ -877,6 +3127,69 @@ let
         sha512 = "N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==";
       };
     };
+    "random-access-file-2.1.3" = {
+      name = "random-access-file";
+      packageName = "random-access-file";
+      version = "2.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/random-access-file/-/random-access-file-2.1.3.tgz";
+        sha512 = "AE0Z1ywR5gIkzACMC1lCsR6LP8g4ynNm7oYWYdKPSSU6Y3H+mGDJxBqfcV9B9KstfHNemhfX3nYmx99ZC9f/yg==";
+      };
+    };
+    "random-access-memory-3.1.1" = {
+      name = "random-access-memory";
+      packageName = "random-access-memory";
+      version = "3.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/random-access-memory/-/random-access-memory-3.1.1.tgz";
+        sha512 = "Qy1MliJDozZ1A6Hx3UbEnm8PPCfkiG/8CArbnhrxXMx1YRJPWipgPTB9qyhn4Z7WlLvCEqPb6Bd98OayyVuwrA==";
+      };
+    };
+    "random-access-storage-1.4.0" = {
+      name = "random-access-storage";
+      packageName = "random-access-storage";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.4.0.tgz";
+        sha512 = "7oszloM/+PdqWp/oFGyL6SeI14liqo8AAisHAZQGkWdHISyAnngKjNPL0JYIazeLxbHPY6oed2yUffowdq/o6A==";
+      };
+    };
+    "randombytes-2.1.0" = {
+      name = "randombytes";
+      packageName = "randombytes";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz";
+        sha512 = "vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==";
+      };
+    };
+    "range-parser-1.2.1" = {
+      name = "range-parser";
+      packageName = "range-parser";
+      version = "1.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz";
+        sha512 = "Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==";
+      };
+    };
+    "rc-1.2.8" = {
+      name = "rc";
+      packageName = "rc";
+      version = "1.2.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz";
+        sha512 = "y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==";
+      };
+    };
+    "read-1.0.7" = {
+      name = "read";
+      packageName = "read";
+      version = "1.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/read/-/read-1.0.7.tgz";
+        sha1 = "b3da19bd052431a97671d44a42634adf710b40c4";
+      };
+    };
     "readable-stream-2.3.6" = {
       name = "readable-stream";
       packageName = "readable-stream";
@@ -884,6 +3197,87 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz";
         sha512 = "tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==";
+      };
+    };
+    "readable-stream-3.4.0" = {
+      name = "readable-stream";
+      packageName = "readable-stream";
+      version = "3.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz";
+        sha512 = "jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==";
+      };
+    };
+    "recursive-watch-1.1.4" = {
+      name = "recursive-watch";
+      packageName = "recursive-watch";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.4.tgz";
+        sha512 = "fWejAmdLi7B/jipBUjTLnqId+PK+573fbGNbdaNA/AiAnQAx6OYOLCGWRs0W5+PyM1rLzZSWK2f40QpHSR49PQ==";
+      };
+    };
+    "regex-not-1.0.2" = {
+      name = "regex-not";
+      packageName = "regex-not";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz";
+        sha512 = "J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==";
+      };
+    };
+    "registry-auth-token-3.4.0" = {
+      name = "registry-auth-token";
+      packageName = "registry-auth-token";
+      version = "3.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz";
+        sha512 = "4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==";
+      };
+    };
+    "registry-url-3.1.0" = {
+      name = "registry-url";
+      packageName = "registry-url";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz";
+        sha1 = "3d4ef870f73dde1d77f0cf9a381432444e174942";
+      };
+    };
+    "remove-array-items-1.1.1" = {
+      name = "remove-array-items";
+      packageName = "remove-array-items";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz";
+        sha512 = "MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA==";
+      };
+    };
+    "remove-trailing-separator-1.1.0" = {
+      name = "remove-trailing-separator";
+      packageName = "remove-trailing-separator";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz";
+        sha1 = "c24bce2a283adad5bc3f58e0d48249b92379d8ef";
+      };
+    };
+    "repeat-element-1.1.3" = {
+      name = "repeat-element";
+      packageName = "repeat-element";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz";
+        sha512 = "ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==";
+      };
+    };
+    "repeat-string-1.6.1" = {
+      name = "repeat-string";
+      packageName = "repeat-string";
+      version = "1.6.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz";
+        sha1 = "8dcae470e1c88abc2d600fff4a776286da75e637";
       };
     };
     "request-2.88.0" = {
@@ -895,13 +3289,31 @@ let
         sha512 = "NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==";
       };
     };
-    "resolve-1.12.0" = {
+    "resolve-1.13.1" = {
       name = "resolve";
       packageName = "resolve";
-      version = "1.12.0";
+      version = "1.13.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz";
-        sha512 = "B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==";
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz";
+        sha512 = "CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==";
+      };
+    };
+    "resolve-url-0.2.1" = {
+      name = "resolve-url";
+      packageName = "resolve-url";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz";
+        sha1 = "2c637fe77c893afd2a663fe21aa9080068e2052a";
+      };
+    };
+    "ret-0.1.15" = {
+      name = "ret";
+      packageName = "ret";
+      version = "0.1.15";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz";
+        sha512 = "TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==";
       };
     };
     "retry-0.10.1" = {
@@ -911,6 +3323,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz";
         sha1 = "e76388d217992c252750241d3d3956fed98d8ff4";
+      };
+    };
+    "revalidator-0.1.8" = {
+      name = "revalidator";
+      packageName = "revalidator";
+      version = "0.1.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz";
+        sha1 = "fece61bfa0c1b52a206bd6b18198184bdd523a3b";
       };
     };
     "rimraf-2.2.8" = {
@@ -931,6 +3352,33 @@ let
         sha512 = "mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==";
       };
     };
+    "rimraf-2.7.1" = {
+      name = "rimraf";
+      packageName = "rimraf";
+      version = "2.7.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz";
+        sha512 = "uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==";
+      };
+    };
+    "run-series-1.1.8" = {
+      name = "run-series";
+      packageName = "run-series";
+      version = "1.1.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/run-series/-/run-series-1.1.8.tgz";
+        sha512 = "+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg==";
+      };
+    };
+    "rusha-0.8.13" = {
+      name = "rusha";
+      packageName = "rusha";
+      version = "0.8.13";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/rusha/-/rusha-0.8.13.tgz";
+        sha1 = "9a084e7b860b17bff3015b92c67a6a336191513a";
+      };
+    };
     "safe-buffer-5.1.2" = {
       name = "safe-buffer";
       packageName = "safe-buffer";
@@ -947,6 +3395,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz";
         sha512 = "fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==";
+      };
+    };
+    "safe-regex-1.1.0" = {
+      name = "safe-regex";
+      packageName = "safe-regex";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz";
+        sha1 = "40a3669f3b077d1e943d44629e157dd48023bf2e";
       };
     };
     "safer-buffer-2.1.2" = {
@@ -985,6 +3442,15 @@ let
         sha512 = "aymF+56WJJMyXQHcd4hlK4N75rwj5RQpfW8ePlQnJsTYOBLlLbcIErR/G1s9SkIvKBqOudR3KAx4wEqP+F1hNQ==";
       };
     };
+    "semver-diff-2.1.0" = {
+      name = "semver-diff";
+      packageName = "semver-diff";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz";
+        sha1 = "4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36";
+      };
+    };
     "set-blocking-2.0.0" = {
       name = "set-blocking";
       packageName = "set-blocking";
@@ -992,6 +3458,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz";
         sha1 = "045f9782d011ae9a6803ddd382b24392b3d890f7";
+      };
+    };
+    "set-value-2.0.1" = {
+      name = "set-value";
+      packageName = "set-value";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz";
+        sha512 = "JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==";
+      };
+    };
+    "shebang-command-1.2.0" = {
+      name = "shebang-command";
+      packageName = "shebang-command";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz";
+        sha1 = "44aac65b695b03398968c39f363fee5deafdf1ea";
+      };
+    };
+    "shebang-regex-1.0.0" = {
+      name = "shebang-regex";
+      packageName = "shebang-regex";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz";
+        sha1 = "da42f49740c0b42db2ca9728571cb190c98efea3";
       };
     };
     "signal-exit-3.0.2" = {
@@ -1003,6 +3496,51 @@ let
         sha1 = "b5fdc08f1287ea1178628e415e25132b73646c6d";
       };
     };
+    "signed-varint-2.0.1" = {
+      name = "signed-varint";
+      packageName = "signed-varint";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz";
+        sha1 = "50a9989da7c98c2c61dad119bc97470ef8528129";
+      };
+    };
+    "simple-concat-1.0.0" = {
+      name = "simple-concat";
+      packageName = "simple-concat";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz";
+        sha1 = "7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6";
+      };
+    };
+    "simple-get-3.1.0" = {
+      name = "simple-get";
+      packageName = "simple-get";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz";
+        sha512 = "bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==";
+      };
+    };
+    "simple-sha1-2.1.2" = {
+      name = "simple-sha1";
+      packageName = "simple-sha1";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.2.tgz";
+        sha512 = "TQl9rm4rdKAVmhO++sXAb8TNN0D6JAD5iyI1mqEPNpxUzTRrtm4aOG1pDf/5W/qCFihiaoK6uuL9rvQz1x1VKw==";
+      };
+    };
+    "siphash24-1.1.1" = {
+      name = "siphash24";
+      packageName = "siphash24";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/siphash24/-/siphash24-1.1.1.tgz";
+        sha512 = "dKKwjIoTOa587TARYLlBRXq2lkbu5Iz35XrEVWpelhBP1m8r2BGOy1QlaZe84GTFHG/BTucEUd2btnNc8QzIVA==";
+      };
+    };
     "slasp-0.0.4" = {
       name = "slasp";
       packageName = "slasp";
@@ -1012,6 +3550,15 @@ let
         sha1 = "9adc26ee729a0f95095851a5489f87a5258d57a9";
       };
     };
+    "slice-ansi-1.0.0" = {
+      name = "slice-ansi";
+      packageName = "slice-ansi";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz";
+        sha512 = "POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==";
+      };
+    };
     "slide-1.1.6" = {
       name = "slide";
       packageName = "slide";
@@ -1019,6 +3566,114 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz";
         sha1 = "56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707";
+      };
+    };
+    "snapdragon-0.8.2" = {
+      name = "snapdragon";
+      packageName = "snapdragon";
+      version = "0.8.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz";
+        sha512 = "FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==";
+      };
+    };
+    "snapdragon-node-2.1.1" = {
+      name = "snapdragon-node";
+      packageName = "snapdragon-node";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz";
+        sha512 = "O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==";
+      };
+    };
+    "snapdragon-util-3.0.1" = {
+      name = "snapdragon-util";
+      packageName = "snapdragon-util";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz";
+        sha512 = "mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==";
+      };
+    };
+    "sodium-javascript-0.5.5" = {
+      name = "sodium-javascript";
+      packageName = "sodium-javascript";
+      version = "0.5.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.5.5.tgz";
+        sha512 = "UMmCHovws/sxIBZsIRhIl8uRPou/RFDD0vVop81T1hG106NLLgqajKKuHAOtAP6hflnZ0UrVA2VFwddTd/NQyA==";
+      };
+    };
+    "sodium-native-2.4.6" = {
+      name = "sodium-native";
+      packageName = "sodium-native";
+      version = "2.4.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.6.tgz";
+        sha512 = "Ro9lhTjot8M01nwKLXiqLSmjR7B8o+Wg4HmJUjEShw/q6XPlNMzjPkA1VJKaMH8SO8fJ/sggAKVwreTaFszS2Q==";
+      };
+    };
+    "sodium-universal-2.0.0" = {
+      name = "sodium-universal";
+      packageName = "sodium-universal";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sodium-universal/-/sodium-universal-2.0.0.tgz";
+        sha512 = "csdVyakzHJRyCevY4aZC2Eacda8paf+4nmRGF2N7KxCLKY2Ajn72JsExaQlJQ2BiXJncp44p3T+b80cU+2TTsg==";
+      };
+    };
+    "sorted-array-functions-1.2.0" = {
+      name = "sorted-array-functions";
+      packageName = "sorted-array-functions";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.2.0.tgz";
+        sha512 = "sWpjPhIZJtqO77GN+LD8dDsDKcWZ9GCOJNqKzi1tvtjGIzwfoyuRH8S0psunmc6Z5P+qfDqztSbwYR5X/e1UTg==";
+      };
+    };
+    "sorted-indexof-1.0.0" = {
+      name = "sorted-indexof";
+      packageName = "sorted-indexof";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sorted-indexof/-/sorted-indexof-1.0.0.tgz";
+        sha1 = "17c742ff7cf187e2f59a15df9b81f17a62ce0899";
+      };
+    };
+    "source-map-0.5.7" = {
+      name = "source-map";
+      packageName = "source-map";
+      version = "0.5.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz";
+        sha1 = "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc";
+      };
+    };
+    "source-map-resolve-0.5.2" = {
+      name = "source-map-resolve";
+      packageName = "source-map-resolve";
+      version = "0.5.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz";
+        sha512 = "MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==";
+      };
+    };
+    "source-map-url-0.4.0" = {
+      name = "source-map-url";
+      packageName = "source-map-url";
+      version = "0.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz";
+        sha1 = "3e935d7ddd73631b97659956d55128e87b5084a3";
+      };
+    };
+    "sparse-bitfield-3.0.3" = {
+      name = "sparse-bitfield";
+      packageName = "sparse-bitfield";
+      version = "3.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz";
+        sha1 = "ff4ae6e68656056ba4b3e792ab3334d38273ca11";
       };
     };
     "spdx-correct-3.1.0" = {
@@ -1057,6 +3712,24 @@ let
         sha512 = "J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==";
       };
     };
+    "speedometer-1.1.0" = {
+      name = "speedometer";
+      packageName = "speedometer";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/speedometer/-/speedometer-1.1.0.tgz";
+        sha512 = "z/wAiTESw2XVPssY2XRcme4niTc4S5FkkJ4gknudtVoc33Zil8TdTxHy5torRcgqMqksJV2Yz8HQcvtbsnw0mQ==";
+      };
+    };
+    "split-string-3.1.0" = {
+      name = "split-string";
+      packageName = "split-string";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz";
+        sha512 = "NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==";
+      };
+    };
     "sshpk-1.16.1" = {
       name = "sshpk";
       packageName = "sshpk";
@@ -1075,6 +3748,60 @@ let
         sha512 = "XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==";
       };
     };
+    "stack-trace-0.0.10" = {
+      name = "stack-trace";
+      packageName = "stack-trace";
+      version = "0.0.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz";
+        sha1 = "547c70b347e8d32b4e108ea1a2a159e5fdde19c0";
+      };
+    };
+    "static-extend-0.1.2" = {
+      name = "static-extend";
+      packageName = "static-extend";
+      version = "0.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz";
+        sha1 = "60809c39cbff55337226fd5e0b520f341f1fb5c6";
+      };
+    };
+    "stream-collector-1.0.1" = {
+      name = "stream-collector";
+      packageName = "stream-collector";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stream-collector/-/stream-collector-1.0.1.tgz";
+        sha1 = "4d4e55f171356121b2c5f6559f944705ab28db15";
+      };
+    };
+    "stream-each-1.2.3" = {
+      name = "stream-each";
+      packageName = "stream-each";
+      version = "1.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz";
+        sha512 = "vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==";
+      };
+    };
+    "stream-parser-0.3.1" = {
+      name = "stream-parser";
+      packageName = "stream-parser";
+      version = "0.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz";
+        sha1 = "1618548694420021a1182ff0af1911c129761773";
+      };
+    };
+    "stream-shift-1.0.1" = {
+      name = "stream-shift";
+      packageName = "stream-shift";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz";
+        sha512 = "AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==";
+      };
+    };
     "string-width-1.0.2" = {
       name = "string-width";
       packageName = "string-width";
@@ -1082,6 +3809,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz";
         sha1 = "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3";
+      };
+    };
+    "string-width-2.1.1" = {
+      name = "string-width";
+      packageName = "string-width";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz";
+        sha512 = "nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==";
       };
     };
     "string_decoder-1.1.1" = {
@@ -1102,6 +3838,51 @@ let
         sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
       };
     };
+    "strip-ansi-4.0.0" = {
+      name = "strip-ansi";
+      packageName = "strip-ansi";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz";
+        sha1 = "a8479022eb1ac368a871389b635262c505ee368f";
+      };
+    };
+    "strip-eof-1.0.0" = {
+      name = "strip-eof";
+      packageName = "strip-eof";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz";
+        sha1 = "bb43ff5598a6eb05d89b59fcd129c983313606bf";
+      };
+    };
+    "strip-json-comments-2.0.1" = {
+      name = "strip-json-comments";
+      packageName = "strip-json-comments";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz";
+        sha1 = "3c531942e908c2697c0ec344858c286c7ca0a60a";
+      };
+    };
+    "subcommand-2.1.1" = {
+      name = "subcommand";
+      packageName = "subcommand";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/subcommand/-/subcommand-2.1.1.tgz";
+        sha512 = "cm7TQq9I8dA5LKUr+r8W7RzQlLsmTdCr6wXmjYueOoh/bQu55ODEw7GFhT42pUyoaLtO2rgmx1+8cSIjY9lR9g==";
+      };
+    };
+    "supports-color-5.5.0" = {
+      name = "supports-color";
+      packageName = "supports-color";
+      version = "5.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz";
+        sha512 = "QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==";
+      };
+    };
     "tar-4.4.13" = {
       name = "tar";
       packageName = "tar";
@@ -1120,6 +3901,105 @@ let
         sha512 = "WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==";
       };
     };
+    "term-size-1.2.0" = {
+      name = "term-size";
+      packageName = "term-size";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz";
+        sha1 = "458b83887f288fc56d6fffbfad262e26638efa69";
+      };
+    };
+    "throttle-1.0.3" = {
+      name = "throttle";
+      packageName = "throttle";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/throttle/-/throttle-1.0.3.tgz";
+        sha1 = "8a32e4a15f1763d997948317c5ebe3ad8a41e4b7";
+      };
+    };
+    "thunky-0.1.0" = {
+      name = "thunky";
+      packageName = "thunky";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz";
+        sha1 = "bf30146824e2b6e67b0f2d7a4ac8beb26908684e";
+      };
+    };
+    "thunky-1.1.0" = {
+      name = "thunky";
+      packageName = "thunky";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz";
+        sha512 = "eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==";
+      };
+    };
+    "timed-out-4.0.1" = {
+      name = "timed-out";
+      packageName = "timed-out";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz";
+        sha1 = "f32eacac5a175bea25d7fab565ab3ed8741ef56f";
+      };
+    };
+    "timeout-refresh-1.0.1" = {
+      name = "timeout-refresh";
+      packageName = "timeout-refresh";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.1.tgz";
+        sha512 = "bW5oSShdwFCN9K7RpB5dkq5bqNlGt8Lwbfxr8vprysk8hDiK5yy7Mgf2Qlz2ssE0gfQfoYhk4VLY9Hhsnr9Ulw==";
+      };
+    };
+    "to-buffer-1.1.1" = {
+      name = "to-buffer";
+      packageName = "to-buffer";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz";
+        sha512 = "lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==";
+      };
+    };
+    "to-object-path-0.3.0" = {
+      name = "to-object-path";
+      packageName = "to-object-path";
+      version = "0.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz";
+        sha1 = "297588b7b0e7e0ac08e04e672f85c1f4999e17af";
+      };
+    };
+    "to-regex-3.0.2" = {
+      name = "to-regex";
+      packageName = "to-regex";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz";
+        sha512 = "FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==";
+      };
+    };
+    "to-regex-range-2.1.1" = {
+      name = "to-regex-range";
+      packageName = "to-regex-range";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz";
+        sha1 = "7c80c17b9dfebe599e27367e0d4dd5590141db38";
+      };
+    };
+    "toiletdb-1.4.1" = {
+      name = "toiletdb";
+      packageName = "toiletdb";
+      version = "1.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/toiletdb/-/toiletdb-1.4.1.tgz";
+        sha512 = "FOinMMjECHmDt6PZkSmcbM8ir41kGwYCbVW7NczWkWNNeuX9/mQHz31oNSJKZrkvgfas692ZoZ+G1jdM43qVGA==";
+      };
+    };
     "tough-cookie-2.4.3" = {
       name = "tough-cookie";
       packageName = "tough-cookie";
@@ -1127,6 +4007,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz";
         sha512 = "Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==";
+      };
+    };
+    "township-client-1.3.2" = {
+      name = "township-client";
+      packageName = "township-client";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/township-client/-/township-client-1.3.2.tgz";
+        sha512 = "6Di70O1dWm45SJ5xrGzlE805z3gYn4ZUmNKomIrI4OojzRA4zyQzJ/4lAxQbJlq0ihG/mUE2xbP4q85Q68ig2g==";
+      };
+    };
+    "ttl-1.3.1" = {
+      name = "ttl";
+      packageName = "ttl";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ttl/-/ttl-1.3.1.tgz";
+        sha512 = "+bGy9iDAqg3WSfc2ZrprToSPJhZjqy7vUv9wupQzsiv+BVPVx1T2a6G4T0290SpQj+56Toaw9BiLO5j5Bd7QzA==";
       };
     };
     "tunnel-agent-0.6.0" = {
@@ -1165,6 +4063,105 @@ let
         sha1 = "5a3db23ef5dbd55b81fce0ec9a2ac6fccdebb81e";
       };
     };
+    "uint64be-2.0.2" = {
+      name = "uint64be";
+      packageName = "uint64be";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uint64be/-/uint64be-2.0.2.tgz";
+        sha512 = "9QqdvpGQTXgxthP+lY4e/gIBy+RuqcBaC6JVwT5I3bDLgT/btL6twZMR0pI3/Fgah9G/pdwzIprE5gL6v9UvyQ==";
+      };
+    };
+    "union-value-1.0.1" = {
+      name = "union-value";
+      packageName = "union-value";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz";
+        sha512 = "tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==";
+      };
+    };
+    "unique-string-1.0.0" = {
+      name = "unique-string";
+      packageName = "unique-string";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz";
+        sha1 = "9e1057cca851abb93398f8b33ae187b99caec11a";
+      };
+    };
+    "unixify-1.0.0" = {
+      name = "unixify";
+      packageName = "unixify";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz";
+        sha1 = "3a641c8c2ffbce4da683a5c70f03a462940c2090";
+      };
+    };
+    "unordered-array-remove-1.0.2" = {
+      name = "unordered-array-remove";
+      packageName = "unordered-array-remove";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unordered-array-remove/-/unordered-array-remove-1.0.2.tgz";
+        sha1 = "c546e8f88e317a0cf2644c97ecb57dba66d250ef";
+      };
+    };
+    "unordered-set-1.1.0" = {
+      name = "unordered-set";
+      packageName = "unordered-set";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unordered-set/-/unordered-set-1.1.0.tgz";
+        sha1 = "2ba7ef316edd0b9590cc547c74f76a2f164fecca";
+      };
+    };
+    "unordered-set-2.0.1" = {
+      name = "unordered-set";
+      packageName = "unordered-set";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz";
+        sha512 = "eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==";
+      };
+    };
+    "unset-value-1.0.0" = {
+      name = "unset-value";
+      packageName = "unset-value";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz";
+        sha1 = "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559";
+      };
+    };
+    "untildify-3.0.3" = {
+      name = "untildify";
+      packageName = "untildify";
+      version = "3.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz";
+        sha512 = "iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==";
+      };
+    };
+    "unzip-response-2.0.1" = {
+      name = "unzip-response";
+      packageName = "unzip-response";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz";
+        sha1 = "d2f0f737d16b0615e72a6935ed04214572d56f97";
+      };
+    };
+    "update-notifier-2.5.0" = {
+      name = "update-notifier";
+      packageName = "update-notifier";
+      version = "2.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz";
+        sha512 = "gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==";
+      };
+    };
     "uri-js-4.2.2" = {
       name = "uri-js";
       packageName = "uri-js";
@@ -1174,6 +4171,33 @@ let
         sha512 = "KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==";
       };
     };
+    "urix-0.1.0" = {
+      name = "urix";
+      packageName = "urix";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz";
+        sha1 = "da937f7a62e21fec1fd18d49b35c2935067a6c72";
+      };
+    };
+    "url-parse-lax-1.0.0" = {
+      name = "url-parse-lax";
+      packageName = "url-parse-lax";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz";
+        sha1 = "7af8f303645e9bd79a272e7a14ac68bc0609da73";
+      };
+    };
+    "use-3.1.1" = {
+      name = "use";
+      packageName = "use";
+      version = "3.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/use/-/use-3.1.1.tgz";
+        sha512 = "cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==";
+      };
+    };
     "util-deprecate-1.0.2" = {
       name = "util-deprecate";
       packageName = "util-deprecate";
@@ -1181,6 +4205,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz";
         sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
+      };
+    };
+    "utile-0.3.0" = {
+      name = "utile";
+      packageName = "utile";
+      version = "0.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz";
+        sha1 = "1352c340eb820e4d8ddba039a4fbfaa32ed4ef3a";
+      };
+    };
+    "utp-native-1.7.3" = {
+      name = "utp-native";
+      packageName = "utp-native";
+      version = "1.7.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/utp-native/-/utp-native-1.7.3.tgz";
+        sha512 = "vRAKaS8WcYNgzbxyH2LdheqgL4sQLis8LXl7r/mN+O4mpWlUpoCsTtietxepLrft2q0TFA2gaIvSWN1iRkzW/w==";
+      };
+    };
+    "utp-native-2.1.5" = {
+      name = "utp-native";
+      packageName = "utp-native";
+      version = "2.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/utp-native/-/utp-native-2.1.5.tgz";
+        sha512 = "vQ193WXyOOo+LikYgXlhFLVU7w9zdLOuXr1mgmS/kRMtq/B7DgVbPPSWzKzfcUnBeS1vRApVzR8+o4xYItObcw==";
       };
     };
     "uuid-3.3.3" = {
@@ -1210,6 +4261,33 @@ let
         sha1 = "5fa912d81eb7d0c74afc140de7317f0ca7df437e";
       };
     };
+    "varint-3.0.1" = {
+      name = "varint";
+      packageName = "varint";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/varint/-/varint-3.0.1.tgz";
+        sha1 = "9d3f53e036c0ab12000a74bc2d24cbf093a581d9";
+      };
+    };
+    "varint-4.0.1" = {
+      name = "varint";
+      packageName = "varint";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/varint/-/varint-4.0.1.tgz";
+        sha1 = "490829b942d248463b2b35097995c3bf737198e9";
+      };
+    };
+    "varint-5.0.0" = {
+      name = "varint";
+      packageName = "varint";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz";
+        sha1 = "d826b89f7490732fabc0c0ed693ed475dcb29ebf";
+      };
+    };
     "verror-1.10.0" = {
       name = "verror";
       packageName = "verror";
@@ -1228,6 +4306,15 @@ let
         sha512 = "5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==";
       };
     };
+    "which-1.3.1" = {
+      name = "which";
+      packageName = "which";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/which/-/which-1.3.1.tgz";
+        sha512 = "HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==";
+      };
+    };
     "wide-align-1.1.3" = {
       name = "wide-align";
       packageName = "wide-align";
@@ -1237,6 +4324,24 @@ let
         sha512 = "QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==";
       };
     };
+    "widest-line-2.0.1" = {
+      name = "widest-line";
+      packageName = "widest-line";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz";
+        sha512 = "Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==";
+      };
+    };
+    "winston-2.1.1" = {
+      name = "winston";
+      packageName = "winston";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz";
+        sha1 = "3c9349d196207fd1bdff9d4bc43ef72510e3a12e";
+      };
+    };
     "wrappy-1.0.2" = {
       name = "wrappy";
       packageName = "wrappy";
@@ -1244,6 +4349,60 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz";
         sha1 = "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f";
+      };
+    };
+    "write-file-atomic-2.4.3" = {
+      name = "write-file-atomic";
+      packageName = "write-file-atomic";
+      version = "2.4.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz";
+        sha512 = "GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==";
+      };
+    };
+    "xdg-basedir-3.0.0" = {
+      name = "xdg-basedir";
+      packageName = "xdg-basedir";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz";
+        sha1 = "496b2cc109eca8dbacfe2dc72b603c17c5870ad4";
+      };
+    };
+    "xhr-2.5.0" = {
+      name = "xhr";
+      packageName = "xhr";
+      version = "2.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz";
+        sha512 = "4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==";
+      };
+    };
+    "xsalsa20-1.1.0" = {
+      name = "xsalsa20";
+      packageName = "xsalsa20";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.1.0.tgz";
+        sha512 = "zd3ytX2cm+tcSndRU+krm0eL4TMMpZE7evs5hLRAoOy6gviqLfe3qOlkjF3i5SeAkQUCeJk0lJZrEU56kHRfWw==";
+      };
+    };
+    "xtend-4.0.2" = {
+      name = "xtend";
+      packageName = "xtend";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz";
+        sha512 = "LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==";
+      };
+    };
+    "yallist-2.1.2" = {
+      name = "yallist";
+      packageName = "yallist";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz";
+        sha1 = "1c11f9218f076089a47dd512f93c6699a6a81d52";
       };
     };
     "yallist-3.1.1" = {
@@ -1276,7 +4435,7 @@ in
       sources."assert-plus-1.0.0"
       sources."asynckit-0.4.0"
       sources."aws-sign2-0.7.0"
-      sources."aws4-1.8.0"
+      sources."aws4-1.9.0"
       sources."balanced-match-1.0.0"
       sources."base64-js-1.3.1"
       sources."bcrypt-pbkdf-1.0.2"
@@ -1299,7 +4458,7 @@ in
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-2.0.1"
-      sources."fast-json-stable-stringify-2.0.0"
+      sources."fast-json-stable-stringify-2.1.0"
       sources."findit-2.0.0"
       sources."foreachasync-3.0.0"
       sources."forever-agent-0.6.1"
@@ -1339,8 +4498,8 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-1.0.1"
       sources."jsprim-1.4.1"
-      sources."mime-db-1.40.0"
-      sources."mime-types-2.1.24"
+      sources."mime-db-1.42.0"
+      sources."mime-types-2.1.25"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."minipass-2.9.0"
@@ -1384,7 +4543,7 @@ in
       sources."performance-now-2.1.0"
       sources."process-nextick-args-2.0.1"
       sources."proto-list-1.2.4"
-      sources."psl-1.4.0"
+      sources."psl-1.6.0"
       sources."punycode-2.1.1"
       sources."qs-6.5.2"
       (sources."readable-stream-2.3.6" // {
@@ -1393,7 +4552,7 @@ in
         ];
       })
       sources."request-2.88.0"
-      sources."resolve-1.12.0"
+      sources."resolve-1.13.1"
       sources."retry-0.10.1"
       sources."rimraf-2.6.3"
       sources."safe-buffer-5.2.0"
@@ -1443,6 +4602,668 @@ in
       description = "Generate Nix expressions to build NPM packages";
       homepage = https://github.com/svanderburg/node2nix;
       license = "MIT";
+    };
+    production = true;
+    bypassCache = true;
+    reconstructLock = true;
+  };
+  dat = nodeEnv.buildNodePackage {
+    name = "dat";
+    packageName = "dat";
+    version = "13.13.1";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/dat/-/dat-13.13.1.tgz";
+      sha512 = "I6r+8jeGKdZ5ztkxXQUu+2DmzoCkRB4KS0bPfu85u2RoK5xz0ypt3h/WP7GjRBBvhOOM7/LdYKUcOob6RKMtRQ==";
+    };
+    dependencies = [
+      sources."abstract-random-access-1.1.2"
+      sources."ajv-6.10.2"
+      sources."ansi-align-2.0.0"
+      sources."ansi-diff-1.1.1"
+      sources."ansi-regex-3.0.0"
+      sources."ansi-split-1.0.1"
+      sources."ansi-styles-3.2.1"
+      sources."anymatch-2.0.0"
+      sources."ap-0.1.0"
+      (sources."append-tree-2.4.4" // {
+        dependencies = [
+          sources."process-nextick-args-1.0.7"
+          sources."varint-5.0.0"
+        ];
+      })
+      sources."arr-diff-4.0.0"
+      sources."arr-flatten-1.1.0"
+      sources."arr-union-3.1.0"
+      sources."array-lru-1.1.1"
+      sources."array-unique-0.3.2"
+      sources."asn1-0.2.4"
+      sources."assert-plus-1.0.0"
+      sources."assign-symbols-1.0.0"
+      sources."async-0.9.2"
+      sources."asynckit-0.4.0"
+      sources."atob-2.1.2"
+      sources."atomic-batcher-1.0.2"
+      sources."aws-sign2-0.7.0"
+      sources."aws4-1.9.0"
+      sources."balanced-match-1.0.0"
+      (sources."base-0.11.2" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+        ];
+      })
+      sources."bcrypt-pbkdf-1.0.2"
+      sources."bencode-1.0.0"
+      (sources."bitfield-rle-2.2.1" // {
+        dependencies = [
+          sources."varint-4.0.1"
+        ];
+      })
+      (sources."bittorrent-dht-7.10.0" // {
+        dependencies = [
+          sources."debug-3.2.6"
+        ];
+      })
+      sources."blake2b-2.1.3"
+      sources."blake2b-wasm-1.1.7"
+      sources."body-0.1.0"
+      sources."boxen-1.3.0"
+      sources."brace-expansion-1.1.11"
+      (sources."braces-2.3.2" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."buffer-alloc-1.2.0"
+      sources."buffer-alloc-unsafe-1.1.0"
+      sources."buffer-equals-1.0.4"
+      sources."buffer-fill-1.0.0"
+      sources."buffer-from-1.1.1"
+      sources."bulk-write-stream-1.1.4"
+      sources."bytes-3.1.0"
+      sources."cache-base-1.0.1"
+      sources."call-me-maybe-1.0.1"
+      sources."camelcase-4.1.0"
+      sources."capture-stack-trace-1.0.1"
+      sources."caseless-0.12.0"
+      sources."chalk-2.4.2"
+      sources."chrome-dgram-3.0.4"
+      sources."chrome-dns-1.0.1"
+      sources."chrome-net-3.3.3"
+      sources."ci-info-1.6.0"
+      sources."circular-append-file-1.0.1"
+      (sources."class-utils-0.3.6" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."cli-boxes-1.0.0"
+      sources."cli-spinners-1.3.1"
+      sources."cli-truncate-1.1.0"
+      sources."cliclopts-1.1.1"
+      sources."codecs-1.2.1"
+      sources."collection-visit-1.0.0"
+      sources."color-convert-1.9.3"
+      sources."color-name-1.1.3"
+      sources."colors-1.4.0"
+      sources."combined-stream-1.0.8"
+      sources."component-emitter-1.3.0"
+      sources."concat-map-0.0.1"
+      sources."concat-stream-1.6.2"
+      sources."configstore-3.1.2"
+      sources."connections-1.4.2"
+      sources."content-types-0.1.0"
+      sources."copy-descriptor-0.1.1"
+      sources."core-util-is-1.0.2"
+      sources."corsify-2.1.0"
+      sources."count-trailing-zeros-1.0.1"
+      sources."create-error-class-3.0.2"
+      sources."cross-spawn-5.1.0"
+      sources."crypto-random-string-1.0.0"
+      sources."cycle-1.0.3"
+      sources."dashdash-1.14.1"
+      sources."dat-dns-3.2.1"
+      sources."dat-doctor-2.1.2"
+      sources."dat-encoding-5.0.1"
+      sources."dat-ignore-2.1.2"
+      sources."dat-json-1.0.3"
+      sources."dat-link-resolve-2.3.0"
+      (sources."dat-log-1.2.0" // {
+        dependencies = [
+          sources."neat-log-2.4.0"
+        ];
+      })
+      sources."dat-node-3.5.15"
+      sources."dat-registry-4.0.1"
+      sources."dat-secret-storage-4.0.1"
+      sources."dat-storage-1.1.1"
+      sources."dat-swarm-defaults-1.0.2"
+      sources."debug-4.1.1"
+      sources."decode-uri-component-0.2.0"
+      sources."decompress-response-4.2.1"
+      sources."deep-equal-0.2.2"
+      sources."deep-extend-0.6.0"
+      sources."define-property-2.0.2"
+      sources."delayed-stream-1.0.0"
+      sources."diffy-2.1.0"
+      sources."directory-index-html-2.1.0"
+      (sources."discovery-channel-5.5.1" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+          sources."thunky-0.1.0"
+        ];
+      })
+      (sources."discovery-swarm-5.1.4" // {
+        dependencies = [
+          sources."utp-native-1.7.3"
+        ];
+      })
+      (sources."dns-discovery-6.2.3" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."lru-2.0.1"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."dns-packet-4.2.0"
+      sources."dns-socket-3.0.0"
+      sources."dom-walk-0.1.1"
+      sources."dot-prop-4.2.0"
+      sources."duplexer3-0.1.4"
+      sources."duplexify-3.7.1"
+      sources."ecc-jsbn-0.1.2"
+      sources."end-of-stream-1.4.4"
+      sources."escape-string-regexp-1.0.5"
+      sources."execa-0.7.0"
+      (sources."expand-brackets-2.1.4" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."extend-3.0.2"
+      (sources."extend-shallow-3.0.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      (sources."extglob-2.0.4" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."extsprintf-1.3.0"
+      sources."eyes-0.1.8"
+      sources."fast-bitfield-1.2.2"
+      sources."fast-deep-equal-2.0.1"
+      sources."fast-json-stable-stringify-2.1.0"
+      (sources."fd-lock-1.0.2" // {
+        dependencies = [
+          sources."napi-macros-1.8.2"
+        ];
+      })
+      sources."fd-read-stream-1.1.0"
+      sources."figures-2.0.0"
+      (sources."fill-range-4.0.0" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."flat-tree-1.6.0"
+      sources."for-in-1.0.2"
+      sources."forever-agent-0.6.1"
+      sources."form-data-2.3.3"
+      sources."fragment-cache-0.2.1"
+      sources."from2-2.3.0"
+      sources."fs.realpath-1.0.0"
+      sources."get-stream-3.0.0"
+      sources."get-value-2.0.6"
+      sources."getpass-0.1.7"
+      sources."glob-7.1.6"
+      sources."global-4.3.2"
+      sources."global-dirs-0.1.1"
+      sources."got-6.7.1"
+      sources."graceful-fs-4.2.3"
+      sources."har-schema-2.0.0"
+      sources."har-validator-5.1.3"
+      sources."has-flag-3.0.0"
+      sources."has-value-1.0.0"
+      (sources."has-values-1.0.0" // {
+        dependencies = [
+          sources."kind-of-4.0.0"
+        ];
+      })
+      sources."http-methods-0.1.0"
+      sources."http-signature-1.2.0"
+      (sources."hypercore-7.7.1" // {
+        dependencies = [
+          sources."codecs-2.0.0"
+          sources."unordered-set-2.0.1"
+        ];
+      })
+      sources."hypercore-crypto-1.0.0"
+      (sources."hypercore-protocol-6.12.0" // {
+        dependencies = [
+          sources."varint-5.0.0"
+        ];
+      })
+      sources."hyperdrive-9.16.0"
+      sources."hyperdrive-http-4.4.0"
+      (sources."hyperdrive-network-speed-2.1.0" // {
+        dependencies = [
+          sources."debug-3.2.6"
+        ];
+      })
+      sources."i-0.3.6"
+      sources."import-lazy-2.1.0"
+      sources."imurmurhash-0.1.4"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.4"
+      sources."ini-1.3.5"
+      sources."inspect-custom-symbol-1.1.1"
+      sources."ip-1.1.5"
+      sources."is-accessor-descriptor-1.0.0"
+      sources."is-buffer-1.1.6"
+      sources."is-ci-1.2.1"
+      sources."is-data-descriptor-1.0.0"
+      sources."is-descriptor-1.0.2"
+      sources."is-extendable-0.1.1"
+      sources."is-fullwidth-code-point-2.0.0"
+      sources."is-function-1.0.1"
+      sources."is-installed-globally-0.1.0"
+      sources."is-npm-1.0.0"
+      (sources."is-number-3.0.0" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."is-obj-1.0.1"
+      sources."is-options-1.0.1"
+      sources."is-path-inside-1.0.1"
+      sources."is-plain-object-2.0.4"
+      sources."is-redirect-1.0.0"
+      sources."is-retry-allowed-1.2.0"
+      sources."is-stream-1.1.0"
+      sources."is-string-1.0.4"
+      sources."is-typedarray-1.0.0"
+      sources."is-windows-1.0.2"
+      sources."isarray-1.0.0"
+      sources."isexe-2.0.0"
+      sources."isobject-3.0.1"
+      sources."isstream-0.1.2"
+      sources."iterators-0.1.0"
+      sources."jsbn-0.1.1"
+      sources."json-schema-0.2.3"
+      sources."json-schema-traverse-0.4.1"
+      sources."json-stringify-safe-5.0.1"
+      sources."jsprim-1.4.1"
+      sources."k-bucket-3.3.1"
+      (sources."k-rpc-4.3.1" // {
+        dependencies = [
+          sources."k-bucket-4.0.1"
+        ];
+      })
+      (sources."k-rpc-socket-1.11.1" // {
+        dependencies = [
+          sources."bencode-2.0.1"
+        ];
+      })
+      sources."keypress-0.2.1"
+      sources."kind-of-6.0.2"
+      sources."last-one-wins-1.0.4"
+      sources."latest-version-3.1.0"
+      sources."length-prefixed-message-3.0.4"
+      sources."lodash.throttle-4.1.1"
+      sources."lowercase-keys-1.0.1"
+      sources."lru-3.1.0"
+      sources."lru-cache-4.1.5"
+      sources."make-dir-1.3.0"
+      sources."map-cache-0.2.2"
+      sources."map-visit-1.0.0"
+      sources."memory-pager-1.5.0"
+      sources."menu-string-1.3.0"
+      sources."merkle-tree-stream-3.0.3"
+      sources."micromatch-3.1.10"
+      sources."mime-2.4.4"
+      sources."mime-db-1.42.0"
+      sources."mime-types-2.1.25"
+      sources."mimic-response-2.0.0"
+      sources."min-document-2.19.0"
+      sources."minimatch-3.0.4"
+      sources."minimist-1.2.0"
+      sources."mirror-folder-3.0.0"
+      (sources."mixin-deep-1.3.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      (sources."mkdirp-0.5.1" // {
+        dependencies = [
+          sources."minimist-0.0.8"
+        ];
+      })
+      sources."ms-2.1.2"
+      sources."multi-random-access-2.1.1"
+      sources."multicast-dns-7.2.0"
+      sources."multistream-2.1.1"
+      sources."mute-stream-0.0.8"
+      sources."mutexify-1.2.0"
+      sources."nan-2.14.0"
+      sources."nanoassert-1.1.0"
+      sources."nanobus-4.4.0"
+      sources."nanoguard-1.2.2"
+      sources."nanomatch-1.2.13"
+      sources."nanoscheduler-1.0.3"
+      sources."nanotiming-7.3.1"
+      sources."napi-macros-2.0.0"
+      sources."ncp-1.0.1"
+      sources."neat-input-1.10.0"
+      sources."neat-log-3.1.0"
+      sources."neat-spinner-1.0.0"
+      sources."neat-tasks-1.1.1"
+      sources."nets-3.2.0"
+      sources."network-address-1.1.2"
+      sources."node-gyp-build-3.9.0"
+      sources."normalize-path-2.1.1"
+      sources."npm-run-path-2.0.2"
+      sources."oauth-sign-0.9.0"
+      (sources."object-copy-0.1.0" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          sources."is-accessor-descriptor-0.1.6"
+          sources."is-data-descriptor-0.1.4"
+          (sources."is-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-5.1.0"
+            ];
+          })
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."object-visit-1.0.1"
+      sources."object.pick-1.3.0"
+      sources."once-1.4.0"
+      sources."os-homedir-1.0.2"
+      sources."p-finally-1.0.0"
+      sources."package-json-4.0.1"
+      sources."parse-headers-2.0.3"
+      sources."pascalcase-0.1.1"
+      sources."path-is-absolute-1.0.1"
+      sources."path-is-inside-1.0.2"
+      sources."path-key-2.0.1"
+      sources."performance-now-2.1.0"
+      sources."pify-3.0.0"
+      sources."pkginfo-0.4.1"
+      sources."posix-character-classes-0.1.1"
+      sources."prepend-http-1.0.4"
+      sources."prettier-bytes-1.0.4"
+      sources."pretty-hash-1.0.1"
+      sources."process-0.5.2"
+      sources."process-nextick-args-2.0.1"
+      sources."progress-string-1.2.2"
+      sources."prompt-1.0.0"
+      (sources."protocol-buffers-encodings-1.1.0" // {
+        dependencies = [
+          sources."varint-5.0.0"
+        ];
+      })
+      sources."pseudomap-1.0.2"
+      sources."psl-1.6.0"
+      sources."pump-3.0.0"
+      sources."punycode-2.1.1"
+      sources."qs-6.5.2"
+      sources."random-access-file-2.1.3"
+      sources."random-access-memory-3.1.1"
+      sources."random-access-storage-1.4.0"
+      sources."randombytes-2.1.0"
+      sources."range-parser-1.2.1"
+      sources."rc-1.2.8"
+      sources."read-1.0.7"
+      (sources."readable-stream-2.3.6" // {
+        dependencies = [
+          sources."safe-buffer-5.1.2"
+        ];
+      })
+      sources."recursive-watch-1.1.4"
+      sources."regex-not-1.0.2"
+      sources."registry-auth-token-3.4.0"
+      sources."registry-url-3.1.0"
+      sources."remove-array-items-1.1.1"
+      sources."remove-trailing-separator-1.1.0"
+      sources."repeat-element-1.1.3"
+      sources."repeat-string-1.6.1"
+      sources."request-2.88.0"
+      sources."resolve-url-0.2.1"
+      sources."ret-0.1.15"
+      sources."revalidator-0.1.8"
+      sources."rimraf-2.7.1"
+      sources."run-series-1.1.8"
+      sources."rusha-0.8.13"
+      sources."safe-buffer-5.2.0"
+      sources."safe-regex-1.1.0"
+      sources."safer-buffer-2.1.2"
+      sources."semver-5.7.1"
+      sources."semver-diff-2.1.0"
+      (sources."set-value-2.0.1" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."shebang-command-1.2.0"
+      sources."shebang-regex-1.0.0"
+      sources."signal-exit-3.0.2"
+      (sources."signed-varint-2.0.1" // {
+        dependencies = [
+          sources."varint-5.0.0"
+        ];
+      })
+      sources."simple-concat-1.0.0"
+      sources."simple-get-3.1.0"
+      sources."simple-sha1-2.1.2"
+      sources."siphash24-1.1.1"
+      sources."slice-ansi-1.0.0"
+      (sources."snapdragon-0.8.2" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
+        ];
+      })
+      (sources."snapdragon-node-2.1.1" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+        ];
+      })
+      (sources."snapdragon-util-3.0.1" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."sodium-javascript-0.5.5"
+      (sources."sodium-native-2.4.6" // {
+        dependencies = [
+          sources."node-gyp-build-4.2.0"
+        ];
+      })
+      sources."sodium-universal-2.0.0"
+      sources."sorted-array-functions-1.2.0"
+      sources."sorted-indexof-1.0.0"
+      sources."source-map-0.5.7"
+      sources."source-map-resolve-0.5.2"
+      sources."source-map-url-0.4.0"
+      sources."sparse-bitfield-3.0.3"
+      sources."speedometer-1.1.0"
+      sources."split-string-3.1.0"
+      sources."sshpk-1.16.1"
+      sources."stack-trace-0.0.10"
+      (sources."static-extend-0.1.2" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."stream-collector-1.0.1"
+      sources."stream-each-1.2.3"
+      (sources."stream-parser-0.3.1" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
+      sources."stream-shift-1.0.1"
+      sources."string-width-2.1.1"
+      (sources."string_decoder-1.1.1" // {
+        dependencies = [
+          sources."safe-buffer-5.1.2"
+        ];
+      })
+      sources."strip-ansi-4.0.0"
+      sources."strip-eof-1.0.0"
+      sources."strip-json-comments-2.0.1"
+      sources."subcommand-2.1.1"
+      sources."supports-color-5.5.0"
+      sources."term-size-1.2.0"
+      sources."throttle-1.0.3"
+      sources."thunky-1.1.0"
+      sources."timed-out-4.0.1"
+      sources."timeout-refresh-1.0.1"
+      sources."to-buffer-1.1.1"
+      (sources."to-object-path-0.3.0" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."to-regex-3.0.2"
+      sources."to-regex-range-2.1.1"
+      (sources."toiletdb-1.4.1" // {
+        dependencies = [
+          sources."debug-2.6.9"
+          sources."ms-2.0.0"
+        ];
+      })
+      (sources."tough-cookie-2.4.3" // {
+        dependencies = [
+          sources."punycode-1.4.1"
+        ];
+      })
+      (sources."township-client-1.3.2" // {
+        dependencies = [
+          sources."is-number-2.1.0"
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."ttl-1.3.1"
+      sources."tunnel-agent-0.6.0"
+      sources."tweetnacl-0.14.5"
+      sources."typedarray-0.0.6"
+      sources."uint64be-2.0.2"
+      sources."union-value-1.0.1"
+      sources."unique-string-1.0.0"
+      sources."unixify-1.0.0"
+      sources."unordered-array-remove-1.0.2"
+      sources."unordered-set-1.1.0"
+      (sources."unset-value-1.0.0" // {
+        dependencies = [
+          (sources."has-value-0.3.1" // {
+            dependencies = [
+              sources."isobject-2.1.0"
+            ];
+          })
+          sources."has-values-0.1.4"
+        ];
+      })
+      sources."untildify-3.0.3"
+      sources."unzip-response-2.0.1"
+      sources."update-notifier-2.5.0"
+      sources."uri-js-4.2.2"
+      sources."urix-0.1.0"
+      sources."url-parse-lax-1.0.0"
+      sources."use-3.1.1"
+      sources."util-deprecate-1.0.2"
+      sources."utile-0.3.0"
+      (sources."utp-native-2.1.5" // {
+        dependencies = [
+          sources."node-gyp-build-4.2.0"
+          sources."readable-stream-3.4.0"
+          sources."unordered-set-2.0.1"
+        ];
+      })
+      sources."uuid-3.3.3"
+      sources."varint-3.0.1"
+      sources."verror-1.10.0"
+      sources."which-1.3.1"
+      sources."widest-line-2.0.1"
+      (sources."winston-2.1.1" // {
+        dependencies = [
+          sources."async-1.0.0"
+          sources."colors-1.0.3"
+          sources."pkginfo-0.3.1"
+        ];
+      })
+      sources."wrappy-1.0.2"
+      sources."write-file-atomic-2.4.3"
+      sources."xdg-basedir-3.0.0"
+      sources."xhr-2.5.0"
+      sources."xsalsa20-1.1.0"
+      sources."xtend-4.0.2"
+      sources."yallist-2.1.2"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "Dat is the package manager for data. Easily share and version control data.";
+      homepage = https://datproject.org/;
+      license = "BSD-3-Clause";
     };
     production = true;
     bypassCache = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done
<details>
<summary>Buld fails with the following error:</summary>


```
nix-env -f . -iA nodePackages.dat                                                                                                                                 ✔ 

installing 'node_dat-13.13.1'
these derivations will be built:
  /nix/store/00a94s7ma2swihp9f4ibm4g5zfs15c48-hypercore-crypto-1.0.0.tgz.drv
  /nix/store/0axh4g1pyaxsi91b0rk9kfvxmnx3alyn-nets-3.2.0.tgz.drv
  /nix/store/0iihcdg9125sc7is8qq0f8wkx4k3159m-k-rpc-4.3.1.tgz.drv
  /nix/store/0m0l52xaigi92z6kcranv31anyhzdwrj-corsify-2.1.0.tgz.drv
  /nix/store/0w1zkk75m2vgc2c4brh0qc3fpmky57h3-crypto-random-string-1.0.0.tgz.drv
  /nix/store/1099h5dz9r5kn9rg5vn3izsdnmp1pc7r-menu-string-1.3.0.tgz.drv
  /nix/store/15rawpc9545ih2brwjdz04fh692k7glf-lru-3.1.0.tgz.drv
  /nix/store/16q3dbg4p3c2p4yb8h58biwqxp1wdpbd-flat-tree-1.6.0.tgz.drv
  /nix/store/24z9kd1f2xva75qg34f7w7xw1vws95mp-recursive-watch-1.1.4.tgz.drv
  /nix/store/2bbj2kpgv755l7am9k9drpmi49dh0065-dns-discovery-6.2.3.tgz.drv
  /nix/store/2ljizsqc92s8brv02rwww6nv0pjlcy84-discovery-channel-5.5.1.tgz.drv
  /nix/store/2sslgpzp4lrh7gq9ik8wyqk6jlq891ng-connections-1.4.2.tgz.drv
  /nix/store/32wjqfjppjicazaivs4pi2s73zxr7k79-cliclopts-1.1.1.tgz.drv
  /nix/store/3mq2dkp57qapgqdaz24hb09xx7skydr9-sparse-bitfield-3.0.3.tgz.drv
  /nix/store/41pzrapy96q621w6m97lxq966dmxrjks-township-client-1.3.2.tgz.drv
  /nix/store/bz36ahs06kykdsd7qlsk78ah80zf8l6i-node-gyp-build-4.2.0.tgz.drv
  /nix/store/g369djr6r0h8374xgqha7hngfsribq3d-addintegrityfields.js.drv
  /nix/store/jvgpxzcdh0xgwd9mmiiwyjj638zdv1cx-pinpointDependencies.js.drv
  /nix/store/kwmx5hxcnpkv9y8i0md8bpa3sicq3694-addintegrityfields.js.drv
  /nix/store/4basbrdqc1p798662bml9ppz2wna3fca-node_node-gyp-build-4.2.0.drv
  /nix/store/4gpzjdmind18qxjf5g18s06i8hnhhp57-lodash.throttle-4.1.1.tgz.drv
  /nix/store/4mm3g9yh827l5pa9rlsmdw0mdk0z320c-atomic-batcher-1.0.2.tgz.drv
  /nix/store/4r8sm3adi26bzk880fqgb1v5v7k62lzc-dns-socket-3.0.0.tgz.drv
  /nix/store/509j3gqlhd4qlfphfkzs5yrkd1wj94rs-ap-0.1.0.tgz.drv
  /nix/store/526xp2g2m1arggp6qnmz94js6616nii3-update-notifier-2.5.0.tgz.drv
  /nix/store/56324mfz331s1sdcj1yhhqfh25xvp1xz-array-lru-1.1.1.tgz.drv
  /nix/store/62x1v8j0ajmb0mdsn2cil2vkp1qh298b-inspect-custom-symbol-1.1.1.tgz.drv
  /nix/store/65nqkjdg5r5lr3ivh8v60x2h0wim4h8b-unordered-set-1.1.0.tgz.drv
  /nix/store/66jpwhjac6yhznjj5qmc43fff6ijxqb0-varint-3.0.1.tgz.drv
  /nix/store/68dfg2gy6zjkbapjwr8bc2gjamzc9r8g-sodium-universal-2.0.0.tgz.drv
  /nix/store/6c0hpdbm7gr4bfp69vyqqd9af0zk5i36-fd-read-stream-1.1.0.tgz.drv
  /nix/store/6mrf9jvqpyrz6j8y8k4j8wqaam8kv21d-is-installed-globally-0.1.0.tgz.drv
  /nix/store/6rsapfhq72xvsxkgava8f87cy5v7swqm-parse-headers-2.0.3.tgz.drv
  /nix/store/70sflmh0k4xszr7nlb80cwg7rwrr40dz-k-bucket-3.3.1.tgz.drv
  /nix/store/75j6n44mf8bfcmpfz56x3w8na68lw1lz-ansi-split-1.0.1.tgz.drv
  /nix/store/7clnaipawsqlrawqxlk89a2w7z4d4q30-iterators-0.1.0.tgz.drv
  /nix/store/7k4na3yb74jrh0bklc47vrr9mxdxbfkr-count-trailing-zeros-1.0.1.tgz.drv
  /nix/store/7mni4fl3wyd9dxmfjvr3zvmdi9m1qnp6-bitfield-rle-2.2.1.tgz.drv
  /nix/store/7r91hgzqq1r6my2yr9mwbka6q09xdjmr-signed-varint-2.0.1.tgz.drv
  /nix/store/7vs25w9193vkyzbfykj4fcm5nd2c1g42-term-size-1.2.0.tgz.drv
  /nix/store/86118pwmkc2b8z2dmfwyxa5shplb2rni-speedometer-1.1.0.tgz.drv
  /nix/store/8frhn8zg9l8rbxl287ycj9ljp2cvhk5d-unordered-array-remove-1.0.2.tgz.drv
  /nix/store/8gkb058ddxvv1qgryhv8ymp58iffsrsc-protocol-buffers-encodings-1.1.0.tgz.drv
  /nix/store/8wyhazcbrffb05z18b9aili8rrxwffhv-content-types-0.1.0.tgz.drv
  /nix/store/91hjmgfw1zap2d7cp3y5k7p6b2m40wls-sodium-native-2.4.6.tgz.drv
  /nix/store/94j71qhy70ndpjjfv50880kgi487zvqy-hypercore-protocol-6.12.0.tgz.drv
  /nix/store/97jf7qri3n7hjqi4r5mqcnq386h0ff81-diffy-2.1.0.tgz.drv
  /nix/store/9aril8xj98641qsyyi5q7qwjvyzdzs1a-merkle-tree-stream-3.0.3.tgz.drv
  /nix/store/9bk8pjl2sc54hlf90dfigvpqz1ads5i8-random-access-memory-3.1.1.tgz.drv
  /nix/store/9rpwf0n4mz83gwbypbp185c472b9ph1h-unique-string-1.0.0.tgz.drv
  /nix/store/9y39bxq11hvdmzgwdm7985zc5mvx68ax-progress-string-1.2.2.tgz.drv
  /nix/store/a0dc4jc159zbvprq1nikwak62w9d0zya-dat-log-1.2.0.tgz.drv
  /nix/store/a0m0pslha20gr63hsdgahk7058ib0vcn-sodium-javascript-0.5.5.tgz.drv
  /nix/store/a62y6affhls0vfpd5h9hlr005dksfnzl-stream-collector-1.0.1.tgz.drv
  /nix/store/afi1mnms0z23zzw9hzj726zhl0l8grii-pretty-hash-1.0.1.tgz.drv
  /nix/store/ajsd65fqi6lylaprc9jndjylvgz2mic8-circular-append-file-1.0.1.tgz.drv
  /nix/store/ak6y26fs9zv87i08d6v26jbjvlvsz7lz-nanoassert-1.1.0.tgz.drv
  /nix/store/akwplng8y947sm59x56kdm5a1dz2hipy-neat-tasks-1.1.1.tgz.drv
  /nix/store/awkvig7pwp5ismhdb50ivivq4sajy32r-remove-array-items-1.1.1.tgz.drv
  /nix/store/ay9xcz2xfdrdv39pd96vfgdmfa6g8n7p-codecs-2.0.0.tgz.drv
  /nix/store/b3jfwh46spf183daa5bw0si6ig20bxxh-mirror-folder-3.0.0.tgz.drv
  /nix/store/b3mayk89bflg6hl9ndy3k34p9k377p82-boxen-1.3.0.tgz.drv
  /nix/store/b7zpyz83qa68p3awdva9nka8ycrhlm2g-dat-encoding-5.0.1.tgz.drv
  /nix/store/c63phagfss5vcfxh1w21g6yj7s3j4b76-ci-info-1.6.0.tgz.drv
  /nix/store/c98kv42nfpa5v7pvr5c3g585rks465qh-latest-version-3.1.0.tgz.drv
  /nix/store/cpxpqsnkjzdjs4gvhl5rdv0rlrqzmm91-nanoscheduler-1.0.3.tgz.drv
  /nix/store/cqb60bv1m12k0dlq7384h64vh3p1wp6p-cli-truncate-1.1.0.tgz.drv
  /nix/store/d0kgzmspwj091wsx96vrzc4mb82vd6hz-dat-json-1.0.3.tgz.drv
  /nix/store/dj4mr57khgzx3ap7imz23iy4cgk6s15b-last-one-wins-1.0.4.tgz.drv
  /nix/store/dzlwlnnzf4w41w6wkhm85ln2j9zab41z-is-ci-1.2.1.tgz.drv
  /nix/store/fg3yw0az231q67lhn53fmwn3qx8wfxww-timeout-refresh-1.0.1.tgz.drv
  /nix/store/fh9928ndb34qjdr3ynvv3s34nj0ir8x6-varint-5.0.0.tgz.drv
  /nix/store/fsl9mq4maix3chm6xcw9cm2l6bjdxnwc-global-dirs-0.1.1.tgz.drv
  /nix/store/g2h6n3cq6hka1wbf9pkd53wfxiaz2xhi-ansi-diff-1.1.1.tgz.drv
  /nix/store/g5z86gwdr486hv8n4zh85j4gzyiqynzx-napi-macros-1.8.2.tgz.drv
  /nix/store/g9083zli2q45lc133a56459l9djrpjp5-dat-dns-3.2.1.tgz.drv
  /nix/store/gl48x7wmnyw5f5csnfrrfv8gsn541bk8-is-string-1.0.4.tgz.drv
  /nix/store/gl8awgjsap79dvs8m8asd6v2qcbzbdzl-dat-link-resolve-2.3.0.tgz.drv
  /nix/store/gyha3ym0a8v1s7360lamzgllb6ylnwhr-nanotiming-7.3.1.tgz.drv
  /nix/store/h2kckdymvd84ky19yjir45q30as1fljk-append-tree-2.4.4.tgz.drv
  /nix/store/h32b68bxyd2li7cw976dj0yp4wvy77vw-hypercore-7.7.1.tgz.drv
  /nix/store/h8s65m2wfzrh1q7hfwjgkkd2vvzb54xk-xhr-2.5.0.tgz.drv
  /nix/store/haaf0vdmqx0miih28a1sn6ff7wqg0lbx-dat-node-3.5.15.tgz.drv
  /nix/store/hf084wbzhd2n4zpni3xj77i3m86pbxm5-memory-pager-1.5.0.tgz.drv
  /nix/store/i459qfgxgzv4annhchccw44r3ra05mik-dot-prop-4.2.0.tgz.drv
  /nix/store/ij8hdja6dx76569bghpmh9ac3h5jiid1-body-0.1.0.tgz.drv
  /nix/store/jjsw110s7kp7smn6s9d0bjmk9d9dwjpq-varint-4.0.1.tgz.drv
  /nix/store/jssp2ygkrw1fhvn6wq3b8awkpfwy6by0-napi-macros-2.0.0.tgz.drv
  /nix/store/k501lvvpr30indkz25aqcmicgcgqbzhx-k-bucket-4.0.1.tgz.drv
  /nix/store/khzdf9inmi7aviqskp8s44slws5ipzwi-fd-lock-1.0.2.tgz.drv
  /nix/store/kr5ri9b9clig69rqg0q8mwrlxjjnj7nz-throttle-1.0.3.tgz.drv
  /nix/store/kwicbqiiygac6mkiw5jphj2hkr8749x8-untildify-3.0.3.tgz.drv
  /nix/store/l866ml2sajgsqhn74nyw2an1l1qw44z8-blake2b-2.1.3.tgz.drv
  /nix/store/m47n32lb5075gs1pcc2mz51lgqgi4izs-mutexify-1.2.0.tgz.drv
  /nix/store/m65y664cxjap6r4zpbnqwdpkzarqi0yn-widest-line-2.0.1.tgz.drv
  /nix/store/m897drabcrkvf0dhm4bzh89w2jg7jwp4-ttl-1.3.1.tgz.drv
  /nix/store/mavypf02xw50vkgbl7l0gzxrr08bczpg-nanoguard-1.2.2.tgz.drv
  /nix/store/mwrc4js1qmz86hpyvhsdmgg7z5gv5qna-uint64be-2.0.2.tgz.drv
  /nix/store/n7k705sqlgmg2cq9pz9zxis3fq0ih7nw-discovery-swarm-5.1.4.tgz.drv
  /nix/store/nd6vni2b75138z7f2bqsgf3xv0m5bm3n-abstract-random-access-1.1.2.tgz.drv
  /nix/store/nkxfzc01da38kb6mrs7qmpkywqrj7xir-configstore-3.1.2.tgz.drv
  /nix/store/p6by33fprwdy66cram5q7y0q1npxygbq-stream-parser-0.3.1.tgz.drv
  /nix/store/pbsls1nvszhkr9y0gmk2zcc1qkqxbpln-dat-storage-1.1.1.tgz.drv
  /nix/store/pifpb41rxxklbxyd6hw6yp14wnf6xwn0-hyperdrive-network-speed-2.1.0.tgz.drv
  /nix/store/px50sv4ngnaflbvhyk25fg6hfryy12pi-bulk-write-stream-1.1.4.tgz.drv
  /nix/store/pz6yfqgbpapv1zv9zf10xdwym0gnn4yr-sorted-array-functions-1.2.0.tgz.drv
  /nix/store/q4cgiqxnvwkriz59pvvyiniaf06h3pyj-hyperdrive-9.16.0.tgz.drv
  /nix/store/qgxj7x46jgx9qdwah036z3479cjkdxlc-dat-secret-storage-4.0.1.tgz.drv
  /nix/store/qikxvik62f6m8ba4rz7gqm0byy8i3vbi-import-lazy-2.1.0.tgz.drv
  /nix/store/qrfr70f85lcn1nj85qrwwrp5ph21b8gw-dat-ignore-2.1.2.tgz.drv
  /nix/store/r39ffrqrq71b9grql42a8a3v4ks0q6gp-dns-packet-4.2.0.tgz.drv
  /nix/store/rfvrzk1w27z9vykjf5697zcf8fq524ir-blake2b-wasm-1.1.7.tgz.drv
  /nix/store/rgm6xwg4mc8w853g05ynlkvglri3vbyd-cli-boxes-1.0.0.tgz.drv
  /nix/store/rm7y36mnfw5s8wwdkim8iqw04007an29-toiletdb-1.4.1.tgz.drv
  /nix/store/rmqawhqvqkiywx9334m96kscvrv94s3p-fast-json-stable-stringify-2.1.0.tgz.drv
  /nix/store/rs8l35s8szpn598ka2fqx08cx0bfyip3-neat-log-2.4.0.tgz.drv
  /nix/store/rwlrsldzr7ysxccj8clv7l43ccxcdph5-subcommand-2.1.1.tgz.drv
  /nix/store/s5l1f3zhvys63rkv6pnlqzfnwsjyf9xk-codecs-1.2.1.tgz.drv
  /nix/store/s718k9l7vwrbnwhvik3dbh69hnwcw2s0-neat-input-1.10.0.tgz.drv
  /nix/store/s8gc0n99saa70wlkgmcl2gs9vjs38dhg-package-json-4.0.1.tgz.drv
  /nix/store/sb67881nnkkz20ldq8dj4ara3wra22ma-multi-random-access-2.1.1.tgz.drv
  /nix/store/sg0rnznqcbxvwyw7ji2xwk32ra2yw3l3-dat-registry-4.0.1.tgz.drv
  /nix/store/simp3x22i0gb3z3ydnkwmyc5kfijdnhg-http-methods-0.1.0.tgz.drv
  /nix/store/ss00qnlfxyc7qg2nd1x0x8glw609wrf2-fast-bitfield-1.2.2.tgz.drv
  /nix/store/sykahyzfyp9x8jy4rxdkk8caxqlfv02n-sorted-indexof-1.0.0.tgz.drv
  /nix/store/v10a1kwimmdh6j5kz0nvw05viaafhnr8-nanobus-4.4.0.tgz.drv
  /nix/store/v3z6vgr50bb730pjf1p63lyc197xmy8j-dat-doctor-2.1.2.tgz.drv
  /nix/store/vgiddk2h8h0hjzf05ss681syv4sk4n81-stream-shift-1.0.1.tgz.drv
  /nix/store/vjmrxy3mzkl2xz77gf2gg0cy6g0mw7gd-neat-log-3.1.0.tgz.drv
  /nix/store/w8qz7yaa6idcc87s0drq9phz6zcg35k2-hyperdrive-http-4.4.0.tgz.drv
  /nix/store/w9y1dlcws299kgisq39fan4ghaig166a-unixify-1.0.0.tgz.drv
  /nix/store/wnf0mshkmvlsirc41fbzvc50jah7nlmd-xsalsa20-1.1.0.tgz.drv
  /nix/store/wwpw2mrwjx8hma4wv7i51x2njr0akghf-utp-native-1.7.3.tgz.drv
  /nix/store/x884mjfm6lz05fzbmghl99yf3i9acwn5-neat-spinner-1.0.0.tgz.drv
  /nix/store/xckjrsq99djp7g6m1854aym2yz0gzy5r-siphash24-1.1.1.tgz.drv
  /nix/store/xhs3a0xl28kpb768pq45fa17j7bwd3qn-utp-native-2.1.5.tgz.drv
  /nix/store/xs8rv2hx0l6a91a4fi2x6d193s7gsspc-multicast-dns-7.2.0.tgz.drv
  /nix/store/xzksnak1xmkpr35xjzp4xd59f327i3lr-prettier-bytes-1.0.4.tgz.drv
  /nix/store/yd3n19drnq7rsby6ilfjigcv0y7cca57-length-prefixed-message-3.0.4.tgz.drv
  /nix/store/yhnds4bnyh1c561fjg8q0gi7v35zmpi2-dat-13.13.1.tgz.drv
  /nix/store/ymagyr5dg2z2cgrb4iw3k8dggqw9yafw-ansi-align-2.0.0.tgz.drv
  /nix/store/yrr4h80kz60ni3b5nc07jx153bwlfrzc-is-options-1.0.1.tgz.drv
  /nix/store/yzah8fpw62xcvim22zaf9c5pw962nays-dat-swarm-defaults-1.0.2.tgz.drv
  /nix/store/z3bpijb1prvwann577b1cdqb6hg4i4g6-bittorrent-dht-7.10.0.tgz.drv
  /nix/store/z3mbh0jgcvhv6xp6flv0lim20nkcyj8g-keypress-0.2.1.tgz.drv
  /nix/store/zgb0ww824czq72agiqc0inxxd51k6k94-directory-index-html-2.1.0.tgz.drv
  /nix/store/zrclqr7zbzi71wgrbyv47paqfjwcjwgm-node-gyp-build-3.9.0.tgz.drv
  /nix/store/zyr1k4m2arsvziavcfl7bm3n5rdk3lqi-write-file-atomic-2.4.3.tgz.drv
  /nix/store/zzid033ag4cqh8kkxb094s7bf7h34lik-unordered-set-2.0.1.tgz.drv
  /nix/store/cbw6487wqdc9jg44i51v0vkra70hjwvi-node_dat-13.13.1.drv
these paths will be fetched (26.54 MiB download, 244.34 MiB unpacked):
  /nix/store/0a85n9y8w7ivjj584vk82d4778452lig-to-buffer-1.1.1.tgz
  /nix/store/1pl2m0lmrwmmq50bvkzizlrrmay9i6fy-xdg-basedir-3.0.0.tgz
  /nix/store/1rrkm410vp3xw8v2j0j5b9nxmg233lw6-util-linux-2.33.2-dev
  /nix/store/23irz8l1axz7kll20dqb5zcdg48h32nx-thunky-1.1.0.tgz
  /nix/store/2n37yvlkcmvfcmvjj1bmjv0f4xlgg2yz-stack-trace-0.0.10.tgz
  /nix/store/2n5qkqdr75ifmap43rgvicivymk7n92w-winston-2.1.1.tgz
  /nix/store/2pc30dnwx91sjhhv947b4vmxi1hnvq8n-signal-exit-3.0.2.tgz
  /nix/store/2scfk50vq38cidvbv6j0kj86i0zxsx5k-string-width-2.1.1.tgz
  /nix/store/35w0c1f0rw19x6p1b4b9lvbc3x23w8cs-util-deprecate-1.0.2.tgz
  /nix/store/38s551sc6kx6j616fi1nnj228hq3i3b2-sshpk-1.16.1.tgz
  /nix/store/42b6lbplga1lbz8cn9d51j74w4g2y6b0-strip-eof-1.0.0.tgz
  /nix/store/49kqql1h5njvh7cmlsyrnrl6ljqnjy1q-rimraf-2.7.1.tgz
  /nix/store/528x99gc947pl56y4lgmm4a9d4m8mhm4-rusha-0.8.13.tgz
  /nix/store/619dk008mxwmnwjp1kdx9rv8cmlp3z7l-static-extend-0.1.2.tgz
  /nix/store/63hfa6y2p5fbrjasjilhgskv08p3sp1w-utile-0.3.0.tgz
  /nix/store/8cqj54pff0s2jhil3lxy3r0m1is0x800-which-1.3.1.tgz
  /nix/store/9bd9n0k5ww99m2irbyv9kfrzrcpgng83-source-map-resolve-0.5.2.tgz
  /nix/store/9f8j0b9b9zvna19w9c2cb51qqy7nln0m-snapdragon-util-3.0.1.tgz
  /nix/store/9q51lrizxa0llyy42iwsmgsrk90y8yis-to-object-path-0.3.0.tgz
  /nix/store/a3vihfaa2ryci8p5v5y7dwyqgqghdxfd-split-string-3.1.0.tgz
  /nix/store/aazscwmbmx7n91nx2rr118iq4a0a6h9v-safe-buffer-5.1.2.tgz
  /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources
  /nix/store/ayxlyk7jf53masjr87bw8pymfz358qdr-run-series-1.1.8.tgz
  /nix/store/bcvwjwg1zbngvjv57nkppv5kkjh4xfvl-simple-get-3.1.0.tgz
  /nix/store/c4w4vf1afbah7dhfalc28i1diihp2s9w-shebang-regex-1.0.0.tgz
  /nix/store/clildawvd8ykm8ni5yqdizfp14nji8vd-tough-cookie-2.4.3.tgz
  /nix/store/cnapsycwv8wb9iqpaiyiypj02y2i8lnj-util-linux-2.33.2
  /nix/store/dpacg0ppk26x8vwr7f68naszk7sidhq8-source-map-0.5.7.tgz
  /nix/store/f201bdwdhwqnn6q94rcg1nh7ckkhd4ik-to-regex-range-2.1.1.tgz
  /nix/store/f5z033w9f95lhiy1vapa8a44mjgaj7d8-snapdragon-node-2.1.1.tgz
  /nix/store/g21ar084fqc710br78cdxj9d4l1vhmqf-source-map-url-0.4.0.tgz
  /nix/store/g86vjrib9ypnni2kl3lm1rpgxwr32i5n-url-parse-lax-1.0.0.tgz
  /nix/store/gll14kwxsz9ggfhngafafh64rv4a02fr-semver-5.7.1.tgz
  /nix/store/h5cknby55g5srfbnw5vabb52c7vsisc4-unzip-response-2.0.1.tgz
  /nix/store/hj7p7yvnn1663sl52lcahcr7nl1m8d7y-set-value-2.0.1.tgz
  /nix/store/hkdfsf6gmzslax6v0izh15aw9s6kw2zm-string_decoder-1.1.1.tgz
  /nix/store/hljswnl6z9ix9ly5x546d6qjia9wpp60-snapdragon-0.8.2.tgz
  /nix/store/i1lkgrv7l3s8hl58rswr9n2ag9zzm0lq-util-linux-2.33.2-bin
  /nix/store/ikpdr887y96sybx61gy4yag0lyrwky0q-yallist-2.1.2.tgz
  /nix/store/j93r3grj36pzbq4bz47qfximx7ffawgy-xtend-4.0.2.tgz
  /nix/store/jkmzw6xwl4pqadq5sb8r895vsb3k11q5-shebang-command-1.2.0.tgz
  /nix/store/k4my4lczsa9i0ay5a3252pqsb92g3cnx-semver-diff-2.1.0.tgz
  /nix/store/kbb461ljysngpa4v2w32wvbf2rzy46mg-strip-ansi-4.0.0.tgz
  /nix/store/kr0cwrqxjdjx9zr98mv7q0di7dqnxlby-to-regex-3.0.2.tgz
  /nix/store/l00dhyvywymcy3345znvkfm4lvw4z0q2-slice-ansi-1.0.0.tgz
  /nix/store/m597499nqdp0mdnj3mr83c99p2l6wm0l-safe-buffer-5.2.0.tgz
  /nix/store/mfaakxwjpl42472h7p9vvafm3nid6m99-revalidator-0.1.8.tgz
  /nix/store/mkji4gkga8az4bsyfals7clzx68h0zqq-uuid-3.3.3.tgz
  /nix/store/mzyhh82sa8l2w01wxzp3wnbdxyv8ql2i-tarWrapper
  /nix/store/p2a55pi17q2i9dnwlcbfc9mk0iwmw9dl-safer-buffer-2.1.2.tgz
  /nix/store/p3m1kn6hyinns1p9g95mz74q9hbjqk2k-strip-json-comments-2.0.1.tgz
  /nix/store/phsi152rnh2z4xxvyxcqsdswngmvcdnn-simple-concat-1.0.0.tgz
  /nix/store/pjma93pkqdyjybpgmmyhyz0glpx5sw8y-typedarray-0.0.6.tgz
  /nix/store/q49b2g88cml42b3zl7w3q099n9nq7dzv-urix-0.1.0.tgz
  /nix/store/q9drqpfb11zad973l2q5h08yc81l4skp-uri-js-4.2.2.tgz
  /nix/store/rqnp3mxxf03pnvnm7rd7vkz04gqmki3h-supports-color-5.5.0.tgz
  /nix/store/s1dyvar6kxm4gdkn6wm4lv8y5vha4yyq-tunnel-agent-0.6.0.tgz
  /nix/store/s3g883kwf6q8f9rm3c7dd0sqs0ldcbg6-tweetnacl-0.14.5.tgz
  /nix/store/shrjl7kvwg6hhxczbs45lzd4rhzakxy5-use-3.1.1.tgz
  /nix/store/srqc391azzqdpajsn5fvp2rg55agdllj-unset-value-1.0.0.tgz
  /nix/store/vl7c4dx9dbwmagjp332ybylls292kd44-ret-0.1.15.tgz
  /nix/store/w2cyj8h3fbaahjnsic4i5s4m1m3cx5bb-safe-regex-1.1.0.tgz
  /nix/store/wa4iwdsy5dsa4fpgkmfb3wbkln886im5-wrappy-1.0.2.tgz
  /nix/store/whpnlfj79vd8p175rp1bwg0x7wz5lmj1-stdenv-linux
  /nix/store/wm71kdas3zajakw8zkfzf51fbr6vas3g-thunky-0.1.0.tgz
  /nix/store/wpi89y86krq9rbvwcbx0hc36ibp5d0v7-stdenv-linux
  /nix/store/x7jm3cmy61528gb9m92cpmdwk3s8zag6-verror-1.10.0.tgz
  /nix/store/y8aq3s1449iwpqfzsmgw6d7frawb9rak-timed-out-4.0.1.tgz
  /nix/store/yaakqw1scjvj91vb14b29d4hvj8ldxfq-shadow-4.7
  /nix/store/yim9jaglwfmy53sadvr7gs11am46mfzn-union-value-1.0.1.tgz
  /nix/store/z2m4yadq46lg96hz9a44wg68whsyjikf-stream-each-1.2.3.tgz
  /nix/store/zsb1346ibkk5vfcvkajfc8yzrg5wcnsv-simple-sha1-2.1.2.tgz
copying path '/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources' from 'https://cache.nixos.org'...
copying path '/nix/store/mfaakxwjpl42472h7p9vvafm3nid6m99-revalidator-0.1.8.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/vl7c4dx9dbwmagjp332ybylls292kd44-ret-0.1.15.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/49kqql1h5njvh7cmlsyrnrl6ljqnjy1q-rimraf-2.7.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/ayxlyk7jf53masjr87bw8pymfz358qdr-run-series-1.1.8.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/528x99gc947pl56y4lgmm4a9d4m8mhm4-rusha-0.8.13.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/aazscwmbmx7n91nx2rr118iq4a0a6h9v-safe-buffer-5.1.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/m597499nqdp0mdnj3mr83c99p2l6wm0l-safe-buffer-5.2.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/w2cyj8h3fbaahjnsic4i5s4m1m3cx5bb-safe-regex-1.1.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/p2a55pi17q2i9dnwlcbfc9mk0iwmw9dl-safer-buffer-2.1.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/gll14kwxsz9ggfhngafafh64rv4a02fr-semver-5.7.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/k4my4lczsa9i0ay5a3252pqsb92g3cnx-semver-diff-2.1.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/hj7p7yvnn1663sl52lcahcr7nl1m8d7y-set-value-2.0.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/yaakqw1scjvj91vb14b29d4hvj8ldxfq-shadow-4.7' from 'https://cache.nixos.org'...
copying path '/nix/store/c4w4vf1afbah7dhfalc28i1diihp2s9w-shebang-regex-1.0.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/jkmzw6xwl4pqadq5sb8r895vsb3k11q5-shebang-command-1.2.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/2pc30dnwx91sjhhv947b4vmxi1hnvq8n-signal-exit-3.0.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/phsi152rnh2z4xxvyxcqsdswngmvcdnn-simple-concat-1.0.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/bcvwjwg1zbngvjv57nkppv5kkjh4xfvl-simple-get-3.1.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/zsb1346ibkk5vfcvkajfc8yzrg5wcnsv-simple-sha1-2.1.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/l00dhyvywymcy3345znvkfm4lvw4z0q2-slice-ansi-1.0.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/hljswnl6z9ix9ly5x546d6qjia9wpp60-snapdragon-0.8.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/f5z033w9f95lhiy1vapa8a44mjgaj7d8-snapdragon-node-2.1.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/9f8j0b9b9zvna19w9c2cb51qqy7nln0m-snapdragon-util-3.0.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/dpacg0ppk26x8vwr7f68naszk7sidhq8-source-map-0.5.7.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/9bd9n0k5ww99m2irbyv9kfrzrcpgng83-source-map-resolve-0.5.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/g21ar084fqc710br78cdxj9d4l1vhmqf-source-map-url-0.4.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/a3vihfaa2ryci8p5v5y7dwyqgqghdxfd-split-string-3.1.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/38s551sc6kx6j616fi1nnj228hq3i3b2-sshpk-1.16.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/2n37yvlkcmvfcmvjj1bmjv0f4xlgg2yz-stack-trace-0.0.10.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/619dk008mxwmnwjp1kdx9rv8cmlp3z7l-static-extend-0.1.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/whpnlfj79vd8p175rp1bwg0x7wz5lmj1-stdenv-linux' from 'https://cache.nixos.org'...
copying path '/nix/store/wpi89y86krq9rbvwcbx0hc36ibp5d0v7-stdenv-linux' from 'https://cache.nixos.org'...
copying path '/nix/store/z2m4yadq46lg96hz9a44wg68whsyjikf-stream-each-1.2.3.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/hkdfsf6gmzslax6v0izh15aw9s6kw2zm-string_decoder-1.1.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/2scfk50vq38cidvbv6j0kj86i0zxsx5k-string-width-2.1.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/kbb461ljysngpa4v2w32wvbf2rzy46mg-strip-ansi-4.0.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/42b6lbplga1lbz8cn9d51j74w4g2y6b0-strip-eof-1.0.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/p3m1kn6hyinns1p9g95mz74q9hbjqk2k-strip-json-comments-2.0.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/rqnp3mxxf03pnvnm7rd7vkz04gqmki3h-supports-color-5.5.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/wm71kdas3zajakw8zkfzf51fbr6vas3g-thunky-0.1.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/mzyhh82sa8l2w01wxzp3wnbdxyv8ql2i-tarWrapper' from 'https://cache.nixos.org'...
copying path '/nix/store/23irz8l1axz7kll20dqb5zcdg48h32nx-thunky-1.1.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/y8aq3s1449iwpqfzsmgw6d7frawb9rak-timed-out-4.0.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/0a85n9y8w7ivjj584vk82d4778452lig-to-buffer-1.1.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/9q51lrizxa0llyy42iwsmgsrk90y8yis-to-object-path-0.3.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/kr0cwrqxjdjx9zr98mv7q0di7dqnxlby-to-regex-3.0.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/f201bdwdhwqnn6q94rcg1nh7ckkhd4ik-to-regex-range-2.1.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/clildawvd8ykm8ni5yqdizfp14nji8vd-tough-cookie-2.4.3.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/s1dyvar6kxm4gdkn6wm4lv8y5vha4yyq-tunnel-agent-0.6.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/s3g883kwf6q8f9rm3c7dd0sqs0ldcbg6-tweetnacl-0.14.5.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/pjma93pkqdyjybpgmmyhyz0glpx5sw8y-typedarray-0.0.6.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/yim9jaglwfmy53sadvr7gs11am46mfzn-union-value-1.0.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/srqc391azzqdpajsn5fvp2rg55agdllj-unset-value-1.0.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/h5cknby55g5srfbnw5vabb52c7vsisc4-unzip-response-2.0.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/q9drqpfb11zad973l2q5h08yc81l4skp-uri-js-4.2.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/q49b2g88cml42b3zl7w3q099n9nq7dzv-urix-0.1.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/g86vjrib9ypnni2kl3lm1rpgxwr32i5n-url-parse-lax-1.0.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/shrjl7kvwg6hhxczbs45lzd4rhzakxy5-use-3.1.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/35w0c1f0rw19x6p1b4b9lvbc3x23w8cs-util-deprecate-1.0.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/cnapsycwv8wb9iqpaiyiypj02y2i8lnj-util-linux-2.33.2' from 'https://cache.nixos.org'...
copying path '/nix/store/63hfa6y2p5fbrjasjilhgskv08p3sp1w-utile-0.3.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/mkji4gkga8az4bsyfals7clzx68h0zqq-uuid-3.3.3.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/x7jm3cmy61528gb9m92cpmdwk3s8zag6-verror-1.10.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/8cqj54pff0s2jhil3lxy3r0m1is0x800-which-1.3.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/2n5qkqdr75ifmap43rgvicivymk7n92w-winston-2.1.1.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/wa4iwdsy5dsa4fpgkmfb3wbkln886im5-wrappy-1.0.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/1pl2m0lmrwmmq50bvkzizlrrmay9i6fy-xdg-basedir-3.0.0.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/j93r3grj36pzbq4bz47qfximx7ffawgy-xtend-4.0.2.tgz' from 'https://cache.nixos.org'...
copying path '/nix/store/ikpdr887y96sybx61gy4yag0lyrwky0q-yallist-2.1.2.tgz' from 'https://cache.nixos.org'...
building '/nix/store/nd6vni2b75138z7f2bqsgf3xv0m5bm3n-abstract-random-access-1.1.2.tgz.drv'...
building '/nix/store/g369djr6r0h8374xgqha7hngfsribq3d-addintegrityfields.js.drv'...
copying path '/nix/store/i1lkgrv7l3s8hl58rswr9n2ag9zzm0lq-util-linux-2.33.2-bin' from 'https://cache.nixos.org'...
building '/nix/store/kwmx5hxcnpkv9y8i0md8bpa3sicq3694-addintegrityfields.js.drv'...
building '/nix/store/ymagyr5dg2z2cgrb4iw3k8dggqw9yafw-ansi-align-2.0.0.tgz.drv'...
error checking the existence of http://tarballs.nixos.org/sha1/9a8eac8ff79866f3f9b4bb1443ca778f1598aeda:
curl: (28) Resolving timed out after 15000 milliseconds

trying https://registry.npmjs.org/abstract-random-access/-/abstract-random-access-1.1.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
building '/nix/store/g2h6n3cq6hka1wbf9pkd53wfxiaz2xhi-ansi-diff-1.1.1.tgz.drv'...
error checking the existence of http://tarballs.nixos.org/sha1/c36aeccba563b89ceb556f3690f0b1d9e3547f7f:
curl: (28) Resolving timed out after 15000 milliseconds

trying https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/ansi-diff/-/ansi-diff-1.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3056  100  3056    0     0    287      0  0:00:10  0:00:10 --:--:--   687
copying path '/nix/store/1rrkm410vp3xw8v2j0j5b9nxmg233lw6-util-linux-2.33.2-dev' from 'https://cache.nixos.org'...
100  1875  100  1875    0     0    119      0  0:00:15  0:00:15 --:--:--   461
building '/nix/store/75j6n44mf8bfcmpfz56x3w8na68lw1lz-ansi-split-1.0.1.tgz.drv'...
building '/nix/store/509j3gqlhd4qlfphfkzs5yrkd1wj94rs-ap-0.1.0.tgz.drv'...

trying https://registry.npmjs.org/ap/-/ap-0.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/ansi-split/-/ansi-split-1.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1682  100  1682    0     0   7188      0 --:--:-- --:--:-- --:--:--  7188
100  2077  100  2077    0     0   8914      0 --:--:-- --:--:-- --:--:--  8914
building '/nix/store/h2kckdymvd84ky19yjir45q30as1fljk-append-tree-2.4.4.tgz.drv'...
100  3070  100  3070    0     0   1002      0  0:00:03  0:00:03 --:--:--  1002
building '/nix/store/56324mfz331s1sdcj1yhhqfh25xvp1xz-array-lru-1.1.1.tgz.drv'...

trying https://registry.npmjs.org/append-tree/-/append-tree-2.4.4.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
building '/nix/store/4mm3g9yh827l5pa9rlsmdw0mdk0z320c-atomic-batcher-1.0.2.tgz.drv'...
100 10195  100 10195    0     0  25941      0 --:--:-- --:--:-- --:--:-- 25941

trying https://registry.npmjs.org/array-lru/-/array-lru-1.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4551  100  4551    0     0  26928      0 --:--:-- --:--:-- --:--:-- 26928
building '/nix/store/7mni4fl3wyd9dxmfjvr3zvmdi9m1qnp6-bitfield-rle-2.2.1.tgz.drv'...
building '/nix/store/z3bpijb1prvwann577b1cdqb6hg4i4g6-bittorrent-dht-7.10.0.tgz.drv'...

trying https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2632  100  2632    0     0  12073      0 --:--:-- --:--:-- --:--:-- 12073
building '/nix/store/l866ml2sajgsqhn74nyw2an1l1qw44z8-blake2b-2.1.3.tgz.drv'...

trying https://registry.npmjs.org/bitfield-rle/-/bitfield-rle-2.2.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3627  100  3627    0     0  24673      0 --:--:-- --:--:-- --:--:-- 24673
building '/nix/store/rfvrzk1w27z9vykjf5697zcf8fq524ir-blake2b-wasm-1.1.7.tgz.drv'...

trying https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-7.10.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21631  100 21631    0     0   115k      0 --:--:-- --:--:-- --:--:--  114k

trying https://registry.npmjs.org/blake2b/-/blake2b-2.1.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 55759  100 55759    0     0   128k      0 --:--:-- --:--:-- --:--:--  128k
building '/nix/store/ij8hdja6dx76569bghpmh9ac3h5jiid1-body-0.1.0.tgz.drv'...
building '/nix/store/b3mayk89bflg6hl9ndy3k34p9k377p82-boxen-1.3.0.tgz.drv'...

trying https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13091  100 13091    0     0  35670      0 --:--:-- --:--:-- --:--:-- 35670

trying https://registry.npmjs.org/body/-/body-0.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2507  100  2507    0     0  16174      0 --:--:-- --:--:-- --:--:-- 16174
building '/nix/store/px50sv4ngnaflbvhyk25fg6hfryy12pi-bulk-write-stream-1.1.4.tgz.drv'...
building '/nix/store/c63phagfss5vcfxh1w21g6yj7s3j4b76-ci-info-1.6.0.tgz.drv'...

trying https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3400  100  3400    0     0  27200      0 --:--:-- --:--:-- --:--:-- 27200
building '/nix/store/ajsd65fqi6lylaprc9jndjylvgz2mic8-circular-append-file-1.0.1.tgz.drv'...

trying https://registry.npmjs.org/bulk-write-stream/-/bulk-write-stream-1.1.4.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2681  100  2681    0     0  20465      0 --:--:-- --:--:-- --:--:-- 20465
building '/nix/store/rgm6xwg4mc8w853g05ynlkvglri3vbyd-cli-boxes-1.0.0.tgz.drv'...
100  4573  100  4573    0     0  30284      0 --:--:-- --:--:-- --:--:-- 30284

trying https://registry.npmjs.org/circular-append-file/-/circular-append-file-1.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
building '/nix/store/cqb60bv1m12k0dlq7384h64vh3p1wp6p-cli-truncate-1.1.0.tgz.drv'...
100  1979  100  1979    0     0   2243      0 --:--:-- --:--:-- --:--:--  2241

trying https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1875  100  1875    0     0  12842      0 --:--:-- --:--:-- --:--:-- 12842
building '/nix/store/32wjqfjppjicazaivs4pi2s73zxr7k79-cliclopts-1.1.1.tgz.drv'...
building '/nix/store/s5l1f3zhvys63rkv6pnlqzfnwsjyf9xk-codecs-1.2.1.tgz.drv'...

trying https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2338  100  2338    0     0  15797      0 --:--:-- --:--:-- --:--:-- 15904

trying https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
building '/nix/store/ay9xcz2xfdrdv39pd96vfgdmfa6g8n7p-codecs-2.0.0.tgz.drv'...
100 17396  100 17396    0     0   106k      0 --:--:-- --:--:-- --:--:--  106k

trying https://registry.npmjs.org/codecs/-/codecs-1.2.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2470  100  2470    0     0  18712      0 --:--:-- --:--:-- --:--:-- 18712
building '/nix/store/nkxfzc01da38kb6mrs7qmpkywqrj7xir-configstore-3.1.2.tgz.drv'...
building '/nix/store/2sslgpzp4lrh7gq9ik8wyqk6jlq891ng-connections-1.4.2.tgz.drv'...

trying https://registry.npmjs.org/codecs/-/codecs-2.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2404  100  2404    0     0  16929      0 --:--:-- --:--:-- --:--:-- 16929
building '/nix/store/8wyhazcbrffb05z18b9aili8rrxwffhv-content-types-0.1.0.tgz.drv'...

trying https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/connections/-/connections-1.4.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3080  100  3080    0     0  12320      0 --:--:-- --:--:-- --:--:-- 12270
building '/nix/store/0m0l52xaigi92z6kcranv31anyhzdwrj-corsify-2.1.0.tgz.drv'...
100  2053  100  2053    0     0   8887      0 --:--:-- --:--:-- --:--:--  8887

trying https://registry.npmjs.org/content-types/-/content-types-0.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2160  100  2160    0     0   9432      0 --:--:-- --:--:-- --:--:--  9432
building '/nix/store/7k4na3yb74jrh0bklc47vrr9mxdxbfkr-count-trailing-zeros-1.0.1.tgz.drv'...
building '/nix/store/0w1zkk75m2vgc2c4brh0qc3fpmky57h3-crypto-random-string-1.0.0.tgz.drv'...

trying https://registry.npmjs.org/corsify/-/corsify-2.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/count-trailing-zeros/-/count-trailing-zeros-1.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3153  100  3153    0     0   3611      0 --:--:-- --:--:-- --:--:--  3607
building '/nix/store/yhnds4bnyh1c561fjg8q0gi7v35zmpi2-dat-13.13.1.tgz.drv'...
100  1995  100  1995    0     0  14250      0 --:--:-- --:--:-- --:--:-- 14250

trying https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1818  100  1818    0     0  15024      0 --:--:-- --:--:-- --:--:-- 15024
building '/nix/store/g9083zli2q45lc133a56459l9djrpjp5-dat-dns-3.2.1.tgz.drv'...
building '/nix/store/v3z6vgr50bb730pjf1p63lyc197xmy8j-dat-doctor-2.1.2.tgz.drv'...

trying https://registry.npmjs.org/dat/-/dat-13.13.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/dat-dns/-/dat-dns-3.2.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5799  100  5799    0     0  34724      0 --:--:-- --:--:-- --:--:-- 34724
building '/nix/store/b7zpyz83qa68p3awdva9nka8ycrhlm2g-dat-encoding-5.0.1.tgz.drv'...

trying https://registry.npmjs.org/dat-doctor/-/dat-doctor-2.1.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/dat-encoding/-/dat-encoding-5.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 43264  100 43264    0     0  39011      0  0:00:01  0:00:01 --:--:-- 38976
building '/nix/store/qrfr70f85lcn1nj85qrwwrp5ph21b8gw-dat-ignore-2.1.2.tgz.drv'...

trying https://registry.npmjs.org/dat-ignore/-/dat-ignore-2.1.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4051  100  4051    0     0  31403      0 --:--:-- --:--:-- --:--:-- 31403
building '/nix/store/d0kgzmspwj091wsx96vrzc4mb82vd6hz-dat-json-1.0.3.tgz.drv'...
100  5785  100  5785    0     0   6485      0 --:--:-- --:--:-- --:--:--  6478
building '/nix/store/gl8awgjsap79dvs8m8asd6v2qcbzbdzl-dat-link-resolve-2.3.0.tgz.drv'...
100  1867  100  1867    0     0   2016      0 --:--:-- --:--:-- --:--:--  2014
building '/nix/store/a0dc4jc159zbvprq1nikwak62w9d0zya-dat-log-1.2.0.tgz.drv'...

trying https://registry.npmjs.org/dat-json/-/dat-json-1.0.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/dat-link-resolve/-/dat-link-resolve-2.3.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/dat-log/-/dat-log-1.2.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3246  100  3246    0     0   3722      0 --:--:-- --:--:-- --:--:--  3722
building '/nix/store/haaf0vdmqx0miih28a1sn6ff7wqg0lbx-dat-node-3.5.15.tgz.drv'...
100  3867  100  3867    0     0   4598      0 --:--:-- --:--:-- --:--:--  4603
building '/nix/store/sg0rnznqcbxvwyw7ji2xwk32ra2yw3l3-dat-registry-4.0.1.tgz.drv'...
100  3369  100  3369    0     0   3841      0 --:--:-- --:--:-- --:--:--  3837
building '/nix/store/qgxj7x46jgx9qdwah036z3479cjkdxlc-dat-secret-storage-4.0.1.tgz.drv'...

trying https://registry.npmjs.org/dat-node/-/dat-node-3.5.15.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/dat-registry/-/dat-registry-4.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/dat-secret-storage/-/dat-secret-storage-4.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3230  100  3230    0     0  20838      0 --:--:-- --:--:-- --:--:-- 20838
building '/nix/store/pbsls1nvszhkr9y0gmk2zcc1qkqxbpln-dat-storage-1.1.1.tgz.drv'...
100  2429  100  2429    0     0  17860      0 --:--:-- --:--:-- --:--:-- 17860
building '/nix/store/yzah8fpw62xcvim22zaf9c5pw962nays-dat-swarm-defaults-1.0.2.tgz.drv'...

trying https://registry.npmjs.org/dat-storage/-/dat-storage-1.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3231  100  3231    0     0  25440      0 --:--:-- --:--:-- --:--:-- 25242
building '/nix/store/97jf7qri3n7hjqi4r5mqcnq386h0ff81-diffy-2.1.0.tgz.drv'...

trying https://registry.npmjs.org/dat-swarm-defaults/-/dat-swarm-defaults-1.0.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2226  100  2226    0     0  17951      0 --:--:-- --:--:-- --:--:-- 17951
building '/nix/store/zgb0ww824czq72agiqc0inxxd51k6k94-directory-index-html-2.1.0.tgz.drv'...

trying https://registry.npmjs.org/diffy/-/diffy-2.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 22595  100 22595    0     0  20355      0  0:00:01  0:00:01 --:--:-- 20374
building '/nix/store/2ljizsqc92s8brv02rwww6nv0pjlcy84-discovery-channel-5.5.1.tgz.drv'...
100  4164  100  4164    0     0  21687      0 --:--:-- --:--:-- --:--:-- 21687

trying https://registry.npmjs.org/directory-index-html/-/directory-index-html-2.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
building '/nix/store/n7k705sqlgmg2cq9pz9zxis3fq0ih7nw-discovery-swarm-5.1.4.tgz.drv'...
100  151k  100  151k    0     0   209k      0 --:--:-- --:--:-- --:--:--  208k

trying https://registry.npmjs.org/discovery-channel/-/discovery-channel-5.5.1.tgz
building '/nix/store/2bbj2kpgv755l7am9k9drpmi49dh0065-dns-discovery-6.2.3.tgz.drv'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/discovery-swarm/-/discovery-swarm-5.1.4.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/dns-discovery/-/dns-discovery-6.2.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4662  100  4662    0     0  10892      0 --:--:-- --:--:-- --:--:-- 10892
building '/nix/store/r39ffrqrq71b9grql42a8a3v4ks0q6gp-dns-packet-4.2.0.tgz.drv'...
100  7639  100  7639    0     0  24562      0 --:--:-- --:--:-- --:--:-- 24562
building '/nix/store/4r8sm3adi26bzk880fqgb1v5v7k62lzc-dns-socket-3.0.0.tgz.drv'...
100 13444  100 13444    0     0  23020      0 --:--:-- --:--:-- --:--:-- 22981
building '/nix/store/i459qfgxgzv4annhchccw44r3ra05mik-dot-prop-4.2.0.tgz.drv'...

trying https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/dns-socket/-/dns-socket-3.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4055  100  4055    0     0  12832      0 --:--:-- --:--:-- --:--:-- 12791
building '/nix/store/ss00qnlfxyc7qg2nd1x0x8glw609wrf2-fast-bitfield-1.2.2.tgz.drv'...
100  8993  100  8993    0     0  19423      0 --:--:-- --:--:-- --:--:-- 19381
100  2466  100  2466    0     0  12454      0 --:--:-- --:--:-- --:--:-- 12454
building '/nix/store/rmqawhqvqkiywx9334m96kscvrv94s3p-fast-json-stable-stringify-2.1.0.tgz.drv'...
building '/nix/store/khzdf9inmi7aviqskp8s44slws5ipzwi-fd-lock-1.0.2.tgz.drv'...

trying https://registry.npmjs.org/fast-bitfield/-/fast-bitfield-1.2.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6318  100  6318    0     0  32735      0 --:--:-- --:--:-- --:--:-- 32735
building '/nix/store/6c0hpdbm7gr4bfp69vyqqd9af0zk5i36-fd-read-stream-1.1.0.tgz.drv'...

trying https://registry.npmjs.org/fd-lock/-/fd-lock-1.0.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5202  100  5202    0     0   4959      0  0:00:01  0:00:01 --:--:--  4959
building '/nix/store/16q3dbg4p3c2p4yb8h58biwqxp1wdpbd-flat-tree-1.6.0.tgz.drv'...
100  215k  100  215k    0     0   301k      0 --:--:-- --:--:-- --:--:--  300k
building '/nix/store/fsl9mq4maix3chm6xcw9cm2l6bjdxnwc-global-dirs-0.1.1.tgz.drv'...

trying https://registry.npmjs.org/fd-read-stream/-/fd-read-stream-1.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2118  100  2118    0     0  15347      0 --:--:-- --:--:-- --:--:-- 15347

trying https://registry.npmjs.org/flat-tree/-/flat-tree-1.6.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3887  100  3887    0     0  18421      0 --:--:-- --:--:-- --:--:-- 18421
building '/nix/store/simp3x22i0gb3z3ydnkwmyc5kfijdnhg-http-methods-0.1.0.tgz.drv'...
building '/nix/store/h32b68bxyd2li7cw976dj0yp4wvy77vw-hypercore-7.7.1.tgz.drv'...

trying https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2353  100  2353    0     0  12255      0 --:--:-- --:--:-- --:--:-- 12255
building '/nix/store/00a94s7ma2swihp9f4ibm4g5zfs15c48-hypercore-crypto-1.0.0.tgz.drv'...

trying https://registry.npmjs.org/http-methods/-/http-methods-0.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/hypercore/-/hypercore-7.7.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2660  100  2660    0     0  19416      0 --:--:-- --:--:-- --:--:-- 19416
building '/nix/store/94j71qhy70ndpjjfv50880kgi487zvqy-hypercore-protocol-6.12.0.tgz.drv'...
100 45213  100 45213    0     0   294k      0 --:--:-- --:--:-- --:--:--  294k
building '/nix/store/q4cgiqxnvwkriz59pvvyiniaf06h3pyj-hyperdrive-9.16.0.tgz.drv'...

trying https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-1.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2744  100  2744    0     0  22866      0 --:--:-- --:--:-- --:--:-- 22866

trying https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.12.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12746  100 12746    0     0    98k      0 --:--:-- --:--:-- --:--:--   98k
building '/nix/store/w8qz7yaa6idcc87s0drq9phz6zcg35k2-hyperdrive-http-4.4.0.tgz.drv'...
building '/nix/store/pifpb41rxxklbxyd6hw6yp14wnf6xwn0-hyperdrive-network-speed-2.1.0.tgz.drv'...

trying https://registry.npmjs.org/hyperdrive/-/hyperdrive-9.16.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15113  100 15113    0     0   111k      0 --:--:-- --:--:-- --:--:--  111k

trying https://registry.npmjs.org/hyperdrive-http/-/hyperdrive-http-4.4.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6154  100  6154    0     0    814      0  0:00:07  0:00:07 --:--:--   814
building '/nix/store/qikxvik62f6m8ba4rz7gqm0byy8i3vbi-import-lazy-2.1.0.tgz.drv'...
building '/nix/store/62x1v8j0ajmb0mdsn2cil2vkp1qh298b-inspect-custom-symbol-1.1.1.tgz.drv'...

trying https://registry.npmjs.org/hyperdrive-network-speed/-/hyperdrive-network-speed-2.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2859  100  2859    0     0  15708      0 --:--:-- --:--:-- --:--:-- 15708
building '/nix/store/dzlwlnnzf4w41w6wkhm85ln2j9zab41z-is-ci-1.2.1.tgz.drv'...

trying https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/inspect-custom-symbol/-/inspect-custom-symbol-1.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2293  100  2293    0     0  17503      0 --:--:-- --:--:-- --:--:-- 17503
building '/nix/store/6mrf9jvqpyrz6j8y8k4j8wqaam8kv21d-is-installed-globally-0.1.0.tgz.drv'...

trying https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1413  100  1413    0     0   9116      0 --:--:-- --:--:-- --:--:--  9116
building '/nix/store/yrr4h80kz60ni3b5nc07jx153bwlfrzc-is-options-1.0.1.tgz.drv'...
100  1932  100  1932    0     0  14976      0 --:--:-- --:--:-- --:--:-- 14976
building '/nix/store/gl48x7wmnyw5f5csnfrrfv8gsn541bk8-is-string-1.0.4.tgz.drv'...

trying https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1630  100  1630    0     0  12635      0 --:--:-- --:--:-- --:--:-- 12635
building '/nix/store/7clnaipawsqlrawqxlk89a2w7z4d4q30-iterators-0.1.0.tgz.drv'...

trying https://registry.npmjs.org/is-options/-/is-options-1.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1693  100  1693    0     0  12825      0 --:--:-- --:--:-- --:--:-- 12825
building '/nix/store/70sflmh0k4xszr7nlb80cwg7rwrr40dz-k-bucket-3.3.1.tgz.drv'...
100  7097  100  7097    0     0  51427      0 --:--:-- --:--:-- --:--:-- 51427
building '/nix/store/k501lvvpr30indkz25aqcmicgcgqbzhx-k-bucket-4.0.1.tgz.drv'...

trying https://registry.npmjs.org/iterators/-/iterators-0.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5861  100  5861    0     0  42165      0 --:--:-- --:--:-- --:--:-- 42471
building '/nix/store/0iihcdg9125sc7is8qq0f8wkx4k3159m-k-rpc-4.3.1.tgz.drv'...

trying https://registry.npmjs.org/k-bucket/-/k-bucket-3.3.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/k-bucket/-/k-bucket-4.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13300  100 13300    0     0  78235      0 --:--:-- --:--:-- --:--:-- 78235
building '/nix/store/z3mbh0jgcvhv6xp6flv0lim20nkcyj8g-keypress-0.2.1.tgz.drv'...
100 13704  100 13704    0     0  85118      0 --:--:-- --:--:-- --:--:-- 85118

trying https://registry.npmjs.org/k-rpc/-/k-rpc-4.3.1.tgz
building '/nix/store/dj4mr57khgzx3ap7imz23iy4cgk6s15b-last-one-wins-1.0.4.tgz.drv'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6081  100  6081    0     0  48261      0 --:--:-- --:--:-- --:--:-- 48261
building '/nix/store/c98kv42nfpa5v7pvr5c3g585rks465qh-latest-version-3.1.0.tgz.drv'...

trying https://registry.npmjs.org/keypress/-/keypress-0.2.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5091  100  5091    0     0  40728      0 --:--:-- --:--:-- --:--:-- 40728
building '/nix/store/yd3n19drnq7rsby6ilfjigcv0y7cca57-length-prefixed-message-3.0.4.tgz.drv'...
100  2578  100  2578    0     0  18027      0 --:--:-- --:--:-- --:--:-- 18027
building '/nix/store/4gpzjdmind18qxjf5g18s06i8hnhhp57-lodash.throttle-4.1.1.tgz.drv'...

trying https://registry.npmjs.org/length-prefixed-message/-/length-prefixed-message-3.0.4.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1684  100  1684    0     0  13156      0 --:--:-- --:--:-- --:--:-- 13156
building '/nix/store/15rawpc9545ih2brwjdz04fh692k7glf-lru-3.1.0.tgz.drv'...
100  4288  100  4288    0     0  27844      0 --:--:-- --:--:-- --:--:-- 27844
100  5554  100  5554    0     0  36781      0 --:--:-- --:--:-- --:--:-- 36781
building '/nix/store/hf084wbzhd2n4zpni3xj77i3m86pbxm5-memory-pager-1.5.0.tgz.drv'...
building '/nix/store/1099h5dz9r5kn9rg5vn3izsdnmp1pc7r-menu-string-1.3.0.tgz.drv'...

trying https://registry.npmjs.org/lru/-/lru-3.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4257  100  4257    0     0  29358      0 --:--:-- --:--:-- --:--:-- 29358
building '/nix/store/9aril8xj98641qsyyi5q7qwjvyzdzs1a-merkle-tree-stream-3.0.3.tgz.drv'...

trying https://registry.npmjs.org/menu-string/-/menu-string-1.3.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3107  100  3107    0     0  19664      0 --:--:-- --:--:-- --:--:-- 19664
building '/nix/store/b3jfwh46spf183daa5bw0si6ig20bxxh-mirror-folder-3.0.0.tgz.drv'...
100  4658  100  4658    0     0  34250      0 --:--:-- --:--:-- --:--:-- 34250
building '/nix/store/sb67881nnkkz20ldq8dj4ara3wra22ma-multi-random-access-2.1.1.tgz.drv'...

trying https://registry.npmjs.org/merkle-tree-stream/-/merkle-tree-stream-3.0.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3860  100  3860    0     0  26081      0 --:--:-- --:--:-- --:--:-- 26081
building '/nix/store/xs8rv2hx0l6a91a4fi2x6d193s7gsspc-multicast-dns-7.2.0.tgz.drv'...

trying https://registry.npmjs.org/mirror-folder/-/mirror-folder-3.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/multi-random-access/-/multi-random-access-2.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5730  100  5730    0     0  29843      0 --:--:-- --:--:-- --:--:-- 29843
building '/nix/store/m47n32lb5075gs1pcc2mz51lgqgi4izs-mutexify-1.2.0.tgz.drv'...
100  5764  100  5764    0     0   6440      0 --:--:-- --:--:-- --:--:--  6433

trying https://registry.npmjs.org/mutexify/-/mutexify-1.2.0.tgz
building '/nix/store/ak6y26fs9zv87i08d6v26jbjvlvsz7lz-nanoassert-1.1.0.tgz.drv'...
100  4132  100  4132    0     0   4550      0 --:--:-- --:--:-- --:--:--  4545
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
building '/nix/store/v10a1kwimmdh6j5kz0nvw05viaafhnr8-nanobus-4.4.0.tgz.drv'...
100  2299  100  2299    0     0  16190      0 --:--:-- --:--:-- --:--:-- 16190
building '/nix/store/mavypf02xw50vkgbl7l0gzxrr08bczpg-nanoguard-1.2.2.tgz.drv'...

trying https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1800  100  1800    0     0  13533      0 --:--:-- --:--:-- --:--:-- 13533

trying https://registry.npmjs.org/nanoguard/-/nanoguard-1.2.2.tgz
building '/nix/store/cpxpqsnkjzdjs4gvhl5rdv0rlrqzmm91-nanoscheduler-1.0.3.tgz.drv'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5463  100  5463    0     0  35245      0 --:--:-- --:--:-- --:--:-- 35245
building '/nix/store/gyha3ym0a8v1s7360lamzgllb6ylnwhr-nanotiming-7.3.1.tgz.drv'...
100  2379  100  2379    0     0  15250      0 --:--:-- --:--:-- --:--:-- 15250
building '/nix/store/g5z86gwdr486hv8n4zh85j4gzyiqynzx-napi-macros-1.8.2.tgz.drv'...

trying https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5744  100  5744    0     0  35900      0 --:--:-- --:--:-- --:--:-- 36125
building '/nix/store/jssp2ygkrw1fhvn6wq3b8awkpfwy6by0-napi-macros-2.0.0.tgz.drv'...

trying https://registry.npmjs.org/napi-macros/-/napi-macros-1.8.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3181  100  3181    0     0  26957      0 --:--:-- --:--:-- --:--:-- 26957
building '/nix/store/s718k9l7vwrbnwhvik3dbh69hnwcw2s0-neat-input-1.10.0.tgz.drv'...
100  4618  100  4618    0     0  35251      0 --:--:-- --:--:-- --:--:-- 35251
building '/nix/store/rs8l35s8szpn598ka2fqx08cx0bfyip3-neat-log-2.4.0.tgz.drv'...

trying https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/neat-input/-/neat-input-1.10.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4634  100  4634    0     0  32633      0 --:--:-- --:--:-- --:--:-- 32633
building '/nix/store/vjmrxy3mzkl2xz77gf2gg0cy6g0mw7gd-neat-log-3.1.0.tgz.drv'...
100  4152  100  4152    0     0  30755      0 --:--:-- --:--:-- --:--:-- 30755
building '/nix/store/x884mjfm6lz05fzbmghl99yf3i9acwn5-neat-spinner-1.0.0.tgz.drv'...

trying https://registry.npmjs.org/neat-log/-/neat-log-2.4.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/neat-log/-/neat-log-3.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3832  100  3832    0     0  27970      0 --:--:-- --:--:-- --:--:-- 27970
building '/nix/store/akwplng8y947sm59x56kdm5a1dz2hipy-neat-tasks-1.1.1.tgz.drv'...

trying https://registry.npmjs.org/neat-spinner/-/neat-spinner-1.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2173  100  2173    0     0  15977      0 --:--:-- --:--:-- --:--:-- 15977
building '/nix/store/0axh4g1pyaxsi91b0rk9kfvxmnx3alyn-nets-3.2.0.tgz.drv'...

trying https://registry.npmjs.org/neat-tasks/-/neat-tasks-1.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/nets/-/nets-3.2.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2985  100  2985    0     0  17558      0 --:--:-- --:--:-- --:--:-- 17558
building '/nix/store/zrclqr7zbzi71wgrbyv47paqfjwcjwgm-node-gyp-build-3.9.0.tgz.drv'...
100  4610  100  4610    0     0   5168      0 --:--:-- --:--:-- --:--:--  5162
building '/nix/store/bz36ahs06kykdsd7qlsk78ah80zf8l6i-node-gyp-build-4.2.0.tgz.drv'...

trying https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3764  100  3764    0     0  28953      0 --:--:-- --:--:-- --:--:-- 28953
building '/nix/store/s8gc0n99saa70wlkgmcl2gs9vjs38dhg-package-json-4.0.1.tgz.drv'...
100  3903  100  3903    0     0   4481      0 --:--:-- --:--:-- --:--:--  4475

trying https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.0.tgz
building '/nix/store/6rsapfhq72xvsxkgava8f87cy5v7swqm-parse-headers-2.0.3.tgz.drv'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4636  100  4636    0     0  31753      0 --:--:-- --:--:-- --:--:-- 31753
building '/nix/store/jvgpxzcdh0xgwd9mmiiwyjj638zdv1cx-pinpointDependencies.js.drv'...

trying https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
building '/nix/store/xzksnak1xmkpr35xjzp4xd59f327i3lr-prettier-bytes-1.0.4.tgz.drv'...
100  2715  100  2715    0     0  21895      0 --:--:-- --:--:-- --:--:-- 22073

trying https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
building '/nix/store/afi1mnms0z23zzw9hzj726zhl0l8grii-pretty-hash-1.0.1.tgz.drv'...
100  6754  100  6754    0     0  52356      0 --:--:-- --:--:-- --:--:-- 51953
building '/nix/store/9y39bxq11hvdmzgwdm7985zc5mvx68ax-progress-string-1.2.2.tgz.drv'...

trying https://registry.npmjs.org/prettier-bytes/-/prettier-bytes-1.0.4.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/pretty-hash/-/pretty-hash-1.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5080  100  5080    0     0  38484      0 --:--:-- --:--:-- --:--:-- 38484
building '/nix/store/8gkb058ddxvv1qgryhv8ymp58iffsrsc-protocol-buffers-encodings-1.1.0.tgz.drv'...

trying https://registry.npmjs.org/progress-string/-/progress-string-1.2.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2819  100  2819    0     0  17084      0 --:--:-- --:--:-- --:--:-- 17084
building '/nix/store/9bk8pjl2sc54hlf90dfigvpqz1ads5i8-random-access-memory-3.1.1.tgz.drv'...

trying https://registry.npmjs.org/protocol-buffers-encodings/-/protocol-buffers-encodings-1.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3670  100  3670    0     0  26402      0 --:--:-- --:--:-- --:--:-- 26402
building '/nix/store/24z9kd1f2xva75qg34f7w7xw1vws95mp-recursive-watch-1.1.4.tgz.drv'...

trying https://registry.npmjs.org/random-access-memory/-/random-access-memory-3.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2889  100  2889    0     0  20202      0 --:--:-- --:--:-- --:--:-- 20202
building '/nix/store/awkvig7pwp5ismhdb50ivivq4sajy32r-remove-array-items-1.1.1.tgz.drv'...

trying https://registry.npmjs.org/recursive-watch/-/recursive-watch-1.1.4.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   742  100   742    0     0    885      0 --:--:-- --:--:-- --:--:--   884
building '/nix/store/7r91hgzqq1r6my2yr9mwbka6q09xdjmr-signed-varint-2.0.1.tgz.drv'...
100  2619  100  2619    0     0  19992      0 --:--:-- --:--:-- --:--:-- 20146
building '/nix/store/xckjrsq99djp7g6m1854aym2yz0gzy5r-siphash24-1.1.1.tgz.drv'...

trying https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2347  100  2347    0     0  18480      0 --:--:-- --:--:-- --:--:-- 18480
building '/nix/store/a0m0pslha20gr63hsdgahk7058ib0vcn-sodium-javascript-0.5.5.tgz.drv'...

trying https://registry.npmjs.org/siphash24/-/siphash24-1.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1845  100  1845    0     0  12812      0 --:--:-- --:--:-- --:--:-- 12812
building '/nix/store/91hjmgfw1zap2d7cp3y5k7p6b2m40wls-sodium-native-2.4.6.tgz.drv'...

trying https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.5.5.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5341  100  5341    0     0  23843      0 --:--:-- --:--:-- --:--:-- 23950
building '/nix/store/68dfg2gy6zjkbapjwr8bc2gjamzc9r8g-sodium-universal-2.0.0.tgz.drv'...

trying https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.6.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14313  100 14313    0     0  81788      0 --:--:-- --:--:-- --:--:-- 81788
building '/nix/store/pz6yfqgbpapv1zv9zf10xdwym0gnn4yr-sorted-array-functions-1.2.0.tgz.drv'...

trying https://registry.npmjs.org/sodium-universal/-/sodium-universal-2.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.2.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2148  100  2148    0     0    962      0  0:00:02  0:00:02 --:--:--   962
building '/nix/store/sykahyzfyp9x8jy4rxdkk8caxqlfv02n-sorted-indexof-1.0.0.tgz.drv'...
100  3258  100  3258    0     0    964      0  0:00:03  0:00:03 --:--:--   964
building '/nix/store/3mq2dkp57qapgqdaz24hb09xx7skydr9-sparse-bitfield-3.0.3.tgz.drv'...

trying https://registry.npmjs.org/sorted-indexof/-/sorted-indexof-1.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2041  100  2041    0     0   3638      0 --:--:-- --:--:-- --:--:--  3631
building '/nix/store/86118pwmkc2b8z2dmfwyxa5shplb2rni-speedometer-1.1.0.tgz.drv'...
100  3146  100  3146    0     0   6839      0 --:--:-- --:--:-- --:--:--  6839
building '/nix/store/a62y6affhls0vfpd5h9hlr005dksfnzl-stream-collector-1.0.1.tgz.drv'...

trying https://registry.npmjs.org/speedometer/-/speedometer-1.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/stream-collector/-/stream-collector-1.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1730  100  1730    0     0   5474      0 --:--:-- --:--:-- --:--:--  5457
building '/nix/store/p6by33fprwdy66cram5q7y0q1npxygbq-stream-parser-0.3.1.tgz.drv'...
100  2117  100  2117    0     0   6474      0 --:--:-- --:--:-- --:--:--  6454
building '/nix/store/vgiddk2h8h0hjzf05ss681syv4sk4n81-stream-shift-1.0.1.tgz.drv'...

trying https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7363  100  7363    0     0  18225      0 --:--:-- --:--:-- --:--:-- 18225
building '/nix/store/rwlrsldzr7ysxccj8clv7l43ccxcdph5-subcommand-2.1.1.tgz.drv'...
100  1844  100  1844    0     0   4359      0 --:--:-- --:--:-- --:--:--  4349
building '/nix/store/7vs25w9193vkyzbfykj4fcm5nd2c1g42-term-size-1.2.0.tgz.drv'...

trying https://registry.npmjs.org/subcommand/-/subcommand-2.1.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10162  100 10162    0     0  43242      0 --:--:-- --:--:-- --:--:-- 43242
building '/nix/store/kr5ri9b9clig69rqg0q8mwrlxjjnj7nz-throttle-1.0.3.tgz.drv'...

trying https://registry.npmjs.org/throttle/-/throttle-1.0.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4830  100  4830    0     0   4726      0  0:00:01  0:00:01 --:--:--  4726
building '/nix/store/fg3yw0az231q67lhn53fmwn3qx8wfxww-timeout-refresh-1.0.1.tgz.drv'...
100  3980  100  3980    0     0  10698      0 --:--:-- --:--:-- --:--:-- 10698
building '/nix/store/rm7y36mnfw5s8wwdkim8iqw04007an29-toiletdb-1.4.1.tgz.drv'...

trying https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/toiletdb/-/toiletdb-1.4.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2355  100  2355    0     0   6330      0 --:--:-- --:--:-- --:--:--  6313
building '/nix/store/41pzrapy96q621w6m97lxq966dmxrjks-township-client-1.3.2.tgz.drv'...

trying https://registry.npmjs.org/township-client/-/township-client-1.3.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3023  100  3023    0     0   2895      0  0:00:01  0:00:01 --:--:--  2895
building '/nix/store/m897drabcrkvf0dhm4bzh89w2jg7jwp4-ttl-1.3.1.tgz.drv'...

trying https://registry.npmjs.org/ttl/-/ttl-1.3.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1569  100  1569    0     0  10530      0 --:--:-- --:--:-- --:--:-- 10530
building '/nix/store/mwrc4js1qmz86hpyvhsdmgg7z5gv5qna-uint64be-2.0.2.tgz.drv'...
100  5947  100  5947    0     0   5516      0  0:00:01  0:00:01 --:--:--  5516
building '/nix/store/9rpwf0n4mz83gwbypbp185c472b9ph1h-unique-string-1.0.0.tgz.drv'...

trying https://registry.npmjs.org/uint64be/-/uint64be-2.0.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2240  100  2240    0     0   4676      0 --:--:-- --:--:-- --:--:--  4666
building '/nix/store/w9y1dlcws299kgisq39fan4ghaig166a-unixify-1.0.0.tgz.drv'...
100  1536  100  1536    0     0   5545      0 --:--:-- --:--:-- --:--:--  5545
building '/nix/store/8frhn8zg9l8rbxl287ycj9ljp2cvhk5d-unordered-array-remove-1.0.2.tgz.drv'...

trying https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/unordered-array-remove/-/unordered-array-remove-1.0.2.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2862  100  2862    0     0   8130      0 --:--:-- --:--:-- --:--:--  8153
building '/nix/store/65nqkjdg5r5lr3ivh8v60x2h0wim4h8b-unordered-set-1.1.0.tgz.drv'...
100  1788  100  1788    0     0   3947      0 --:--:-- --:--:-- --:--:--  3938
building '/nix/store/zzid033ag4cqh8kkxb094s7bf7h34lik-unordered-set-2.0.1.tgz.drv'...

trying https://registry.npmjs.org/unordered-set/-/unordered-set-1.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2271  100  2271    0     0   6470      0 --:--:-- --:--:-- --:--:--  6488
building '/nix/store/kwicbqiiygac6mkiw5jphj2hkr8749x8-untildify-3.0.3.tgz.drv'...

trying https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2213  100  2213    0     0   6872      0 --:--:-- --:--:-- --:--:--  6894
building '/nix/store/526xp2g2m1arggp6qnmz94js6616nii3-update-notifier-2.5.0.tgz.drv'...

trying https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1577  100  1577    0     0   5612      0 --:--:-- --:--:-- --:--:--  5612
building '/nix/store/wwpw2mrwjx8hma4wv7i51x2njr0akghf-utp-native-1.7.3.tgz.drv'...
100  5599  100  5599    0     0  15339      0 --:--:-- --:--:-- --:--:-- 15339
building '/nix/store/xhs3a0xl28kpb768pq45fa17j7bwd3qn-utp-native-2.1.5.tgz.drv'...

trying https://registry.npmjs.org/utp-native/-/utp-native-1.7.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/utp-native/-/utp-native-2.1.5.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1051k  100 1051k    0     0   556k      0  0:00:01  0:00:01 --:--:--  556k
building '/nix/store/66jpwhjac6yhznjj5qmc43fff6ijxqb0-varint-3.0.1.tgz.drv'...

trying https://registry.npmjs.org/varint/-/varint-3.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3411  100  3411    0     0  22149      0 --:--:-- --:--:-- --:--:-- 22149
building '/nix/store/jjsw110s7kp7smn6s9d0bjmk9d9dwjpq-varint-4.0.1.tgz.drv'...
100 4796k  100 4796k    0     0  1523k      0  0:00:03  0:00:03 --:--:-- 1523k
building '/nix/store/fh9928ndb34qjdr3ynvv3s34nj0ir8x6-varint-5.0.0.tgz.drv'...

trying https://registry.npmjs.org/varint/-/varint-4.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3475  100  3475    0     0  18682      0 --:--:-- --:--:-- --:--:-- 18582
building '/nix/store/m65y664cxjap6r4zpbnqwdpkzarqi0yn-widest-line-2.0.1.tgz.drv'...

trying https://registry.npmjs.org/varint/-/varint-5.0.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3531  100  3531    0     0  25773      0 --:--:-- --:--:-- --:--:-- 25773
building '/nix/store/zyr1k4m2arsvziavcfl7bm3n5rdk3lqi-write-file-atomic-2.4.3.tgz.drv'...

trying https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1709  100  1709    0     0  10112      0 --:--:-- --:--:-- --:--:-- 10112
building '/nix/store/h8s65m2wfzrh1q7hfwjgkkd2vvzb54xk-xhr-2.5.0.tgz.drv'...

trying https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4495  100  4495    0     0  21103      0 --:--:-- --:--:-- --:--:-- 21103
building '/nix/store/wnf0mshkmvlsirc41fbzvc50jah7nlmd-xsalsa20-1.1.0.tgz.drv'...

trying https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.1.0.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7934  100  7934    0     0  25928      0 --:--:-- --:--:-- --:--:-- 25928
100  9576  100  9576    0     0  31192      0 --:--:-- --:--:-- --:--:-- 31192
100 11.4M  100 11.4M    0     0   592k      0  0:00:19  0:00:19 --:--:-- 1301k
building '/nix/store/4basbrdqc1p798662bml9ppz2wna3fca-node_node-gyp-build-4.2.0.drv'...
unpacking sources
patching sources
configuring
no configure script, doing nothing
building
installing
unpacking source archive /nix/store/q066079m577lfz91zl4kk0sfzr72pzfn-node-gyp-build-4.2.0.tgz
pinpointing versions of dependencies...
patching script interpreter paths in .
./node-gyp-build/bin.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./node-gyp-build/build-test.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./node-gyp-build/optional.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
No package-lock.json file found, reconstructing...
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: array-shuffle@^1.0.1 (node_modules/array-shuffle):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: request to https://registry.npmjs.org/array-shuffle failed: cache mode is 'only-if-cached' but no cached response available.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: standard@^14.0.0 (node_modules/standard):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: request to https://registry.npmjs.org/standard failed: cache mode is 'only-if-cached' but no cached response available.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: tape@^4.10.1 (node_modules/tape):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: request to https://registry.npmjs.org/tape failed: cache mode is 'only-if-cached' but no cached response available.

up to date in 6.079s
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/y7cq5szih80wgcf9wxyj9cydfbhg2cx1-node_node-gyp-build-4.2.0
patching script interpreter paths in /nix/store/y7cq5szih80wgcf9wxyj9cydfbhg2cx1-node_node-gyp-build-4.2.0
checking for references to /build/ in /nix/store/y7cq5szih80wgcf9wxyj9cydfbhg2cx1-node_node-gyp-build-4.2.0...
building '/nix/store/cbw6487wqdc9jg44i51v0vkra70hjwvi-node_dat-13.13.1.drv'...
unpacking sources
patching sources
configuring
no configure script, doing nothing
building
installing
unpacking source archive /nix/store/sb3b3wif04vzwzc5sgh23jnc3clqb1z8-dat-13.13.1.tgz
unpacking source archive /nix/store/jw57n7cpqawf5mhw7lbas4lz3sn0diq6-abstract-random-access-1.1.2.tgz
unpacking source archive /nix/store/1r6qbgyf23syw02lqwm10ym8iv71gwjz-ajv-6.10.2.tgz
unpacking source archive /nix/store/whzcbwpk7icjwp6dch3ig1lpz2xsaism-ansi-align-2.0.0.tgz
unpacking source archive /nix/store/c7hhskcrzw8gqz0s5dfkv0biqilbsi7h-ansi-diff-1.1.1.tgz
unpacking source archive /nix/store/csk5c1n1lwi1nmvjzxzzg89dyzvdlm17-ansi-regex-3.0.0.tgz
unpacking source archive /nix/store/xpvlnhk9xxscna10jsryw7ma5f3l15m5-ansi-split-1.0.1.tgz
unpacking source archive /nix/store/03kmg89247yjd52b2c4jhsm37rs703rn-ansi-styles-3.2.1.tgz
unpacking source archive /nix/store/xbg2c1z2gpcprriy60bnpak9gwzgj3vf-anymatch-2.0.0.tgz
unpacking source archive /nix/store/zvbjc1qcd9jbh9l1mnzbk0jd04vzs514-ap-0.1.0.tgz
unpacking source archive /nix/store/g84nqkhm9ax1rg2hk7majvm5c3ryx6ph-append-tree-2.4.4.tgz
unpacking source archive /nix/store/nl0h10zy5f1zlnzmk3wmhi2rl6h6pjcj-process-nextick-args-1.0.7.tgz
unpacking source archive /nix/store/g0phad04967k2n7zj1wn13xs45n34aj8-varint-5.0.0.tgz
unpacking source archive /nix/store/bgk9c0c5l3x0xq51p13rh84i615wq36j-arr-diff-4.0.0.tgz
unpacking source archive /nix/store/4dwai7g0z460qmlvb6j1s5nnzpnrr6g8-arr-flatten-1.1.0.tgz
unpacking source archive /nix/store/6wd90dpa267fk7ykgzjf7x8xwvi0n0ch-arr-union-3.1.0.tgz
unpacking source archive /nix/store/d276lgklvzhiy26saa7shz424k534jd2-array-lru-1.1.1.tgz
unpacking source archive /nix/store/hq1lxyyhdfbk255nnfnxi423695vlnbz-array-unique-0.3.2.tgz
unpacking source archive /nix/store/yr3qa1vis2wfbcw8874fi8rqnhrczkc1-asn1-0.2.4.tgz
unpacking source archive /nix/store/5491y092lgpnr7w847mp4nzfvp1vpnns-assert-plus-1.0.0.tgz
unpacking source archive /nix/store/f53rbhi2q1gnhy87683wmb735m899xva-assign-symbols-1.0.0.tgz
unpacking source archive /nix/store/14gy2czx4pyggd02867rzai2b28fzhpk-async-0.9.2.tgz
unpacking source archive /nix/store/n66ky048clbx6kilz6q3wms4pgbs0a76-asynckit-0.4.0.tgz
unpacking source archive /nix/store/f8zax6azfb1varp7hlqpg1c660bcbd73-atob-2.1.2.tgz
unpacking source archive /nix/store/3h0n3n8s94wjw04h6jdv3h9b7m79x2pl-atomic-batcher-1.0.2.tgz
unpacking source archive /nix/store/g7jrx0mfvsfb4knsrn3xdg2gy44k93cz-aws-sign2-0.7.0.tgz
unpacking source archive /nix/store/mcmqv5ddv3ny3dpkj38g2189l9b3ln08-aws4-1.9.0.tgz
unpacking source archive /nix/store/bzhvbfy2rbvskss7456ywd8f54qmnnyj-balanced-match-1.0.0.tgz
unpacking source archive /nix/store/2m0a2ndp7qmvpfvqh32v0ck4m8g7fwg3-base-0.11.2.tgz
unpacking source archive /nix/store/snx7isj4kkqbkcayhnagmwfrl6ds4ywj-define-property-1.0.0.tgz
unpacking source archive /nix/store/5qlhrr62sjj0zqj75121lzj8zhlfag8x-bcrypt-pbkdf-1.0.2.tgz
unpacking source archive /nix/store/jhgrm5bpbpl3lijm7a75gmvnr4nh81l2-bencode-1.0.0.tgz
unpacking source archive /nix/store/0g3akr3k5zjc2hp78n1279k4xm6dkivd-bitfield-rle-2.2.1.tgz
unpacking source archive /nix/store/cvsa3lwgxbi7s4av01agk26bj2i2f6s5-varint-4.0.1.tgz
unpacking source archive /nix/store/l2qwy7mnm0pg2xr1hjav11qj82ls02fk-bittorrent-dht-7.10.0.tgz
unpacking source archive /nix/store/v74gjb9fai7viwz81hx8dwbdlf0hh5m1-debug-3.2.6.tgz
unpacking source archive /nix/store/5s0ki7szjh987gvgbylzmsxv47wcwgrq-blake2b-2.1.3.tgz
unpacking source archive /nix/store/mp886mpsppkl20fllr4dc9qq6hr2awr7-blake2b-wasm-1.1.7.tgz
unpacking source archive /nix/store/w1w5nwyigwgiyk2czyqpwppx0x7cnni4-body-0.1.0.tgz
unpacking source archive /nix/store/74pqviwa7man1dl0biy29jwgfvrbdi9p-boxen-1.3.0.tgz
unpacking source archive /nix/store/x5jga3jrdl6cprja3w53cd3jrss6w28w-brace-expansion-1.1.11.tgz
unpacking source archive /nix/store/mj8lv11zb2yk6d45m0bqf032zmz8fkd4-braces-2.3.2.tgz
unpacking source archive /nix/store/aj629667z1iplzia8a21srcqcl2ngw57-extend-shallow-2.0.1.tgz
unpacking source archive /nix/store/ipb2r1nn1ga0dfh1l3b9j58psdymr9lr-buffer-alloc-1.2.0.tgz
unpacking source archive /nix/store/bvvv7nj22i41x6vdlswcdxkfh41pcfrg-buffer-alloc-unsafe-1.1.0.tgz
unpacking source archive /nix/store/dwqbdrvgmphycvijk3007qp9hywx765x-buffer-equals-1.0.4.tgz
unpacking source archive /nix/store/8wms8gz89fww6lb9kxv5l51r8lys54d5-buffer-fill-1.0.0.tgz
unpacking source archive /nix/store/2ddj0jv3ylzpmz857nkgvhk38663ixmj-buffer-from-1.1.1.tgz
unpacking source archive /nix/store/gqghpqz1z6kiw7chm4pkvkia6krvpvsl-bulk-write-stream-1.1.4.tgz
unpacking source archive /nix/store/zp41s45yrv6a5hnmz04fx1490dwpad2r-bytes-3.1.0.tgz
unpacking source archive /nix/store/q36bsrnpp73ldcgqchm4gbyq9azf486y-cache-base-1.0.1.tgz
unpacking source archive /nix/store/qxsrjn7l7pf3n49l1cp543cbqbs8gxz9-call-me-maybe-1.0.1.tgz
unpacking source archive /nix/store/nph18wy1kd74w3wdgbkw6y3gas5rxycx-camelcase-4.1.0.tgz
unpacking source archive /nix/store/p6rxmp11gzkah9wk3b8d934q663lh3pd-capture-stack-trace-1.0.1.tgz
unpacking source archive /nix/store/7f6slvqx5ny5dmn2xrs5c8fc65ag4jhw-caseless-0.12.0.tgz
unpacking source archive /nix/store/pxw9nmkd3jyx7sdbkwd509i2y1sq4hsg-chalk-2.4.2.tgz
unpacking source archive /nix/store/gqq76z6wrs629h6aj0cna13y0nrfn3sa-chrome-dgram-3.0.4.tgz
unpacking source archive /nix/store/wyii9mmra09csfy7dp6wj5yc4zzfpv5h-chrome-dns-1.0.1.tgz
unpacking source archive /nix/store/zlkhy083k3cii5x0xp38g806r1gc0iry-chrome-net-3.3.3.tgz
unpacking source archive /nix/store/0pviy0d7c63m67alpww8y4k95r51wzjj-ci-info-1.6.0.tgz
unpacking source archive /nix/store/3lack7vzrkjzcgway2bfvfq4qbrffada-circular-append-file-1.0.1.tgz
unpacking source archive /nix/store/q1yy192nxns2dgj4gw478yid3lr7r8qw-class-utils-0.3.6.tgz
unpacking source archive /nix/store/f13s5dfl0dpnw199f73sp92snhd0m4y2-define-property-0.2.5.tgz
unpacking source archive /nix/store/0y1k2ijz2zl37wyf59l2nbiid48yizcz-is-accessor-descriptor-0.1.6.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/q3knxv2zzbflx23jvh2iwjkbai5769x5-is-data-descriptor-0.1.4.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/dgdm8q03x6rpsmyd166yjdfrvrq09q4h-is-descriptor-0.1.6.tgz
unpacking source archive /nix/store/yp6ciididizmrslxjpg2w8f5ngnyx81s-kind-of-5.1.0.tgz
unpacking source archive /nix/store/ykjimmniy3azrjk36yvazvsc7clvfspa-cli-boxes-1.0.0.tgz
unpacking source archive /nix/store/4dyh5fd9vh4vbcvmq9f12fwqzbbxrazb-cli-spinners-1.3.1.tgz
unpacking source archive /nix/store/7s3pa395r212j9c17mci5mzs2rajnsdx-cli-truncate-1.1.0.tgz
unpacking source archive /nix/store/a3s3ll009vzvxl2m08ic1mf9qhcswkyj-cliclopts-1.1.1.tgz
unpacking source archive /nix/store/ivnzv0klkjyafa0gfw7v2fp946hzy3i6-codecs-1.2.1.tgz
unpacking source archive /nix/store/gilx50rwrjiahwsj96pk8pgmjw20lnn2-collection-visit-1.0.0.tgz
unpacking source archive /nix/store/5hkvvgzr3vmwq1c8fsdhbabnyymk0gds-color-convert-1.9.3.tgz
unpacking source archive /nix/store/2jnhbp500dvwr0r6017s4zxs8l368sfl-color-name-1.1.3.tgz
unpacking source archive /nix/store/25sxkx913fkd5ip5pab7aw4yy3knmc57-colors-1.4.0.tgz
unpacking source archive /nix/store/w8z0ql2xqw7r8xy27faiyd2ly4244fv9-combined-stream-1.0.8.tgz
unpacking source archive /nix/store/kn9nw3mkgdhsq715xpaivviclb9iyw66-component-emitter-1.3.0.tgz
unpacking source archive /nix/store/v538mdl3px04xxhxjxkz2v9sq2psdna9-concat-map-0.0.1.tgz
unpacking source archive /nix/store/spfsxrv93sbd5k3blknlcsc0g2amrn3x-concat-stream-1.6.2.tgz
unpacking source archive /nix/store/j4mfshv43cl3f1y3xm8ylb8mb42crbzh-configstore-3.1.2.tgz
unpacking source archive /nix/store/170m35sqkyjhgalycdz02b6y9l23hdjz-connections-1.4.2.tgz
unpacking source archive /nix/store/b60gf6qad0dn3b5yn8malix7328fdd37-content-types-0.1.0.tgz
unpacking source archive /nix/store/7k5n5nafb68hb81fqdp0fs1ydsn9gxri-copy-descriptor-0.1.1.tgz
unpacking source archive /nix/store/1im5r97nmkjzvy0d9yavg8pqjmva0a4k-core-util-is-1.0.2.tgz
unpacking source archive /nix/store/f58h70n7i28nlmyvzcdsa0jdbfdrd1pz-corsify-2.1.0.tgz
unpacking source archive /nix/store/4vnja8xf36rq0qfif803pbczvvbcvwkw-count-trailing-zeros-1.0.1.tgz
unpacking source archive /nix/store/hz73pbfr6dqp3zps6m0s6s7szycrajpm-create-error-class-3.0.2.tgz
unpacking source archive /nix/store/kzc57slc77qnxw3s1yay5c7jpxp8dddh-cross-spawn-5.1.0.tgz
unpacking source archive /nix/store/l910p14ffain3dwmmkmh271wxdx2ffcy-crypto-random-string-1.0.0.tgz
unpacking source archive /nix/store/2nxscnniz2ll0xgv4sifjwgfj2xjgxjf-cycle-1.0.3.tgz
unpacking source archive /nix/store/1a1y5cdhkbk798cmrc7yxxr8zsrhs1wf-dashdash-1.14.1.tgz
unpacking source archive /nix/store/ip1ga139can4xff5svssfncpcgzpn09f-dat-dns-3.2.1.tgz
unpacking source archive /nix/store/s44q50fx5qrq1i7rksmsfzg5y27jihcb-dat-doctor-2.1.2.tgz
unpacking source archive /nix/store/5zfsy5vdgbflkdh4dlvp57y1l02nraa3-dat-encoding-5.0.1.tgz
unpacking source archive /nix/store/0v51m7fs10syzcpmz6162if83hxilf7i-dat-ignore-2.1.2.tgz
unpacking source archive /nix/store/0x6md1dc6ypfg3nwv9127cmh5jb5619q-dat-json-1.0.3.tgz
unpacking source archive /nix/store/vak34vca1ayirivq9vmdm1xh596rr92f-dat-link-resolve-2.3.0.tgz
unpacking source archive /nix/store/v7invxs8r24rjbvw9kjaqihw0y8qh7p5-dat-log-1.2.0.tgz
unpacking source archive /nix/store/gm8l1jksnrhpjwv9sd38rja6qxmb026j-neat-log-2.4.0.tgz
unpacking source archive /nix/store/g8lv1rz788z3yfb9ry7qcf6jch93qkr1-dat-node-3.5.15.tgz
unpacking source archive /nix/store/zs0qamn3rr7rb1dibml5cf799wf1wh9l-dat-registry-4.0.1.tgz
unpacking source archive /nix/store/ajchq00805wnh3ysdxvrd9asqgr8awx4-dat-secret-storage-4.0.1.tgz
unpacking source archive /nix/store/ir6r2zwbjq0ns8igfpg2saasa2hw8h22-dat-storage-1.1.1.tgz
unpacking source archive /nix/store/vlmyn59j8lg0i9j63qmy6vsgcm67a4sn-dat-swarm-defaults-1.0.2.tgz
unpacking source archive /nix/store/wpqlb2ybanmh3qm24i07l1cgwjnjdj1f-debug-4.1.1.tgz
unpacking source archive /nix/store/d75g3gi97mnfzyfzsh5kyffcbrh5qy94-decode-uri-component-0.2.0.tgz
unpacking source archive /nix/store/jyr0jzg6bycbfkq0x04yc95i489x8pb6-decompress-response-4.2.1.tgz
unpacking source archive /nix/store/zhr3fc6lny4xdw8gfka51w3hkwsqpcqf-deep-equal-0.2.2.tgz
unpacking source archive /nix/store/xfanygpw7lp4c7dlaprq7rrf6bnyl7p1-deep-extend-0.6.0.tgz
unpacking source archive /nix/store/0di34pavvsk0naa03ll387va3573fbm1-define-property-2.0.2.tgz
unpacking source archive /nix/store/0a6gsm39162g8gjfbcsswvl76cn7yhaa-delayed-stream-1.0.0.tgz
unpacking source archive /nix/store/mayzykknc5bf1jny9k89i9w5d6y5yji6-diffy-2.1.0.tgz
unpacking source archive /nix/store/7j4qh2kd5sw23xqwpm0dhf2dbj9s715l-directory-index-html-2.1.0.tgz
unpacking source archive /nix/store/18n6vciswf1snlfvv20zwcdv0z5925hz-discovery-channel-5.5.1.tgz
unpacking source archive /nix/store/c87mxz88kja781hbmb4ap2fkzmmdhh3f-debug-2.6.9.tgz
unpacking source archive /nix/store/j0bd0bp0r25dlyrlbbi81m702vczzbd4-ms-2.0.0.tgz
unpacking source archive /nix/store/wm71kdas3zajakw8zkfzf51fbr6vas3g-thunky-0.1.0.tgz
unpacking source archive /nix/store/xfr64adkl8qpb0h3w8adbwk1nnhksh6l-discovery-swarm-5.1.4.tgz
unpacking source archive /nix/store/vcds8q53g739xs6zh3qb455n7kbvwkqk-utp-native-1.7.3.tgz
unpacking source archive /nix/store/wsmhfpqhwvzg7axx08l2038cck2gnxh8-dns-discovery-6.2.3.tgz
unpacking source archive /nix/store/c87mxz88kja781hbmb4ap2fkzmmdhh3f-debug-2.6.9.tgz
unpacking source archive /nix/store/m7r5jpdinyrsz6bmq1llrswnzq8ks05j-lru-2.0.1.tgz
unpacking source archive /nix/store/j0bd0bp0r25dlyrlbbi81m702vczzbd4-ms-2.0.0.tgz
unpacking source archive /nix/store/571z9ralpn1fc15hz0nibm7xcyixwk18-dns-packet-4.2.0.tgz
unpacking source archive /nix/store/68ijy5mrk6dvn8wy65r91g55pqwhnhh0-dns-socket-3.0.0.tgz
unpacking source archive /nix/store/rlw02zgqcwh7rzqgqkj3sxhq9xshczc2-dom-walk-0.1.1.tgz
unpacking source archive /nix/store/6lncns7dzgrycf4p3kcrfdq875nrjn6k-dot-prop-4.2.0.tgz
unpacking source archive /nix/store/g4q9cq6507662fq46cribksqzzjw4p76-duplexer3-0.1.4.tgz
unpacking source archive /nix/store/qmz674z5ddm9clvywy57pykla9m2h8g7-duplexify-3.7.1.tgz
unpacking source archive /nix/store/d8f5j3k561b59l9qpqm4dmcmza05sif2-ecc-jsbn-0.1.2.tgz
unpacking source archive /nix/store/ksfdj542fcgpghrc26idiha2dm45qc0b-end-of-stream-1.4.4.tgz
unpacking source archive /nix/store/xfirwlc3qbp3437fsdlqy7j1nyjg68ab-escape-string-regexp-1.0.5.tgz
unpacking source archive /nix/store/c72lfq6qb0md03ib0y57rarvchj3vq5b-execa-0.7.0.tgz
unpacking source archive /nix/store/a99wl0w41fhbj2y4sbppkl1020r6hfj2-expand-brackets-2.1.4.tgz
unpacking source archive /nix/store/c87mxz88kja781hbmb4ap2fkzmmdhh3f-debug-2.6.9.tgz
unpacking source archive /nix/store/f13s5dfl0dpnw199f73sp92snhd0m4y2-define-property-0.2.5.tgz
unpacking source archive /nix/store/aj629667z1iplzia8a21srcqcl2ngw57-extend-shallow-2.0.1.tgz
unpacking source archive /nix/store/0y1k2ijz2zl37wyf59l2nbiid48yizcz-is-accessor-descriptor-0.1.6.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/q3knxv2zzbflx23jvh2iwjkbai5769x5-is-data-descriptor-0.1.4.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/dgdm8q03x6rpsmyd166yjdfrvrq09q4h-is-descriptor-0.1.6.tgz
unpacking source archive /nix/store/yp6ciididizmrslxjpg2w8f5ngnyx81s-kind-of-5.1.0.tgz
unpacking source archive /nix/store/j0bd0bp0r25dlyrlbbi81m702vczzbd4-ms-2.0.0.tgz
unpacking source archive /nix/store/kjacn03x2c1hvcds5szzbjcqzyq8x95g-extend-3.0.2.tgz
unpacking source archive /nix/store/4dhvdx287pbv4bpmz3m9va9adi8pfvbg-extend-shallow-3.0.2.tgz
unpacking source archive /nix/store/1fp3iyl6sh0ychqcm286awj4pyrh7vmn-is-extendable-1.0.1.tgz
unpacking source archive /nix/store/5maqd5hv8dzrpvvmvkwk7dgmznhqlqmw-extglob-2.0.4.tgz
unpacking source archive /nix/store/snx7isj4kkqbkcayhnagmwfrl6ds4ywj-define-property-1.0.0.tgz
unpacking source archive /nix/store/aj629667z1iplzia8a21srcqcl2ngw57-extend-shallow-2.0.1.tgz
unpacking source archive /nix/store/wnk95xfhag0wa1gl05qdcsc7hpay4f6f-extsprintf-1.3.0.tgz
unpacking source archive /nix/store/7s62k7nvc9q8dq3fcy5yk5m6hhkwjl8q-eyes-0.1.8.tgz
unpacking source archive /nix/store/s6lprv6mnkzyb4s67b67gzj8qlqxn9qs-fast-bitfield-1.2.2.tgz
unpacking source archive /nix/store/029jn5gb9x0fpcb3qmm87prcn6lri0rm-fast-deep-equal-2.0.1.tgz
unpacking source archive /nix/store/jgidxwahv01x3xzjgdzbv98nfmp4nj3w-fast-json-stable-stringify-2.1.0.tgz
unpacking source archive /nix/store/0jkvbzxdh295vmcayshc5p017lav58fk-fd-lock-1.0.2.tgz
unpacking source archive /nix/store/63p0v5nbx8zrnfcmpl0h6428r4g8r4r2-napi-macros-1.8.2.tgz
unpacking source archive /nix/store/wm97mzncyjgcyfxf3x5qjzjd17wrggcq-fd-read-stream-1.1.0.tgz
unpacking source archive /nix/store/n3y01y2f7zmh0dz80cfzsrmgss7v0h8j-figures-2.0.0.tgz
unpacking source archive /nix/store/7lwsngvswck1p29bmlvah0mmqbknfb8z-fill-range-4.0.0.tgz
unpacking source archive /nix/store/aj629667z1iplzia8a21srcqcl2ngw57-extend-shallow-2.0.1.tgz
unpacking source archive /nix/store/f87r55vxa1zkqr395nycskl3angjq2nh-flat-tree-1.6.0.tgz
unpacking source archive /nix/store/8myh064crxqjns9dgriygncj541gdvjv-for-in-1.0.2.tgz
unpacking source archive /nix/store/nkkq9vs0ghzk9jlcs5k2nac7pbx4nz8j-forever-agent-0.6.1.tgz
unpacking source archive /nix/store/sfq4rallkn18jnll6vb9fm98psa3g7sb-form-data-2.3.3.tgz
unpacking source archive /nix/store/y8jr2walk5s73x4d8jafcl8w8zq5scld-fragment-cache-0.2.1.tgz
unpacking source archive /nix/store/irgck0yn4znl0yf72y902vnfvm46maa6-from2-2.3.0.tgz
unpacking source archive /nix/store/ba8x7lli4r1aby1925daq01i9i9s8b32-fs.realpath-1.0.0.tgz
unpacking source archive /nix/store/bi5qasbhkyj0xghp27idab1c6qf2svpa-get-stream-3.0.0.tgz
unpacking source archive /nix/store/05k5qmq3r9rzvgx0wfajr1x0nbxv20vc-get-value-2.0.6.tgz
unpacking source archive /nix/store/spzkhhyhpr583qy4w7gy8sjpfffpvklc-getpass-0.1.7.tgz
unpacking source archive /nix/store/c0agaclhjn92f8ca7830qs04idk0gnym-glob-7.1.6.tgz
unpacking source archive /nix/store/h5kvik5zw64h013sdh7pbymr3sdg4z85-global-4.3.2.tgz
unpacking source archive /nix/store/kjh4x7h4d3nk3ma83dyrh00y5h7srjvh-global-dirs-0.1.1.tgz
unpacking source archive /nix/store/c1yb5yz70jxnwgwd2lx9pp4yk3r722qg-got-6.7.1.tgz
unpacking source archive /nix/store/b9986rg6s9bxbrjzrv70agvnvwwf7p7l-graceful-fs-4.2.3.tgz
unpacking source archive /nix/store/kjqkhwv9w3262i8idr3pns97pw5mjnay-har-schema-2.0.0.tgz
unpacking source archive /nix/store/0lgdlzmsp9dli46j7g1i8jpd8q8qispv-har-validator-5.1.3.tgz
unpacking source archive /nix/store/yl7c2kh37v2c7vw8hmiiglgjh5pg770d-has-flag-3.0.0.tgz
unpacking source archive /nix/store/d060ryyx2f2hlc36vhigm9slykjfg9ln-has-value-1.0.0.tgz
unpacking source archive /nix/store/4jjnl7na69c2l14159g6lspbczywx30y-has-values-1.0.0.tgz
unpacking source archive /nix/store/znz0c1ra8brxgj30gp7ah68s75a3a203-kind-of-4.0.0.tgz
unpacking source archive /nix/store/n9jhjygi4ymq4dh3y97ky79ky58vh2j5-http-methods-0.1.0.tgz
unpacking source archive /nix/store/g6sysxxy5gzl5z3l35g1747mn21b1lvp-http-signature-1.2.0.tgz
unpacking source archive /nix/store/wb0b5hq8qql9y2iyhsb8x0z86v6xraf4-hypercore-7.7.1.tgz
unpacking source archive /nix/store/ams03ka11acgpmx84d81a1kcj6srvvvz-codecs-2.0.0.tgz
unpacking source archive /nix/store/xs8z6m31l8373vjm5hgbrsgjjwf92jlp-unordered-set-2.0.1.tgz
unpacking source archive /nix/store/61x72lxn19nr5yiybi8ik08cz35cm6yc-hypercore-crypto-1.0.0.tgz
unpacking source archive /nix/store/p46b9c2zavspccrj6zc7j3z9fafmsy4d-hypercore-protocol-6.12.0.tgz
unpacking source archive /nix/store/g0phad04967k2n7zj1wn13xs45n34aj8-varint-5.0.0.tgz
unpacking source archive /nix/store/rl6j0s1slxcqb2dcap8l7mwqs6va1a92-hyperdrive-9.16.0.tgz
unpacking source archive /nix/store/xl53i9qn105xdacssgxllmdnm69f9p7x-hyperdrive-http-4.4.0.tgz
unpacking source archive /nix/store/vlj35n7apln1a96127hbwqbn80scgrjc-hyperdrive-network-speed-2.1.0.tgz
unpacking source archive /nix/store/v74gjb9fai7viwz81hx8dwbdlf0hh5m1-debug-3.2.6.tgz
unpacking source archive /nix/store/k1nvhcp06ris51h7c4vwnx4ff66s6y57-i-0.3.6.tgz
unpacking source archive /nix/store/jbg311ry96cqa12ghf81n0x10yxdik35-import-lazy-2.1.0.tgz
unpacking source archive /nix/store/19nrnfqfp0k560x1aikkf0aifkwvyi9b-imurmurhash-0.1.4.tgz
unpacking source archive /nix/store/m5b3lxagv9x67kwz3mp0bfjpxi27ww57-inflight-1.0.6.tgz
unpacking source archive /nix/store/azvzr4mg5gc3av5b7jr3wzs20ldjrkxz-inherits-2.0.4.tgz
unpacking source archive /nix/store/agdhw2lh7m7qinij52b6fzrvhizxjdwd-ini-1.3.5.tgz
unpacking source archive /nix/store/1pi5a7mf3ig7hhrfl96zk7iz4q01yk3p-inspect-custom-symbol-1.1.1.tgz
unpacking source archive /nix/store/hms24dbayfk63plcvyfwlpd4zgyigx0p-ip-1.1.5.tgz
unpacking source archive /nix/store/g2hdvmmj0ffpm8i9bis53hdybwp4g5vg-is-accessor-descriptor-1.0.0.tgz
unpacking source archive /nix/store/011f5148hdsm6yznj4rl30j4jhzlhrb6-is-buffer-1.1.6.tgz
unpacking source archive /nix/store/hxa8njbvbfikhqi27hrwsd8pyl6qj465-is-ci-1.2.1.tgz
unpacking source archive /nix/store/kis6mxim2cmqrksi1x6v8g1dwzv487a1-is-data-descriptor-1.0.0.tgz
unpacking source archive /nix/store/pcgck1nxqmbh44z2wnynhmvdm1x5sw04-is-descriptor-1.0.2.tgz
unpacking source archive /nix/store/d40566q1li9wdd2jskwhkn4l9yfraqs7-is-extendable-0.1.1.tgz
unpacking source archive /nix/store/jbjmrrggvy3nwj8b7f4fznjw02zr0a03-is-fullwidth-code-point-2.0.0.tgz
unpacking source archive /nix/store/h9r227pgg5ba161pxylpq26rh9lgnj6k-is-function-1.0.1.tgz
unpacking source archive /nix/store/pa478glqnhn040q4a00qbha1d2in3zk2-is-installed-globally-0.1.0.tgz
unpacking source archive /nix/store/h4vj875s0c2dima9jq5dj4ni1y5xbnwm-is-npm-1.0.0.tgz
unpacking source archive /nix/store/x6jjyr3x5x6wsarqcdbrfwsnpjb0p74b-is-number-3.0.0.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/1rn9y0sm1y803jbra4jzwgvdih8vzpcb-is-obj-1.0.1.tgz
unpacking source archive /nix/store/ypi7v9zp5g1wzrmcqi2nxdaw7x5957ii-is-options-1.0.1.tgz
unpacking source archive /nix/store/whx2i6zvf8j1z76ycv7b74cg00cqz2bp-is-path-inside-1.0.1.tgz
unpacking source archive /nix/store/mym3xfamsi2xhps48zaxa22wp8rz16zz-is-plain-object-2.0.4.tgz
unpacking source archive /nix/store/i0c2vlglnqa2968w09z848iagvc2cibv-is-redirect-1.0.0.tgz
unpacking source archive /nix/store/6i2hi2syjra752bfhdi23gb4d4yy9lxi-is-retry-allowed-1.2.0.tgz
unpacking source archive /nix/store/4n7kn97mp9zhgwb5w2dwx5nbnz8lxahq-is-stream-1.1.0.tgz
unpacking source archive /nix/store/fz3lim6w2lxcgxqq8c5b8q4hzp5xlaq2-is-string-1.0.4.tgz
unpacking source archive /nix/store/2q3bvx58jcpr1ksmmf1wj88wla39wa48-is-typedarray-1.0.0.tgz
unpacking source archive /nix/store/gaf6dhdrfkwjp826bjskv5i9xd3rbrpy-is-windows-1.0.2.tgz
unpacking source archive /nix/store/mxcs504nxhjx3hyjb63z0cfswh85r5k9-isarray-1.0.0.tgz
unpacking source archive /nix/store/430bf0maxy0480dnzh78f1lf0kq4cbdg-isexe-2.0.0.tgz
unpacking source archive /nix/store/gnygqhc0hciz75mzm87z04va98fkk38l-isobject-3.0.1.tgz
unpacking source archive /nix/store/adl3mb4i8415wpf7fzhgkiswi84hf92k-isstream-0.1.2.tgz
unpacking source archive /nix/store/advzdzz5xhhfyg0xbgdfi4s8c8lp1j4p-iterators-0.1.0.tgz
unpacking source archive /nix/store/djk0njynha44jbg9wy4jk5lkjj61g3gb-jsbn-0.1.1.tgz
unpacking source archive /nix/store/4pa80kjjkwd41ya0j20r2hhdm9zchmx2-json-schema-0.2.3.tgz
unpacking source archive /nix/store/qygc146r018a0dg6pq3y854fq75p7czq-json-schema-traverse-0.4.1.tgz
unpacking source archive /nix/store/zmlhkym8qc63w98csia5mfp1nyirqgy0-json-stringify-safe-5.0.1.tgz
unpacking source archive /nix/store/jrvhviygv1is89b7icqpsbbdf906acp3-jsprim-1.4.1.tgz
unpacking source archive /nix/store/ns3hhm0vxza4wxmcl37rj7pvimx0pxrr-k-bucket-3.3.1.tgz
unpacking source archive /nix/store/1335m24nb81094grk8gwwd0d7q2nb3bd-k-rpc-4.3.1.tgz
unpacking source archive /nix/store/hj6iqnqkm4y3g1za34skyngxzfjsqhk5-k-bucket-4.0.1.tgz
unpacking source archive /nix/store/3gf36sg9i1s9m6l26y2wy4mqf9f9fqwk-k-rpc-socket-1.11.1.tgz
unpacking source archive /nix/store/j8ln4wvnw8bg24b49ix8zvnh9mrsj45a-bencode-2.0.1.tgz
unpacking source archive /nix/store/xpwpq65b9manf1n6qcghfl45jywx1jz1-keypress-0.2.1.tgz
unpacking source archive /nix/store/7zswnzn0g13zk3b7njfpy4kwq3x6a5zs-kind-of-6.0.2.tgz
unpacking source archive /nix/store/bcb242zkgcck1h11c7mpmdrdmr34l1yv-last-one-wins-1.0.4.tgz
unpacking source archive /nix/store/qh47biy6r3knwfq3yd3g8a8hnqh4ryl1-latest-version-3.1.0.tgz
unpacking source archive /nix/store/jg64xk5lkm408mk6fq6my76ca5f4jhp3-length-prefixed-message-3.0.4.tgz
unpacking source archive /nix/store/7p943awl2pflqgpk0w37py82y1kcc1xp-lodash.throttle-4.1.1.tgz
unpacking source archive /nix/store/50r17c9b9n3lrqzlpvvrk25bdzmip4xd-lowercase-keys-1.0.1.tgz
unpacking source archive /nix/store/svs3952n59707z06mj0zn3nf52jp3wd9-lru-3.1.0.tgz
unpacking source archive /nix/store/nijbxr462rdsq4zmi4ca6m9q3rifz7f9-lru-cache-4.1.5.tgz
unpacking source archive /nix/store/s7xh1q7ix49yp9p9q8pjx3753phs4qlr-make-dir-1.3.0.tgz
unpacking source archive /nix/store/zqqyjq9jpxhwx003kim6l9dp7mz8krjg-map-cache-0.2.2.tgz
unpacking source archive /nix/store/cb1wsdkxjwbr76kyppihafxkgpf54bfd-map-visit-1.0.0.tgz
unpacking source archive /nix/store/ikfjmn9f0c1ilnc8fhcshl3x492mmq3c-memory-pager-1.5.0.tgz
unpacking source archive /nix/store/piniwl889ws1qcw2p84gcy6r3pswddbd-menu-string-1.3.0.tgz
unpacking source archive /nix/store/v1asn7kf0r025iarcbkisdwjwwl46jvw-merkle-tree-stream-3.0.3.tgz
unpacking source archive /nix/store/c9qmmzzi13nhj0zbn00v1kbnngyshk3g-micromatch-3.1.10.tgz
unpacking source archive /nix/store/9ggr9jy8xf5df7k94qvccbmjzhmiag35-mime-2.4.4.tgz
unpacking source archive /nix/store/vvgwa5cc5fan2fqy00wi1l7jg100zwxb-mime-db-1.42.0.tgz
unpacking source archive /nix/store/j1qpbc3fvsm4ba2qjnp6ga0xx7hgl45v-mime-types-2.1.25.tgz
unpacking source archive /nix/store/kwwha7360ab7c5c1180y0r2h8k2r9kjg-mimic-response-2.0.0.tgz
unpacking source archive /nix/store/8rpw72fkqccqkrkwk0cax167bhn9rnd1-min-document-2.19.0.tgz
unpacking source archive /nix/store/9xm69v2r4kddrkdv7q8if4c4jyhpra0w-minimatch-3.0.4.tgz
unpacking source archive /nix/store/806ihpwlngawi49k4k4v6mfvj5inxadc-minimist-1.2.0.tgz
unpacking source archive /nix/store/8frrjqzp40ifnazpzq505hi3fw5gckkh-mirror-folder-3.0.0.tgz
unpacking source archive /nix/store/myw6ykgxfnhvl8kdcjhh9yzhcldnn0pz-mixin-deep-1.3.2.tgz
unpacking source archive /nix/store/1fp3iyl6sh0ychqcm286awj4pyrh7vmn-is-extendable-1.0.1.tgz
unpacking source archive /nix/store/m37f4lw83xjss0r2vah1krpcr9g6bg7v-mkdirp-0.5.1.tgz
unpacking source archive /nix/store/8vk41mi7rx832h8yxla8mh6zpxhjfavz-minimist-0.0.8.tgz
unpacking source archive /nix/store/lc4rclv3327mnkvm33f3zbkqqc0jl9rc-ms-2.1.2.tgz
unpacking source archive /nix/store/qxk85lwi58z1vdlp11kg9c0063z5i0k6-multi-random-access-2.1.1.tgz
unpacking source archive /nix/store/yxhi054qks9sb63i1baavlvsckxj82p4-multicast-dns-7.2.0.tgz
unpacking source archive /nix/store/khqvfkh3plqbdfcb3ql6qxs7gp4jyzg2-multistream-2.1.1.tgz
unpacking source archive /nix/store/zx894hs6zsji6imh4xvmmryn8b46s44f-mute-stream-0.0.8.tgz
unpacking source archive /nix/store/snzm4agrfhryp1n2v7j0h7gyvnlh6i2y-mutexify-1.2.0.tgz
unpacking source archive /nix/store/r7mavpgx2sr21q2cqsg3178x9gxgnc29-nan-2.14.0.tgz
unpacking source archive /nix/store/mdpwly7scb5ksnj4cq942yqdmwd4qzsa-nanoassert-1.1.0.tgz
unpacking source archive /nix/store/5f57ja2b1ybd0f9agrg96fgsb9znkm85-nanobus-4.4.0.tgz
unpacking source archive /nix/store/cncxijyxp3vkfbcfz8d5f72b39pmvb2x-nanoguard-1.2.2.tgz
unpacking source archive /nix/store/zy9iwshs509235lh5v51384vgm1n7rxj-nanomatch-1.2.13.tgz
unpacking source archive /nix/store/sa446qaal6yz475i8gavlz9hisf0hps8-nanoscheduler-1.0.3.tgz
unpacking source archive /nix/store/jk9l2j4aswzdnlla9wgj2b8y2vr30adj-nanotiming-7.3.1.tgz
unpacking source archive /nix/store/f966ihkf01ixcrny1qz4wxbwf83q8ssp-napi-macros-2.0.0.tgz
unpacking source archive /nix/store/ippxl6gfik0grl5x0hkd09r78xyzwfsk-ncp-1.0.1.tgz
unpacking source archive /nix/store/nydhrn6syha1bksj1cy6pd1nxbvldhi1-neat-input-1.10.0.tgz
unpacking source archive /nix/store/bbpjz4impwkcj13wl1girwgjfqmnvngk-neat-log-3.1.0.tgz
unpacking source archive /nix/store/6384cc737v1x3kkx7d21p8pb56nvx0dx-neat-spinner-1.0.0.tgz
unpacking source archive /nix/store/96c5pjdnnm1vmhxs1lavz9p8wjmb89s3-neat-tasks-1.1.1.tgz
unpacking source archive /nix/store/fj8yxznyx8lb0a5jdja7k9fq0ghykn1n-nets-3.2.0.tgz
unpacking source archive /nix/store/k8az3sm3bvjz79axydwf5mnpcarvc6nh-network-address-1.1.2.tgz
unpacking source archive /nix/store/g5wm1gbxv3fp4k2hp9kcw3v2pyij260w-node-gyp-build-3.9.0.tgz
unpacking source archive /nix/store/jkn6s65x2pr4hzvrcghlnl4szkpr83s7-normalize-path-2.1.1.tgz
unpacking source archive /nix/store/102km0mk77d88q964aqcy1qchyjjdpw6-npm-run-path-2.0.2.tgz
unpacking source archive /nix/store/q5sa43383532yxjf24jshvp92nxlcgyl-oauth-sign-0.9.0.tgz
unpacking source archive /nix/store/knsvqhmffpdj649z2fmq5bqx5lf4hfph-object-copy-0.1.0.tgz
unpacking source archive /nix/store/f13s5dfl0dpnw199f73sp92snhd0m4y2-define-property-0.2.5.tgz
unpacking source archive /nix/store/0y1k2ijz2zl37wyf59l2nbiid48yizcz-is-accessor-descriptor-0.1.6.tgz
unpacking source archive /nix/store/q3knxv2zzbflx23jvh2iwjkbai5769x5-is-data-descriptor-0.1.4.tgz
unpacking source archive /nix/store/dgdm8q03x6rpsmyd166yjdfrvrq09q4h-is-descriptor-0.1.6.tgz
unpacking source archive /nix/store/yp6ciididizmrslxjpg2w8f5ngnyx81s-kind-of-5.1.0.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/cpx5pp70qx8609hlqzwynlfxj57zcgg0-object-visit-1.0.1.tgz
unpacking source archive /nix/store/a7z3xhbxyjdgn0r2xmwz33pkcp9ryg87-object.pick-1.3.0.tgz
unpacking source archive /nix/store/99vx2fb0np7kj6kk2srccv8lh5fgqsx6-once-1.4.0.tgz
unpacking source archive /nix/store/f1fn2m42ggp614ancs42s9x7llsxvfw5-os-homedir-1.0.2.tgz
unpacking source archive /nix/store/nyhy65vd3s3vk4nmifhqxclaa70r9n2n-p-finally-1.0.0.tgz
unpacking source archive /nix/store/fz28d7vgk43s90izzj0pws9gbq98ysy5-package-json-4.0.1.tgz
unpacking source archive /nix/store/s1113xm9w8sc2423ia3q2x3c4w5vzcbh-parse-headers-2.0.3.tgz
unpacking source archive /nix/store/svgymh1s98m17cjd2chbwva0lq5nj4r1-pascalcase-0.1.1.tgz
unpacking source archive /nix/store/c9w6bjbsqfvchm7l6xbs30lhak7pp1jh-path-is-absolute-1.0.1.tgz
unpacking source archive /nix/store/a6pg7wzhyryggn3mpz50lvj79w92ig7p-path-is-inside-1.0.2.tgz
unpacking source archive /nix/store/iwwx4gzwczj87mkfc437ypdp6bk7289v-path-key-2.0.1.tgz
unpacking source archive /nix/store/9x49bgly8qi39gvm56lf9ngisjpvzl2l-performance-now-2.1.0.tgz
unpacking source archive /nix/store/xxd5qc3vlzb2ajgd2543i0ffg583xr6v-pify-3.0.0.tgz
unpacking source archive /nix/store/2mb63nxr91lfwvs1ahdh9njkb8vhdm8f-pkginfo-0.4.1.tgz
unpacking source archive /nix/store/946smwrr7fhav7pa1d0jykchlmjmka29-posix-character-classes-0.1.1.tgz
unpacking source archive /nix/store/f4rasdqp2n7lnq6nl3gsnp4q1w8fjgvb-prepend-http-1.0.4.tgz
unpacking source archive /nix/store/pg2324j4izkjx4cxawi87xz0aml05qx2-prettier-bytes-1.0.4.tgz
unpacking source archive /nix/store/vj8w145v2w6y5qndd345xh26jsiisakx-pretty-hash-1.0.1.tgz
unpacking source archive /nix/store/b4wcvnrixxz6nrfwv7al4hc5xkxrgrfv-process-0.5.2.tgz
unpacking source archive /nix/store/cqb735d0x1imja100fk540rjdks3gva1-process-nextick-args-2.0.1.tgz
unpacking source archive /nix/store/ni756xlsyf673ra2kvf7pi181y1ccb50-progress-string-1.2.2.tgz
unpacking source archive /nix/store/zb5h41llczhmhsk7aw89kcgxkzrjgkw8-prompt-1.0.0.tgz
unpacking source archive /nix/store/825shjjdxfx1mbpw5nsb0ki3ivb6df2m-protocol-buffers-encodings-1.1.0.tgz
unpacking source archive /nix/store/g0phad04967k2n7zj1wn13xs45n34aj8-varint-5.0.0.tgz
unpacking source archive /nix/store/farq10jzx942n2mw19jccg7jrqr69a90-pseudomap-1.0.2.tgz
unpacking source archive /nix/store/7l2wsjf3d11qcav1565pq46vcj9nm4ax-psl-1.6.0.tgz
unpacking source archive /nix/store/hndnjzv46c44irlafhz6k3i4ldh176cf-pump-3.0.0.tgz
unpacking source archive /nix/store/z2miz6wmxdh97qw3z88d352rg11lzgf7-punycode-2.1.1.tgz
unpacking source archive /nix/store/qwhb24khl7r5qd21qc0wgcvmd0k2b27k-qs-6.5.2.tgz
unpacking source archive /nix/store/c8mbambz8p6wzfn23pvcb3s3807b1qs6-random-access-file-2.1.3.tgz
unpacking source archive /nix/store/c08rbkk4mid6i4z00jm914mcyhad2bqq-random-access-memory-3.1.1.tgz
unpacking source archive /nix/store/hs51n8wdp29dddsqiz4c8xxl75pbb777-random-access-storage-1.4.0.tgz
unpacking source archive /nix/store/cfyh2lan3bb004988gdqnmscqv4s5yrv-randombytes-2.1.0.tgz
unpacking source archive /nix/store/s6dpcifbplm7sj5ig8v96mccr5kgxacj-range-parser-1.2.1.tgz
unpacking source archive /nix/store/z0dpj3cdfbxwmpl4y32n680ygn8kihqz-rc-1.2.8.tgz
unpacking source archive /nix/store/qgm78bp546f7pryg1flrapd11axapn7w-read-1.0.7.tgz
unpacking source archive /nix/store/h97syl269gsgns63z38kxs4wb5za8ws3-readable-stream-2.3.6.tgz
unpacking source archive /nix/store/aazscwmbmx7n91nx2rr118iq4a0a6h9v-safe-buffer-5.1.2.tgz
unpacking source archive /nix/store/x8629ga743wnqhnac356q6pwkd548qar-recursive-watch-1.1.4.tgz
unpacking source archive /nix/store/d9qygkxk0kfm04zvmg11nqzrp901z870-regex-not-1.0.2.tgz
unpacking source archive /nix/store/azv1qh43cshy2v95prayqivfab4fldgp-registry-auth-token-3.4.0.tgz
unpacking source archive /nix/store/crs91dw4k58vscvkpl70affn58gybggp-registry-url-3.1.0.tgz
unpacking source archive /nix/store/vs0jrksmsbzbnqw8iil1llqh1sfrf4sx-remove-array-items-1.1.1.tgz
unpacking source archive /nix/store/l36vq748inxdn9c7wz4mfs9h466698i8-remove-trailing-separator-1.1.0.tgz
unpacking source archive /nix/store/r445saim4b7ab9nvv5wr58xr26pkrzvm-repeat-element-1.1.3.tgz
unpacking source archive /nix/store/8v3vb9cisk7jpxirjj7g3yl9b9r7br9s-repeat-string-1.6.1.tgz
unpacking source archive /nix/store/rmfzfs81ykqmj7l8w8857cygllv1bgap-request-2.88.0.tgz
unpacking source archive /nix/store/5s4y9wawgckbj62rzxlifr15ly3jf8qh-resolve-url-0.2.1.tgz
unpacking source archive /nix/store/vl7c4dx9dbwmagjp332ybylls292kd44-ret-0.1.15.tgz
unpacking source archive /nix/store/mfaakxwjpl42472h7p9vvafm3nid6m99-revalidator-0.1.8.tgz
unpacking source archive /nix/store/49kqql1h5njvh7cmlsyrnrl6ljqnjy1q-rimraf-2.7.1.tgz
unpacking source archive /nix/store/ayxlyk7jf53masjr87bw8pymfz358qdr-run-series-1.1.8.tgz
unpacking source archive /nix/store/528x99gc947pl56y4lgmm4a9d4m8mhm4-rusha-0.8.13.tgz
unpacking source archive /nix/store/m597499nqdp0mdnj3mr83c99p2l6wm0l-safe-buffer-5.2.0.tgz
unpacking source archive /nix/store/w2cyj8h3fbaahjnsic4i5s4m1m3cx5bb-safe-regex-1.1.0.tgz
unpacking source archive /nix/store/p2a55pi17q2i9dnwlcbfc9mk0iwmw9dl-safer-buffer-2.1.2.tgz
unpacking source archive /nix/store/gll14kwxsz9ggfhngafafh64rv4a02fr-semver-5.7.1.tgz
unpacking source archive /nix/store/k4my4lczsa9i0ay5a3252pqsb92g3cnx-semver-diff-2.1.0.tgz
unpacking source archive /nix/store/hj7p7yvnn1663sl52lcahcr7nl1m8d7y-set-value-2.0.1.tgz
unpacking source archive /nix/store/aj629667z1iplzia8a21srcqcl2ngw57-extend-shallow-2.0.1.tgz
unpacking source archive /nix/store/jkmzw6xwl4pqadq5sb8r895vsb3k11q5-shebang-command-1.2.0.tgz
unpacking source archive /nix/store/c4w4vf1afbah7dhfalc28i1diihp2s9w-shebang-regex-1.0.0.tgz
unpacking source archive /nix/store/2pc30dnwx91sjhhv947b4vmxi1hnvq8n-signal-exit-3.0.2.tgz
unpacking source archive /nix/store/w87fsn2xg3jrb2dvs0rfa31c0i743c69-signed-varint-2.0.1.tgz
unpacking source archive /nix/store/g0phad04967k2n7zj1wn13xs45n34aj8-varint-5.0.0.tgz
unpacking source archive /nix/store/phsi152rnh2z4xxvyxcqsdswngmvcdnn-simple-concat-1.0.0.tgz
unpacking source archive /nix/store/bcvwjwg1zbngvjv57nkppv5kkjh4xfvl-simple-get-3.1.0.tgz
unpacking source archive /nix/store/zsb1346ibkk5vfcvkajfc8yzrg5wcnsv-simple-sha1-2.1.2.tgz
unpacking source archive /nix/store/i6r8p0fy4a9z5r3w04a4pvyh8iziacl3-siphash24-1.1.1.tgz
unpacking source archive /nix/store/l00dhyvywymcy3345znvkfm4lvw4z0q2-slice-ansi-1.0.0.tgz
unpacking source archive /nix/store/hljswnl6z9ix9ly5x546d6qjia9wpp60-snapdragon-0.8.2.tgz
unpacking source archive /nix/store/c87mxz88kja781hbmb4ap2fkzmmdhh3f-debug-2.6.9.tgz
unpacking source archive /nix/store/f13s5dfl0dpnw199f73sp92snhd0m4y2-define-property-0.2.5.tgz
unpacking source archive /nix/store/aj629667z1iplzia8a21srcqcl2ngw57-extend-shallow-2.0.1.tgz
unpacking source archive /nix/store/0y1k2ijz2zl37wyf59l2nbiid48yizcz-is-accessor-descriptor-0.1.6.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/q3knxv2zzbflx23jvh2iwjkbai5769x5-is-data-descriptor-0.1.4.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/dgdm8q03x6rpsmyd166yjdfrvrq09q4h-is-descriptor-0.1.6.tgz
unpacking source archive /nix/store/yp6ciididizmrslxjpg2w8f5ngnyx81s-kind-of-5.1.0.tgz
unpacking source archive /nix/store/j0bd0bp0r25dlyrlbbi81m702vczzbd4-ms-2.0.0.tgz
unpacking source archive /nix/store/f5z033w9f95lhiy1vapa8a44mjgaj7d8-snapdragon-node-2.1.1.tgz
unpacking source archive /nix/store/snx7isj4kkqbkcayhnagmwfrl6ds4ywj-define-property-1.0.0.tgz
unpacking source archive /nix/store/9f8j0b9b9zvna19w9c2cb51qqy7nln0m-snapdragon-util-3.0.1.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/pqj1gvbwr98asqscps4mmrcx3fwv14mw-sodium-javascript-0.5.5.tgz
unpacking source archive /nix/store/dlsdvpyzk2bx31k6wal5b0bbn71l8yjp-sodium-native-2.4.6.tgz
unpacking source archive /nix/store/q066079m577lfz91zl4kk0sfzr72pzfn-node-gyp-build-4.2.0.tgz
unpacking source archive /nix/store/4h1bqbfljkm3a2gfzqq15l6d8xim25hk-sodium-universal-2.0.0.tgz
unpacking source archive /nix/store/ck49ma753r45qadbzi082d75x6iiw1y4-sorted-array-functions-1.2.0.tgz
unpacking source archive /nix/store/5j9g60s1j6mh9m1m09gfmf0v9agcxs2r-sorted-indexof-1.0.0.tgz
unpacking source archive /nix/store/dpacg0ppk26x8vwr7f68naszk7sidhq8-source-map-0.5.7.tgz
unpacking source archive /nix/store/9bd9n0k5ww99m2irbyv9kfrzrcpgng83-source-map-resolve-0.5.2.tgz
unpacking source archive /nix/store/g21ar084fqc710br78cdxj9d4l1vhmqf-source-map-url-0.4.0.tgz
unpacking source archive /nix/store/15cfzqvrbl9z5gn7x5ibvfyf1a957n1s-sparse-bitfield-3.0.3.tgz
unpacking source archive /nix/store/5z03yn3m0zaq30gwqrflmhabk8yp24fy-speedometer-1.1.0.tgz
unpacking source archive /nix/store/a3vihfaa2ryci8p5v5y7dwyqgqghdxfd-split-string-3.1.0.tgz
unpacking source archive /nix/store/38s551sc6kx6j616fi1nnj228hq3i3b2-sshpk-1.16.1.tgz
unpacking source archive /nix/store/2n37yvlkcmvfcmvjj1bmjv0f4xlgg2yz-stack-trace-0.0.10.tgz
unpacking source archive /nix/store/619dk008mxwmnwjp1kdx9rv8cmlp3z7l-static-extend-0.1.2.tgz
unpacking source archive /nix/store/f13s5dfl0dpnw199f73sp92snhd0m4y2-define-property-0.2.5.tgz
unpacking source archive /nix/store/0y1k2ijz2zl37wyf59l2nbiid48yizcz-is-accessor-descriptor-0.1.6.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/q3knxv2zzbflx23jvh2iwjkbai5769x5-is-data-descriptor-0.1.4.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/dgdm8q03x6rpsmyd166yjdfrvrq09q4h-is-descriptor-0.1.6.tgz
unpacking source archive /nix/store/yp6ciididizmrslxjpg2w8f5ngnyx81s-kind-of-5.1.0.tgz
unpacking source archive /nix/store/i3fbpf26d4chjr986lsdxr749362hggl-stream-collector-1.0.1.tgz
unpacking source archive /nix/store/z2m4yadq46lg96hz9a44wg68whsyjikf-stream-each-1.2.3.tgz
unpacking source archive /nix/store/g7j59rfp2id4bxpr0nqif5i5bh8ngqw9-stream-parser-0.3.1.tgz
unpacking source archive /nix/store/c87mxz88kja781hbmb4ap2fkzmmdhh3f-debug-2.6.9.tgz
unpacking source archive /nix/store/j0bd0bp0r25dlyrlbbi81m702vczzbd4-ms-2.0.0.tgz
unpacking source archive /nix/store/b1bdjma99r297qw1h3d04scq7vz49ahi-stream-shift-1.0.1.tgz
unpacking source archive /nix/store/2scfk50vq38cidvbv6j0kj86i0zxsx5k-string-width-2.1.1.tgz
unpacking source archive /nix/store/hkdfsf6gmzslax6v0izh15aw9s6kw2zm-string_decoder-1.1.1.tgz
unpacking source archive /nix/store/aazscwmbmx7n91nx2rr118iq4a0a6h9v-safe-buffer-5.1.2.tgz
unpacking source archive /nix/store/kbb461ljysngpa4v2w32wvbf2rzy46mg-strip-ansi-4.0.0.tgz
unpacking source archive /nix/store/42b6lbplga1lbz8cn9d51j74w4g2y6b0-strip-eof-1.0.0.tgz
unpacking source archive /nix/store/p3m1kn6hyinns1p9g95mz74q9hbjqk2k-strip-json-comments-2.0.1.tgz
unpacking source archive /nix/store/lyaybwjqmjmyqs1mjq0jiinihff2454m-subcommand-2.1.1.tgz
unpacking source archive /nix/store/rqnp3mxxf03pnvnm7rd7vkz04gqmki3h-supports-color-5.5.0.tgz
unpacking source archive /nix/store/03cj05inkm74lp7s0nxwpkjm77kzpsli-term-size-1.2.0.tgz
unpacking source archive /nix/store/nb1xy1zp9ssji33b7ywrngc5xwgfj5nq-throttle-1.0.3.tgz
unpacking source archive /nix/store/23irz8l1axz7kll20dqb5zcdg48h32nx-thunky-1.1.0.tgz
unpacking source archive /nix/store/y8aq3s1449iwpqfzsmgw6d7frawb9rak-timed-out-4.0.1.tgz
unpacking source archive /nix/store/d7vbs8ddbn8v0kcl28pgq6gyqxkgw5nr-timeout-refresh-1.0.1.tgz
unpacking source archive /nix/store/0a85n9y8w7ivjj584vk82d4778452lig-to-buffer-1.1.1.tgz
unpacking source archive /nix/store/9q51lrizxa0llyy42iwsmgsrk90y8yis-to-object-path-0.3.0.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/kr0cwrqxjdjx9zr98mv7q0di7dqnxlby-to-regex-3.0.2.tgz
unpacking source archive /nix/store/f201bdwdhwqnn6q94rcg1nh7ckkhd4ik-to-regex-range-2.1.1.tgz
unpacking source archive /nix/store/pk22fpi57d9p15kkb5nmz9hqxmsfw03b-toiletdb-1.4.1.tgz
unpacking source archive /nix/store/c87mxz88kja781hbmb4ap2fkzmmdhh3f-debug-2.6.9.tgz
unpacking source archive /nix/store/j0bd0bp0r25dlyrlbbi81m702vczzbd4-ms-2.0.0.tgz
unpacking source archive /nix/store/clildawvd8ykm8ni5yqdizfp14nji8vd-tough-cookie-2.4.3.tgz
unpacking source archive /nix/store/w5js7fk0r4kk6zjpq4jas95lxvh76cgr-punycode-1.4.1.tgz
unpacking source archive /nix/store/2cl5pczj46kz54y524r7a4nfvlm6hvf8-township-client-1.3.2.tgz
unpacking source archive /nix/store/x0lii7nby2id84b7x4k6pvlwrgdaxy29-is-number-2.1.0.tgz
unpacking source archive /nix/store/qzyzkhzi41h719dgsf2pyd6f6abzxrii-kind-of-3.2.2.tgz
unpacking source archive /nix/store/cg5xym0a6rsfvxhrg8lqala24gigsnim-ttl-1.3.1.tgz
unpacking source archive /nix/store/s1dyvar6kxm4gdkn6wm4lv8y5vha4yyq-tunnel-agent-0.6.0.tgz
unpacking source archive /nix/store/s3g883kwf6q8f9rm3c7dd0sqs0ldcbg6-tweetnacl-0.14.5.tgz
unpacking source archive /nix/store/pjma93pkqdyjybpgmmyhyz0glpx5sw8y-typedarray-0.0.6.tgz
unpacking source archive /nix/store/rzbjh8fgc2fch457ka8wvkvwqg7p63h8-uint64be-2.0.2.tgz
unpacking source archive /nix/store/yim9jaglwfmy53sadvr7gs11am46mfzn-union-value-1.0.1.tgz
unpacking source archive /nix/store/mzijdpy58da187n27lf8m4lfvniglsrd-unique-string-1.0.0.tgz
unpacking source archive /nix/store/7s1ysysgf4q0n064wgb8k2pw02jsziql-unixify-1.0.0.tgz
unpacking source archive /nix/store/0fj1izpj3cn8cb04d2cphncjlhj85ar1-unordered-array-remove-1.0.2.tgz
unpacking source archive /nix/store/03vy41hinf40195jn5z23kmf8bp4a3g5-unordered-set-1.1.0.tgz
unpacking source archive /nix/store/srqc391azzqdpajsn5fvp2rg55agdllj-unset-value-1.0.0.tgz
unpacking source archive /nix/store/khavka4w753fg44cvhi3w3sa5ymvr4xy-has-value-0.3.1.tgz
unpacking source archive /nix/store/040g38rrj3w0x69b3almv5nn361clfz4-isobject-2.1.0.tgz
unpacking source archive /nix/store/idxplwcqv8j8fzfn20f93xh90d3169ni-has-values-0.1.4.tgz
unpacking source archive /nix/store/b6l1qh8d97ryfadvfgvdk83j4ygfmhpk-untildify-3.0.3.tgz
unpacking source archive /nix/store/h5cknby55g5srfbnw5vabb52c7vsisc4-unzip-response-2.0.1.tgz
unpacking source archive /nix/store/cnxhh63zwf83wlm8hmjvw8cph6r0bj8p-update-notifier-2.5.0.tgz
unpacking source archive /nix/store/q9drqpfb11zad973l2q5h08yc81l4skp-uri-js-4.2.2.tgz
unpacking source archive /nix/store/q49b2g88cml42b3zl7w3q099n9nq7dzv-urix-0.1.0.tgz
unpacking source archive /nix/store/g86vjrib9ypnni2kl3lm1rpgxwr32i5n-url-parse-lax-1.0.0.tgz
unpacking source archive /nix/store/shrjl7kvwg6hhxczbs45lzd4rhzakxy5-use-3.1.1.tgz
unpacking source archive /nix/store/35w0c1f0rw19x6p1b4b9lvbc3x23w8cs-util-deprecate-1.0.2.tgz
unpacking source archive /nix/store/63hfa6y2p5fbrjasjilhgskv08p3sp1w-utile-0.3.0.tgz
unpacking source archive /nix/store/ivv2yx4n9gbd8652dizran63rs5hy1p4-utp-native-2.1.5.tgz
unpacking source archive /nix/store/q066079m577lfz91zl4kk0sfzr72pzfn-node-gyp-build-4.2.0.tgz
unpacking source archive /nix/store/37924w5f638bvzf3kq9mgbxdxw6z9fjh-readable-stream-3.4.0.tgz
unpacking source archive /nix/store/xs8z6m31l8373vjm5hgbrsgjjwf92jlp-unordered-set-2.0.1.tgz
unpacking source archive /nix/store/mkji4gkga8az4bsyfals7clzx68h0zqq-uuid-3.3.3.tgz
unpacking source archive /nix/store/8ssk8wjdakzkjiwyn03vixyf1gjw11dg-varint-3.0.1.tgz
unpacking source archive /nix/store/x7jm3cmy61528gb9m92cpmdwk3s8zag6-verror-1.10.0.tgz
unpacking source archive /nix/store/8cqj54pff0s2jhil3lxy3r0m1is0x800-which-1.3.1.tgz
unpacking source archive /nix/store/jhi3jsbmj7bj8dzf46873w4qqad7x4np-widest-line-2.0.1.tgz
unpacking source archive /nix/store/2n5qkqdr75ifmap43rgvicivymk7n92w-winston-2.1.1.tgz
unpacking source archive /nix/store/f9ri5v1l3dsj6q2w3b1dyy1rbg8v57jd-async-1.0.0.tgz
unpacking source archive /nix/store/qwmb90rw6q9ifi5c93yn4smg1kb9mrsy-colors-1.0.3.tgz
unpacking source archive /nix/store/4w60mxj1jrki2mkky5k15zkwn84v8l3m-pkginfo-0.3.1.tgz
unpacking source archive /nix/store/wa4iwdsy5dsa4fpgkmfb3wbkln886im5-wrappy-1.0.2.tgz
unpacking source archive /nix/store/969zpmw0f54g4jzz1wcwvl7fm49d8lk5-write-file-atomic-2.4.3.tgz
unpacking source archive /nix/store/1pl2m0lmrwmmq50bvkzizlrrmay9i6fy-xdg-basedir-3.0.0.tgz
unpacking source archive /nix/store/3iwa21l3yasirh6230ri2d7n0mfc6rfp-xhr-2.5.0.tgz
unpacking source archive /nix/store/1148xbk4niagy8x832lfv41wf1cvr4xv-xsalsa20-1.1.0.tgz
unpacking source archive /nix/store/j93r3grj36pzbq4bz47qfximx7ffawgy-xtend-4.0.2.tgz
unpacking source archive /nix/store/ikpdr887y96sybx61gy4yag0lyrwky0q-yallist-2.1.2.tgz
pinpointing versions of dependencies...
patching script interpreter paths in .
./dat/download.sh: interpreter directive changed from "/bin/bash" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/bash"
./dat/package.sh: interpreter directive changed from "/usr/bin/env sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/bin/cli.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/ajv/scripts/info: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/ajv/scripts/prepare-tests: interpreter directive changed from "/usr/bin/env sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/ajv/scripts/publish-built-version: interpreter directive changed from "/usr/bin/env bash" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/bash"
./dat/node_modules/ajv/scripts/travis-gh-pages: interpreter directive changed from "/usr/bin/env bash" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/bash"
./dat/node_modules/async/support/sync-package-managers.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/bittorrent-dht/bin/update-authors.sh: interpreter directive changed from "/bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/dat-doctor/cli.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/dat-log/cli.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/discovery-swarm/node_modules/utp-native/ucat.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/dns-discovery/bin.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/is-ci/bin.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/mime/cli.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/mime/src/build.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/mkdirp/bin/cmd.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/multicast-dns/cli.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/nan/tools/1to2.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/ncp/bin/ncp: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/network-address/cli.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/node-gyp-build/bin.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/node-gyp-build/build-test.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/node-gyp-build/optional.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/rc/cli.js: interpreter directive changed from " /usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/recursive-watch/bin.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/rimraf/bin.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/semver/bin/semver: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/sodium-native/configure: interpreter directive changed from "/bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/autogen.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/android-arm.sh: interpreter directive changed from "/bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/android-armv7-a.sh: interpreter directive changed from "/bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/android-armv8-a.sh: interpreter directive changed from "/bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/android-build.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/android-mips32.sh: interpreter directive changed from "/bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/android-mips64.sh: interpreter directive changed from "/bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/android-x86_64.sh: interpreter directive changed from "/bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/android-x86.sh: interpreter directive changed from "/bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/emscripten.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/generate-emscripten-symbols.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/ios.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/msys2-win32.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/msys2-win64.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/nativeclient-pnacl.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/nativeclient-x86_64.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/nativeclient-x86.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/osx.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/dist-build/watchos.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/test/constcheck.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/libsodium/test/default/nacl-test-wrapper.sh: interpreter directive changed from " /bin/sh" to "/nix/store/b34zjdmq5l8k6rwdykjx55yl9r9isl8k-bash-4.4-p23/bin/sh"
./dat/node_modules/sodium-native/node_modules/node-gyp-build/bin.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/sodium-native/node_modules/node-gyp-build/build-test.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/sodium-native/node_modules/node-gyp-build/optional.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/sshpk/bin/sshpk-conv: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/sshpk/bin/sshpk-sign: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/sshpk/bin/sshpk-verify: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/utp-native/ucat.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/utp-native/node_modules/node-gyp-build/bin.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/utp-native/node_modules/node-gyp-build/build-test.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/utp-native/node_modules/node-gyp-build/optional.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/uuid/bin/uuid: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/which/bin/which: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
./dat/node_modules/winston/node_modules/async/support/sync-package-managers.js: interpreter directive changed from "/usr/bin/env node" to "/nix/store/879mgm5i0has8bi67janh0dk1h1bxqnj-nodejs-10.17.0/bin/node"
No package-lock.json file found, reconstructing...
Adding metadata fields to: node_modules/abstract-random-access/package.json
Adding metadata fields to: node_modules/ajv/package.json
Adding metadata fields to: node_modules/ansi-align/package.json
Adding metadata fields to: node_modules/ansi-diff/package.json
Adding metadata fields to: node_modules/ansi-regex/package.json
Adding metadata fields to: node_modules/ansi-split/package.json
Adding metadata fields to: node_modules/ansi-styles/package.json
Adding metadata fields to: node_modules/anymatch/package.json
Adding metadata fields to: node_modules/ap/package.json
Adding metadata fields to: node_modules/append-tree/package.json
Adding metadata fields to: node_modules/append-tree/node_modules/process-nextick-args/package.json
Adding metadata fields to: node_modules/append-tree/node_modules/varint/package.json
Adding metadata fields to: node_modules/arr-diff/package.json
Adding metadata fields to: node_modules/arr-flatten/package.json
Adding metadata fields to: node_modules/arr-union/package.json
Adding metadata fields to: node_modules/array-lru/package.json
Adding metadata fields to: node_modules/array-unique/package.json
Adding metadata fields to: node_modules/asn1/package.json
Adding metadata fields to: node_modules/assert-plus/package.json
Adding metadata fields to: node_modules/assign-symbols/package.json
Adding metadata fields to: node_modules/async/package.json
Adding metadata fields to: node_modules/asynckit/package.json
Adding metadata fields to: node_modules/atob/package.json
Adding metadata fields to: node_modules/atomic-batcher/package.json
Adding metadata fields to: node_modules/aws-sign2/package.json
Adding metadata fields to: node_modules/aws4/package.json
Adding metadata fields to: node_modules/balanced-match/package.json
Adding metadata fields to: node_modules/base/package.json
Adding metadata fields to: node_modules/base/node_modules/define-property/package.json
Adding metadata fields to: node_modules/bcrypt-pbkdf/package.json
Adding metadata fields to: node_modules/bencode/package.json
Adding metadata fields to: node_modules/bitfield-rle/package.json
Adding metadata fields to: node_modules/bitfield-rle/node_modules/varint/package.json
Adding metadata fields to: node_modules/bittorrent-dht/package.json
Adding metadata fields to: node_modules/bittorrent-dht/node_modules/debug/package.json
Adding metadata fields to: node_modules/blake2b/package.json
Adding metadata fields to: node_modules/blake2b-wasm/package.json
Adding metadata fields to: node_modules/body/package.json
Adding metadata fields to: node_modules/boxen/package.json
Adding metadata fields to: node_modules/brace-expansion/package.json
Adding metadata fields to: node_modules/braces/package.json
Adding metadata fields to: node_modules/braces/node_modules/extend-shallow/package.json
Adding metadata fields to: node_modules/buffer-alloc/package.json
Adding metadata fields to: node_modules/buffer-alloc-unsafe/package.json
Adding metadata fields to: node_modules/buffer-equals/package.json
Adding metadata fields to: node_modules/buffer-fill/package.json
Adding metadata fields to: node_modules/buffer-from/package.json
Adding metadata fields to: node_modules/bulk-write-stream/package.json
Adding metadata fields to: node_modules/bytes/package.json
Adding metadata fields to: node_modules/cache-base/package.json
Adding metadata fields to: node_modules/call-me-maybe/package.json
Adding metadata fields to: node_modules/camelcase/package.json
Adding metadata fields to: node_modules/capture-stack-trace/package.json
Adding metadata fields to: node_modules/caseless/package.json
Adding metadata fields to: node_modules/chalk/package.json
Adding metadata fields to: node_modules/chrome-dgram/package.json
Adding metadata fields to: node_modules/chrome-dns/package.json
Adding metadata fields to: node_modules/chrome-net/package.json
Adding metadata fields to: node_modules/ci-info/package.json
Adding metadata fields to: node_modules/circular-append-file/package.json
Adding metadata fields to: node_modules/class-utils/package.json
Adding metadata fields to: node_modules/class-utils/node_modules/define-property/package.json
Adding metadata fields to: node_modules/class-utils/node_modules/is-accessor-descriptor/package.json
Adding metadata fields to: node_modules/class-utils/node_modules/is-accessor-descriptor/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/class-utils/node_modules/is-data-descriptor/package.json
Adding metadata fields to: node_modules/class-utils/node_modules/is-data-descriptor/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/class-utils/node_modules/is-descriptor/package.json
Adding metadata fields to: node_modules/class-utils/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/cli-boxes/package.json
Adding metadata fields to: node_modules/cli-spinners/package.json
Adding metadata fields to: node_modules/cli-truncate/package.json
Adding metadata fields to: node_modules/cliclopts/package.json
Adding metadata fields to: node_modules/codecs/package.json
Adding metadata fields to: node_modules/collection-visit/package.json
Adding metadata fields to: node_modules/color-convert/package.json
Adding metadata fields to: node_modules/color-name/package.json
Adding metadata fields to: node_modules/colors/package.json
Adding metadata fields to: node_modules/combined-stream/package.json
Adding metadata fields to: node_modules/component-emitter/package.json
Adding metadata fields to: node_modules/concat-map/package.json
Adding metadata fields to: node_modules/concat-stream/package.json
Adding metadata fields to: node_modules/configstore/package.json
Adding metadata fields to: node_modules/connections/package.json
Adding metadata fields to: node_modules/content-types/package.json
Adding metadata fields to: node_modules/copy-descriptor/package.json
Adding metadata fields to: node_modules/core-util-is/package.json
Adding metadata fields to: node_modules/corsify/package.json
Adding metadata fields to: node_modules/count-trailing-zeros/package.json
Adding metadata fields to: node_modules/create-error-class/package.json
Adding metadata fields to: node_modules/cross-spawn/package.json
Adding metadata fields to: node_modules/crypto-random-string/package.json
Adding metadata fields to: node_modules/cycle/package.json
Adding metadata fields to: node_modules/dashdash/package.json
Adding metadata fields to: node_modules/dat-dns/package.json
Adding metadata fields to: node_modules/dat-doctor/package.json
Adding metadata fields to: node_modules/dat-encoding/package.json
Adding metadata fields to: node_modules/dat-ignore/package.json
Adding metadata fields to: node_modules/dat-json/package.json
Adding metadata fields to: node_modules/dat-link-resolve/package.json
Adding metadata fields to: node_modules/dat-log/package.json
Adding metadata fields to: node_modules/dat-log/node_modules/neat-log/package.json
Adding metadata fields to: node_modules/dat-node/package.json
Adding metadata fields to: node_modules/dat-registry/package.json
Adding metadata fields to: node_modules/dat-secret-storage/package.json
Adding metadata fields to: node_modules/dat-storage/package.json
Adding metadata fields to: node_modules/dat-swarm-defaults/package.json
Adding metadata fields to: node_modules/debug/package.json
Adding metadata fields to: node_modules/decode-uri-component/package.json
Adding metadata fields to: node_modules/decompress-response/package.json
Adding metadata fields to: node_modules/deep-equal/package.json
Adding metadata fields to: node_modules/deep-extend/package.json
Adding metadata fields to: node_modules/define-property/package.json
Adding metadata fields to: node_modules/delayed-stream/package.json
Adding metadata fields to: node_modules/diffy/package.json
Adding metadata fields to: node_modules/directory-index-html/package.json
Adding metadata fields to: node_modules/discovery-channel/package.json
Adding metadata fields to: node_modules/discovery-channel/node_modules/debug/package.json
Adding metadata fields to: node_modules/discovery-channel/node_modules/ms/package.json
Adding metadata fields to: node_modules/discovery-channel/node_modules/thunky/package.json
Adding metadata fields to: node_modules/discovery-swarm/package.json
Adding metadata fields to: node_modules/discovery-swarm/node_modules/utp-native/package.json
Adding metadata fields to: node_modules/dns-discovery/package.json
Adding metadata fields to: node_modules/dns-discovery/node_modules/debug/package.json
Adding metadata fields to: node_modules/dns-discovery/node_modules/lru/package.json
Adding metadata fields to: node_modules/dns-discovery/node_modules/ms/package.json
Adding metadata fields to: node_modules/dns-packet/package.json
Adding metadata fields to: node_modules/dns-socket/package.json
Adding metadata fields to: node_modules/dom-walk/package.json
Adding metadata fields to: node_modules/dot-prop/package.json
Adding metadata fields to: node_modules/duplexer3/package.json
Adding metadata fields to: node_modules/duplexify/package.json
Adding metadata fields to: node_modules/ecc-jsbn/package.json
Adding metadata fields to: node_modules/end-of-stream/package.json
Adding metadata fields to: node_modules/escape-string-regexp/package.json
Adding metadata fields to: node_modules/execa/package.json
Adding metadata fields to: node_modules/expand-brackets/package.json
Adding metadata fields to: node_modules/expand-brackets/node_modules/debug/package.json
Adding metadata fields to: node_modules/expand-brackets/node_modules/define-property/package.json
Adding metadata fields to: node_modules/expand-brackets/node_modules/extend-shallow/package.json
Adding metadata fields to: node_modules/expand-brackets/node_modules/is-accessor-descriptor/package.json
Adding metadata fields to: node_modules/expand-brackets/node_modules/is-accessor-descriptor/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/expand-brackets/node_modules/is-data-descriptor/package.json
Adding metadata fields to: node_modules/expand-brackets/node_modules/is-data-descriptor/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/expand-brackets/node_modules/is-descriptor/package.json
Adding metadata fields to: node_modules/expand-brackets/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/expand-brackets/node_modules/ms/package.json
Adding metadata fields to: node_modules/extend/package.json
Adding metadata fields to: node_modules/extend-shallow/package.json
Adding metadata fields to: node_modules/extend-shallow/node_modules/is-extendable/package.json
Adding metadata fields to: node_modules/extglob/package.json
Adding metadata fields to: node_modules/extglob/node_modules/define-property/package.json
Adding metadata fields to: node_modules/extglob/node_modules/extend-shallow/package.json
Adding metadata fields to: node_modules/extsprintf/package.json
Adding metadata fields to: node_modules/eyes/package.json
Adding metadata fields to: node_modules/fast-bitfield/package.json
Adding metadata fields to: node_modules/fast-deep-equal/package.json
Adding metadata fields to: node_modules/fast-json-stable-stringify/package.json
Adding metadata fields to: node_modules/fd-lock/package.json
Adding metadata fields to: node_modules/fd-lock/node_modules/napi-macros/package.json
Adding metadata fields to: node_modules/fd-read-stream/package.json
Adding metadata fields to: node_modules/figures/package.json
Adding metadata fields to: node_modules/fill-range/package.json
Adding metadata fields to: node_modules/fill-range/node_modules/extend-shallow/package.json
Adding metadata fields to: node_modules/flat-tree/package.json
Adding metadata fields to: node_modules/for-in/package.json
Adding metadata fields to: node_modules/forever-agent/package.json
Adding metadata fields to: node_modules/form-data/package.json
Adding metadata fields to: node_modules/fragment-cache/package.json
Adding metadata fields to: node_modules/from2/package.json
Adding metadata fields to: node_modules/fs.realpath/package.json
Adding metadata fields to: node_modules/get-stream/package.json
Adding metadata fields to: node_modules/get-value/package.json
Adding metadata fields to: node_modules/getpass/package.json
Adding metadata fields to: node_modules/glob/package.json
Adding metadata fields to: node_modules/global/package.json
Adding metadata fields to: node_modules/global-dirs/package.json
Adding metadata fields to: node_modules/got/package.json
Adding metadata fields to: node_modules/graceful-fs/package.json
Adding metadata fields to: node_modules/har-schema/package.json
Adding metadata fields to: node_modules/har-validator/package.json
Adding metadata fields to: node_modules/has-flag/package.json
Adding metadata fields to: node_modules/has-value/package.json
Adding metadata fields to: node_modules/has-values/package.json
Adding metadata fields to: node_modules/has-values/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/http-methods/package.json
Adding metadata fields to: node_modules/http-signature/package.json
Adding metadata fields to: node_modules/hypercore/package.json
Adding metadata fields to: node_modules/hypercore/node_modules/codecs/package.json
Adding metadata fields to: node_modules/hypercore/node_modules/unordered-set/package.json
Adding metadata fields to: node_modules/hypercore-crypto/package.json
Adding metadata fields to: node_modules/hypercore-protocol/package.json
Adding metadata fields to: node_modules/hypercore-protocol/node_modules/varint/package.json
Adding metadata fields to: node_modules/hyperdrive/package.json
Adding metadata fields to: node_modules/hyperdrive-http/package.json
Adding metadata fields to: node_modules/hyperdrive-network-speed/package.json
Adding metadata fields to: node_modules/hyperdrive-network-speed/node_modules/debug/package.json
Adding metadata fields to: node_modules/i/package.json
Adding metadata fields to: node_modules/import-lazy/package.json
Adding metadata fields to: node_modules/imurmurhash/package.json
Adding metadata fields to: node_modules/inflight/package.json
Adding metadata fields to: node_modules/inherits/package.json
Adding metadata fields to: node_modules/ini/package.json
Adding metadata fields to: node_modules/inspect-custom-symbol/package.json
Adding metadata fields to: node_modules/ip/package.json
Adding metadata fields to: node_modules/is-accessor-descriptor/package.json
Adding metadata fields to: node_modules/is-buffer/package.json
Adding metadata fields to: node_modules/is-ci/package.json
Adding metadata fields to: node_modules/is-data-descriptor/package.json
Adding metadata fields to: node_modules/is-descriptor/package.json
Adding metadata fields to: node_modules/is-extendable/package.json
Adding metadata fields to: node_modules/is-fullwidth-code-point/package.json
Adding metadata fields to: node_modules/is-function/package.json
Adding metadata fields to: node_modules/is-installed-globally/package.json
Adding metadata fields to: node_modules/is-npm/package.json
Adding metadata fields to: node_modules/is-number/package.json
Adding metadata fields to: node_modules/is-number/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/is-obj/package.json
Adding metadata fields to: node_modules/is-options/package.json
Adding metadata fields to: node_modules/is-path-inside/package.json
Adding metadata fields to: node_modules/is-plain-object/package.json
Adding metadata fields to: node_modules/is-redirect/package.json
Adding metadata fields to: node_modules/is-retry-allowed/package.json
Adding metadata fields to: node_modules/is-stream/package.json
Adding metadata fields to: node_modules/is-string/package.json
Adding metadata fields to: node_modules/is-typedarray/package.json
Adding metadata fields to: node_modules/is-windows/package.json
Adding metadata fields to: node_modules/isarray/package.json
Adding metadata fields to: node_modules/isexe/package.json
Adding metadata fields to: node_modules/isobject/package.json
Adding metadata fields to: node_modules/isstream/package.json
Adding metadata fields to: node_modules/iterators/package.json
Adding metadata fields to: node_modules/jsbn/package.json
Adding metadata fields to: node_modules/json-schema/package.json
Adding metadata fields to: node_modules/json-schema-traverse/package.json
Adding metadata fields to: node_modules/json-stringify-safe/package.json
Adding metadata fields to: node_modules/jsprim/package.json
Adding metadata fields to: node_modules/k-bucket/package.json
Adding metadata fields to: node_modules/k-rpc/package.json
Adding metadata fields to: node_modules/k-rpc/node_modules/k-bucket/package.json
Adding metadata fields to: node_modules/k-rpc-socket/package.json
Adding metadata fields to: node_modules/k-rpc-socket/node_modules/bencode/package.json
Adding metadata fields to: node_modules/keypress/package.json
Adding metadata fields to: node_modules/kind-of/package.json
Adding metadata fields to: node_modules/last-one-wins/package.json
Adding metadata fields to: node_modules/latest-version/package.json
Adding metadata fields to: node_modules/length-prefixed-message/package.json
Adding metadata fields to: node_modules/lodash.throttle/package.json
Adding metadata fields to: node_modules/lowercase-keys/package.json
Adding metadata fields to: node_modules/lru/package.json
Adding metadata fields to: node_modules/lru-cache/package.json
Adding metadata fields to: node_modules/make-dir/package.json
Adding metadata fields to: node_modules/map-cache/package.json
Adding metadata fields to: node_modules/map-visit/package.json
Adding metadata fields to: node_modules/memory-pager/package.json
Adding metadata fields to: node_modules/menu-string/package.json
Adding metadata fields to: node_modules/merkle-tree-stream/package.json
Adding metadata fields to: node_modules/micromatch/package.json
Adding metadata fields to: node_modules/mime/package.json
Adding metadata fields to: node_modules/mime-db/package.json
Adding metadata fields to: node_modules/mime-types/package.json
Adding metadata fields to: node_modules/mimic-response/package.json
Adding metadata fields to: node_modules/min-document/package.json
Adding metadata fields to: node_modules/minimatch/package.json
Adding metadata fields to: node_modules/minimist/package.json
Adding metadata fields to: node_modules/mirror-folder/package.json
Adding metadata fields to: node_modules/mixin-deep/package.json
Adding metadata fields to: node_modules/mixin-deep/node_modules/is-extendable/package.json
Adding metadata fields to: node_modules/mkdirp/package.json
Adding metadata fields to: node_modules/mkdirp/node_modules/minimist/package.json
Adding metadata fields to: node_modules/ms/package.json
Adding metadata fields to: node_modules/multi-random-access/package.json
Adding metadata fields to: node_modules/multicast-dns/package.json
Adding metadata fields to: node_modules/multistream/package.json
Adding metadata fields to: node_modules/mute-stream/package.json
Adding metadata fields to: node_modules/mutexify/package.json
Adding metadata fields to: node_modules/nan/package.json
Adding metadata fields to: node_modules/nanoassert/package.json
Adding metadata fields to: node_modules/nanobus/package.json
Adding metadata fields to: node_modules/nanoguard/package.json
Adding metadata fields to: node_modules/nanomatch/package.json
Adding metadata fields to: node_modules/nanoscheduler/package.json
Adding metadata fields to: node_modules/nanotiming/package.json
Adding metadata fields to: node_modules/napi-macros/package.json
Adding metadata fields to: node_modules/ncp/package.json
Adding metadata fields to: node_modules/neat-input/package.json
Adding metadata fields to: node_modules/neat-log/package.json
Adding metadata fields to: node_modules/neat-spinner/package.json
Adding metadata fields to: node_modules/neat-tasks/package.json
Adding metadata fields to: node_modules/nets/package.json
Adding metadata fields to: node_modules/network-address/package.json
Adding metadata fields to: node_modules/node-gyp-build/package.json
Adding metadata fields to: node_modules/normalize-path/package.json
Adding metadata fields to: node_modules/npm-run-path/package.json
Adding metadata fields to: node_modules/oauth-sign/package.json
Adding metadata fields to: node_modules/object-copy/package.json
Adding metadata fields to: node_modules/object-copy/node_modules/define-property/package.json
Adding metadata fields to: node_modules/object-copy/node_modules/is-accessor-descriptor/package.json
Adding metadata fields to: node_modules/object-copy/node_modules/is-data-descriptor/package.json
Adding metadata fields to: node_modules/object-copy/node_modules/is-descriptor/package.json
Adding metadata fields to: node_modules/object-copy/node_modules/is-descriptor/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/object-copy/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/object-visit/package.json
Adding metadata fields to: node_modules/object.pick/package.json
Adding metadata fields to: node_modules/once/package.json
Adding metadata fields to: node_modules/os-homedir/package.json
Adding metadata fields to: node_modules/p-finally/package.json
Adding metadata fields to: node_modules/package-json/package.json
Adding metadata fields to: node_modules/parse-headers/package.json
Adding metadata fields to: node_modules/pascalcase/package.json
Adding metadata fields to: node_modules/path-is-absolute/package.json
Adding metadata fields to: node_modules/path-is-inside/package.json
Adding metadata fields to: node_modules/path-key/package.json
Adding metadata fields to: node_modules/performance-now/package.json
Adding metadata fields to: node_modules/pify/package.json
Adding metadata fields to: node_modules/pkginfo/package.json
Adding metadata fields to: node_modules/posix-character-classes/package.json
Adding metadata fields to: node_modules/prepend-http/package.json
Adding metadata fields to: node_modules/prettier-bytes/package.json
Adding metadata fields to: node_modules/pretty-hash/package.json
Adding metadata fields to: node_modules/process/package.json
Adding metadata fields to: node_modules/process-nextick-args/package.json
Adding metadata fields to: node_modules/progress-string/package.json
Adding metadata fields to: node_modules/prompt/package.json
Adding metadata fields to: node_modules/protocol-buffers-encodings/package.json
Adding metadata fields to: node_modules/protocol-buffers-encodings/node_modules/varint/package.json
Adding metadata fields to: node_modules/pseudomap/package.json
Adding metadata fields to: node_modules/psl/package.json
Adding metadata fields to: node_modules/pump/package.json
Adding metadata fields to: node_modules/punycode/package.json
Adding metadata fields to: node_modules/qs/package.json
Adding metadata fields to: node_modules/random-access-file/package.json
Adding metadata fields to: node_modules/random-access-memory/package.json
Adding metadata fields to: node_modules/random-access-storage/package.json
Adding metadata fields to: node_modules/randombytes/package.json
Adding metadata fields to: node_modules/range-parser/package.json
Adding metadata fields to: node_modules/rc/package.json
Adding metadata fields to: node_modules/read/package.json
Adding metadata fields to: node_modules/readable-stream/package.json
Adding metadata fields to: node_modules/readable-stream/node_modules/safe-buffer/package.json
Adding metadata fields to: node_modules/recursive-watch/package.json
Adding metadata fields to: node_modules/regex-not/package.json
Adding metadata fields to: node_modules/registry-auth-token/package.json
Adding metadata fields to: node_modules/registry-url/package.json
Adding metadata fields to: node_modules/remove-array-items/package.json
Adding metadata fields to: node_modules/remove-trailing-separator/package.json
Adding metadata fields to: node_modules/repeat-element/package.json
Adding metadata fields to: node_modules/repeat-string/package.json
Adding metadata fields to: node_modules/request/package.json
Adding metadata fields to: node_modules/resolve-url/package.json
Adding metadata fields to: node_modules/ret/package.json
Adding metadata fields to: node_modules/revalidator/package.json
Adding metadata fields to: node_modules/rimraf/package.json
Adding metadata fields to: node_modules/run-series/package.json
Adding metadata fields to: node_modules/rusha/package.json
Adding metadata fields to: node_modules/safe-buffer/package.json
Adding metadata fields to: node_modules/safe-regex/package.json
Adding metadata fields to: node_modules/safer-buffer/package.json
Adding metadata fields to: node_modules/semver/package.json
Adding metadata fields to: node_modules/semver-diff/package.json
Adding metadata fields to: node_modules/set-value/package.json
Adding metadata fields to: node_modules/set-value/node_modules/extend-shallow/package.json
Adding metadata fields to: node_modules/shebang-command/package.json
Adding metadata fields to: node_modules/shebang-regex/package.json
Adding metadata fields to: node_modules/signal-exit/package.json
Adding metadata fields to: node_modules/signed-varint/package.json
Adding metadata fields to: node_modules/signed-varint/node_modules/varint/package.json
Adding metadata fields to: node_modules/simple-concat/package.json
Adding metadata fields to: node_modules/simple-get/package.json
Adding metadata fields to: node_modules/simple-sha1/package.json
Adding metadata fields to: node_modules/siphash24/package.json
Adding metadata fields to: node_modules/slice-ansi/package.json
Adding metadata fields to: node_modules/snapdragon/package.json
Adding metadata fields to: node_modules/snapdragon/node_modules/debug/package.json
Adding metadata fields to: node_modules/snapdragon/node_modules/define-property/package.json
Adding metadata fields to: node_modules/snapdragon/node_modules/extend-shallow/package.json
Adding metadata fields to: node_modules/snapdragon/node_modules/is-accessor-descriptor/package.json
Adding metadata fields to: node_modules/snapdragon/node_modules/is-accessor-descriptor/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/snapdragon/node_modules/is-data-descriptor/package.json
Adding metadata fields to: node_modules/snapdragon/node_modules/is-data-descriptor/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/snapdragon/node_modules/is-descriptor/package.json
Adding metadata fields to: node_modules/snapdragon/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/snapdragon/node_modules/ms/package.json
Adding metadata fields to: node_modules/snapdragon-node/package.json
Adding metadata fields to: node_modules/snapdragon-node/node_modules/define-property/package.json
Adding metadata fields to: node_modules/snapdragon-util/package.json
Adding metadata fields to: node_modules/snapdragon-util/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/sodium-javascript/package.json
Adding metadata fields to: node_modules/sodium-native/package.json
Adding metadata fields to: node_modules/sodium-native/node_modules/node-gyp-build/package.json
Adding metadata fields to: node_modules/sodium-universal/package.json
Adding metadata fields to: node_modules/sorted-array-functions/package.json
Adding metadata fields to: node_modules/sorted-indexof/package.json
Adding metadata fields to: node_modules/source-map/package.json
Adding metadata fields to: node_modules/source-map-resolve/package.json
Adding metadata fields to: node_modules/source-map-url/package.json
Adding metadata fields to: node_modules/sparse-bitfield/package.json
Adding metadata fields to: node_modules/speedometer/package.json
Adding metadata fields to: node_modules/split-string/package.json
Adding metadata fields to: node_modules/sshpk/package.json
Adding metadata fields to: node_modules/stack-trace/package.json
Adding metadata fields to: node_modules/static-extend/package.json
Adding metadata fields to: node_modules/static-extend/node_modules/define-property/package.json
Adding metadata fields to: node_modules/static-extend/node_modules/is-accessor-descriptor/package.json
Adding metadata fields to: node_modules/static-extend/node_modules/is-accessor-descriptor/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/static-extend/node_modules/is-data-descriptor/package.json
Adding metadata fields to: node_modules/static-extend/node_modules/is-data-descriptor/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/static-extend/node_modules/is-descriptor/package.json
Adding metadata fields to: node_modules/static-extend/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/stream-collector/package.json
Adding metadata fields to: node_modules/stream-each/package.json
Adding metadata fields to: node_modules/stream-parser/package.json
Adding metadata fields to: node_modules/stream-parser/node_modules/debug/package.json
Adding metadata fields to: node_modules/stream-parser/node_modules/ms/package.json
Adding metadata fields to: node_modules/stream-shift/package.json
Adding metadata fields to: node_modules/string-width/package.json
Adding metadata fields to: node_modules/string_decoder/package.json
Adding metadata fields to: node_modules/string_decoder/node_modules/safe-buffer/package.json
Adding metadata fields to: node_modules/strip-ansi/package.json
Adding metadata fields to: node_modules/strip-eof/package.json
Adding metadata fields to: node_modules/strip-json-comments/package.json
Adding metadata fields to: node_modules/subcommand/package.json
Adding metadata fields to: node_modules/supports-color/package.json
Adding metadata fields to: node_modules/term-size/package.json
Adding metadata fields to: node_modules/throttle/package.json
Adding metadata fields to: node_modules/thunky/package.json
Adding metadata fields to: node_modules/timed-out/package.json
Adding metadata fields to: node_modules/timeout-refresh/package.json
Adding metadata fields to: node_modules/to-buffer/package.json
Adding metadata fields to: node_modules/to-object-path/package.json
Adding metadata fields to: node_modules/to-object-path/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/to-regex/package.json
Adding metadata fields to: node_modules/to-regex-range/package.json
Adding metadata fields to: node_modules/toiletdb/package.json
Adding metadata fields to: node_modules/toiletdb/node_modules/debug/package.json
Adding metadata fields to: node_modules/toiletdb/node_modules/ms/package.json
Adding metadata fields to: node_modules/tough-cookie/package.json
Adding metadata fields to: node_modules/tough-cookie/node_modules/punycode/package.json
Adding metadata fields to: node_modules/township-client/package.json
Adding metadata fields to: node_modules/township-client/node_modules/is-number/package.json
Adding metadata fields to: node_modules/township-client/node_modules/kind-of/package.json
Adding metadata fields to: node_modules/ttl/package.json
Adding metadata fields to: node_modules/tunnel-agent/package.json
Adding metadata fields to: node_modules/tweetnacl/package.json
Adding metadata fields to: node_modules/typedarray/package.json
Adding metadata fields to: node_modules/uint64be/package.json
Adding metadata fields to: node_modules/union-value/package.json
Adding metadata fields to: node_modules/unique-string/package.json
Adding metadata fields to: node_modules/unixify/package.json
Adding metadata fields to: node_modules/unordered-array-remove/package.json
Adding metadata fields to: node_modules/unordered-set/package.json
Adding metadata fields to: node_modules/unset-value/package.json
Adding metadata fields to: node_modules/unset-value/node_modules/has-value/package.json
Adding metadata fields to: node_modules/unset-value/node_modules/has-value/node_modules/isobject/package.json
Adding metadata fields to: node_modules/unset-value/node_modules/has-values/package.json
Adding metadata fields to: node_modules/untildify/package.json
Adding metadata fields to: node_modules/unzip-response/package.json
Adding metadata fields to: node_modules/update-notifier/package.json
Adding metadata fields to: node_modules/uri-js/package.json
Adding metadata fields to: node_modules/urix/package.json
Adding metadata fields to: node_modules/url-parse-lax/package.json
Adding metadata fields to: node_modules/use/package.json
Adding metadata fields to: node_modules/util-deprecate/package.json
Adding metadata fields to: node_modules/utile/package.json
Adding metadata fields to: node_modules/utp-native/package.json
Adding metadata fields to: node_modules/utp-native/node_modules/node-gyp-build/package.json
Adding metadata fields to: node_modules/utp-native/node_modules/readable-stream/package.json
Adding metadata fields to: node_modules/utp-native/node_modules/unordered-set/package.json
Adding metadata fields to: node_modules/uuid/package.json
Adding metadata fields to: node_modules/varint/package.json
Adding metadata fields to: node_modules/verror/package.json
Adding metadata fields to: node_modules/which/package.json
Adding metadata fields to: node_modules/widest-line/package.json
Adding metadata fields to: node_modules/winston/package.json
Adding metadata fields to: node_modules/winston/node_modules/async/package.json
Adding metadata fields to: node_modules/winston/node_modules/colors/package.json
Adding metadata fields to: node_modules/winston/node_modules/pkginfo/package.json
Adding metadata fields to: node_modules/wrappy/package.json
Adding metadata fields to: node_modules/write-file-atomic/package.json
Adding metadata fields to: node_modules/xdg-basedir/package.json
Adding metadata fields to: node_modules/xhr/package.json
Adding metadata fields to: node_modules/xsalsa20/package.json
Adding metadata fields to: node_modules/xtend/package.json
Adding metadata fields to: node_modules/yallist/package.json

> utp-native@1.7.3 install /nix/store/f3z7yqigrvp7lzvqfrd5jpyrcydhnj87-node_dat-13.13.1/lib/node_modules/dat/node_modules/discovery-swarm/node_modules/utp-native
> node-gyp-build

make: Entering directory '/nix/store/f3z7yqigrvp7lzvqfrd5jpyrcydhnj87-node_dat-13.13.1/lib/node_modules/dat/node_modules/discovery-swarm/node_modules/utp-native/build'
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_internal.o
../deps/libutp/utp_internal.cpp: In function 'size_t utp_process_incoming(UTPSocket*, const byte*, size_t, bool)':
../deps/libutp/utp_internal.cpp:1970:34: warning: comparison of integer expressions of different signedness: 'int' and 'uint32' {aka 'unsigned int'} [-Wsign-compare]
   if (conn->mtu_probe_seq && seq == conn->mtu_probe_seq) {
                              ~~~~^~~~~~~~~~~~~~~~~~~~~~
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_utils.o
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_hash.o
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_callbacks.o
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_api.o
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_packedsockaddr.o
  AR(target) Release/obj.target/deps/utp.a
  COPY Release/utp.a
  CXX(target) Release/obj.target/utp/src/utp_uv.o
In file included from ../src/utp_uv.cc:2:
../../../../nan/nan.h: In function 'void Nan::AsyncQueueWorker(Nan::AsyncWorker*)':
../../../../nan/nan.h:2298:62: warning: cast between incompatible function types from 'void (*)(uv_work_t*)' {aka 'void (*)(uv_work_s*)'} to 'uv_after_work_cb' {aka 'void (*)(uv_work_s*, int)'} [-Wcast-function-type]
     , reinterpret_cast<uv_after_work_cb>(AsyncExecuteComplete)
                                                              ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_uv.cc:2:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h: In instantiation of 'void v8::PersistentBase<T>::SetWeak(P*, typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType) [with P = node::ObjectWrap; T = v8::Object; typename v8::WeakCallbackInfo<P>::Callback = void (*)(const v8::WeakCallbackInfo<node::ObjectWrap>&)]':
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node_object_wrap.h:84:78:   required from here
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:9502:16: warning: cast between incompatible function types from 'v8::WeakCallbackInfo<node::ObjectWrap>::Callback' {aka 'void (*)(const v8::WeakCallbackInfo<node::ObjectWrap>&)'} to 'Callback' {aka 'void (*)(const v8::WeakCallbackInfo<void>&)'} [-Wcast-function-type]
                reinterpret_cast<Callback>(callback), type);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h: In instantiation of 'void v8::PersistentBase<T>::SetWeak(P*, typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType) [with P = Nan::ObjectWrap; T = v8::Object; typename v8::WeakCallbackInfo<P>::Callback = void (*)(const v8::WeakCallbackInfo<Nan::ObjectWrap>&)]':
../../../../nan/nan_object_wrap.h:65:61:   required from here
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:9502:16: warning: cast between incompatible function types from 'v8::WeakCallbackInfo<Nan::ObjectWrap>::Callback' {aka 'void (*)(const v8::WeakCallbackInfo<Nan::ObjectWrap>&)'} to 'Callback' {aka 'void (*)(const v8::WeakCallbackInfo<void>&)'} [-Wcast-function-type]
../src/utp_uv.cc: At global scope:
../src/utp_uv.cc:219:1: warning: 'uint64 on_utp_schedule_ack(utp_callback_arguments*)' defined but not used [-Wunused-function]
 on_utp_schedule_ack (utp_callback_arguments *a) {
 ^~~~~~~~~~~~~~~~~~~
  CXX(target) Release/obj.target/utp/src/socket_wrap.o
In file included from ../src/socket_wrap.h:4,
                 from ../src/socket_wrap.cc:1:
../../../../nan/nan.h: In function 'void Nan::AsyncQueueWorker(Nan::AsyncWorker*)':
../../../../nan/nan.h:2298:62: warning: cast between incompatible function types from 'void (*)(uv_work_t*)' {aka 'void (*)(uv_work_s*)'} to 'uv_after_work_cb' {aka 'void (*)(uv_work_s*, int)'} [-Wcast-function-type]
     , reinterpret_cast<uv_after_work_cb>(AsyncExecuteComplete)
                                                              ^
../src/socket_wrap.cc: In member function 'int SocketWrap::Drain()':
../src/socket_wrap.cc:69:40: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
       this->on_drain->Call(ctx, 0, NULL);
                                        ^
In file included from ../src/socket_wrap.h:4,
                 from ../src/socket_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/socket_wrap.cc: In static member function 'static Nan::NAN_METHOD_RETURN_TYPE SocketWrap::Context(Nan::NAN_METHOD_ARGS_TYPE)':
../src/socket_wrap.cc:99:45: warning: 'v8::Local<v8::Object> v8::Value::ToObject() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   Local<Object> context = info[0]->ToObject();
                                             ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/socket_wrap.h:4,
                 from ../src/socket_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:10046:15: note: declared here
 Local<Object> Value::ToObject() const {
               ^~~~~
../src/socket_wrap.cc: In static member function 'static Nan::NAN_METHOD_RETURN_TYPE SocketWrap::Write(Nan::NAN_METHOD_ARGS_TYPE)':
../src/socket_wrap.cc:113:43: warning: 'v8::Local<v8::Object> v8::Value::ToObject() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   Local<Value> buffer = info[0]->ToObject();
                                           ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/socket_wrap.h:4,
                 from ../src/socket_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:10046:15: note: declared here
 Local<Object> Value::ToObject() const {
               ^~~~~
../src/socket_wrap.cc: In static member function 'static Nan::NAN_METHOD_RETURN_TYPE SocketWrap::Writev(Nan::NAN_METHOD_ARGS_TYPE)':
../src/socket_wrap.cc:141:61: warning: 'v8::Local<v8::Object> v8::Value::ToObject() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
     Local<Value> buffer = Nan::Get(writes->Get(i)->ToObject(), chunk).ToLocalChecked();
                                                             ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/socket_wrap.h:4,
                 from ../src/socket_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:10046:15: note: declared here
 Local<Object> Value::ToObject() const {
               ^~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h: In instantiation of 'void v8::PersistentBase<T>::SetWeak(P*, typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType) [with P = node::ObjectWrap; T = v8::Object; typename v8::WeakCallbackInfo<P>::Callback = void (*)(const v8::WeakCallbackInfo<node::ObjectWrap>&)]':
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node_object_wrap.h:84:78:   required from here
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:9502:16: warning: cast between incompatible function types from 'v8::WeakCallbackInfo<node::ObjectWrap>::Callback' {aka 'void (*)(const v8::WeakCallbackInfo<node::ObjectWrap>&)'} to 'Callback' {aka 'void (*)(const v8::WeakCallbackInfo<void>&)'} [-Wcast-function-type]
                reinterpret_cast<Callback>(callback), type);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h: In instantiation of 'void v8::PersistentBase<T>::SetWeak(P*, typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType) [with P = Nan::ObjectWrap; T = v8::Object; typename v8::WeakCallbackInfo<P>::Callback = void (*)(const v8::WeakCallbackInfo<Nan::ObjectWrap>&)]':
../../../../nan/nan_object_wrap.h:65:61:   required from here
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:9502:16: warning: cast between incompatible function types from 'v8::WeakCallbackInfo<Nan::ObjectWrap>::Callback' {aka 'void (*)(const v8::WeakCallbackInfo<Nan::ObjectWrap>&)'} to 'Callback' {aka 'void (*)(const v8::WeakCallbackInfo<void>&)'} [-Wcast-function-type]
  CXX(target) Release/obj.target/utp/src/utp_wrap.o
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h: In function 'void Nan::AsyncQueueWorker(Nan::AsyncWorker*)':
../../../../nan/nan.h:2298:62: warning: cast between incompatible function types from 'void (*)(uv_work_t*)' {aka 'void (*)(uv_work_s*)'} to 'uv_after_work_cb' {aka 'void (*)(uv_work_s*, int)'} [-Wcast-function-type]
     , reinterpret_cast<uv_after_work_cb>(AsyncExecuteComplete)
                                                              ^
../src/utp_wrap.cc: In function 'void callback_on_message(utp_uv_t*, char*, size_t, int, char*)':
../src/utp_wrap.cc:25:38: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
   wrap->on_message->Call(ctx, 2, argv);
                                      ^
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/utp_wrap.cc: In function 'void callback_on_send(utp_uv_t*, uv_udp_send_t*, int)':
../src/utp_wrap.cc:39:35: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
   wrap->on_send->Call(ctx, 2, argv);
                                   ^
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/utp_wrap.cc: In function 'void callback_on_close(utp_uv_t*)':
../src/utp_wrap.cc:49:36: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
   wrap->on_close->Call(ctx, 0, NULL);
                                    ^
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/utp_wrap.cc: In function 'void callback_on_error(utp_uv_t*)':
../src/utp_wrap.cc:59:36: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
   wrap->on_error->Call(ctx, 0, NULL);
                                    ^
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/utp_wrap.cc: In function 'void callback_on_socket_read(utp_uv_t*, utp_socket*, char*, size_t)':
../src/utp_wrap.cc:72:35: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
   wrap->on_data->Call(ctx, 1, argv);
                                   ^
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/utp_wrap.cc: In function 'void callback_on_socket_end(utp_uv_t*, utp_socket*)':
../src/utp_wrap.cc:86:34: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
   wrap->on_end->Call(ctx, 0, NULL);
                                  ^
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/utp_wrap.cc: In function 'void callback_on_socket_error(utp_uv_t*, utp_socket*, int)':
../src/utp_wrap.cc:107:36: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
   wrap->on_error->Call(ctx, 1, argv);
                                    ^
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/utp_wrap.cc: In function 'void callback_on_socket_close(utp_uv_t*, utp_socket*)':
../src/utp_wrap.cc:117:36: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
   wrap->on_close->Call(ctx, 0, NULL);
                                    ^
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/utp_wrap.cc: In function 'void callback_on_socket_connect(utp_uv_t*, utp_socket*)':
../src/utp_wrap.cc:129:38: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
   wrap->on_connect->Call(ctx, 0, NULL);
                                      ^
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/utp_wrap.cc: In function 'void callback_on_socket(utp_uv_t*, utp_socket*)':
../src/utp_wrap.cc:144:89: warning: 'v8::Local<v8::Object> v8::Value::ToObject() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   SocketWrap *socket_unwrap = Nan::ObjectWrap::Unwrap<SocketWrap>(socket_wrap->ToObject());
                                                                                         ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:10046:15: note: declared here
 Local<Object> Value::ToObject() const {
               ^~~~~
../src/utp_wrap.cc:149:37: warning: 'v8::Local<v8::Value> Nan::Callback::Call(v8::Local<v8::Object>, int, v8::Local<v8::Value>*) const' is deprecated [-Wdeprecated-declarations]
   wrap->on_socket->Call(ctx, 1, argv);
                                     ^
In file included from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
../../../../nan/nan.h:1718:3: note: declared here
   Call(v8::Local<v8::Object> target
   ^~~~
../src/utp_wrap.cc: In static member function 'static Nan::NAN_METHOD_RETURN_TYPE UTPWrap::Bind(Nan::NAN_METHOD_ARGS_TYPE)':
../src/utp_wrap.cc:205:35: warning: 'uint32_t v8::Value::Uint32Value() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   int port = info[0]->Uint32Value();
                                   ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:26,
                 from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:2477:47: note: declared here
   V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
                                               ^~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8config.h:324:3: note: in definition of macro 'V8_DEPRECATED'
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/utp_wrap.cc: In static member function 'static Nan::NAN_METHOD_RETURN_TYPE UTPWrap::Context(Nan::NAN_METHOD_ARGS_TYPE)':
../src/utp_wrap.cc:218:45: warning: 'v8::Local<v8::Object> v8::Value::ToObject() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   Local<Object> context = info[0]->ToObject();
                                             ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:10046:15: note: declared here
 Local<Object> Value::ToObject() const {
               ^~~~~
../src/utp_wrap.cc: In static member function 'static Nan::NAN_METHOD_RETURN_TYPE UTPWrap::MaxSockets(Nan::NAN_METHOD_ARGS_TYPE)':
../src/utp_wrap.cc:250:55: warning: 'uint32_t v8::Value::Uint32Value() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   handle->max_sockets = (size_t) info[0]->Uint32Value();
                                                       ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:26,
                 from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:2477:47: note: declared here
   V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
                                               ^~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8config.h:324:3: note: in definition of macro 'V8_DEPRECATED'
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/utp_wrap.cc: In static member function 'static Nan::NAN_METHOD_RETURN_TYPE UTPWrap::Send(Nan::NAN_METHOD_ARGS_TYPE)':
../src/utp_wrap.cc:257:45: warning: 'uint32_t v8::Value::Uint32Value() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   size_t id = (size_t) info[0]->Uint32Value();
                                             ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:26,
                 from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:2477:47: note: declared here
   V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
                                               ^~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8config.h:324:3: note: in definition of macro 'V8_DEPRECATED'
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/utp_wrap.cc:259:44: warning: 'v8::Local<v8::Object> v8::Value::ToObject() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   Local<Object> buffer = info[1]->ToObject();
                                            ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:10046:15: note: declared here
 Local<Object> Value::ToObject() const {
               ^~~~~
../src/utp_wrap.cc:260:37: warning: 'uint32_t v8::Value::Uint32Value() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   int offset = info[2]->Uint32Value();
                                     ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:26,
                 from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:2477:47: note: declared here
   V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
                                               ^~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8config.h:324:3: note: in definition of macro 'V8_DEPRECATED'
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/utp_wrap.cc:261:34: warning: 'uint32_t v8::Value::Uint32Value() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   int len = info[3]->Uint32Value();
                                  ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:26,
                 from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:2477:47: note: declared here
   V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
                                               ^~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8config.h:324:3: note: in definition of macro 'V8_DEPRECATED'
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/utp_wrap.cc:262:35: warning: 'uint32_t v8::Value::Uint32Value() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   int port = info[4]->Uint32Value();
                                   ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:26,
                 from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:2477:47: note: declared here
   V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
                                               ^~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8config.h:324:3: note: in definition of macro 'V8_DEPRECATED'
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/utp_wrap.cc: In static member function 'static Nan::NAN_METHOD_RETURN_TYPE UTPWrap::Connect(Nan::NAN_METHOD_ARGS_TYPE)':
../src/utp_wrap.cc:284:35: warning: 'uint32_t v8::Value::Uint32Value() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   int port = info[0]->Uint32Value();
                                   ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:26,
                 from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:2477:47: note: declared here
   V8_DEPRECATED("Use maybe version", uint32_t Uint32Value() const);
                                               ^~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8config.h:324:3: note: in definition of macro 'V8_DEPRECATED'
   declarator __attribute__((deprecated(message)))
   ^~~~~~~~~~
../src/utp_wrap.cc:296:89: warning: 'v8::Local<v8::Object> v8::Value::ToObject() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
   SocketWrap *socket_unwrap = Nan::ObjectWrap::Unwrap<SocketWrap>(socket_wrap->ToObject());
                                                                                         ^
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../src/utp_wrap.h:4,
                 from ../src/utp_wrap.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:10046:15: note: declared here
 Local<Object> Value::ToObject() const {
               ^~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h: In instantiation of 'void v8::PersistentBase<T>::SetWeak(P*, typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType) [with P = node::ObjectWrap; T = v8::Object; typename v8::WeakCallbackInfo<P>::Callback = void (*)(const v8::WeakCallbackInfo<node::ObjectWrap>&)]':
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node_object_wrap.h:84:78:   required from here
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:9502:16: warning: cast between incompatible function types from 'v8::WeakCallbackInfo<node::ObjectWrap>::Callback' {aka 'void (*)(const v8::WeakCallbackInfo<node::ObjectWrap>&)'} to 'Callback' {aka 'void (*)(const v8::WeakCallbackInfo<void>&)'} [-Wcast-function-type]
                reinterpret_cast<Callback>(callback), type);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h: In instantiation of 'void v8::PersistentBase<T>::SetWeak(P*, typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType) [with P = Nan::ObjectWrap; T = v8::Object; typename v8::WeakCallbackInfo<P>::Callback = void (*)(const v8::WeakCallbackInfo<Nan::ObjectWrap>&)]':
../../../../nan/nan_object_wrap.h:65:61:   required from here
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:9502:16: warning: cast between incompatible function types from 'v8::WeakCallbackInfo<Nan::ObjectWrap>::Callback' {aka 'void (*)(const v8::WeakCallbackInfo<Nan::ObjectWrap>&)'} to 'Callback' {aka 'void (*)(const v8::WeakCallbackInfo<void>&)'} [-Wcast-function-type]
  CXX(target) Release/obj.target/utp/binding.o
In file included from ../binding.cc:1:
../../../../nan/nan.h: In function 'void Nan::AsyncQueueWorker(Nan::AsyncWorker*)':
../../../../nan/nan.h:2298:62: warning: cast between incompatible function types from 'void (*)(uv_work_t*)' {aka 'void (*)(uv_work_s*)'} to 'uv_after_work_cb' {aka 'void (*)(uv_work_s*, int)'} [-Wcast-function-type]
     , reinterpret_cast<uv_after_work_cb>(AsyncExecuteComplete)
                                                              ^
In file included from ../../../../nan/nan.h:54,
                 from ../binding.cc:1:
../binding.cc: At global scope:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:573:43: warning: cast between incompatible function types from 'void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)' {aka 'void (*)(v8::Local<v8::Object>)'} to 'node::addon_register_func' {aka 'void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)'} [-Wcast-function-type]
       (node::addon_register_func) (regfunc),                          \
                                           ^
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:607:3: note: in expansion of macro 'NODE_MODULE_X'
   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
   ^~~~~~~~~~~~~
../binding.cc:15:1: note: in expansion of macro 'NODE_MODULE'
 NODE_MODULE(utp, InitAll)
 ^~~~~~~~~~~
In file included from /nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node.h:63,
                 from ../../../../nan/nan.h:54,
                 from ../binding.cc:1:
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h: In instantiation of 'void v8::PersistentBase<T>::SetWeak(P*, typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType) [with P = node::ObjectWrap; T = v8::Object; typename v8::WeakCallbackInfo<P>::Callback = void (*)(const v8::WeakCallbackInfo<node::ObjectWrap>&)]':
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/src/node_object_wrap.h:84:78:   required from here
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:9502:16: warning: cast between incompatible function types from 'v8::WeakCallbackInfo<node::ObjectWrap>::Callback' {aka 'void (*)(const v8::WeakCallbackInfo<node::ObjectWrap>&)'} to 'Callback' {aka 'void (*)(const v8::WeakCallbackInfo<void>&)'} [-Wcast-function-type]
                reinterpret_cast<Callback>(callback), type);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h: In instantiation of 'void v8::PersistentBase<T>::SetWeak(P*, typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType) [with P = Nan::ObjectWrap; T = v8::Object; typename v8::WeakCallbackInfo<P>::Callback = void (*)(const v8::WeakCallbackInfo<Nan::ObjectWrap>&)]':
../../../../nan/nan_object_wrap.h:65:61:   required from here
/nix/store/ayhbj9jfp2zy1flndbx11b6a7r4fcagf-node-sources/deps/v8/include/v8.h:9502:16: warning: cast between incompatible function types from 'v8::WeakCallbackInfo<Nan::ObjectWrap>::Callback' {aka 'void (*)(const v8::WeakCallbackInfo<Nan::ObjectWrap>&)'} to 'Callback' {aka 'void (*)(const v8::WeakCallbackInfo<void>&)'} [-Wcast-function-type]
  SOLINK_MODULE(target) Release/obj.target/utp.node
  COPY Release/utp.node
make: Leaving directory '/nix/store/f3z7yqigrvp7lzvqfrd5jpyrcydhnj87-node_dat-13.13.1/lib/node_modules/dat/node_modules/discovery-swarm/node_modules/utp-native/build'

> utp-native@2.1.5 install /nix/store/f3z7yqigrvp7lzvqfrd5jpyrcydhnj87-node_dat-13.13.1/lib/node_modules/dat/node_modules/utp-native
> node-gyp-build

make: Entering directory '/nix/store/f3z7yqigrvp7lzvqfrd5jpyrcydhnj87-node_dat-13.13.1/lib/node_modules/dat/node_modules/utp-native/build'
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_internal.o
../deps/libutp/utp_internal.cpp: In function 'size_t utp_process_incoming(UTPSocket*, const byte*, size_t, bool)':
../deps/libutp/utp_internal.cpp:1974:34: warning: comparison of integer expressions of different signedness: 'int' and 'uint32' {aka 'unsigned int'} [-Wsign-compare]
   if (conn->mtu_probe_seq && seq == conn->mtu_probe_seq) {
                              ~~~~^~~~~~~~~~~~~~~~~~~~~~
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_utils.o
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_hash.o
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_callbacks.o
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_api.o
  CXX(target) Release/obj.target/libutp/deps/libutp/utp_packedsockaddr.o
  AR(target) Release/obj.target/deps/utp.a
  COPY Release/utp.a
  CXX(target) Release/obj.target/utp_native/binding.o
  SOLINK_MODULE(target) Release/obj.target/utp_native.node
  COPY Release/utp_native.node
make: Leaving directory '/nix/store/f3z7yqigrvp7lzvqfrd5jpyrcydhnj87-node_dat-13.13.1/lib/node_modules/dat/node_modules/utp-native/build'
...............] - : info lifecycle utp-native@2.1.5~install: utp-native@2.[0m
> fd-lock@1.0.2 install /nix/store/f3z7yqigrvp7lzvqfrd5jpyrcydhnj87-node_dat-13.13.1/lib/node_modules/dat/node_modules/fd-lock
> node-gyp-build


> sodium-native@2.4.6 install /nix/store/f3z7yqigrvp7lzvqfrd5jpyrcydhnj87-node_dat-13.13.1/lib/node_modules/dat/node_modules/sodium-native
> node-gyp-build "node preinstall.js" "node postinstall.js"

libtool is required, but wasn't found on this system
./configure: line 5: ./configure: No such file or directory
/nix/store/f3z7yqigrvp7lzvqfrd5jpyrcydhnj87-node_dat-13.13.1/lib/node_modules/dat/node_modules/sodium-native/preinstall.js:119
    if (err) throw err
             ^

Error: ./configure exited with 127
    at ChildProcess.<anonymous> (/nix/store/f3z7yqigrvp7lzvqfrd5jpyrcydhnj87-node_dat-13.13.1/lib/node_modules/dat/node_modules/sodium-native/preinstall.js:149:25)
    at ChildProcess.emit (events.js:198:13)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:248:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! sodium-native@2.4.6 install: `node-gyp-build "node preinstall.js" "node postinstall.js"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the sodium-native@2.4.6 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /build/.npm/_logs/2019-12-17T17_57_08_183Z-debug.log

builder for '/nix/store/cbw6487wqdc9jg44i51v0vkra70hjwvi-node_dat-13.13.1.drv' failed with exit code 1
error: build of '/nix/store/cbw6487wqdc9jg44i51v0vkra70hjwvi-node_dat-13.13.1.drv' failed
```


</details>


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
