### PR TITLE
nixos/python-test-driver: add an option to disable python linter

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.xml
+++ b/nixos/doc/manual/development/writing-nixos-tests.xml
@@ -419,4 +419,23 @@ machine.wait_for_unit("xautolock.service", "x-session-user")
   <literal>wait_for_unit</literal>, <literal>start_job</literal> and
   <literal>stop_job</literal>.
  </para>
+
+ <para>
+  For faster dev cycles it's also possible to disable the code-linters (this shouldn't
+  be commited though):
+<programlisting>
+import ./make-test-python.nix {
+  skipLint = true;
+  machine =
+    { config, pkgs, ... }:
+    { <replaceable>configuration…</replaceable>
+    };
+
+  testScript =
+    ''
+      <replaceable>Python code…</replaceable>
+    '';
+}
+</programlisting>
+ </para>
 </section>

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -95,6 +95,8 @@ in rec {
     , makeCoverageReport ? false
     , enableOCR ? false
     , name ? "unnamed"
+    # Skip linting (mainly intended for faster dev cycles)
+    , skipLint ? false
     , ...
     } @ t:
 
@@ -133,7 +135,7 @@ in rec {
       # Generate onvenience wrappers for running the test driver
       # interactively with the specified network, and for starting the
       # VMs from the command line.
-      driver = runCommand testDriverName
+      driver = let warn = if skipLint then lib.warn "Linting is disabled!" else lib.id; in warn (runCommand testDriverName
         { buildInputs = [ makeWrapper];
           testScript = testScript';
           preferLocalBuild = true;
@@ -143,7 +145,9 @@ in rec {
           mkdir -p $out/bin
 
           echo -n "$testScript" > $out/test-script
-          ${python3Packages.black}/bin/black --check --diff $out/test-script
+          ${lib.optionalString (!skipLint) ''
+            ${python3Packages.black}/bin/black --check --diff $out/test-script
+          ''}
 
           ln -s ${testDriver}/bin/nixos-test-driver $out/bin/
           vms=($(for i in ${toString vms}; do echo $i/bin/run-*-vm; done))
@@ -160,7 +164,7 @@ in rec {
             --set tests 'start_all(); join_all();' \
             --set VLANS '${toString vlans}' \
             ${lib.optionalString (builtins.length vms == 1) "--set USE_SERIAL 1"}
-        ''; # "
+        ''); # "
 
       passMeta = drv: drv // lib.optionalAttrs (t ? meta) {
         meta = (drv.meta or {}) // t.meta;


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

While it's a good idea to automate the linting of the python code used
for our tests, I think that it can be quite distracting when hacking on
a NixOS test.

I figured that it might be more convenient to add an option as a
shortcut for this to avoid that everyone needs to dig into the test
driver again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
