### PR TITLE
rakudo: 2017.01 -> 2020.01

### DIFF
--- a/pkgs/development/interpreters/rakudo/default.nix
+++ b/pkgs/development/interpreters/rakudo/default.nix
@@ -1,29 +1,29 @@
-{ stdenv, fetchurl, perl, icu, zlib, gmp, readline
-, CoreServices, ApplicationServices }:
+{ stdenv, fetchurl, perl, icu, zlib, gmp, lib, nqp }:
 
 stdenv.mkDerivation rec {
-  pname = "rakudo-star";
-  version = "2017.01";
+  pname = "rakudo";
+  version = "2020.01";
 
   src = fetchurl {
-    url    = "http://rakudo.org/downloads/star/${pname}-${version}.tar.gz";
-    sha256 = "07zjqdzxm30pmjqwlnr669d75bsbimy09sk0dvgm0pnn3zr92fjq";
+    url    = "https://github.com/rakudo/rakudo/releases/download/${version}/rakudo-${version}.tar.gz";
+    sha256 = "1c63ns90zy13gyj0l27k63q7dv08w4589w605nywd7pplbygq0if";
   };
 
-  buildInputs = [ icu zlib gmp readline perl ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ApplicationServices ];
+  buildInputs = [ icu zlib gmp perl ];
   configureScript = "perl ./Configure.pl";
-  configureFlags =
-    [ "--backends=moar"
-      "--gen-moar"
-      "--gen-nqp"
-    ];
+  configureFlags = [
+    "--backends=moar"
+    "--with-nqp=${nqp}/bin/nqp"
+  ];
+
+  # Some tests fail on Darwin
+  doCheck = !stdenv.isDarwin;
 
   meta = with stdenv.lib; {
-    description = "A Perl 6 implementation";
+    description = "Raku implementation on top of Moar virtual machine";
     homepage    = https://www.rakudo.org;
     license     = licenses.artistic2;
     platforms   = platforms.unix;
-    maintainers = with maintainers; [ thoughtpolice vrthra ];
+    maintainers = with maintainers; [ thoughtpolice vrthra sgo ];
   };
 }

--- a/pkgs/development/interpreters/rakudo/moarvm.nix
+++ b/pkgs/development/interpreters/rakudo/moarvm.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, perl
+, CoreServices, ApplicationServices }:
+
+stdenv.mkDerivation rec {
+  pname = "moarvm";
+  version = "2020.01.1";
+
+  src = fetchurl {
+    url    = "https://github.com/MoarVM/MoarVM/releases/download/${version}/MoarVM-${version}.tar.gz";
+    sha256 = "11rmlps6r3nqa9m2yyv9i2imahirsqmxbfay71f3gs4ql121xdnw";
+  };
+
+  buildInputs = [ perl ] ++ stdenv.lib.optionals stdenv.isDarwin [ CoreServices ApplicationServices ];
+  doCheck = false; # MoarVM does not come with its own test suite
+
+  configureScript = "${perl}/bin/perl ./Configure.pl";
+
+  meta = with stdenv.lib; {
+    description = "VM with adaptive optimization and JIT compilation, built for Rakudo";
+    homepage    = "https://github.com/MoarVM/MoarVM";
+    license     = licenses.artistic2;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice vrthra sgo ];
+  };
+}

--- a/pkgs/development/interpreters/rakudo/nqp.nix
+++ b/pkgs/development/interpreters/rakudo/nqp.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, perl, lib, moarvm }:
+
+stdenv.mkDerivation rec {
+  pname = "nqp";
+  version = "2020.01";
+
+  src = fetchurl {
+    url    = "https://github.com/perl6/nqp/releases/download/${version}/nqp-${version}.tar.gz";
+    sha256 = "0nwn6a9i9akw1zmywhkn631gqy8l4dvy50d6id63zir28ccrrk2c";
+  };
+
+  buildInputs = [ perl ];
+
+  configureScript = "${perl}/bin/perl ./Configure.pl";
+  configureFlags = [
+    "--backends=moar"
+    "--with-moar=${moarvm}/bin/moar"
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Not Quite Perl -- a lightweight Raku-like environment for virtual machines";
+    homepage    = "https://github.com/perl6/nqp";
+    license     = licenses.artistic2;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice vrthra sgo ];
+  };
+}

--- a/pkgs/development/interpreters/rakudo/zef.nix
+++ b/pkgs/development/interpreters/rakudo/zef.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, rakudo, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "zef";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "ugexe";
+    repo = "zef";
+    rev = "v${version}";
+    sha256 = "064nbl2hz55mpxdcy9zi39s2z6bad3bj73xsna966a7hzkls0a70";
+  };
+
+  buildInputs = [ rakudo makeWrapper ];
+
+  installPhase = ''
+    mkdir -p "$out"
+    # TODO: Find better solution. zef stores cache stuff in $HOME with the
+    # default config.
+    env HOME=$TMPDIR ${rakudo}/bin/raku -I. ./bin/zef --/depends --/test-depends --/build-depends --install-to=$out install .
+  '';
+
+  postFixup =''
+    wrapProgram $out/bin/zef --prefix RAKUDOLIB , "inst#$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Raku / Perl6 Module Management";
+    homepage    = "https://github.com/ugexe/zef";
+    license     = licenses.artistic2;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ sgo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9322,9 +9322,12 @@ in
   };
   racket-minimal = callPackage ../development/interpreters/racket/minimal.nix { };
 
-  rakudo = callPackage ../development/interpreters/rakudo {
+  rakudo = callPackage ../development/interpreters/rakudo {};
+  moarvm = callPackage ../development/interpreters/rakudo/moarvm.nix {
     inherit (darwin.apple_sdk.frameworks) CoreServices ApplicationServices;
   };
+  nqp = callPackage  ../development/interpreters/rakudo/nqp.nix { };
+  zef = callPackage ../development/interpreters/rakudo/zef.nix { };
 
   rascal = callPackage ../development/interpreters/rascal { };
 


### PR DESCRIPTION
dependencies:
    - moarvm: init at 2020.01.1
    - nqp: init at 2020.01
    - zef: init 0.8.2

###### Motivation for this change
Update rakudo to 2020.01, by replacing `rakudo-star` with `rakudo`, `moarvm`, `nqp`. And added the `zef` package manager.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice @vrthra @volth 
