### PR TITLE
networkmanager: 1.20.8 -> 1.22.4, modemmanager: 1.10.6 -> 1.12.2

### DIFF
--- a/pkgs/development/python-modules/python-dbusmock/default.nix
+++ b/pkgs/development/python-modules/python-dbusmock/default.nix
@@ -1,15 +1,17 @@
-{ lib, buildPythonPackage, fetchPypi, runtimeShell,
+{ lib, buildPythonPackage, fetchFromGitHub, runtimeShell,
   nose, dbus, dbus-python, pygobject3,
   which, pyflakes, pycodestyle, bluez, networkmanager
 }:
 
 buildPythonPackage rec {
   pname = "python-dbusmock";
-  version = "0.18.3";
+  version = "0.19";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "994a178268b6d74aeb158c0f155cd141e9a0cfae14226a764cd022c4949fe242";
+  src = fetchFromGitHub {
+    owner = "martinpitt";
+    repo = pname;
+    rev = version;
+    sha256 = "09j338lmrjabbd3fpajr4piz4r20sl33030szfsqfzlwrrmvkyi0";
   };
 
   prePatch = ''

--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   pname = "modem-manager";
-  version = "1.10.6";
+  version = "1.12.2";
 
   package = "ModemManager";
   src = fetchurl {
     url = "https://www.freedesktop.org/software/${package}/${package}-${version}.tar.xz";
-    sha256 = "15n9sd6ymxvw7hidc9pw81j89acwi5cjfhj220a68mi1h8vsfb1w";
+    sha256 = "1si5bnm0d3b5ccpgj7xakl7pgy9mypm8ds6xgj1q0rzds2yx4xjg";
   };
 
   nativeBuildInputs = [ vala gobject-introspection gettext pkgconfig ];

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -4,17 +4,17 @@
 , gobject-introspection, modemmanager, openresolv, libndp, newt, libsoup
 , ethtool, gnused, iputils, kmod, jansson, gtk-doc, libxslt
 , docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_42, docbook_xml_dtd_43
-, openconnect, curl, meson, ninja, libpsl }:
+, openconnect, curl, meson, ninja, libpsl, mobile-broadband-provider-info, runtimeShell }:
 
 let
   pythonForDocs = python3.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in stdenv.mkDerivation rec {
   pname = "network-manager";
-  version = "1.20.8";
+  version = "1.22.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${stdenv.lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "1ijpnx25wy5bcvp4mc49va942q56d0pncpj4jpknpdzwilmf455d";
+    sha256 = "0682hm5l3ix8cq35yl5pxidri4kxbdnvj9llf8vg9mcg5abdaslv";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];
@@ -54,8 +54,8 @@ in stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit iputils kmod openconnect ethtool gnused dbus;
-      inherit (stdenv) shell;
+      inherit iputils kmod openconnect ethtool gnused systemd;
+      inherit runtimeShell;
     })
 
     # Meson does not support using different directories during build and
@@ -64,7 +64,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    systemd libselinux audit libpsl libuuid polkit ppp libndp curl
+    systemd libselinux audit libpsl libuuid polkit ppp libndp curl mobile-broadband-provider-info
     bluez5 dnsmasq gobject-introspection modemmanager readline newt libsoup jansson
   ];
 

--- a/pkgs/tools/networking/network-manager/fix-install-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-install-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 4105a9c80..3d912557f 100644
+index 0af69f35d..9ab239c8a 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -884,9 +884,9 @@ meson.add_install_script(
+@@ -912,9 +912,9 @@ meson.add_install_script(
    join_paths('tools', 'meson-post-install.sh'),
    nm_datadir,
    nm_bindir,
@@ -11,19 +11,6 @@ index 4105a9c80..3d912557f 100644
    nm_pkglibdir,
 -  nm_pkgstatedir,
 +  nm_prefix + nm_pkgstatedir,
-   enable_docs ? 'install_docs' : '',
    nm_mandir,
- )
-diff --git a/src/settings/plugins/ifcfg-rh/meson.build b/src/settings/plugins/ifcfg-rh/meson.build
-index 58acdcfcb..e3a16d597 100644
---- a/src/settings/plugins/ifcfg-rh/meson.build
-+++ b/src/settings/plugins/ifcfg-rh/meson.build
-@@ -69,7 +69,7 @@ install_data(
- )
- 
- meson.add_install_script('sh', '-c',
--                         'mkdir -p $DESTDIR/@0@/sysconfig/network-scripts'.format(nm_sysconfdir))
-+                         'mkdir -p $DESTDIR/@0@/sysconfig/network-scripts'.format(nm_prefix + nm_sysconfdir))
- 
- if enable_tests
-   subdir('tests')
+   nm_sysconfdir,
+   enable_docs ? '1' : '0',

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/clients/common/nm-vpn-helpers.c b/clients/common/nm-vpn-helpers.c
-index 204b7c286..8bdb734c2 100644
+index ffae5f553..ba1093e4d 100644
 --- a/clients/common/nm-vpn-helpers.c
 +++ b/clients/common/nm-vpn-helpers.c
-@@ -215,10 +215,7 @@ nm_vpn_openconnect_authenticate_helper (const char *host,
+@@ -203,10 +203,7 @@ nm_vpn_openconnect_authenticate_helper (const char *host,
  		NULL,
  	};
  
@@ -15,7 +15,7 @@ index 204b7c286..8bdb734c2 100644
  	if (!g_spawn_sync (NULL,
  	                   (char **) NM_MAKE_STRV (path, "--authenticate", host),
 diff --git a/data/84-nm-drivers.rules b/data/84-nm-drivers.rules
-index e398cb9f2..31c56596a 100644
+index e398cb9f2..a43d61864 100644
 --- a/data/84-nm-drivers.rules
 +++ b/data/84-nm-drivers.rules
 @@ -7,6 +7,6 @@ ACTION!="add|change", GOTO="nm_drivers_end"
@@ -23,27 +23,27 @@ index e398cb9f2..31c56596a 100644
  ENV{ID_NET_DRIVER}=="?*", GOTO="nm_drivers_end"
  DRIVERS=="?*", GOTO="nm_drivers_end"
 -PROGRAM="/bin/sh -c '/usr/sbin/ethtool -i $$1 |/usr/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", ENV{ID_NET_DRIVER}="%c"
-+PROGRAM="@shell@ -c '@ethtool@/bin/ethtool -i $$1 |@gnused@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", ENV{ID_NET_DRIVER}="%c"
++PROGRAM="@runtimeShell@ -c '@ethtool@/bin/ethtool -i $$1 |@gnused@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", ENV{ID_NET_DRIVER}="%c"
  
  LABEL="nm_drivers_end"
 diff --git a/data/NetworkManager.service.in b/data/NetworkManager.service.in
-index 2f442bf23..c3e797bf4 100644
+index 91ebd9a36..5201a56c3 100644
 --- a/data/NetworkManager.service.in
 +++ b/data/NetworkManager.service.in
 @@ -8,7 +8,7 @@ Before=network.target @DISTRO_NETWORK_SERVICE@
  [Service]
  Type=dbus
  BusName=org.freedesktop.NetworkManager
--ExecReload=/usr/bin/dbus-send --print-reply --system --type=method_call --dest=org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager.Reload uint32:0
-+ExecReload=@dbus@/bin/dbus-send --print-reply --system --type=method_call --dest=org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager.Reload uint32:0
+-ExecReload=/usr/bin/busctl call org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Reload u 0
++ExecReload=@systemd@/bin/busctl call org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Reload u 0
  #ExecReload=/bin/kill -HUP $MAINPID
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
 diff --git a/libnm/meson.build b/libnm/meson.build
-index 710ef181d..3aa182dd4 100644
+index 51ca46d2b..0c04cc216 100644
 --- a/libnm/meson.build
 +++ b/libnm/meson.build
-@@ -280,7 +280,7 @@ if enable_introspection
+@@ -261,7 +261,7 @@ if enable_introspection
      name,
      input: libnm_gir[0],
      output: name,
@@ -52,20 +52,20 @@ index 710ef181d..3aa182dd4 100644
      depends: libnm_gir,
    )
  
-@@ -289,7 +289,7 @@ if enable_introspection
+@@ -270,7 +270,7 @@ if enable_introspection
      name,
-     input: libnm_gir[0],
+     input: [libnm_gir[0], nm_settings_docs_overrides],
      output: name,
--    command: [generate_setting_docs_env, python.path(), generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--overrides', nm_settings_docs_overrides, '--output', '@OUTPUT@'],
-+    command: [generate_setting_docs_env, generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT@', '--overrides', nm_settings_docs_overrides, '--output', '@OUTPUT@'],
+-    command: [generate_setting_docs_env, python.path(), generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT0@', '--overrides', '@INPUT1@', '--output', '@OUTPUT@'],
++    command: [generate_setting_docs_env, generate_setting_docs, '--lib-path', meson.current_build_dir(), '--gir', '@INPUT0@', '--overrides', '@INPUT1@', '--output', '@OUTPUT@'],
      depends: libnm_gir,
    )
  endif
 diff --git a/src/devices/nm-device.c b/src/devices/nm-device.c
-index 67e23b8f9..b0ce52711 100644
+index e7a4a059a..0a8f8b7c6 100644
 --- a/src/devices/nm-device.c
 +++ b/src/devices/nm-device.c
-@@ -12840,14 +12840,14 @@ nm_device_start_ip_check (NMDevice *self)
+@@ -13179,14 +13179,14 @@ nm_device_start_ip_check (NMDevice *self)
  			gw = nm_ip4_config_best_default_route_get (priv->ip_config_4);
  			if (gw) {
  				nm_utils_inet4_ntop (NMP_OBJECT_CAST_IP4_ROUTE (gw)->gateway, buf);
@@ -83,10 +83,10 @@ index 67e23b8f9..b0ce52711 100644
  			}
  		}
 diff --git a/src/nm-core-utils.c b/src/nm-core-utils.c
-index d896d4d33..4cacb5cb6 100644
+index fb92289f0..c91b27b09 100644
 --- a/src/nm-core-utils.c
 +++ b/src/nm-core-utils.c
-@@ -446,7 +446,7 @@ nm_utils_modprobe (GError **error, gboolean suppress_error_logging, const char *
+@@ -336,7 +336,7 @@ nm_utils_modprobe (GError **error, gboolean suppress_error_logging, const char *
  
  	/* construct the argument list */
  	argv = g_ptr_array_sized_new (4);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/blob/1.22.0/NEWS
https://gitlab.freedesktop.org/mobile-broadband/ModemManager/blob/1.12.2/NEWS

Experimental features in NetworkManager are not enabled in this PR.


###### Things done
Built on master.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
