### PR TITLE
libbass: 2.4.14 -> 2.4.15

### DIFF
--- a/pkgs/development/libraries/audio/libbass/default.nix
+++ b/pkgs/development/libraries/audio/libbass/default.nix
@@ -9,13 +9,13 @@ let
   allBass = {
     bass = {
       h = "bass.h";
-      version = "2.4.14";
+      version = "2.4.15";
       so = {
         i686_linux = "libbass.so";
         x86_64-linux = "x64/libbass.so";
       };
       urlpath = "bass24-linux.zip";
-      sha256 = "1nyzs08z0djyvz6jx1y9y99y0ksp4sxz9l2x43k1c9irls24xpfy";
+      sha256 = "098vazhm7shnjxglzdrbwj68bpp0simn25vyjjz7l1f6ymrmia35";
     };
 
     bass_fx = {


### PR DESCRIPTION
###### Motivation for this change
`libbass` was updated to 2.4.15 on December 17, 2019. As documented in [the source comment](https://github.com/NixOS/nixpkgs/blob/2d0a2044b3cc2e3ca93588aa49a0d7229dbe3ab6/pkgs/development/libraries/audio/libbass/default.nix#L3-L6) this breaks the package as the download file is replaced in-place and the hash sum changes (of course). It also breaks the packages `ultrastar-manager` and `ultrastar-creator` that depend on `libbass`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @abbradar 
