### PR TITLE
python.pkgs.fpylll: 0.5.0dev -> 0.5.1dev, fix tests on aarch64

### DIFF
--- a/pkgs/development/python-modules/fpylll/default.nix
+++ b/pkgs/development/python-modules/fpylll/default.nix
@@ -14,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "fpylll";
-  version = "0.5.0dev";
+  version = "0.5.1dev";
 
   src = fetchFromGitHub {
     owner = "fplll";
     repo = "fpylll";
     rev = version;
-    sha256 = "091zqgsqd5cqma1hvimkq5xpr9f1jw80v9m2fr6k9hvssqjzgnab";
+    sha256 = "15vdfgx448mr1nf054h7lr2j3dd35fsfhikqzrh9zsng8n12hxa5";
   };
 
   buildInputs = [

--- a/pkgs/development/python-modules/fpylll/default.nix
+++ b/pkgs/development/python-modules/fpylll/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , buildPythonPackage
 , pkgconfig
 , gmp
@@ -22,6 +23,20 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "15vdfgx448mr1nf054h7lr2j3dd35fsfhikqzrh9zsng8n12hxa5";
   };
+
+  patches = [
+    # two patches to fix the testsuite on aarch64 (https://github.com/fplll/fpylll/issues/162)
+    (fetchpatch {
+      url = "https://github.com/fplll/fpylll/commit/d5809a8fdb86b2693b1fa94e655bbbe4ad80e286.patch";
+      name = "less-precision-in-tests.patch";
+      sha256 = "0vkvi25nwwvk5r4a4xmkbf060di4hjq32bys75l2hsaysxmk93nz";
+    })
+    (fetchpatch {
+      url = "https://github.com/fplll/fpylll/commit/b5b146a010d50da219a313adc4b6f7deddcc146b.patch";
+      name = "dont-hardcode-precision.patch";
+      sha256 = "1rsbwh90i1j5p2rp6jd5n25v1jzw1n8728fzz1lhb91zmk0hlxc9";
+    })
+  ];
 
   buildInputs = [
     gmp


### PR DESCRIPTION
###### Motivation for this change

#75796, https://github.com/fplll/fpylll/issues/162

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
