### PR TITLE
haskellPackages.dhall_1_28_0: fix overrides so it builds

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1057,7 +1057,27 @@ self: super: {
     generateOptparseApplicativeCompletion "dhall" (
       dontCheck super.dhall
   );
-  dhall_1_28_0 = dontCheck super.dhall_1_28_0;
+  # https://github.com/dhall-lang/dhall-haskell/commit/dedd5e0ea6fd12f87d887af3d2220eebc61ee8af
+  # This raises the lower bound on prettyprinter to 1.5.1 since
+  # `removeTrailingWhitespace` is buggy in earlier versions.
+  # This will probably be able to be removed when we update to LTS-15.
+  dhall_1_28_0 =
+    dontCheck (super.dhall_1_28_0.override {
+      prettyprinter = self.prettyprinter_1_5_1;
+      prettyprinter-ansi-terminal =
+        self.prettyprinter-ansi-terminal.override {
+          prettyprinter = self.prettyprinter_1_5_1;
+        };
+    });
+  dhall-bash_1_0_25 = super.dhall-bash_1_0_25.override { dhall = self.dhall_1_28_0; };
+  dhall-json_1_6_0 = super.dhall-json_1_6_0.override {
+    dhall = self.dhall_1_28_0;
+    prettyprinter = self.prettyprinter_1_5_1;
+    prettyprinter-ansi-terminal =
+      self.prettyprinter-ansi-terminal.override {
+        prettyprinter = self.prettyprinter_1_5_1;
+      };
+  };
 
   # Missing test files in source distribution, fixed once 1.4.0 is bumped
   # https://github.com/dhall-lang/dhall-haskell/pull/997


### PR DESCRIPTION
This PR fixes dhall_1_28_0, dhall-bash_1_0_25, and dhall-json_1_6_0 so
they build.

They all require a newer version of prettyprinter than we get from the
LTS package set.

This is from https://github.com/NixOS/nixpkgs/pull/75931 by @ijaketak.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
