### PR TITLE
zoom-us: fix web login

### DIFF
--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -105,7 +105,7 @@ let
     to run all update scripts for all packages that lists \`garbas\` as a maintainer
     and have \`updateScript\` defined, or:
 
-        % nix-shell maintainers/scripts/update.nix --argstr package garbas
+        % nix-shell maintainers/scripts/update.nix --argstr package gnome3.nautilus
 
     to run update script for specific package, or
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/75903
Partially helps with https://github.com/NixOS/nixpkgs/issues/73532, because it is now possible to disable `embeddedBrowserForSSOLogin` and login via browser

cc @dtzWill @tadfisher @mkg20001 @pbogdan 

cc @worldofpeace @bjornfor @ttuegel maybe it is possible to reuse existing wrapper, I haven't found a way.