### PR TITLE
stups-fullstop: init at 1.1.31

### DIFF
--- a/pkgs/development/python-modules/stups-fullstop/default.nix
+++ b/pkgs/development/python-modules/stups-fullstop/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, requests
+, stups-cli-support
+, stups-zign
+, pytest
+, pytestcov
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "stups-fullstop";
+  version = "1.1.31";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "zalando-stups";
+    repo = "fullstop-cli";
+    rev = version;
+    sha256 = "1cpzz1b8g2mich7c1p74vfgw70vlxpgwi82a1ld82wv3srwqa0h3";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    stups-cli-support
+    stups-zign
+  ];
+
+  preCheck = "
+    export HOME=$TEMPDIR
+  ";
+
+  checkInputs = [
+    pytest
+    pytestcov
+  ];
+
+  meta = with lib; {
+    description = "Convenience command line tool for fullstop. audit reporting.";
+    homepage = "https://github.com/zalando-stups/stups-fullstop-cli";
+    license = licenses.asl20;
+    maintainers = [ maintainers.mschuwalow ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1343,6 +1343,8 @@ in {
 
   stups-cli-support = callPackage ../development/python-modules/stups-cli-support { };
 
+  stups-fullstop = callPackage ../development/python-modules/stups-fullstop { };
+
   stups-tokens = callPackage ../development/python-modules/stups-tokens { };
 
   stups-zign = callPackage ../development/python-modules/stups-zign { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).