### PR TITLE
rofi: fix displaying hicolor icons

### DIFF
--- a/pkgs/applications/misc/rofi/default.nix
+++ b/pkgs/applications/misc/rofi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeWrapper
+{ stdenv, lib, fetchurl
 , autoreconfHook, pkgconfig, libxkbcommon, pango, which, git
 , cairo, libxcb, xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification
 , bison, flex, librsvg, check
@@ -19,15 +19,10 @@ stdenv.mkDerivation rec {
     sed -i 's/~root/~nobody/g' test/helper-expand.c
   '';
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ libxkbcommon pango cairo git bison flex librsvg check
     libstartup_notification libxcb xcbutil xcbutilwm xcbutilxrm which
   ];
-
-  postInstall = ''
-    wrapProgram $out/bin/rofi-theme-selector \
-      --prefix XDG_DATA_DIRS : $out/share
-  '';
 
   doCheck = false;
 

--- a/pkgs/applications/misc/rofi/wrapper.nix
+++ b/pkgs/applications/misc/rofi/wrapper.nix
@@ -1,6 +1,5 @@
-{ stdenv, rofi-unwrapped, makeWrapper, theme ? null }:
+{ stdenv, rofi-unwrapped, makeWrapper, hicolor-icon-theme, theme ? null }:
 
-if theme == null then rofi-unwrapped else
 stdenv.mkDerivation {
   pname = "rofi";
   version = rofi-unwrapped.version;
@@ -14,8 +13,15 @@ stdenv.mkDerivation {
     rm $out/bin
     mkdir $out/bin
     ln -s ${rofi-unwrapped}/bin/* $out/bin
+
     rm $out/bin/rofi
-    makeWrapper ${rofi-unwrapped}/bin/rofi $out/bin/rofi --add-flags "-theme ${theme}"
+    makeWrapper ${rofi-unwrapped}/bin/rofi $out/bin/rofi \
+      --prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share \
+      ${if theme != null then ''--add-flags "-theme ${theme}"'' else ""}
+
+    rm $out/bin/rofi-theme-selector
+    makeWrapper ${rofi-unwrapped}/bin/rofi-theme-selector $out/bin/rofi-theme-selector \
+      --prefix XDG_DATA_DIRS : $out/share
   '';
 
   meta = rofi-unwrapped.meta // {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes rofi not displaying hicolor icons: #76196

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mbakke @ma27
