### PR TITLE
osmctools: 0.8.5plus1.4.0 -> 0.9

### DIFF
--- a/pkgs/applications/misc/osmctools/default.nix
+++ b/pkgs/applications/misc/osmctools/default.nix
@@ -1,46 +1,27 @@
-{ stdenv, fetchurl, zlib } :
+{ stdenv, fetchFromGitLab, autoreconfHook, zlib }:
 
-let
-
-  convert_src = fetchurl {
-    url = http://m.m.i24.cc/osmconvert.c;
-    sha256 = "1mvmb171c1jqxrm80jc7qicwk4kgg7yq694n7ci65g6i284r984x";
-    # version = 0.8.5
-  };
-
-  filter_src = fetchurl {
-    url = http://m.m.i24.cc/osmfilter.c;
-    sha256 = "0vm3bls9jb2cb5b11dn82sxnc22qzkf4ghmnkivycigrwa74i6xl";
-    # version = 1.4.0
-  };
-
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "osmctools";
-  version = "0.8.5plus1.4.0";
+  version = "0.9";
 
+  src = fetchFromGitLab {
+    owner = "osm-c-tools";
+    repo = pname;
+    rev = version;
+    sha256 = "1m8d3r1q1v05pkr8k9czrmb4xjszw6hvgsf3kn9pf0v14gpn4r8f";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ zlib ];
-
-  phases = [ "buildPhase" "installPhase" ];
-
-  buildPhase = ''
-    cc ${convert_src} -lz -O3 -o osmconvert
-    cc ${filter_src} -O3 -o osmfilter
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    mv osmconvert $out/bin
-    mv osmfilter $out/bin
-  '';
 
   meta = with stdenv.lib; {
     description = "Command line tools for transforming Open Street Map files";
     homepage = [
-      https://wiki.openstreetmap.org/wiki/Osmconvert
-      https://wiki.openstreetmap.org/wiki/Osmfilter
+      https://wiki.openstreetmap.org/wiki/osmconvert
+      https://wiki.openstreetmap.org/wiki/osmfilter
+      https://wiki.openstreetmap.org/wiki/osmupdate
     ];
+    maintainers = with maintainers; [ sikmir ];
     platforms = platforms.unix;
     license = licenses.agpl3;
   };


### PR DESCRIPTION
###### Motivation for this change
[version 0.9](https://gitlab.com/osm-c-tools/osmctools/-/tags/0.9)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/a311nfxabhnm082lrswsvl1w1z7w11hd-osmctools-0.8.5plus1.4.0
/nix/store/a311nfxabhnm082lrswsvl1w1z7w11hd-osmctools-0.8.5plus1.4.0	 177.4M
$ nix path-info -Sh /nix/store/pfw5mlhxjwdkh3sldrg5m39pba4194rx-osmctools-0.9
/nix/store/pfw5mlhxjwdkh3sldrg5m39pba4194rx-osmctools-0.9	  27.4M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @oxij 
