### PR TITLE
cargo-flamegraph: fix runtime dep: linux-perf

### DIFF
--- a/pkgs/development/tools/cargo-flamegraph/default.nix
+++ b/pkgs/development/tools/cargo-flamegraph/default.nix
@@ -23,6 +23,8 @@ rustPlatform.buildRustPackage rec {
   postFixup = lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/cargo-flamegraph \
       --suffix PATH ':' ${perf}/bin
+    wrapProgram $out/bin/flamegraph \
+      --suffix PATH ':' ${perf}/bin
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/cargo-flamegraph/default.nix
+++ b/pkgs/development/tools/cargo-flamegraph/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform
+{ lib, stdenv, fetchFromGitHub, rustPlatform, makeWrapper, perf
 , Security
 }:
 
@@ -15,11 +15,17 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "0kmw2n4j5bisac0bv3npbwfz2z00ncd6w8ichwaz5hac5mi1a72f";
 
-  buildInputs = stdenv.lib.optionals stdenv.isDarwin [
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ makeWrapper ];
+  buildInputs = lib.optionals stdenv.isDarwin [
     Security
   ];
 
-  meta = with stdenv.lib; {
+  postFixup = lib.optionalString stdenv.isLinux ''
+    wrapProgram $out/bin/cargo-flamegraph \
+      --suffix PATH ':' ${perf}/bin
+  '';
+
+  meta = with lib; {
     description = "Easy flamegraphs for Rust projects and everything else, without Perl or pipes <3";
     homepage = https://github.com/ferrous-systems/flamegraph;
     license = with licenses; [ asl20 /* or */ mit ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8680,6 +8680,7 @@ in
 
   cargo-flamegraph = callPackage ../development/tools/cargo-flamegraph {
     inherit (darwin.apple_sdk.frameworks) Security;
+    inherit (linuxPackages) perf;
   };
 
   carnix = (callPackage ../build-support/rust/carnix.nix { }).carnix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix runtime dependency to `perf` from `linuxPackages.perf`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - **31,606,936 (30 MiB) -> 234,971,768 (224 MiB)**
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
