### PR TITLE
bundlerEnv: fix for Ruby 2.7

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/functions.nix
+++ b/pkgs/development/ruby-modules/bundled-common/functions.nix
@@ -64,7 +64,7 @@ in rec {
         "${ruby}/bin/ruby" \
         "${confFiles}/Gemfile" \
         "$out/${ruby.gemPath}" \
-        "${bundler}/${ruby.gemPath}" \
+        "${bundler}/${ruby.gemPath}/gems/bundler-${bundler.version}" \
         ${lib.escapeShellArg binPaths} \
         ${lib.escapeShellArg groups}
     '';

--- a/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
+++ b/pkgs/development/ruby-modules/bundled-common/gen-bin-stubs.rb
@@ -8,7 +8,7 @@ out = ENV["out"]
 ruby = ARGV[0]
 gemfile = ARGV[1]
 bundle_path = ARGV[2]
-bundler_gem_path = ARGV[3]
+bundler_path = ARGV[3]
 paths = ARGV[4].split
 groups = ARGV[5].split
 
@@ -35,7 +35,7 @@ ENV["BUNDLE_GEMFILE"] = #{gemfile.dump}
 ENV["BUNDLE_PATH"] = #{bundle_path.dump}
 ENV['BUNDLE_FROZEN'] = '1'
 
-Gem.use_paths(#{bundler_gem_path.dump}, ENV["GEM_PATH"])
+$LOAD_PATH.unshift #{bundler_path.dump} + "/lib"
 
 require 'bundler'
 Bundler.setup(#{groups.map(&:dump).join(', ')})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Setting a Bundler version with GEM_PATH doesn't seem to work in Ruby
2.7, so we need to use the LOAD_PATH instead.  Without this,
bundlerEnv environments will always use the version of Bundler that
comes with Ruby, which won't necessarily work because it isn't the
version that was used to generate the bundle.

For example, building ronn with Ruby 2.7 without this change results
in a broken executable, but it works (when built with all packaged
Ruby versions) after this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
