### PR TITLE
photoqt: use qt5's mkDerivation 

### DIFF
--- a/pkgs/applications/graphics/photoqt/default.nix
+++ b/pkgs/applications/graphics/photoqt/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, cmake, exiv2, graphicsmagick, libraw, fetchpatch
+{ mkDerivation, stdenv, fetchurl, cmake, exiv2, graphicsmagick, libraw, fetchpatch
 , qtbase, qtdeclarative, qtmultimedia, qtquickcontrols, qttools, qtgraphicaleffects
 , extra-cmake-modules, poppler, kimageformats, libarchive, libdevil
 }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "photoqt";
   version = "1.7.1";
 


### PR DESCRIPTION
##### Motivation for this change
Prior to this PR photoqt would compile but fail on start with the following error:

> qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""                                                 
> This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
>                                                         
> zsh: abort (core dumped)  result/bin/photoqt 

I followed [https://nixos.wiki/wiki/Qt](https://nixos.wiki/wiki/Qt#This_application_failed_to_start_because_it_could_not_find_or_load_the_Qt_platform_plugin_.3F.3F.3F_in_.22.22) and https://github.com/NixOS/nixpkgs/issues/65399 to fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace 
