### PR TITLE
Enable OCR for ccextractor

### DIFF
--- a/pkgs/applications/video/ccextractor/default.nix
+++ b/pkgs/applications/video/ccextractor/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchFromGitHub, pkgconfig, cmake
-, glew, glfw3, leptonica, libiconv, tesseract3, zlib }:
+, glew, glfw3, zlib, libiconv
+, ocrSupport ? true, leptonica ? null, tesseract4 ? null }:
 
 with lib;
 stdenv.mkDerivation rec {
@@ -17,7 +18,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake ];
 
-  buildInputs = [ glew glfw3 leptonica tesseract3 zlib ] ++ lib.optional (!stdenv.isLinux) libiconv;
+  cmakeFlags = [
+    "-DWITH_OCR=${if ocrSupport then "ON" else "OFF"}"
+  ];
+
+  buildInputs = [ glew glfw3 zlib ]
+    ++ lib.optionals ocrSupport [ leptonica tesseract4 ]
+    ++ lib.optional (!stdenv.isLinux) libiconv;
 
   meta = {
     homepage = "https://www.ccextractor.org";
@@ -29,6 +36,6 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.unix;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ titanous ];
+    maintainers = with maintainers; [ nilsirl titanous ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Although tesseract and leptonica are included as buildInputs, they are unused as OCR is disabled. Enabling it.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @titanous 
