### PR TITLE
rust-9p: init

### DIFF
--- a/pkgs/servers/unpfs/default.nix
+++ b/pkgs/servers/unpfs/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "unpfs";
+  version = "0.0.2019-05-17";
+
+  src = fetchFromGitHub {
+    owner = "pfpacket";
+    repo = "rust-9p";
+    rev = "01cf9c60bff0f35567d876db7be7fb86032b44eb";
+    sha256 = "0mhmr1912z5nyfpcvhnlgb3v67a5n7i2n9l5abi05sfqffqssi79";
+  };
+
+  sourceRoot = "source/example/unpfs";
+
+  cargoSha256 = "1d33nwj3i333a6ji3r3037mgg553lc3wsawm0pz13kbvhjf336i8";
+
+  RUSTC_BOOTSTRAP = 1;
+
+  postInstall = ''
+    install -D -m 0444 ../../README* -t "$out/share/doc/${pname}"
+    install -D -m 0444 ../../LICEN* -t "$out/share/doc/${pname}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "9P2000.L server implementation in Rust";
+    homepage = "https://github.com/pfpacket/rust-9p";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ raskin ];
+
+    # macOS build fails: https://github.com/pfpacket/rust-9p/issues/7
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15453,6 +15453,8 @@ in
   riemann = callPackage ../servers/monitoring/riemann { };
   riemann-dash = callPackage ../servers/monitoring/riemann-dash { };
 
+  unpfs = callPackage ../servers/unpfs {};
+
   oidentd = callPackage ../servers/identd/oidentd { };
 
   openfire = callPackage ../servers/xmpp/openfire { };


### PR DESCRIPTION
###### Motivation for this change

A Rust-based implementation of 9p2000.L, seems more trustable than C-based diod

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify

cc @qyliss
