### PR TITLE
kpat: init at 19.12.0

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -138,6 +138,7 @@ let
       konquest = callPackage ./konquest.nix {};
       konqueror = callPackage ./konqueror.nix {};
       korganizer = callPackage ./korganizer.nix {};
+      kpat = callPackage ./kpat.nix {};
       kpimtextedit = callPackage ./kpimtextedit.nix {};
       ksmtp = callPackage ./ksmtp {};
       kqtquickcharts = callPackage ./kqtquickcharts.nix {};

--- a/pkgs/applications/kde/kpat.nix
+++ b/pkgs/applications/kde/kpat.nix
@@ -1,0 +1,25 @@
+{ lib
+, mkDerivation
+, extra-cmake-modules
+, knewstuff
+, shared-mime-info
+, libkdegames
+, freecell-solver
+}:
+
+mkDerivation {
+  name = "kpat";
+  nativeBuildInputs = [
+    extra-cmake-modules
+    shared-mime-info
+  ];
+  buildInputs = [
+    knewstuff
+    libkdegames
+    freecell-solver
+  ];
+  meta = {
+    license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
+    maintainers = with lib.maintainers; [ rnhmjoj ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Needed a card game on NixOS, also #62168.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
