### PR TITLE
gobuster: init at 3.0.1

### DIFF
--- a/pkgs/tools/security/gobuster/default.nix
+++ b/pkgs/tools/security/gobuster/default.nix
@@ -1,0 +1,25 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "gobuster";
+  version = "3.0.1";
+
+  src = fetchFromGitHub {
+    owner = "OJ";
+    repo = "gobuster";
+    rev = "v${version}";
+    sha256 = "0q8ighqykh8qyvidnm6az6dc9mp32bbmhkmkqzl1ybbw6paa8pym";
+  };
+
+  modSha256 = "0jq0z5s05vqdvq7v1gdjwlqqwbl1j2rv9f16k52idl50vdiqviql";
+
+  meta = with lib; {
+    description = "Tool used to brute-force URIs, DNS subdomains, Virtual Host names on target web servers";
+    homepage = "https://github.com/OJ/gobuster";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24533,6 +24533,8 @@ in
     binutils-arm-embedded = pkgsCross.arm-embedded.buildPackages.binutils;
   };
 
+  gobuster = callPackage ../tools/security/gobuster { };
+
   guetzli = callPackage ../applications/graphics/guetzli { };
 
   gummi = callPackage ../applications/misc/gummi { };


### PR DESCRIPTION
##### Motivation for this change

Make [gobuster](https://tools.kali.org/web-applications/gobuster) available via Nix.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
