### PR TITLE
bs-platform: 6.2.1 -> 7.0.1

### DIFF
--- a/pkgs/development/compilers/bs-platform/build-bs-platform.nix
+++ b/pkgs/development/compilers/bs-platform/build-bs-platform.nix
@@ -1,35 +1,33 @@
-{ stdenv, fetchFromGitHub, ninja, nodejs, python3 }:
-let
-  version = "6.2.1";
-  ocaml-version = "4.06.1";
-  src = fetchFromGitHub {
-    owner = "BuckleScript";
-    repo = "bucklescript";
-    rev = "${version}";
-    sha256 = "0zx9nq7cik0c60n3rndqfqy3vdbj5lcrx6zcqcz2d60jjxi1z32y";
-    fetchSubmodules = true;
-  };
-  ocaml =  import ./ocaml.nix {
-    bs-version = version;
+# This file is based on https://github.com/turboMaCk/bs-platform.nix/blob/master/build-bs-platform.nix
+# to make potential future updates simpler
+
+{ stdenv, fetchFromGitHub, ninja, runCommand, nodejs, python3,
+  ocaml-version, version, src,
+  ocaml ? (import ./ocaml.nix {
     version = ocaml-version;
     inherit stdenv;
     src = "${src}/ocaml";
-  };
-in
+  }),
+  custom-ninja ? (ninja.overrideAttrs (attrs: {
+    src = runCommand "ninja-patched-source" {} ''
+      mkdir -p $out
+      tar zxvf ${src}/vendor/ninja.tar.gz -C $out
+    '';
+    patches = [];
+  }))
+}:
 stdenv.mkDerivation {
   inherit src version;
   pname = "bs-platform";
   BS_RELEASE_BUILD = "true";
-  buildInputs = [ nodejs python3 ];
+  buildInputs = [ nodejs python3 custom-ninja ];
 
   patchPhase = ''
     sed -i 's:./configure.py --bootstrap:python3 ./configure.py --bootstrap:' ./scripts/install.js
-
     mkdir -p ./native/${ocaml-version}/bin
-    ln -sf ${ocaml}/bin/* ./native/${ocaml-version}/bin
-
+    ln -sf ${ocaml}/bin/*  ./native/${ocaml-version}/bin
     rm -f vendor/ninja/snapshot/ninja.linux
-    cp ${ninja}/bin/ninja vendor/ninja/snapshot/ninja.linux
+    cp ${custom-ninja}/bin/ninja vendor/ninja/snapshot/ninja.linux
   '';
 
   configurePhase = ''
@@ -42,12 +40,9 @@ stdenv.mkDerivation {
 
   installPhase = ''
     node scripts/install.js
-
     mkdir -p $out/bin
-
     cp -rf jscomp lib vendor odoc_gen native $out
     cp bsconfig.json package.json $out
-
     ln -s $out/lib/bsb $out/bin/bsb
     ln -s $out/lib/bsc $out/bin/bsc
     ln -s $out/lib/bsrefmt $out/bin/bsrefmt

--- a/pkgs/development/compilers/bs-platform/default.nix
+++ b/pkgs/development/compilers/bs-platform/default.nix
@@ -1,15 +1,28 @@
-{ stdenv, fetchFromGitHub, ninja, nodejs, python3, ... }:
+{ stdenv, runCommand, fetchFromGitHub, ninja, nodejs, python3, ... }:
 let
+  build-bs-platform = import ./build-bs-platform.nix;
+in
+(build-bs-platform {
+  inherit stdenv runCommand fetchFromGitHub ninja nodejs python3;
+  version = "7.0.1";
+  ocaml-version = "4.06.1";
+
+  src = fetchFromGitHub {
+    owner = "BuckleScript";
+    repo = "bucklescript";
+    rev = "52770839e293ade2bcf187f2639000ca0a9a1d46";
+    sha256 = "0s7g2zfhshsilv9zyp0246bypg34d294z27alpwz03ws9608yr7k";
+    fetchSubmodules = true;
+  };
+}).overrideAttrs (attrs: {
   meta = with stdenv.lib; {
     description = "A JavaScript backend for OCaml focused on smooth integration and clean generated code.";
     homepage = https://bucklescript.github.io;
     license = licenses.lgpl3;
     maintainers = with maintainers; [ turbomack gamb anmonteiro ];
     platforms = platforms.all;
+    # Currently there is an issue with aarch build in hydra
+    # https://github.com/BuckleScript/bucklescript/issues/4091
+    badPlatforms = platforms.aarch64;
   };
-in
-{
-  bs-platform-621 = import ./bs-platform-62.nix {
-    inherit stdenv fetchFromGitHub ninja nodejs python3;
-  } // { inherit meta; };
-}
+})

--- a/pkgs/development/compilers/bs-platform/ocaml.nix
+++ b/pkgs/development/compilers/bs-platform/ocaml.nix
@@ -1,7 +1,7 @@
-{ stdenv, src, version, bs-version }:
+{ stdenv, src, version }:
 stdenv.mkDerivation rec {
   inherit src version;
-  name = "ocaml-${version}+bs-${bs-version}";
+  name = "ocaml-${version}+bs";
   configurePhase = ''
     ./configure -prefix $out
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1298,7 +1298,7 @@ in
 
   burpsuite = callPackage ../tools/networking/burpsuite {};
 
-  bs-platform = (callPackage ../development/compilers/bs-platform {}).bs-platform-621;
+  bs-platform = callPackage ../development/compilers/bs-platform {};
 
   c3d = callPackage ../applications/graphics/c3d {
     inherit (darwin.apple_sdk.frameworks) Cocoa;


### PR DESCRIPTION
### [see updates](https://github.com/NixOS/nixpkgs/pull/76104#issuecomment-574331322)

~Introduce `buckeScriptPackages` which makes version 6 still available
via `buckleScriptPackages.bs-platform-6`.
BuckleScript compiler is very picky about versions and performs checks
of versions before compilations therefore it's probably a good idea
to support at least few major versions of compiler.~

### Additional notes (not part of commit message):
- [Anouncment of release](https://reasonml.chat/t/ann-bs-platform-7-0-0-is-released/2056) is few weeks old now.
- I'm trying to follow the naming convetions from package sets I'm most familiar with like `nodePackages`, `haskellPackages` and `elmPackages`.
- ~So far I'm thinking about supporting somewhere around 3 last major releases with one default `bs-platform` which is now the latest.~
- ~Build of 6 and 7 is practically identical - I'm not abstracting this just yet because it might not be future proof.~

### Checklist
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
