### PR TITLE
bitwarden_rs: 1.9.1 -> 1.13.0

### DIFF
--- a/pkgs/tools/security/bitwarden_rs/default.nix
+++ b/pkgs/tools/security/bitwarden_rs/default.nix
@@ -2,26 +2,25 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "bitwarden_rs";
-  version = "1.9.1";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = pname;
     rev = version;
-    sha256 = "0jfb4b2lp2v01aw615lx0qj1qh73hyrbjn9kva7zqp74wcfw12gp";
+    sha256 = "1qhfm58x08q6sv9r5nqs0qryggcyrasjlxw3h1wb3j6aq474p6jf";
   };
-
-  cargoPatches = [
-    # type annotations required: cannot resolve `std::string::String: std::convert::AsRef<_>`
-    ./cargo-lock-lettre.patch
-  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ] ++ stdenv.lib.optionals stdenv.isDarwin [ Security CoreServices ];
 
   RUSTC_BOOTSTRAP = 1;
 
-  cargoSha256 = "0p39gqrqdmgqhngp1qyh6jl0sp0ifj5n3bxfqafjbspb4zph3ls4";
+  cargoSha256 = "03szl83r9mjn08mqkwah8fmzpszci8ay7ki69yx1rgv3zx7npnxk";
+
+  cargoBuildFlags = [ "--features sqlite" ];
+
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "An unofficial lightweight implementation of the Bitwarden server API using Rust and SQLite";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I was running bitwarden_rs in docker, but as I'm switching over to NixOS I wanted to use the module instead.

The old version in nixpkgs meant my db was not compatible. So I made a package and added it to nixpkgs.config.packageOverrides with callPackage.

THE ABOVE IS THE ONLY WAY THIS WAS TESTED. But it seems to work fine with the module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @msteen 
