### PR TITLE
cadvisor: 0.34.0 -> 0.35.0

### DIFF
--- a/pkgs/servers/monitoring/cadvisor/default.nix
+++ b/pkgs/servers/monitoring/cadvisor/default.nix
@@ -1,32 +1,21 @@
-{ stdenv, go, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+buildGoPackage rec {
   pname = "cadvisor";
-  version = "0.34.0";
+  version = "0.35.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "cadvisor";
     rev = "v${version}";
-    sha256 = "1hshmhsclja50ja2jqxx2f5lcvbs64n6aw6dw28wbnq3z9v0q8ad";
+    sha256 = "1652yf2a4ng9z0jq8q6jnzh6svj5nwar9j8q7sssgy36bi03ixqa";
   };
 
-  nativeBuildInputs = [ go ];
+  goPackagePath = "github.com/google/cadvisor";
 
-  buildPhase = ''
-    export GOCACHE="$TMPDIR/go-cache"
-    mkdir -p Godeps/_workspace/src/github.com/google/
-    ln -s $(pwd) Godeps/_workspace/src/github.com/google/cadvisor
-    GOPATH=$(pwd)/Godeps/_workspace go build -v -o cadvisor -ldflags="-s -w -X github.com/google/cadvisor/version.Version=${version}" github.com/google/cadvisor
-  '';
+  subPackages = [ "." ];
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 -t $out/bin cadvisor
-
-    runHook postInstall
-  '';
+  buildFlagsArray = [ "-ldflags=-s -w -X github.com/google/cadvisor/version.Version=${version}" ];
 
   meta = with stdenv.lib; {
     description = "Analyzes resource usage and performance characteristics of running docker containers";


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changelog: https://github.com/google/cadvisor/releases/tag/v0.35.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
