### PR TITLE
fsv: fix build with gettext 0.20

### DIFF
--- a/pkgs/applications/misc/fsv/default.nix
+++ b/pkgs/applications/misc/fsv/default.nix
@@ -26,6 +26,11 @@ in stdenv.mkDerivation rec {
     sha256 = "0n09jd7yqj18mx6zqbg7kab4idg5llr15g6avafj74fpg1h7iimj";
   };
 
+  postPatch = ''
+   # fix build with gettext 0.20
+   sed -i 's/AM_GNU_GETTEXT/AM_GNU_GETTEXT([external])/' configure.in
+  '';
+
   nativeBuildInputs = [ autoreconfHook libtool pkgconfig ];
   buildInputs       = [ file gtk2 libGLU gtkglarea ];
 


### PR DESCRIPTION
###### Motivation for this change
Fixes: #75835 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files (fsv)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

