### PR TITLE
spamassassin: use /etc/mail/spamassassin for config

### DIFF
--- a/nixos/modules/services/mail/spamassassin.nix
+++ b/nixos/modules/services/mail/spamassassin.nix
@@ -6,15 +6,6 @@ let
   cfg = config.services.spamassassin;
   spamassassin-local-cf = pkgs.writeText "local.cf" cfg.config;
 
-  spamdEnv = pkgs.buildEnv {
-    name = "spamd-env";
-    paths = [];
-    postBuild = ''
-      ln -sf ${spamassassin-init-pre} $out/init.pre
-      ln -sf ${spamassassin-local-cf} $out/local.cf
-    '';
-  };
-
 in
 
 {
@@ -120,13 +111,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    environment.etc."mail/spamassassin/init.pre".source = cfg.initPreConf;
+    environment.etc."mail/spamassassin/local.cf".source = spamassassin-local-cf;
 
     # Allow users to run 'spamc'.
-
-    environment = {
-      etc.spamassassin.source = spamdEnv;
-      systemPackages = [ pkgs.spamassassin ];
-    };
+    environment.systemPackages = [ pkgs.spamassassin ];
 
     users.users.spamd = {
       description = "Spam Assassin Daemon";
@@ -141,7 +130,7 @@ in
     systemd.services.sa-update = {
       script = ''
         set +e
-        ${pkgs.su}/bin/su -s "${pkgs.bash}/bin/bash" -c "${pkgs.spamassassin}/bin/sa-update --gpghomedir=/var/lib/spamassassin/sa-update-keys/ --siteconfigpath=${spamdEnv}/" spamd
+        ${pkgs.su}/bin/su -s "${pkgs.bash}/bin/bash" -c "${pkgs.spamassassin}/bin/sa-update --gpghomedir=/var/lib/spamassassin/sa-update-keys/" spamd
 
         v=$?
         set -e
@@ -172,7 +161,7 @@ in
       after = [ "network.target" ];
 
       serviceConfig = {
-        ExecStart = "${pkgs.spamassassin}/bin/spamd ${optionalString cfg.debug "-D"} --username=spamd --groupname=spamd --siteconfigpath=${spamdEnv} --virtual-config-dir=/var/lib/spamassassin/user-%u --allow-tell --pidfile=/run/spamd.pid";
+        ExecStart = "${pkgs.spamassassin}/bin/spamd ${optionalString cfg.debug "-D"} --username=spamd --groupname=spamd --virtual-config-dir=/var/lib/spamassassin/user-%u --allow-tell --pidfile=/run/spamd.pid";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       };
 
@@ -183,7 +172,7 @@ in
         mkdir -p /var/lib/spamassassin
         chown spamd:spamd /var/lib/spamassassin -R
         set +e
-        ${pkgs.su}/bin/su -s "${pkgs.bash}/bin/bash" -c "${pkgs.spamassassin}/bin/sa-update --gpghomedir=/var/lib/spamassassin/sa-update-keys/ --siteconfigpath=${spamdEnv}/" spamd
+        ${pkgs.su}/bin/su -s "${pkgs.bash}/bin/bash" -c "${pkgs.spamassassin}/bin/sa-update --gpghomedir=/var/lib/spamassassin/sa-update-keys/" spamd
         v=$?
         set -e
         if [ $v -gt 1 ]; then

--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -9,9 +9,6 @@ perlPackages.buildPerlPackage rec {
     sha256 = "1380cmrgjsyidnznr844c5yr9snz36dw7xchdfryi2s61vjzvf55";
   };
 
-  # https://bz.apache.org/SpamAssassin/show_bug.cgi?id=7434
-  patches = [ ./sa-update_add--siteconfigpath.patch ];
-
   buildInputs = [ makeWrapper ] ++ (with perlPackages; [
     HTMLParser NetCIDRLite NetDNS NetAddrIP DBFile HTTPDate MailDKIM LWP
     IOSocketSSL DBI EncodeDetect IPCountry NetIdent Razor2ClientAgent MailSPF
@@ -22,7 +19,7 @@ perlPackages.buildPerlPackage rec {
   # for the PERL5LIB environment variable. Needs further investigation.
   makeFlags = [ "PERL_BIN=${perlPackages.perl}/bin/perl" "PERL_TAINT=no" ];
 
-  makeMakerFlags = [ "CONFDIR=/homeless/shelter" "LOCALSTATEDIR=/var/lib/spamassassin" ];
+  makeMakerFlags = [ "SYSCONFDIR=/etc LOCALSTATEDIR=/var/lib/spamassassin" ];
 
   doCheck = false;
 

--- a/pkgs/servers/mail/spamassassin/sa-update_add--siteconfigpath.patch
+++ b/pkgs/servers/mail/spamassassin/sa-update_add--siteconfigpath.patch
@@ -30,7 +30,7 @@ index bb7396d..39f681f 100755
  
  # check only disabled gpg
  # https://issues.apache.org/SpamAssassin/show_bug.cgi?id=5854
-@@ -1808,6 +1812,7 @@ Options:
+@@ -1808,7 +1812,7 @@ Options:
    --updatedir path        Directory to place updates, defaults to the
                            SpamAssassin site rules directory
                            (default: @@LOCAL_STATE_DIR@@/@@VERSION@@)
@@ -38,21 +38,6 @@ index bb7396d..39f681f 100755
    --refreshmirrors        Force the MIRRORED.BY file to be updated
    -D, --debug [area=n,...]  Print debugging messages
    -v, --verbose           Be verbose, like print updated channel names;
--- 
-diff --git a/lib/Mail/SpamAssassin/PerMsgStatus.pm b/lib/Mail/SpamAssassin/PerMsgStatus.pm
-index 6d8beaa..6ad87dc 100644
---- a/lib/Mail/SpamAssassin/PerMsgStatus.pm
-+++ b/lib/Mail/SpamAssassin/PerMsgStatus.pm
-@@ -389,7 +389,8 @@ sub check_timed {
-     if (!$self->{main}->have_plugin("check_main")) {
-       die "check: no loaded plugin implements 'check_main': cannot scan!\n".
-             "Check that the necessary '.pre' files are in the config directory.\n".
--              "At a minimum, v320.pre loads the Check plugin which is required.\n";
-+              "At a minimum, v320.pre loads the Check plugin which is required.\n".
-+              "NixOS: Since there is no '/etc/spamassassin' simply restart 'spamd.service' which on its behalf will run 'sa-learn --siteconfigpath=/nix/store/l4hr4yxk8mb4wbkha6vm6rh92pj19rj6-spamd-env ...' to update the /var/lib/spamassassin configs.\n";
-     }
-   }
- 
 -- 
 
 2.12.2


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Using a custom path in the Nix store meant that users of the module
couldn't add their own config files, which is a desirable feature.  I
don't think avoiding /etc buys us anything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
