### PR TITLE
qtcreator: 4.10.0 -> 4.11.0

### DIFF
--- a/pkgs/development/tools/qtcreator/0001-Fix-clang-libcpp-regexp.patch
+++ b/pkgs/development/tools/qtcreator/0001-Fix-clang-libcpp-regexp.patch
@@ -1,15 +1,15 @@
 diff --git a/src/plugins/cpptools/headerpathfilter.cpp b/src/plugins/cpptools/headerpathfilter.cpp
-index e2d1e6a..1a1d839 100644
+index b656f8e1..a830d3c3 100644
 --- a/src/plugins/cpptools/headerpathfilter.cpp
 +++ b/src/plugins/cpptools/headerpathfilter.cpp
-@@ -96,8 +96,8 @@ HeaderPaths::iterator resourceIterator(HeaderPaths &headerPaths, bool isMacOs)
+@@ -124,8 +124,8 @@ HeaderPaths::iterator resourceIterator(HeaderPaths &headerPaths)
  {
      // include/c++, include/g++, libc++\include and libc++abi\include
-     static const QString cppIncludes = R"((.*\/include\/.*(g\+\+|c\+\+).*))"
--                                       R"(|(.*libc\+\+\/include))"
--                                       R"(|(.*libc\+\+abi\/include))";
+     static const QString cppIncludes = R"((.*/include/.*(g\+\+|c\+\+).*))"
+-                                       R"(|(.*libc\+\+/include))"
+-                                       R"(|(.*libc\+\+abi/include))"
 +                                       R"(|(.*libc\+\+.*\/include))"
 +                                       R"(|(.*libc\+\+abi.*\/include))";
+                                        R"(|(/usr/local/include))";
      static const QRegularExpression includeRegExp("\\A(" + cppIncludes + ")\\z");
  
-     // The same as includeRegExp but also matches /usr/local/include

--- a/pkgs/development/tools/qtcreator/0002-Dont-remove-clang-header-paths.patch
+++ b/pkgs/development/tools/qtcreator/0002-Dont-remove-clang-header-paths.patch
@@ -1,13 +1,12 @@
 diff --git a/src/plugins/cpptools/headerpathfilter.cpp b/src/plugins/cpptools/headerpathfilter.cpp
-index e2d1e6a..1a1d839 100644
+index a830d3c3..80e2f933 100644
 --- a/src/plugins/cpptools/headerpathfilter.cpp
 +++ b/src/plugins/cpptools/headerpathfilter.cpp
-@@ -134,8 +134,6 @@ void removeClangSystemHeaderPaths(HeaderPaths &headerPaths)
+@@ -157,7 +157,6 @@ void removeClangSystemHeaderPaths(HeaderPaths &headerPaths)
  
  void HeaderPathFilter::tweakHeaderPaths()
  {
 -    removeClangSystemHeaderPaths(builtInHeaderPaths);
--
-     auto split = resourceIterator(builtInHeaderPaths,
-                                   projectPart.toolChainTargetTriple.contains("darwin"));
+     removeGccInternalIncludePaths();
  
+     auto split = resourceIterator(builtInHeaderPaths);

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -20,12 +20,12 @@ in
 
 mkDerivation rec {
   pname = "qtcreator";
-  version = "4.10.0";
+  version = "4.11.0";
   baseVersion = builtins.concatStringsSep "." (lib.take 2 (builtins.splitVersion version));
 
   src = fetchurl {
     url = "http://download.qt-project.org/official_releases/${pname}/${baseVersion}/${version}/qt-creator-opensource-src-${version}.tar.xz";
-    sha256 = "12hgxdghz05ms4zl8prz2w8l66vmgw1qw2gsmmwqi2rdaay3lpcg";
+    sha256 = "0ibn7bapw7m26nmxl26dns1hnpawfdqk1i1mgg0gjssja8famszg";
   };
 
   buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative ] ++ 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Minor qtcreator [update](https://www.qt.io/blog/qt-creator-4.11.0-is-released).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Updated patches to fit new qtc codebase
- [X] Tested that code model is working and clang-tidy/clazy checks are executed on cmake project
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @akaWolf 
