### PR TITLE
emacsPackages.pod-mode: init at 1.04

### DIFF
--- a/pkgs/applications/editors/emacs-modes/manual-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/manual-packages.nix
@@ -113,6 +113,8 @@
   perl-completion =
     callPackage ./perl-completion { };
 
+  pod-mode = callPackage ./pod-mode { };
+
   railgun = callPackage ./railgun { };
 
   structured-haskell-mode = self.shm;

--- a/pkgs/applications/editors/emacs-modes/pod-mode/default.nix
+++ b/pkgs/applications/editors/emacs-modes/pod-mode/default.nix
@@ -1,0 +1,18 @@
+{ trivialBuild, lib, fetchurl }:
+
+trivialBuild rec {
+  pname = "pod-mode";
+  version = "1.04";
+
+  src = fetchurl {
+    url = "mirror://cpan/authors/id/F/FL/FLORA/pod-mode-${version}.tar.gz";
+    sha256 = "1wr0khymkaa65blrc5nya607c1a3sjsww49bbf8f0a6176as71sv";
+  };
+
+  meta = with lib; {
+    description = "Major mode for editing .pod-files";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ qyliss ];
+    platform = platforms.all;
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
