### PR TITLE
Fix haskell-lsp and lsp-test references

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1327,4 +1327,8 @@ self: super: {
   haskell-lsp_0_18_0_0 = super.haskell-lsp_0_18_0_0.override { haskell-lsp-types = self.haskell-lsp-types_0_18_0_0; };
   lsp-test_0_8_2_0 = (dontCheck super.lsp-test_0_8_2_0).override { haskell-lsp = self.haskell-lsp_0_18_0_0; };
 
+  # 2019-12-19 - glirc wants regex-tdfa >=1.3 which results in errors with regex-base which errors more
+  # hoping to make a proper derivation with plugins enabled and more reliable building -- kiwi
+  glirc = doJailbreak super.glirc;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1057,7 +1057,27 @@ self: super: {
     generateOptparseApplicativeCompletion "dhall" (
       dontCheck super.dhall
   );
-  dhall_1_28_0 = dontCheck super.dhall_1_28_0;
+  # https://github.com/dhall-lang/dhall-haskell/commit/dedd5e0ea6fd12f87d887af3d2220eebc61ee8af
+  # This raises the lower bound on prettyprinter to 1.5.1 since
+  # `removeTrailingWhitespace` is buggy in earlier versions.
+  # This will probably be able to be removed when we update to LTS-15.
+  dhall_1_28_0 =
+    dontCheck (super.dhall_1_28_0.override {
+      prettyprinter = self.prettyprinter_1_5_1;
+      prettyprinter-ansi-terminal =
+        self.prettyprinter-ansi-terminal.override {
+          prettyprinter = self.prettyprinter_1_5_1;
+        };
+    });
+  dhall-bash_1_0_25 = super.dhall-bash_1_0_25.override { dhall = self.dhall_1_28_0; };
+  dhall-json_1_6_0 = super.dhall-json_1_6_0.override {
+    dhall = self.dhall_1_28_0;
+    prettyprinter = self.prettyprinter_1_5_1;
+    prettyprinter-ansi-terminal =
+      self.prettyprinter-ansi-terminal.override {
+        prettyprinter = self.prettyprinter_1_5_1;
+      };
+  };
 
   # Missing test files in source distribution, fixed once 1.4.0 is bumped
   # https://github.com/dhall-lang/dhall-haskell/pull/997

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1331,4 +1331,19 @@ self: super: {
   # hoping to make a proper derivation with plugins enabled and more reliable building -- kiwi
   glirc = doJailbreak super.glirc;
 
+  # apply patches from https://github.com/snapframework/snap-server/pull/126
+  # manually until they are accepted upstream
+  snap-server = overrideCabal super.snap-server (drv: {
+    patches = [(pkgs.fetchpatch {
+      # allow compilation with network >= 3
+      url = https://github.com/snapframework/snap-server/pull/126/commits/4338fe15d68e11e3c7fd0f9862f818864adc1d45.patch;
+      sha256 = "1nlw9lckm3flzkmhkzwc7zxhdh9ns33w8p8ds8nf574nqr5cr8bv";
+    })
+    (pkgs.fetchpatch {
+      # prefer fdSocket over unsafeFdSocket
+      url = https://github.com/snapframework/snap-server/pull/126/commits/410de2df123b1d56b3093720e9c6a1ad79fe9de6.patch;
+      sha256 = "08psvw0xny64q4bw1nwg01pkzh01ak542lw6k1ps7cdcwaxk0n94";
+    })];
+  });
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1343,7 +1343,7 @@ self: super: {
   spacecookie = super.spacecookie.override { systemd = self.systemd_2_2_0; };
 
   # ghcide needs the latest versions of haskell-lsp.
-  ghcide = super.ghcide.override { haskell-lsp = self.haskell-lsp_0_18_0_0; lsp-test = self.lsp-test_0_8_2_0; };
+  ghcide = super.ghcide.override { haskell-lsp = self.haskell-lsp_0_19_0_0; lsp-test = self.lsp-test_0_9_0_0; };
   haskell-lsp_0_19_0_0 = super.haskell-lsp_0_19_0_0.override { haskell-lsp-types = self.haskell-lsp-types_0_19_0_0; };
   lsp-test_0_9_0_0 = (dontCheck super.lsp-test_0_9_0_0).override { haskell-lsp = self.haskell-lsp_0_19_0_0; };
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1344,8 +1344,8 @@ self: super: {
 
   # ghcide needs the latest versions of haskell-lsp.
   ghcide = super.ghcide.override { haskell-lsp = self.haskell-lsp_0_18_0_0; lsp-test = self.lsp-test_0_8_2_0; };
-  haskell-lsp_0_18_0_0 = super.haskell-lsp_0_18_0_0.override { haskell-lsp-types = self.haskell-lsp-types_0_18_0_0; };
-  lsp-test_0_8_2_0 = (dontCheck super.lsp-test_0_8_2_0).override { haskell-lsp = self.haskell-lsp_0_18_0_0; };
+  haskell-lsp_0_19_0_0 = super.haskell-lsp_0_19_0_0.override { haskell-lsp-types = self.haskell-lsp-types_0_19_0_0; };
+  lsp-test_0_9_0_0 = (dontCheck super.lsp-test_0_9_0_0).override { haskell-lsp = self.haskell-lsp_0_19_0_0; };
 
   # 2019-12-19 - glirc wants regex-tdfa >=1.3 which results in errors with regex-base which errors more
   # hoping to make a proper derivation with plugins enabled and more reliable building -- kiwi

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9199,7 +9199,6 @@ broken-packages:
   - stack-run-auto
   - stack-type
   - stack-wrapper
-  - stack2cabal
   - stack2nix
   - stackage
   - stackage-build-plan

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2489,6 +2489,7 @@ extra-packages:
   - control-monad-free < 0.6            # newer versions don't compile with anything but GHC 7.8.x
   - dbus <1                             # for xmonad-0.26
   - deepseq == 1.3.0.1                  # required to build Cabal with GHC 6.12.3
+  - dhall == 1.27.0                     # required for spago 0.13.0.  Probably can be removed when next version of spago is available.
   - generic-deriving == 1.10.5.*        # new versions don't compile with GHC 7.10.x
   - gloss < 1.9.3                       # new versions don't compile with GHC 7.8.x
   - haddock == 2.22.*                   # required on GHC 8.0.x

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2497,6 +2497,8 @@ extra-packages:
   - happy <1.19.6                       # newer versions break Agda
   - happy == 1.19.9                     # for purescript
   - haskell-gi-overloading == 0.0       # gi-* packages use this dependency to disable overloading support
+  - haskell-lsp == 0.18.*               # for ghcide
+  - haskell-lsp-types == 0.18.*         # for ghcide
   - haskell-src-exts == 1.19.*          # required by hindent and structured-haskell-mode
   - hinotify == 0.3.9                   # for xmonad-0.26: https://github.com/kolmodin/hinotify/issues/29
   - hoogle == 5.0.14                    # required by hie-hoogle

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2575,6 +2575,8 @@ package-maintainers:
     - elm-export-persistent
     - pipes-mongodb
     - streaming-wai
+  kiwi:
+    - glirc
   psibi:
     - path-pieces
     - persistent
@@ -5080,7 +5082,6 @@ broken-packages:
   - gli
   - glicko
   - glider-nlp
-  - glirc
   - GLMatrix
   - glob-posix
   - global

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8065,7 +8065,6 @@ broken-packages:
   - postgresql-simple-queue
   - postgresql-simple-sop
   - postgresql-simple-typed
-  - postgresql-simple-url
   - postgresql-typed
   - postgresql-typed-lifted
   - postgrest

--- a/pkgs/development/tools/purescript/spago/update.sh
+++ b/pkgs/development/tools/purescript/spago/update.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p cabal2nix curl jq
+#
+# This script will update the spago derivation to the latest version using
+# cabal2nix.
+#
+# Note that you should always try building spago after updating it here, since
+# some of the overrides in pkgs/development/haskell/configuration-nix.nix may
+# need to be updated/changed.
+
+set -eo pipefail
+
+# This is the directory of this update.sh script.
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Spago derivation created with cabal2nix.
+spago_derivation_file="${script_dir}/default.nix"
+
+# This is the current revision of spago in Nixpkgs.
+old_version="$(sed -En 's/.*\bversion = "(.*?)".*/\1/p' "$spago_derivation_file")"
+
+# This is the latest release version of spago on GitHub.
+new_version=$(curl --silent "https://api.github.com/repos/spacchetti/spago/releases" | jq '.[0].tag_name' --raw-output)
+
+echo "Updating spago from old version $old_version to new version $new_version."
+echo "Running cabal2nix and outputting to ${spago_derivation_file}..."
+
+cabal2nix --revision "$new_version" "https://github.com/spacchetti/spago.git" > "$spago_derivation_file"
+
+echo "Finished."

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11621,6 +11621,8 @@ in
 
   glib-networking = callPackage ../development/libraries/glib-networking {};
 
+  glirc = haskell.lib.justStaticExecutables haskellPackages.glirc;
+
   gom = callPackage ../development/libraries/gom { };
 
   ace = callPackage ../development/libraries/ace { };


### PR DESCRIPTION
###### Motivation for this change

Tree did not evaluate otherwise due to broken references

###### Things done

Tested that tree evaluates

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).