### PR TITLE
Add many new pythonPackages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3560,6 +3560,16 @@
     githubId = 87115;
     name = "Wael Nasreddine";
   };
+  kamadorueda = {
+    name = "Kevin Amado";
+    email = "kamadorueda@gmail.com";
+    github = "kamadorueda";
+    githubId = 47480384;
+    keys = [{
+      longkeyid = "rsa4096/0x04D0CEAF916A9A40";
+      fingerprint = "2BE3 BAFD 793E A349 ED1F  F00F 04D0 CEAF 916A 9A40";
+    }];
+  };
   kamilchm = {
     email = "kamil.chm@gmail.com";
     github = "kamilchm";

--- a/pkgs/development/python-modules/azure-identity/default.nix
+++ b/pkgs/development/python-modules/azure-identity/default.nix
@@ -1,0 +1,53 @@
+{ buildPythonPackage
+, fetchPypi
+, isPy38
+, lib
+
+# pythonPackages
+, azure-common
+, azure-core
+, azure-nspkg
+, cryptography
+, mock
+, msal
+, msal-extensions
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  pname = "azure-identity";
+  version = "1.1.0";
+  disabled = isPy38;
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "1xn4nwi4vly8n3mmphv0wbdg9k55gsgmk3fdwma8rm3m3c7593hc";
+  };
+
+  propagatedBuildInputs = [
+    azure-common
+    azure-core
+    azure-nspkg
+    cryptography
+    mock
+    msal
+    msal-extensions
+    msrest
+    msrestazure
+  ];
+
+  # Requires checkout from mono-repo and a mock account:
+  #   https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/identity/tests.yml
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Microsoft Azure Identity Library for Python";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/azure-keyvault-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault-nspkg/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+
+# pythonPackages
+, azure-nspkg
+}:
+
+buildPythonPackage rec {
+  pname = "azure-keyvault-nspkg";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "0hdnd6124hx7s16z1pssmq5m5mqqqz8s38ixl9aayv4wmf5bhs5c";
+  };
+
+  propagatedBuildInputs = [
+    azure-nspkg
+  ];
+
+  # Just a namespace package, no tests exist:
+  #   https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/keyvault/tests.yml
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Microsoft Azure Key Vault Namespace Package [Internal]";
+    homepage = "https://github.com/Azure/azure-sdk-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/bandit/default.nix
+++ b/pkgs/development/python-modules/bandit/default.nix
@@ -1,0 +1,44 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, isPy3k
+
+# pythonPackages
+, GitPython
+, pbr
+, pyyaml
+, six
+, stevedore
+}:
+
+buildPythonPackage rec {
+  pname = "bandit";
+  version = "1.6.2";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rb034c99pyhb4a60z7f2kz40cjydhm8m9v2blaal1rmhlam7rs1";
+  };
+
+  propagatedBuildInputs = [
+    GitPython
+    pbr
+    pyyaml
+    six
+    stevedore
+  ];
+
+  # Framework is Tox, tox performs 'pip install' inside the virtual-env
+  #   and this requires Network Connectivity
+  doCheck = false;
+
+  meta = {
+    description = "Security oriented static analyser for python code";
+    homepage = "https://bandit.readthedocs.io/en/latest/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/javaobj-py3/default.nix
+++ b/pkgs/development/python-modules/javaobj-py3/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "javaobj-py3";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0j9532i7bnjd0v4a8c36mjj9rsdnbmckk65dh9sbmvnhy3j6jx55";
+  };
+
+  # Tests assume network connectivity
+  doCheck = false;
+
+  meta = {
+    description = "Module for serializing and de-serializing Java objects";
+    homepage = "https://github.com/tcalmant/python-javaobj";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/msal-extensions/default.nix
+++ b/pkgs/development/python-modules/msal-extensions/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+
+# pythonPackages
+, msal
+, portalocker
+}:
+
+buildPythonPackage rec {
+  pname = "msal-extensions";
+  version = "0.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p05cbfksnhijx1il7s24js2ydzgxbpiasf607qdpb5sljlp3qar";
+  };
+
+  propagatedBuildInputs = [
+    msal
+    portalocker
+  ];
+
+  # No tests found
+  doCheck = false;
+
+  meta = with lib; {
+    description = "The Microsoft Authentication Library Extensions (MSAL-Extensions) for Python";
+    homepage = "https://github.com/AzureAD/microsoft-authentication-library-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/msal/default.nix
+++ b/pkgs/development/python-modules/msal/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+
+# pythonPackages
+, pyjwt
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "msal";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0h33wayvakggr684spdyhiqvrwraavcbk3phmcbavb3zqxd3zgpc";
+  };
+
+  propagatedBuildInputs = [
+    pyjwt
+    requests
+  ];
+
+  # Tests assume Network Connectivity:
+  #   https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/e2958961e8ec16d0af4199f60c36c3f913497e48/tests/test_authority.py#L73
+  doCheck = false;
+
+  meta = with lib; {
+    description = "The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect";
+    homepage = "https://github.com/AzureAD/microsoft-authentication-library-for-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/names/default.nix
+++ b/pkgs/development/python-modules/names/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+
+# pythonPackages
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "names";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "treyhunner";
+    repo = pname;
+    rev = version;
+    sha256 = "0jfn11bl05k3qkqw0f4vi2i2lhllxdrbb1732qiisdy9fbvv8611";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = {
+    description = "Generate random names";
+    homepage = "https://github.com/treyhunner/names";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/oyaml/default.nix
+++ b/pkgs/development/python-modules/oyaml/default.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+
+# pythonPackages
+, pytest
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "oyaml";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "wimglenn";
+    repo = "oyaml";
+    rev = "v${version}";
+    sha256 = "13xjdym0p0jh9bvyjsbhi4yznlp68bamy3xi4w5wpcrzlcq6cfh9";
+  };
+
+  propagatedBuildInputs = [
+    pyyaml
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest test_oyaml.py
+  '';
+
+  meta = {
+    description = "Ordered YAML: drop-in replacement for PyYAML which preserves dict ordering";
+    homepage = "https://github.com/wimglenn/oyaml";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pyjks/default.nix
+++ b/pkgs/development/python-modules/pyjks/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+
+# pythonPackages
+, pyasn1-modules
+, pycryptodomex
+, twofish
+}:
+
+buildPythonPackage rec {
+  pname = "pyjks";
+  version = "19.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06h1cybsdj2wi0jf7igbr722xfm87crqn4g7m3bgrpxwi41b9rcw";
+  };
+
+  propagatedBuildInputs = [
+    pyasn1-modules
+    pycryptodomex
+    twofish
+  ];
+
+  # Tests assume network connectivity
+  doCheck = false;
+
+  meta = {
+    description = "Pure-Python Java Keystore (JKS) library";
+    homepage = "https://github.com/kurtbrose/pyjks";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/pysmb/default.nix
+++ b/pkgs/development/python-modules/pysmb/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+
+# pythonPackages
+, pyasn1
+}:
+
+buildPythonPackage rec {
+  pname = "pysmb";
+  version = "1.1.28";
+
+  src = fetchPypi {
+    inherit pname version;
+    format = "setuptools";
+    extension = "zip";
+    sha256 = "0x44yq440c1j3xnl7qigz2fpfzhx68n9mbj7ps7rd0kj0plcmr2q";
+  };
+
+  propagatedBuildInputs = [
+    pyasn1
+  ];
+
+  # Tests require Network Connectivity and a server up and running
+  #   https://github.com/miketeo/pysmb/blob/master/python3/tests/README_1st.txt
+  doCheck = false;
+
+  meta = {
+    description = "Experimental SMB/CIFS library written in Python to support file sharing between Windows and Linux machines";
+    homepage = "https://miketeo.net/wp/index.php/projects/pysmb";
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/requirements-detector/default.nix
+++ b/pkgs/development/python-modules/requirements-detector/default.nix
@@ -1,0 +1,38 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, lib
+
+# pythonPackages
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "requirements-detector";
+  version = "0.6";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "yuvadm";
+    repo = pname;
+    rev = version;
+    sha256 = "15s0n1lhkz0zwi33waqkkjipal3f7s45rxsj1bw89xpr4dj87qx5";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = {
+    description = "Python tool to find and list requirements of a Python project";
+    homepage = "https://github.com/landscapeio/requirements-detector";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/twofish/default.nix
+++ b/pkgs/development/python-modules/twofish/default.nix
@@ -1,0 +1,33 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+
+# pythonPackages
+, javaobj-py3
+}:
+
+buildPythonPackage rec {
+  pname = "twofish";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1yihp2n42amrxw0wk9f66llpb3w5kwhgkcdg9krkzcik1nsqp7dh";
+  };
+
+  propagatedBuildInputs = [
+    javaobj-py3
+  ];
+
+  # No tests implemented
+  doCheck = false;
+
+  meta = {
+    description = "Bindings for the Twofish implementation by Niels Ferguson";
+    homepage = "https://github.com/keybase/python-twofish";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/viewstate/default.nix
+++ b/pkgs/development/python-modules/viewstate/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, lib
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "viewstate";
+  version = "0.4.3";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "yuvadm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "15s0n1lhkz0zwi33waqkkjipal3f7s45rxsj1bw89xpr4dj87qx5";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = {
+    description = ".NET viewstate decoder";
+    homepage = "https://github.com/yuvadm/viewstate";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6458,6 +6458,8 @@ in {
 
   twilio = callPackage ../development/python-modules/twilio { };
 
+  twofish = callPackage ../development/python-modules/twofish { };
+
   uranium = callPackage ../development/python-modules/uranium { };
 
   uuid = callPackage ../development/python-modules/uuid { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1670,6 +1670,8 @@ in {
 
   babelfish = callPackage ../development/python-modules/babelfish {};
 
+  bandit = callPackage ../development/python-modules/bandit {};
+
   basiciw = callPackage ../development/python-modules/basiciw {
     inherit (pkgs) gcc wirelesstools;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5099,6 +5099,8 @@ in {
 
   requests-http-signature = callPackage ../development/python-modules/requests-http-signature { };
 
+  requirements-detector = callPackage ../development/python-modules/requirements-detector { };
+
   resampy = callPackage ../development/python-modules/resampy { };
 
   restructuredtext_lint = callPackage ../development/python-modules/restructuredtext_lint { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1155,6 +1155,8 @@ in {
     slurm = pkgs.slurm;
   };
 
+  pysmb = callPackage ../development/python-modules/pysmb { };
+
   pysmf = callPackage ../development/python-modules/pysmf { };
 
   pyspinel = callPackage ../development/python-modules/pyspinel {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -288,6 +288,8 @@ in {
 
   azure-keyvault-keys = callPackage ../development/python-modules/azure-keyvault-keys { };
 
+  azure-keyvault-nspkg = callPackage ../development/python-modules/azure-keyvault-nspkg { };
+
   azure-keyvault-secrets = callPackage ../development/python-modules/azure-keyvault-secrets { };
 
   azure-loganalytics = callPackage ../development/python-modules/azure-loganalytics { };
@@ -1969,7 +1971,7 @@ in {
   certifi = callPackage ../development/python-modules/certifi { };
 
   certipy = callPackage ../development/python-modules/certipy {};
- 
+
   characteristic = callPackage ../development/python-modules/characteristic { };
 
   chart-studio = callPackage ../development/python-modules/chart-studio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6464,6 +6464,8 @@ in {
 
   versioneer = callPackage ../development/python-modules/versioneer { };
 
+  viewstate = callPackage ../development/python-modules/viewstate { };
+
   vine = callPackage ../development/python-modules/vine { };
 
   visitor = callPackage ../development/python-modules/visitor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -839,6 +839,8 @@ in {
 
   msal = callPackage ../development/python-modules/msal { };
 
+  msal-extensions = callPackage ../development/python-modules/msal-extensions { };
+
   msrest = callPackage ../development/python-modules/msrest { };
 
   msrestazure = callPackage ../development/python-modules/msrestazure { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -837,8 +837,11 @@ in {
     mpi = pkgs.openmpi;
   };
 
-  msrestazure = callPackage ../development/python-modules/msrestazure { };
+  msal = callPackage ../development/python-modules/msal { };
+
   msrest = callPackage ../development/python-modules/msrest { };
+
+  msrestazure = callPackage ../development/python-modules/msrestazure { };
 
   multiset = callPackage ../development/python-modules/multiset { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2839,6 +2839,8 @@ in {
 
   oset = callPackage ../development/python-modules/oset { };
 
+  oyaml = callPackage ../development/python-modules/oyaml { };
+
   pamela = callPackage ../development/python-modules/pamela { };
 
   paperspace = callPackage ../development/python-modules/paperspace { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6387,6 +6387,8 @@ in {
 
   jaraco_stream = callPackage ../development/python-modules/jaraco_stream { };
 
+  javaobj-py3 = callPackage ../development/python-modules/javaobj-py3 { };
+
   javaproperties = callPackage ../development/python-modules/javaproperties { };
 
   tempora= callPackage ../development/python-modules/tempora { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2179,6 +2179,8 @@ in {
 
   pyjet = callPackage ../development/python-modules/pyjet {};
 
+  pyjks = callPackage ../development/python-modules/pyjks {};
+
   PyLD = callPackage ../development/python-modules/PyLD { };
 
   python-jose = callPackage ../development/python-modules/python-jose {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4196,6 +4196,8 @@ in {
 
   nameparser = callPackage ../development/python-modules/nameparser { };
 
+  names = callPackage ../development/python-modules/names { };
+
   nbconvert = callPackage ../development/python-modules/nbconvert { };
 
   nbformat = callPackage ../development/python-modules/nbformat { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -282,6 +282,8 @@ in {
 
   azure-graphrbac = callPackage ../development/python-modules/azure-graphrbac { };
 
+  azure-identity = callPackage ../development/python-modules/azure-identity { };
+
   azure-keyvault = callPackage ../development/python-modules/azure-keyvault { };
 
   azure-keyvault-keys = callPackage ../development/python-modules/azure-keyvault-keys { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

- Add many pythonPackages that exist on PyPi and not on nixpkgs

###### Motivation for this change

- Nixpkgs completeness

###### Things done

- Added myself as maintainer
- Enforced Contributing guidelines on three existing packages (refactoring)
- Added new packages at its current stable version

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


```
kamado:~/Documents/nixpkgs$ nix-review rev HEAD
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nix-review/0
$ git worktree add /home/kamado/.cache/nix-review/rev-509a25d2cbb870af19cd8646a21be1a7b060cee8-1/nixpkgs 3d70d4ba0b6be256974910e635fadcc0e9579b2a
Preparing worktree (detached HEAD 3d70d4ba0b6)
HEAD is now at 3d70d4ba0b6 nixos/displayManager: fix typo in legacy sessions (#76626)
$ nix-env -f /home/kamado/.cache/nix-review/rev-509a25d2cbb870af19cd8646a21be1a7b060cee8-1/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 509a25d2cbb870af19cd8646a21be1a7b060cee8
Updating 3d70d4ba0b6..509a25d2cbb
Fast-forward
 maintainers/maintainer-list.nix                                    | 10 ++++++++++
 pkgs/applications/misc/gcalcli/default.nix                         |  2 +-
 pkgs/applications/networking/gmailieer/default.nix                 |  2 +-
 pkgs/applications/networking/instant-messengers/blink/default.nix  |  2 +-
 pkgs/development/python-modules/alot/default.nix                   |  4 ++--
 pkgs/development/python-modules/azure-core/default.nix             | 35 +++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/azure-identity/default.nix         | 43 +++++++++++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/azure-keyvault-keys/default.nix    | 39 +++++++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/azure-keyvault-nspkg/default.nix   | 31 ++++++++++++++++++++++++++++++
 pkgs/development/python-modules/azure-keyvault-secrets/default.nix | 39 +++++++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/bandit/default.nix                 | 38 ++++++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/beancount/default.nix              |  8 ++++----
 pkgs/development/python-modules/eyed3/default.nix                  |  4 ++--
 pkgs/development/python-modules/gdrivefs/default.nix               |  4 ++--
 pkgs/development/python-modules/goobook/default.nix                |  4 ++--
 pkgs/development/python-modules/graphitepager/default.nix          |  4 ++--
 pkgs/development/python-modules/javaobj-py3/default.nix            | 25 ++++++++++++++++++++++++
 pkgs/development/python-modules/msal-extensions/default.nix        | 34 ++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/msal/default.nix                   | 34 ++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/mysql-connector-python/default.nix | 33 +++++++++++++++++++++++++++++++
 pkgs/development/python-modules/mysql-connector/default.nix        | 34 +++++++++++++-------------------
 pkgs/development/python-modules/names/default.nix                  | 25 ++++++++++++++++++++++++
 pkgs/development/python-modules/oyaml/default.nix                  | 32 ++++++++++++++++++++++++++++++
 pkgs/development/python-modules/peewee/default.nix                 |  4 ++--
 pkgs/development/python-modules/pushbullet/default.nix             |  4 ++--
 pkgs/development/python-modules/pydrive/default.nix                |  4 ++--
 pkgs/development/python-modules/pyjks/default.nix                  | 34 ++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/pysmb/default.nix                  | 34 ++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/relatorio/default.nix              |  4 ++--
 pkgs/development/python-modules/requirements-detector/default.nix  | 32 ++++++++++++++++++++++++++++++
 pkgs/development/python-modules/thumbor/default.nix                |  4 ++--
 pkgs/development/python-modules/twofish/default.nix                | 32 ++++++++++++++++++++++++++++++
 pkgs/development/python-modules/viewstate/default.nix              | 27 ++++++++++++++++++++++++++
 pkgs/development/python-modules/weboob/default.nix                 |  4 ++--
 pkgs/servers/home-assistant/component-packages.nix                 |  2 +-
 pkgs/servers/mautrix-telegram/default.nix                          |  2 +-
 pkgs/tools/misc/diffoscope/default.nix                             |  2 +-
 pkgs/tools/networking/s3cmd/default.nix                            |  4 ++--
 pkgs/top-level/python-packages.nix                                 | 47 +++++++++++++++++++++++++++++++++++++++------
 39 files changed, 665 insertions(+), 61 deletions(-)
 create mode 100644 pkgs/development/python-modules/azure-core/default.nix
 create mode 100644 pkgs/development/python-modules/azure-identity/default.nix
 create mode 100644 pkgs/development/python-modules/azure-keyvault-keys/default.nix
 create mode 100644 pkgs/development/python-modules/azure-keyvault-nspkg/default.nix
 create mode 100644 pkgs/development/python-modules/azure-keyvault-secrets/default.nix
 create mode 100644 pkgs/development/python-modules/bandit/default.nix
 create mode 100644 pkgs/development/python-modules/javaobj-py3/default.nix
 create mode 100644 pkgs/development/python-modules/msal-extensions/default.nix
 create mode 100644 pkgs/development/python-modules/msal/default.nix
 create mode 100644 pkgs/development/python-modules/mysql-connector-python/default.nix
 create mode 100644 pkgs/development/python-modules/names/default.nix
 create mode 100644 pkgs/development/python-modules/oyaml/default.nix
 create mode 100644 pkgs/development/python-modules/pyjks/default.nix
 create mode 100644 pkgs/development/python-modules/pysmb/default.nix
 create mode 100644 pkgs/development/python-modules/requirements-detector/default.nix
 create mode 100644 pkgs/development/python-modules/twofish/default.nix
 create mode 100644 pkgs/development/python-modules/viewstate/default.nix
$ nix-env -f /home/kamado/.cache/nix-review/rev-509a25d2cbb870af19cd8646a21be1a7b060cee8-1/nixpkgs -qaP --xml --out-path --show-trace --meta
$ nix build --no-link --keep-going --max-jobs 4 --option build-use-sandbox true -f /home/kamado/.cache/nix-review/rev-509a25d2cbb870af19cd8646a21be1a7b060cee8-1/build.nix
55 package were built:
python27Packages.azure-core python27Packages.azure-identity python27Packages.azure-keyvault-keys python27Packages.azure-keyvault-nspkg python27Packages.azure-keyvault-secrets python27Packages.google-api-python-client python27Packages.javaobj-py3 python27Packages.msal python27Packages.msal-extensions python27Packages.mysql-connector python27Packages.mysql-connector-python python27Packages.names python27Packages.oyaml python27Packages.pyjks python27Packages.pysmb python27Packages.python-magic python27Packages.requirements-detector python27Packages.twofish python37Packages.azure-core python37Packages.azure-identity python37Packages.azure-keyvault-keys python37Packages.azure-keyvault-nspkg python37Packages.azure-keyvault-secrets python37Packages.bandit python37Packages.google-api-python-client python37Packages.javaobj-py3 python37Packages.msal python37Packages.msal-extensions python37Packages.mysql-connector python37Packages.mysql-connector-python python37Packages.names python37Packages.oyaml python37Packages.pyjks python37Packages.pysmb python37Packages.python-magic python37Packages.requirements-detector python37Packages.twofish python37Packages.viewstate python38Packages.azure-core python38Packages.azure-keyvault-nspkg python38Packages.bandit python38Packages.google-api-python-client python38Packages.javaobj-py3 python38Packages.msal python38Packages.msal-extensions python38Packages.mysql-connector python38Packages.mysql-connector-python python38Packages.names python38Packages.oyaml python38Packages.pyjks python38Packages.pysmb python38Packages.python-magic python38Packages.requirements-detector python38Packages.twofish python38Packages.viewstate

[0.0 MiB DL]
error: build log of '/nix/store/wg0k7wzh1s9vr10dknnzlnmm8i3fszgk-python2.7-google-api-python-client-1.7.6.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/qz88qv9498h1iw20in8gri11fx6aasw5-python2.7-python-magic-0.4.15.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/7mvq1n72ib4yd2c7r94rx1dgmxah37db-python3.7-google-api-python-client-1.7.11.drv' is not available
[0.0 MiB DL]
error: build log of '/nix/store/vm78sav3drbblq7rfpd6a5c2m9mvpmgg-python3.7-python-magic-0.4.15.drv' is not available
[0.0 MiB DL]
[0.0 MiB DL]
```

logs are not found because those packages are not built, it's just a refactor