### PR TITLE
what: init at 0.5.1

### DIFF
--- a/pkgs/tools/networking/what/default.nix
+++ b/pkgs/tools/networking/what/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  pname = "what";
+  version = "0.5.1";
+
+  cargoSha256 = "1rixpljqddwhryddzni5l6m4sjyn1krrj0ig0rzc701am7srhg3a";
+
+  src = fetchFromGitHub {
+    owner = "imsnif";
+    repo = "what";
+    rev = "${version}";
+    sha256 = "1q926w6c4hhf6gim6dn3jfcibgj5zbsgwnf5crmh8wv6a8fg6pxg";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A CLI utility for displaying current network utilization by process, connection and remote IP/hostname";
+    homepage = https://github.com/imsnif/what;
+    license = licenses.mit;
+    maintainers = with maintainers; [ fadenb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10663,6 +10663,8 @@ in
 
   vtable-dumper = callPackage ../development/tools/misc/vtable-dumper { };
 
+  what = callPackage ../tools/networking/what { };
+
   whatstyle = callPackage ../development/tools/misc/whatstyle {
     inherit (llvmPackages) clang-unwrapped;
   };


### PR DESCRIPTION
###### Motivation for this change
New package: `what` ( https://github.com/imsnif/what )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.