### PR TITLE
alure2: init at unstable-2019-09-21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4307,6 +4307,12 @@
     githubId = 158568;
     name = "Matthias C. M. Troffaes";
   };
+  McSinyx = {
+    email = "vn.mcsinyx@gmail.com";
+    github = "McSinyx";
+    githubId = 13689192;
+    name = "Nguyễn Gia Phong";
+  };
   mdaiter = {
     email = "mdaiter8121@gmail.com";
     github = "mdaiter";

--- a/pkgs/development/libraries/alure2/default.nix
+++ b/pkgs/development/libraries/alure2/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, openal, libvorbis, opusfile, libsndfile }:
+
+stdenv.mkDerivation rec {
+  pname = "alure2";
+  version = "unstable-2020-01-09";
+
+  src = fetchFromGitHub {
+    owner = "kcat";
+    repo = "alure";
+    rev = "4b7b58d3f0de444d6f26aa705704deb59145f586";
+    sha256 = "0ds18hhy2wpvx498z5hcpzfqz9i60ixsi0cjihyvk20rf4qy12vg";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openal libvorbis opusfile libsndfile ];
+
+  meta = with stdenv.lib; {
+    description = "A utility library for OpenAL, providing a C++ API and managing common tasks that include file loading, caching, and streaming";
+    homepage = "https://github.com/kcat/alure";
+    license = licenses.zlib;
+    platforms = platforms.linux;
+    maintainers  = with maintainers; [ McSinyx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10616,6 +10616,8 @@ in
 
   alure = callPackage ../development/libraries/alure { };
 
+  alure2 = callPackage ../development/libraries/alure2 { };
+
   agg = callPackage ../development/libraries/agg { };
 
   allegro = allegro4;


### PR DESCRIPTION
###### Motivation for this change
I am trying to add the new major release of alure, which has C++11 API instead of the previous C API.  This should not replace alure 1 since the two are incompatible.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Tested compilation and usage of examples
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).