### PR TITLE
squeezelite: Fix codec libraries loading by using a wrapper

### DIFF
--- a/pkgs/applications/audio/squeezelite/default.nix
+++ b/pkgs/applications/audio/squeezelite/default.nix
@@ -1,6 +1,9 @@
-{ stdenv, fetchFromGitHub, alsaLib, faad2, flac, libmad, libvorbis, mpg123 }:
+{ stdenv, fetchFromGitHub, alsaLib, faad2, flac, libmad, libvorbis, makeWrapper, mpg123 }:
 
-stdenv.mkDerivation {
+let
+  runtimeDeps  = [ faad2 flac libmad libvorbis mpg123 ];
+  rpath = stdenv.lib.makeLibraryPath runtimeDeps;
+in stdenv.mkDerivation {
   name = "squeezelite-git-2018-08-14";
 
   src = fetchFromGitHub {
@@ -10,7 +13,8 @@ stdenv.mkDerivation {
     sha256 = "0di3d5qy8fhawijq6bxy524fgffvzl08dprrws0fs2j1a70fs0fh";
   };
 
-  buildInputs = [ alsaLib faad2 flac libmad libvorbis mpg123 ];
+  buildInputs = [ alsaLib ] ++ runtimeDeps;
+  nativeBuildInputs = [ makeWrapper ];
 
   enableParallelBuilding = true;
 
@@ -20,6 +24,7 @@ stdenv.mkDerivation {
     install -Dm755 -t $out/bin                   squeezelite
     install -Dm644 -t $out/share/doc/squeezelite *.txt *.md
 
+    wrapProgram $out/bin/squeezelite --set LD_LIBRARY_PATH $RPATH
     runHook postInstall
   '';
 
@@ -29,4 +34,5 @@ stdenv.mkDerivation {
     license = licenses.gpl3;
     platforms = platforms.linux;
   };
+  RPATH = rpath;
 }


### PR DESCRIPTION
###### Motivation for this change
This application really doesn't so much as it is, It's only able to play PCM music. The music encoded with the codecs (flac, mp3, ogg) doesn't work because the corresponding libraries are dynamically loaded at runtime. This  PR fixes the situation by wrapping the executable and defining an LD_LIBRARY_PATH.

To see the problem install the `squeezelite` binary and run the following command:
```
$ squeezelit -c flac,ogg,pcm,mp3 -n squeezender -d all=debug
```
you should see the following lines:
```
...
[22:07:49.481102] load_vorbis:289 dlerror: libvorbisidec.so.1: cannot open shared object file: No such file or directory
[22:07:49.481177] load_flac:266 loaded libFLAC.so.8
[22:07:49.481354] load_mad:366 dlerror: libmad.so.0: cannot open shared object file: No such file or directory
[22:07:49.481389] decode_init:187 include codecs: flac,ogg,pcm,mp3 exclude codecs: 
[22:07:49.481576] discover_server:784 sending discovery
[22:07:49.483470] discover_server:795 got response from: 192.168.1.3:3483
[22:07:49.484691] alsa_open:422 opened device default using format: S32_LE sample rate: 44100 mmap: 0
...
```
###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

no maintainers listed  unfortunately...
