### PR TITLE
Lumpy, sambamba, and samblaster

### DIFF
--- a/pkgs/applications/science/biology/lumpy/default.nix
+++ b/pkgs/applications/science/biology/lumpy/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, htslib, zlib, curl, openssl, samblaster, sambamba
+, samtools, hexdump, python2Packages, which }:
+
+let
+  python =
+    python2Packages.python.withPackages (pkgs: with pkgs; [ pysam numpy ]);
+
+in stdenv.mkDerivation rec {
+  pname = "lumpy";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "arq5x";
+    repo = "lumpy-sv";
+    rev = version;
+    sha256 = "0azhzvmh9az9jcq0xprlzdz6w16azgszv4kshb903bwbnqirmk18";
+  };
+
+  nativeBuildInputs = [ which ];
+  buildInputs =
+    [ htslib zlib curl openssl python samblaster sambamba samtools hexdump ];
+
+  preConfigure = ''
+    patchShebangs ./.
+
+    # Use Nix htslib over bundled version
+    sed -i 's/lumpy_filter: htslib/lumpy_filter:/' Makefile
+    sed -i 's|../../lib/htslib/libhts.a|-lhts|' src/filter/Makefile
+  '';
+
+  # Upstream's makefile doesn't have an install target
+  installPhase = ''
+    mkdir -p $out
+    cp -r bin $out
+    cp -r scripts $out
+    sed -i 's|/build/source|'$out'|' $out/bin/lumpyexpress.config
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Probabilistic structural variant caller";
+    homepage = "https://github.com/arq5x/lumpy-sv";
+    maintainers = with maintainers; [ jbedo ];
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+  };
+
+}

--- a/pkgs/applications/science/biology/sambamba/default.nix
+++ b/pkgs/applications/science/biology/sambamba/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, python3, which, dmd, ldc, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "sambamba";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "biod";
+    repo = "sambamba";
+    rev = "v${version}";
+    sha256 = "0k5wy06zrbsc40x6answgz7rz2phadyqwlhi9nqxbfqanbg9kq20";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ which python3 dmd ldc ];
+  buildInputs = [ zlib ];
+
+  # Upstream's install target is broken; copy manually
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/sambamba-${version} $out/bin/sambamba
+  '';
+
+  meta = with stdenv.lib; {
+    description = "SAM/BAM processing tool";
+    homepage = "https://lomereiter.github.io/sambamba/";
+    maintainers = with maintainers; [ jbedo ];
+    license = with licenses; gpl2;
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/applications/science/biology/samblaster/default.nix
+++ b/pkgs/applications/science/biology/samblaster/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "samblaster";
+  version = "0.1.24";
+
+  src = fetchFromGitHub {
+    owner = "GregoryFaust";
+    repo = "samblaster";
+    rev = "v.${version}";
+    sha256 = "0iv2ddfw8363vb2x8gr3p8g88whb6mb9m0pf71i2cqsbv6jghap7";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp samblaster $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool for marking duplicates and extracting discordant/split reads from SAM/BAM files";
+    maintainers = with maintainers; [ jbedo ];
+    license = licenses.mit;
+    homepage = "https://github.com/GregoryFaust/samblaster";
+    platforms = platforms.x86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24919,6 +24919,8 @@ in
     mpi = true;
   });
 
+  sambamba = callPackage ../applications/science/biology/sambamba { };
+
   samblaster = callPackage ../applications/science/biology/samblaster { };
 
   samtools = callPackage ../applications/science/biology/samtools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24845,6 +24845,8 @@ in
 
   last = callPackage ../applications/science/biology/last { };
 
+  lumpy = callPackage ../applications/science/biology/lumpy { };
+
   macse = callPackage ../applications/science/biology/macse { };
 
   migrate = callPackage ../applications/science/biology/migrate { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24919,6 +24919,8 @@ in
     mpi = true;
   });
 
+  samblaster = callPackage ../applications/science/biology/samblaster { };
+
   samtools = callPackage ../applications/science/biology/samtools { };
   samtools_0_1_19 = callPackage ../applications/science/biology/samtools/samtools_0_1_19.nix {
     stdenv = gccStdenv;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add lumpy and prerequisites to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).