### PR TITLE
gzdoom: include missing soundfont files

### DIFF
--- a/pkgs/games/gzdoom/default.nix
+++ b/pkgs/games/gzdoom/default.nix
@@ -35,6 +35,12 @@ stdenv.mkDerivation rec {
     for i in *.pk3; do
       install -Dm644 "$i" "$out/lib/gzdoom/$i"
     done
+    for i in fm_banks/*; do
+      install -Dm644 "$i" "$out/lib/gzdoom/$i"
+    done
+    for i in soundfonts/*; do
+      install -Dm644 "$i" "$out/lib/gzdoom/$i"
+    done
     mkdir $out/bin
     makeWrapper $out/lib/gzdoom/gzdoom $out/bin/gzdoom
   '';


### PR DESCRIPTION

###### Motivation for this change
Including missing soundfont files fixes audio issues

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Lassulus 
