### PR TITLE
python3Packages.gpxpy: init at 1.3.5

### DIFF
--- a/pkgs/development/python-modules/gpxpy/default.nix
+++ b/pkgs/development/python-modules/gpxpy/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, buildPythonPackage, python, lxml }:
+
+buildPythonPackage rec {
+  pname = "gpxpy";
+  version = "1.3.5";
+
+  src = fetchFromGitHub {
+    owner = "tkrajina";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "18r7pfda7g3l0hv8j9565n52cvvgjxiiqqzagfdfaba1djgl6p8b";
+  };
+
+  propagatedBuildInputs = [ lxml ];
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest test
+  '';
+
+  meta = with lib; {
+    description = "Python GPX (GPS eXchange format) parser";
+    homepage = "https://github.com/tkrajina/gpxpy";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2652,6 +2652,8 @@ in {
 
   gpsoauth = callPackage ../development/python-modules/gpsoauth { };
 
+  gpxpy = callPackage ../development/python-modules/gpxpy { };
+
   grip = callPackage ../development/python-modules/grip { };
 
   gst-python = callPackage ../development/python-modules/gst-python {


### PR DESCRIPTION
###### Motivation for this change
[**gpxpy**](https://github.com/tkrajina/gpxpy) - GPX file parser.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```sh
$ nix path-info -Sh ./result
/nix/store/83z3y74jbf9n711ndvcp37fravn9h01m-gpxpy-1.3.5	 103.8M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
