### PR TITLE
haskellPackages.GLUT: Fix freeglut.pc -> glut.pc

### DIFF
--- a/pkgs/development/haskell-modules/patches/GLUT.patch
+++ b/pkgs/development/haskell-modules/patches/GLUT.patch
@@ -6,7 +6,7 @@ index f370d6c..a404e1e 100644
    else
      cpp-options: "-DCALLCONV=ccall"
      cc-options: "-DUSE_DLSYM"
-+  pkgconfig-depends: freeglut
++  pkgconfig-depends: glut
  
  executable BOGLGP01-OnYourOwn1
    if !flag(BuildExamples)


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/70235#issuecomment-567753164

This was broken by PR #70235 with commit:

* f5ae5cac - freeglut: 3.0.0 -> 3.2.1

The in the newer freeglut version, the pkg-config file is called `glut.pc`, no longer `freeglut.pc`.

Found in:

* https://github.com/NixOS/nixpkgs/pull/70235#issuecomment-567536852

Fixes error:

```
Setup: The pkg-config package 'freeglut' is required but it could not be found.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peti

FYI @bjornfor @barryfm @jonringer 
