### PR TITLE
{h,a}spell: split outputs -> closure size reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 * [NixOS Manual](https://nixos.org/nixos/manual) - how to install, configure, and maintain a purely-functional Linux distribution
 * [Nixpkgs Manual](https://nixos.org/nixpkgs/manual/) - contributing to Nixpkgs and using programming-language-specific Nix expressions
-* [Nix Package Manager Manual](https://nixos.org/nix/manual) - how to write Nix expresssions (programs), and how to use Nix command line tools
+* [Nix Package Manager Manual](https://nixos.org/nix/manual) - how to write Nix expressions (programs), and how to use Nix command line tools
 
 # Community
 
@@ -27,7 +27,7 @@
 
 # Other Project Repositories
 
-The sources of all offical Nix-related projects are in the [NixOS
+The sources of all official Nix-related projects are in the [NixOS
 organization on GitHub](https://github.com/NixOS/). Here are some of
 the main ones:
 

--- a/pkgs/development/libraries/aspell/default.nix
+++ b/pkgs/development/libraries/aspell/default.nix
@@ -30,20 +30,21 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ perl ];
 
-  doCheck = true;
+  outputs = [ "bin" "out" "man" "dev" "lib" ];
 
-  preConfigure = ''
-    configureFlagsArray=(
-      --enable-pkglibdir=$out/lib/aspell
-      --enable-pkgdatadir=$out/lib/aspell
-    );
-  '';
+  doCheck = true;
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--enable-pkglibdir=${placeholder "lib"}/lib/aspell"
+    "--enable-pkgdatadir=${placeholder "lib"}/lib/aspell"
+  ];
 
   # Include u-deva.cmap and u-deva.cset in the aspell package
   # to avoid conflict between 'mr' and 'hi' dictionaries as they
   # both include those files.
   postInstall = ''
-    cp ${devaMapsSource}/u-deva.{cmap,cset} $out/lib/aspell/
+    cp ${devaMapsSource}/u-deva.{cmap,cset} $lib/lib/aspell/
   '';
 
   meta = {

--- a/pkgs/development/libraries/hspell/default.nix
+++ b/pkgs/development/libraries/hspell/default.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
   PERL_USE_UNSAFE_INC = "1";
 
+  outputs = [ "bin" "out" "man" "dev" "lib" ];
+
   src = fetchurl {
     url = "${meta.homepage}${name}.tar.gz";
     sha256 = "08x7rigq5pa1pfpl30qp353hbdkpadr1zc49slpczhsn0sg36pd6";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18747,10 +18747,9 @@ let
       url = mirror://cpan/authors/id/H/HA/HANK/Text-Aspell-0.09.tar.gz;
       sha256 = "0r9g31rd55934mp6n45b96g934ck4qns8x9i7qckn9wfy44k5sib";
     };
-    propagatedBuildInputs = [ pkgs.aspell ];
+    buildInputs = [ pkgs.aspell ];
     ASPELL_CONF = "dict-dir ${pkgs.aspellDicts.en}/lib/aspell";
-    NIX_CFLAGS_COMPILE = "-I${pkgs.aspell}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.aspell}/lib -laspell";
+    NIX_CFLAGS_LINK = "-laspell";
   };
 
   TextAutoformat = buildPerlPackage {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

tested by fixing typos in our README, also build all packages that have aspell/hspell in buildInputs.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
