### PR TITLE
simplenote: fix libstdc++ error

### DIFF
--- a/pkgs/applications/misc/simplenote/default.nix
+++ b/pkgs/applications/misc/simplenote/default.nix
@@ -87,6 +87,7 @@ let
 
     postFixup = ''
       makeWrapper $out/opt/Simplenote/simplenote $out/bin/simplenote \
+        --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ] }" \
         "''${gappsWrapperArgs[@]}"
     '';
   };


### PR DESCRIPTION
Fixes a bug that was noticed during an automated version bump.

What was needed was to add an LD_LIBRARY_PATH entry for stdenv.cc.cc in
makeWrapper

```
--prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ] }" \
```

The error as seen in developer tools console was:

```
/nix/store/d4b2xcpdf4y4hspbwrmjdz540m493894-simplenote-1.12.0/opt/Simplenote/resources/electron.asar/renderer/init.js:158 Unable to load preload script: /nix/store/d4b2xcpdf4y4hspbwrmjdz540m493894-simplenote-1.12.0/opt/Simplenote/resources/app.asar/desktop/preload.js
(anonymous) @ /nix/store/d4b2xcpdf4y4hspbwrmjdz540m493894-simplenote-1.12.0/opt/Simplenote/resources/electron.asar/renderer/init.js:158
/nix/store/d4b2xcpdf4y4hspbwrmjdz540m493894-simplenote-1.12.0/opt/Simplenote/resources/electron.asar/renderer/init.js:159 Error: libstdc++.so.6: cannot open shared object file: No such file or directory
    at process.module.(anonymous function) [as dlopen] (ELECTRON_ASAR.js:160:31)
    at Object.Module._extensions..node (internal/modules/cjs/loader.js:722)
    at Object.module.(anonymous function) [as .node] (ELECTRON_ASAR.js:169:18)
    at Module.load (internal/modules/cjs/loader.js:602)
    at tryModuleLoad (internal/modules/cjs/loader.js:541)
    at Function.Module._load (internal/modules/cjs/loader.js:533)
    at Module.require (internal/modules/cjs/loader.js:640)
    at require (internal/modules/cjs/helpers.js:20)
    at Object.<anonymous> (/nix/store/d4b2xcpdf4y4hspbwrmjdz540m493894-simplenote-1.12.0/opt/Simplenote/resources/app.asar/node_modules/@paulcbetts/spellchecker/lib/spellchecker.js:3)
    at Object.<anonymous> (/nix/store/d4b2xcpdf4y4hspbwrmjdz540m493894-simplenote-1.12.0/opt/Simplenote/resources/app.asar/node_modules/@paulcbetts/spellchecker/lib/spellchecker.js:116)
```
To (help) anyone that may find have errors like this in the future:

makeWrapper requiring the makeLibraryPath with stdenv.cc.cc is fairly common for electron apps.
At least ones that use dpkg on prebuilt debian .deb files (my `bitwarden` derivation requires it, too) that use gappsWrapperArgs

Thanks @ryantm / r-ryantm and @worldofpeace :)

Reference: https://github.com/NixOS/nixpkgs/pull/76421#pullrequestreview-336359695

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
