### PR TITLE
pythonPackages.haas-nabucasa: init at 0.29

### DIFF
--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchFromGitHub, acme, aiohttp, snitun, attrs, pytest-aiohttp, warrant, pytest }:
+
+buildPythonPackage rec {
+  pname = "hass-nabucasa";
+  version = "0.29";
+
+  src = fetchFromGitHub {
+    owner = "nabucasa";
+    repo = pname;
+    rev = version;
+    sha256 = "182nh5i3hlj0kqkbynk69md0ddq83w02l8lz4m03d8xbjixzi1k1";
+  };
+
+  propagatedBuildInputs = [ acme aiohttp snitun attrs warrant ];
+
+  checkInputs = [ pytest pytest-aiohttp ];
+
+  checkPhase = ''
+    pytest tests/
+    '';
+
+  meta = with lib; {
+    homepage = "https://github.com/NabuCasa/hass-nabucasa";
+    description = "Home Assistant cloud integration by Nabu Casa, inc.";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ Scriptkiddi ];
+  };
+}

--- a/pkgs/development/python-modules/snitun/default.nix
+++ b/pkgs/development/python-modules/snitun/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, python, fetchFromGitHub, attrs, cryptography, async-timeout, pytest-aiohttp, pytest }:
+
+buildPythonPackage rec {
+  pname = "snitun";
+  version = "0.20";
+
+  src = fetchFromGitHub {
+    owner = "NabuCasa";
+    repo = pname;
+    rev = version;
+    sha256 = "1nscfwycclfbll709w1q46w6rl0r5c3b85rsc7zwc3ixd1k8aajp";
+  };
+
+  propagatedBuildInputs = [ attrs cryptography async-timeout ];
+
+  checkInputs = [ pytest pytest-aiohttp ];
+
+  checkPhase = ''
+    pytest tests/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/nabucasa/snitun";
+    description = "SNI proxy with TCP multiplexer";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ Scriptkiddi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2546,6 +2546,8 @@ in {
   then callPackage ../development/python-modules/gurobipy/linux.nix {}
   else throw "gurobipy not yet supported on ${stdenv.hostPlatform.system}";
 
+  hass-nabucasa = callPackage ../development/python-modules/hass-nabucasa { };
+
   hbmqtt = callPackage ../development/python-modules/hbmqtt { };
 
   hiro = callPackage ../development/python-modules/hiro {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5132,6 +5132,8 @@ in {
 
   snowballstemmer = callPackage ../development/python-modules/snowballstemmer { };
 
+  snitun = callPackage ../development/python-modules/snitun { };
+
   snscrape = callPackage ../development/python-modules/snscrape { };
 
   snug = callPackage ../development/python-modules/snug { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
