### PR TITLE
bitwig-studio: 3.0.3 -> 3.1.1

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio3.nix
@@ -1,16 +1,25 @@
-{ fetchurl, bitwig-studio1,
-  pulseaudio }:
+{ fetchurl, bitwig-studio1, pulseaudio, xorg }:
 
 bitwig-studio1.overrideAttrs (oldAttrs: rec {
   name = "bitwig-studio-${version}";
-  version = "3.0.3";
+  version = "3.1.1";
 
   src = fetchurl {
     url = "https://downloads.bitwig.com/stable/${version}/bitwig-studio-${version}.deb";
-    sha256 = "162l95imq2fb4blfkianlkymm690by9ri73xf9zigknqf0gacgsa";
+    sha256 = "1mgyyl1mr8hmzn3qdmg77km6sk58hyd0gsqr9jksh0a8p6hj24pk";
   };
+
+  buildInputs = oldAttrs.buildInputs ++ [ xorg.libXtst ];
 
   runtimeDependencies = [
     pulseaudio
   ];
+
+  installPhase = ''
+    ${oldAttrs.installPhase}
+
+    # recover commercial jre
+    rm -f $out/libexec/lib/jre
+    cp -r opt/bitwig-studio/lib/jre $out/libexec/lib
+  '';
 })


### PR DESCRIPTION
##### Motivation for this change
Upgrade to the latest version

###### Things done
Fixed dependencies; switched (temporarily) to the provided java engine because it is ahead and incompatible with the system one.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @michalrus @mrVanDalo
