### PR TITLE
python3.pkgs.graph-tool: 2.27 -> 2.29

### DIFF
--- a/pkgs/development/python-modules/graph-tool/2.x.x.nix
+++ b/pkgs/development/python-modules/graph-tool/2.x.x.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python, cairomm, sparsehash, pycairo, autoreconfHook
-, pkgconfig, boost, expat, scipy, cgal, gmp, mpfr
+, pkg-config, boost, expat, scipy, cgal, gmp, mpfr
 , gobject-introspection, pygobject3, gtk3, matplotlib, ncurses
 , buildPythonPackage
 , fetchpatch
@@ -10,7 +10,7 @@
 buildPythonPackage rec {
   pname = "graph-tool";
   format = "other";
-  version = "2.27";
+  version = "2.29";
 
   meta = with stdenv.lib; {
     description = "Python module for manipulation and statistical analysis of graphs";
@@ -21,24 +21,8 @@ buildPythonPackage rec {
 
   src = fetchurl {
     url = "https://downloads.skewed.de/graph-tool/graph-tool-${version}.tar.bz2";
-    sha256 = "04s31qwlfcl7bwsggnic8gqcqmx2wsrmfw77nf7vzgnz42bwch27";
+    sha256 = "0ykzcnqc5bhqb4xlf9ahpp807vj5868xdrmcj6fggqnnpqv4633c";
   };
-
-  patches = [
-    # fix build with cgal 4.13 (https://git.skewed.de/count0/graph-tool/issues/509)
-    (fetchpatch {
-      name = "cgal-4.13.patch";
-      url = "https://git.skewed.de/count0/graph-tool/commit/aa39e4a6b42d43fac30c841d176c75aff92cc01a.patch";
-      sha256 = "1578inb4jqwq2fhhwscn5z95nzmaxvmvk30nzs5wirr26iznap4m";
-    })
-  ] ++ (lib.optionals (pythonAtLeast "3.7") [
-    # # python 3.7 compatibility (`async` is now reserved)
-    (fetchpatch {
-      name = "async-reserved.patch";
-      url = "https://git.skewed.de/count0/graph-tool/commit/0407f41a35b6be7c670927fb5dc578cbd0e88be4.patch";
-      sha256 = "1fklznhmfvbb3ykwzyf8p2hiczby6y7r0xnkkjl2jkxlvr24000q";
-    })
-  ]);
 
   configureFlags = [
     "--with-python-module-path=$(out)/${python.sitePackages}"
@@ -48,7 +32,7 @@ buildPythonPackage rec {
     "--enable-openmp"
   ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ ncurses ];
 
   propagatedBuildInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3194,7 +3194,7 @@ in {
   wtforms = callPackage ../development/python-modules/wtforms { };
 
   graph-tool = callPackage ../development/python-modules/graph-tool/2.x.x.nix {
-    inherit (pkgs) pkgconfig;
+    inherit (pkgs) pkg-config;
   };
 
   grappelli_safe = callPackage ../development/python-modules/grappelli_safe { };


### PR DESCRIPTION
The dependency 'pkg-config' was renamed and the two patches have since been
included or resolved.

###### Motivation for this change
I wanted to use features from a newer version. [Changelog](https://git.skewed.de/count0/graph-tool/commits/release-2.29)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @joelmo @dasJ 