### PR TITLE
WIP: Fix hie-bios test suite

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1327,4 +1327,9 @@ self: super: {
   haskell-lsp_0_18_0_0 = super.haskell-lsp_0_18_0_0.override { haskell-lsp-types = self.haskell-lsp-types_0_18_0_0; };
   lsp-test_0_8_2_0 = (dontCheck super.lsp-test_0_8_2_0).override { haskell-lsp = self.haskell-lsp_0_18_0_0; };
 
+  # test suite needs cabal and stack executables
+  hie-bios = addTestDepends super.hie-bios [
+    pkgs.stack
+    pkgs.cabal-install
+  ];
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9199,7 +9199,6 @@ broken-packages:
   - stack-run-auto
   - stack-type
   - stack-wrapper
-  - stack2cabal
   - stack2nix
   - stackage
   - stackage-build-plan

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -157,6 +157,9 @@ rec {
   addSetupDepend = drv: x: addSetupDepends drv [x];
   addSetupDepends = drv: xs: overrideCabal drv (drv: { setupHaskellDepends = (drv.setupHaskellDepends or []) ++ xs; });
 
+  addTestDepend = drv: x: addTestDepends drv [x];
+  addTestDepends = drv: xs: overrideCabal drv (drv: { testHaskellDepends = (drv.testHaskellDepends or []) ++ xs; });
+
   enableCabalFlag = drv: x: appendConfigureFlag (removeConfigureFlag drv "-f-${x}") "-f${x}";
   disableCabalFlag = drv: x: appendConfigureFlag (removeConfigureFlag drv "-f${x}") "-f-${x}";
 


### PR DESCRIPTION
@peti I tried to fix the `hie-bios` test suite, see https://github.com/mpickering/hie-bios/issues/107. It needs the `stack` and `cabal` executables in path. But they need to access directories `~/.stack` and `~/.cabal`, so I guess we need to `mkdir` them before the `checkPhase`? I'm not sure where to do that.