### PR TITLE
pynagsystemd: init at 1.2.0 and dependencies

### DIFF
--- a/pkgs/development/python-modules/nagiosplugin/default.nix
+++ b/pkgs/development/python-modules/nagiosplugin/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, twine
+, numpy
+, pytest
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "nagiosplugin";
+  version = "1.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vr3zy0zfvbrqc4nf81zxv4gs2q82sv5sjamdm4573ld529mk2nv";
+  };
+
+  buildInputs = [ twine ];
+  checkInputs = [ pytest numpy ];
+
+  doCheck = true;
+  checkPhase = ''
+    # this test relies on who, which does not work in the sandbox
+    pytest -k "not test_check_users" tests/
+  '';
+
+  meta = with lib; {
+    description = "A Python class library which helps with writing Nagios (Icinga) compatible plugins";
+    homepage =  https://github.com/mpounsett/nagiosplugin;
+    license = licenses.zpl21;
+    maintainers = with maintainers; [ symphorien ];
+  };
+}

--- a/pkgs/development/python-modules/nagiosplugin/default.nix
+++ b/pkgs/development/python-modules/nagiosplugin/default.nix
@@ -15,10 +15,9 @@ buildPythonPackage rec {
     sha256 = "1vr3zy0zfvbrqc4nf81zxv4gs2q82sv5sjamdm4573ld529mk2nv";
   };
 
-  buildInputs = [ twine ];
+  nativeBuildInputs = [ twine ];
   checkInputs = [ pytest numpy ];
 
-  doCheck = true;
   checkPhase = ''
     # this test relies on who, which does not work in the sandbox
     pytest -k "not test_check_users" tests/

--- a/pkgs/servers/monitoring/nagios/plugins/pynagsystemd.nix
+++ b/pkgs/servers/monitoring/nagios/plugins/pynagsystemd.nix
@@ -1,0 +1,22 @@
+{ fetchFromGitHub, python3Packages, lib }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pynagsystemd";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "kbytesys";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1xjhkhdpmqa7ngcpcfhrkmj4cid2wla3fzgr04wvw672ysffv2vz";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ nagiosplugin ];
+
+  meta = with lib; {
+    description = "Simple and easy nagios check for systemd status";
+    homepage = "https://github.com/kbytesys/pynagsystemd";
+    maintainers = with maintainers; [ symphorien ];
+    license = licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15456,6 +15456,8 @@ in
 
   checkSSLCert = callPackage ../servers/monitoring/nagios/plugins/check_ssl_cert.nix { };
 
+  pynagsystemd = callPackage ../servers/monitoring/nagios/plugins/pynagsystemd.nix { };
+
   neo4j = callPackage ../servers/nosql/neo4j { };
 
   check-esxi-hardware = callPackage ../servers/monitoring/plugins/esxi.nix {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -830,6 +830,8 @@ in {
 
   mwoauth = callPackage ../development/python-modules/mwoauth { };
 
+  nagiosplugin = callPackage ../development/python-modules/nagiosplugin { };
+
   nanomsg-python = callPackage ../development/python-modules/nanomsg-python { inherit (pkgs) nanomsg; };
 
   nbsmoke = callPackage ../development/python-modules/nbsmoke { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
