### PR TITLE
nixos/nginx: drop extra semicolon in return example

### DIFF
--- a/nixos/modules/services/web-servers/nginx/location-options.nix
+++ b/nixos/modules/services/web-servers/nginx/location-options.nix
@@ -67,7 +67,7 @@ with lib;
     return = mkOption {
       type = types.nullOr types.str;
       default = null;
-      example = "301 http://example.com$request_uri;";
+      example = "301 http://example.com$request_uri";
       description = ''
         Adds a return directive, for e.g. redirections.
       '';


### PR DESCRIPTION
nix appends a semicolon when it generates nginx's configuration file. If the string has a trailing semicolon, then nginx complains about having a duplicated semicolon.

The manual builds and has the correct example when this patch is applied to release-19.09.
However, the manual appears broken on master, so it was not tested there.
(
```
manual-combined.xml:19885: element para: Relax-NG validity error : Did not expect element para there
 19881    </para></listitem>
 19882    <listitem><para>
 19883      <literal>"strong"</literal>: authentication by username/password. If user is not registered his access is denied regardless of ACLs.
 19884    </para></listitem>
 19885  </itemizedlist></para><para>Double authentication is possible, e.g.
 19886  <para>
 19887    {
```
)

There is still the problem that in the [manual's options.html](https://nixos.org/nixos/manual/options.html#opt-services.nginx.virtualHosts._name_.locations._name_.return), the embedded `$` shows up escaped: `Example: "301 http://example.com\$request_uri;" `, but it is correctly not escaped in the [searchable options](https://nixos.org/nixos/options.html#nginx.virtualhosts.%3Cname%3E.locations.%3Cname%3E.return). I haven't yet looked into this.