### PR TITLE
Python: Add missing setuptools dependency to branca

### DIFF
--- a/pkgs/development/python-modules/branca/default.nix
+++ b/pkgs/development/python-modules/branca/default.nix
@@ -5,6 +5,7 @@
 , jinja2
 , selenium
 , six
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -17,7 +18,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest selenium ];
-  propagatedBuildInputs = [ jinja2 six ];
+  propagatedBuildInputs = [ jinja2 six setuptools ];
 
   # Seems to require a browser
   doCheck = false;


### PR DESCRIPTION
cc @FRidh 

Without this dependency then any library which uses branca fails with the following kind of error:

```
Traceback (most recent call last):
  File "/home/matt/map-scraper/funflow-example/store/item-c8b3cf4dd29bb13fed4f6c9ca79271a8bb747d66ae39e57fe1791e025ff8eca9/create-leaflet.py", line 5, in <module>
    import folium
  File "/nix/store/mbajvnm6hx0pgm9cs7zhdlrh0nm235nq-python3-3.7.4-env/lib/python3.7/site-packages/folium/__init__.py", line 5, in <module>
    import branca
  File "/nix/store/mbajvnm6hx0pgm9cs7zhdlrh0nm235nq-python3-3.7.4-env/lib/python3.7/site-packages/branca/__init__.py", line 5, in <module>
    import branca.colormap as colormap
  File "/nix/store/mbajvnm6hx0pgm9cs7zhdlrh0nm235nq-python3-3.7.4-env/lib/python3.7/site-packages/branca/colormap.py", line 14, in <module>
    from branca.element import ENV, Figure, JavascriptLink, MacroElement
  File "/nix/store/mbajvnm6hx0pgm9cs7zhdlrh0nm235nq-python3-3.7.4-env/lib/python3.7/site-packages/branca/element.py", line 20, in <module>
    from .utilities import _camelify, _parse_size, none_max, none_min
  File "/nix/store/mbajvnm6hx0pgm9cs7zhdlrh0nm235nq-python3-3.7.4-env/lib/python3.7/site-packages/branca/utilities.py", line 20, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```