### PR TITLE
zsh-powerlevel10k: init at unstable-2019-12-19

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "gitstatus";
-  version = "unstable-2019-05-06";
+  version = "unstable-2019-12-18";
 
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "gitstatus";
-    rev = "9c791f93c23c04dadfab8b4309a863b62a6ee424";
-    sha256 = "0jbdrgl62x6j920h72n2q6304fb6gdgnmllpv4aa76m13b9qhgq6";
+    rev = "8ae9c17a60158dcf91f56d9167493e3988a5e921";
+    sha256 = "1czjwsgbmxd1d656srs3n6wj6bmqr8p3aw5gw61q4wdxw3mni2a6";
   };
 
   buildInputs = [ (callPackage ./romkatv_libgit2.nix {}) ];

--- a/pkgs/applications/version-management/git-and-tools/gitstatus/romkatv_libgit2.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/romkatv_libgit2.nix
@@ -13,7 +13,7 @@ libgit2.overrideAttrs (oldAttrs: {
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "libgit2";
-    rev = "aab6c56e6766fa752bef00c745067d875925fc89";
-    sha256 = "1yqqhpi5xi6s86411sixw4yq5c6n2v8pdh447c8b7q5lfc089lvl";
+    rev = "75be63625a0de418ec3551306362ee1e21034039";
+    sha256 = "1bwr1ahfxn1nn2f78ri91icxpv8xhpmgypcvg042cmcpm2qrahz9";
   };
 })

--- a/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
+++ b/pkgs/shells/zsh/zsh-powerlevel10k/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, substituteAll, pkgs }:
+
+# To make use of this derivation, use
+# `programs.zsh.promptInit = "source ${pkgs.zsh-powerlevel10k}/share/zsh-powerlevel10k/powerlevel10k.zsh-theme";`
+
+stdenv.mkDerivation {
+  pname = "powerlevel10k";
+  version = "unstable-2019-12-19";
+  src = fetchFromGitHub {
+    owner = "romkatv";
+    repo = "powerlevel10k";
+    rev = "8ef2b737d1f6099966a1eb16bdfc90d67b367f22";
+    sha256 = "02b25klkyyhpdbf2vwzzbrd8hnfjpckbpjy6532ir6jqp2n2ivpj";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./gitstatusd.patch;
+      gitstatusdPath = "${pkgs.gitAndTools.gitstatus}/bin/gitstatusd";
+    })
+  ];
+
+  installPhase = ''
+    install -D powerlevel10k.zsh-theme --target-directory=$out/share/zsh-powerlevel10k
+    install -D config/* --target-directory=$out/share/zsh-powerlevel10k/config
+    install -D internal/* --target-directory=$out/share/zsh-powerlevel10k/internal
+    rm -r gitstatus/bin
+    install -D gitstatus/* --target-directory=$out/share/zsh-powerlevel10k/gitstatus
+  '';
+
+  meta = {
+    description = "A fast reimplementation of Powerlevel9k ZSH theme";
+    homepage = "https://github.com/romkatv/powerlevel10k";
+    license = stdenv.lib.licenses.mit;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.hexa ];
+  };
+}

--- a/pkgs/shells/zsh/zsh-powerlevel10k/gitstatusd.patch
+++ b/pkgs/shells/zsh/zsh-powerlevel10k/gitstatusd.patch
@@ -1,0 +1,14 @@
+diff --git a/gitstatus/gitstatus.plugin.zsh b/gitstatus/gitstatus.plugin.zsh
+index 46d0b3c..b082e24 100644
+--- a/gitstatus/gitstatus.plugin.zsh
++++ b/gitstatus/gitstatus.plugin.zsh
+@@ -53,6 +53,8 @@
+ 
+ [[ -o 'interactive' ]] || 'return'
+ 
++GITSTATUS_DAEMON=@gitstatusdPath@
++
+ # Temporarily change options.
+ 'builtin' 'local' '-a' '_gitstatus_opts'
+ [[ ! -o 'aliases'         ]] || _gitstatus_opts+=('aliases')
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7543,6 +7543,8 @@ in
 
   zsh-autosuggestions = callPackage ../shells/zsh/zsh-autosuggestions { };
 
+  zsh-powerlevel10k = callPackage ../shells/zsh/zsh-powerlevel10k { };
+
   zsh-powerlevel9k = callPackage ../shells/zsh/zsh-powerlevel9k { };
 
   zsh-command-time = callPackage ../shells/zsh/zsh-command-time { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Powerlevel10k is a faster implementation of the popular powerlevel9k theme for zsh with fast git integration using gitstatusd, a custom implementation on top of it's own libgit2 fork. The latter two packages are already packaged and just needed bumping to work with the latest powerlevel10k theme.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @mmlb (gitstatus maintainer)
cc @flokli @andir @maralorn (p10k users)
