### PR TITLE
nixos/networking: Add the FQDN and hostname to /etc/hosts

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -431,6 +431,16 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
        <literal>networking.hosts = lib.mkForce { "127.0.1.1" = [ config.networking.hostName ]; };</literal>.
      </para>
    </listitem>
+   <listitem>
+     <para>
+       The hostname (<literal>networking.hostName</literal>) must now be a valid
+       DNS label (see RFC 1035) and as such must not contain the domain part.
+       This means that the hostname must start with a letter, end with a letter
+       or digit, and have as interior characters only letters, digits, and
+       hyphen. The maximum length is 63 characters. Additionally it is
+       recommended to only use lower-case characters.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/doc/manual/release-notes/rl-2009.xml
+++ b/nixos/doc/manual/release-notes/rl-2009.xml
@@ -415,6 +415,22 @@ systemd.services.nginx.serviceConfig.ReadWritePaths = [ "/var/www" ];
       continue to work through Breezy.
     </para>
    </listitem>
+   <listitem>
+     <para>
+       In addition to the hostname, the fully qualified domain name (FQDN),
+       which consists of <literal>${cfg.hostName}</literal> and
+       <literal>${cfg.domain}</literal> is now added to
+       <literal>/etc/hosts</literal>, to allow local FQDN resolution, as used by the
+       <literal>hostname --fqdn</literal> command and other applications that
+       try to determine the FQDN. These new entries take precedence over entries
+       from the DNS which could cause regressions in some very specific setups.
+       Additionally the hostname is now resolved to <literal>127.0.0.2</literal>
+       instead of <literal>127.0.1.1</literal> to be consistent with what
+       <literal>nss-myhostname</literal> (from systemd) returns.
+       The old behaviour can e.g. be restored by using
+       <literal>networking.hosts = lib.mkForce { "127.0.1.1" = [ config.networking.hostName ]; };</literal>.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -8,9 +8,6 @@ let
 
   cfg = config.networking;
 
-  localhostMapped4 = cfg.hosts ? "127.0.0.1" && elem "localhost" cfg.hosts."127.0.0.1";
-  localhostMapped6 = cfg.hosts ? "::1"       && elem "localhost" cfg.hosts."::1";
-
   localhostMultiple = any (elem "localhost") (attrValues (removeAttrs cfg.hosts [ "127.0.0.1" "::1" ]));
 
 in
@@ -147,12 +144,6 @@ in
   config = {
 
     assertions = [{
-      assertion = localhostMapped4;
-      message = ''`networking.hosts` doesn't map "127.0.0.1" to "localhost"'';
-    } {
-      assertion = !cfg.enableIPv6 || localhostMapped6;
-      message = ''`networking.hosts` doesn't map "::1" to "localhost"'';
-    } {
       assertion = !localhostMultiple;
       message = ''
         `networking.hosts` maps "localhost" to something other than "127.0.0.1"
@@ -161,22 +152,34 @@ in
       '';
     }];
 
-    networking.hosts = {
-      "127.0.0.1" = [ "localhost" ];
-    } // optionalAttrs (cfg.hostName != "") {
-      "127.0.1.1" = [ cfg.hostName ];
+    # These entries are required for "hostname -f" and to resolve both the
+    # hostname and FQDN correctly:
+    networking.hosts = let
+      hostnames = # Note: The FQDN (canonical hostname) has to come first:
+        optional (cfg.hostName != "" && cfg.domain != null) "${cfg.hostName}.${cfg.domain}"
+        ++ optional (cfg.hostName != "") cfg.hostName; # Then the hostname (without the domain)
+    in {
+      "127.0.0.2" = hostnames;
     } // optionalAttrs cfg.enableIPv6 {
-      "::1" = [ "localhost" ];
+      "::1" = hostnames;
     };
 
     networking.hostFiles = let
+      # Note: localhostHosts has to appear first in /etc/hosts so that 127.0.0.1
+      # resolves back to "localhost" (as some applications assume) instead of
+      # the FQDN! By default "networking.hosts" also contains entries for the
+      # FQDN so that e.g. "hostname -f" works correctly.
+      localhostHosts = pkgs.writeText "localhost-hosts" ''
+        127.0.0.1 localhost
+        ${optionalString cfg.enableIPv6 "::1 localhost"}
+      '';
       stringHosts =
         let
           oneToString = set: ip: ip + " " + concatStringsSep " " set.${ip} + "\n";
           allToString = set: concatMapStrings (oneToString set) (attrNames set);
         in pkgs.writeText "string-hosts" (allToString (filterAttrs (_: v: v != []) cfg.hosts));
       extraHosts = pkgs.writeText "extra-hosts" cfg.extraHosts;
-    in mkBefore [ stringHosts extraHosts ];
+    in mkBefore [ localhostHosts stringHosts extraHosts ];
 
     environment.etc =
       { # /etc/services: TCP/UDP port assignments.

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -376,10 +376,20 @@ in
 
     networking.hostName = mkOption {
       default = "nixos";
-      type = types.str;
+      # Only allow hostnames without the domain name part (i.e. no FQDNs, see
+      # e.g. "man 5 hostname") and require valid DNS labels (recommended
+      # syntax). Note: We also allow underscores for compatibility/legacy
+      # reasons (as undocumented feature):
+      type = types.strMatching
+        "^[[:alpha:]]([[:alnum:]_-]{0,61}[[:alnum:]])?$";
       description = ''
-        The name of the machine.  Leave it empty if you want to obtain
-        it from a DHCP server (if using DHCP).
+        The name of the machine. Leave it empty if you want to obtain it from a
+        DHCP server (if using DHCP). The hostname must be a valid DNS label (see
+        RFC 1035 section 2.3.1: "Preferred name syntax") and as such must not
+        contain the domain part. This means that the hostname must start with a
+        letter, end with a letter or digit, and have as interior characters only
+        letters, digits, and hyphen. The maximum length is 63 characters.
+        Additionally it is recommended to only use lower-case characters.
       '';
     };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -134,6 +134,7 @@ in
   hitch = handleTest ./hitch {};
   hocker-fetchdocker = handleTest ./hocker-fetchdocker {};
   home-assistant = handleTest ./home-assistant.nix {};
+  hostname = handleTest ./hostname.nix {};
   hound = handleTest ./hound.nix {};
   hydra = handleTest ./hydra {};
   hydra-db-migration = handleTest ./hydra/db-migration.nix {};

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -1,0 +1,66 @@
+{ system ? builtins.currentSystem,
+  config ? {},
+  pkgs ? import ../.. { inherit system config; }
+}:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+with pkgs.lib;
+
+let
+  makeHostNameTest = hostName: domain:
+    let
+      fqdn = hostName + (optionalString (domain != null) ".${domain}");
+    in
+      makeTest {
+        name = "hostname-${fqdn}";
+        meta = with pkgs.stdenv.lib.maintainers; {
+          maintainers = [ primeos blitz ];
+        };
+
+        machine = { lib, ... }: {
+          networking.hostName = hostName;
+          networking.domain = domain;
+
+          environment.systemPackages = with pkgs; [
+            inetutils
+          ];
+        };
+
+        testScript = ''
+          start_all()
+
+          machine = ${hostName}
+
+          machine.wait_for_unit("network-online.target")
+
+          # The FQDN, domain name, and hostname detection should work as expected:
+          assert "${fqdn}" == machine.succeed("hostname --fqdn").strip()
+          assert "${optionalString (domain != null) domain}" == machine.succeed("dnsdomainname").strip()
+          assert (
+              "${hostName}"
+              == machine.succeed(
+                  'hostnamectl status | grep "Static hostname" | cut -d: -f2'
+              ).strip()
+          )
+
+          # 127.0.0.1 and ::1 should resolve back to "localhost":
+          assert (
+              "localhost" == machine.succeed("getent hosts 127.0.0.1 | awk '{print $2}'").strip()
+          )
+          assert "localhost" == machine.succeed("getent hosts ::1 | awk '{print $2}'").strip()
+
+          # 127.0.0.2 should resolve back to the FQDN and hostname:
+          fqdn_and_host_name = "${optionalString (domain != null) "${hostName}.${domain} "}${hostName}"
+          assert (
+              fqdn_and_host_name
+              == machine.succeed("getent hosts 127.0.0.2 | awk '{print $2,$3}'").strip()
+          )
+        '';
+      };
+
+in
+{
+  noExplicitDomain = makeHostNameTest "ahost" null;
+
+  explicitDomain = makeHostNameTest "ahost" "adomain";
+}


### PR DESCRIPTION
This fixes the output of "hostname --fqdn" (previously the domain name
was not appended). Additionally it's now possible to use the FQDN.

This works by unconditionally adding two entries to /etc/hosts:
127.0.0.1 localhost
::1 localhost

These are the first two entries and therefore gethostbyaddr() will
always resolve "127.0.0.1" and "::1" to "localhost".
This works because nscd (or rather the nss-files module) returns the
first matching row from /etc/hosts (and ignores the rest).

The FQDN and hostname entries are appended later to /etc/hosts, e.g.:
127.0.0.2 nixos-unstable.test.tld nixos-unstable
::1 nixos-unstable.test.tld nixos-unstable
Note: We use 127.0.0.2 here to follow nss-myhostname (systemd) as close
as possible. This has the advantage that 127.0.0.2 can be resolved back
to the FQDN but also the drawback that applications that only listen to
127.0.0.1 (and not additionally ::1) cannot be reached via the FQDN.
If you would like this to work you can use the following configuration:
```nix
networking.hosts."127.0.0.1" = [
  "${config.networking.hostName}.${config.networking.domain}"
  config.networking.hostName
];
```

Therefore gethostbyname() resolves "nixos-unstable" to the FQDN
(canonical name): "nixos-unstable.test.tld".

Advantages to the previous behaviour:
- The FQDN will now also be resolved correctly (the entry was missing).
- E.g. the command "hostname --fqdn" will now work as expected.

Drawbacks:
- Overrides entries form the DNS (an issue if e.g. `$FQDN` should resolve to the public IP address instead of `127.0.0.1`)
  - Note: This was already partly an issue as there's an entry for `$HOSTNAME` (without the domain part) that resolves to `127.0.1.1` (!= `127.0.0.1`).
- Unknown (could potentially cause other unexpected issues, but special
  care was taken).

Optional TODOs:
- [x] Document this in the changelog (not really optional!)
- [x] `nixos/tests/hostname`: Also check that `127.0.0.1` and `::1` still resolve back to `localhost` as this is apparently required by some applications (see https://github.com/NixOS/nixpkgs/commit/c57892462bf22e537a2cd5ee5e6f88b0b59a2d33)
- [x] Print a warning/error if `networking.hostName` contains a dot: https://github.com/NixOS/nixpkgs/commit/fc7a9b82e30f819f4d08c33995002df1710bb28f
- [x] Investigate edge cases (e.g. FQDN in `/etc/hostname`)

Future improvements:
- Ideally this should be done by `nss-myhostname` (part of systemd) but unfortunately it only returns the hostname without the domain part
  - Update: I've opened https://github.com/systemd/systemd/issues/15894 to see what upstream thinks about this
  - To test this: `getent hosts 127.0.0.2`
  - Also: `nss-myhostname` might be replaced by `nss-resolved` soon (references: https://github.com/systemd/systemd/pull/6231/files, https://github.com/systemd/systemd/issues/1605#issuecomment-149306837, https://github.com/systemd/systemd/blob/v245/TODO#L537) - but: we don't use `nss-resolved` yet
  - Returning the FQDN via `nss-myhostname` would require patching `systemd`: [src/basic/hostname-util.c#L43](https://github.com/systemd/systemd/blob/v245/src/basic/hostname-util.c#L43) or maybe better only `gethostname_malloc()` in `src/nss-myhostname/nss-myhostname.c`
    - `uname --nodename` corresponds to `sysctl kernel.hostname` which we could change but it shouldn't contain the domain part [admin-guide/sysctl/kernel.html#domainname-hostname](https://www.kernel.org/doc/html/latest/admin-guide/sysctl/kernel.html#domainname-hostname)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
