### PR TITLE
emplace: 0.2.8 -> 0.2.10

### DIFF
--- a/pkgs/tools/package-management/emplace/default.nix
+++ b/pkgs/tools/package-management/emplace/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "emplace";
-  version = "0.2.8";
+  version = "0.2.9";
 
   src = fetchFromGitHub {
     owner = "tversteeg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0s04hi0i1ssg9dp75f9qdglnvqmh0cxmbk8nnhd4w45v9m5sadph";
+    sha256 = "01snlgpqa5khnnkv8idm6xdwr42pqg3bqp92vvggqxn17n3fd8kn";
   };
 
-  cargoSha256 = "10y7lpgj9mxrh3rmc15km4rfzspwdjr8dcdh0747rjn6dcpfhcdq";
+  cargoSha256 = "0q7y9wa7fi0j71mxlcfxfijpccjfyazp5ipsnaj28r9mj1c6lkis";
 
   meta = with lib; {
     description = "Mirror installed software on multiple machines";

--- a/pkgs/tools/package-management/emplace/default.nix
+++ b/pkgs/tools/package-management/emplace/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "emplace";
-  version = "0.2.9";
+  version = "0.2.10";
 
   src = fetchFromGitHub {
     owner = "tversteeg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "01snlgpqa5khnnkv8idm6xdwr42pqg3bqp92vvggqxn17n3fd8kn";
+    sha256 = "1y77cla6bgy8pjb21cawx7cb69hhri4r7gyjkhnjyiixkh945mwj";
   };
 
-  cargoSha256 = "0q7y9wa7fi0j71mxlcfxfijpccjfyazp5ipsnaj28r9mj1c6lkis";
+  cargoSha256 = "119llsc8m7qda2cjnd45ndml148z8074f76xygkz6fp3m1c2z3pw";
 
   meta = with lib; {
     description = "Mirror installed software on multiple machines";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/tversteeg/emplace/releases/tag/v0.2.9
https://github.com/tversteeg/emplace/releases/tag/v0.2.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/gh4527ywcsiavricyb399dymsw5ph9m7-emplace-0.2.8	  29.8M
/nix/store/zzd7227m0f6i0y6cln1mj8m68zq1w64a-emplace-0.2.9     30.1M
/nix/store/4irn6v5iy6mp5sr4ci4r6lcrvpq3s133-emplace-0.2.10    30.1M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/76581)
<!-- Reviewable:end -->
