### PR TITLE
bat: insert less into PATH

### DIFF
--- a/pkgs/tools/misc/bat/default.nix
+++ b/pkgs/tools/misc/bat/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, rustPlatform, fetchFromGitHub, llvmPackages, pkgconfig
-, Security, libiconv, installShellFiles
+{ stdenv, rustPlatform, fetchFromGitHub, llvmPackages, pkgconfig, less
+, Security, libiconv, installShellFiles, makeWrapper
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0d7h0kn41w6wm4w63vjy2i7r19jkansfvfjn7vgh2gqh5m60kal2";
 
-  nativeBuildInputs = [ pkgconfig llvmPackages.libclang installShellFiles ];
+  nativeBuildInputs = [ pkgconfig llvmPackages.libclang installShellFiles makeWrapper ];
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security libiconv ];
 
@@ -25,6 +25,13 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     installManPage doc/bat.1
     installShellCompletion assets/completions/bat.fish
+  '';
+
+  # Insert Nix-built `less` into PATH because the system-provided one may be too old to behave as
+  # expected with certain flag combinations.
+  postFixup = ''
+    wrapProgram "$out/bin/bat" \
+      --prefix PATH : "${stdenv.lib.makeBinPath [ less ]}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
The default pager for `bat` is `less -RF --no-init`. Overriding this to `less -RF` in order to enable alternate screen behavior (e.g. page up/down keys) causes the `-F` flag to behave badly in the version of `less` shipped on macOS. The simplest way to fix this is to simply put Nix's `less` into the `PATH` so it takes precedence.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
