### PR TITLE
php: 7.2.25 -> 7.2.26, 7.3.12 -> 7.3.13, 7.4.0 -> 7.4.1

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -271,8 +271,8 @@ in {
   };
 
   php73 = generic {
-    version = "7.3.12";
-    sha256 = "0fccmnrwwyy5zvhj8wbyqqlyqr7pr5v4pfiqriw0ahciz4lv05yk";
+    version = "7.3.13";
+    sha256 = "1g376b9caw21mw8738z354llbzb3shzgc60m7naw7wql5038jysw";
 
     # https://bugs.php.net/bug.php?id=76826
     extraPatches = optional stdenv.isDarwin ./php73-darwin-isfinite.patch;

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -263,8 +263,8 @@ let
 
 in {
   php72 = generic {
-    version = "7.2.25";
-    sha256 = "17kb7b3wpdmdhnlv23qc0vax0lp2gr1v7dxwdgs8g78gxnqkdcvw";
+    version = "7.2.26";
+    sha256 = "0yw49v3rk3cd0fb4gsli74pgd4qrykhn9c37dyfr3zsprzp8cvgk";
 
     # https://bugs.php.net/bug.php?id=76826
     extraPatches = optional stdenv.isDarwin ./php72-darwin-isfinite.patch;

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -279,7 +279,7 @@ in {
   };
 
   php74 = generic {
-    version = "7.4.0";
-    sha256 = "1h01bahvcm9kgm5jqhm2j9k9d4q4rpfkkpqk00c47rirdblnn85z";
+    version = "7.4.1";
+    sha256 = "0klfwhm2935ariwzqdri1fwh4a0vbrk3jis53qzi18isp3qa073b";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Addresses several CVEs https://www.php.net/ChangeLog-7.php
closes https://github.com/NixOS/nixpkgs/issues/76019

See also https://github.com/NixOS/nixpkgs/pull/76133
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
 * nextcloud
 * php-pcre
 * wordpress
 * roundcube 
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Result of `nix-review` [1](https://github.com/Mic92/nix-review)
<details>
  <summary>127 package were build:</summary>

  - arcanist (matomo)
  - drush (matomo)
  - icingaweb2 (matomo)
  - kcachegrind (matomo)
  - lsp-plugins (matomo)
  - piwik (matomo)
  - matomo-beta (matomo)
  - nagios (matomo)
  - nextcloud-news-updater (matomo)
  - phoronix-test-suite (matomo)
  - php (matomo)
  - php-embed (matomo)
  - php-unit (matomo)
  - php73Packages-unit.apcu (matomo)
  - php73Packages-unit.apcu_bc (matomo)
  - php73Packages-unit.ast (matomo)
  - php73Packages-unit.box (matomo)
  - php73Packages-unit.composer (matomo)
  - php73Packages-unit.couchbase (matomo)
  - php73Packages-unit.event (matomo)
  - php73Packages-unit.igbinary (matomo)
  - php73Packages-unit.imagick (matomo)
  - php73Packages-unit.mailparse (matomo)
  - php73Packages-unit.maxminddb (matomo)
  - php73Packages-unit.memcached (matomo)
  - php73Packages-unit.mongodb (matomo)
  - php73Packages-unit.oci8 (matomo)
  - php73Packages-unit.pcov (matomo)
  - php73Packages-unit.pcs (matomo)
  - php73Packages-unit.pdo_sqlsrv (matomo)
  - php73Packages-unit.php-cs-fixer (matomo)
  - php73Packages-unit.php-parallel-lint (matomo)
  - php73Packages-unit.phpcbf (matomo)
  - php73Packages-unit.phpcs (matomo)
  - php73Packages-unit.phpstan (matomo)
  - php73Packages-unit.pinba (matomo)
  - php73Packages-unit.protobuf (matomo)
  - php73Packages-unit.psalm (matomo)
  - php73Packages-unit.redis (matomo)
  - php73Packages-unit.sqlsrv (matomo)
  - php73Packages-unit.xdebug (matomo)
  - php73Packages-unit.yaml (matomo)
  - php73Packages.apcu (matomo)
  - php73Packages.apcu_bc (matomo)
  - php73Packages.ast (matomo)
  - php73Packages.box (matomo)
  - php73Packages.composer (matomo)
  - php73Packages.couchbase (matomo)
  - php73Packages.event (matomo)
  - php73Packages.igbinary (matomo)
  - php73Packages.imagick (matomo)
  - php73Packages.mailparse (matomo)
  - php73Packages.maxminddb (matomo)
  - php73Packages.memcached (matomo)
  - php73Packages.mongodb (matomo)
  - php73Packages.oci8 (matomo)
  - php73Packages.pcov (matomo)
  - php73Packages.pcs (matomo)
  - php73Packages.pdo_sqlsrv (matomo)
  - php73Packages.php-cs-fixer (matomo)
  - php73Packages.php-parallel-lint (matomo)
  - php73Packages.phpcbf (matomo)
  - php73Packages.phpcs (matomo)
  - php73Packages.phpstan (matomo)
  - php73Packages.pinba (matomo)
  - php73Packages.protobuf (matomo)
  - php73Packages.psalm (matomo)
  - php73Packages.redis (matomo)
  - php73Packages.sqlsrv (matomo)
  - php73Packages.xdebug (matomo)
  - php73Packages.yaml (matomo)
  - php74 (matomo)
  - php74-embed (matomo)
  - php74-unit (matomo)
  - php74Packages-unit.apcu (matomo)
  - php74Packages-unit.apcu_bc (matomo)
  - php74Packages-unit.ast (matomo)
  - php74Packages-unit.box (matomo)
  - php74Packages-unit.composer (matomo)
  - php74Packages-unit.event (matomo)
  - php74Packages-unit.igbinary (matomo)
  - php74Packages-unit.imagick (matomo)
  - php74Packages-unit.mailparse (matomo)
  - php74Packages-unit.maxminddb (matomo)
  - php74Packages-unit.memcached (matomo)
  - php74Packages-unit.mongodb (matomo)
  - php74Packages-unit.oci8 (matomo)
  - php74Packages-unit.pcov (matomo)
  - php74Packages-unit.php-cs-fixer (matomo)
  - php74Packages-unit.php-parallel-lint (matomo)
  - php74Packages-unit.phpcbf (matomo)
  - php74Packages-unit.phpcs (matomo)
  - php74Packages-unit.phpstan (matomo)
  - php74Packages-unit.pinba (matomo)
  - php74Packages-unit.psalm (matomo)
  - php74Packages-unit.redis (matomo)
  - php74Packages-unit.xdebug (matomo)
  - php74Packages-unit.yaml (matomo)
  - php74Packages.apcu (matomo)
  - php74Packages.apcu_bc (matomo)
  - php74Packages.ast (matomo)
  - php74Packages.box (matomo)
  - php74Packages.composer (matomo)
  - php74Packages.event (matomo)
  - php74Packages.igbinary (matomo)
  - php74Packages.imagick (matomo)
  - php74Packages.mailparse (matomo)
  - php74Packages.maxminddb (matomo)
  - php74Packages.memcached (matomo)
  - php74Packages.mongodb (matomo)
  - php74Packages.oci8 (matomo)
  - php74Packages.pcov (matomo)
  - php74Packages.php-cs-fixer (matomo)
  - php74Packages.php-parallel-lint (matomo)
  - php74Packages.phpcbf (matomo)
  - php74Packages.phpcs (matomo)
  - php74Packages.phpstan (matomo)
  - php74Packages.pinba (matomo)
  - php74Packages.psalm (matomo)
  - php74Packages.redis (matomo)
  - php74Packages.xdebug (matomo)
  - php74Packages.yaml (matomo)
  - pulseeffects (matomo)
  - qcachegrind (matomo)
  - unit (matomo)
  - wp-cli (matomo)
  - yle-dl (matomo)
</details>
