### PR TITLE
buildGoModule: support impure modules

### DIFF
--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -73,7 +73,7 @@ pet = buildGoModule rec {
     When `null` is used as a value, the derivation won't be a
     fixed-output derivation but disable the build sandbox instead. This can be useful outside
     of nixpkgs where re-generating the modSha256 on each mod.sum changes is cumbersome,
-    but will fail to build by Hydra, as builds with a disabled sanboxe are discouraged.
+    but will fail to build by Hydra, as builds with a disabled sandbox are discouraged.
     this in nixpkgs as Hydra won't build those packages.
   </para>
  </section>

--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -66,6 +66,14 @@ pet = buildGoModule rec {
     </callout>
    </calloutlist>
   </para>
+
+  <para>
+    <varname>modSha256</varname> can also take <varname>null</varname> as an input.
+
+    When `null` is used as a value, the derivation won't be a
+    fixed-output derivation but disable the build sandbox instead. Don't use
+    this in nixpkgs as Hydra won't build those packages.
+  </para>
  </section>
 
  <section xml:id="ssec-go-legacy">

--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -71,7 +71,9 @@ pet = buildGoModule rec {
     <varname>modSha256</varname> can also take <varname>null</varname> as an input.
 
     When `null` is used as a value, the derivation won't be a
-    fixed-output derivation but disable the build sandbox instead. Don't use
+    fixed-output derivation but disable the build sandbox instead. This can be useful outside
+    of nixpkgs where re-generating the modSha256 on each mod.sum changes is cumbersome,
+    but will fail to build by Hydra, as builds with a disabled sanboxe are discouraged.
     this in nixpkgs as Hydra won't build those packages.
   </para>
  </section>

--- a/doc/languages-frameworks/go.xml
+++ b/doc/languages-frameworks/go.xml
@@ -74,7 +74,6 @@ pet = buildGoModule rec {
     fixed-output derivation but disable the build sandbox instead. This can be useful outside
     of nixpkgs where re-generating the modSha256 on each mod.sum changes is cumbersome,
     but will fail to build by Hydra, as builds with a disabled sandbox are discouraged.
-    this in nixpkgs as Hydra won't build those packages.
   </para>
  </section>
 

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -84,10 +84,16 @@ let
     '';
 
     dontFixup = true;
-    outputHashMode = "recursive";
-    outputHashAlgo = "sha256";
-    outputHash = modSha256;
-  }; in modArgs // overrideModAttrs modArgs);
+  }; in modArgs // (
+    if modSha256 == null then
+      { __noChroot = true; }
+    else
+      {
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        outputHash = modSha256;
+      }
+  ) // overrideModAttrs modArgs);
 
   package = go.stdenv.mkDerivation (args // {
     nativeBuildInputs = [ removeReferencesTo go ] ++ nativeBuildInputs;

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -14,6 +14,10 @@
 , modRoot ? "./"
 
 # modSha256 is the sha256 of the vendored dependencies
+#
+# CAUTION: if `null` is used as a value, the derivation won't be a
+# fixed-output derivation but disable the build sandbox instead. Don't use
+# this in nixpkgs as Hydra won't build those packages.
 , modSha256
 
 # We want parallel builds by default


### PR DESCRIPTION
When modSha256 is null, disable the nix sandbox instead of using a
fixed-output derivation. This requires the nix-daemon to have
`sandbox = relaxed` set in their config to work properly.

Because the output is (hopefully) deterministic based on the inputs,
this should give a reproducible output. This is useful for development
outside of nixpkgs where re-generating the modSha256 on each mod.sum
changes is cumbersome.

Don't use this in nixpkgs! This is why null is not the default value.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
