### PR TITLE
Fix Python packages nevow and magic-wormhole-mailbox-server

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
@@ -12,6 +12,10 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ six attrs twisted pyopenssl service-identity autobahn ];
   checkInputs = [ treq mock ];
 
+  checkPhase = ''
+    trial wormhole_mailbox_server
+  '';
+
   meta = with stdenv.lib; {
     description = "Securely transfer data between computers";
     homepage = https://github.com/warner/magic-wormhole-mailbox-server;

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -18,6 +18,7 @@
 , mock
 , magic-wormhole-transit-relay
 , magic-wormhole-mailbox-server
+, isPy27
 }:
 
 buildPythonPackage rec {
@@ -55,6 +56,9 @@ buildPythonPackage rec {
     description = "Securely transfer data between computers";
     homepage = https://github.com/warner/magic-wormhole;
     license = licenses.mit;
+    # Currently broken on Python 2.7. See
+    # https://github.com/NixOS/nixpkgs/issues/71826
+    broken = isPy27;
     maintainers = with maintainers; [ asymmetric ];
   };
 }

--- a/pkgs/development/python-modules/nevow/default.nix
+++ b/pkgs/development/python-modules/nevow/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k, twisted }:
+{ stdenv, buildPythonPackage, fetchpatch, fetchPypi, isPy3k, twisted }:
 
 buildPythonPackage rec {
   pname = "Nevow";
@@ -9,6 +9,14 @@ buildPythonPackage rec {
     inherit version pname;
     sha256 = "2299a0d2a0c1312040705599d5d571acfea74df82b968c0b9264f6f45266cf6e";
   };
+
+  patches = [
+    # Fix builds against recent Twisted.
+    (fetchpatch {
+      url = "https://github.com/twisted/nevow/commit/f1b366f1a73009b6a1df12fa6f4dc464c564c944.patch";
+      sha256 = "147fibcbqh715in8cbkp7jlkh4b3qvn95v1mv9si0ln1747wbby2";
+    })
+  ];
 
   propagatedBuildInputs = [ twisted ];
 

--- a/pkgs/development/python-modules/txtorcon/default.nix
+++ b/pkgs/development/python-modules/txtorcon/default.nix
@@ -1,6 +1,6 @@
 {lib, buildPythonPackage, fetchPypi, isPy3k, incremental, ipaddress, twisted
 , automat, zope_interface, idna, pyopenssl, service-identity, pytest, mock, lsof
-, GeoIP}:
+, GeoIP, isPy27}:
 
 buildPythonPackage rec {
   pname = "txtorcon";
@@ -28,6 +28,9 @@ buildPythonPackage rec {
     description = "Twisted-based Tor controller client, with state-tracking and configuration abstractions";
     homepage = https://github.com/meejah/txtorcon;
     maintainers = with lib.maintainers; [ jluttine ];
+    # Currently broken on Python 2.7. See
+    # https://github.com/NixOS/nixpkgs/issues/71826
+    broken = isPy27;
     license = lib.licenses.mit;
   };
 }


### PR DESCRIPTION
To get a bit closer to an unbroken tahoe-lafs package…