### PR TITLE
Do not depend on pangox_compat

### DIFF
--- a/pkgs/applications/graphics/k3d/default.nix
+++ b/pkgs/applications/graphics/k3d/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch, ftgl, glew, asciidoc
 , cmake, ninja, libGLU, libGL, zlib, python, expat, libxml2, libsigcxx, libuuid, freetype
 , libpng, boost, doxygen, cairomm, pkgconfig, libjpeg, libtiff
-, gettext, intltool, perl, gtkmm2, glibmm, gtkglext, pangox_compat, libXmu }:
+, gettext, intltool, perl, gtkmm2, glibmm, gtkglext, libXmu }:
 
 stdenv.mkDerivation rec {
   version = "0.8.0.6";
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
      libGLU libGL zlib python expat libxml2 libsigcxx libuuid freetype libpng
      boost cairomm libjpeg libtiff
-     ftgl glew gtkmm2 glibmm gtkglext pangox_compat libXmu
+     ftgl glew gtkmm2 glibmm gtkglext libXmu
     ];
 
   #doCheck = false;

--- a/pkgs/applications/misc/lutris/chrootenv.nix
+++ b/pkgs/applications/misc/lutris/chrootenv.nix
@@ -5,7 +5,7 @@
 let
 
   qt5Deps = pkgs: with pkgs.qt5; [ qtbase qtmultimedia ];
-  gnome3Deps = pkgs: with pkgs.gnome3; [ zenity gtksourceview gnome-desktop libgnome-keyring webkitgtk ];
+  gnome3Deps = pkgs: with pkgs; [ gnome3.zenity gtksourceview gnome3.gnome-desktop gnome3.libgnome-keyring webkitgtk ];
   xorgDeps = pkgs: with pkgs.xorg; [
     libX11 libXrender libXrandr libxcb libXmu libpthreadstubs libXext libXdmcp
     libXxf86vm libXinerama libSM libXv libXaw libXi libXcursor libXcomposite
@@ -23,7 +23,7 @@ in buildFHSUserEnv {
     allegro dumb
 
     # Desmume
-    lua agg soundtouch openal desktop-file-utils pangox_compat atk
+    lua agg soundtouch openal desktop-file-utils atk
 
     # DGen // TODO: libarchive is broken
 
@@ -92,7 +92,7 @@ in buildFHSUserEnv {
   multiPkgs = pkgs: with pkgs; [
     # Common
     libsndfile libtheora libogg libvorbis libopus libGLU libpcap libpulseaudio
-    libao libusb libevdev libudev libgcrypt libxml2 libusb libpng libmpeg2 libv4l
+    libao libusb libevdev udev libgcrypt libxml2 libusb libpng libmpeg2 libv4l
     libjpeg libxkbcommon libass libcdio libjack2 libsamplerate libzip libmad libaio
     libcap libtiff libva libgphoto2 libxslt libtxc_dxtn libsndfile giflib zlib glib
     alsaLib zziplib bash dbus keyutils zip cabextract freetype unzip coreutils

--- a/pkgs/applications/science/electronics/pcb/default.nix
+++ b/pkgs/applications/science/electronics/pcb/default.nix
@@ -1,25 +1,59 @@
-{ stdenv, fetchurl, pkgconfig, gtk2, bison, intltool, flex
-, netpbm, imagemagick, dbus, xlibsWrapper, libGLU, libGL
-, shared-mime-info, tcl, tk, gnome2, pangox_compat, gd, xorg
+{ stdenv
+, fetchurl
+, pkgconfig
+, gtk2
+, bison
+, intltool
+, flex
+, netpbm
+, imagemagick
+, dbus
+, xlibsWrapper
+, libGLU
+, libGL
+, shared-mime-info
+, tcl
+, tk
+, gnome2
+, gd
+, xorg
 }:
 
 stdenv.mkDerivation rec {
   pname = "pcb";
-  version = "20140316";
+  version = "4.2.0";
 
   src = fetchurl {
-    url = "http://ftp.geda-project.org/pcb/pcb-20140316/${pname}-${version}.tar.gz";
-    sha256 = "0l6944hq79qsyp60i5ai02xwyp8l47q7xdm3js0jfkpf72ag7i42";
+    url = "mirror://sourceforge/pcb/${pname}-${version}.tar.gz";
+    sha256 = "0hwsqmcrnk4wipbmfqx1yckmmgfn8vr37d1gh5srfy27czgkcjyd";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    gtk2 bison intltool flex netpbm imagemagick dbus xlibsWrapper
-    libGLU libGL tcl shared-mime-info tk
-    gnome2.gtkglext pangox_compat gd xorg.libXmu
+  nativeBuildInputs = [
+    pkgconfig
+    bison
+    intltool
+    flex
+    netpbm
+    imagemagick
   ];
 
-  configureFlags = ["--disable-update-desktop-database"];
+  buildInputs = [
+    gtk2
+    dbus
+    xlibsWrapper
+    libGLU
+    libGL
+    tcl
+    shared-mime-info
+    tk
+    gnome2.gtkglext
+    gd
+    xorg.libXmu
+  ];
+
+  configureFlags = [
+    "--disable-update-desktop-database"
+  ];
 
   meta = with stdenv.lib; {
     description = "Printed Circuit Board editor";

--- a/pkgs/desktops/gnome-2/platform/gtkglext/default.nix
+++ b/pkgs/desktops/gnome-2/platform/gtkglext/default.nix
@@ -1,31 +1,57 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, glib, gtk2, libGLU, libGL, pango, pangox_compat, xorg }:
+{ stdenv
+, fetchFromGitLab
+, pkgconfig
+, gtk-doc
+, autoconf
+, automake
+, which
+, libtool
+, gobject-introspection
+, glib
+, gtk2
+, libGLU
+, libGL
+, pango
+, xorg
+}:
 
 stdenv.mkDerivation rec {
-  name = "gtkglext-1.2.0";
+  pname = "gtkglext";
+  version = "unstable-2019-12-19";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/gtkglext/1.2/${name}.tar.bz2";
-    sha256 = "0lbz96jwz57hnn52b8rfj54inwpwcc9fkdq6ya043cgnfih77g8n";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "Archive";
+    repo = pname;
+    # build fixes
+    # https://gitlab.gnome.org/Archive/gtkglext/merge_requests/1
+    rev = "ad95fbab68398f81d7a5c895276903b0695887e2";
+    sha256 = "1d1bp4635nla7d07ci40c7w4drkagdqk8wg93hywvdipmjfb4yqb";
   };
 
-  buildInputs = with xorg;
-    [ pkgconfig glib gtk2 libGLU libGL pango libX11 libXmu ];
-  propagatedBuildInputs = [ pangox_compat ];
-
-  patches = [
-    # The library uses `GTK_WIDGET_REALIZED', `GTK_WIDGET_TOPLEVEL', and
-    # `GTK_WIDGET_NO_WINDOW', all of which appear to be deprecated nowadays.
-    (fetchpatch {
-      name = "02_fix_gtk-2.20_deprecated_symbols.diff";
-      url = https://git.gnome.org/browse/gtkglext/patch/?id=d8f285d1397f6c41099c67e668288eecc1cdae67;
-      sha256 = "1zxak73plhy3m6psil1q9ssvjh9aqrif7kcbcz69y480qfb4ja08";
-    })
-    # Fix build with glibc ≥ 2.27
-    (fetchurl {
-      url = https://salsa.debian.org/gewo/gtkglext/raw/3b002677c907890c7de002c9f5b4b3ec71d11b31/debian/patches/04_glibc2.27-ftbfs.diff;
-      sha256 = "1l1swkjkai6pnah23xfsfpbq2fgbhp5pzj3l0ybsx6b858cxqzj5";
-    })
+  nativeBuildInputs = [
+    pkgconfig
+    gtk-doc
+    autoconf
+    automake
+    which
+    libtool
+    gobject-introspection
   ];
+
+  buildInputs = [
+    glib
+    gtk2
+    libGLU
+    libGL
+    pango
+    xorg.libX11
+    xorg.libXmu
+  ];
+
+  preConfigure = ''
+    NOCONFIGURE=1 ./autogen.sh
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://projects.gnome.org/gtkglext/;

--- a/pkgs/misc/emulators/desmume/default.nix
+++ b/pkgs/misc/emulators/desmume/default.nix
@@ -5,7 +5,7 @@
 , tinyxml
 , agg, alsaLib, soundtouch, openal
 , desktop-file-utils
-, gtk2, gtkglext, libglade, pangox_compat
+, gtk2, gtkglext, libglade
 , libGLU, libpcap, SDL, zziplib }:
 
 with stdenv.lib;
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
   [ pkgconfig libtool intltool libXmu lua agg alsaLib soundtouch
-    openal desktop-file-utils gtk2 gtkglext libglade pangox_compat
+    openal desktop-file-utils gtk2 gtkglext libglade
     libGLU libpcap SDL zziplib tinyxml ];
 
   configureFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19869,7 +19869,7 @@ in
   luppp = callPackage ../applications/audio/luppp { };
 
   lutris-unwrapped = python3.pkgs.callPackage ../applications/misc/lutris {
-    inherit (gnome3) gnome-desktop libgnome-keyring webkitgtk;
+    inherit (gnome3) gnome-desktop libgnome-keyring;
     wine = wineWowPackages.staging;
   };
   lutris = callPackage ../applications/misc/lutris/chrootenv.nix { };


### PR DESCRIPTION
`pango` recently broke `pangox_compat` package but most packages do not actually need it – they were probably only adding it because `gtkglext` required it. We switched to master branch of gtkglext which fixes lot of issues and also no longer requires *pangox*.

|      package      | builds |   runs  |
|-------------------|--------|---------|
| `gnome2.gtkglext` | ✔️      | 🤷‍♀️️ |
| `pcb`             | ✔️      | ✔️       |
| `k3d`             |  ✔️      |   ✔️      |
| `lutris`          |   ⌛️     |         |
| `desmume`         | ✔️      | ✔️       |
| `anydesk`         | ❌      |         |
| `openmodelica`    |     ❌    |         |

`anydesk` seems to be an exception:

```
result/bin/anydesk: error while loading shared libraries: libpangox-1.0.so.0: cannot open shared object file: No such file or directory
```

but what can we expect from unfree software 😜️


`openmodelica` seems to fail for unrelated reasons:

```
checking LAPACK/BLAS flags... configure: error: dgesv (LAPACK) linking failed using -llapack -lblas
configure: error: ./configure failed for OMCompiler
builder for '/nix/store/2ivdliyd5f5r6xigz6j2z7id7bz9vsfw-openmodelica.drv' failed with exit code 1
```

Fixes: https://github.com/NixOS/nixpkgs/issues/75790