### PR TITLE
pkgsStatic: set BUILD_SHARED_LIBS=OFF for cmake

### DIFF
--- a/pkgs/development/libraries/double-conversion/default.nix
+++ b/pkgs/development/libraries/double-conversion/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake, static ? false }:
+{ stdenv, lib, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "double-conversion";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}" ];
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
 
   # Case sensitivity issue
   preConfigure = lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, enableShared ? true }:
+{ stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   version = "6.0.0";
@@ -17,16 +17,16 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DFMT_TEST=TRUE"
-    "-DBUILD_SHARED_LIBS=${if enableShared then "TRUE" else "FALSE"}"
+    "-DBUILD_SHARED_LIBS=TRUE"
   ];
 
   enableParallelBuilding = true;
 
   doCheck = true;
   # preCheckHook ensures the test binaries can find libfmt.so
-  preCheck = if enableShared
-             then "export LD_LIBRARY_PATH=\"$PWD\""
-             else "";
+  preCheck = ''
+    export LD_LIBRARY_PATH="$PWD"
+  '';
 
   meta = with stdenv.lib; {
     description = "Small, safe and fast formatting library";

--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, perl, static ? false }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, perl }:
 
 stdenv.mkDerivation rec {
   pname = "glog";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}" ];
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
 
   checkInputs = [ perl ];
   doCheck = false; # fails with "Mangled symbols (28 out of 380) found in demangle.dm"

--- a/pkgs/development/libraries/gtest/default.nix
+++ b/pkgs/development/libraries/gtest/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, cmake, ninja, fetchFromGitHub
-, static ? false }:
+{ stdenv, cmake, ninja, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "gtest";
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ninja ];
 
-  cmakeFlags = stdenv.lib.optional (!static) "-DBUILD_SHARED_LIBS=ON";
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
 
   meta = with stdenv.lib; {
     description = "Google's framework for writing C++ tests";

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -60,6 +60,7 @@ rec {
           "--enable-static"
           "--disable-shared"
         ];
+        cmakeFlags = (args.cmakeFlags or []) ++ [ "-DBUILD_SHARED_LIBS:BOOL=OFF" ];
         mesonFlags = (args.mesonFlags or []) ++ [ "-Ddefault_library=static" ];
       });
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10787,7 +10787,7 @@ in
   arrayfire = callPackage ../development/libraries/arrayfire {};
 
   arrow-cpp = callPackage ../development/libraries/arrow-cpp ({
-    gtest = gtest.override { static = true; };
+    inherit (pkgsStatic) gtest;
   } // stdenv.lib.optionalAttrs (stdenv.hostPlatform.isi686 && stdenv.cc.isGNU) {
     stdenv = overrideCC stdenv buildPackages.gcc6; # hidden symbol `__divmoddi4'
   });

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -193,9 +193,6 @@ in {
   gflags = super.gflags.override {
     enableShared = false;
   };
-  glog = super.glog.override {
-    static = true;
-  };
   cdo = super.cdo.override {
     enable_all_static = true;
   };

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -184,9 +184,6 @@ in {
     static = true;
     twisted = null;
   };
-  double-conversion = super.double-conversion.override {
-    static = true;
-  };
   gmp = super.gmp.override {
     withStatic = true;
   };

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -196,9 +196,6 @@ in {
   glog = super.glog.override {
     static = true;
   };
-  gtest = super.gtest.override {
-    static = true;
-  };
   cdo = super.cdo.override {
     enable_all_static = true;
   };


### PR DESCRIPTION
## Motivation for this change

While reviewing #75798 I've noticed a repetitive pattern of setting BUILD_SHARED_LIBS=OFF for many of the cmake builds. It makes sense to just set it for all builds.

## Background

CMake has a [BUILD_SHARED_LIBS](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) option which governs the behaviour of the add_library() function in case when the library type is not specified. Its default value is "OFF" meaning default to STATIC. It is not uncommon to explicitly redefine the option:

```cmake
option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
```

This adds the BUILD_SHARED_LIBS option to the list of options in the CMake gui. There is a different variation of the redefinition where the default value is changed to "ON".

Some packages allow to provide both shared and static libraries. Additional custom options are defined to facilitate this. These options may or may not break the default convention for the BUILD_SHARED_LIBS.

### In Nixpkgs
Here are a few data points for nixpkgs:
```
# grep -r -iE "\\-DBUILD_SHARED_LIBS=(ON|TRUE|1)" pkgs/ | wc -l
39
# grep -r -iE "\\-DBUILD_SHARED_LIBS=(OFF|FALSE|0)" pkgs/ | wc -l
2
# grep -r "\\-DBUILD_SHARED_LIBS" . | wc -l
46
```

```
# grep -r "\\-DBUILD_STATIC_LIBS" . | wc -l
4
# grep -r "\\-DBUILD_" . | grep SHARED | wc -l
48
# grep -r "\\-DBUILD_" . | grep STATIC | wc -l
9
```

This PR should help with 39 cases where we enabled building of shared libraries. It will also help in cases when the default value of the BUILD_STATIC_LIBS option was changed to "ON"

### In upstream

* `fmt`: chose to not override BUILD_STATIC_LIBS (fmtlib/fmt#600).
* `gtest`: BUILD_STATIC_LIBS overridden with default to "OFF" https://github.com/google/googletest/blob/306f3754a71d6d1ac644681d3544d06744914228/googletest/CMakeLists.txt#L69-L71
* `hyperscan`: BUILD_SHARED_LIBS overridden with default to "OFF", additional option BUILD_SHARED_AND_STATIC_LIBS available https://github.com/intel/hyperscan/blob/d79973efb1fcf5ed338122882c1f896829767fb6/CMakeLists.txt#L109-L110
* `pugixml`: BUILD_SHARED_LIBS overridden with default to "OFF", additional option BUILD_SHARED_AND_STATIC_LIBS available
https://github.com/zeux/pugixml/blob/41b6ff21c455865bb8ef67c5952b7f895b62bacc/CMakeLists.txt#L26-L28

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

### `fmt`
```
# ls -1 $(nix-build . -A fmt)/lib
libfmt.so
libfmt.so.6
libfmt.so.6.0.0
# ls -1 $(nix-build . -A pkgsStatic.fmt)/lib
libfmt.a
```
### `gtest`
```
# ls -1 $(nix-build . -A gtest)/lib
libgmock_main.so
libgmock.so
libgtest_main.so
libgtest.so
# ls -1 $(nix-build . -A pkgsStatic.gtest)/lib
libgmock.a
libgmock_main.a
libgtest.a
libgtest_main.a
```