### PR TITLE
kdeFrameworks.ki18n: python2 -> python3

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/ki18n.nix
+++ b/pkgs/development/libraries/kde-frameworks/ki18n.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation, lib,
-  extra-cmake-modules, gettext, python,
+  extra-cmake-modules, gettext, python3,
   qtbase, qtdeclarative, qtscript,
 }:
 
@@ -11,6 +11,6 @@ mkDerivation {
     broken = builtins.compareVersions qtbase.version "5.7.0" < 0;
   };
   nativeBuildInputs = [ extra-cmake-modules ];
-  propagatedNativeBuildInputs = [ gettext python ];
+  propagatedNativeBuildInputs = [ gettext python3 ];
   buildInputs = [ qtdeclarative qtscript ];
 }


### PR DESCRIPTION
Upstream has support: https://github.com/KDE/ki18n/blame/8f84d19aad04b2a925f2373ad26323bb8324b982/cmake/KF5I18nMacros.cmake.in#L34


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
