### PR TITLE
monitoring plugins: fix path to sudo and mailq

### DIFF
--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, runCommand
 , coreutils, gnugrep, gnused, lm_sensors, net-snmp, openssh, openssl, perl
 , dnsutils, libdbi, libmysqlclient, zlib, openldap, procps
 , runtimeShell }:
@@ -44,6 +44,11 @@ in stdenv.mkDerivation {
     configureFlagsArray=(
       --with-ping-command='/run/wrappers/bin/ping -4 -n -U -w %d -c %d %s'
       --with-ping6-command='/run/wrappers/bin/ping -6 -n -U -w %d -c %d %s'
+      --with-sudo-command='/run/wrappers/bin/sudo'
+      --with-mailq-command='${runCommand "mailq-wrapper" {preferLocalBuild=true;} ''
+        mkdir -p $out/bin
+        ln -s /run/wrappers/bin/sendmail $out/bin/mailq
+        ''}/bin/mailq'
     )
   '';
 


### PR DESCRIPTION
this fixes check_mailq with postfix at least


###### Things done

(all tests ran on this PR but rebased on 19.09)

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of ~all~ many binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice  @relrod 
