### PR TITLE
nixpkgs-review: 2.1.0 -> 2.1.1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
    - [ ] macOS
    - [ ] other Linux distributions
 - [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
-- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
+- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
 - [ ] Tested execution of all binary files (usually in `./result/bin/`)
 - [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
 - [ ] Ensured that relevant documentation is up to date

--- a/doc/contributing/reviewing-contributions.xml
+++ b/doc/contributing/reviewing-contributions.xml
@@ -141,10 +141,10 @@
      </listitem>
      <listitem>
       <para>
-       The <link xlink:href="https://github.com/Mic92/nix-review">nix-review</link> tool can be used to review a pull request content in a single command. <varname>PRNUMBER</varname> should be replaced by the number at the end of the pull request title. You can also provide the full github pull request url.
+       The <link xlink:href="https://github.com/Mic92/nixpkgs-review">nixpkgs-review</link> tool can be used to review a pull request content in a single command. <varname>PRNUMBER</varname> should be replaced by the number at the end of the pull request title. You can also provide the full github pull request url.
       </para>
 <screen>
-<prompt>$ </prompt>nix-shell -p nix-review --run "nix-review pr PRNUMBER"
+<prompt>$ </prompt>nix-shell -p nixpkgs-review --run "nixpkgs-review pr PRNUMBER"
 </screen>
      </listitem>
     </itemizedlist>

--- a/doc/contributing/submitting-changes.xml
+++ b/doc/contributing/submitting-changes.xml
@@ -317,25 +317,25 @@ Additional information.
   </section>
 
   <section xml:id="submitting-changes-tested-compilation">
-   <title>Tested compilation of all pkgs that depend on this change using <command>nix-review</command></title>
+   <title>Tested compilation of all pkgs that depend on this change using <command>nixpkgs-review</command></title>
 
    <para>
-    If you are updating a package's version, you can use nix-review to make sure all packages that depend on the updated package still compile correctly. The <command>nix-review</command> utility can look for and build all dependencies either based on uncommited changes with the <literal>wip</literal> option or specifying a github pull request number.
+    If you are updating a package's version, you can use nixpkgs-review to make sure all packages that depend on the updated package still compile correctly. The <command>nixpkgs-review</command> utility can look for and build all dependencies either based on uncommited changes with the <literal>wip</literal> option or specifying a github pull request number.
    </para>
 
    <para>
     review changes from pull request number 12345:
-    <screen>nix run nixpkgs.nix-review -c nix-review pr 12345</screen>
+    <screen>nix run nixpkgs.nixpkgs-review -c nixpkgs-review pr 12345</screen>
    </para>
 
    <para>
     review uncommitted changes:
-    <screen>nix run nixpkgs.nix-review -c nix-review wip</screen>
+    <screen>nix run nixpkgs.nixpkgs-review -c nixpkgs-review wip</screen>
    </para>
 
    <para>
     review changes from last commit:
-    <screen>nix run nixpkgs.nix-review -c nix-review rev HEAD</screen>
+    <screen>nix run nixpkgs.nixpkgs-review -c nixpkgs-review rev HEAD</screen>
    </para>
   </section>
 
@@ -408,7 +408,7 @@ Additional information.
   <section xml:id="submitting-changes-master-branch">
    <title>Master branch</title>
    <para>
-    The <literal>master</literal> branch is the main development branch. 
+    The <literal>master</literal> branch is the main development branch.
     It should only see non-breaking commits that do not cause mass rebuilds.
    </para>
   </section>
@@ -416,8 +416,8 @@ Additional information.
   <section xml:id="submitting-changes-staging-branch">
    <title>Staging branch</title>
    <para>
-    The <literal>staging</literal> branch is a development branch where mass-rebuilds go. 
-    It should only see non-breaking mass-rebuild commits. 
+    The <literal>staging</literal> branch is a development branch where mass-rebuilds go.
+    It should only see non-breaking mass-rebuild commits.
     That means it is not to be used for testing, and changes must have been well tested already.
     If the branch is already in a broken state, please refrain from adding extra new breakages.
    </para>
@@ -426,10 +426,10 @@ Additional information.
   <section xml:id="submitting-changes-staging-next-branch">
    <title>Staging-next branch</title>
    <para>
-    The <literal>staging-next</literal> branch is for stabilizing mass-rebuilds submitted to the <literal>staging</literal> branch prior to merging them into <literal>master</literal>. 
-    Mass-rebuilds should go via the <literal>staging</literal> branch. 
+    The <literal>staging-next</literal> branch is for stabilizing mass-rebuilds submitted to the <literal>staging</literal> branch prior to merging them into <literal>master</literal>.
+    Mass-rebuilds should go via the <literal>staging</literal> branch.
     It should only see non-breaking commits that are fixing issues blocking it from being merged into the <literal>master </literal> branch.
-   </para>  
+   </para>
    <para>
     If the branch is already in a broken state, please refrain from adding extra new breakages. Stabilize it for a few days and then merge into master.
    </para>

--- a/pkgs/tools/package-management/nixpkgs-review/default.nix
+++ b/pkgs/tools/package-management/nixpkgs-review/default.nix
@@ -7,14 +7,14 @@
 }:
 
 python3.pkgs.buildPythonApplication rec {
-  pname = "nix-review";
-  version = "2.1.0";
+  pname = "nixpkgs-review";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "Mic92";
-    repo = "nix-review";
+    repo = "nixpkgs-review";
     rev = version;
-    sha256 = "0bdar2d88qjkf76hi3ar1lyfxnbwzhx1fi8fv65bw95m2sp1p0b5";
+    sha256 = "0rx0ld2ihsvlr1yiap5cq7h227jr79zf3xhkninh2m00x384s6bd";
   };
 
   makeWrapperArgs = [
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     description = "Review pull-requests on https://github.com/NixOS/nixpkgs";
-    homepage = https://github.com/Mic92/nix-review;
+    homepage = https://github.com/Mic92/nixpkgs-review;
     license = licenses.mit;
     maintainers = [ maintainers.mic92 ];
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -270,6 +270,7 @@ mapAliases ({
   networkmanager_openconnect = networkmanager-openconnect; # added 2018-02-25
   networkmanager_openvpn = networkmanager-openvpn; # added 2018-02-25
   networkmanager_vpnc = networkmanager-vpnc; # added 2018-02-25
+  nix-review = nixpkgs-review; # added 2019-12-22
   nfsUtils = nfs-utils;  # added 2014-12-06
   nginxUnstable = nginxMainline; # added 2018-04-25
   nilfs_utils = nilfs-utils; # added 2018-04-25

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24900,7 +24900,7 @@ in
     "Also see https://github.com/NixOS/nixpkgs/pull/44903"
   );
 
-  nix-review = callPackage ../tools/package-management/nix-review { };
+  nixpkgs-review = callPackage ../tools/package-management/nixpkgs-review { };
 
   nix-serve = callPackage ../tools/package-management/nix-serve { };
 


### PR DESCRIPTION
changelog: https://github.com/Mic92/nixpkgs-review/releases/tag/2.1.1

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
