### PR TITLE
lgogdownloader: fix build

### DIFF
--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv , fetchFromGitHub , cmake , python }:
+{ stdenv, fetchFromGitHub, cmake, python, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "jsoncpp";
@@ -29,6 +29,14 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake python ];
+
+  # fix inverted sense in isAnyCharRequiredQuoting on aarch64. See: https://github.com/open-source-parsers/jsoncpp/pull/1120
+  patches = stdenv.lib.optionals stdenv.isAarch64 [
+    (fetchpatch {
+      url = "https://github.com/open-source-parsers/jsoncpp/commit/9093358efae9e5981aa60013487fc7215f040a59.patch";
+      sha256 = "1wiqp70sck2md14sfc0zdkblqk9750cl55ykf9d6b9vs1ifzzzq5";
+     })
+  ];
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"

--- a/pkgs/games/lgogdownloader/default.nix
+++ b/pkgs/games/lgogdownloader/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, curl, boost, liboauth, jsoncpp
-, htmlcxx, rhash, tinyxml-2, help2man }:
+, htmlcxx, rhash, tinyxml-2, help2man, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "lgogdownloader";
@@ -15,6 +15,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig help2man ];
 
   buildInputs = [ curl boost liboauth jsoncpp htmlcxx rhash tinyxml-2 ];
+
+  patches = [
+    # Fix find_path for newer jsoncpp. Remove with the next release
+    (fetchpatch {
+      url = "https://github.com/Sude-/lgogdownloader/commit/ff353126ecda61824cf866d3807c9ebada96282e.patch";
+      sha256 = "1xr1lwxlrncrj662s9l1is1x1mhs1jbwlj8qafixz5hw2kx22w19";
+    })
+  ];
 
   meta = {
     homepage = https://github.com/Sude-/lgogdownloader;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/75836
cc: @alexarice
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
