### PR TITLE
Add NVIDIA licenses

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -546,6 +546,18 @@ lib.mapAttrs (n: v: v // { shortName = n; }) {
     fullName = "Non-Profit Open Software License 3.0";
   };
 
+  nvidiaCuda = {
+    fullName = "CUDA Toolkit Supplement to Software License Agreement for NVIDIA Software Development Kits";
+    url = "https://docs.nvidia.com/cuda/eula/index.html#cuda-toolkit-supplement-license-agreement";
+    free = false;
+  };
+
+  nvidiaCudnn = {
+    fullName = "cuDNN Supplement to Software License Agreement for NVIDIA Software Development Kits";
+    url = "https://docs.nvidia.com/deeplearning/sdk/cudnn-sla/index.html#supplement";
+    free = false;
+  };
+
   ocamlpro_nc = {
     fullName = "OCamlPro Non Commercial license version 1";
     url = "https://alt-ergo.ocamlpro.com/http/alt-ergo-2.2.0/OCamlPro-Non-Commercial-License.pdf";

--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -214,7 +214,6 @@ stdenv.mkDerivation rec {
     description = "A compiler for NVIDIA GPUs, math libraries, and tools";
     homepage = "https://developer.nvidia.com/cuda-toolkit";
     platforms = [ "x86_64-linux" ];
-    license = licenses.unfree;
+    license = licenses.nvidiaCuda;
   };
 }
-

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "NVIDIA CUDA Deep Neural Network library (cuDNN)";
     homepage = "https://developer.nvidia.com/cudnn";
-    license = licenses.unfree;
+    license = licenses.nvidiaCudnn;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ mdaiter ];
   };


### PR DESCRIPTION
###### Motivation for this change
NVIDIA software is unfree, but redistributable. To facilitate data science infrastructure by community, the licenses should be made more precise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @