### PR TITLE
buildpack: 0.5.0 -> 0.6.0

### DIFF
--- a/pkgs/development/tools/buildpack/default.nix
+++ b/pkgs/development/tools/buildpack/default.nix
@@ -2,20 +2,20 @@
 
 buildGoPackage rec {
   pname = "pack";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
-    owner = "buildpack";
+    owner = "buildpacks";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0yh62h7lz2i07gixccmfyxk607djp1nrs57rzk7nkxnjcj4jj5sr";
+    sha256 = "00v4kb9cv6nn7vrybjkv0kgcvfm5dsg0168dv253mrp9xmv8kd9l";
   };
 
-  goPackagePath = "github.com/buildpack/pack";
+  goPackagePath = "github.com/buildpacks/pack";
 
   subPackages = [ "cmd/pack" ];
 
-  buildFlagsArray = [ "-ldflags=-s -w -X github.com/buildpack/pack/cmd.Version=${version}" ];
+  buildFlagsArray = [ "-ldflags=-s -w -X github.com/buildpacks/pack/cmd.Version=${version}" ];
 
   meta = with lib; {
     homepage = "https://buildpacks.io/";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/buildpacks/pack/releases/tag/v0.6.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
