### PR TITLE
Added micronucleus

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1075,6 +1075,21 @@
     githubId = 510553;
     name = "Jos van Bakel";
   };
+  cab404 = {
+    email = "cab404@mailbox.org";
+    github = "cab404";
+    githubId = 6453661;
+    name = "Vladimir Serov";
+    keys = [
+      # compare with https://keybase.io/cab404
+      { longkeyid = "1BB96810926F4E715DEF567E6BA7C26C3FDF7BB3";
+        fingerprint = "rsa3072/0xCBDECF658C38079E";
+      }
+      { longkeyid = "1EBC648C64D6045463013B3EB7EFFC271D55DB8A";
+        fingerprint = "ed25519/0xB7EFFC271D55DB8A";
+      }
+    ];
+  };
   calbrecht = {
     email = "christian.albrecht@mayflower.de";
     github = "calbrecht";

--- a/pkgs/development/tools/misc/micronucleus/default.nix
+++ b/pkgs/development/tools/misc/micronucleus/default.nix
@@ -1,0 +1,37 @@
+{
+  pkgs
+, stdenv
+, libusb
+, fetchFromGitHub
+, lib
+}:
+stdenv.mkDerivation rec {
+   pname = "micronucleus";
+   version = "2.04";
+
+   sourceRoot = "source/commandline";
+
+   src = fetchFromGitHub {
+     owner = "micronucleus";
+     repo = "micronucleus";
+     rev = version;
+     sha256 = "14msy9amlbflw5mqrbs57b7bby3nsgx43srr7215zyhfdgsla0in";
+   };
+
+   buildInputs = [ libusb ];
+
+   installPhase = ''
+     mkdir -p $out/bin
+     mkdir -p $out/lib/udev
+     cp micronucleus $out/bin
+     cp 49-micronucleus.rules $out/lib/udev
+   '';
+
+   meta = with lib; {
+     description = "Upload tool for micronucleus";
+     homepage = "https://github.com/micronucleus/micronucleus";
+     license = licenses.gpl3;
+     maintainers = [ maintainers.cab404 ];
+   };
+
+}

--- a/pkgs/development/tools/misc/micronucleus/default.nix
+++ b/pkgs/development/tools/misc/micronucleus/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
    };
 
    buildInputs = [ libusb ];
+   makeFlags = stdenv.lib.optionals stdenv.isDarwin [ "CC=cc" ];
 
    installPhase = ''
      mkdir -p $out/bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13219,6 +13219,8 @@ in
 
   microsoft_gsl = callPackage ../development/libraries/microsoft_gsl { };
 
+  micronucleus = callPackage ../development/tools/misc/micronucleus { };
+
   mimalloc = callPackage ../development/libraries/mimalloc { };
 
   minizip = callPackage ../development/libraries/minizip { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Micronucleus is a nice bootloader for ATTiny boards, and is used by Digispark. This is a command line tool to flash stuff into it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).