### PR TITLE
Bemenu: 0.1.0 -> 0.3.0

### DIFF
--- a/pkgs/applications/misc/bemenu/default.nix
+++ b/pkgs/applications/misc/bemenu/default.nix
@@ -9,18 +9,24 @@ assert ncursesSupport -> ncurses != null;
 assert waylandSupport -> wayland != null;
 assert x11Support -> xlibs != null && xorg != null;
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "bemenu";
-  version = "0.1.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "Cloudef";
-    repo = "bemenu";
-    rev = "33e540a2b04ce78f5c7ab4a60b899c67f586cc32";
-    sha256 = "11h55m9dx6ai12pqij52ydjm36dvrcc856pa834njihrp626pl4w";
+    repo = pname;
+    rev = version;
+    sha256 = "03k8wijdgj5nwmvgjhsrlh918n719789fhs4dqm23pd00rapxipk";
   };
 
   nativeBuildInputs = [ cmake pkgconfig pcre ];
+
+  cmakeFlags =  [
+    "-DBEMENU_CURSES_RENDERER=${if ncursesSupport then "ON" else "OFF"}"
+    "-DBEMENU_WAYLAND_RENDERER=${if waylandSupport then "ON" else "OFF"}"
+    "-DBEMENU_X11_RENDERER=${if x11Support then "ON" else "OFF"}"
+  ];
 
   buildInputs = with stdenv.lib; [
     cairo


### PR DESCRIPTION
###### Motivation for this change

New bemenu version.

###### Things done

Bump version. Use rec to not hard code commit.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of ~~all~~ only wayland and ncurses support. X11 didn't work for me binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thiagokokada 
