### PR TITLE
qtpass: Fix /usr/lib hardcode to pass-otp.

### DIFF
--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -1,5 +1,6 @@
 { lib, mkDerivation, fetchFromGitHub
 , git, gnupg, pass, pwgen, qrencode
+, fetchpatch
 , qtbase, qtsvg, qttools, qmake
 }:
 
@@ -24,6 +25,16 @@ mkDerivation rec {
   nativeBuildInputs = [ qmake qttools ];
 
   enableParallelBuilding = true;
+
+  patches = [
+    # Fix path to pass-otp plugin `/usr/lib/password-store/extensions/otp.bash` being hardcoded.
+    # TODO: Remove when https://github.com/IJHack/QtPass/pull/499 is merged and available.
+    (fetchpatch {
+      name = "qtpass-Dont-hardcode-pass-otp-usr-lib-path.patch";
+      url = "https://github.com/IJHack/QtPass/commit/2ca9f0ec5a8d709c97a2433c5cd814040c82d4f3.patch";
+      sha256 = "0ljlvqxvarrz2a4j71i66aflrxi84zirb6cg9kvygnvhvm1zbc7d";
+    })
+  ];
 
   qmakeFlags = [
     # setup hook only sets QMAKE_LRELEASE, set QMAKE_LUPDATE too:


### PR DESCRIPTION
###### Motivation for this change

Before, the checkbox for OTP functionality could not be enabled on NixOS, even when `(pass.withExtensions (exts: [ exts.pass-otp ]))` was installed correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @hrdinka