### PR TITLE
csfml: 2.4 -> 2.5

### DIFF
--- a/pkgs/development/libraries/csfml/default.nix
+++ b/pkgs/development/libraries/csfml/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, sfml }:
 
 let
-  version = "2.4";
+  version = "2.5";
 in
 
 stdenv.mkDerivation {
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "SFML";
     repo  = "CSFML";
-    rev   = "b5facb85d13bff451a5fd2d088a97472a685576c";
-    sha256 = "1q716gd7c7jlxzwpq5z4rjj5lsrn71ql2djphccdf9jannllqizn";
+    rev   = version;
+    sha256 = "071magxif5nrdddzk2z34czqmz1dfws4d7dqynb2zpn7cwhwxcpm";
   };
   buildInputs = [ cmake sfml ];
   cmakeFlags = [ "-DCMAKE_MODULE_PATH=${sfml}/share/SFML/cmake/Modules/" ];


### PR DESCRIPTION
##### Motivation for this change

Updating the package to the latest version

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jpdoyle
