### PR TITLE
pythonPackages.colorgram: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/colorgram/default.nix
+++ b/pkgs/development/python-modules/colorgram/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pillow
+}:
+
+buildPythonPackage rec {
+  pname = "colorgram.py";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname;
+    inherit version;
+    sha256 = "e77766a5f9de7207bdef8f1c22a702cbf09630eae3bc46a450b9d9f12a7bfdbf";
+  };
+
+  propagatedBuildInputs = [ pillow ];
+
+  meta = with stdenv.lib; {
+    description = "A Python module for extracting colors from images. Get a palette of any picture!";
+    homepage = https://github.com/obskyr/colorgram.py;
+    license = licenses.mit;
+  };
+
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1739,6 +1739,8 @@ in {
 
   colorclass = callPackage ../development/python-modules/colorclass {};
 
+  colorgram = callPackage ../development/python-modules/colorgram {};
+
   colorlog = callPackage ../development/python-modules/colorlog { };
 
   colorspacious = callPackage ../development/python-modules/colorspacious { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
