### PR TITLE
python.pkgs.bacpypes: init at 0.18.0

### DIFF
--- a/pkgs/development/python-modules/bacpypes/default.nix
+++ b/pkgs/development/python-modules/bacpypes/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, fetchFromGitHub
+, wheel, pytestCheckHook, pytestrunner }:
+
+buildPythonPackage rec {
+  version = "0.18.0";
+  pname = "bacpypes";
+
+  src = fetchFromGitHub {
+    owner = "JoelBender";
+    repo = "bacpypes";
+    rev = "${version}";
+    sha256 = "1nz0qi46z6n455mw2ppxgz091qh0irizlxpvkx7iw1l7f6mmgj0x";
+  };
+
+  propagatedBuildInputs = [ wheel ];
+
+  # Using pytes instead of setuptools check hook allows disabling specific tests
+  checkInputs = [ pytestCheckHook pytestrunner ];
+  dontUseSetuptoolsCheck = true;
+  disabledTests = [
+    # Test fails with a an error: AssertionError: assert 30 == 31
+    "test_recurring_task_5"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/JoelBender/bacpypes";
+    description = "BACpypes provides a BACnet application layer and network layer written in Python for daemons, scripting, and graphical interfaces.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bachp ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -477,6 +477,8 @@ in {
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};
 
+  bacpypes = callPackage ../development/python-modules/bacpypes {};
+
   bap = callPackage ../development/python-modules/bap {
     bap = pkgs.ocaml-ng.ocamlPackages_4_06.bap;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Include the bacnet python library in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
