### PR TITLE
pythonPackages.pyomo: python2 no longer supported

### DIFF
--- a/pkgs/development/python-modules/pyomo/default.nix
+++ b/pkgs/development/python-modules/pyomo/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, isPy27
 , pyutilib
 , appdirs
 , ply
@@ -11,6 +12,7 @@
 buildPythonPackage rec {
   pname = "pyomo";
   version = "5.6.1";
+  disabled = isPy27; # unable to import pyutilib.th
 
   src = fetchPypi {
     pname = "Pyomo";


### PR DESCRIPTION
###### Motivation for this change
follow up to #76383

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
Nothing changed
https://github.com/NixOS/nixpkgs/pull/76440
$ nix-shell /home/jon/.cache/nix-review/pr-76440/shell.nix
```