### PR TITLE
WIP jdk: use `placeholder` for jdk.home

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -66,7 +66,7 @@ let result = stdenv.mkDerivation rec {
   # FIXME: use multiple outputs or return actual JRE package
   passthru.jre = result;
 
-  passthru.home = result;
+  passthru.home = placeholder "out";
 
   meta = with stdenv.lib; {
     license = licenses.gpl2Classpath;

--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -399,7 +399,7 @@ in rec {
     '';
 
     enableParallelBuilding = true;
-    passthru.home = graalvm8;
+    passthru.home = placeholder "out";
 
     meta = with stdenv.lib; {
       homepage = https://github.com/oracle/graal;

--- a/pkgs/development/compilers/graalvm/enterprise-edition.nix
+++ b/pkgs/development/compilers/graalvm/enterprise-edition.nix
@@ -1,7 +1,6 @@
 { stdenv, requireFile, perl, unzip, glibc, zlib, gdk-pixbuf, xorg, glib, fontconfig, freetype, cairo, pango, gtk3, gtk2, ffmpeg, libGL, atk, alsaLib, libav_0_8, setJavaClassPath }:
 
-let
-  graalvm8-ee = stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
     pname = "graalvm8-ee";
     version = "19.2.0";
     srcs = [
@@ -92,7 +91,7 @@ let
     '';
 
     propagatedBuildInputs = [ setJavaClassPath zlib ]; # $out/bin/native-image needs zlib to build native executables
-    
+
     doInstallCheck = true;
     installCheckPhase = ''
       echo ${stdenv.lib.escapeShellArg ''
@@ -119,7 +118,7 @@ let
       ./helloworld | fgrep 'Hello World'
     '';
 
-    passthru.home = graalvm8-ee;
+    passthru.home = placeholder "out";
 
     meta = with stdenv.lib; {
       homepage = https://www.graalvm.org/;
@@ -128,6 +127,4 @@ let
       maintainers = with maintainers; [ volth hlolli ];
       platforms = [ "x86_64-linux" ];
     };
-  };
-in
-  graalvm8-ee
+}

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -5,7 +5,7 @@
 # TODO: Investigate building from source instead of patching binaries.
 # TODO: Binary patching for not just x86_64-linux but also x86_64-darwin i686-linux
 
-let drv = stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "jetbrainsjdk";
   version = "485.1";
 
@@ -47,7 +47,7 @@ let drv = stdenv.mkDerivation rec {
     libX11 libXext libXtst libXi libXp libXt libXrender libXxf86vm
   ])) + ":${placeholder "out"}/lib/jli");
 
-  passthru.home = drv;
+  passthru.home = placeholder "out";
 
   meta = with stdenv.lib; {
     description = "An OpenJDK fork to better support Jetbrains's products.";
@@ -67,4 +67,4 @@ let drv = stdenv.mkDerivation rec {
     maintainers = with maintainers; [ edwtjo ];
     platforms = with platforms; [ "x86_64-linux" "x86_64-darwin" ];
   };
-}; in drv
+}

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -192,7 +192,7 @@ let result = stdenv.mkDerivation rec {
 
   passthru.jre = result; # FIXME: use multiple outputs or return actual JRE package
 
-  passthru.home = result;
+  passthru.home = placeholder "out";
 
   passthru.architecture = architecture;
 


### PR DESCRIPTION
Previously it used non-fixpointed derivation, which brought old derivation
into closure during overrides.

Fixes https://discourse.nixos.org/t/how-do-you-discover-the-override-attributes-for-a-derivation/5214

However doesn't fix this same problem for `oraclejdk` and `adoptopenjdk-bin`,
because those use also self-link for `passthru.jre`.

I've also omitted this same change for `openjdk/bootstrap.nix`, because I don't quite understand what is this for, what for is `openjdk/make-boostrap.nix` and [the explanation](https://github.com/NixOS/nixpkgs/issues/9743#issuecomment-139657655).

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
