### PR TITLE
age: init at v1.0.0-beta2

### DIFF
--- a/pkgs/tools/security/age/default.nix
+++ b/pkgs/tools/security/age/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "age";
+  version = "1.0.0-beta2";
+  goPackagePath = "github.com/FiloSottile/age";
+  modSha256 = "0kwdwhkxgqjd8h1p7pm4h4xidp2vk840h1j4qya4qz8bjf9vskl9";
+
+  subPackages = [
+    "cmd/age"
+    "cmd/age-keygen"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "FiloSottile";
+    repo = "age";
+    rev = "v${version}";
+    sha256 = "1n1ww8yjw0mg00dvnfmggww9kwp1hls0a85iv6vx9k89mzv8mdrq";
+  };
+
+  meta = with lib; {
+    homepage = "https://age-encryption.org/";
+    description = "Modern encryption tool with small explicit keys";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ tazjin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2518,6 +2518,8 @@ in
     caps2esc = callPackage ../tools/inputmethods/interception-tools/caps2esc.nix { };
   };
 
+  age = callPackage ../tools/security/age { };
+
   brotli = callPackage ../tools/compression/brotli { };
 
   biosdevname = callPackage ../tools/networking/biosdevname { };


### PR DESCRIPTION
age is a new modern encryption tool with small explicit keys, no config and UNIX-style composability.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
