### PR TITLE
meli: init at alpha-0.5.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/meli/default.nix
+++ b/pkgs/applications/networking/mailreaders/meli/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, lib
+, fetchgit
+, rustPlatform
+, pkgconfig
+, openssl
+, dbus
+, sqlite
+, file
+, gzip
+, notmuch
+  # Build with support for notmuch backend
+, withNotmuch ? true
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "meli";
+  version = "alpha-0.5.1";
+
+  src = fetchgit {
+    url = "https://git.meli.delivery/meli/meli.git";
+    rev = version;
+    sha256 = "1y5567hdm1s2s272drxvmp6x4y1jpyl7423iz58hgqcsjm9085zv";
+  };
+
+  cargoSha256 = "040dfr09bg5z5pn68dy323hcppd599d3f6k7zxqw5f8n4whnlc9y";
+
+  cargoBuildFlags = lib.optional withNotmuch "--features=notmuch";
+
+  nativeBuildInputs = [ pkgconfig gzip ];
+
+  buildInputs = [ openssl dbus sqlite ] ++ lib.optional withNotmuch notmuch;
+
+  checkInputs = [ file ];
+
+  postInstall = ''
+    mkdir -p $out/share/man/man1
+    gzip < meli.1 > $out/share/man/man1/meli.1.gz
+    mkdir -p $out/share/man/man5
+    gzip < meli.conf.5 > $out/share/man/man5/meli.conf.5.gz
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Experimental terminal mail client aiming for configurability and extensibility with sane defaults";
+    homepage = "https://meli.delivery";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ maintainers."0x4A6F" matthiasbeyer erictapen ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20567,6 +20567,8 @@ in
 
   meld = callPackage ../applications/version-management/meld { };
 
+  meli = callPackage ../applications/networking/mailreaders/meli { };
+
   meme = callPackage ../applications/graphics/meme { };
 
   mendeley = libsForQt5.callPackage ../applications/office/mendeley {


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is a new approach to init `meli` and also would close #69169.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @0x4A6F @matthiasbeyer 
