### PR TITLE
volctl: init at 0.6.2

### DIFF
--- a/pkgs/tools/audio/volctl/default.nix
+++ b/pkgs/tools/audio/volctl/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchFromGitHub, pythonPackages, libpulseaudio, glib, gtk3, gobject-introspection, wrapGAppsHook }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "volctl";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "buzz";
+    repo = pname;
+    rev = version;
+    sha256 = "1bqq5mrpi7qxzl37z6fj67pqappjmwhi8d8db95j3lmf16svm2xk";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libpulseaudio
+  ];
+
+  pythonPath = with pythonPackages; [
+    pygobject3
+  ];
+
+  strictDeps = false;
+
+  postPatch = ''
+    # The user can set a mixer application in the preferences. The
+    # default is pavucontrol. Do not hard code its path and hope it
+    # can be found in $PATH.
+
+    substituteInPlace volctl/app.py --replace /usr/bin/pavucontrol pavucontrol
+  '';
+
+  preBuild = ''
+    export LD_LIBRARY_PATH=${libpulseaudio}/lib
+  '';
+
+  preFixup = ''
+    glib-compile-schemas ${glib.makeSchemaPath "$out" "${pname}-${version}"}
+
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "${libpulseaudio}/lib"
+    )
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PulseAudio enabled volume control featuring per-app sliders";
+    homepage = https://buzz.github.io/volctl/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2951,6 +2951,8 @@ in
     inherit (pythonPackages) sphinx;
   };
 
+  volctl = callPackage ../tools/audio/volctl { };
+
   wallutils = callPackage ../tools/graphics/wallutils { };
 
   wev = callPackage ../tools/misc/wev { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [volctl](https://buzz.github.io/volctl/), a volume control for GNU/Linux desktops featuring per-app sliders.

It is a PulseAudio-enabled tray icon volume control for GNU/Linux desktops.

![screenshot](https://user-images.githubusercontent.com/1217934/71184385-75615180-2258-11ea-82b6-53183e65b5f1.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).