### PR TITLE
cipher: 2.0.0 -> 2.5.0

### DIFF
--- a/pkgs/applications/misc/cipher/default.nix
+++ b/pkgs/applications/misc/cipher/default.nix
@@ -10,18 +10,17 @@
 , glib
 , gtk3
 , libgee
-, xdg_utils
 , wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "cipher";
-  version = "2.0.0";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "arshubham";
     repo = "cipher";
     rev = version;
-    sha256 = "0n5aigcyxnl4k52mdmavbxx6afc1ixymn3k3l2ryhyzi5q31x0x3";
+    sha256 = "00azc5ck17zkdypfza6x1viknwhimd9fqgk2ybff3mx6aphmla7a";
   };
 
   nativeBuildInputs = [
@@ -42,10 +41,10 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-  	substituteInPlace data/com.github.arshubham.cipher.desktop.in \
-  		--replace xdg-open ${xdg_utils}/bin/xdg-open
-    chmod +x post_install.py
-    patchShebangs post_install.py
+    substituteInPlace data/com.github.arshubham.cipher.desktop.in \
+      --replace "gio" "${glib.bin}/bin/gio"
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
   '';
 
   passthru = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version update and `postPatch` cleaning since https://github.com/arshubham/cipher/pull/44 is part of the new release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
