### PR TITLE
Fix haskellPackages.dhall_1_28_0 and spago

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1327,4 +1327,7 @@ self: super: {
   haskell-lsp_0_18_0_0 = super.haskell-lsp_0_18_0_0.override { haskell-lsp-types = self.haskell-lsp-types_0_18_0_0; };
   lsp-test_0_8_2_0 = (dontCheck super.lsp-test_0_8_2_0).override { haskell-lsp = self.haskell-lsp_0_18_0_0; };
 
+  # spago-0.12.1 fails to build with dhall-1.28.0
+  spago = appendPatch super.spago ./patches/spago-0.12.1-dhall-1.28.0.patch;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -692,4 +692,18 @@ self: super: builtins.intersectAttrs super {
       spagoWithoutChecks = dontCheck spagoWithoutHaddocks;
     in
     spagoWithoutChecks;
+
+  # https://github.com/dhall-lang/dhall-haskell/commit/dedd5e0ea6fd12f87d887af3d2220eebc61ee8af
+  # This raises the lower bound on prettyprinter to 1.5.1 since
+  # `removeTrailingWhitespace` is buggy in earlier versions.
+  dhall_1_28_0 =
+    let
+      prettyprinter-ansi-terminal = super.prettyprinter-ansi-terminal.override { prettyprinter = self.prettyprinter_1_5_1; };
+    in
+      super.dhall_1_28_0.override {
+        prettyprinter = self.prettyprinter_1_5_1;
+        prettyprinter-ansi-terminal = prettyprinter-ansi-terminal;
+      };
+  dhall-bash_1_0_25 = super.dhall-bash_1_0_25.override { dhall = self.dhall_1_28_0; };
+  dhall-json_1_6_0 = super.dhall-json_1_6_0.override { dhall = self.dhall_1_28_0; };
 }

--- a/pkgs/development/haskell-modules/patches/spago-0.12.1-dhall-1.28.0.patch
+++ b/pkgs/development/haskell-modules/patches/spago-0.12.1-dhall-1.28.0.patch
@@ -1,0 +1,122 @@
+--- a/src/Spago/Config.hs
++++ b/src/Spago/Config.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE ViewPatterns #-}
+ {-# LANGUAGE OverloadedLists #-}
+ module Spago.Config
+@@ -71,13 +72,22 @@ isLocationType (Dhall.Union kvs) | locationUnionMap == Dhall.Map.toMap kvs = Tru
+ isLocationType _ = False
+ 
+ 
++#if MIN_VERSION_dhall(1,28,0)
++dependenciesType :: Dhall.Decoder [PackageName]
++dependenciesType = Dhall.list (Dhall.auto :: Dhall.Decoder PackageName)
++#else
+ dependenciesType :: Dhall.Type [PackageName]
+ dependenciesType = Dhall.list (Dhall.auto :: Dhall.Type PackageName)
++#endif
+ 
+ 
+ parsePackage :: (MonadIO m, MonadThrow m, MonadReader env m, HasLogFunc env) => ResolvedExpr -> m Package
+ parsePackage (Dhall.RecordLit ks) = do
++#if MIN_VERSION_dhall(1,28,0)
++  repo         <- Dhall.requireTypedKey ks "repo" (Dhall.auto :: Dhall.Decoder PackageSet.Repo)
++#else
+   repo         <- Dhall.requireTypedKey ks "repo" (Dhall.auto :: Dhall.Type PackageSet.Repo)
++#endif
+   version      <- Dhall.requireTypedKey ks "version" Dhall.strictText
+   dependencies <- Dhall.requireTypedKey ks "dependencies" dependenciesType
+   let location = PackageSet.Remote{..}
+@@ -121,7 +131,11 @@ parseConfig = do
+           $ traverse parsePackage pkgs
+         something -> throwM $ Dhall.PackagesIsNotRecord something)
+ 
++#if MIN_VERSION_dhall(1,28,0)
++      let sourcesType  = Dhall.list (Dhall.auto :: Dhall.Decoder Purs.SourcePath)
++#else
+       let sourcesType  = Dhall.list (Dhall.auto :: Dhall.Type Purs.SourcePath)
++#endif
+       name              <- Dhall.requireTypedKey ks "name" Dhall.strictText
+       dependencies      <- Dhall.requireTypedKey ks "dependencies" dependenciesType
+       configSourcePaths <- Dhall.requireTypedKey ks "sources" sourcesType
+--- a/src/Spago/Dhall.hs
++++ b/src/Spago/Dhall.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP #-}
+ {-# LANGUAGE GADTs #-}
+ module Spago.Dhall
+   ( module Spago.Dhall
+@@ -11,7 +12,11 @@ import qualified Data.Text                             as Text
+ import qualified Data.Text.Prettyprint.Doc             as Pretty
+ import qualified Data.Text.Prettyprint.Doc.Render.Text as PrettyText
+ import           Dhall
++#if MIN_VERSION_dhall(1,28,0)
++import           Dhall.Core                            as Dhall hiding (pretty)
++#else
+ import           Dhall.Core                            as Dhall hiding (Type, pretty)
++#endif
+ import qualified Dhall.Format
+ import qualified Dhall.Import
+ import qualified Dhall.Map
+@@ -83,7 +88,11 @@ readRawExpr pathText = do
+   if exists
+     then (do
+       packageSetText <- readTextFile $ pathFromText pathText
++#if MIN_VERSION_dhall(1,28,0)
++      fmap (\(Header text, expr) -> Just (text, expr)) $ throws $ Parser.exprAndHeaderFromText mempty packageSetText)
++#else
+       fmap Just $ throws $ Parser.exprAndHeaderFromText mempty packageSetText)
++#endif
+     else pure Nothing
+ 
+ 
+@@ -129,7 +138,11 @@ requireTypedKey
+   :: (MonadIO m, MonadThrow m)
+   => Dhall.Map.Map Text (DhallExpr Void)
+   -> Text
++#if MIN_VERSION_dhall(1,28,0)
++  -> Dhall.Decoder a
++#else
+   -> Dhall.Type a
++#endif
+   -> m a
+ requireTypedKey ks name typ = requireKey ks name $ \expr -> case Dhall.extract typ expr of
+   Success v -> pure v
+@@ -141,7 +154,11 @@ maybeTypedKey
+   :: (MonadIO m, MonadThrow m)
+   => Dhall.Map.Map Text (DhallExpr Void)
+   -> Text
++#if MIN_VERSION_dhall(1,28,0)
++  -> Dhall.Decoder a
++#else
+   -> Dhall.Type a
++#endif
+   -> m (Maybe a)
+ maybeTypedKey ks name typ = typify `mapM` Dhall.Map.lookup name ks
+   where
+@@ -157,7 +174,11 @@ maybeTypedKey ks name typ = typify `mapM` Dhall.Map.lookup name ks
+ --   result of the normalization (we need to normalize so that extract can work)
+ --   and return a `Right` only if both typecheck and normalization succeeded.
+ coerceToType
+-  :: Type a -> DhallExpr Void -> Either (ReadError Void) a
++#if MIN_VERSION_dhall(1,28,0)
++  :: Dhall.Decoder a -> DhallExpr Void -> Either (ReadError Void) a
++#else
++  :: Dhall.Type a -> DhallExpr Void -> Either (ReadError Void) a
++#endif
+ coerceToType typ expr = do
+   let annot = Dhall.Annot expr $ Dhall.expected typ
+   let checkedType = typeOf annot
+@@ -168,7 +189,11 @@ coerceToType typ expr = do
+ 
+ -- | Spago configuration cannot be read
+ data ReadError a where
++#if MIN_VERSION_dhall(1,28,0)
++ WrongType             :: Typeable a => Dhall.Decoder b -> DhallExpr a -> ReadError a
++#else
+  WrongType             :: Typeable a => Dhall.Type b -> DhallExpr a -> ReadError a
++#endif
+    -- ^ a package has the wrong type
+  ConfigIsNotRecord     :: Typeable a => DhallExpr a -> ReadError a
+    -- ^ the toplevel value is not a record


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix #75930. See also spacchetti/spago#529

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
