### PR TITLE
python.pkgs.sympy: 1.4 -> 1.5

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -118,6 +118,13 @@ stdenv.mkDerivation rec {
       url = "https://git.sagemath.org/sage.git/patch?id=fcc11d6effa39f375bc5f4ea5831fb7a2f2767da";
       sha256 = "0hnmc8ld3bblks0hcjvjjaydkgwdr1cs3dbl2ys4gfq964pjgqwc";
     })
+
+    # https://trac.sagemath.org/ticket/28911
+    (fetchpatch {
+      name = "sympy-1.5.patch";
+      url = "https://git.sagemath.org/sage.git/patch/?h=c6d0308db15efd611211d26cfcbefbd180fc0831";
+      sha256 = "0nwai2jr22h49km4hx3kwafs3mzsc5kwsv7mqwjf6ibwfx2bbgyq";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/development/python-modules/sympy/default.nix
+++ b/pkgs/development/python-modules/sympy/default.nix
@@ -8,11 +8,11 @@
 
 buildPythonPackage rec {
   pname = "sympy";
-  version = "1.4"; # Upgrades may break sage. Please test or ping @timokau.
+  version = "1.5"; # Upgrades may break sage. Please test or ping @timokau.
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1q937csy8rd18pk2fz1ssj7jyj7l3rjx4nzbiz5vcymfhrb1x8bi";
+    sha256 = "1s4w7q8gndim2ky825a84jmwcf7ryfn10wm8yxz9dw5z2307smii";
   };
 
   checkInputs = [ glibcLocales ];
@@ -21,14 +21,6 @@ buildPythonPackage rec {
 
   # tests take ~1h
   doCheck = false;
-
-  patches = [
-    # to be fixed by https://github.com/sympy/sympy/pull/13476
-    (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/sympy/patches/03_undeffun_sage.patch?id=3277ba76d0ba7174608a31a0c6623e9210c63e3d";
-      sha256 = "0xcp1qafvqnivvvi0byh51mbgqicjhmswwvqvamjz9rxfzm5f7d7";
-    })
-  ];
 
   preCheck = ''
     export LANG="en_US.UTF-8"


### PR DESCRIPTION
###### Motivation for this change

Sage needs some doctest changes. The patch was included upstream.
Modelled after https://trac.sagemath.org/ticket/28911.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
