### PR TITLE
qemu: 4.1.0 -> 4.2.0, including patch for minor CVE-2019-15890

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -35,7 +35,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "4.1.0";
+  version = "4.2.0";
   pname = "qemu"
     + stdenv.lib.optionalString xenSupport "-xen"
     + stdenv.lib.optionalString hostCpuOnly "-host-cpu-only"
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://wiki.qemu.org/download/qemu-${version}.tar.bz2";
-    sha256 = "1bpl6hwiw1jdxk4xmqp10qgki0dji0l2rzr10dyhyk8d85vxxw29";
+    sha256 = "1gczv8hn3wqci86css3mhzrppp3z8vppxw25l08j589k6bvz7x1w";
   };
 
   nativeBuildInputs = [ python python.pkgs.sphinx pkgconfig flex bison ];

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -77,6 +77,13 @@ stdenv.mkDerivation rec {
     ./no-etc-install.patch
     ./fix-qemu-ga.patch
     ./9p-ignore-noatime.patch
+    (fetchpatch {
+      name = "CVE-2019-15890.patch";
+      url = "https://git.qemu.org/?p=libslirp.git;a=patch;h=c59279437eda91841b9d26079c70b8a540d41204";
+      sha256 = "1q2rc67mfdz034mk81z9bw105x9zad7n954sy3kq068b1svrf7iy";
+      stripLen = 1;
+      extraPrefix = "slirp/";
+    })
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch
     ++ optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {

--- a/pkgs/applications/virtualization/qemu/no-etc-install.patch
+++ b/pkgs/applications/virtualization/qemu/no-etc-install.patch
@@ -1,13 +1,12 @@
 diff --git a/Makefile b/Makefile
-index 85862fb8..ed52c5ec 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -841,7 +841,7 @@ endif
+@@ -867,7 +867,7 @@ install-includedir:
+ 	$(INSTALL_DIR) "$(DESTDIR)$(includedir)"
  
- ICON_SIZES=16x16 24x24 32x32 48x48 64x64 128x128 256x256 512x512
- 
--install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir \
-+install: all $(if $(BUILD_DOCS),install-doc) install-datadir \
+ install: all $(if $(BUILD_DOCS),install-doc) \
+-	install-datadir install-localstatedir install-includedir \
++	install-datadir install-includedir \
  	$(if $(INSTALL_BLOBS),$(edk2-decompressed)) \
  	recurse-install
  ifneq ($(TOOLS),)


### PR DESCRIPTION
###### Motivation for this change
Mostly the bump but also https://nvd.nist.gov/vuln/detail/CVE-2019-15890

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
