### PR TITLE
cloud-print-connector: fix build against cups

### DIFF
--- a/pkgs/servers/cloud-print-connector/default.nix
+++ b/pkgs/servers/cloud-print-connector/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, avahi, cups }:
+{ stdenv, buildGoPackage, fetchFromGitHub, avahi, cups, fetchpatch }:
 
 # TODO: Add a service for gcp-cups-connector and perhaps some other
 # kind of configuration for the same thing that gcp-connector-util
@@ -17,6 +17,14 @@ buildGoPackage rec {
   subPackages = [
     "gcp-connector-util"
     "gcp-cups-connector"
+  ];
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/google/cloud-print-connector/pull/475
+      url = "https://github.com/google/cloud-print-connector/commit/6a77c7c283b83cbcc9cbfab59710023cd09da3ed.patch";
+      sha256 = "054pi9nz402va95z5k6wq3dalnv5rcya078wa99p1kdwb7cqmrcq";
+    })
   ];
 
   src = fetchFromGitHub {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
