### PR TITLE
nixos/nginx: fixup permissions for Nginx state dir

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -671,7 +671,7 @@ in
     systemd.tmpfiles.rules = [
       "d '${cfg.stateDir}' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/logs' 0750 ${cfg.user} ${cfg.group} - -"
-      "Z '${cfg.stateDir}/logs' 0750 ${cfg.user} ${cfg.group} - -"
+      "Z '${cfg.stateDir}' - ${cfg.user} ${cfg.group} - -"
     ];
 
     systemd.services.nginx = {


### PR DESCRIPTION
The commit b0bbacb52134a7e731e549f4c0a7a2a39ca6b481 was a bit too fast
It did set executable bit for log files.

Also, it didn't account for other directories in state dir:
```
 # ls -la /var/spool/nginx/
total 32
drwxr-x--- 8 nginx nginx 4096 Dec 26 12:00 .
drwxr-xr-x 4 root  root  4096 Oct 10 20:24 ..
drwx------ 2 root  root  4096 Oct 10 20:24 client_body_temp
drwx------ 2 root  root  4096 Oct 10 20:24 fastcgi_temp
drwxr-x--- 2 nginx nginx 4096 Dec 26 12:00 logs
drwx------ 2 root  root  4096 Oct 10 20:24 proxy_temp
drwx------ 2 root  root  4096 Oct 10 20:24 scgi_temp
drwx------ 2 root  root  4096 Oct 10 20:24 uwsgi_temp
```

With proposed change, only ownership is changed for state files, and mode is left as is
except that statedir/logs is now group accessible.

https://github.com/NixOS/nixpkgs/pull/76174

cc @flokli @Izorkin @aanderse 