### PR TITLE
Another batch of Python 2 clean-ups

### DIFF
--- a/pkgs/applications/audio/mda-lv2/default.nix
+++ b/pkgs/applications/audio/mda-lv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fftwSinglePrec, lv2, pkgconfig, python, wafHook }:
+{ stdenv, fetchurl, fftwSinglePrec, lv2, pkgconfig, wafHook }:
 
 stdenv.mkDerivation rec {
   pname = "mda-lv2";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig wafHook ];
-  buildInputs = [ fftwSinglePrec lv2 python ];
+  buildInputs = [ fftwSinglePrec lv2 ];
 
   meta = with stdenv.lib; {
     homepage = http://drobilla.net/software/mda-lv2/;

--- a/pkgs/applications/office/gnumeric/default.nix
+++ b/pkgs/applications/office/gnumeric/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, pkgconfig, intltool, perlPackages
-, goffice, gnome3, wrapGAppsHook, gtk3, bison, pythonPackages
+, goffice, gnome3, wrapGAppsHook, gtk3, bison, python3Packages
 , itstool
 }:
 
 let
-  inherit (pythonPackages) python pygobject3;
+  inherit (python3Packages) python pygobject3;
 in stdenv.mkDerivation rec {
   pname = "gnumeric";
   version = "1.12.46";

--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchgit, flex, bison, pkgconfig, which
-, pythonSupport ? stdenv.buildPlatform == stdenv.hostPlatform, python, swig
+, pythonSupport ? false, python, swig
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/folks/default.nix
+++ b/pkgs/development/libraries/folks/default.nix
@@ -21,7 +21,6 @@
 , libsecret
 , db
 , python3
-, python
 , readline
 , gtk3
 }:
@@ -51,7 +50,6 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkgconfig
-    python
     python3
     vala
   ];

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -4,11 +4,10 @@
 , meson
 , ninja
 , pkgconfig
-, python
+, python3
 , gst-plugins-base
 , libxml2
 , flex
-, perl
 , gettext
 , gobject-introspection
 }:
@@ -34,9 +33,8 @@ stdenv.mkDerivation rec {
     pkgconfig
     gettext
     gobject-introspection
-    python
+    python3
     flex
-    perl
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -3,7 +3,7 @@
 , meson
 , ninja
 , pkgconfig
-, python
+, python3
 , gst-plugins-base
 , orc
 , gettext
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     ninja
     gettext
     pkgconfig
-    python
+    python3
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/gstreamer/validate/default.nix
+++ b/pkgs/development/libraries/gstreamer/validate/default.nix
@@ -3,7 +3,7 @@
 , pkgconfig
 , gstreamer
 , gst-plugins-base
-, python
+, python3
 , gobject-introspection
 , json-glib
 }:
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    python
+    python3
     json-glib
   ];
 

--- a/pkgs/development/libraries/libplist/default.nix
+++ b/pkgs/development/libraries/libplist/default.nix
@@ -1,8 +1,5 @@
-{ stdenv,  autoreconfHook, fetchFromGitHub, pkgconfig, python2Packages, glib }:
+{ stdenv, autoreconfHook, fetchFromGitHub, pkgconfig, enablePython ? false, python, glib }:
 
-let
-  inherit (python2Packages) python cython;
-in
 stdenv.mkDerivation rec {
   pname = "libplist";
   version = "2019-04-04";
@@ -14,18 +11,23 @@ stdenv.mkDerivation rec {
     sha256 = "19yw80yblq29i2jx9yb7bx0lfychy9dncri3fk4as35kq5bf26i8";
   };
 
-  outputs = ["bin" "dev" "out" "py"];
+  outputs = ["bin" "dev" "out" ] ++ stdenv.lib.optional enablePython "py";
 
   nativeBuildInputs = [
     pkgconfig
-    python
-    cython
     autoreconfHook
+  ] ++ stdenv.lib.optionals enablePython [
+    python
+    python.pkgs.cython
+  ];
+
+  configureFlags = stdenv.lib.optionals (!enablePython) [
+    "--without-cython"
   ];
 
   propagatedBuildInputs = [ glib ];
 
-  postFixup = ''
+  postFixup = stdenv.lib.optionalString enablePython ''
     moveToOutput "lib/${python.libPrefix}" "$py"
   '';
 

--- a/pkgs/development/libraries/libpwquality/default.nix
+++ b/pkgs/development/libraries/libpwquality/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, perl, cracklib, python }:
+{ stdenv, lib, fetchFromGitHub, autoreconfHook, perl, cracklib, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "libpwquality";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook perl ];
-  buildInputs = [ cracklib python ];
+  buildInputs = [ cracklib python3 ];
 
   meta = with lib; {
     description = "Password quality checking and random password generation library";

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -1,11 +1,11 @@
-{ qtModule, lib, python2, qtbase, qtsvg }:
+{ qtModule, lib, python3, qtbase, qtsvg }:
 
 with lib;
 
 qtModule {
   name = "qtdeclarative";
   qtInputs = [ qtbase qtsvg ];
-  nativeBuildInputs = [ python2 ];
+  nativeBuildInputs = [ python3 ];
   outputs = [ "out" "dev" "bin" ];
   preConfigure = ''
     NIX_CFLAGS_COMPILE+=" -DNIXPKGS_QML2_IMPORT_PREFIX=\"$qtQmlPrefix\""

--- a/pkgs/development/tools/build-managers/gn/default.nix
+++ b/pkgs/development/tools/build-managers/gn/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchgit, darwin, writeText
-, git, ninja, python2 }:
+, git, ninja, python3 }:
 
 let
   rev = "64b846c96daeb3eaf08e26d8a84d8451c6cb712b";
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     inherit rev sha256;
   };
 
-  nativeBuildInputs = [ ninja python2 git ];
+  nativeBuildInputs = [ ninja python3 git ];
   buildInputs = lib.optionals stdenv.isDarwin (with darwin; with apple_sdk.frameworks; [
     libobjc
     cctools

--- a/pkgs/os-specific/linux/crda/default.nix
+++ b/pkgs/os-specific/linux/crda/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libgcrypt, libnl, pkgconfig, python2Packages, wireless-regdb }:
+{ stdenv, fetchurl, fetchpatch, libgcrypt, libnl, pkgconfig, python3, wireless-regdb }:
 
 stdenv.mkDerivation rec {
   pname = "crda";
@@ -9,9 +9,24 @@ stdenv.mkDerivation rec {
     url = "http://kernel.org/pub/software/network/crda/crda-${version}.tar.xz";
   };
 
+  patches = [
+    # Switch to Python 3
+    # https://lore.kernel.org/linux-wireless/1437542484-23409-1-git-send-email-ahmed.taahir@gmail.com/
+    (fetchpatch {
+      url = "https://lore.kernel.org/linux-wireless/1437542484-23409-2-git-send-email-ahmed.taahir@gmail.com/raw";
+      sha256 = "0s2n340cgaasvg1k8g9v8xjrbh4y2mcgrhdmv97ja2fs8xjcjbf1";
+    })
+    (fetchpatch {
+      url = "https://lore.kernel.org/linux-wireless/1437542484-23409-3-git-send-email-ahmed.taahir@gmail.com/raw";
+      sha256 = "01dlfw7kqhyx025jxq2l75950b181p9r7i9zkflcwvbzzdmx59md";
+    })
+  ];
+
   buildInputs = [ libgcrypt libnl ];
   nativeBuildInputs = [
-    pkgconfig python2Packages.m2crypto python2Packages.python
+    pkgconfig
+    python3
+    python3.pkgs.pycrypto
   ];
 
   postPatch = ''
@@ -36,6 +51,11 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkTarget = "verify";
+
+  postInstall = ''
+    # The patch installs build header
+    rm $out/include/reglib/keys-gcrypt.h
+  '';
 
   meta = with stdenv.lib; {
     description = "Linux wireless Central Regulatory Domain Agent";

--- a/pkgs/os-specific/linux/libnl/default.nix
+++ b/pkgs/os-specific/linux/libnl/default.nix
@@ -1,5 +1,5 @@
 { stdenv, file, lib, fetchFromGitHub, autoreconfHook, bison, flex, pkgconfig
-, pythonSupport ? stdenv.buildPlatform == stdenv.hostPlatform, swig ? null, python}:
+, pythonSupport ? false, swig ? null, python}:
 
 stdenv.mkDerivation rec {
   pname = "libnl";

--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchpatch
 , pkgconfig, autoreconfHook
-, gmp, python, iptables, ldns, unbound, openssl, pcsclite, glib
+, gmp, python3, iptables, ldns, unbound, openssl, pcsclite, glib
 , openresolv
 , systemd, pam
 , curl
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs =
-    [ curl gmp python ldns unbound openssl pcsclite ]
+    [ curl gmp python3 ldns unbound openssl pcsclite ]
     ++ optionals enableTNC [ trousers sqlite libxml2 ]
     ++ optionals stdenv.isLinux [ systemd.dev pam iptables ]
     ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ SystemConfiguration ])

--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, lib
-, intltool, glib, pkgconfig, polkit, python, sqlite
+, intltool, glib, pkgconfig, polkit, python3, sqlite
 , gobject-introspection, vala, gtk-doc, autoreconfHook, autoconf-archive
 # TODO: set enableNixBackend to true, as soon as it builds
 , nix, enableNixBackend ? false, boost
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sha256 = "02wq3jw3mkdld90irh5vdfd5bri2g1p89mhrmj56kvif1fqak46x";
   };
 
-  buildInputs = [ glib polkit python gobject-introspection ]
+  buildInputs = [ glib polkit python3 gobject-introspection ]
                   ++ lib.optional enableSystemd systemd
                   ++ lib.optional enableBashCompletion bash-completion;
   propagatedBuildInputs = [ sqlite nix boost ];

--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchurl, stdenv, ncurses,
-IOKit, python }:
+IOKit, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "htop";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mrwpb3cpn3ai7ar33m31yklj64c3pp576vh1naqff6f21pq5mnr";
   };
 
-  nativeBuildInputs = [ python ];
+  nativeBuildInputs = [ python3 ];
   buildInputs =
     [ ncurses ] ++
     lib.optionals stdenv.isDarwin [ IOKit ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3863,7 +3863,7 @@ in {
   libsavitar = callPackage ../development/python-modules/libsavitar { };
 
   libplist = disabledIf isPy3k
-    (toPythonModule (pkgs.libplist.override{python2Packages=self; })).py;
+    (toPythonModule (pkgs.libplist.override { enablePython = true; inherit python; })).py;
 
   libxml2 = (toPythonModule (pkgs.libxml2.override{pythonSupport=true; inherit python;})).py;
 


### PR DESCRIPTION
Continued from https://github.com/NixOS/nixpkgs/pull/75668

I was digging through my system’s build-time closure using `nix-store -q --graph $(nix-instantiate -I nixos-config=/etc/nixos/configuration.nix -I nixpkgs=$PWD '<nixpkgs/nixos>' -A system) | dijkstra -da $(nix-instantiate '<nixpkgs>' -A python2) | gvpr -c 'N[dist>1000.0]{delete(NULL, $)}' | xdot -` and eliminating Python 2 from derivations referencing it by replacing it with Python 3 whenever possible.

#### Testing

- [x] Built individual packages based against unstable:
    - [x] `libplist`
    - [x] `gst_all_1.gst-validate`
    - [x] `gst_all_1.gst-editing-services`
    - [x] `strongswan`
    - [x] `libnl`
    - [x] `gst_all_1.gst-plugins-ugly`
    - [x] `gn`
        - [x] test if `v8` builds with this as well
    - [x] `htop`
    - [x] `mda_lv2`
    - [x] `folks`
    - [x] `qt5.qtdeclarative`
    - [x] `gnumeric`
    - [x] `packagekit`
    - [x] `libpwquality`
    - [x] `crda` (https://lore.kernel.org/linux-wireless/24df021f5e30c51e2d9fff8533ff5591d37d2d2d.camel@gmail.com/)

Some packages were not handled in https://github.com/NixOS/nixpkgs/pull/75668:
* `asciidoc` (`asciidoctor` in Ruby is the new upstream, switch to https://github.com/asciidoc/asciidoc-py3/releases)
* `llvm_*` (not sure about bootstrapping)
* `ninja` (Darwin bootstrapping issue https://github.com/NixOS/nixpkgs/pull/75668#issuecomment-565812451, https://gist.github.com/GrahamcOfBorg/130aa188dad522a3e0df7ce27006565e)
* `parted` (two tests are failing)
* `spidermonkey_60` (takes too long to build)
* `qtbase` (takes too long to build)
* `telepathy-glib` (`telepathy-logger` depends on Python 2)

New findings not covered here or in the previous PR:
- ~~`crda`~~ now patched
    <details>
    <summary><del>error</del></summary>

    ```
      GEN  keys-gcrypt.c
      Trusted pubkeys: pubkeys/sforshee.key.pub.pem pubkeys/linville.key.pub.pem
      File "./utils/key2pub.py", line 6
        except ImportError, e:
                          ^
    SyntaxError: invalid syntax
    make: *** [Makefile:115: keys-gcrypt.c] Error 1
    ```
    </details>

- `lilypond`: `ERROR: Please install required programs:  python3 < 3.0 (installed: 3.7.5) python3 < 3.0 (installed: 3.7.5) python3 < 3.0 (installed: 3.7.5) Python.h (python-devel, python-dev or libpython-dev package)`
- `dblatex`:
    ```
      File "./setup.py", line 86
        print self._package_base
                 ^
    SyntaxError: Missing parentheses in call to 'print'. Did you mean print(self._package_base)?
    ``` https://sourceforge.net/p/dblatex/mailman/dblatex-devel/thread/CAA19uiQVNJezugn6t9BsL3rY481DOG65B2buw2hs2KmK6Z9wBg%40mail.gmail.com/#msg36759114
- `zziplib` (handled in https://github.com/NixOS/nixpkgs/pull/85147) https://github.com/gdraheim/zziplib/issues/47:
    ```
    make[3]: Entering directory '/build/zziplib-0.13.69/x86_64-pc-linux-gnu/docs'
    PYTHONDONTWRITEBYTECODE=1  /nix/store/5dbidajmgrvskv7kj6bwrkza8szxkgar-python3-3.7.5/bin/python  ../../docs/makedocs.py ../../zzip/*.c  \
                       "--package=zziplib" "--version=0.13.69" \
                       "--onlymainheader=zzip/lib.h" "--output=zziplib"
      File "../../docs/makedocs.py", line 40
        print t_fileheader.get_filename(), t_fileheader.src_mainheader()
                         ^
    SyntaxError: invalid syntax
    make[3]: *** [Makefile:584: zziplib.xml] Error 1
    ```
- `mercurial` (handled in https://github.com/NixOS/nixpkgs/pull/76126)
* `duplicity` (does no support Python 3 in stable version)
* `backblaze-b2` ([should be](https://github.com/Backblaze/B2_Command_Line_Tool#140-april-25-2019) supported but cannot test it)
* `scons` (handled in https://github.com/NixOS/nixpkgs/pull/75877)
* `subversion` (via `checkInputs`, even when tests are disabled)
* `inkscape` (fixed in upcoming release https://github.com/NixOS/nixpkgs/pull/50286)
* `gimp` (fixed in upcoming release https://github.com/NixOS/nixpkgs/pull/67576)
* `mypaint` (fixed in upcoming release https://github.com/NixOS/nixpkgs/pull/54677)
* `wafHook` (???)
* `gitAndTools.git-bz` (???)
* `nodejs` (too big, ??? firefox depends on this)
* `firefox` (too big)
* `chromium` (too big)
* `v8`
    ```
    ERROR at //build/config/linux/pkg_config.gni:103:17: Script returned non-zero exit code.
        pkgresult = exec_script(pkg_config_script, args, "value")
                    ^----------
    Current dir: /build/source/out/Release/
    Command: python /build/source/build/config/linux/pkg-config.py glib-2.0 gmodule-2.0 gobject-2.0 gthread-2.0
    Returned 1.
    stderr:

      File "/build/source/build/config/linux/pkg-config.py", line 57
        print "You must specify an architecture via -a if using a sysroot."
                                                                          ^
    SyntaxError: Missing parentheses in call to 'print'. Did you mean print("You must specify an architecture via -a if using a sysroot.")?

    See //build/config/linux/BUILD.gn:89:3: whence it was called.
      pkg_config("glib") {
      ^-------------------
    See //build/config/compiler/BUILD.gn:228:18: which caused the file to be included.
        configs += [ "//build/config/linux:compiler" ]
                     ^------------------------------
    ```
* `tdesktop` (`error: gyp-2015-06-11 not supported for interpreter python3.7`)
* `neard` (GUI tools depend on PyGTK)
* `gitAndTools.git-hub` (:disappointed: https://github.com/sociomantic-tsunami/git-hub/issues/224)