### PR TITLE
 pythonPackages.compiledb: init at 0.10.1 + dependencies

### DIFF
--- a/pkgs/development/python-modules/bashlex/default.nix
+++ b/pkgs/development/python-modules/bashlex/default.nix
@@ -1,0 +1,38 @@
+{ enum-compat
+, lib
+, buildPythonPackage
+, fetchFromGitHub
+, nose
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "bashlex";
+  version = "0.14";
+
+  src = fetchFromGitHub {
+    owner = "idank";
+    repo = pname;
+    rev = version;
+    sha256 = "070spmbf53y18miky5chgky4x5h8kp9czkp7dm173klv9pi2cn0k";
+  };
+
+  checkInputs = [ nose ];
+  propagatedBuildInputs = [ enum-compat ];
+
+  # workaround https://github.com/idank/bashlex/issues/51
+  preBuild = ''
+    ${python.interpreter} -c 'import bashlex'
+  '';
+
+  checkPhase = ''
+    ${python.interpreter} -m nose --with-doctest
+  '';
+
+  meta = with lib; {
+    description = "Python parser for bash";
+    license = licenses.gpl3;
+    homepage = https://github.com/idank/bashlex;
+    maintainers = with maintainers; [ multun ];
+  };
+}

--- a/pkgs/development/python-modules/compiledb/default.nix
+++ b/pkgs/development/python-modules/compiledb/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, bashlex
+, click
+, shutilwhich
+, gcc
+, coreutils
+}:
+
+buildPythonPackage rec {
+  pname = "compiledb";
+  version = "0.10.1";
+
+  src = fetchFromGitHub {
+    owner = "nickdiego";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0qricdgqzry7j3rmgwyd43av3c2kxpzkh6f9zcqbzrjkn78qbpd4";
+  };
+
+  # fix the tests
+  patchPhase = ''
+    substituteInPlace tests/data/multiple_commands_oneline.txt \
+                      --replace /bin/echo ${coreutils}/bin/echo
+  '';
+
+  checkInputs = [ pytest gcc coreutils ];
+  propagatedBuildInputs = [ click bashlex shutilwhich ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Tool for generating Clang's JSON Compilation Database files";
+    license = licenses.gpl3;
+    homepage = https://github.com/nickdiego/compiledb;
+    maintainers = with maintainers; [ multun ];
+  };
+}

--- a/pkgs/development/python-modules/shutilwhich/default.nix
+++ b/pkgs/development/python-modules/shutilwhich/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "shutilwhich";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "mbr";
+    repo = pname;
+    rev = version;
+    sha256 = "05fwcjn86w8wprck04iv1zccfi39skdf0lhwpb4b9gpvklyc9mj0";
+  };
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    pytest -rs
+  '';
+
+  meta = with lib; {
+    description = "Backport of shutil.which";
+    license = licenses.psfl;
+    homepage = https://github.com/mbr/shutilwhich;
+    maintainers = with maintainers; [ multun ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5211,6 +5211,8 @@ in {
 
   shippai = callPackage ../development/python-modules/shippai {};
 
+  shutilwhich = callPackage ../development/python-modules/shutilwhich { };
+
   simanneal = callPackage ../development/python-modules/simanneal { };
 
   simplegeneric = callPackage ../development/python-modules/simplegeneric { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -534,6 +534,8 @@ in {
 
   cocotb = callPackage ../development/python-modules/cocotb { };
 
+  compiledb = callPackage ../development/python-modules/compiledb { };
+
   connexion = callPackage ../development/python-modules/connexion { };
 
   cozy = callPackage ../development/python-modules/cozy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -466,6 +466,8 @@ in {
 
   bash_kernel = callPackage ../development/python-modules/bash_kernel { };
 
+  bashlex = callPackage ../development/python-modules/bashlex { };
+
   bayespy = callPackage ../development/python-modules/bayespy { };
 
   beanstalkc = callPackage ../development/python-modules/beanstalkc { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I need compiledb to run some proprietary software

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
