### PR TITLE
vscode-extensions.ms-vscode-remote.remote-ssh: init at 0.48.0

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -122,6 +122,8 @@ in
 
   ms-vscode.cpptools = callPackage ./cpptools {};
 
+  ms-vscode-remote.remote-ssh = callPackage ./remote-ssh {};
+
   ms-python.python = callPackage ./python {
     extractNuGet = callPackage ./python/extract-nuget.nix { };
   };

--- a/pkgs/misc/vscode-extensions/remote-ssh/default.nix
+++ b/pkgs/misc/vscode-extensions/remote-ssh/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, vscode-utils
+, useLocalExtensions ? false}:
+# Note that useLocalExtensions requires that vscode-server is not running
+# on host. If it is, you'll need to remove ~/.vscode-server,
+# and redo the install by running "Connect to host" on client
+
+let
+  inherit (vscode-utils) buildVscodeMarketplaceExtension;
+  
+  # patch runs on remote machine hence use of which
+  patch = ''
+    f="/home/''$USER/.vscode-server/bin/''$COMMIT_ID/node"
+    nodePath=''$(which node)
+    if [ -x "''$nodePath" ]; then
+      nodeVersion=''$(node -v)
+      if [[ "${nodeVersion:1:2}" == "12" ]]; then
+        echo PATCH: replacing ''$f with ''$nodePath
+        rm ''$f
+        ln -s ''$nodePath ''$f
+      fi
+    fi
+    ${stdenv.lib.optionalString useLocalExtensions ''
+      # Use local extensions
+      if test -f "~/.vscode/extensions"; then
+        if ! test -L "~/.vscode-server/extensions"; then
+          ln -s ~/.vscode/extensions ~/.vscode-server/
+        fi
+      fi
+    ''}
+  '';
+in
+  buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "remote-ssh";
+      publisher = "ms-vscode-remote";
+      version = "0.48.0";
+      sha256 = "04q53gljqh5snkrdf5l69g0ahn1s5z35a4ipfcbf1rsjjmm85a19";
+    };
+
+    postPatch = ''
+      substituteInPlace "out/extension.js" \
+        --replace "# install extensions" '${patch}'
+    '';
+
+    meta = with stdenv.lib; {
+      description ="Use any remote machine with a SSH server as your development environment.";
+      license = licenses.unfree;
+      maintainers = with maintainers; [
+        tbenst
+      ];
+    };
+  }


### PR DESCRIPTION
###### Motivation for this change
Currently, using VSCode extension remote-ssh with NixOS host requires an [annoying patch](https://github.com/microsoft/vscode-remote-release/issues/648#issuecomment-503148523). This client-side patch changes the package so the host node (as found by `which node`)  is *always* used. 

Main limitation: prior to patch, you could remote-ssh to Ubuntu without `nodejs_12` installed, and it would work by locally installing node binary. With this patch, you'll need to first `sudo apt install nodejs` or install nodejs in userspace via another means.

Benefit: as long as a NixOS box has `nodejs-12_x` installed, it now works out-of-the-box with `remote-ssh`. As does any other old OS, so this effectively fixes https://github.com/microsoft/vscode-remote-release/issues/103.

Closes https://github.com/rycee/home-manager/issues/939

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
Not maintainers, but following people may have input:
cc @simonchatts @luxferresum @aanderse @Mic92 