### PR TITLE
python3Packages.fsspec: 0.5.2 -> 0.6.2 enable tests

### DIFF
--- a/pkgs/development/python-modules/diskcache/default.nix
+++ b/pkgs/development/python-modules/diskcache/default.nix
@@ -1,21 +1,35 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, tox
+, fetchFromGitHub
+, pytest
+, pytestcov
+, pytest_xdist
+, pytest-django
+, mock
 }:
 
 buildPythonPackage rec {
   pname = "diskcache";
   version = "4.1.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "bcee5a59f9c264e2809e58d01be6569a3bbb1e36a1e0fb83f7ef9b2075f95ce0";
+  src = fetchFromGitHub {
+    owner = "grantjenks";
+    repo = "python-diskcache";
+    rev = "v${version}";
+    sha256 = "0xy2vpk4hixb4gg871d9sx9wxdz8pi0pmnfdwg4bf8jqfjg022w8";
   };
 
   checkInputs = [
-    tox
+    pytest
+    pytestcov
+    pytest_xdist
+    pytest-django
+    mock
   ];
+
+  checkPhase = ''
+    pytest
+  '';
 
   meta = with lib; {
     description = "Disk and file backed persistent cache";

--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -1,26 +1,34 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, pythonOlder
+, fetchFromGitHub
+, isPy27
+, pytest
 }:
 
 buildPythonPackage rec {
   pname = "fsspec";
-  version = "0.5.2";
+  version = "0.6.2";
+  disabled = isPy27;
 
-  disabled = pythonOlder "3.5";
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "6531a5fa9ea6bf27a5180d225558a8a7aa5d7c3cbf7e8b146dd37ac699017937";
+  src = fetchFromGitHub {
+    owner = "intake";
+    repo = "filesystem_spec";
+    rev = version;
+    sha256 = "1y3d6xw14rcldz9779ir6mjaff4rk82ch6ahn4y9mya0qglpc31i";
   };
 
-  # no tests
-  doCheck = false;
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
 
   meta = with lib; {
-    description = "A specification that python filesystems should adhere to.";
-    homepage = "https://github.com/intake/filesystem_spec";
+    description = "A specification that python filesystems should adhere to";
+    homepage = https://github.com/intake/filesystem_spec;
     license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
   };
 }

--- a/pkgs/development/python-modules/imagecodecs-lite/default.nix
+++ b/pkgs/development/python-modules/imagecodecs-lite/default.nix
@@ -6,15 +6,28 @@
 
 buildPythonPackage rec {
   pname = "imagecodecs-lite";
-  version = "2019.4.20";
+  version = "2019.12.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1cp88g7g91gdhjhaz6gvb4jzvi5ad817id9f2bnc5r95ag93bqb0";
+    sha256 = "0s4xb17qd7vimc46rafbjnibj4sf0lnv8cwl22k1h6zb7jhqmlcm";
   };
 
-  checkInputs = [ pytest ];
-  propagatedBuildInputs = [ numpy cython ];
+  nativeBuildInputs = [
+    cython
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
 
   meta = with lib; {
     description = "Block-oriented, in-memory buffer transformation, compression, and decompression functions";

--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -1,5 +1,12 @@
-{ lib, fetchPypi, buildPythonPackage, isPy27
-, numpy, enum34, futures, pathlib
+{ lib
+, fetchPypi
+, buildPythonPackage
+, isPy27
+, numpy
+, imagecodecs-lite
+, enum34
+, futures
+, pathlib
 , pytest
 }:
 
@@ -17,13 +24,23 @@ buildPythonPackage rec {
   # Missing dependencies: imagecodecs, czifile, cmapfile, oiffile, lfdfiles
   # and test data missing from PyPI tarball
   doCheck = false;
-  checkInputs = [ pytest ];
+
+  checkInputs = [
+    pytest
+  ];
+
   checkPhase = ''
     pytest
   '';
 
-  propagatedBuildInputs = [ numpy ]
-    ++ lib.optionals isPy27 [ futures enum34 pathlib ];
+  propagatedBuildInputs = [
+    numpy
+    imagecodecs-lite
+  ] ++ lib.optionals isPy27 [
+    futures
+    enum34
+    pathlib
+  ];
 
   meta = with lib; {
     description = "Read and write image data from and to TIFF files.";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
