### PR TITLE
vscode-extensions.ms-vscode-remote.remote-ssh: fix patch for 0.48.0

### DIFF
--- a/pkgs/misc/vscode-extensions/remote-ssh/default.nix
+++ b/pkgs/misc/vscode-extensions/remote-ssh/default.nix
@@ -9,21 +9,23 @@ let
   inherit (vscode-utils) buildVscodeMarketplaceExtension;
   
   # patch runs on remote machine hence use of which
+  # links to local node if version is 12
   patch = ''
     f="/home/''$USER/.vscode-server/bin/''$COMMIT_ID/node"
-    nodePath=''$(which node)
-    if [ -x "''$nodePath" ]; then
-      nodeVersion=''$(node -v)
-      if [[ "${nodeVersion:1:2}" == "12" ]]; then
-        echo PATCH: replacing ''$f with ''$nodePath
+    localNodePath=''$(which node)
+    if [ -x "''$localNodePath" ]; then
+      localNodeVersion=''$(node -v)
+      if [ "\''${localNodeVersion:1:2}" = "12" ]; then
+        echo PATCH: replacing ''$f with ''$localNodePath
         rm ''$f
-        ln -s ''$nodePath ''$f
+        ln -s ''$localNodePath ''$f
       fi
     fi
     ${stdenv.lib.optionalString useLocalExtensions ''
       # Use local extensions
-      if test -f "~/.vscode/extensions"; then
+      if [ -d ~/.vscode/extensions ]; then
         if ! test -L "~/.vscode-server/extensions"; then
+          mkdir -p ~/.vscode-server
           ln -s ~/.vscode/extensions ~/.vscode-server/
         fi
       fi


### PR DESCRIPTION
###### Motivation for this change
I neglected to escape `${` which is a javascript template literal. Fixed here + changed variable names to reduce chance of future collision + fixed `useLocalExtensions` to `mkdir -p`.

Continuation of https://github.com/NixOS/nixpkgs/pull/76202

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Mic92 
