### PR TITLE
wireguard-tools 1.0.20191226 / wireguard 0.0.20191226

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,11 +1,18 @@
-{ stdenv, kernel, wireguard-tools, perl }:
+{ stdenv, fetchzip, kernel, perl, wireguard-tools }:
 
 # module requires Linux >= 3.10 https://www.wireguard.io/install/#kernel-requirements
 assert stdenv.lib.versionAtLeast kernel.version "3.10";
+# wireguard upstreamed since 5.6 https://lists.zx2c4.com/pipermail/wireguard/2019-December/004704.html
+assert stdenv.lib.versionOlder kernel.version "5.6";
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "wireguard";
-  inherit (wireguard-tools) src version;
+  version = "0.0.20191226";
+
+  src = fetchzip {
+    url = "https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-${version}.tar.xz";
+    sha256 = "1q618h385kqnzxa8xswnw9i1yqrlnl3fglkhbzc8w1181qr4fhra";
+  };
 
   preConfigure = ''
     cd src
@@ -27,6 +34,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     inherit (wireguard-tools.meta) homepage license maintainers;
     description = "Kernel module for the WireGuard secure network tunnel";
+    downloadPage = "https://git.zx2c4.com/wireguard-linux-compat/refs/";
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -14,14 +14,14 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "wireguard-tools";
-  version = "0.0.20191219";
+  version = "1.0.20191226";
 
   src = fetchzip {
-    url = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "1qxpjvj3927xdly022rp2sndbifmr0c2y6ik77v43k95ch94716d";
+    url = "https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${version}.tar.xz";
+    sha256 = "14v5asdjazz0p3bhg8na9w6y66i3jhnn8imxhq8xlix1k4n93l4z";
   };
 
-  sourceRoot = "source/src/tools";
+  sourceRoot = "source/src";
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = optional stdenv.isLinux libmnl;
@@ -51,10 +51,10 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Tools for the WireGuard secure network tunnel";
-    downloadPage = "https://git.zx2c4.com/WireGuard/refs/";
+    downloadPage = "https://git.zx2c4.com/wireguard-tools/refs/";
     homepage = "https://www.wireguard.com/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ elseym ericsagnes mic92 zx2c4 globin ma27 ];
+    maintainers = with maintainers; [ elseym ericsagnes mic92 zx2c4 globin ma27 xwvvvvwx ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

There has been a wireguard repo reorg as a result of it's acceptance into `net-next`. More details [here](https://lists.zx2c4.com/pipermail/wireguard/2019-December/004711.html).

The kernel module and userspace tools now live in separate repos and are versioned separately.

The announcements for the module and tools releases are here:

https://lists.zx2c4.com/pipermail/wireguard/2019-December/004796.html
https://lists.zx2c4.com/pipermail/wireguard/2019-December/004787.html

There should be no functional changes as a part of these releases.

I have also added myself as a package maintainer :).

*tests performed*

- `nix-build nixos/tests/wireguard/*` passes
- `nix-build nixos/tests/systemd-networkd-wireguard.nix` passes
- `nix-review rev 6332c4ac92f151a9cff77c6596470fff1b332069` passes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @elseym @ericsagnes @Mic92  @zx2c4  @globin  @Ma27
