### PR TITLE
luckybackup: init at 0.5.0

### DIFF
--- a/pkgs/tools/backup/luckybackup/default.nix
+++ b/pkgs/tools/backup/luckybackup/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl
+, pkgconfig, libtool, qmake
+, rsync, ssh
+}:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  pname = "luckybackup";
+  version = "0.5.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/luckybackup/${version}/source/${pname}-${version}.tar.gz";
+    sha256 = "0nwjsk1j33pm8882jbj8h6nxn6n5ab9dxqpqkay65pfbhcjay0g8";
+  };
+
+  buildInputs = [ rsync ssh ];
+
+  nativeBuildInputs = [ pkgconfig libtool qmake ];
+  
+  prePatch = ''
+    for File in luckybackup.pro menu/luckybackup-pkexec \
+        menu/luckybackup-su.desktop menu/luckybackup.desktop \
+        menu/net.luckybackup.su.policy src/functions.cpp \
+        src/global.cpp src/scheduleDialog.cpp; do
+      substituteInPlace $File --replace "/usr" "$out"
+    done
+  '';
+
+  meta = {
+    description = "A powerful, fast and reliable backup & sync tool";
+    longDescription = ''
+      luckyBackup is an application for data back-up and synchronization 
+      powered by the rsync tool.
+      
+      It is simple to use, fast (transfers over only changes made and not
+      all data), safe (keeps your data safe by checking all declared directories
+      before proceeding in any data manipulation), reliable and fully 
+      customizable.
+    '';
+    homepage = "http://luckybackup.sourceforge.net/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2942,6 +2942,10 @@ in
 
   epubcheck = callPackage ../tools/text/epubcheck { };
 
+  luckybackup = libsForQt5.callPackage ../tools/backup/luckybackup {
+    ssh = openssh;
+  };
+
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
   s-tar = callPackage ../tools/archivers/s-tar {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
