### PR TITLE
pulumi: 1.4.0 -> 1.7.1

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,50 +1,50 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "1.4.0";
+  version = "1.7.1";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.4.0-linux-x64.tar.gz";
-        sha256 = "00ywy2ba4xha6gwd42i3fdrk1myivkd1r6ijdr2vkianmg524k6f";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.7.1-linux-x64.tar.gz";
+        sha256 = "1ssaq3y0lbdni6drrv9ndxfql89zk3952yxi0cq24b80vcxfpsc7";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v0.2.0-linux-amd64.tar.gz";
-        sha256 = "1hj4gysjipd091f106a7xz02g9cail5d11rn6j08m0xphg9cf3fn";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v1.4.0-linux-amd64.tar.gz";
+        sha256 = "158wrmb132118swanqi5xw0jin2n0ih0knr4qa3yds81yciywz7d";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v1.4.1-linux-amd64.tar.gz";
-        sha256 = "0r6xpsb2riqmxwxw28lbi3xd7w4ds510gw99j1rr57h5b9bq19jj";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v2.1.0-linux-amd64.tar.gz";
+        sha256 = "0cr4l0skq6mysi687kdf012qfdh758bjvvvp0kpf72qc2ynrj4xp";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.2.3-linux-amd64.tar.gz";
-        sha256 = "0m7fajy3cy1agsz787ak548khwj8rwahs1ibaswqfyyw092iyzb9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.4.1-linux-amd64.tar.gz";
+        sha256 = "1dknf3m647lw0jni604a483g7sgc20rcr6p4iyq0xj0qsxlr054m";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.7.0-linux-amd64.tar.gz";
-        sha256 = "1qw90l7h8yn06bz2l2995nbrc3svs223dm3ys1807amj4n2jyfwb";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.17.0-linux-amd64.tar.gz";
+        sha256 = "1n90w9s8652ni6rh4bm4zf2fpwv0g54wwz86fgmzw0p48ash1dl2";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.4.0-darwin-x64.tar.gz";
-        sha256 = "02vqw9gn17dy3rfh0j00k9f827l42g3nl3rhlcbc8jbgx3n9c9qy";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.7.1-darwin-x64.tar.gz";
+        sha256 = "1yl2b5vhnpswc9qnidk9869qm9cpzzy0416fc7wahqx3c1x1nl4c";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v0.2.0-darwin-amd64.tar.gz";
-        sha256 = "077j9fp8ix00rcqrq8qxk3kvz6gz6sknzb2iv3qjvkh6yh292mz3";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v1.4.0-darwin-amd64.tar.gz";
+        sha256 = "0lh2v5lj677iyskqj6ka6p1633mvv72ix5zm8p2zv8xylbm86dgg";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v1.4.1-darwin-amd64.tar.gz";
-        sha256 = "1i2vf3bxwf8awvw183hq9bbnmznda1jpv1zqghgz2ybx4s0915nx";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v2.1.0-darwin-amd64.tar.gz";
+        sha256 = "1vl62r121rywmk71wk1a00rg7wcm4fbj1by7wsf7xkg87wh4mrvk";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.2.3-darwin-amd64.tar.gz";
-        sha256 = "123czx1c31r5r91k2jhdgmnffypnl8w1a6h9mr2rdhwgbx8hzq40";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.4.1-darwin-amd64.tar.gz";
+        sha256 = "1k79kq2rbfayi75xyfsmr7qkmics285yg8h4ihw72sjslm2mx3yi";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.7.0-darwin-amd64.tar.gz";
-        sha256 = "0cl0vakppxi0v8ym8b4fzhzb10nl84wd0vfik8gpfwsg7zwdzhlp";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.17.0-darwin-amd64.tar.gz";
+        sha256 = "0pzzj8ys96ayj33jnf0i3bwnsld7l2fhs0gk0kf9lpfm6ryp5miq";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-VERSION="1.4.0"
+VERSION="1.7.1"
 
 declare -A plugins
 plugins=(
-    ["aws"]="1.7.0"
-    ["gcp"]="1.4.1"
-    ["kubernetes"]="1.2.3"
-    ["random"]="0.2.0"
+    ["aws"]="1.17.0"
+    ["gcp"]="2.1.0"
+    ["kubernetes"]="1.4.1"
+    ["random"]="1.4.0"
 )
 
 function genMainSrc() {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
  - **only the pulumi command is working** I think it was like this on the previous version.
  - [X] pulumi
  - [ ] pulumi-analyzer-policy
  - [ ] pulumi-language-dotnet
  - [ ] pulumi-language-go
  - [ ] pulumi-language-nodejs
  - [ ] pulumi-language-python
  - [ ] pulumi-resource-aws
  - [ ] pulumi-resource-gcp
  - [ ] pulumi-resource-kubernetes
  - [ ] pulumi-resource-pulumi-nodejs
  - [ ] pulumi-resource-pulumi-python
  - [ ] pulumi-resource-random
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @peterromfeldhk @jlesquembre
