### PR TITLE
uberwriter: init at 2019-11-29 (and update dependency pypandoc to unstable)

### DIFF
--- a/pkgs/applications/editors/uberwriter/default.nix
+++ b/pkgs/applications/editors/uberwriter/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitHub, meson, ninja, cmake
+, wrapGAppsHook, pkgconfig, desktop-file-utils
+, appstream-glib, pythonPackages, glib, gobject-introspection
+, gtk3, webkitgtk, glib-networking, gnome3, gspell, texlive
+, haskellPackages}:
+
+let
+  pythonEnv = pythonPackages.python.withPackages(p: with p;
+    [ regex setuptools python-Levenshtein pyenchant pygobject3 pycairo pypandoc ]);
+  texliveDist = texlive.combined.scheme-medium;
+
+in stdenv.mkDerivation rec {
+  pname = "uberwriter";
+  version = "unstable-2019-11-29";
+
+  src = fetchFromGitHub {
+    owner  = pname;
+    repo   = pname;
+    rev    = "7606a55389f8516d9fed7927fa50ff8822ee9e38";
+    sha256 = "0ky001vs9nfvqf05h4q7fl0n8vsgim59z22i66a8sw6bqipv62sg";
+  };
+
+  nativeBuildInputs = [ meson ninja cmake pkgconfig desktop-file-utils
+    appstream-glib wrapGAppsHook ];
+
+  buildInputs = [ glib pythonEnv gobject-introspection gtk3
+    gnome3.adwaita-icon-theme webkitgtk gspell texliveDist
+    glib-networking ];
+
+  postPatch = ''
+    patchShebangs --build build-aux/meson_post_install.py
+
+    substituteInPlace uberwriter/config.py --replace "/usr/share/uberwriter" "$out/share/uberwriter"
+
+    # get rid of unused distributed dependencies
+    rm -r uberwriter/{pylocales,pressagio}
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PYTHONPATH : "$out/lib/python${pythonEnv.pythonVersion}/site-packages/"
+      --prefix PATH : "${texliveDist}/bin"
+      --prefix PATH : "${haskellPackages.pandoc-citeproc}/bin"
+    )
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://uberwriter.github.io/uberwriter/;
+    description = "A distraction free Markdown editor for GNU/Linux";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sternenseemann ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6847,6 +6847,10 @@ in
 
   ua = callPackage ../tools/networking/ua { };
 
+  uberwriter = callPackage ../applications/editors/uberwriter {
+    pythonPackages = python3Packages;
+  };
+
   ubridge = callPackage ../tools/networking/ubridge { };
 
   ucl = callPackage ../development/libraries/ucl { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [uberwriter](https://github.com/UberWriter/uberwriter), a simple, but feature-rich markdown editor.

###### Changes

First I updated `pypandoc` to an unstable version to make it work with pandoc v2. I based my change on PR #56592. There's also news on the `pypandoc` situation: It seems like the maintainer of `uberwriter` will [maintain `pypandoc` in the future](https://github.com/UberWriter/uberwriter/issues/184#issuecomment-565523550).

Then I added a package for `uberwriter`'s current master revision. I chose to use an unstable version because `uberwriter` recently switched build system. I had already previously tried to get `uberwriter` to work, but I couldn't manage to make Nix and its custom build system to get along. Now they use `meson` and `ninja` which works pretty well together with `wrapGAppsHook`. As they'll probably stick with this for the next major release 2.2.0, it's probably not worth it to invest any more time into the old build system. Sadly the last beta release also includes this old build system.

I also delete two packages that are distributed with UberWriter: `pylocales` and `pressagio`. These could probably be distributed by Nix, but would require light patching of UberWriter. However this is currently not necessary as `pylocale` is never imported and `pressagio` is only used in an internal module for auto correct that is in turn never imported, as this feature is not used currently.

###### Things done

Tested the following features of UberWriter that I am aware of:

* Editing, Different Editor modes
* Preview
* Inline Preview (for footnotes, LaTeX formulas, images ...)
* Inline Dictonary Integration
* Dark Mode
* Export (pdf and xml)
* Tutorial

What I haven't thoroughly tested so far is Spell Checking with Gspell, as I don't have a proper Gspell dictionary set up on my system. Gspell behaves in Gedit same as in UberWriter, so it seems fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

