### PR TITLE
zenpower: init at 0.1.5

### DIFF
--- a/nixos/modules/hardware/sensor/zenpower.nix
+++ b/nixos/modules/hardware/sensor/zenpower.nix
@@ -1,0 +1,16 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+{
+  options = {
+    hardware.sensor.zenpower = {
+      enable = mkEnableOption "additional sensors for AMD Zen family CPUs";
+    };
+  };
+
+  config = mkIf config.hardware.sensor.zenpower.enable {
+    boot.kernelModules = [ "zenpower" ];
+    boot.blacklistedKernelModules = [ "k10temp" ];
+    boot.extraModulePackages = [ config.boot.kernelPackages.zenpower ];
+  };
+}

--- a/pkgs/os-specific/linux/zenpower/default.nix
+++ b/pkgs/os-specific/linux/zenpower/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  name = "zenpower-${version}";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "ocerman";
+    repo = "zenpower";
+    rev = "3406cda35c44013a181a535e852c65985f45e242";
+    sha256 = "1ay1q666bc7czgc95invw523c0ds2gj85wxypc3wi418vfaha5vy";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = "KERNEL_MODULES=${kernel.dev}/lib/modules/${kernel.modDirVersion}/";
+
+  installPhase = let
+    modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/hwmon/zenpower";
+  in ''
+    mkdir -p ${modDestDir}
+    cp zenpower.ko ${modDestDir}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Driver for reading sensors data for AMD Zen family CPUs.";
+    homepage = https://github.com/ocerman/zenpower;
+    license = licenses.unfree; # actually, not specified
+    maintainers = with maintainers; [ wedens ];
+    platforms = platforms.linux;
+    longDescription = ''
+      Zenpower is Linux kernel driver for reading temperature, voltage(SVI2), current(SVI2) and power(SVI2) for AMD Zen family CPUs.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16497,6 +16497,8 @@ in
 
      zfs = zfsStable;
 
+     zenpower = callPackage ../os-specific/linux/zenpower { };
+
      can-isotp = callPackage ../os-specific/linux/can-isotp { };
   });
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Zenpower is Linux kernel driver for reading temperature, voltage(SVI2), current(SVI2) and power(SVI2) for AMD Zen family CPUs.

This PR zenpower kernel module and corresponding NixOS module.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
