### PR TITLE
asus-wmi-sensors: init at 0.0.1

### DIFF
--- a/pkgs/os-specific/linux/asus-wmi-sensors/default.nix
+++ b/pkgs/os-specific/linux/asus-wmi-sensors/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  name = "asus-wmi-sensors-${version}-${kernel.version}";
+  version = "unstable-2019-11-07";
+
+  # The original was deleted from github, but this seems to be an active fork
+  src = fetchFromGitHub {
+    owner = "electrified";
+    repo = "asus-wmi-sensors";
+    rev = "8daafd45d1b860cf5b17eee1c94d93feb04164a9";
+    sha256 = "0kc0xlrsmf783ln5bqyj6qxzmrhdxdfdd2b9ygf2lbl2153i04vc";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  preConfigure = ''
+    sed -i 's|depmod|#depmod|' Makefile
+  '';
+
+  makeFlags = [
+    "TARGET=${kernel.modDirVersion}"
+    "KERNEL_MODULES=${kernel.dev}/lib/modules/${kernel.modDirVersion}"
+    "MODDESTDIR=${placeholder "out"}/lib/modules/${kernel.modDirVersion}/kernel/drivers/hwmon"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Linux HWMON (lmsensors) sensors driver for various ASUS Ryzen and Threadripper motherboards";
+    homepage = "https://github.com/electrified/asus-wmi-sensors";
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [ Frostman ];
+    broken = versionOlder kernel.version "4.12";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16328,6 +16328,8 @@ in
 
     it87 = callPackage ../os-specific/linux/it87 {};
 
+    asus-wmi-sensors = callPackage ../os-specific/linux/asus-wmi-sensors {};
+
     ena = callPackage ../os-specific/linux/ena {};
 
     v4l2loopback = callPackage ../os-specific/linux/v4l2loopback { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Not really sure if this module should be included but i think it would be nice if nixos support asus ryzen and threadripper's motherboard monitor but default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
