### PR TITLE
nixos/acme: implement postRun using ExecStartPost

### DIFF
--- a/nixos/modules/security/acme.nix
+++ b/nixos/modules/security/acme.nix
@@ -241,9 +241,9 @@ in
                     StateDirectoryMode = rights;
                     WorkingDirectory = "/var/lib/${lpath}";
                     ExecStart = "${pkgs.simp_le}/bin/simp_le ${escapeShellArgs cmdline}";
-                    ExecStopPost =
+                    ExecStartPost =
                       let
-                        script = pkgs.writeScript "acme-post-stop" ''
+                        script = pkgs.writeScript "acme-post-start" ''
                           #!${pkgs.runtimeShell} -e
                           ${data.postRun}
                         '';


### PR DESCRIPTION

###### Motivation for this change
Consider
`security.acme.certs.<name>.postRun = "systemctl reload nginx.service";`.
I would expect this to reload the certificates into nginx whenever new ones arrive.
However, it appears this does not happen after https://github.com/NixOS/nixpkgs/commit/5532065d0690645f0a813fed6e68163b0f4774d4.
That commit changed the systemd service to be `Type=oneshot, RemainAfterExit=true`, but the `postRun` commands are implemented as `ExecStopPost`.
Systemd believes the service is still running, because of `RemainAfterExit`, and thus will not reload nginx. Moving to `ExecStartPost` will reload nginx when the new certificates arrive.

###### Things done
I've built this change and deployed using NixOps, and tested it on the remote server.
I'm happy to do more tests (please yell!), but may need more detailed instructions
(in particular, my machine swiftly OOMs with nix-review, I'm not sure what I'm doing wrong here!)

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions, and deployed via NixOps
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

