### PR TITLE
safeclib: init at 08112019

### DIFF
--- a/pkgs/development/libraries/safeclib/default.nix
+++ b/pkgs/development/libraries/safeclib/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, perl }:
+
+stdenv.mkDerivation rec {
+  pname = "safeclib";
+  version = "08112019";
+
+  src = fetchFromGitHub {
+    owner = "rurban";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "1wlr3w65q0hlisg4xkhirva0bp63y7sxg03vkvwz4vymk0xmxkgn";
+  };
+
+  buildInputs = [
+    perl
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/rurban/safeclib";
+    description = "An implementation of the secure C11 Annex K functions";
+    license = licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13935,6 +13935,8 @@ in
 
   sad = callPackage ../applications/science/logic/sad { };
 
+  safeclib = callPackage ../development/libraries/safeclib {};
+
   safefile = callPackage ../development/libraries/safefile {};
 
   sbc = callPackage ../development/libraries/sbc { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
