### PR TITLE
platformio: 4.0.3 -> 4.1.0

### DIFF
--- a/pkgs/development/arduino/platformio/core.nix
+++ b/pkgs/development/arduino/platformio/core.nix
@@ -1,8 +1,10 @@
 { stdenv, lib, buildPythonApplication, fetchFromGitHub
 , bottle, click, colorama
 , lockfile, pyserial, requests
-, pytest, semantic-version, tox, tabulate
-, git
+, pytest, semantic-version, tox, tabulate, pyelftools
+, jsondiff, git
+# Marshmallow deps
+, buildPythonPackage, fetchPypi, dateutil, simplejson
 }:
 
 let
@@ -39,26 +41,57 @@ let
     "test_pkgmanifest.py::test_packages"
   ]) ++ (map (e: "--ignore=tests/${e}") [
     "commands/test_boards.py"
+    "commands/test_check.py"
     "commands/test_platform.py"
     "commands/test_update.py"
     "test_maintenance.py"
     "test_ino2cpp.py"
   ]));
 
+  # Waiting for marshmallow 3.0 support - https://github.com/platformio/platformio-core/pull/3296
+  marshmallow = buildPythonPackage rec {
+    pname = "marshmallow";
+    version = "2.20.5";
+
+    meta = {
+      homepage = "https://github.com/marshmallow-code/marshmallow";
+      description = ''
+        A lightweight library for converting complex objects to and from
+        simple Python datatypes.
+      '';
+      license = lib.licenses.mit;
+    };
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "19yb2936ay2fc9aby4lyzscipf9gd9lk0zwjy7wm3b5j84pqj87f";
+    };
+
+    propagatedBuildInputs = [ dateutil simplejson ];
+
+    doCheck = false;
+  };
+
+  spdx = builtins.fetchurl {
+    url = "https://raw.githubusercontent.com/spdx/license-list-data/v3.6/json/licenses.json";
+    sha256 = "1knwbfhd1gxr0b9cbxizajvnhr67yfmaq6ds3ajvsjmyqp7bk0cl";
+  };
+
 in buildPythonApplication rec {
   pname = "platformio";
-  version = "4.0.3";
+  version = "4.1.0";
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
   src = fetchFromGitHub {
     owner = "platformio";
     repo = "platformio-core";
     rev = "v${version}";
-    sha256 = "1naaa53cc7n7zyqggqjvvgkcq8cyzngdf904y9ag0x1vvb70f8j9";
+    sha256 = "10v9jw1zjfqr3wl6kills3cfp0ky7xbm1gc3z0n57wrqbc6cmz95";
   };
 
   propagatedBuildInputs =  [
-    bottle click colorama git lockfile
+    bottle click colorama git jsondiff
+    lockfile marshmallow pyelftools
     pyserial requests semantic-version
     tabulate
   ];
@@ -70,12 +103,16 @@ in buildPythonApplication rec {
   checkPhase = ''
     runHook preCheck
 
+    export SPDX_LICENSE_FILE="${spdx}"
     py.test -v tests ${args}
 
     runHook postCheck
   '';
 
-  patches = [ ./fix-searchpath.patch ];
+  patches = [
+    ./fix-schema-tests.patch
+    ./fix-searchpath.patch
+  ];
 
   meta = with stdenv.lib; {
     broken = stdenv.isAarch64;

--- a/pkgs/development/arduino/platformio/fix-schema-tests.patch
+++ b/pkgs/development/arduino/platformio/fix-schema-tests.patch
@@ -1,0 +1,33 @@
+--- a/platformio/package/manifest/schema.py
++++ b/platformio/package/manifest/schema.py
+@@ -12,7 +12,8 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+
+-import requests
++import json
++import os
+ import semantic_version
+ from marshmallow import Schema, ValidationError, fields, validate, validates
+
+@@ -161,7 +162,7 @@ class ManifestSchema(Schema):
+     def validate_license(self, value):
+         try:
+             spdx = self.load_spdx_licenses()
+-        except requests.exceptions.RequestException:
++        except (ValueError, OSError):
+             raise ValidationError("Could not load SPDX licenses for validation")
+         for item in spdx.get("licenses", []):
+             if item.get("licenseId") == value:
+@@ -174,9 +175,5 @@ class ManifestSchema(Schema):
+     @staticmethod
+     @memoized(expire="1h")
+     def load_spdx_licenses():
+-        r = requests.get(
+-            "https://raw.githubusercontent.com/spdx/license-list-data"
+-            "/v3.6/json/licenses.json"
+-        )
+-        r.raise_for_status()
+-        return r.json()
++        with open(os.environ["SPDX_LICENSE_FILE"]) as f:
++            return json.load(f)

--- a/pkgs/development/arduino/platformio/fix-searchpath.patch
+++ b/pkgs/development/arduino/platformio/fix-searchpath.patch
@@ -1,11 +1,11 @@
---- ./platformio/proc.py-old	2017-09-29 01:20:08.174548250 +0200
-+++ ./platformio/proc.py	2017-09-29 01:19:48.410485308 +0200
-@@ -164,7 +164,7 @@
-                 isdir(join(p, "click")) or isdir(join(p, "platformio")))
+--- a/platformio/proc.py
++++ b/platformio/proc.py
+@@ -167,7 +167,7 @@ def copy_pythonpath_to_osenv():
+             conditions.append(isdir(join(p, "click")) or isdir(join(p, "platformio")))
          if all(conditions):
              _PYTHONPATH.append(p)
--    os.environ['PYTHONPATH'] = os.pathsep.join(_PYTHONPATH)
+-    os.environ["PYTHONPATH"] = os.pathsep.join(_PYTHONPATH)
 +    os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
  
  
- def get_serialports(filter_hwid=False):
+ def where_is_program(program, envpath=None):


### PR DESCRIPTION
###### Motivation for this change

Upgrade PlatformIO package to latest release.

Only tested `pio run` and `pio --version` briefly on an existing project I started with platformio v4.0.3.  Will start a new project this week to test more subcommands.  CC'd others in case they want to test something of particular interest.

- Install marshmallow 2.20.5 with internal package.  
  PlatformIO is working on upgrading to marshmallow 3.x.  
  Nixpkgs only supplies marshmallow 3.x.
- Ignore tests/commands/test_check.py because it depends on internet access.
- Add missing python dependencies for PlatformIO.
- Fix schema tests by letting Nix download the SPDX license file.
- Update patch for python search path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mogorman @makefu @peterhoeg @dotlambda 