### PR TITLE
Fix services.xserver.extraLayouts under GNOME 3

### DIFF
--- a/nixos/modules/services/x11/extra-layouts.nix
+++ b/nixos/modules/services/x11/extra-layouts.nix
@@ -158,6 +158,12 @@ in
 
     });
 
+    environment.sessionVariables = {
+      # runtime override supported by multiple libraries e. g. libxkbcommon
+      # https://xkbcommon.org/doc/current/group__include-path.html
+      XKB_CONFIG_ROOT = "${pkgs.xkb_patched}/etc/X11/xkb";
+    };
+
     services.xserver = {
       xkbDir = "${pkgs.xkb_patched}/etc/X11/xkb";
       exportConfiguration = config.services.xserver.displayManager.startx.enable;

--- a/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, substituteAll, pkgconfig, libxslt, ninja, libX11, gnome3, gtk3, glib
+{ stdenv, fetchurl, fetchpatch, substituteAll, pkgconfig, libxslt, ninja, libX11, gnome3, gtk3, glib
 , gettext, libxml2, xkeyboard_config, isocodes, meson, wayland
 , libseccomp, systemd, bubblewrap, gobject-introspection, gtk-doc, docbook_xsl, gsettings-desktop-schemas }:
 
@@ -29,6 +29,14 @@ stdenv.mkDerivation rec {
       src = ./bubblewrap-paths.patch;
       bubblewrap_bin = "${bubblewrap}/bin/bwrap";
       inherit (builtins) storeDir;
+    })
+
+    # honor $XKB_CONFIG_ROOT
+    # addresses #76590: services.xserver.extraLayouts aren't honored by GNOME3
+    # NOTE: should be merged upstream in 3.36.
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-desktop/commit/450446b5353e8231edded4d5b5db90a67a9fa9b7.diff";
+      sha256 = "07y989x7mbgn3rsm2qfdi8qkkc8i60k28hw87l744nlkydn78kq5";
     })
   ];
 

--- a/pkgs/development/libraries/libxklavier/default.nix
+++ b/pkgs/development/libraries/libxklavier/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "1w1x5mrgly2ldiw3q2r6y620zgd89gk7n90ja46775lhaswxzv7a";
   };
 
+  patches = [ ./honor-XKB_CONFIG_ROOT.patch ];
+
   outputs = [ "out" "dev" "devdoc" ];
 
   # TODO: enable xmodmap support, needs xmodmap DB

--- a/pkgs/development/libraries/libxklavier/honor-XKB_CONFIG_ROOT.patch
+++ b/pkgs/development/libraries/libxklavier/honor-XKB_CONFIG_ROOT.patch
@@ -1,0 +1,89 @@
+From 999a419f4b36764a7269650a7f965d48bd4b73f7 Mon Sep 17 00:00:00 2001
+From: Louis Bettens <louis@bettens.info>
+Date: Sat, 28 Dec 2019 14:30:58 +0100
+Subject: [PATCH] honor $XKB_CONFIG_ROOT
+
+---
+ libxklavier/xklavier_config_xkb.c | 30 +++++++++++++++++++++++++-----
+ 1 file changed, 25 insertions(+), 5 deletions(-)
+
+diff --git a/libxklavier/xklavier_config_xkb.c b/libxklavier/xklavier_config_xkb.c
+index baec569..00e8de5 100644
+--- a/libxklavier/xklavier_config_xkb.c
++++ b/libxklavier/xklavier_config_xkb.c
+@@ -45,6 +45,18 @@
+ #define XK_XKB_KEYS
+ #include <X11/keysymdef.h>
+ 
++static const gchar *
++xkl_xkb_get_base_path(void)
++{
++	const gchar *base_path;
++
++	base_path = g_getenv ("XKB_CONFIG_ROOT");
++	if (!base_path)
++		base_path = XKB_BASE;
++
++	return base_path;
++}
++
+ #ifdef LIBXKBFILE_PRESENT
+ static XkbRF_RulesPtr xkl_rules;
+ 
+@@ -65,7 +77,8 @@ xkl_rules_set_load(XklEngine * engine)
+ 
+ 	locale = setlocale(LC_ALL, NULL);
+ 
+-	g_snprintf(file_name, sizeof file_name, XKB_BASE "/rules/%s", rf);
++	g_snprintf(file_name, sizeof file_name, "%s/rules/%s",
++		   xkl_xkb_get_base_path(), rf);
+ 	xkl_debug(160, "Loading rules from [%s]\n", file_name);
+ 
+ 	rules_set = XkbRF_Load(file_name, locale, True, True);
+@@ -98,10 +111,14 @@ gboolean
+ xkl_xkb_load_config_registry(XklConfigRegistry * config,
+ 			     gboolean if_extras_needed)
+ {
+-	return xkl_config_registry_load_helper(config,
++	const gchar *rules_path = g_strdup_printf("%s/rules",
++					  xkl_xkb_get_base_path());
++	gboolean ok = xkl_config_registry_load_helper(config,
+ 					       XKB_DEFAULT_RULESET,
+-					       XKB_BASE "/rules",
++					       rules_path,
+ 					       if_extras_needed);
++	g_free(rules_path);
++	return ok;
+ }
+ 
+ #ifdef LIBXKBFILE_PRESENT
+@@ -249,6 +266,7 @@ xkl_config_get_keyboard(XklEngine * engine,
+ 		pid_t cpid, pid;
+ 		int status = 0;
+ 		FILE *tmpxkb;
++		const gchar *opt_I;
+ 
+ 		xkl_debug(150, "tmp XKB/XKM file names: [%s]/[%s]\n",
+ 			  xkb_fn, xkm_fn);
+@@ -296,14 +314,16 @@ xkl_config_get_keyboard(XklEngine * engine,
+ 				break;
+ 			case 0:
+ 				/* child */
++				opt_I = g_strdup_printf("-I%s", xkl_xkb_get_base_path());
+ 				xkl_debug(160, "Executing %s\n", XKBCOMP);
+ 				xkl_debug(160, "%s %s %s %s %s %s %s %s\n",
+ 					  XKBCOMP, XKBCOMP, "-w0", "-I",
+-					  "-I" XKB_BASE, "-xkm", xkb_fn,
++					  opt_I, "-xkm", xkb_fn,
+ 					  xkm_fn);
+ 				execl(XKBCOMP, XKBCOMP, "-w0", "-I",
+-				      "-I" XKB_BASE, "-xkm", xkb_fn,
++				      opt_I, "-xkm", xkb_fn,
+ 				      xkm_fn, NULL);
++				g_free(opt_I);
+ 				xkl_debug(0, "Could not exec %s: %d\n",
+ 					  XKBCOMP, errno);
+ 				exit(1);
+-- 
+2.24.1
+


### PR DESCRIPTION
##### Motivation for this change
Fix #76590

###### Things done
- Alter the extra-layouts module to set an existing conventional environment variable.
- Forward-port a [patch](https://gitlab.gnome.org/GNOME/gnome-desktop/commit/450446b5353e8231edded4d5b5db90a67a9fa9b7) to libgnomedesktop to honor it. It will be in upstream 3.36 but I understand that Markhor will ship with 3.34.

Targeting staging because it cascades through lots of GNOME derivations unfortunately.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] _Function-tested in 19.09 and unstable_
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS **inapplicable**
   - [ ] other Linux distributions **inapplicable**
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (gnome3 and gnome3-xorg passing)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) **inapplicable**
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after) **inapplicable**
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @lethalman @jtojnar @hedning @worldofpeace for GNOME 3
cc @rnhmjoj for x11/extra-layouts