### PR TITLE
alertmanager-bot: init at 0.4.0

### DIFF
--- a/pkgs/servers/monitoring/alertmanager-bot/default.nix
+++ b/pkgs/servers/monitoring/alertmanager-bot/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "alertmanager-bot";
+  version = "0.4.0";
+
+  goPackagePath = "github.com/metalmatze/alertmanager-bot";
+
+  src = fetchFromGitHub {
+    owner = "metalmatze";
+    repo = pname;
+    rev = version;
+    sha256 = "10v0fxxcs5s6zmqindr30plyw7p2yg0a64rdw1b2cj2mc1m3byx3";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "Bot for Prometheus' Alertmanager";
+    homepage = "https://github.com/metalmatze/alertmanager-bot";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ mmahut ];
+  };
+}

--- a/pkgs/servers/monitoring/alertmanager-bot/deps.nix
+++ b/pkgs/servers/monitoring/alertmanager-bot/deps.nix
@@ -1,0 +1,948 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/DataDog/datadog-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DataDog/datadog-go";
+      rev = "0ddda6bee211";
+      sha256 = "07ap1qhz8vwdypmlny5gxnc191c0qbm6acacs30m1d4p22x6wxip";
+    };
+  }
+  {
+    goPackagePath = "github.com/OneOfOne/xxhash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/OneOfOne/xxhash";
+      rev = "v1.2.5";
+      sha256 = "15ai4nzm8cv8nqs4xm5h6ghnms19c2sp8z0zpkc46rld6y7k0xky";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/template";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/template";
+      rev = "a0175ee3bccc";
+      sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev = "2efee857e7cf";
+      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+    };
+  }
+  {
+    goPackagePath = "github.com/armon/circbuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/circbuf";
+      rev = "bbbad097214e";
+      sha256 = "1idpr0lzb2px2p3wgfq2276yl7jpaz43df6n91kf790404s4zmk3";
+    };
+  }
+  {
+    goPackagePath = "github.com/armon/go-metrics";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/go-metrics";
+      rev = "f0300d1749da";
+      sha256 = "13l7c35ps0r27vxfil2w0xhhc7w5rh00awvlmn4cz0a937b9ffpv";
+    };
+  }
+  {
+    goPackagePath = "github.com/armon/go-radix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/go-radix";
+      rev = "7fddfc383310";
+      sha256 = "0y8chspn14n9xpsfb9gxnnf819rfpriaz64v81p7873a42kkhxb4";
+    };
+  }
+  {
+    goPackagePath = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev = "v1.0.1";
+      sha256 = "17n4yygjxa6p499dj3yaqzfww2g7528165cl13haj97hlx94dgl7";
+    };
+  }
+  {
+    goPackagePath = "github.com/bgentry/speakeasy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bgentry/speakeasy";
+      rev = "v0.1.0";
+      sha256 = "02dfrj0wyphd3db9zn2mixqxwiz1ivnyc5xc7gkz58l5l27nzp8s";
+    };
+  }
+  {
+    goPackagePath = "github.com/boltdb/bolt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/boltdb/bolt";
+      rev = "v1.3.1";
+      sha256 = "0z7j06lijfi4y30ggf2znak2zf2srv2m6c68ar712wd2ys44qb3r";
+    };
+  }
+  {
+    goPackagePath = "github.com/cenkalti/backoff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cenkalti/backoff";
+      rev = "v2.1.1";
+      sha256 = "1mf4lsl3rbb8kk42x0mrhzzy4ikqy0jf6nxpzhkr02rdgwh6rjk8";
+    };
+  }
+  {
+    goPackagePath = "github.com/cespare/xxhash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cespare/xxhash";
+      rev = "v1.0.0";
+      sha256 = "02aii7z46sasagw816zz3v0gzax1z5d1hkjslz7ng25386p0gzk1";
+    };
+  }
+  {
+    goPackagePath = "github.com/circonus-labs/circonus-gometrics";
+    fetch = {
+      type = "git";
+      url = "https://github.com/circonus-labs/circonus-gometrics";
+      rev = "v2.0.0";
+      sha256 = "0d6cnswq28mjak7092vf89f9l0ga2ziwyamq9kdgfc7aavpwr6l9";
+    };
+  }
+  {
+    goPackagePath = "github.com/circonus-labs/circonusllhist";
+    fetch = {
+      type = "git";
+      url = "https://github.com/circonus-labs/circonusllhist";
+      rev = "6e85b9352cf0";
+      sha256 = "182gry1clk12m34574qif7bx74qpxib2zv0mr5kv2j9hfq7f9m01";
+    };
+  }
+  {
+    goPackagePath = "github.com/creack/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/creack/pty";
+      rev = "v1.1.7";
+      sha256 = "1plwwlk1i9b80zv8zdplvv81shfyc9gf0flydnydsh5sr3ib5vrc";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath = "github.com/docker/libkv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/libkv";
+      rev = "v0.2.1";
+      sha256 = "0blq7kxjy1bvm3j5q4i6csnc4i88c1wvj4gjvxbqfk3sny73gjkr";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "v1.7.0";
+      sha256 = "0v8msvg38r8d1iiq2i5r4xyfx0invhc941kjrsg5gzwvagv55inv";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-kit/kit";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-kit/kit";
+      rev = "v0.8.0";
+      sha256 = "1rcywbc2pvab06qyf8pc2rdfjv7r6kxdv2v4wnpqnjhz225wqvc0";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-logfmt/logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-logfmt/logfmt";
+      rev = "v0.3.0";
+      sha256 = "1gkgh3k5w1xwb2qbjq52p6azq3h1c1rr6pfwjlwj1zrijpzn2xb9";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-stack/stack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-stack/stack";
+      rev = "v1.8.0";
+      sha256 = "0wk25751ryyvxclyp8jdk5c3ar0cmfr8lrjb66qbg4808x66b96v";
+    };
+  }
+  {
+    goPackagePath = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev = "v1.1.1";
+      sha256 = "1525pq7r6h3s8dncvq8gxi893p2nq8dxpzvq0nfl5b4p6mq0v1c2";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.3.2";
+      sha256 = "1k1wb4zr0qbwgpvz9q5ws9zhlal8hq7dmq62pwxxriksayl6hzym";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/btree";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/btree";
+      rev = "4030bb1f1f0c";
+      sha256 = "0ba430m9fbnagacp57krgidsyrgp3ycw5r7dj71brgp5r52g82p6";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.3.1";
+      sha256 = "1caw49i0plkjxir7kdf5qhwls3krqwfmi7g4h392rdfwi3kfahx1";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/gofuzz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/gofuzz";
+      rev = "v1.0.0";
+      sha256 = "0qz439qvccm91w0mmjz4fqgx48clxdwagkvvx89cr43q1d4iry36";
+    };
+  }
+  {
+    goPackagePath = "github.com/hako/durafmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hako/durafmt";
+      rev = "ea3ab126a649";
+      sha256 = "1niq0v6av5vsn4rizfda4zq922jvavig5b0qg9g0gyz6cj62rjzs";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/consul";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/consul";
+      rev = "v1.4.5";
+      sha256 = "0gpg3cbpsmzcaab3scqhpzz57892s95hwq5z0l9bq7qqm6iqfr9d";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/errwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/errwrap";
+      rev = "v1.0.0";
+      sha256 = "0slfb6w3b61xz04r32bi0a1bygc82rjzhqkxj2si2074wynqnr1c";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-cleanhttp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-cleanhttp";
+      rev = "3573b8b52aa7";
+      sha256 = "1pbl6p7w5wp1c70x7fp94h4ynk2ajfa76rqin3d2hq1w2fcb7byr";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-immutable-radix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-immutable-radix";
+      rev = "v1.0.0";
+      sha256 = "1v3nmsnk1s8bzpclrhirz7iq0g5xxbw9q5gvrg9ss6w9crs72qr6";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-msgpack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-msgpack";
+      rev = "v0.5.5";
+      sha256 = "0fqmfx3dxnvb0d23cpn2xpd067pibwlchdc58ln8w6lznzrbzaan";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-multierror";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-multierror";
+      rev = "v1.0.0";
+      sha256 = "00nyn8llqzbfm8aflr9kwsvpzi4kv8v45c141v88xskxp5xf6z49";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-retryablehttp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-retryablehttp";
+      rev = "794af36148bf";
+      sha256 = "1686d4qav0ayj3f5881w3kd9pz4fxsmknfqwccbj9yklxm3khvp4";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-rootcerts";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-rootcerts";
+      rev = "v1.0.1";
+      sha256 = "0ca5h7vlvrghf24dzh8l6w5px293n173qxfkjxb9kgsl6hsrsl3y";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-sockaddr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-sockaddr";
+      rev = "v1.0.2";
+      sha256 = "0y106nhd3s63lj7h7k21iq0br97h0z9qjrvx028zqcsq9407k9is";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-syslog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-syslog";
+      rev = "v1.0.0";
+      sha256 = "09vccqggz212cg0jir6vv708d6mx0f9w5bxrcdah3h6chgmal6v1";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-uuid";
+      rev = "v1.0.1";
+      sha256 = "0jvb88m0rq41bwgirsadgw7mnayl27av3gd2vqa3xvxp3fy0hp5k";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev = "v0.5.3";
+      sha256 = "1p2igd58xkm8yaj2c2wxiplkf2hj6kxwrg6ss7mx61s5rd71v5xb";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/logutils";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/logutils";
+      rev = "v1.0.0";
+      sha256 = "076wf4sh5p3f953ndqk1cc0x7jhmlqrxak9953rz79rcdw77rjvv";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/mdns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/mdns";
+      rev = "v1.0.1";
+      sha256 = "185zpyj1jf1jm7hihg73gqnspr0a359aqwv11v4a6mwd5bkdh19j";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/memberlist";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/memberlist";
+      rev = "v0.1.4";
+      sha256 = "0l9qx8j7mm00ia6m41zbn39z7p77jjf95zph2nw8j2vihm56q9ql";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/serf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/serf";
+      rev = "v0.8.3";
+      sha256 = "0isaq2m08rpwvlzd72gvy3caapkrzgr9cwizl99ainsjgj2nkds9";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/uuid";
+      rev = "ebb0a03e909c";
+      sha256 = "0bzqr8y81h96cw299lhc5nxi9203a7xpd7csjsm6rh4k1bx4hdlf";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/yamux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/yamux";
+      rev = "f5742cb6b856";
+      sha256 = "1k9b399ljsp443s1v69c1m5jqdiw1998ryz4b4lh86nkz775ws5s";
+    };
+  }
+  {
+    goPackagePath = "github.com/hpcloud/tail";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hpcloud/tail";
+      rev = "v1.0.0";
+      sha256 = "1njpzc0pi1acg5zx9y6vj9xi6ksbsc5d387rd6904hy6rh2m6kn0";
+    };
+  }
+  {
+    goPackagePath = "github.com/joho/godotenv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/joho/godotenv";
+      rev = "v1.3.0";
+      sha256 = "0ri8if0pc3x6jg4c3i8wr58xyfpxkwmcjk3rp8gb398a1aa3gpjm";
+    };
+  }
+  {
+    goPackagePath = "github.com/json-iterator/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/json-iterator/go";
+      rev = "v1.1.7";
+      sha256 = "0n79p4s67zl5zprxv7diayw3vavnmmfqkmd6snz0i9bxp825dsyz";
+    };
+  }
+  {
+    goPackagePath = "github.com/julienschmidt/httprouter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/julienschmidt/httprouter";
+      rev = "v1.2.0";
+      sha256 = "1k8bylc9s4vpvf5xhqh9h246dl1snxrzzz0614zz88cdh8yzs666";
+    };
+  }
+  {
+    goPackagePath = "github.com/konsorten/go-windows-terminal-sequences";
+    fetch = {
+      type = "git";
+      url = "https://github.com/konsorten/go-windows-terminal-sequences";
+      rev = "v1.0.2";
+      sha256 = "09mn209ika7ciy87xf2x31dq5fnqw39jidgaljvmqxwk7ff1hnx7";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/logfmt";
+      rev = "b84e30acd515";
+      sha256 = "02ldzxgznrfdzvghfraslhgp19la1fczcbzh7wm2zdc6lmpd1qq9";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pretty";
+      rev = "v0.1.0";
+      sha256 = "18m4pwg2abd0j9cn5v3k2ksk9ig4vlwxmlw9rrglanziv9l967qp";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.1.8";
+      sha256 = "1vcl6f90n0f8s8b4fyh0832ilybjqcypqyj233lqj1hx62fvgdbk";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/text";
+      rev = "v0.1.0";
+      sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
+    };
+  }
+  {
+    goPackagePath = "github.com/kylelemons/godebug";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kylelemons/godebug";
+      rev = "v1.1.0";
+      sha256 = "0dkk3friykg8p6wgqryx6745ahhb9z1j740k7px9dac6v5xjp78c";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "v0.0.9";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.9";
+      sha256 = "0i3km37lajahh1y2392g4hpgvq05arcgiiv93yhzxxyv0fpqj72m";
+    };
+  }
+  {
+    goPackagePath = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev = "v1.0.1";
+      sha256 = "1d0c1isd2lk9pnfq2nk0aih356j30k3h1gi2w0ixsivi5csl7jya";
+    };
+  }
+  {
+    goPackagePath = "github.com/miekg/dns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/miekg/dns";
+      rev = "v1.0.15";
+      sha256 = "051f51fyrsnj69j9ni9j72acqnrvvzqda4l831ijffy5h5jdl8f2";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/cli";
+      rev = "v1.0.0";
+      sha256 = "1i9kmr7rcf10d2hji8h4247hmc0nbairv7a0q51393aw2h1bnwg2";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev = "v1.1.0";
+      sha256 = "0ydzkipf28hwj2bfxqmwlww47khyk6d152xax4bnyh60f4lq3nx1";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-testing-interface";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-testing-interface";
+      rev = "v1.0.0";
+      sha256 = "1dl2js8di858bawg7dadlf1qjpkl2g3apziihjyf5imri3znyfpw";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-wordwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-wordwrap";
+      rev = "v1.0.0";
+      sha256 = "1jffbwcr3nnq6c12c5856bwzv2nxjzqk3jwgvxkwi1xhpd2by0bf";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/hashstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/hashstructure";
+      rev = "2bca23e0e452";
+      sha256 = "0vpacsls26474wya360fjhzi6l4y8s8s251c4szvqxh17n5f5gk1";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev = "d0303fe80992";
+      sha256 = "1fjwi5ghc1ibyx93apz31n4hj6gcq1hzismpdfbg2qxwshyg0ya8";
+    };
+  }
+  {
+    goPackagePath = "github.com/modern-go/concurrent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/concurrent";
+      rev = "bacd9c7ef1dd";
+      sha256 = "0s0fxccsyb8icjmiym5k7prcqx36hvgdwl588y0491gi18k5i4zs";
+    };
+  }
+  {
+    goPackagePath = "github.com/modern-go/reflect2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/reflect2";
+      rev = "v1.0.1";
+      sha256 = "06a3sablw53n1dqqbr2f53jyksbxdmmk8axaas4yvnhyfi55k4lf";
+    };
+  }
+  {
+    goPackagePath = "github.com/mwitkow/go-conntrack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mwitkow/go-conntrack";
+      rev = "cc309e4a2223";
+      sha256 = "0nbrnpk7bkmqg9mzwsxlm0y8m7s9qd9phr1q30qlx2qmdmz7c1mf";
+    };
+  }
+  {
+    goPackagePath = "github.com/oklog/run";
+    fetch = {
+      type = "git";
+      url = "https://github.com/oklog/run";
+      rev = "v1.0.0";
+      sha256 = "1pbjza4claaj95fpqvvfrysvs10y7dm0pl6qr5lzh6qy1vnhmcgw";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/ginkgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/ginkgo";
+      rev = "v1.6.0";
+      sha256 = "0x0gc89vgq38xhgmi2h22bhr73cf2gmk42g89nz89k8dgg9hhr25";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/gomega";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/gomega";
+      rev = "v1.4.3";
+      sha256 = "1c8rqg5i2hz3snmq7s41yar1zjnzilb0fyiyhkg83v97afcfx79v";
+    };
+  }
+  {
+    goPackagePath = "github.com/pascaldekloe/goe";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pascaldekloe/goe";
+      rev = "v0.1.0";
+      sha256 = "1dqd3mfb4z2vmv6pg6fhgvfc53vhndk24wcl9lj1rz02n6m279fq";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.8.1";
+      sha256 = "0g5qcb4d4fd96midz0zdk8b9kz8xkzwfa8kr1cliqbg8sxsy5vd1";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/posener/complete";
+    fetch = {
+      type = "git";
+      url = "https://github.com/posener/complete";
+      rev = "v1.1.2";
+      sha256 = "02xrnfkk9r2jarna8jqfkksrn469jdap716037zq84waq3d5xk3l";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/alertmanager";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/alertmanager";
+      rev = "v0.9.1";
+      sha256 = "1lkfj63pp4jf58xmn015r7s42p1wyj6fryihpmdn0k76b0ccwqzj";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev = "v0.9.4";
+      sha256 = "0s134fj4i7k6pxdmxwkdi7amb1882yq33spv15hg3pkpbd3h311p";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev = "fd36f4220a90";
+      sha256 = "1bs5d72k361llflgl94c22n0w53j30rsfh84smgk8mbjbcmjsaa5";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev = "v0.4.1";
+      sha256 = "0sf4sjdckblz1hqdfvripk3zyp8xq89w7q75kbsyg4c078af896s";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev = "v0.0.3";
+      sha256 = "18c4m795fwng8f8qa395f3crvamlbk5y5afk8b5rzyisnmjq774y";
+    };
+  }
+  {
+    goPackagePath = "github.com/ryanuber/columnize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ryanuber/columnize";
+      rev = "v2.1.0";
+      sha256 = "0m9jhagb1k44zfcdai76xdf9vpi3bqdl7p078ffyibmz0z9jfap6";
+    };
+  }
+  {
+    goPackagePath = "github.com/satori/go.uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/satori/go.uuid";
+      rev = "v1.1.0";
+      sha256 = "1nbydsmjr60904kz5d46nib0zid5kcv4gk9wayi44gn5wlzz80zp";
+    };
+  }
+  {
+    goPackagePath = "github.com/sean-/seed";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sean-/seed";
+      rev = "e2103e2c3529";
+      sha256 = "0glir8jxi1w7aga2jwdb63pp1h8q4whknili7xixsqzwyy716125";
+    };
+  }
+  {
+    goPackagePath = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev = "v1.2.0";
+      sha256 = "0r6334x2bls8ddznvzaldx4g88msjjns4mlks95rqrrg7h0ijigg";
+    };
+  }
+  {
+    goPackagePath = "github.com/spaolacci/murmur3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spaolacci/murmur3";
+      rev = "v1.1.0";
+      sha256 = "1lv3zyz3jy2d76bhvvs8svygx66606iygdvwy5cwc0p5z8yghq25";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.1";
+      sha256 = "0iph0qmpyqg4kwv8jsx6a56a7hhqq8swrazv40ycxk9rzr0s8yls";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.3.0";
+      sha256 = "0wjchp2c8xbgcbbq32w3kvblk6q6yn533g78nxl6iskq6y95lxsy";
+    };
+  }
+  {
+    goPackagePath = "github.com/tucnak/telebot";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tucnak/telebot";
+      rev = "00cebf376d79";
+      sha256 = "0yay3h7gp6yag8jbapbq10vhmszad7svn68nnq5yp6pl1hmykzd6";
+    };
+  }
+  {
+    goPackagePath = "github.com/weaveworks/mesh";
+    fetch = {
+      type = "git";
+      url = "https://github.com/weaveworks/mesh";
+      rev = "f74318fb713b";
+      sha256 = "093j5i7wrkq1g92xaprd0rlfv9i74381wns4941bhbp6x6ahdcz7";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "45a5f77698d3";
+      sha256 = "0636jjj89wkzqchajwwzgcn4aafc334p70nawh9jzavg2mkx0ch4";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "891ebc4b82d6";
+      sha256 = "1rgw5gl2lc6bkmsx0fak84s6zdc1bhzfxgqg4mg4yh5hlnhpwrki";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "37e7f081c4d4";
+      sha256 = "1bb0mw6ckb1k7z8v3iil2qlqwfj408fvvp8m1cik2b46p7snyjhm";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "fde4db37ae7a";
+      sha256 = "16k4w4pzziq1kln18k5fg01qgk4hpzb5xsm7175kaky6d6gwyhg3";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.2";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "90fa682c2a6e";
+      sha256 = "03ic2xsy51jw9749wl7gszdbz99iijbd2bckgygl6cm9w5m364ak";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev = "v1.1.0";
+      sha256 = "1pz202zszg8f35dk5pfhwgcdi3r6dx1l4yk6x6ly7nb4j45zi96x";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/airbrake/gobrake.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/airbrake/gobrake.v2";
+      rev = "v2.0.9";
+      sha256 = "1x06f7n7qlyzqgyz0sdfcidf3w4ldn6zs6qx2mhibggk2z4whcjw";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/alecthomas/kingpin.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/alecthomas/kingpin.v2";
+      rev = "v2.2.6";
+      sha256 = "0mndnv3hdngr3bxp7yxfd47cas4prv98sqw534mx7vp38gd88n5r";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "788fd7840127";
+      sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/fsnotify.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/fsnotify.v1";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/gemnasium/logrus-airbrake-hook.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/gemnasium/logrus-airbrake-hook.v2";
+      rev = "v2.1.2";
+      sha256 = "0sbg0dn6cysmf8f2bi209jwl4jnpiwp4rdghnxlzirw3c32ms5y5";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/tomb.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/tomb.v1";
+      rev = "dd632973f1e7";
+      sha256 = "1lqmq1ag7s4b3gc3ddvr792c5xb5k6sfn0cchr3i2s7f1c231zjv";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/vmihailenco/msgpack.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/vmihailenco/msgpack.v2";
+      rev = "v2.9.1";
+      sha256 = "0ah9j7i97ifyqhiscq8d43gcrhksb3bx83s2p1nyfi1bxw78jwfi";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.2";
+      sha256 = "01wj12jzsdqlnidpyjssmj0r4yavlqy7dwrg7adqd8dicjc4ncsa";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15813,6 +15813,8 @@ in
 
   alfred = callPackage ../os-specific/linux/batman-adv/alfred.nix { };
 
+  alertmanager-bot = callPackage ../servers/monitoring/alertmanager-bot { };
+
   alsa-firmware = callPackage ../os-specific/linux/alsa-firmware { };
 
   alsaLib = callPackage ../os-specific/linux/alsa-lib { };


### PR DESCRIPTION
###### Motivation for this change

alertmanager-bot: init at 0.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).