### PR TITLE
ppsspp: 1.4.2 -> 1.9.3

### DIFF
--- a/pkgs/misc/emulators/ppsspp/default.nix
+++ b/pkgs/misc/emulators/ppsspp/default.nix
@@ -1,45 +1,69 @@
-{ stdenv, mkDerivation, fetchFromGitHub, cmake, pkgconfig, qtbase, qtmultimedia
-, glew, libzip, snappy, zlib, withGamepads ? true, SDL2 }:
-
-assert withGamepads -> (SDL2 != null);
-with stdenv.lib;
+{ SDL2
+, cmake
+, fetchFromGitHub
+, ffmpeg
+, glew
+, lib
+, libzip
+, mkDerivation
+, pkgconfig
+, python3
+, qtbase
+, qtmultimedia
+, snappy
+, zlib
+}:
 
 mkDerivation rec {
   pname = "ppsspp";
-  version = "1.4.2";
+  version = "1.9.3";
 
   src = fetchFromGitHub {
     owner = "hrydgard";
     repo = "ppsspp";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "0m4qkhx7q496sm7ibg2n7rm3npxzfr93iraxgndk0vhfk8vy8w75";
+    sha256 = "17sym0vk72lzbh9a1501mhw98c78x1gq7k1fpy69nvvb119j37wa";
   };
 
-  patchPhase = ''
-    echo 'const char *PPSSPP_GIT_VERSION = "${src.rev}";' >> git-version.cpp
-    substituteInPlace UI/NativeApp.cpp --replace /usr/share $out/share
+  postPatch = ''
+    substituteInPlace git-version.cmake \
+      --replace unknown ${src.rev}
+    substituteInPlace UI/NativeApp.cpp \
+      --replace /usr/share $out/share
   '';
 
-  nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ qtbase qtmultimedia glew libzip snappy zlib ]
-    ++ optionals withGamepads [ SDL2 SDL2.dev ];
+  nativeBuildInputs = [ cmake pkgconfig python3 ];
 
-  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" "-DUSING_QT_UI=ON" ];
+  buildInputs = [
+    SDL2
+    ffmpeg
+    glew
+    libzip
+    qtbase
+    qtmultimedia
+    snappy
+    zlib
+  ];
+
+  cmakeFlags = [
+    "-DOpenGL_GL_PREFERENCE=GLVND"
+    "-DUSE_SYSTEM_FFMPEG=ON"
+    "-DUSE_SYSTEM_LIBZIP=ON"
+    "-DUSE_SYSTEM_SNAPPY=ON"
+    "-DUSING_QT_UI=ON"
+  ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/ppsspp
-    mv PPSSPPQt $out/bin/ppsspp
+    mkdir -p $out/share/ppsspp
+    install -Dm555 PPSSPPQt $out/bin/ppsspp
     mv assets $out/share/ppsspp
   '';
 
-  enableParallelBuilding = true;
-
-  meta = {
-    homepage = https://www.ppsspp.org/;
+  meta = with lib; {
     description = "A PSP emulator for Android, Windows, Mac and Linux, written in C++";
+    homepage = "https://www.ppsspp.org/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];
-    platforms = platforms.linux ++ platforms.darwin ++ platforms.cygwin;
   };
 }


### PR DESCRIPTION

###### Motivation for this change

Regular update.

SDL2 is no longer an optional dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @AndersonTorres 
