### PR TITLE
Upgrade pyrsistent

### DIFF
--- a/pkgs/development/python-modules/cachy/default.nix
+++ b/pkgs/development/python-modules/cachy/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "cachy";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0v6mjyhgx6j7ya20bk69cr3gdzdkdf6psay0h090rscclgji65dp";
+    sha256 = "1cb9naly8ampzlky7h74n5wj628l7jkpsh0c0jz0namlrvs82r8q";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/clikit/default.nix
+++ b/pkgs/development/python-modules/clikit/default.nix
@@ -4,11 +4,11 @@
 
 buildPythonPackage rec {
   pname = "clikit";
-  version = "0.3.2";
+  version = "0.4.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1pvzq3glf4sjgrm0wyxln3s6vicdc9q8r5sgaiqmxdmd9pylw0xm";
+    sha256 = "10gab65pq0jdf589n33sj2513pxal2lisl4xwf1ijysdjxmpdr4a";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -19,40 +19,34 @@
 , functools32
 , pytest
 , jsonschema
+, intreehooks
+, keyring
+, pexpect
 }:
 
 let
-  cleo6 = cleo.overridePythonAttrs (oldAttrs: rec {
-    version = "0.6.8";
-    src = fetchPypi {
-      inherit (oldAttrs) pname;
-      inherit version;
-      sha256 = "06zp695hq835rkaq6irr1ds1dp2qfzyf32v60vxpd8rcnxv319l5";
-    };
-  });
   glob2 = callPackage ./glob2.nix { };
 
 in buildPythonPackage rec {
   pname = "poetry";
-  version = "0.12.17";
+  version = "1.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0gxwcd65qjmzqzppf53x51sic1rbcd9py6cdzx3aprppipimslvf";
+    sha256 = "0gzifln8mns4cr43gc1gacbhzr83wpdwfaz65am4i9vi0f8k0agm";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py --replace \
-      "requests-toolbelt>=0.8.0,<0.9.0" \
-      "requests-toolbelt>=0.8.0,<0.10.0" \
-      --replace 'pyrsistent>=0.14.2,<0.15.0' 'pyrsistent>=0.14.2,<0.16.0'
+  patchPhase = ''
+    substituteInPlace pyproject.toml \
+      --replace 'requests-toolbelt = "^0.8.0"' 'requests-toolbelt = ">=0.8.0"' \
+      --replace 'pyrsistent = "^0.14.2"' 'pyrsistent = ">=0.14.2"'
   '';
 
   format = "pyproject";
 
   propagatedBuildInputs = [
     cachy
-    cleo6
+    cleo
     requests
     cachy
     requests-toolbelt
@@ -65,6 +59,9 @@ in buildPythonPackage rec {
     html5lib
     shellingham
     tomlkit
+    intreehooks
+    keyring
+    pexpect
   ] ++ lib.optionals (isPy27 || isPy34) [ typing pathlib2 glob2 ]
     ++ lib.optionals isPy27 [ virtualenv functools32 subprocess32 ];
 
@@ -85,7 +82,7 @@ in buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    homepage = https://github.com/sdispater/poetry;
+    homepage = https://github.com/python-poetry/poetry;
     description = "Python dependency management and packaging made easy";
     license = licenses.mit;
     maintainers = with maintainers; [ jakewaksbaum ];

--- a/pkgs/development/python-modules/pyrsistent/default.nix
+++ b/pkgs/development/python-modules/pyrsistent/default.nix
@@ -9,11 +9,11 @@
 
 buildPythonPackage rec {
   pname = "pyrsistent";
-  version = "0.15.5";
+  version = "0.15.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "eb6545dbeb1aa69ab1fb4809bfbf5a8705e44d92ef8fc7c2361682a47c46c778";
+    sha256 = "06yzycl8vqk60nacgpsqk9f3bhf5axhmiib7kpvm5dmg63881cpk";
   };
 
   propagatedBuildInputs = [ six ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upgrade pyrsistent to its latest released version on PyPI.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
