### PR TITLE
nixosTests.graphite: port to python and mark as broken

### DIFF
--- a/nixos/tests/graphite.nix
+++ b/nixos/tests/graphite.nix
@@ -1,6 +1,11 @@
-import ./make-test.nix ({ pkgs, ... } :
+import ./make-test-python.nix ({ pkgs, ... } :
 {
   name = "graphite";
+  meta = {
+    # Fails on dependency `python-2.7-Twisted`'s test suite
+    # complaining `ImportError: No module named zope.interface`.
+    broken = true;
+  };
   nodes = {
     one =
       { ... }: {
@@ -22,20 +27,20 @@ import ./make-test.nix ({ pkgs, ... } :
   };
 
   testScript = ''
-    startAll;
-    $one->waitForUnit("default.target");
-    $one->waitForUnit("graphiteWeb.service");
-    $one->waitForUnit("graphiteApi.service");
-    $one->waitForUnit("graphitePager.service");
-    $one->waitForUnit("graphite-beacon.service");
-    $one->waitForUnit("carbonCache.service");
-    $one->waitForUnit("seyren.service");
+    start_all()
+    one.wait_for_unit("default.target")
+    one.wait_for_unit("graphiteWeb.service")
+    one.wait_for_unit("graphiteApi.service")
+    one.wait_for_unit("graphitePager.service")
+    one.wait_for_unit("graphite-beacon.service")
+    one.wait_for_unit("carbonCache.service")
+    one.wait_for_unit("seyren.service")
     # The services above are of type "simple". systemd considers them active immediately
     # even if they're still in preStart (which takes quite long for graphiteWeb).
     # Wait for ports to open so we're sure the services are up and listening.
-    $one->waitForOpenPort(8080);
-    $one->waitForOpenPort(2003);
-    $one->succeed("echo \"foo 1 `date +%s`\" | nc -N localhost 2003");
-    $one->waitUntilSucceeds("curl 'http://localhost:8080/metrics/find/?query=foo&format=treejson' --silent | grep foo >&2");
+    one.wait_for_open_port(8080)
+    one.wait_for_open_port(2003)
+    one.succeed('echo "foo 1 `date +%s`" | nc -N localhost 2003')
+    one.wait_until_succeeds("curl 'http://localhost:8080/metrics/find/?query=foo&format=treejson' --silent | grep foo >&2")
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

The test did not succeed for me before this commit because
the dependencies fail their tests (see added comment, `ImportError: No module named zope.interface` for Twisted).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @basvandijk as main historic contributer
