### PR TITLE
Fix build and update dpdk and dependent packages

### DIFF
--- a/pkgs/development/libraries/spdk/default.nix
+++ b/pkgs/development/libraries/spdk/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchFromGitHub, python, cunit, dpdk, libaio, libuuid, numactl, openssl }:
+{ stdenv, fetchFromGitHub, python, cunit, dpdk, libaio, libbsd, libuuid, numactl, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "spdk";
-  version = "19.04";
+  version = "19.10";
 
   src = fetchFromGitHub {
     owner = "spdk";
     repo = "spdk";
     rev = "v${version}";
-    sha256 = "10mzal1hspnh26ws5d7sc54gyjfzkf6amr0gkd7b368ng2a9z8s6";
+    sha256 = "16v2vswn3rnnj7ak5w5rsak6r8f9b85gyhyll4ac1k4xpyj488hj";
   };
+
+  patches = [ ./spdk-dpdk-meson.patch ];
 
   nativeBuildInputs = [ python ];
 
-  buildInputs = [ cunit dpdk libaio libuuid numactl openssl ];
+  buildInputs = [ cunit dpdk libaio libbsd libuuid numactl openssl ];
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/development/libraries/spdk/spdk-dpdk-meson.patch
+++ b/pkgs/development/libraries/spdk/spdk-dpdk-meson.patch
@@ -1,0 +1,17 @@
+1. dpdk built with meson generates rte_build_config.h rather than rte_config.h.
+2. dpdk configured with libbsd requires that dependents link with libbsd.
+
+--- a/lib/env_dpdk/env.mk
++++ b/lib/env_dpdk/env.mk
+@@ -140,6 +140,9 @@ endif
+ 
+-ifneq (,$(wildcard $(DPDK_INC_DIR)/rte_config.h))
+-ifneq (,$(shell grep -e "define RTE_LIBRTE_VHOST_NUMA 1" -e "define RTE_EAL_NUMA_AWARE_HUGEPAGES 1" $(DPDK_INC_DIR)/rte_config.h))
++ifneq (,$(wildcard $(DPDK_INC_DIR)/rte_build_config.h))
++ifneq (,$(shell grep -e "define RTE_LIBRTE_VHOST_NUMA 1" -e "define RTE_EAL_NUMA_AWARE_HUGEPAGES 1" $(DPDK_INC_DIR)/rte_build_config.h))
+ ENV_LINKER_ARGS += -lnuma
+ endif
++ifneq (,$(shell grep -e "define RTE_USE_LIBBSD 1" $(DPDK_INC_DIR)/rte_build_config.h))
++ENV_LINKER_ARGS += -lbsd
++endif
+ endif

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -12,11 +12,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "dpdk-${version}" + lib.optionalString mod "-${kernel.version}";
-  version = "19.08.2";
+  version = "19.11";
 
   src = fetchurl {
     url = "https://fast.dpdk.org/rel/dpdk-${version}.tar.xz";
-    sha256 = "141bqqy4w6nzs9z70x7yv94a4gmxjfal46pxry9bwdh3zi1jwnyd";
+    sha256 = "1aqjn6bm9miv3v2rbqi1rh1c19wa8nip9fvnqaqpnrs3i2b36wa6";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -5,7 +5,7 @@
     version = "18.11.5";
     src = fetchurl {
       url = "https://fast.dpdk.org/rel/dpdk-${version}.tar.xz";
-      sha256 = "0000000000000000000000000000000000000000000000000000";
+      sha256 = "1n6nfaj7703l19jcw540lm8avni48hj9q1rq4mfp8b8gd4zjprj0";
     };
   });
 
@@ -45,6 +45,8 @@ in stdenv.mkDerivation rec {
 
   # binaries will segfault otherwise
   dontStrip = true;
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Open Data Plane optimized for DPDK";

--- a/pkgs/os-specific/linux/pktgen/configure.patch
+++ b/pkgs/os-specific/linux/pktgen/configure.patch
@@ -1,0 +1,17 @@
+1. librte_process_info does not exist.
+2. lua5.3 library is liblua.
+3. app/meson.build uses undeclared drivers_install_subdir.
+--- a/lib/common/meson.build
++++ b/lib/common/meson.build
+@@ -34,1 +34,1 @@
+-libs = ['eal', 'kvargs', 'cmdline', 'process_info']
++libs = ['eal', 'kvargs', 'cmdline']
+--- a/lib/lua/meson.build
++++ b/lib/lua/meson.build
+@@ -31 +31 @@ endforeach
+-ext_deps += cc.find_library('lua5.3', required: true)
++ext_deps += cc.find_library('lua', required: true)
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -0,0 +1,1 @@
++option('drivers_install_subdir', type: 'string', value: '')

--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -1,40 +1,39 @@
-{ stdenv, lib, fetchurl, pkgconfig
-, dpdk, libpcap, lua5_3, numactl, utillinux
+{ stdenv, lib, fetchurl, meson, ninja, pkgconfig
+, dpdk, libbsd, libpcap, lua5_3, numactl, utillinux
 , gtk2, which, withGtk ? false
 }:
 
 stdenv.mkDerivation rec {
   pname = "pktgen";
-  version = "3.7.2";
+  version = "19.12.0";
 
   src = fetchurl {
     url = "http://dpdk.org/browse/apps/pktgen-dpdk/snapshot/${pname}-${version}.tar.xz";
-    sha256 = "03k7h4j2lsrh6b7477hgn87ljrjh2673ncffx9v261bx1ns54y7w";
+    sha256 = "1clfviz1qa4hysslcg6i29vsxwl9f6j1y7zf9wwx9br3yq08x956";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ meson ninja pkgconfig ];
 
   buildInputs =
-    [ dpdk libpcap lua5_3 numactl which ]
+    [ dpdk libbsd libpcap lua5_3 numactl which ]
     ++ stdenv.lib.optionals withGtk [gtk2];
 
-  RTE_SDK = "${dpdk}/share/dpdk";
-  RTE_TARGET = "x86_64-native-linuxapp-gcc";
+  RTE_SDK = dpdk;
   GUI = stdenv.lib.optionalString withGtk "true";
 
   NIX_CFLAGS_COMPILE = [ "-msse3" ];
 
-  postPatch = let dpdkMajor = lib.versions.major dpdk.version; in ''
+  patches = [ ./configure.patch ];
+
+  postPatch = ''
     substituteInPlace lib/common/lscpu.h --replace /usr/bin/lscpu ${utillinux}/bin/lscpu
   '';
 
-  installPhase = ''
-    install -d $out/bin
-    install -m 0755 app/${RTE_TARGET}/pktgen $out/bin
-    install -m 0644 Pktgen.lua $out/bin
+  postInstall = ''
+    # meson installs unneeded files with conflicting generic names, such as
+    # include/cli.h and lib/liblua.so.
+    rm -rf $out/include $out/lib
   '';
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Traffic generator powered by DPDK";


### PR DESCRIPTION
###### Motivation for this change

Fix building everything that depends on dpdk after it was switched to the meson build system in #73186:

1. spdk does not expect the meson-only-generated rte_build_config.h.
2. spdk does not expect that dpdk can depend on libbsd.
3. dpdk with meson does not support customizing kernel modules install directory.
4. odp-dpdk .nix did not specify the overridden dpdk source hash.
5. pktgen does not support meson-built dpdk unless it is also built with meson, which did not work at all before 19.12.0, but now requires only minor patching.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).