### PR TITLE
[WIP] zkg: init at 2.0.7

### DIFF
--- a/pkgs/applications/networking/ids/zeek/default.nix
+++ b/pkgs/applications/networking/ids/zeek/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  ZEEK_DIST = "${placeholder "out"}";
+  preConfigure = ''
+    substituteInPlace zeek-config.in --subst-var ZEEK_DIST
+  '';
+
   cmakeFlags = [
     "-DPY_MOD_INSTALL_DIR=${placeholder "out"}/${python.sitePackages}"
     "-DENABLE_PERFTOOLS=true"

--- a/pkgs/development/tools/btest/default.nix
+++ b/pkgs/development/tools/btest/default.nix
@@ -1,0 +1,22 @@
+{ lib, python3Packages }:
+
+with python3Packages;
+buildPythonApplication rec {
+  pname = "btest";
+  version = "0.59";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ic2c1gvp448d5h0b9vsk6813hfffznb26b5si7jk1dhqb27hva4";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Simple Driver for Basic Unit Tests";
+    homepage = "https://github.com/zeek/btest";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.tobim ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/package-management/zkg/default.nix
+++ b/pkgs/tools/package-management/zkg/default.nix
@@ -1,0 +1,25 @@
+{ lib, python3Packages, btest }:
+
+with python3Packages;
+buildPythonApplication rec {
+  pname = "zkg";
+  version = "2.0.7";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "1z4xf650nsd74xs8yddqpj60wp92b2yyw9sp3qy07as98ppzgr2w";
+  };
+
+  propagatedBuildInputs = [ GitPython semantic-version configparser btest ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "The Zeek package manager";
+    homepage = "https://docs.zeek.org/projects/package-manager/";
+    license = "University of Illinois/NCSA Open Source License";
+    maintainers = [ maintainers.tobim ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9686,6 +9686,8 @@ in
     wxGTK = wxGTK30;
   };
 
+  btest = callPackage ../development/tools/btest { };
+
   buck = callPackage ../development/tools/build-managers/buck { };
 
   buildkite-agent = buildkite-agent2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2975,6 +2975,8 @@ in
 
   zeek = callPackage ../applications/networking/ids/zeek { };
 
+  zkg = callPackage ../tools/package-management/zkg { };
+
   zzuf = callPackage ../tools/security/zzuf { };
 
   ### DEVELOPMENT / EMSCRIPTEN


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
In order to get a more idiomatic integration of the Zeek network monitor the accompanying package manager should be available.

###### Things done
This PR only concerns itself with making zkg itself available. The packages and wrapping can be added later (maybe even in a separate flake).

###### Remaining Problems
- [ ] The `ZEEK_DIST` variable needs to point to a source tree of zeek instead of the build output.
- [ ] The configuration in `$HOME/.zkg/config` has to be edit manually to point plugin and script dirs to a writable location.

###### Default Checkboxes
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @marsam, you might be interested?
