### PR TITLE
wofi: 2019-10-28 -> 1.0

### DIFF
--- a/pkgs/applications/misc/wofi/default.nix
+++ b/pkgs/applications/misc/wofi/default.nix
@@ -1,24 +1,17 @@
-{ stdenv, lib, fetchhg, pkg-config, wayland, gtk3 }:
+{ stdenv, lib, fetchhg, pkg-config, meson, ninja, wayland, gtk3 }:
 
 stdenv.mkDerivation rec {
   pname = "wofi";
-  version = "2019-10-28";
+  version = "1.0";
 
   src = fetchhg {
     url = "https://hg.sr.ht/~scoopta/wofi";
-    rev = "3fac708b2b541bb9927ec1b2389c4eb294e1b35b";
-    sha256 = "0sp9hqm1lv9wyxj8z7vazs25nvl6yznd5vfhmwb51axwkr79s2ym";
+    rev = "v${version}";
+    sha256 = "147yarm26nl0zc0a2rs7qi4jd7bz48vvyaygsif1qsv8fx0xiqqf";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config meson ninja ];
   buildInputs = [ wayland gtk3 ];
-
-  sourceRoot = "hg-archive/Release";
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp wofi $out/bin/
-  '';
 
   meta = with lib; {
     description = "A launcher/menu program for wlroots based wayland compositors such as sway";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
