### PR TITLE
Systemd v243.4

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -263,6 +263,6 @@ in stdenv.mkDerivation {
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     priority = 10;
-    maintainers = with maintainers; [ eelco andir mic92 ];
+    maintainers = with maintainers; [ andir eelco flokli mic92 ];
   };
 }

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -36,10 +36,10 @@ in stdenv.mkDerivation {
   # When updating, use https://github.com/systemd/systemd-stable tree, not the development one!
   # Also fresh patches should be cherry-picked from that tree to our current one.
   src = fetchFromGitHub {
-    owner = "NixOS";
+    owner = "nixos";
     repo = "systemd";
-    rev = "491a247eff9b7ce1e5877f5f3431517c95f3222f";
-    sha256 = "1xqiahapg480m165glrwqbfmc1fxw5sacdlm933cwyi1q8x4537g";
+    rev = "d8853d39a28b9884e0acd3ae5732a1e7caaf08af";
+    sha256 = "1wqm51i2czbbb3nara11mnxzqng4na1l8fvz7qnbxcrjsqm7hz18";
   };
 
   outputs = [ "out" "lib" "man" "dev" ];


### PR DESCRIPTION
closes #74207 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- [x] Built on NixOS
- [x] Tested via `nixos/tests/timezone.nix`

cc @flokli 
