### PR TITLE
python3Packages.jupyterhub: 0.9.4 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/certipy/default.nix
+++ b/pkgs/development/python-modules/certipy/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pyopenssl
+}:
+
+buildPythonPackage rec {
+  pname = "certipy";
+  version = "0.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n980gqpzh0fm58h3i4mi2i10wgj606lscm1r5sk60vbf6vh8mv9";
+  };
+
+  propagatedBuildInputs = [ pyopenssl ];
+  
+  doCheck = false; #no tests were included
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/LLNL/certipy;
+    description = "wrapper for pyOpenSSL";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ isgy ];
+  };
+
+}

--- a/pkgs/development/python-modules/jupyterhub/default.nix
+++ b/pkgs/development/python-modules/jupyterhub/default.nix
@@ -16,6 +16,8 @@
 , notebook
 , pythonOlder
 , nodePackages
+, oauthlib
+, certipy
 }:
 
 let
@@ -51,12 +53,12 @@ in
 
 buildPythonPackage rec {
   pname = "jupyterhub";
-  version = "0.9.4";
+  version = "1.0.0";
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7848bbb299536641a59eb1977ec3c7c95d931bace4a2803d7e9b28b9256714da";
+    sha256 = "0zx6gw9yhgki05j21p6x1x2sf5a2mg2c2mx0ii8rl6q4b98ilm1k";
   };
 
   # Most of this only applies when building from source (e.g. js/css assets are
@@ -107,7 +109,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     alembic ipython jinja2 pamela python-oauth2 requests sqlalchemy tornado
-    traitlets prometheus_client async_generator notebook
+    traitlets prometheus_client async_generator notebook certipy oauthlib
   ];
 
   # Disable tests because they take an excessive amount of time to complete.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1942,6 +1942,8 @@ in {
 
   certifi = callPackage ../development/python-modules/certifi { };
 
+  certipy = callPackage ../development/python-modules/certipy {};
+ 
   characteristic = callPackage ../development/python-modules/characteristic { };
 
   chart-studio = callPackage ../development/python-modules/chart-studio { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
update jupyterhub to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jonringer @FRidh 
