### PR TITLE
iosevka: 2.3.2 -> 2.3.3

### DIFF
--- a/pkgs/data/fonts/iosevka/default.nix
+++ b/pkgs/data/fonts/iosevka/default.nix
@@ -30,13 +30,13 @@ assert (privateBuildPlan != null) -> set != null;
 stdenv.mkDerivation rec {
   pname = if set != null then "iosevka-${set}" else "iosevka";
 
-  version = "2.3.2";
+  version = "2.3.3";
 
   src = fetchFromGitHub {
     owner = "be5invis";
     repo = "Iosevka";
     rev = "v${version}";
-    sha256 = "0s0vdvp1sn8p2pi2xm9n05pabk30ki7wjlmr0zz0nkhidb8apw6k";
+    sha256 = "0k7xij473g5g0lwhb6qpn70v3n2d025dww3nlb7jwbpnp03zliz0";
   };
 
   nativeBuildInputs = [

--- a/pkgs/data/fonts/iosevka/package.json
+++ b/pkgs/data/fonts/iosevka/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "iosevka-build-deps",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"scripts": {
 		"build": "verda -f verdafile.js"
 	},
@@ -15,12 +15,12 @@
 		"patrisika-scopes": "^0.11.1",
 		"primitive-quadify-off-curves": "^0.4.0",
 		"stylus": "^0.54.5",
-		"toml": "^2.3.2",
+		"toml": "^3.0.0",
 		"topsort": "0.0.2",
 		"ttf2woff": "^2.0.1",
 		"ttf2woff2": "^2.0.3",
-		"unorm": "^1.4.1",
+		"unorm": "^1.6.0",
 		"verda": "^1.0.0-0",
-		"yargs": "^12.0.0"
+		"yargs": "^14.2.0"
 	}
 }


### PR DESCRIPTION
##### Motivation for this change

Update Iosevka to latest version. I have also updated `package.json` versions when a version matching the constraint was already present in nixpkgs. This is not the case with `otfcc-ttcize`. I don't know if there are tools to help this kind of update (or if this is necessary). Compared to upstream `package.json` file, there are dependencies missing, but they were already missing in 2.3.2.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @babariviere, @rileyinman 
