### PR TITLE
mercurial: 4.9.1 -> 5.2.1 + python3  🚀

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -1,21 +1,19 @@
-{ stdenv, fetchurl, python2Packages, makeWrapper, unzip
+{ stdenv, fetchurl, python3Packages, makeWrapper, unzip
 , guiSupport ? false, tk ? null
 , ApplicationServices
-, mercurialSrc ? fetchurl rec {
-    meta.name = "mercurial-${meta.version}";
-    meta.version = "4.9.1";
-    url = "https://mercurial-scm.org/release/${meta.name}.tar.gz";
-    sha256 = "0iybbkd9add066729zg01kwz5hhc1s6lhp9rrnsmzq6ihyxj3p8v";
-  }
 }:
 
 let
-  inherit (python2Packages) docutils hg-git dulwich python;
+  inherit (python3Packages) docutils dulwich python;
 
-in python2Packages.buildPythonApplication {
+in python3Packages.buildPythonApplication rec {
+  pname = "mercurial";
+  version = "5.2.1";
 
-  inherit (mercurialSrc.meta) name version;
-  src = mercurialSrc;
+  src = fetchurl {
+    url = "https://mercurial-scm.org/release/mercurial-${version}.tar.gz";
+    sha256 = "1pxkd37b0a1mi2zakk1hi122lgz1ffy2fxdnbs8acwlqpw55bc8q";
+  };
 
   format = "other";
 
@@ -24,41 +22,39 @@ in python2Packages.buildPythonApplication {
   buildInputs = [ makeWrapper docutils unzip ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ ApplicationServices ];
 
-  propagatedBuildInputs = [ hg-git dulwich ];
+  propagatedBuildInputs = [ dulwich ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  postInstall = (stdenv.lib.optionalString guiSupport
-    ''
-      mkdir -p $out/etc/mercurial
-      cp contrib/hgk $out/bin
-      cat >> $out/etc/mercurial/hgrc << EOF
-      [extensions]
-      hgk=$out/lib/${python.libPrefix}/site-packages/hgext/hgk.py
-      EOF
-      # setting HG so that hgk can be run itself as well (not only hg view)
-      WRAP_TK=" --set TK_LIBRARY ${tk}/lib/${tk.libPrefix}
-                --set HG $out/bin/hg
-                --prefix PATH : ${tk}/bin "
-    '') +
-    ''
-      for i in $(cd $out/bin && ls); do
-        wrapProgram $out/bin/$i \
-          $WRAP_TK
-      done
+  postInstall = (stdenv.lib.optionalString guiSupport ''
+    mkdir -p $out/etc/mercurial
+    cp contrib/hgk $out/bin
+    cat >> $out/etc/mercurial/hgrc << EOF
+    [extensions]
+    hgk=$out/lib/${python.libPrefix}/site-packages/hgext/hgk.py
+    EOF
+    # setting HG so that hgk can be run itself as well (not only hg view)
+    WRAP_TK=" --set TK_LIBRARY ${tk}/lib/${tk.libPrefix}
+              --set HG $out/bin/hg
+              --prefix PATH : ${tk}/bin "
+  '') + ''
+    for i in $(cd $out/bin && ls); do
+      wrapProgram $out/bin/$i \
+        $WRAP_TK
+    done
 
-      # copy hgweb.cgi to allow use in apache
-      mkdir -p $out/share/cgi-bin
-      cp -v hgweb.cgi contrib/hgweb.wsgi $out/share/cgi-bin
-      chmod u+x $out/share/cgi-bin/hgweb.cgi
+    # copy hgweb.cgi to allow use in apache
+    mkdir -p $out/share/cgi-bin
+    cp -v hgweb.cgi contrib/hgweb.wsgi $out/share/cgi-bin
+    chmod u+x $out/share/cgi-bin/hgweb.cgi
 
-      # install bash/zsh completions
-      install -v -m644 -D contrib/bash_completion $out/share/bash-completion/completions/_hg
-      install -v -m644 -D contrib/zsh_completion $out/share/zsh/site-functions/_hg
-    '';
+    # install bash/zsh completions
+    install -v -m644 -D contrib/bash_completion $out/share/bash-completion/completions/_hg
+    install -v -m644 -D contrib/zsh_completion $out/share/zsh/site-functions/_hg
+  '';
 
   meta = {
-    inherit (mercurialSrc.meta) version;
+    inherit version;
     description = "A fast, lightweight SCM system for very large distributed projects";
     homepage = https://www.mercurial-scm.org;
     downloadPage = https://www.mercurial-scm.org/release/;

--- a/pkgs/development/python-modules/qscintilla-qt5/default.nix
+++ b/pkgs/development/python-modules/qscintilla-qt5/default.nix
@@ -12,8 +12,7 @@ buildPythonPackage {
   format = "other";
 
   nativeBuildInputs = [ lndir sip qtbase ];
-  buildInputs = [ qscintilla ];
-  propagatedBuildInputs = [ pyqt5 ];
+  buildInputs = [ qscintilla pyqt5 ];
 
   postPatch = ''
     substituteInPlace Python/configure.py \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Get python2 out of my nix profile

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
