### PR TITLE
services.xserver.imwheel: Fix default extraOptions

### DIFF
--- a/nixos/modules/services/x11/imwheel.nix
+++ b/nixos/modules/services/x11/imwheel.nix
@@ -10,7 +10,7 @@ in
 
         extraOptions = mkOption {
           type = types.listOf types.str;
-          default = [ "--buttons 45" ];
+          default = [ "--buttons=45" ];
           example = [ "--debug" ];
           description = ''
             Additional command-line arguments to pass to


### PR DESCRIPTION
###### Motivation for this change

related to https://github.com/NixOS/nixpkgs/pull/71052 it seems there was a mistake made during refactoring. `escapeShellArgs` wraps flags to `''` which results in imwheel not being able to parse them.

###### Things done
~Replace `escapeShellArgs` with `concatStringsSep " "` which fixes the problem.~
Change default `extraOptions` to be compatible with `escapeShellArgs`.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Infinisil sorry that this sliped. 
