### PR TITLE
coreutils: Fix cross compilation for Android

### DIFF
--- a/pkgs/tools/misc/coreutils/coreutils-8.31-android-cross.patch
+++ b/pkgs/tools/misc/coreutils/coreutils-8.31-android-cross.patch
@@ -1,0 +1,51 @@
+From 3bd82a82cf4ba693d2c31c7b95aaec4e56dc92a4 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Mon, 11 Mar 2019 16:40:29 -0700
+Subject: [PATCH 1/1] strtod: fix clash with strtold
+
+Problem reported for RHEL 5 by Jesse Caldwell (Bug#34817).
+* lib/strtod.c (compute_minus_zero, minus_zero):
+Simplify by remving the macro / external variable,
+and having just a function.  User changed.  This avoids
+the need for an external variable that might clash.
+---
+ ChangeLog    |  9 +++++++++
+ lib/strtod.c | 11 +++++------
+ 2 files changed, 14 insertions(+), 6 deletions(-)
+
+diff --git a/lib/strtod.c b/lib/strtod.c
+index b9eaa51..69b1564 100644
+--- a/lib/strtod.c
++++ b/lib/strtod.c
+@@ -294,16 +294,15 @@ parse_number (const char *nptr,
+    ICC 10.0 has a bug when optimizing the expression -zero.
+    The expression -MIN * MIN does not work when cross-compiling
+    to PowerPC on Mac OS X 10.5.  */
+-#if defined __hpux || defined __sgi || defined __ICC
+ static DOUBLE
+-compute_minus_zero (void)
++minus_zero (void)
+ {
++#if defined __hpux || defined __sgi || defined __ICC
+   return -MIN * MIN;
+-}
+-# define minus_zero compute_minus_zero ()
+ #else
+-DOUBLE minus_zero = -0.0;
++  return -0.0;
+ #endif
++}
+ 
+ /* Convert NPTR to a DOUBLE.  If ENDPTR is not NULL, a pointer to the
+    character after the last one used in the number is put in *ENDPTR.  */
+@@ -479,6 +478,6 @@ STRTOD (const char *nptr, char **endptr)
+   /* Special case -0.0, since at least ICC miscompiles negation.  We
+      can't use copysign(), as that drags in -lm on some platforms.  */
+   if (!num && negative)
+-    return minus_zero;
++    return minus_zero ();
+   return negative ? -num : num;
+ }
+-- 
+1.9.1
+

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -15,7 +15,7 @@ assert selinuxSupport -> libselinux != null && libsepol != null;
 
 with lib;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (rec {
   pname = "coreutils";
   version = "8.31";
 
@@ -29,7 +29,9 @@ stdenv.mkDerivation rec {
          # To be removed in coreutils-8.32.
          ++ optional stdenv.hostPlatform.isMusl ./avoid-false-positive-in-date-debug-test.patch
          # Fix compilation in musl-cross environments. To be removed in coreutils-8.32.
-         ++ optional stdenv.hostPlatform.isMusl ./coreutils-8.31-musl-cross.patch;
+         ++ optional stdenv.hostPlatform.isMusl ./coreutils-8.31-musl-cross.patch
+         # Fix compilation in android-cross environments. To be removed in coreutils-8.32.
+         ++ [ ./coreutils-8.31-android-cross.patch ];
 
   postPatch = ''
     # The test tends to fail on btrfs,f2fs and maybe other unusual filesystems.
@@ -143,8 +145,9 @@ stdenv.mkDerivation rec {
 
     maintainers = [ maintainers.eelco ];
   };
-
 } // optionalAttrs stdenv.hostPlatform.isMusl {
   # Work around a bogus warning in conjunction with musl.
   NIX_CFLAGS_COMPILE = "-Wno-error";
-}
+} // stdenv.lib.optionalAttrs stdenv.hostPlatform.isAndroid {
+  NIX_CFLAGS_COMPILE = "-D__USE_FORTIFY_LEVEL=0";
+})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

CC @matthewbauer @dtzWill 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
