### PR TITLE
kmahjongg: init at 19.08.3

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -121,6 +121,7 @@ let
       kio-extras = callPackage ./kio-extras.nix {};
       kldap = callPackage ./kldap.nix {};
       kleopatra = callPackage ./kleopatra.nix {};
+      kmahjongg = callPackage ./kmahjongg.nix {};
       kmail = callPackage ./kmail.nix {};
       kmail-account-wizard = callPackage ./kmail-account-wizard.nix {};
       kmailtransport = callPackage ./kmailtransport.nix {};
@@ -159,6 +160,7 @@ let
       libkgapi = callPackage ./libkgapi.nix {};
       libkipi = callPackage ./libkipi.nix {};
       libkleo = callPackage ./libkleo.nix {};
+      libkmahjongg = callPackage ./libkmahjongg.nix {};
       libkomparediff2 = callPackage ./libkomparediff2.nix {};
       libksane = callPackage ./libksane.nix {};
       libksieve = callPackage ./libksieve.nix {};

--- a/pkgs/applications/kde/kmahjongg.nix
+++ b/pkgs/applications/kde/kmahjongg.nix
@@ -1,0 +1,19 @@
+{ lib
+, mkDerivation
+, extra-cmake-modules
+, kdoctools
+, kdeclarative
+, knewstuff
+, libkdegames
+, libkmahjongg
+}:
+
+mkDerivation {
+  name = "kmahjongg";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [ kdeclarative libkmahjongg knewstuff libkdegames ];
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = with lib.maintainers; [ genesis ];
+  };
+}

--- a/pkgs/applications/kde/libkmahjongg.nix
+++ b/pkgs/applications/kde/libkmahjongg.nix
@@ -1,0 +1,18 @@
+{
+  mkDerivation, lib, kdepimTeam,
+  extra-cmake-modules, kdoctools,
+  kcompletion, kconfig, kconfigwidgets, kcoreaddons, ki18n,
+  kwidgetsaddons
+}:
+
+mkDerivation {
+  name = "libkmahjongg";
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = with lib.maintainers; [ genesis ];
+  };
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [ kcompletion kconfig kconfigwidgets kcoreaddons ki18n
+    kwidgetsaddons ];
+  outputs = [ "out" "dev" ];
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

see #62168
