### PR TITLE
xorg.xf86-video-intel: 2018-12-03 -> 2019-12-09

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1,5 +1,5 @@
 { abiCompat ? null,
-  stdenv, makeWrapper, fetchurl, fetchpatch, buildPackages,
+  stdenv, makeWrapper, fetchurl, fetchpatch, fetchFromGitLab, buildPackages,
   automake, autoconf, gettext, libiconv, libtool, intltool,
   freetype, tradcpp, fontconfig, meson, ninja, ed,
   libGL, spice-protocol, zlib, libGLU, dbus, libunwind, libdrm,
@@ -727,11 +727,14 @@ self: super:
 
   xf86videointel = super.xf86videointel.overrideAttrs (attrs: {
     # the update script only works with released tarballs :-/
-    name = "xf86-video-intel-2018-12-03";
-    src = fetchurl {
-      url = "http://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/"
-          + "e5ff8e1828f97891c819c919d7115c6e18b2eb1f.tar.gz";
-      sha256 = "01136zljk6liaqbk8j9m43xxzqj6xy4v50yjgi7l7g6pp8pw0gx6";
+    name = "xf86-video-intel-2019-12-09";
+    src = fetchFromGitLab {
+      domain = "gitlab.freedesktop.org";
+      group = "xorg";
+      owner = "driver";
+      repo = "xf86-video-intel";
+      rev = "f66d39544bb8339130c96d282a80f87ca1606caf";
+      sha256 = "14rwbbn06l8qpx7s5crxghn80vgcx8jmfc7qvivh72d81r0kvywl";
     };
     buildInputs = attrs.buildInputs ++ [self.libXfixes self.libXScrnSaver self.pixman];
     nativeBuildInputs = attrs.nativeBuildInputs ++ [autoreconfHook self.utilmacros];


### PR DESCRIPTION
###### Motivation for this change
IRC user couldn't compile it on 32bit. Turns out the gcc 8 update broke the 32 bit build, which was already fixed in master, see https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/commit/9e6e003e3468dca674ac848e2669af973da02fd4

I updated it to latest master and also switched the repository to the new gitlab-hosted one. The old source https://cgit.freedesktop.org/xorg/driver/xf86-video-intel/ points to it at the top

Ping @dtzWill (last update in https://github.com/NixOS/nixpkgs/pull/51705), @abbradar @fpletz @steveeJ (testers from https://github.com/NixOS/nixpkgs/issues/21953)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Build the package successfully with `nix-build -A pkgsi686Linux.xorg.xf86videointel -A xorg.xf86videointel`
- [x] Tested it