### PR TITLE
emscripten: 1.38.28 -> 1.39.1

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, python, fetchFromGitHub, emscriptenRev ? null }:
+{ stdenv, cmake, python, git, fetchFromGitHub, emscriptenRev ? null }:
 
 let
   defaultVersion = "89";
@@ -6,7 +6,7 @@ let
   # Map from git revs to SHA256 hashes
   sha256s = {
     version_89 = "0rh1dq33ilq54szfgi1ajaiaj7rbylai02rhp9zm9vpwp0rw8mij";
-    "1.38.28" = "172s7y5f38736ic8ri3mnbdqcrkadd40a26cxcfwbscc53phl11v";
+    "1.39.1" = "0ygm9m5322h4vfpf3j63q32qxk2l26yk62hh7dkb49j51zwl1y3y";
   };
 in
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     inherit rev;
   };
 
-  nativeBuildInputs = [ cmake python ];
+  nativeBuildInputs = [ cmake python git ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/WebAssembly/binaryen;

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "emscripten-core";
     repo = "emscripten";
-    sha256 = "1j3f0hpy05qskaiyv75l7wv4n0nzxhrh9b296zchx3f6f9h2rghq";
+    sha256 = "1bavcdhqx6bk8f4ra2qd2vjl33aklcj3ib9d49m4f0plwqka0w7k";
     inherit rev;
   };
 

--- a/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
+++ b/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
@@ -10,14 +10,14 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "emscripten-core";
     repo = "emscripten-fastcomp";
-    sha256 = "0bd0l5k2fa4k0nax2cpxi003pqffqivx4z4m2j5xdha1a12sid8i";
+    sha256 = "03czd9hkgn8xn4jyiqf7qxmv9fxi6ryjvkzfv9163mc52vq91i1z";
     inherit rev;
   };
 
   srcFL = fetchFromGitHub {
     owner = "emscripten-core";
     repo = "emscripten-fastcomp-clang";
-    sha256 = "1iw2qplhp489qzw0rma73sab7asnm27g4m95sr36c6kq9cq6agri";
+    sha256 = "0bpsbbb0z6k8lzd5gj6c5377gsyzzpsdiq1m3gsx5c5qxnsa0shv";
     inherit rev;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2975,7 +2975,7 @@ in
 
   cholmod-extra = callPackage ../development/libraries/science/math/cholmod-extra { };
 
-  emscriptenVersion = "1.38.28";
+  emscriptenVersion = "1.39.1";
 
   emscripten = callPackage ../development/compilers/emscripten { };
 

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -26,7 +26,7 @@ rec {
           `pkg-config zlib --cflags` \
           `pkg-config zlib --libs` \
           -I . \
-          .libs/libjson-c.so \
+          .libs/libjson-c.${if pkgs.stdenv.isDarwin then "dylib" else "so"} \
           -o ./test1.js
 
         echo "Using node to execute the test which basically outputs an error on stderr which we grep for" 
@@ -163,7 +163,7 @@ rec {
         echo "Compiling a custom test"
         set -x
         emcc -O2 -s EMULATE_FUNCTION_POINTER_CASTS=1 test/example.c -DZ_SOLO \
-        libz.so.${old.version} -I . -o example.js
+        ${if pkgs.stdenv.isDarwin then "libz.${old.version}.dylib" else "libz.so.${old.version}"} -I . -o example.js
 
         echo "Using node to execute the test"
         ${pkgs.nodejs}/bin/node ./example.js 


### PR DESCRIPTION
#### Motivation for this change

It's been almost a year since the last emscripten update. 1.39.1 is the latest release that has matching version releases of `emscripten` and `binaryen`.

###### Things done

Tested via `nix-build default.nix -A emscriptenPackages` on Linux and macOS.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
