### PR TITLE
qpaeq: init at 13.0

### DIFF
--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -108,7 +108,10 @@ stdenv.mkDerivation rec {
     rm -rf $out/{bin,share,etc,lib/{pulse-*,systemd}}
     sed 's|-lltdl|-L${libtool.lib}/lib -lltdl|' -i $out/lib/pulseaudio/libpulsecore-${version}.la
   ''
-    + ''moveToOutput lib/cmake "$dev" '';
+    + ''
+    moveToOutput lib/cmake "$dev"
+    rm -f $out/bin/qpaeq # this is packaged by the "qpaeq" package now, because of missing deps
+  '';
 
   preFixup = lib.optionalString stdenv.isLinux ''
     wrapProgram $out/libexec/pulse/gsettings-helper \

--- a/pkgs/servers/pulseaudio/qpaeq.nix
+++ b/pkgs/servers/pulseaudio/qpaeq.nix
@@ -1,0 +1,54 @@
+{ mkDerivation
+, makeDesktopItem
+, python3
+, fetchurl
+, lib
+, pulseaudio
+}:
+
+let
+  desktopItem = makeDesktopItem {
+    name = "qpaeq";
+    exec = "@out@/bin/qpaeq";
+    icon = "audio-volume-high";
+    desktopName = "qpaeq";
+    genericName = "Audio equalizer";
+    categories = "Music;Sound;";
+    startupNotify = "false";
+  };
+in
+mkDerivation rec {
+  pname = "qpaeq";
+  inherit (pulseaudio) version src;
+
+  buildInputs = [
+    ((python3.withPackages (ps: with ps; [
+          pyqt5
+          dbus-python
+        ])))
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D ./src/utils/qpaeq $out/bin/qpaeq
+    install -D ${desktopItem}/share/applications/qpaeq.desktop $out/share/applications/qpaeq.desktop
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    sed "s|,sip|,PyQt5.sip|g" -i $out/bin/qpaeq
+    wrapQtApp $out/bin/qpaeq
+    sed "s|@out@|$out|g" -i $out/share/applications/qpaeq.desktop
+  '';
+
+  meta = {
+    description = "An equalizer interface for pulseaudio's equalizer sinks";
+    homepage = http://www.pulseaudio.org/;
+    license = lib.licenses.lgpl2Plus;
+    maintainers = with lib.maintainers; [ lovek323 mkg20001 ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15409,6 +15409,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit Cocoa;
   };
 
+  qpaeq = qt5.callPackage ../servers/pulseaudio/qpaeq.nix { };
+
   pulseaudioFull = pulseaudio.override {
     x11Support = true;
     jackaudioSupport = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixing the binary

See https://github.com/NixOS/nixpkgs/issues/8384

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lovek323
