### PR TITLE
python3Packages.dask-ml: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/dask-ml/default.nix
+++ b/pkgs/development/python-modules/dask-ml/default.nix
@@ -20,13 +20,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.1.1";
+  version = "1.2.0";
   pname = "dask-ml";
   disabled = pythonOlder "3.6"; # >= 3.6
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1yad9b9hd02rbdf6m1gfj74cjgcbyp7lxdj22d5h5rhv7xa3127x";
+    sha256 = "0ppg8licvkxz1af2q87cxms2p6ss2r5d4fdkbcivph56r0v0ci2k";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
noticed it was broken on hydra :(

EDIT:
i guess with updates to the dask package, fsspec is no loner a dependency, re-purposed PR for version bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[2 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/76047
2 package were built:
python37Packages.dask-ml python38Packages.dask-ml
```