### PR TITLE
darktable: fix missing lensfun files

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -37,7 +37,9 @@ stdenv.mkDerivation rec {
   # darktable changed its rpath handling in commit
   # 83c70b876af6484506901e6b381304ae0d073d3c and as a result the
   # binaries can't find libdarktable.so, so change LD_LIBRARY_PATH in
-  # the wrappers:
+  # the wrappers.
+  # We also need to add a symlink to the shared dir containing the
+  # lensfun database:
   preFixup = let
     libPathEnvVar = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
     libPathPrefix = "$out/lib/darktable" + stdenv.lib.optionalString stdenv.isLinux ":${ocl-icd}/lib";
@@ -45,6 +47,7 @@ stdenv.mkDerivation rec {
     gappsWrapperArgs+=(
       --prefix ${libPathEnvVar} ":" "${libPathPrefix}"
     )
+    ln -s ${lensfun}/share/lensfun $out/share
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

When darktable starts we get an error that looks like this:

```
[iop_lens]: could not load lensfun database in `/nix/store/...-darktable-3.0.0/share/lensfun/version_2'!
```

Lens correction fails to work correctly (no thing is found).

###### Things done

A symlink to the `lensfun` database is added in `preFixup`.

It looks like there might be an error in `lensfun` or the darktable
code that uses it. With the missing database fixed the following
error is reported on startup:

```
** (darktable:62412): WARNING **: 00:23:58.558: [Lensfun] /nix/store/fs6lc5pa9jvy15fb3hvjmmdhs9nlsbp2-darktable-3.0.0/share/lensfun/version_2/mil-sigma.xml:35:40: Error on line 35 char 40: Element “mount” was closed, but the currently open element is “”
```

And when the program exits it gives:

```
(darktable:62412): GLib-GObject-CRITICAL **: 00:24:10.429: g_object_unref: assertion 'G_IS_OBJECT (object)' failed
darktable(62412,0x10fdeb5c0) malloc: *** error for object 0x7fac25505400: pointer being freed was not allocated
darktable(62412,0x10fdeb5c0) malloc: *** set a breakpoint in malloc_error_break to debug
Abort trap: 6
```

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
