### PR TITLE
ibus-table-vietnamese: init at 20190825

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4307,6 +4307,12 @@
     githubId = 158568;
     name = "Matthias C. M. Troffaes";
   };
+  McSinyx = {
+    email = "vn.mcsinyx@gmail.com";
+    github = "McSinyx";
+    githubId = 13689192;
+    name = "Nguyễn Gia Phong";
+  };
   mdaiter = {
     email = "mdaiter8121@gmail.com";
     github = "mdaiter";

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-vietnamese/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-vietnamese/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, pkgconfig, ibus, ibus-table, python3 }:
+
+stdenv.mkDerivation rec {
+  pname = "ibus-table-vietnamese";
+  version = "20190825";
+
+  src = fetchFromGitHub {
+    owner = "McSinyx";
+    repo = "ibus-table-vietnamese";
+    rev = "32d577929a2f65c20287d773f112354a41aa52e6";
+    sha256 = "0i86rbhrjxbvkkxib37hsvrm610qi2gi624an94plw243hffnz32";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ ibus ibus-table python3 ];
+
+  preBuild = ''
+    export HOME=$(mktemp -d)/ibus-table-vietnamese
+  '';
+
+  preInstall = ''
+    export DATADIR=$out/share
+  '';
+
+  postFixup = ''
+    rm -rf $HOME
+  '';
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    description  = "Telex and VNI IM for ibus-table";
+    homepage     = https://github.com/McSinyx/ibus-table-vietnamese;
+    license      = licenses.gpl3Plus;
+    platforms    = platforms.linux;
+    maintainers  = with maintainers; [ McSinyx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2471,6 +2471,10 @@ in
       ibus-table = ibus-engines.table;
     };
 
+    table-vietnamese = callPackage ../tools/inputmethods/ibus-engines/ibus-table-vietnamese {
+      ibus-table = ibus-engines.table;
+    };
+
     uniemoji = callPackage ../tools/inputmethods/ibus-engines/ibus-uniemoji { };
 
     typing-booster-unwrapped = callPackage ../tools/inputmethods/ibus-engines/ibus-typing-booster { };


### PR DESCRIPTION
###### Motivation for this change
I am trying to add some Vietnamese IBus tables I have been using on regular basis for quite a few year.  This is the first time I am doing this so I am not sure if there is anything missing.

Additionally, is setting `$HOME` to a temporary directory before build necessary in this case?  This is almost a copypasta from the `ibus-table-others` which does it.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (`nix-build -A ibus-engines.table-vietnamese`)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).