### PR TITLE
monitor: init at 0.6.1

### DIFF
--- a/pkgs/applications/system/monitor/default.nix
+++ b/pkgs/applications/system/monitor/default.nix
@@ -1,0 +1,83 @@
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, meson
+, ninja
+, vala
+, pkg-config
+, pantheon
+, python3
+, gettext
+, glib
+, gtk3
+, bamf
+, libwnck3
+, libgee
+, libgtop
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "monitor";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "stsdc";
+    repo = "monitor";
+    rev = version;
+    sha256 = "17z1m193s7qygavfwd8qsw97blxbfmq9gnsymdjlc1ddk8hldw0z";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    vala
+    pkg-config
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    bamf
+    glib
+    gtk3
+    pantheon.granite
+    pantheon.wingpanel
+    libgee
+    libgtop
+    libwnck3
+  ];
+
+   patches =  [
+     (fetchpatch {
+       name = "07d1984175fcaef2909029a387f830efd647471b.patch";
+       url = "https://github.com/stsdc/monitor/commit/07d1984175fcaef2909029a387f830efd647471b.patch";
+       sha256 = "0nrfsg8k6spcgk1aw227vgyvz73xfl49yck7gm0id6aj180bmcx8";
+     })
+     (fetchpatch {
+       name = "ab2cfed150cd2a6b5c3fcee5297a65c1b429c674.patch";
+       url = "https://github.com/stsdc/monitor/commit/ab2cfed150cd2a6b5c3fcee5297a65c1b429c674.patch";
+       sha256 = "1imzsir654symx646w1w1nm2zaq3z4sn6c9hak9n54ziwa7wn171";
+     })
+   ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  passthru = {
+    updateScript = pantheon.updateScript {
+      attrPath = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Manage processes and monitor system resources";
+    homepage = "https://github.com/stsdc/monitor";
+    maintainers = with maintainers; [ kjuvi ] ++ pantheon.maintainers;
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20103,6 +20103,8 @@ in
     ocamlPackages = ocaml-ng.ocamlPackages_4_01_0;
   };
 
+  monitor = callPackage ../applications/system/monitor { };
+
   moolticute = libsForQt5.callPackage ../applications/misc/moolticute { };
 
   moonlight-embedded = callPackage ../applications/misc/moonlight-embedded { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add more curated apps from Elementary OS app store for Pantheon Desktop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

 Everything seems to work fine, except for the Wingpanel indicator. As I've understood, there should be one (as far as the option is checked), but unfortunately nothing appears for me. 

Note that I haven't tested the app on ElementaryOS to see what the indicator should look like.


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
