### PR TITLE
rambox: fix hash

### DIFF
--- a/pkgs/applications/networking/instant-messengers/rambox/bare.nix
+++ b/pkgs/applications/networking/instant-messengers/rambox/bare.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     inherit src;
 
     nodejs = nodejs-10_x;
-    sha256 = "0slzw4791nl7v6sca9xlhzx16p91m92ln2agbkbdx4zpgasg4gnq";
+    sha256 = "1zw3pjj3z29n9s08xyid41yq765d4c16lgml79m24zw36qaji6h1";
   };
 
   patches = [ ./isDev.patch ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes the hash of the fixed-output derivation (for me) which fetches NPM-dependencies for `rambox`. fpletz told me that this hash appears to change from time to time, so before somebody merges this we should discuss the following questions:

* Is the hash I got reproducible? (I'd like to avoid that my change causes build failures on other setups)
* If that hash changes regularly: shouldn't we modify the build process (e.g. by explicitly pinning *all* dependencies with `yarn2nix`) to avoid that kind of issues in the future?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @gnidorah (package maintainer), @zimbatm (who changed the hash the last time in 727c20f8e1afc0da494e83ced465bc8f65470df5)
