### PR TITLE
pythonPackages.pcpp: init at 1.21

### DIFF
--- a/pkgs/development/python-modules/pcpp/default.nix
+++ b/pkgs/development/python-modules/pcpp/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, stdenv
+}:
+
+buildPythonPackage rec {
+  pname = "pcpp";
+  version = "1.21";
+
+  src = fetchFromGitHub {
+    owner = "ned14";
+    repo = "pcpp";
+    rev = "v${version}";
+    sha256 = "0k52qyxzdngdhyn4sya2qn1w1a4ll0mcla4h4gb1v91fk4lw25dm";
+    fetchSubmodules = true;
+  };
+ 
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ned14/pcpp;
+    description = "A C99 preprocessor written in pure Python";
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ rakesh4g ];
+ };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -897,6 +897,8 @@ in {
 
   pc-ble-driver-py = toPythonModule (callPackage ../development/python-modules/pc-ble-driver-py { });
 
+  pcpp = callPackage ../development/python-modules/pcpp { };
+
   pdf2image = callPackage ../development/python-modules/pdf2image { };
 
   pdfminer = callPackage ../development/python-modules/pdfminer_six { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A C99 preprocessor written in pure Python

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @CMCDragonkai 
