### PR TITLE
gnome2.GConf: python2 -> python3

### DIFF
--- a/pkgs/desktops/gnome-2/platform/GConf/default.nix
+++ b/pkgs/desktops/gnome-2/platform/GConf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, dbus-glib, glib, ORBit2, libxml2, polkit, python2, intltool }:
+{ stdenv, fetchurl, pkgconfig, dbus-glib, glib, ORBit2, libxml2, polkit, python3, intltool }:
 
 stdenv.mkDerivation rec {
   pname = "gconf";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "man" ];
 
-  buildInputs = [ ORBit2 libxml2 python2 ]
+  buildInputs = [ ORBit2 libxml2 python3 ]
     # polkit requires pam, which requires shadow.h, which is not available on
     # darwin
     ++ stdenv.lib.optional (!stdenv.isDarwin) polkit;
@@ -23,6 +23,10 @@ stdenv.mkDerivation rec {
   configureFlags =
     # fixes the "libgconfbackend-oldxml.so is not portable" error on darwin
     stdenv.lib.optional stdenv.isDarwin [ "--enable-static" ];
+
+  postPatch = ''
+    2to3 --write --nobackup gsettings/gsettings-schema-convert
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://projects.gnome.org/gconf/;


### PR DESCRIPTION
Borrowing fedora's 2to3 trick:
https://src.fedoraproject.org/rpms/GConf2/blob/master/f/GConf2.spec#_90

(thank you, @worldofpeace!)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
