### PR TITLE
mautrix-telegram: fix build

### DIFF
--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -5,6 +5,7 @@ with python3.pkgs;
 buildPythonPackage rec {
   pname = "mautrix-telegram";
   version = "0.6.1";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -16,12 +17,17 @@ buildPythonPackage rec {
       url = https://github.com/tulir/mautrix-telegram/commit/be6d395ed66d86ec7f13a262f9ae37731987019c.patch;
       sha256 = "1q69ip17r45yhyrxr0pj8bvqj2grw2l39wak8pi5pm7qrxra93j2";
     })
+    # bump dependencies, remove on next bump
+    (fetchpatch {
+      url = "https://github.com/tulir/mautrix-telegram/commit/cdee0df5ab9e04d6831e34590959496061c6621c.patch";
+      sha256 = "0sbfaais0jgg305dcjg9hn8b975ymdivvhmlzsxm1nm2ksa4c0v1";
+    })
   ];
-
-  disabled = pythonOlder "3.6";
 
   postPatch = ''
     sed -i -e '/alembic>/d' setup.py
+    substituteInPlace setup.py \
+      --replace "telethon>=1.9,<1.10" "telethon~=1.9"
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
follow-up to #76395

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
https://github.com/NixOS/nixpkgs/pull/76430
1 package were built:
mautrix-telegram
```