### PR TITLE
pythonPackages.junitparser: init at 1.4.1

### DIFF
--- a/pkgs/development/python-modules/junitparser/default.nix
+++ b/pkgs/development/python-modules/junitparser/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, future
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "junitparser";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "gastlygem";
+    repo = pname;
+    rev = version;
+    sha256 = "16xwayr0rbp7xdg7bzmyf8s7al0dhkbmkcnil66ax7r8bznp5lmp";
+  };
+
+  propagatedBuildInputs = [ future ];
+
+  checkPhase = ''
+    ${python.interpreter} test.py
+  '';
+
+  meta = with lib; {
+    description = "A JUnit/xUnit Result XML Parser";
+    license = licenses.asl20;
+    homepage = https://github.com/gastlygem/junitparser;
+    maintainers = with maintainers; [ multun ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -757,6 +757,8 @@ in {
 
   jira = callPackage ../development/python-modules/jira { };
 
+  junitparser = callPackage ../development/python-modules/junitparser { };
+
   jwcrypto = callPackage ../development/python-modules/jwcrypto { };
 
   kconfiglib = callPackage ../development/python-modules/kconfiglib { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Packaging closed source software for NixOS!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
