### PR TITLE
mdcat: 0.13.0 -> 0.14.0

### DIFF
--- a/pkgs/tools/text/mdcat/default.nix
+++ b/pkgs/tools/text/mdcat/default.nix
@@ -2,24 +2,26 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mdcat";
-  version = "0.13.0";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "lunaryorn";
     repo = pname;
     rev = "mdcat-${version}";
-    sha256 = "0xlcpyfmil7sszv4008v4ipqswz49as4nzac0kzmzsb86np191q0";
+    sha256 = "1q8h6pc1i89j1zl4s234inl9v95vsdrry1fzlis89sl2mnbv8ywy";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ (stdenv.lib.optional stdenv.isDarwin Security) openssl ];
 
-  cargoSha256 = "16q17gm59lpjqa18q289cjmjlf2jicag12jz529x5kh11x6bjl8v";
+  cargoSha256 = "1hxsfls6fpllc9yg5ib3qz6pa62j1y1va8a6356j6812csk4ifnn";
 
   checkInputs = [ ansi2html ];
   checkPhase = ''
-    # Skip tests that use the network.
-    cargo test -- --skip terminal::iterm2
+    # Skip tests that use the network and that include files.
+    cargo test -- --skip terminal::iterm2 --skip terminal::resources::tests::remote \
+      --skip magic::tests::detect_mimetype_of_svg_image \
+      --skip magic::tests::detect_mimetype_of_png_image
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[0.14.0 of mdcat was released](https://github.com/lunaryorn/mdcat/releases/tag/mdcat-0.14.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc me!
