### PR TITLE
python.pkgs.wrapPython: fix makeWrapperArgs

### DIFF
--- a/pkgs/development/interpreters/python/wrap.sh
+++ b/pkgs/development/interpreters/python/wrap.sh
@@ -78,7 +78,16 @@ wrapPythonProgramsIn() {
 
                     # Add any additional arguments provided by makeWrapperArgs
                     # argument to buildPythonPackage.
-                    local -a user_args="($makeWrapperArgs)"
+                    local -a user_args
+                    # We need to support both the case when makeWrapperArgs
+                    # is an array and a IFS-separated string.
+                    # TODO: remove the string branch when __structuredAttrs are used.
+                    if [[ "$(declare -p makeWrapperArgs)" =~ ^'declare -a makeWrapperArgs=' ]]; then
+                        user_args=("${makeWrapperArgs[@]}")
+                    else
+                        user_args="($makeWrapperArgs)"
+                    fi
+
                     local -a wrapProgramArgs=("${wrap_args[@]}" "${user_args[@]}")
                     wrapProgram "${wrapProgramArgs[@]}"
                 fi


### PR DESCRIPTION
###### Motivation for this change
When `makeWrapperArgs` is a Bash array, we only passed the first item to `wrapProgram`. We need to use `"${makeWrapperArgs[@]}"` to extract all the items. But that breaks the common string case so we need to handle that case separately.

Closes: https://github.com/NixOS/nixpkgs/issues/76158


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @worldofpeace

---