### PR TITLE
runwayml: 0.9.0 -> 0.10.11

### DIFF
--- a/pkgs/applications/graphics/runwayml/default.nix
+++ b/pkgs/applications/graphics/runwayml/default.nix
@@ -6,12 +6,12 @@
 
 let
   pname = "runwayml";
-  version = "0.9.0";
+  version = "0.10.11";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://runway-releases.s3.amazonaws.com/Runway%20${version}.AppImage";
-    sha256 = "0rg7ipp7kx0l4qgcymfg5d3saz0c6d2j0c6rf28rwqgbm92gbjjq";
+    sha256 = "0f3icgpwj1sk9bkycqw65c8bhrzzpw5yzacw52siv4j1gl4casnl";
     name="${pname}-${version}.AppImage";
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
