### PR TITLE
imgp: init at 2.7

### DIFF
--- a/pkgs/applications/graphics/imgp/default.nix
+++ b/pkgs/applications/graphics/imgp/default.nix
@@ -1,0 +1,38 @@
+{ lib, fetchFromGitHub, buildPythonApplication, pillow, imgp }:
+
+buildPythonApplication rec {
+  pname = "imgp";
+  version = "2.7";
+
+  src = fetchFromGitHub {
+    owner = "jarun";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "13r4fn3dd0nyidfhrr7zzpls5ifbyqdwxhyvpkqr8ahchws7wfc6";
+  };
+
+  propagatedBuildInputs = [ pillow ];
+
+  installFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX="
+  ];
+
+  postInstall = ''
+    install -Dm555 auto-completion/bash/imgp-completion.bash $out/share/bash-completion/completions/imgp.bash
+    install -Dm555 auto-completion/fish/imgp.fish -t $out/share/fish/vendor_completions.d
+    install -Dm555 auto-completion/zsh/_imgp -t $out/share/zsh/site-functions
+  '';
+
+  checkPhase = ''
+    $out/bin/imgp --help
+  '';
+
+  meta = with lib; {
+    description = "High-performance CLI batch image resizer & rotator";
+    homepage = "https://github.com/jarun/imgp";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19701,6 +19701,8 @@ in
 
   imgcat = callPackage ../applications/graphics/imgcat { };
 
+  imgp = python3Packages.callPackage ../applications/graphics/imgp { };
+
   # Impressive, formerly known as "KeyJNote".
   impressive = callPackage ../applications/office/impressive { };
 


### PR DESCRIPTION
###### Motivation for this change
[**imgp**](https://github.com/jarun/imgp) - :camera_flash: High-performance CLI batch image resizer & rotator 

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh /nix/store/b2plf5lq1hsc6n2dhmm92mvim9m4rp2c-imgp-2.7
/nix/store/b2plf5lq1hsc6n2dhmm92mvim9m4rp2c-imgp-2.7	 110.4M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
