### PR TITLE
warsaw-bin: init at 2.21.1.13

### DIFF
--- a/pkgs/servers/warsaw-bin/default.nix
+++ b/pkgs/servers/warsaw-bin/default.nix
@@ -1,0 +1,111 @@
+{ stdenv
+, lib
+, buildFHSUserEnv
+, fetchurl
+, dpkg
+, pkg-config
+, chrpath
+, openssl
+, curl
+, dbus
+, nss
+, at-spi2-core
+, gtk2
+, xorg
+, python3Packages
+, mc
+, hello
+, sudo
+, firefox-bin
+, autoPatchelfHook
+}:
+
+let
+  warsaw-bin-core = stdenv.mkDerivation rec {
+    pname = "warsaw-bin-core";
+    version = "2.21.1.13";
+
+    src = fetchurl {
+      url = "https://cloud.gastecnologia.com.br/gas/diagnostico/warsaw_setup_64.deb";
+      sha256 = "sha256-Xd6MRbR33g6dBaBj9mxdmRIkgOFxM0IaKVSxU0SmyUI=";
+    };
+
+    # src = fetchurl {
+    #   url = "https://cloud.gastecnologia.com.br/cef/warsaw/install/GBPCEFwr64.deb";
+    #   sha256 = "sha256-Ll+Joc6Ayp7EHx89fhNegpIcvat1UKEidHpWH6ulQhI=";
+    # };
+
+    nativeBuildInputs = [
+      dpkg
+      pkg-config
+      chrpath
+      python3Packages.wrapPython
+      autoPatchelfHook
+    ];
+
+    buildInputs = [
+      openssl
+      curl
+      dbus
+      nss
+      at-spi2-core
+      gtk2
+      python3Packages.python
+      mc
+      firefox-bin
+    ];
+
+    unpackPhase = ''
+      dpkg-deb -x ${src} ./
+    '';
+
+    installPhase = ''
+      echo ---------------
+      find -ls | sort
+      echo ---------------
+      mkdir -p $out
+      cp -a etc $out
+      cp -a usr/* $out
+      cp -a lib $out
+      echo ---------------
+      find $out -ls | sort
+      echo ---------------
+    '';
+
+    dontConfigure = true;
+
+    dontBuild = true;
+
+    dontPatchELF = true;
+  };
+
+in
+# warsaw-bin-core
+
+buildFHSUserEnv {
+  name = "warsaw-bin";
+
+  targetPkgs = pkgs: with pkgs; [
+    at-spi2-core
+    curl
+    dbus
+    gtk2
+    nss
+    openssl
+    sudo
+    warsaw-bin-core
+    firefox-bin
+    #ping
+  ];
+
+  runScript = "bash";
+
+  meta = with lib; {
+    description = "Banking security tool developed by GAS Tecnologia";
+    homepage = "https://diagnostico.gasantifraud.com";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ romildo ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22233,6 +22233,8 @@ with pkgs;
 
   wallabag = callPackage ../servers/web-apps/wallabag { };
 
+  warsaw-bin = callPackage ../servers/warsaw-bin { };
+
   webdav = callPackage ../servers/webdav { };
 
   webdav-server-rs = callPackage ../servers/webdav-server-rs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add `warsaw-bin` to nixpkgs.

Warsaw is a security solution developed by GAS Software that is used by most banks (in Brazil) that do not use Java technology to authenticate Internet Banking users.

[Como instalar o Warsaw para usar Internet Banking no Linux](https://www.edivaldobrito.com.br/warsaw-para-usar-internet-banking-no-linux/) (in Portuguese)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
