### PR TITLE
Cross-compiled sheevaplug support

### DIFF
--- a/pkgs/development/libraries/libgpg-error/default.nix
+++ b/pkgs/development/libraries/libgpg-error/default.nix
@@ -39,6 +39,7 @@ in stdenv.mkDerivation (rec {
     sed '/BUILD_TIMESTAMP=/s/=.*/=1970-01-01T00:01+0000/' -i ./configure
   '' + lib.optionalString (stdenv.hostPlatform.isAarch32 && stdenv.buildPlatform != stdenv.hostPlatform) ''
     ln -s lock-obj-pub.arm-unknown-linux-gnueabi.h src/syscfg/lock-obj-pub.linux-gnueabihf.h
+    ln -s lock-obj-pub.arm-unknown-linux-gnueabi.h src/syscfg/lock-obj-pub.linux-gnueabi.h
   '' + lib.optionalString (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isMusl) ''
     ln -s lock-obj-pub.x86_64-pc-linux-musl.h src/syscfg/lock-obj-pub.linux-musl.h
   '' + lib.optionalString (stdenv.hostPlatform.isAarch32 && stdenv.hostPlatform.isMusl) ''

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -10,11 +10,12 @@
 let
   # See https://mesonbuild.com/Reference-tables.html#cpu-families
   cpuFamilies = {
-    aarch64 = "aarch64";
-    armv6l  = "arm";
-    armv7l  = "arm";
-    i686    = "x86";
-    x86_64  = "x86_64";
+    aarch64  = "aarch64";
+    armv5tel = "arm";
+    armv6l   = "arm";
+    armv7l   = "arm";
+    i686     = "x86";
+    x86_64   = "x86_64";
   };
 in
 python3Packages.buildPythonApplication rec {

--- a/pkgs/development/tools/misc/openocd/default.nix
+++ b/pkgs/development/tools/misc/openocd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, libftdi1, libusb1, pkgconfig, hidapi }:
+{ stdenv, lib, fetchurl, fetchpatch, libftdi1, libusb1, pkgconfig, hidapi }:
 
 stdenv.mkDerivation rec {
   pname = "openocd";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/openocd/openocd-${version}.tar.bz2";
     sha256 = "1bhn2c85rdz4gf23358kg050xlzh7yxbbwmqp24c0akmh3bff4kk";
   };
+
+  patches = [
+    # Fix FTDI channel configuration for SheevaPlug
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=837989
+    (fetchpatch {
+      url = "https://salsa.debian.org/electronics-team/openocd/raw/9a94335daa332a37a51920f87afbad4d36fad2d5/debian/patches/fix-sheeva.patch";
+      sha256 = "01x021fagwvgxdpzk7psap7ryqiya4m4mi4nqr27asbmb3q46g5r";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libftdi1 libusb1 hidapi ];

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -6,6 +6,10 @@
 , interactive ? false, ncurses, procps
 }:
 
+let
+  crossBuildTools = interactive && stdenv.hostPlatform != stdenv.buildPlatform;
+in
+
 with stdenv.lib;
 
 stdenv.mkDerivation {
@@ -17,7 +21,13 @@ stdenv.mkDerivation {
     inherit sha256;
   };
 
-  patches = optional (version == "6.5") ./perl.patch;
+  patches = optional (version == "6.5") ./perl.patch
+    ++ optional crossBuildTools ./cross-tools-flags.patch;
+
+  # ncurses is required to build `makedoc'
+  # this feature is introduced by the ./cross-tools-flags.patch
+  NATIVE_TOOLS_CFLAGS = if crossBuildTools then "-I${getDev buildPackages.ncurses}/include" else null;
+  NATIVE_TOOLS_LDFLAGS = if crossBuildTools then "-L${getLib buildPackages.ncurses}/lib" else null;
 
   # We need a native compiler to build perl XS extensions
   # when cross-compiling.

--- a/pkgs/development/tools/misc/texinfo/cross-tools-flags.patch
+++ b/pkgs/development/tools/misc/texinfo/cross-tools-flags.patch
@@ -1,0 +1,12 @@
+diff -ur texinfo-6.5/configure texinfo-6.5-patched/configure
+--- texinfo-6.5/configure	2017-09-13 03:50:18.000000000 +0900
++++ texinfo-6.5-patched/configure	2019-12-28 17:39:06.692818866 +0900
+@@ -23281,7 +23281,7 @@
+   # env -i gives this build host configure a clean environment;
+   # consequently, we have to re-initialize $PATH.
+   env -i CC="$BUILD_CC" AR="$BUILD_AR" RANLIB="$BUILD_RANLIB" \
+-      PATH="$PATH" \
++      PATH="$PATH" CFLAGS="$NATIVE_TOOLS_CFLAGS" LDFLAGS="$NATIVE_TOOLS_LDFLAGS" \
+       tools_only=1 \
+     ${confdir}/configure --build=${build} --host=${build} \
+                          --disable-rpath --disable-nls

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -300,7 +300,7 @@ in {
   ubootSheevaplug = buildUBoot {
     defconfig = "sheevaplug_defconfig";
     extraMeta.platforms = ["armv5tel-linux"];
-    filesToInstall = ["u-boot.bin"];
+    filesToInstall = ["u-boot.kwb"];
   };
 
   ubootSopine = buildUBoot {

--- a/pkgs/tools/filesystems/mtdutils/default.nix
+++ b/pkgs/tools/filesystems/mtdutils/default.nix
@@ -9,13 +9,16 @@ stdenv.mkDerivation rec {
     sha256 = "1lijl89l7hljx8xx70vrz9srd3h41v5gh4b0lvqnlv831yvyh5cd";
   };
 
-  nativeBuildInputs = [ autoreconfHook cmocka pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ] ++ stdenv.lib.optional doCheck cmocka;
   buildInputs = [ acl libuuid lzo zlib zstd ];
 
-  configureFlags = [ "--enable-unit-tests" "--enable-tests" ];
+  configureFlags = [
+    (stdenv.lib.enableFeature doCheck "unit-tests")
+    (stdenv.lib.enableFeature doCheck "tests")
+  ];
   enableParallelBuilding = true;
 
-  doCheck = true;
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
 
   meta = {
     description = "Tools for MTD filesystems";

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -57,7 +57,7 @@ common =
       propagatedBuildInputs = [ boehmgc ];
 
       # Seems to be required when using std::atomic with 64-bit types
-      NIX_LDFLAGS = lib.optionalString (stdenv.hostPlatform.system == "armv6l-linux") "-latomic";
+      NIX_LDFLAGS = lib.optionalString (stdenv.hostPlatform.system == "armv5tel-linux" || stdenv.hostPlatform.system == "armv6l-linux") "-latomic";
 
       preConfigure =
         # Copy libboost_context so we don't get all of Boost in our closure.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Running NixOS on a Sheevaplug via cross-compilation.

This is a small batch of changes that either adds support for ancient arm (`armv5tel-linux`) or improves cross compilation in general. Submitted as a single pull request, since each change is very small.

The issue for texinfoInteractive affects all cross builds, for example https://github.com/ElvishJerricco/cross-nixos-aarch64/issues/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
