### PR TITLE
libspnav: init at 2.3.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -377,6 +377,7 @@
   ./services/hardware/sane.nix
   ./services/hardware/sane_extra_backends/brscan4.nix
   ./services/hardware/sane_extra_backends/dsseries.nix
+  ./services/hardware/spacenavd.nix
   ./services/hardware/tcsd.nix
   ./services/hardware/tlp.nix
   ./services/hardware/thinkfan.nix

--- a/nixos/modules/services/hardware/spacenavd.nix
+++ b/nixos/modules/services/hardware/spacenavd.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.hardware.spacenavd;
+
+in {
+
+  options = {
+    hardware.spacenavd = {
+      enable = mkEnableOption "spacenavd to support 3DConnexion devices";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.spacenavd = {
+      description = "Daemon for the Spacenavigator 6DOF mice by 3Dconnexion";
+      after = [ "syslog.target" ];
+      wantedBy = [ "graphical.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.spacenavd}/bin/spacenavd -d -l syslog";
+        StandardError = "syslog";
+      };
+    };
+  };
+}

--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -1,9 +1,8 @@
 { lib, mkDerivation, fetchFromGitHub, fetchpatch, cmake, ninja, coin3d,
 xercesc, ode, eigen, qtbase, qttools, qtwebengine, qtxmlpatterns, wrapQtAppsHook,
 opencascade-occt, gts, hdf5, vtk, medfile, zlib, python3Packages, swig,
-gfortran, libXmu, soqt, libf2c, libGLU, makeWrapper, pkg-config, mpi ? null }:
-
-assert mpi != null;
+gfortran, libXmu, soqt, libf2c, libGLU, makeWrapper, pkg-config, mpi,
+spaceNavSupport ? true, libspnav, qtx11extras }:
 
 let
   pythonPackages = python3Packages;
@@ -34,7 +33,7 @@ in mkDerivation rec {
     matplotlib pycollada shiboken2 pyside2 pyside2-tools pivy python boost
     GitPython # for addon manager
     scipy pyyaml # (at least for) PyrateWorkbench
-  ]);
+  ]) ++ lib.optionals spaceNavSupport [ libspnav qtx11extras ];
 
   cmakeFlags = [
     "-DBUILD_QT5=ON"

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -7,6 +7,7 @@
 , jackaudioSupport ? false, libjack2
 , cudaSupport ? config.cudaSupport or false, cudatoolkit
 , colladaSupport ? true, opencollada
+, spaceNavSupport ? false, libspnav
 , makeWrapper
 , pugixml, llvmPackages, SDL, Cocoa, CoreGraphics, ForceFeedback, OpenAL, OpenGL
 , embree, gmp
@@ -56,7 +57,8 @@ stdenv.mkDerivation rec {
     ])
     ++ optional jackaudioSupport libjack2
     ++ optional cudaSupport cudatoolkit
-    ++ optional colladaSupport opencollada;
+    ++ optional colladaSupport opencollada
+    ++ optional spaceNavSupport libspnav;
 
   postPatch = ''
     # allow usage of dynamically linked embree

--- a/pkgs/applications/misc/spacenav-cube-example/default.nix
+++ b/pkgs/applications/misc/spacenav-cube-example/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, libspnav, libX11, mesa_glu }:
+
+stdenv.mkDerivation {
+  pname = "spacenav-cube-example";
+  version = libspnav.version;
+
+  src = libspnav.src;
+
+  sourceRoot = "source/examples/cube";
+
+  buildInputs = [ libX11 mesa_glu libspnav ];
+
+  configureFlags = [ "--disable-debug" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp cube $out/bin/spacenav-cube-example
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "http://spacenav.sourceforge.net/";
+    description = "An example application to test the spacenavd driver";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sohalt ];
+  };
+}

--- a/pkgs/development/libraries/libspnav/configure-socket-path.patch
+++ b/pkgs/development/libraries/libspnav/configure-socket-path.patch
@@ -1,0 +1,47 @@
+diff --git a/spnav.c b/spnav.c
+index f9e10f8..27149f7 100644
+--- a/spnav.c
++++ b/spnav.c
+@@ -36,7 +36,7 @@ OF SUCH DAMAGE.
+ #include <sys/select.h>
+ #include "spnav.h"
+ 
+-#define SPNAV_SOCK_PATH "/var/run/spnav.sock"
++#define DEFAULT_SPNAV_SOCK_PATH "/run/spnav.sock"
+ 
+ #ifdef USE_X11
+ #include <X11/Xlib.h>
+@@ -70,6 +70,24 @@ static struct event_node *ev_queue, *ev_queue_tail;
+ /* AF_UNIX socket used for alternative communication with daemon */
+ static int sock = -1;
+ 
++static char *spath = NULL;
++
++static char *socket_path()
++{
++	char *xdg_runtime_dir;
++	if((xdg_runtime_dir = getenv("XDG_RUNTIME_DIR"))) {
++		if ( spath == NULL ) {
++			spath = malloc(strlen(xdg_runtime_dir) + strlen("/spnav.sock") + 1);
++			if ( spath != NULL ) {
++				sprintf(spath, sizeof(spath), "%s/spnav.sock", xdg_runtime_dir);
++			}
++		}
++		if(access(spath, F_OK)){
++			return spath;
++		}
++	}
++	return DEFAULT_SPNAV_SOCK_PATH;
++}
+ 
+ int spnav_open(void)
+ {
+@@ -92,7 +110,7 @@ int spnav_open(void)
+ 
+ 	memset(&addr, 0, sizeof addr);
+ 	addr.sun_family = AF_UNIX;
+-	strncpy(addr.sun_path, SPNAV_SOCK_PATH, sizeof(addr.sun_path));
++	strncpy(addr.sun_path, socket_path(), sizeof(addr.sun_path));
+ 
+ 
+ 	if(connect(s, (struct sockaddr*)&addr, sizeof addr) == -1) {

--- a/pkgs/development/libraries/libspnav/default.nix
+++ b/pkgs/development/libraries/libspnav/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, libX11}:
+
+stdenv.mkDerivation rec {
+  version = "0.2.3";
+  pname = "libspnav";
+
+  src = fetchFromGitHub {
+    owner = "FreeSpacenav";
+    repo = "libspnav";
+    rev = "${pname}-${version}";
+    sha256 = "098h1jhlj87axpza5zgy58prp0zn94wyrbch6x0s7q4mzh7dc8ba";
+  };
+
+  buildInputs = [ libX11 ];
+
+  patches = [
+    # Changes the socket path from /run/spnav.sock to $XDG_RUNTIME_DIR/spnav.sock
+    # to allow for a user service
+    ./configure-socket-path.patch
+  ];
+
+  configureFlags = [ "--disable-debug"];
+
+  preInstall = ''
+    mkdir -p $out/{lib,include}
+  '';
+
+  meta = with lib; {
+    homepage = "http://spacenav.sourceforge.net/";
+    description = "Device driver and SDK for 3Dconnexion 3D input devices";
+    longDescription = "A free, compatible alternative, to the proprietary 3Dconnexion device driver and SDK, for their 3D input devices (called 'space navigator', 'space pilot', 'space traveller', etc)";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sohalt ];
+  };
+}

--- a/pkgs/misc/drivers/spacenavd/configure-socket-path.patch
+++ b/pkgs/misc/drivers/spacenavd/configure-socket-path.patch
@@ -1,0 +1,118 @@
+diff --git a/src/proto_unix.c b/src/proto_unix.c
+index 998f234..d38452c 100644
+--- a/src/proto_unix.c
++++ b/src/proto_unix.c
+@@ -36,11 +36,14 @@ enum {
+ 
+ static int lsock = -1;
+ 
++static char *spath = NULL;
++
+ int init_unix(void)
+ {
+ 	int s;
+ 	mode_t prev_umask;
+ 	struct sockaddr_un addr;
++	char *sock_path;
+ 
+ 	if(lsock >= 0) return 0;
+ 
+@@ -49,16 +52,18 @@ int init_unix(void)
+ 		return -1;
+ 	}
+ 
+-	unlink(SOCK_NAME);	/* in case it already exists */
++	sock_path = socket_path();
++
++	unlink(sock_path);	/* in case it already exists */
+ 
+ 	memset(&addr, 0, sizeof addr);
+ 	addr.sun_family = AF_UNIX;
+-	strcpy(addr.sun_path, SOCK_NAME);
++	strcpy(addr.sun_path, sock_path);
+ 
+ 	prev_umask = umask(0);
+ 
+ 	if(bind(s, (struct sockaddr*)&addr, sizeof addr) == -1) {
+-		logmsg(LOG_ERR, "failed to bind unix socket: %s: %s\n", SOCK_NAME, strerror(errno));
++		logmsg(LOG_ERR, "failed to bind unix socket: %s: %s\n", sock_path, strerror(errno));
+ 		close(s);
+ 		return -1;
+ 	}
+@@ -68,7 +73,7 @@ int init_unix(void)
+ 	if(listen(s, 8) == -1) {
+ 		logmsg(LOG_ERR, "listen failed: %s\n", strerror(errno));
+ 		close(s);
+-		unlink(SOCK_NAME);
++		unlink(sock_path);
+ 		return -1;
+ 	}
+ 
+@@ -82,7 +87,7 @@ void close_unix(void)
+ 		close(lsock);
+ 		lsock = -1;
+ 
+-		unlink(SOCK_NAME);
++		unlink(socket_path());
+ 	}
+ }
+ 
+@@ -173,3 +178,19 @@ int handle_uevents(fd_set *rset)
+ 
+ 	return 0;
+ }
++
++char *socket_path(void)
++{
++	char *xdg_runtime_dir;
++	if((xdg_runtime_dir = getenv("XDG_RUNTIME_DIR"))) {
++		if ( spath == NULL ) {
++			spath = malloc(strlen(xdg_runtime_dir) + strlen("/spnav.sock") + 1);
++			if ( spath != NULL ) {
++				sprintf(spath, "%s/spnav.sock", xdg_runtime_dir);
++			}
++		};
++		return spath;
++	} else {
++		return DEFAULT_SOCK_NAME;
++	}
++}
+diff --git a/src/proto_unix.h b/src/proto_unix.h
+index 045b379..ec4509c 100644
+--- a/src/proto_unix.h
++++ b/src/proto_unix.h
+@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include "event.h"
+ #include "client.h"
+ 
++char *socket_path(void);
+ int init_unix(void);
+ void close_unix(void);
+ int get_unix_socket(void);
+diff --git a/src/spnavd.c b/src/spnavd.c
+index cbea191..03080da 100644
+--- a/src/spnavd.c
++++ b/src/spnavd.c
+@@ -344,7 +344,7 @@ static int find_running_daemon(void)
+ 	}
+ 	memset(&addr, 0, sizeof addr);
+ 	addr.sun_family = AF_UNIX;
+-	strncpy(addr.sun_path, SOCK_NAME, sizeof addr.sun_path);
++	strncpy(addr.sun_path, socket_path(), sizeof addr.sun_path);
+ 
+ 	if(connect(s, (struct sockaddr*)&addr, sizeof addr) == -1) {
+ 		close(s);
+diff --git a/src/spnavd.h b/src/spnavd.h
+index fa0a916..deea4e0 100644
+--- a/src/spnavd.h
++++ b/src/spnavd.h
+@@ -26,7 +26,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #define DEF_CFGFILE		"/etc/spnavrc"
+ #define DEF_LOGFILE		"/var/log/spnavd.log"
+ 
+-#define SOCK_NAME	"/var/run/spnav.sock"
++#define DEFAULT_SOCK_NAME	"/run/spnav.sock"
++#define SOCK_NAME_ENV	"SPNAVD_SOCK_LOCATION"
+ #define PIDFILE		"/var/run/spnavd.pid"
+ #define SYSLOG_ID	"spnavd"
+ 

--- a/pkgs/misc/drivers/spacenavd/default.nix
+++ b/pkgs/misc/drivers/spacenavd/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub, libX11 }:
+
+stdenv.mkDerivation rec {
+  version = "0.8";
+  pname = "spacenavd";
+
+  src = fetchFromGitHub {
+    owner = "FreeSpacenav";
+    repo = "spacenavd";
+    rev = "v${version}";
+    sha256 = "1zz0cm5cgvp9s5n4nzksl8rb11c7sw214bdafzra74smvqfjcjcf";
+  };
+
+  buildInputs = [ libX11 ];
+
+  patches = [
+    # Changes the socket path from /run/spnav.sock to $XDG_RUNTIME_DIR/spnav.sock
+    # to allow for a user service
+    ./configure-socket-path.patch
+  ];
+
+  configureFlags = [ "--disable-debug"];
+
+  meta = with lib; {
+    homepage = "http://spacenav.sourceforge.net/";
+    description = "Device driver and SDK for 3Dconnexion 3D input devices";
+    longDescription = "A free, compatible alternative, to the proprietary 3Dconnexion device driver and SDK, for their 3D input devices (called 'space navigator', 'space pilot', 'space traveller', etc)";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sohalt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29226,6 +29226,8 @@ in
 
   spacenavd = callPackage ../misc/drivers/spacenavd { };
 
+  spacenav-cube-example = callPackage ../applications/misc/spacenav-cube-example { };
+
   splix = callPackage ../misc/cups/drivers/splix { };
 
   steamcontroller = callPackage ../misc/drivers/steamcontroller { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29224,6 +29224,8 @@ in
     hasktags = haskellPackages.hasktags;
   };
 
+  spacenavd = callPackage ../misc/drivers/spacenavd { };
+
   splix = callPackage ../misc/cups/drivers/splix { };
 
   steamcontroller = callPackage ../misc/drivers/steamcontroller { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15061,6 +15061,8 @@ in
 
   libspectre = callPackage ../development/libraries/libspectre { };
 
+  libspnav = callPackage ../development/libraries/libspnav { };
+
   libgsf = callPackage ../development/libraries/libgsf { };
 
   # GNU libc provides libiconv so systems with glibc don't need to build


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This adds libspnav and spacenavd to use 6DOF mice, such as the 3DConnexion SpaceNavigator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
