### PR TITLE
nixos/nixos-installer: add flags for verbosity and build logs

### DIFF
--- a/nixos/doc/manual/man-nixos-install.xml
+++ b/nixos/doc/manual/man-nixos-install.xml
@@ -15,6 +15,26 @@
   <cmdsynopsis>
    <command>nixos-install</command>
    <arg>
+    <group choice='req'>
+     <arg choice='plain'>
+      <option>--verbose</option>
+     </arg>
+     <arg choice='plain'>
+      <option>-v</option>
+     </arg>
+    </group>
+   </arg>
+   <arg>
+    <group choice='req'>
+     <arg choice='plain'>
+      <option>--print-build-logs</option>
+     </arg>
+     <arg choice='plain'>
+      <option>-L</option>
+     </arg>
+    </group>
+   </arg>
+   <arg>
     <arg choice='plain'>
      <option>-I</option>
     </arg>
@@ -134,6 +154,23 @@
    This command accepts the following options:
   </para>
   <variablelist>
+   <varlistentry>
+    <term><option>--verbose</option> / <option>-v</option></term>
+    <listitem>
+     <para>Increases the level of verbosity of diagnostic messages
+     printed on standard error.  For each Nix operation, the information
+     printed on standard output is well-defined; any diagnostic
+     information is printed on standard error, never on standard
+     output.</para>
+     <para>Please note that this option may be specified repeatedly.</para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><option>--print-build-logs</option> / <option>-L</option></term>
+    <listitem>
+     <para>Print the full build logs of <command>nix build</command> to stderr.</para>
+    </listitem>
+   </varlistentry>
    <varlistentry>
     <term>
      <option>--root</option>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

When installing a fresh NixOS system it occasionally happens that you
encounter issues that are rather hard to track down since
`nixos-install(8)` doesn't provide any debugging flags.

This patch adds `-L` to force `nix build` to display the build-log on
stderr and `-v` to increase the log-level of Nix.

-----

Tested whether the installer builds a fresh NixOS in an artifical tmpfs mounted to `/mnt` as described in the [manual](https://nixos.org/nixos/manual/index.html#ch-testing-installer).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
