### PR TITLE
wfuzz: init at 2.4.2

### DIFF
--- a/pkgs/development/python-modules/wfuzz/default.nix
+++ b/pkgs/development/python-modules/wfuzz/default.nix
@@ -1,0 +1,51 @@
+{ buildPythonPackage
+, chardet
+, configparser
+, fetchFromGitHub
+, future
+, isPy27
+, lib
+, mock
+, netaddr
+, pkgs
+, pyparsing
+, pycurl
+, pytest
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "wfuzz";
+  version = "2.4.2";
+
+  src = fetchFromGitHub {
+    owner = "xmendez";
+    repo = pname;
+    rev = "v.${version}";
+    sha256 = "15dihrc7jsvpxcmb4fp254s633mkjm7ksjfkr9pqaai49qmnddyf";
+  };
+
+  buildInputs = [ pyparsing configparser ];
+
+  propagatedBuildInputs = [
+    chardet
+    future
+    pycurl
+    six
+  ];
+
+  checkInputs = [ netaddr pytest ] ++ lib.optionals isPy27 [ mock ];
+
+  # Skip tests requiring a local web server.
+  checkPhase = ''
+    HOME=$TMPDIR pytest \
+      tests/test_{moduleman,filterintro,reqresp,api,clparser,dotdict}.py
+  '';
+
+  meta = with lib; {
+    description = "Web content fuzzer, to facilitate web applications assessments";
+    homepage = "https://wfuzz.readthedocs.io";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25556,6 +25556,8 @@ in
 
   wasmtime = callPackage ../development/interpreters/wasmtime {};
 
+  wfuzz = with python3Packages; toPythonApplication wfuzz;
+
   bemenu = callPackage ../applications/misc/bemenu { };
 
   dapper = callPackage ../development/tools/dapper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6601,6 +6601,8 @@ in {
 
   webrtcvad = callPackage ../development/python-modules/webrtcvad { };
 
+  wfuzz = callPackage ../development/python-modules/wfuzz { };
+
   wget = callPackage ../development/python-modules/wget { };
 
   runway-python = callPackage ../development/python-modules/runway-python { };


### PR DESCRIPTION
##### Motivation for this change

Make [wfuzz](https://github.com/xmendez/wfuzz) available on Nix.

Contains the related Python3 package.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).