### PR TITLE
xow: init at 0.2

### DIFF
--- a/nixos/modules/hardware/uinput.nix
+++ b/nixos/modules/hardware/uinput.nix
@@ -1,0 +1,19 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.hardware.uinput;
+in {
+  options.hardware.uinput = {
+    enable = lib.mkEnableOption "Whether to enable uinput support";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.kernelModules = [ "uinput" ];
+
+    users.groups.uinput = {};
+
+    services.udev.extraRules = ''
+      SUBSYSTEM=="misc", KERNEL=="uinput", MODE="0660", GROUP="uinput", OPTIONS+="static_node=uinput"
+    '';
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -64,6 +64,7 @@
   ./hardware/steam-hardware.nix
   ./hardware/usb-wwan.nix
   ./hardware/onlykey.nix
+  ./hardware/uinput.nix
   ./hardware/video/amdgpu.nix
   ./hardware/video/amdgpu-pro.nix
   ./hardware/video/ati.nix
@@ -357,6 +358,7 @@
   ./services/hardware/thermald.nix
   ./services/hardware/undervolt.nix
   ./services/hardware/vdr.nix
+  ./services/hardware/xow.nix
   ./services/logging/SystemdJournal2Gelf.nix
   ./services/logging/awstats.nix
   ./services/logging/fluentd.nix

--- a/nixos/modules/services/hardware/xow.nix
+++ b/nixos/modules/services/hardware/xow.nix
@@ -1,0 +1,30 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.services.hardware.xow;
+in {
+  options.services.hardware.xow = {
+    enable = lib.mkEnableOption "Whether to enable xow or not.";
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.uinput.enable = true;
+
+    users.users.xow = {
+      group = "uinput";
+      isSystemUser = true;
+    };
+
+    systemd.services.xow = {
+      wantedBy = [ "multi-user.target" ];
+      description = "Xbox One Wireless Dongle Driver";
+      after = [ "systemd-udev-settle.service" ];
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.xow}/bin/xow
+        '';
+        User = "xow";
+      };
+    };
+  };
+}

--- a/pkgs/misc/drivers/xow/default.nix
+++ b/pkgs/misc/drivers/xow/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, libusb, gitMinimal }:
+
+stdenv.mkDerivation rec {
+  pname = "xow";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "medusalix";
+    repo = "xow";
+    rev = "v${version}";
+    sha256 = "03ajal91xi52svzy621aa4jcdf0vj4pqd52kljam0wryrlmcpbr3";
+  };
+
+  makeFlags = [ "BUILD=RELEASE" "VERSION=${version}" ];
+  enableParallelBuilding = true;
+  buildInputs = [ libusb ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp xow $out/bin
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/medusalix/xow";
+    description = "Linux driver for the Xbox One wireless dongle";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.pmiddend ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25343,6 +25343,8 @@ in
 
   xboxdrv = callPackage ../misc/drivers/xboxdrv { };
 
+  xow = callPackage ../misc/drivers/xow { };
+
   xbps = callPackage ../tools/package-management/xbps { };
 
   xcftools = callPackage ../tools/graphics/xcftools { };


### PR DESCRIPTION
###### Motivation for this change

I have first tested xow on my local machine and it worked flawlessly. Then I created the package and my first NixOS service with it. I tested this service using a VM and it worked.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).