### PR TITLE
pythonPackages: 4.41.0 -> 4.51.1

### DIFF
--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
   # pytz fake_factory django numpy pytest
   # If you need these, you can just add them to your environment.
 
-  version = "4.41.0";
+  version = "4.51.1";
   pname = "hypothesis";
 
   # Use github tarballs that includes tests
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     description = "A Python library for property based testing";
     homepage = https://github.com/HypothesisWorks/hypothesis;
     license = licenses.mpl20;
+    maintainers = with maintainers; [ pamplemousse ];
   };
 }


### PR DESCRIPTION
##### Motivation for this change

A more recent version of the package is available.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

Added myself as a maintainer as there was none...
