### PR TITLE
dbeaver: 6.3.0 -> 6.3.1

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "dbeaver-ce";
-  version = "6.3.0";
+  version = "6.3.1";
 
   desktopItem = makeDesktopItem {
     name = "dbeaver";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dbeaver.io/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "07j2r2kfjhfv8zzzzp5qj3ppx4vv7llpx4lwip6bnjfkh80ny22a";
+    sha256 = "0w7nsxm66gbwwql1zk7zh6zvvsjcn78qm0miv0w8nj1qk24zr494";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

https://dbeaver.io/2019/12/22/dbeaver-6-3-1/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/qvxic859jwzahphi9scznyv4qgg78p39-dbeaver-ce-6.3.0	 1183968432
/nix/store/x0x6k4s7b8nbjynhba91cfyk85ln10h8-dbeaver-ce-6.3.1	 1184335952
```
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).