### PR TITLE
Docker-containers: Consider the exit status of docker run in ExecStop

### DIFF
--- a/nixos/modules/virtualisation/docker-containers.nix
+++ b/nixos/modules/virtualisation/docker-containers.nix
@@ -186,7 +186,7 @@ let
         ++ map escapeShellArg container.cmd
       );
       ExecStartPre = "-${pkgs.docker}/bin/docker rm -f %n";
-      ExecStop = "${pkgs.docker}/bin/docker stop %n";
+      ExecStop = ''${pkgs.bash}/bin/sh -c "[ $SERVICE_RESULT = success ] || ${pkgs.docker}/bin/docker stop %n"'';
       ExecStopPost = "-${pkgs.docker}/bin/docker rm -f %n";
 
       ### There is no generalized way of supporting `reload` for docker


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

If the docker run command exits with a positive exit status we don't need to stop it.  

In fact, if we try to stop it, the `docker stop` command will fail which then makes the service fail and that obviously shouldn't happen (see #73114).

I am aware that checking things with a shell script like that seems hacky but the systemd manual states that `ExecStop` needs to account for exit status by itself and there is no simpler way to make it do that afaik.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) ~5K
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I have no idea how I would go about using NixOS tests and a link to the source of a bunch of tests doesn't help. If someone could give me an example for this, that'd teach me a lot. (I did test it manually though.)   
I tried the nixpkgs-review command but I don't think I used it properly, how do I do that? Is this even relevant for modules?  

This is my first PR, I am pretty sure I missed something else too. Please tell me if I did and what.

###### Notify maintainers

cc @
