### PR TITLE
darktable: Add openmp when cc.isClang to fix macos

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -3,7 +3,7 @@
 , ilmbase, gtk3, intltool, lcms2, lensfun, libX11, libexif, libgphoto2, libjpeg
 , libpng, librsvg, libtiff, openexr, osm-gps-map, pkgconfig, sqlite, libxslt
 , openjpeg, lua, pugixml, colord, colord-gtk, libwebp, libsecret, gnome3
-, ocl-icd, pcre, gtk-mac-integration, isocodes
+, ocl-icd, pcre, gtk-mac-integration, isocodes, llvmPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -24,7 +24,8 @@ stdenv.mkDerivation rec {
     libwebp libsecret gnome3.adwaita-icon-theme osm-gps-map pcre isocodes
   ] ++ stdenv.lib.optionals stdenv.isLinux [
     colord colord-gtk libX11 ocl-icd
-  ] ++ stdenv.lib.optional stdenv.isDarwin gtk-mac-integration;
+  ] ++ stdenv.lib.optional stdenv.isDarwin gtk-mac-integration
+    ++ stdenv.lib.optional stdenv.cc.isClang llvmPackages.openmp;
 
   cmakeFlags = [
     "-DBUILD_USERMANUAL=False"
@@ -51,7 +52,7 @@ stdenv.mkDerivation rec {
     description = "Virtual lighttable and darkroom for photographers";
     homepage = https://www.darktable.org;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ goibhniu flosse mrVanDalo ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

darktable currently fails to build on macos

###### Things done

This fix is based on similar code [here](https://github.com/NixOS/nixpkgs/blob/69d58ee24506e2b3b5aff347ae3b0791110340ec/pkgs/development/libraries/xgboost/default.nix#L22).

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
