### PR TITLE
golden-cheetah: Add libusb (ANT+ sensors), 3.5-DEV1903 -> 3.5-RC2X

### DIFF
--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, mkDerivation
 , qtbase, qtsvg, qtserialport, qtwebkit, qtmultimedia, qttools
-, qtconnectivity, qtcharts
+, qtconnectivity, qtcharts, libusb
 , yacc, flex, zlib, qmake, makeDesktopItem, makeWrapper
 }:
 
@@ -27,7 +27,7 @@ in mkDerivation rec {
 
   buildInputs = [
     qtbase qtsvg qtserialport qtwebkit qtmultimedia qttools zlib
-    qtconnectivity qtcharts
+    qtconnectivity qtcharts libusb
   ];
   nativeBuildInputs = [ flex makeWrapper qmake yacc ];
 
@@ -39,6 +39,9 @@ in mkDerivation rec {
     cp src/gcconfig.pri.in src/gcconfig.pri
     cp qwt/qwtconfig.pri.in qwt/qwtconfig.pri
     echo 'QMAKE_LRELEASE = ${qttools.dev}/bin/lrelease' >> src/gcconfig.pri
+    echo 'LIBUSB_INSTALL = ${libusb}' >> src/gcconfig.pri
+    echo 'LIBUSB_INCLUDE = ${libusb.dev}/include' >> src/gcconfig.pri
+    echo 'LIBUSB_LIBS = -L${libusb}/lib -lusb' >> src/gcconfig.pri
     sed -i -e '21,23d' qwt/qwtconfig.pri # Removed forced installation to /usr/local
   '';
 

--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, mkDerivation
-, qtbase, qtsvg, qtserialport, qtwebkit, qtmultimedia, qttools
+, qtbase, qtsvg, qtserialport, qtwebengine, qtmultimedia, qttools
 , qtconnectivity, qtcharts, libusb
 , yacc, flex, zlib, qmake, makeDesktopItem, makeWrapper
 }:
@@ -26,7 +26,7 @@ in mkDerivation rec {
   };
 
   buildInputs = [
-    qtbase qtsvg qtserialport qtwebkit qtmultimedia qttools zlib
+    qtbase qtsvg qtserialport qtwebengine qtmultimedia qttools zlib
     qtconnectivity qtcharts libusb
   ];
   nativeBuildInputs = [ flex makeWrapper qmake yacc ];
@@ -43,6 +43,10 @@ in mkDerivation rec {
     echo 'LIBUSB_INCLUDE = ${libusb.dev}/include' >> src/gcconfig.pri
     echo 'LIBUSB_LIBS = -L${libusb}/lib -lusb' >> src/gcconfig.pri
     sed -i -e '21,23d' qwt/qwtconfig.pri # Removed forced installation to /usr/local
+
+    # Use qtwebengine instead of qtwebkit
+    substituteInPlace src/gcconfig.pri \
+      --replace "#DEFINES += NOWEBKIT" "DEFINES += NOWEBKIT"
   '';
 
   installPhase = ''

--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -16,13 +16,13 @@ let
   };
 in mkDerivation rec {
   pname = "golden-cheetah";
-  version = "3.5-DEV1903";
+  version = "3.5-RC2X";
 
   src = fetchFromGitHub {
     owner = "GoldenCheetah";
     repo = "GoldenCheetah";
-    rev = "v${version}";
-    sha256 = "130b0hm04i0hf97rs1xrdfhbal5vjsknj3x4cdxjh7rgbg2p1sm3";
+    rev = "V${version}";
+    sha256 = "1d85700gjbcw2badwz225rjdr954ai89900vp8sal04sk79wbr6g";
   };
 
   buildInputs = [
@@ -55,9 +55,6 @@ in mkDerivation rec {
 
     runHook postInstall
   '';
-
-  # RCC: Error in 'Resources/application.qrc': Cannot find file 'translations/gc_fr.qm'
-  enableParallelBuilding = false;
 
   meta = with stdenv.lib; {
     description = "Performance software for cyclists, runners and triathletes";


### PR DESCRIPTION
###### Motivation for this change
I wanted to use ANT+ sensors with GoldenCheetah, now with libusb it's possible.
I tested it using the ANT USB-Stick-m and a handful of ANT+ sensors - works flawlessly.

While at it, I upgraded the version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ocharles
