### PR TITLE
nixosTests.mumble: port to python

### DIFF
--- a/nixos/tests/mumble.nix
+++ b/nixos/tests/mumble.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, ...} : 
+import ./make-test-python.nix ({ pkgs, ...} :
 
 let
   client = { pkgs, ... }: {
@@ -24,50 +24,50 @@ in
   };
 
   testScript = ''
-    startAll;
+    start_all()
 
-    $server->waitForUnit("murmur.service");
-    $client1->waitForX;
-    $client2->waitForX;
+    server.wait_for_unit("murmur.service")
+    client1.wait_for_x()
+    client2.wait_for_x()
 
-    $client1->execute("mumble mumble://client1\@server/test &");
-    $client2->execute("mumble mumble://client2\@server/test &");
+    client1.execute("mumble mumble://client1\@server/test &")
+    client2.execute("mumble mumble://client2\@server/test &")
 
     # cancel client audio configuration
-    $client1->waitForWindow(qr/Audio Tuning Wizard/);
-    $client2->waitForWindow(qr/Audio Tuning Wizard/);
-    $server->sleep(5); # wait because mumble is slow to register event handlers
-    $client1->sendKeys("esc");
-    $client2->sendKeys("esc");
+    client1.wait_for_window(r"Audio Tuning Wizard")
+    client2.wait_for_window(r"Audio Tuning Wizard")
+    server.sleep(5)  # wait because mumble is slow to register event handlers
+    client1.send_key("esc")
+    client2.send_key("esc")
 
     # cancel client cert configuration
-    $client1->waitForWindow(qr/Certificate Management/);
-    $client2->waitForWindow(qr/Certificate Management/);
-    $server->sleep(5); # wait because mumble is slow to register event handlers
-    $client1->sendKeys("esc");
-    $client2->sendKeys("esc");
+    client1.wait_for_window(r"Certificate Management")
+    client2.wait_for_window(r"Certificate Management")
+    server.sleep(5)  # wait because mumble is slow to register event handlers
+    client1.send_key("esc")
+    client2.send_key("esc")
 
     # accept server certificate
-    $client1->waitForWindow(qr/^Mumble$/);
-    $client2->waitForWindow(qr/^Mumble$/);
-    $server->sleep(5); # wait because mumble is slow to register event handlers
-    $client1->sendChars("y");
-    $client2->sendChars("y");
-    $server->sleep(5); # wait because mumble is slow to register event handlers
+    client1.wait_for_window(r"^Mumble$")
+    client2.wait_for_window(r"^Mumble$")
+    server.sleep(5)  # wait because mumble is slow to register event handlers
+    client1.send_chars("y")
+    client2.send_chars("y")
+    server.sleep(5)  # wait because mumble is slow to register event handlers
 
     # sometimes the wrong of the 2 windows is focused, we switch focus and try pressing "y" again
-    $client1->sendKeys("alt-tab");
-    $client2->sendKeys("alt-tab");
-    $server->sleep(5); # wait because mumble is slow to register event handlers
-    $client1->sendChars("y");
-    $client2->sendChars("y");
+    client1.send_key("alt-tab")
+    client2.send_key("alt-tab")
+    server.sleep(5)  # wait because mumble is slow to register event handlers
+    client1.send_chars("y")
+    client2.send_chars("y")
 
     # Find clients in logs
-    $server->waitUntilSucceeds("journalctl -eu murmur -o cat | grep -q client1");
-    $server->waitUntilSucceeds("journalctl -eu murmur -o cat | grep -q client2");
+    server.wait_until_succeeds("journalctl -eu murmur -o cat | grep -q client1")
+    server.wait_until_succeeds("journalctl -eu murmur -o cat | grep -q client2")
 
-    $server->sleep(5); # wait to get screenshot
-    $client1->screenshot("screen1");
-    $client2->screenshot("screen2");
+    server.sleep(5)  # wait to get screenshot
+    client1.screenshot("screen1")
+    client2.screenshot("screen2")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

#72828

Tangential question I had: https://github.com/NixOS/nixpkgs/issues/72828#issuecomment-568764139

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - I've checked that the screenshots look good.
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

~no tests maintainer~ @thoughtpolice @edolstra 

CC @flokli 
