### PR TITLE
awscli: pin colorama to 0.4.1

### DIFF
--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -7,6 +7,13 @@
 let
   py = python3.override {
     packageOverrides = self: super: {
+      colorama = super.colorama.overridePythonAttrs (oldAttrs: rec {
+        version = "0.4.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d";
+        };
+      });
       rsa = super.rsa.overridePythonAttrs (oldAttrs: rec {
         version = "3.4.2";
         src = oldAttrs.src.override {


### PR DESCRIPTION
Later versions of colorama have removed support for EOL pythons.
This is why this has been pinned to 0.3.9 in the upstream awscli
package.

This fixes the currently broken expression for the awscli:
```
$ nix-build --no-build-output -A awscli
these derivations will be built:
  /nix/store/i07n9rhxvcj5ylah36i4q3gd05xyjc03-awscli-1.16.266.drv
building '/nix/store/i07n9rhxvcj5ylah36i4q3gd05xyjc03-awscli-1.16.266.drv'...
builder for '/nix/store/i07n9rhxvcj5ylah36i4q3gd05xyjc03-awscli-1.16.266.drv' failed with exit code 1; last 10 log lines:
  Finished executing setuptoolsBuildPhase
  installing
  Executing pipInstallPhase
  /build/awscli-1.16.266/dist /build/awscli-1.16.266
  Processing ./awscli-1.16.266-py2.py3-none-any.whl
  Requirement already satisfied: PyYAML<5.2,>=3.10 in /nix/store/gn0wy1wdz0n3pwgk14dynddw4bkgb5db-python3.7-PyYAML-5.1.2/lib/python3.7/site-packages (from awscli==1.16.266) (5.1.2)
  Requirement already satisfied: rsa<=3.5.0,>=3.1.2 in /nix/store/bx2m06rdgw46qms806pxv0nkriijq118-python3.7-rsa-3.4.2/lib/python3.7/site-packages (from awscli==1.16.266) (3.4.2)
  Requirement already satisfied: docutils<0.16,>=0.10 in /nix/store/lf18ijqmzalmvhr6nwg7lfysx5q024ma-python3.7-docutils-0.15.2/lib/python3.7/site-packages (from awscli==1.16.266) (0.15.2)
  ERROR: Could not find a version that satisfies the requirement colorama<0.4.2,>=0.2.5 (from awscli==1.16.266) (from versions: none)
  ERROR: No matching distribution found for colorama<0.4.2,>=0.2.5 (from awscli==1.16.266)
error: build of '/nix/store/i07n9rhxvcj5ylah36i4q3gd05xyjc03-awscli-1.16.266.drv' failed
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @muflax 
