### PR TITLE
flacon: improvements

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7782,4 +7782,10 @@
     githubId = 52650;
     name = "Marc Busqué";
   };
+  snglth = {
+    email = "illia@ishestakov.com";
+    github = "snglth";
+    githubId = 8686360;
+    name = "Illia Shestakov";
+  };
 }

--- a/pkgs/applications/audio/flacon/default.nix
+++ b/pkgs/applications/audio/flacon/default.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     homepage = https://flacon.github.io/;
     license = licenses.lgpl21;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ nico202 ];
+    maintainers = with maintainers; [ snglth ];
   };
 }

--- a/pkgs/applications/audio/flacon/default.nix
+++ b/pkgs/applications/audio/flacon/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, lib, fetchFromGitHub, cmake, qt5, libuchardet, pkgconfig, makeWrapper
+{ stdenv, lib, fetchFromGitHub, cmake, libuchardet, pkgconfig
 , shntool, flac, opusTools, vorbis-tools, mp3gain, lame, wavpack, vorbisgain
 , gtk3
+, qtbase, qttools, wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -14,8 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "05pvg5xhc2azwzld08m81r4b2krqdbcbm5lmdvg2zkk67xq9pqyd";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
-  buildInputs = [ qt5.qtbase qt5.qttools libuchardet ];
+  nativeBuildInputs = [ cmake pkgconfig wrapQtAppsHook ];
+  buildInputs = [ qtbase qttools libuchardet ];
 
   postInstall = ''
     wrapProgram $out/bin/flacon \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18761,7 +18761,7 @@ in
 
   FIL-plugins = callPackage ../applications/audio/FIL-plugins { };
 
-  flacon = callPackage ../applications/audio/flacon { };
+  flacon = libsForQt5.callPackage ../applications/audio/flacon { };
 
   flexget = callPackage ../applications/networking/flexget { };
 


### PR DESCRIPTION
1. Use libsForQt5.callPackage instead of raw callPackage` (this adds
ability to import qtbase and qttools directly instead of importing whole
qt5)
2. Include wrapQtAppsHook in nativeBuildInputs

Closes #76588

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The major point of this changes is to provide support for running
support of running flacon under wayland session, but it may help in some
other use cases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @nico202
