### PR TITLE
clang_9: Correct ClangTargets-release.cmake

### DIFF
--- a/pkgs/development/compilers/llvm/9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/9/clang/default.nix
@@ -73,7 +73,8 @@ let
       moveToOutput "lib/libclang.*" "$lib"
       moveToOutput "lib/libclang-cpp.*" "$lib"
       substituteInPlace $out/lib/cmake/clang/ClangTargets-release.cmake \
-          --replace "\''${_IMPORT_PREFIX}/lib/libclang." "$lib/lib/libclang."
+          --replace "\''${_IMPORT_PREFIX}/lib/libclang." "$lib/lib/libclang." \
+          --replace "\''${_IMPORT_PREFIX}/lib/libclang-cpp." "$lib/lib/libclang-cpp."
 
       mkdir -p $python/bin $python/share/clang/
       mv $out/bin/{git-clang-format,scan-view} $python/bin


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Since commit 4271020 libclang-cpp is also moved to $lib. This adds the missing
substitution in ClangTargets-release.cmake.

I noticed this when building  ccls with clang 9:

```nix
nix-build -E 'with import <nixpkgs>{}; \
   ccls.override { llvmPackages = llvmPackages_9; stdenv = llvmPackages_9.stdenv;}'
```

```
...
CMake Error at /nix/store/jr3gkcg4ky7qvyqd9yn6jijs6621j5ql-clang-9.0.0/lib/cmake/clang/ClangTargets.cmake:579 (message):
  The imported target "clang-cpp" references the file

     "/nix/store/jr3gkcg4ky7qvyqd9yn6jijs6621j5ql-clang-9.0.0/lib/libclang-cpp.so.9"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/nix/store/jr3gkcg4ky7qvyqd9yn6jijs6621j5ql-clang-9.0.0/lib/cmake/clang/ClangTargets.cmake"

  but not all the files it references.

Call Stack (most recent call first):
  /nix/store/jr3gkcg4ky7qvyqd9yn6jijs6621j5ql-clang-9.0.0/lib/cmake/clang/ClangConfig.cmake:18 (include)
  CMakeLists.txt:71 (find_package)
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Mainly tested with ccls.

###### Notify maintainers

cc @matthewbauer, @dtzWill 
