### PR TITLE
oniguruma: set CMake flags for static builds

### DIFF
--- a/pkgs/development/libraries/oniguruma/default.nix
+++ b/pkgs/development/libraries/oniguruma/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchFromGitHub, cmake, staticOnly ? false }:
 
 stdenv.mkDerivation rec {
   pname = "onig";
@@ -12,6 +12,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = []
+    ++ stdenv.lib.optional staticOnly "-DBUILD_SHARED_LIBS=OFF";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/kkos/oniguruma;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -243,4 +243,6 @@ in {
   ) super.ocaml-ng;
   
   python27 = super.python27.override { static = true; };
+
+  oniguruma = super.oniguruma.overrideAttrs (_: { cmakeFlags = ["-DBUILD_SHARED_LIBS=OFF"]; });
 }

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -244,5 +244,7 @@ in {
   
   python27 = super.python27.override { static = true; };
 
-  oniguruma = super.oniguruma.overrideAttrs (_: { cmakeFlags = ["-DBUILD_SHARED_LIBS=OFF"]; });
+  oniguruma = super.oniguruma.override {
+    staticOnly = true;
+  };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This change makes it possible to build oniguruma statically, based on what I found in the [CMakeLists.txt](https://github.com/kkos/oniguruma/blob/master/CMakeLists.txt#L9). Ultimately this unblocks my building PHP 7.4 statically (since multibyte support requires oniguruma now).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
