### PR TITLE
java: set an additional JAVA_HOME per major version

### DIFF
--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -271,6 +271,7 @@ in rec {
       mkdir -p $out/nix-support
       cat <<EOF > $out/nix-support/setup-hook
       if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+      if [ -z "\''${JAVA_8_HOME-}" ]; then export JAVA_8_HOME=$out; fi
       EOF
     '';
     postFixup = openjdk.postFixup or null;

--- a/pkgs/development/compilers/graalvm/enterprise-edition.nix
+++ b/pkgs/development/compilers/graalvm/enterprise-edition.nix
@@ -73,6 +73,7 @@ let
       mkdir -p $out/nix-support
       cat <<EOF > $out/nix-support/setup-hook
       if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+      if [ -z "\''${JAVA_8_HOME-}" ]; then export JAVA_8_HOME=$out; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -107,6 +107,7 @@ let
       mkdir -p $out/nix-support
       cat <<EOF > $out/nix-support/setup-hook
       if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+      if [ -z "\''${JAVA_${major}_HOME-}" ]; then export JAVA_${major}_HOME=$out/lib/openjdk; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -237,6 +237,7 @@ let
       mkdir -p $out/nix-support
       cat <<EOF > $out/nix-support/setup-hook
       if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+      if [ -z "\''${JAVA_8_HOME-}" ]; then export JAVA_8_HOME=$out/lib/openjdk; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/darwin/11.nix
+++ b/pkgs/development/compilers/openjdk/darwin/11.nix
@@ -45,6 +45,7 @@ let
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook
       if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+      if [ -z "\''${JAVA_11_HOME-}" ]; then export JAVA_11_HOME=$out; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -45,6 +45,7 @@ let
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook
       if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+      if [ -z "\''${JAVA_8_HOME-}" ]; then export JAVA_8_HOME=$out; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/darwin/default.nix
+++ b/pkgs/development/compilers/openjdk/darwin/default.nix
@@ -45,6 +45,7 @@ let
       # Set JAVA_HOME automatically.
       cat <<EOF >> $out/nix-support/setup-hook
       if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+      if [ -z "\''${JAVA_12_HOME-}" ]; then export JAVA_12_HOME=$out; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/openjdk/default.nix
+++ b/pkgs/development/compilers/openjdk/default.nix
@@ -115,6 +115,7 @@ let
       mkdir -p $out/nix-support
       cat <<EOF > $out/nix-support/setup-hook
       if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out/lib/openjdk; fi
+      if [ -z "\''${JAVA_${major}_HOME-}" ]; then export JAVA_${major}_HOME=$out/lib/openjdk; fi
       EOF
     '';
 

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -157,6 +157,7 @@ let result = stdenv.mkDerivation rec {
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook
     if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+    if [ -z "\''${JAVA_${productVersion}_HOME-}" ]; then export JAVA_${productVersion}_HOME=$out; fi
     EOF
   '';
 

--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -59,6 +59,7 @@ in stdenv.mkDerivation {
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook
     if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+    if [ -z "\''${JAVA_8_HOME-}" ]; then export JAVA_8_HOME=$out; fi
     EOF
   '';
 

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -56,6 +56,7 @@ in stdenv.mkDerivation {
     # Set JAVA_HOME automatically.
     cat <<EOF >> $out/nix-support/setup-hook
     if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
+    if [ -z "\''${JAVA_${openjdk}_HOME-}" ]; then export JAVA_${openjdk}_HOME=$out; fi
     EOF
   '';
 


### PR DESCRIPTION
This makes it easier to discover multiple JDK installations

###### Motivation for this change

This can be useful for builds that require multiple JDK versions to be available side-by-side.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @NeQuissimus @fpletz @edwtjo @volth @hlolli @taku0 