### PR TITLE
Additional redwax modules 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1743,6 +1743,12 @@
     githubId = 11946442;
     name = "Dipin Hora";
   };
+  dirkx = {
+    email = "dirkx@webweaving.org";
+    github = "dirkx";
+    githubId = 392583;
+    name = "Dirk-Willem van Gulik";
+  };
   disassembler = {
     email = "disasm@gmail.com";
     github = "disassembler";

--- a/pkgs/servers/http/apache-modules/mod_ca/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_ca/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, pkgconfig, apacheHttpd, openssl, openldap }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_ca";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://redwax.eu/dist/rs/${pname}-${version}.tar.gz";
+    sha256 = "1pxapjrzdsk2s25vhgvf56fkakdqcbn9hjncwmqh0asl1pa25iic";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ apacheHttpd openssl openldap ];
+
+  # Note that configureFlags and installFlags are inherited by
+  # the various submodules.
+  #
+  configureFlags = [
+    "--with-apxs=${apacheHttpd.dev}/bin/apxs"
+  ];
+
+  installFlags = [
+    "INCLUDEDIR=${placeholder ''out''}/include"
+    "LIBEXECDIR=${placeholder ''out''}/modules"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "RedWax CA service module";
+
+    homepage = "https://redwax.eu";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dirkx ];
+  };
+}

--- a/pkgs/servers/http/apache-modules/mod_crl/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_crl/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, mod_ca, apr, aprutil }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_crl";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://redwax.eu/dist/rs/${pname}-${version}.tar.gz";
+    sha256 = "0k6iqn5a4bqdz3yx6d53f1r75c21jnwhxmmcq071zq0361xjzzj6";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ mod_ca apr aprutil ];
+  inherit (mod_ca) configureFlags installFlags;
+
+  meta = with stdenv.lib; {
+    description = "RedWax module for Certificate Revocation Lists";
+
+    homepage = "https://redwax.eu";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dirkx ];
+  };
+}

--- a/pkgs/servers/http/apache-modules/mod_csr/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_csr/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, pkgconfig, mod_ca, apr, aprutil }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_csr";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://redwax.eu/dist/rs/${pname}-${version}.tar.gz";
+    sha256 = "01sdvv07kchdd6ssrmd2cbhj50qh2ibp5g5h6jy1jqbzp0b3j9ja";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ mod_ca apr aprutil ];
+  inherit (mod_ca) configureFlags installFlags;
+
+  # After openssl-1.0.2t, starting in  openssl-1.1.0l
+  # parts of the OpenSSL struct API was replaced by
+  # getters - but some setters where forgotten.
+  #
+  # It is expected that these are back/retrofitted in version
+  # openssl-1.1.1d -- but while fixing this it was found
+  # that there were quite a few other setters missing and
+  # that some of the memory management needed was at odds
+  # with the principles used sofar.
+  #
+  # See https://github.com/openssl/openssl/pull/10563
+  #
+  # So as a stopgap - use a minimalist compat. layer
+  # https://source.redwax.eu/projects/RS/repos/mod_csr/browse/openssl_setter_compat.h
+  #
+  preBuild = "cp ${./openssl_setter_compat.h} openssl_setter_compat.h";
+
+  meta = with stdenv.lib; {
+    description = "RedWax CA service module to handle Certificate Signing Requests";
+
+    homepage = "https://redwax.eu";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dirkx ];
+  };
+}

--- a/pkgs/servers/http/apache-modules/mod_csr/openssl_setter_compat.h
+++ b/pkgs/servers/http/apache-modules/mod_csr/openssl_setter_compat.h
@@ -1,0 +1,66 @@
+/* Licensed to Stichting The Commons Conservancy (TCC) under one or more
+ * contributor license agreements.  See the AUTHORS file distributed with
+ * this work for additional information regarding copyright ownership.
+ * TCC licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These routines are copies from OpenSSL/1.1.1 its x509/x509_req.c
+// and the private header files for that. They are needed as
+// starting with OpenSSL 1.1.0 the X509_req structure became
+// private; and got some get0 functions to access its internals.
+// But no getter's until post 1.1.1 (PR#10563). So this is a
+// stopgap for these lacking releases.
+//
+// Testest against: 
+//   openssl-1.0.2t 0x01000214fL (does not need it, privates still accessile)
+//   openssl-1.1.0l 0x0101000cfL (needs it)
+//   openssl-1.1.1d 0x01010104fL (last version that needs it)
+//   openssl-1.1.1-dev		 (should not need it - post PR#10563).
+//
+/* #if OPENSSL_VERSION_NUMBER >= 0x010100000L &&  OPENSSL_VERSION_NUMBER  <= 0x01010104fL */
+#if OPENSSL_VERSION_NUMBER >= 0x010100000L 
+#include "openssl/x509.h"
+
+#define HAS_OPENSSL_PR10563_WORK_AROUND
+
+struct X509_req_info_st {
+    ASN1_ENCODING enc;          
+    ASN1_INTEGER *version;     
+    X509_NAME *subject;       
+    X509_PUBKEY *pubkey;     
+    STACK_OF(X509_ATTRIBUTE) *attributes;
+};
+
+typedef _Atomic int CRYPTO_REF_COUNT;
+
+struct X509_req_st {
+    X509_REQ_INFO req_info; 
+    X509_ALGOR sig_alg;       
+    ASN1_BIT_STRING *signature; /* signature */
+    CRYPTO_REF_COUNT references;
+    CRYPTO_RWLOCK *lock;
+# ifndef OPENSSL_NO_SM2
+    ASN1_OCTET_STRING *sm2_id;
+# endif
+};
+
+
+static void _X509_REQ_set1_signature(X509_REQ *req, X509_ALGOR *palg)
+{
+    if (req->sig_alg.algorithm)
+        ASN1_OBJECT_free(req->sig_alg.algorithm);
+    if (req->sig_alg.parameter)
+        ASN1_TYPE_free(req->sig_alg.parameter);
+    req->sig_alg = *palg;
+}
+#endif

--- a/pkgs/servers/http/apache-modules/mod_ocsp/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_ocsp/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, mod_ca, apr, aprutil }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_ocsp";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://redwax.eu/dist/rs/${pname}-${version}.tar.gz";
+    sha256 = "1vwgai56krdf8knb0mgy07ni9mqxk82bcb4gibwpnxvl6qwgv2i0";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ mod_ca apr aprutil ];
+  inherit (mod_ca) configureFlags installFlags;
+
+  meta = with stdenv.lib; {
+    description = "RedWax CA service modules of OCSP Online Certificate Validation";
+
+    homepage = "https://redwax.eu";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dirkx ];
+  };
+}

--- a/pkgs/servers/http/apache-modules/mod_pkcs12/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_pkcs12/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, mod_ca, apr, aprutil }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_pkcs12";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://redwax.eu/dist/rs/${pname}-${version}.tar.gz";
+    sha256 = "0by4qfjs3a8q0amzwazfq8ii6ydv36v2mjga0jzc9i6xyl4rs6ai";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ mod_ca apr aprutil ];
+  inherit (mod_ca) configureFlags installFlags;
+
+  meta = with stdenv.lib; {
+    description = "RedWax CA service modules for PKCS#12 format files";
+
+    homepage = "https://redwax.eu";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dirkx ];
+  };
+}

--- a/pkgs/servers/http/apache-modules/mod_scep/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_scep/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, pkgconfig, mod_ca, apr, aprutil }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_scep";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://redwax.eu/dist/rs/${pname}-${version}.tar.gz";
+    sha256 = "14l8v6y6kx5dg8avb5ny95qdcgrw40ss80nqrgmw615mk7zcj81f";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ mod_ca apr aprutil ];
+  inherit (mod_ca) configureFlags installFlags;
+
+  # After openssl-1.0.2t, starting in  openssl-1.1.0l
+  # parts of the OpenSSL struct API was replaced by
+  # getters - but some setters where forgotten.
+  #
+  # It is expected that these are back/retrofitted in version
+  # openssl-1.1.1d -- but while fixing this it was found
+  # that there were quite a few other setters missing and
+  # that some of the memory management needed was at odds
+  # with the principles used sofar.
+  #
+  # See https://github.com/openssl/openssl/pull/10563
+  #
+  # So as a stopgap - use a minimalist compat. layer
+  # https://source.redwax.eu/projects/RS/repos/mod_csr/browse/openssl_setter_compat.h
+  #
+  preBuild = "cp ${./openssl_setter_compat.h} openssl_setter_compat.h";
+
+  meta = with stdenv.lib; {
+    description = "RedWax CA service modules for SCEP (Automatic ceritifcate issue/renewal)";
+
+    homepage = "https://redwax.eu";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dirkx ];
+  };
+}

--- a/pkgs/servers/http/apache-modules/mod_scep/openssl_setter_compat.h
+++ b/pkgs/servers/http/apache-modules/mod_scep/openssl_setter_compat.h
@@ -1,0 +1,66 @@
+/* Licensed to Stichting The Commons Conservancy (TCC) under one or more
+ * contributor license agreements.  See the AUTHORS file distributed with
+ * this work for additional information regarding copyright ownership.
+ * TCC licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These routines are copies from OpenSSL/1.1.1 its x509/x509_req.c
+// and the private header files for that. They are needed as
+// starting with OpenSSL 1.1.0 the X509_req structure became
+// private; and got some get0 functions to access its internals.
+// But no getter's until post 1.1.1 (PR#10563). So this is a
+// stopgap for these lacking releases.
+//
+// Testest against: 
+//   openssl-1.0.2t 0x01000214fL (does not need it, privates still accessile)
+//   openssl-1.1.0l 0x0101000cfL (needs it)
+//   openssl-1.1.1d 0x01010104fL (last version that needs it)
+//   openssl-1.1.1-dev		 (should not need it - post PR#10563).
+//
+/* #if OPENSSL_VERSION_NUMBER >= 0x010100000L &&  OPENSSL_VERSION_NUMBER  <= 0x01010104fL */
+#if OPENSSL_VERSION_NUMBER >= 0x010100000L 
+#include "openssl/x509.h"
+
+#define HAS_OPENSSL_PR10563_WORK_AROUND
+
+struct X509_req_info_st {
+    ASN1_ENCODING enc;          
+    ASN1_INTEGER *version;     
+    X509_NAME *subject;       
+    X509_PUBKEY *pubkey;     
+    STACK_OF(X509_ATTRIBUTE) *attributes;
+};
+
+typedef _Atomic int CRYPTO_REF_COUNT;
+
+struct X509_req_st {
+    X509_REQ_INFO req_info; 
+    X509_ALGOR sig_alg;       
+    ASN1_BIT_STRING *signature; /* signature */
+    CRYPTO_REF_COUNT references;
+    CRYPTO_RWLOCK *lock;
+# ifndef OPENSSL_NO_SM2
+    ASN1_OCTET_STRING *sm2_id;
+# endif
+};
+
+
+static void _X509_REQ_set1_signature(X509_REQ *req, X509_ALGOR *palg)
+{
+    if (req->sig_alg.algorithm)
+        ASN1_OBJECT_free(req->sig_alg.algorithm);
+    if (req->sig_alg.parameter)
+        ASN1_TYPE_free(req->sig_alg.parameter);
+    req->sig_alg = *palg;
+}
+#endif

--- a/pkgs/servers/http/apache-modules/mod_spkac/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_spkac/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, mod_ca, apr, aprutil }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_spkac";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://redwax.eu/dist/rs/${pname}-${version}.tar.gz";
+    sha256 = "0x6ia9qcr7lx2awpv9cr4ndic5f4g8yqzmp2hz66zpzkmk2b2pyz";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ mod_ca apr aprutil ];
+  inherit (mod_ca) configureFlags installFlags;
+
+  meta = with stdenv.lib; {
+    description = "RedWax CA service module for handling the Netscape keygen requests. ";
+
+    homepage = "https://redwax.eu";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dirkx ];
+  };
+}

--- a/pkgs/servers/http/apache-modules/mod_timestamp/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_timestamp/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, mod_ca, apr, aprutil }:
+
+stdenv.mkDerivation rec {
+  pname = "mod_timestamp";
+  version = "0.2.1";
+
+  src = fetchurl {
+    url = "https://redwax.eu/dist/rs/${pname}-${version}.tar.gz";
+    sha256 = "0j4b04dbdwn9aff3da9m0lnqi0qbw6c6hhi81skl15kyc3vzp67f";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ mod_ca apr aprutil ];
+  inherit (mod_ca) configureFlags installFlags;
+
+  meta = with stdenv.lib; {
+    description = "RedWax CA service module for issuing signed timestamps";
+
+    homepage = "https://redwax.eu";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dirkx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14947,6 +14947,16 @@ in
 
     mod_auth_mellon = callPackage ../servers/http/apache-modules/mod_auth_mellon { };
 
+    # Redwax collection
+    mod_ca = callPackage ../servers/http/apache-modules/mod_ca { };
+    mod_crl = callPackage ../servers/http/apache-modules/mod_crl { };
+    mod_csr = callPackage ../servers/http/apache-modules/mod_csr { };
+    mod_ocsp = callPackage ../servers/http/apache-modules/mod_ocsp{ };
+    mod_scep = callPackage ../servers/http/apache-modules/mod_scep { };
+    mod_pkcs12 = callPackage ../servers/http/apache-modules/mod_pkcs12 { };
+    mod_spkac= callPackage ../servers/http/apache-modules/mod_spkac { };
+    mod_timestamp = callPackage ../servers/http/apache-modules/mod_timestamp { };
+
     mod_dnssd = callPackage ../servers/http/apache-modules/mod_dnssd { };
 
     mod_evasive = callPackage ../servers/http/apache-modules/mod_evasive { };
@@ -15209,6 +15219,14 @@ in
   mod_fastcgi = pkgs.apacheHttpdPackages.mod_fastcgi;
   mod_python = pkgs.apacheHttpdPackages.mod_python;
   mod_wsgi = pkgs.apacheHttpdPackages.mod_wsgi;
+  mod_ca = pkgs.apacheHttpdPackages.mod_ca;
+  mod_crl = pkgs.apacheHttpdPackages.mod_crl;
+  mod_csr = pkgs.apacheHttpdPackages.mod_csr;
+  mod_ocsp = pkgs.apacheHttpdPackages.mod_ocsp;
+  mod_scep = pkgs.apacheHttpdPackages.mod_scep;
+  mod_spkac = pkgs.apacheHttpdPackages.mod_spkac;
+  mod_pkcs12 = pkgs.apacheHttpdPackages.mod_pkcs12;
+  mod_timestamp = pkgs.apacheHttpdPackages.mod_timestamp;
 
   inherit (callPackages ../servers/mpd { })
     mpd mpd-small mpdWithFeatures;


### PR DESCRIPTION
Submission of redwax modules to NixOS packages; including comments from review on #75620.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
