### PR TITLE
ripgrep-all: add missing dependencies

### DIFF
--- a/pkgs/tools/text/ripgrep-all/default.nix
+++ b/pkgs/tools/text/ripgrep-all/default.nix
@@ -22,6 +22,30 @@ rustPlatform.buildRustPackage rec {
       --prefix PATH ":" "${lib.makeBinPath [ ffmpeg pandoc poppler_utils ripgrep imagemagick tesseract ]}"
   '';
 
+  # Use upstream's example data to run a couple of queries to ensure the dependencies
+  # for all of the adapters are available.
+  installCheckPhase = ''
+    set -e
+    export PATH="$PATH:$out/bin"
+
+    test1=$(rga --rga-no-cache "hello" exampledir/ | wc -l)
+    test2=$(rga --rga-no-cache --rga-adapters=tesseract "crate" exampledir/screenshot.png | wc -l)
+
+    if [ $test1 != 26 ]
+    then
+      echo "ERROR: test1 failed! Could not find the word 'hello' 26 times in the sample data."
+      exit 1
+    fi
+
+    if [ $test2 != 1 ]
+    then
+      echo "ERROR: test2 failed! Could not find the word 'crate' in the screenshot."
+      exit 1
+    fi
+  '';
+
+  doInstallCheck = true;
+
   meta = with stdenv.lib; {
     description = "Ripgrep, but also search in PDFs, E-Books, Office documents, zip, tar.gz, and more";
     longDescription = ''

--- a/pkgs/tools/text/ripgrep-all/default.nix
+++ b/pkgs/tools/text/ripgrep-all/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, rustPlatform, makeWrapper, ffmpeg
-, pandoc, poppler_utils, ripgrep, Security
+, pandoc, poppler_utils, ripgrep, Security, imagemagick, tesseract
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     wrapProgram $out/bin/rga \
-      --prefix PATH ":" "${lib.makeBinPath [ ffmpeg pandoc poppler_utils ripgrep ]}"
+      --prefix PATH ":" "${lib.makeBinPath [ ffmpeg pandoc poppler_utils ripgrep imagemagick tesseract ]}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This change adds additional dependencies so that the program's full functionality is available by simply installing this package.

In addition, a second commit adds a checkInstallPhase which runs a couple of queries to smoke-test the ripgrep-all adapters. The queries are intended to ensure that the dependencies needed by the adapters are included in the package's dependencies.

Closes #75735

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after):
  Before: 2,620,416,224
  After: 3,792,946,536
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @zaninime
