### PR TITLE
spago: 0.12.1.0 -> 0.13.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1079,6 +1079,9 @@ self: super: {
       };
   };
 
+  # Tests for dhall access the network.
+  dhall_1_27_0 = dontCheck super.dhall_1_27_0;
+
   # Missing test files in source distribution, fixed once 1.4.0 is bumped
   # https://github.com/dhall-lang/dhall-haskell/pull/997
   dhall-json =

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -644,8 +644,8 @@ self: super: builtins.intersectAttrs super {
       # we can safely jailbreak spago and use the older directory package from
       # LTS-14.
       spagoWithOverrides = doJailbreak (super.spago.override {
-        # spago requires the latest version of dhall.
-        directory = self.dhall_1_28_0;
+        # spago requires dhall_1_27_0.
+        dhall = self.dhall_1_27_0;
       });
 
       docsSearchAppJsFile = pkgs.fetchurl {
@@ -683,13 +683,9 @@ self: super: builtins.intersectAttrs super {
         '';
       });
 
-      # Haddock generation is broken for spago.
-      # https://github.com/spacchetti/spago/issues/511
-      spagoWithoutHaddocks = dontHaddock spagoFixHpack;
-
       # Because of the problem above with pulling in hspec defaults to the
       # package.yaml file, the tests are disabled.
-      spagoWithoutChecks = dontCheck spagoWithoutHaddocks;
+      spagoWithoutChecks = dontCheck spagoFixHpack;
     in
     spagoWithoutChecks;
 }

--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -15,5 +15,5 @@ self: super: {
 
   # spago is not released to Hackage.
   # https://github.com/spacchetti/spago/issues/512
-  spago = self.callPackage ../tools/purescript/spago { };
+  spago = self.callPackage ../tools/purescript/spago/spago.nix { };
 }

--- a/pkgs/development/tools/purescript/spago/default.nix
+++ b/pkgs/development/tools/purescript/spago/default.nix
@@ -1,47 +1,14 @@
-{ mkDerivation, aeson, aeson-pretty, ansi-terminal, async-pool
-, base, bower-json, bytestring, Cabal, containers, dhall, directory
-, either, exceptions, extra, fetchgit, file-embed, filepath, foldl
-, fsnotify, github, Glob, hpack, hspec, hspec-discover
-, hspec-megaparsec, http-client, http-conduit, lens-family-core
-, megaparsec, mtl, network-uri, open-browser, optparse-applicative
-, prettyprinter, process, QuickCheck, retry, rio, rio-orphans, safe
-, semver-range, stdenv, stm, tar, template-haskell, temporary, text
-, time, transformers, turtle, unliftio, unordered-containers
-, vector, versions, zlib
+{ haskellPackages
+, haskell
+, lib
 }:
-mkDerivation {
-  pname = "spago";
-  version = "0.12.1.0";
-  src = fetchgit {
-    url = "https://github.com/spacchetti/spago";
-    sha256 = "17xgp75yxangmb65sv3raysad31kmc109c4q4aj9dgcdqz23fcn2";
-    rev = "a4679880402ead320f8be2f091b25d30e27b62df";
-    fetchSubmodules = true;
+
+haskell.lib.justStaticExecutables (haskell.lib.overrideCabal haskellPackages.spago (oldAttrs: {
+  maintainers = (oldAttrs.maintainers or []) ++ [
+    lib.maintainers.cdepillabout
+  ];
+
+  passthru = (oldAttrs.passthru or {}) // {
+    updateScript = ./update.sh;
   };
-  isLibrary = true;
-  isExecutable = true;
-  libraryHaskellDepends = [
-    aeson aeson-pretty ansi-terminal async-pool base bower-json
-    bytestring Cabal containers dhall directory either exceptions
-    file-embed filepath foldl fsnotify github Glob http-client
-    http-conduit lens-family-core megaparsec mtl network-uri
-    open-browser prettyprinter process retry rio rio-orphans safe
-    semver-range stm tar template-haskell temporary text time
-    transformers turtle unliftio unordered-containers vector versions
-    zlib
-  ];
-  libraryToolDepends = [ hpack ];
-  executableHaskellDepends = [
-    aeson-pretty async-pool base bytestring containers dhall filepath
-    github lens-family-core megaparsec optparse-applicative process
-    retry stm temporary text time turtle vector
-  ];
-  testHaskellDepends = [
-    base containers directory extra hspec hspec-megaparsec megaparsec
-    process QuickCheck temporary text turtle versions
-  ];
-  testToolDepends = [ hspec-discover ];
-  prePatch = "hpack";
-  homepage = "https://github.com/spacchetti/spago#readme";
-  license = stdenv.lib.licenses.bsd3;
-}
+}))

--- a/pkgs/development/tools/purescript/spago/spago.nix
+++ b/pkgs/development/tools/purescript/spago/spago.nix
@@ -1,0 +1,47 @@
+{ mkDerivation, aeson, aeson-pretty, ansi-terminal, async-pool
+, base, bower-json, bytestring, Cabal, containers, dhall, directory
+, either, exceptions, extra, fetchgit, file-embed, filepath, foldl
+, fsnotify, github, Glob, hpack, hspec, hspec-discover
+, hspec-megaparsec, http-client, http-conduit, lens-family-core
+, megaparsec, mtl, network-uri, open-browser, optparse-applicative
+, prettyprinter, process, QuickCheck, retry, rio, rio-orphans, safe
+, semver-range, stdenv, stm, tar, template-haskell, temporary, text
+, time, transformers, turtle, unliftio, unordered-containers
+, vector, versions, zlib
+}:
+mkDerivation {
+  pname = "spago";
+  version = "0.13.0";
+  src = fetchgit {
+    url = "https://github.com/spacchetti/spago.git";
+    sha256 = "158xq5zn32iwswxmpma92763hl6kzq7kb01cyvphmmlilx55b6yk";
+    rev = "426838670ba9de4593f4c533a6947efb2d8ad4ba";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson aeson-pretty ansi-terminal async-pool base bower-json
+    bytestring Cabal containers dhall directory either exceptions
+    file-embed filepath foldl fsnotify github Glob http-client
+    http-conduit lens-family-core megaparsec mtl network-uri
+    open-browser prettyprinter process retry rio rio-orphans safe
+    semver-range stm tar template-haskell temporary text time
+    transformers turtle unliftio unordered-containers vector versions
+    zlib
+  ];
+  libraryToolDepends = [ hpack ];
+  executableHaskellDepends = [
+    aeson-pretty async-pool base bytestring containers dhall filepath
+    github lens-family-core megaparsec optparse-applicative process
+    retry stm temporary text time turtle vector
+  ];
+  testHaskellDepends = [
+    base containers directory extra hspec hspec-megaparsec megaparsec
+    process QuickCheck temporary text turtle versions
+  ];
+  testToolDepends = [ hspec-discover ];
+  prePatch = "hpack";
+  homepage = "https://github.com/spacchetti/spago#readme";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/development/tools/purescript/spago/update.sh
+++ b/pkgs/development/tools/purescript/spago/update.sh
@@ -14,7 +14,7 @@ set -eo pipefail
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Spago derivation created with cabal2nix.
-spago_derivation_file="${script_dir}/default.nix"
+spago_derivation_file="${script_dir}/spago.nix"
 
 # This is the current revision of spago in Nixpkgs.
 old_version="$(sed -En 's/.*\bversion = "(.*?)".*/\1/p' "$spago_derivation_file")"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8136,7 +8136,7 @@ in
   psc-package = haskell.lib.justStaticExecutables
     (haskellPackages.callPackage ../development/compilers/purescript/psc-package { });
 
-  spago = haskell.lib.justStaticExecutables haskellPackages.spago;
+  spago = callPackage ../development/tools/purescript/spago { };
 
   tacacsplus = callPackage ../servers/tacacsplus { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update spago to the latest release:

https://github.com/spacchetti/spago/releases/tag/0.13.0

This requires that `haskellPackages.dhall_1_27_0` exists, which was added in #76081 but hasn't been generated yet.

When it gets generated, this PR can be rebased on top of `haskell-updates` and merged in.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
