### PR TITLE
gr-osmosdr: 2018-08-15 -> 0.1.5

### DIFF
--- a/pkgs/applications/radio/gnuradio/osmosdr.nix
+++ b/pkgs/applications/radio/gnuradio/osmosdr.nix
@@ -12,14 +12,14 @@
 
 assert pythonSupport -> python != null && swig != null;
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "gr-osmosdr";
-  version = "2018-08-15";
+  version = "0.1.5";
 
   src = fetchgit {
     url = "git://git.osmocom.org/gr-osmosdr";
-    rev = "4d83c6067f059b0c5015c3f59f8117bbd361e877";
-    sha256 = "1d5nb47506qry52bg4cn02d3l4lwxwz44g2fz1ph0q93c7892j60";
+    rev = "v${version}";
+    sha256 = "0bf9bnc1c3c4yqqqgmg3nhygj6rcfmyk6pybi27f7461d2cw1drv";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Switch back to release. This is merely a cosmetic change as the sources only add a single commit setting a version number. 

See http://git.osmocom.org/gr-osmosdr/log/?h=gr3.7
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @betaboon @bjornfor @greydot 
