### PR TITLE
python3Packages: toggl-cli fix pendulum version bounds

### DIFF
--- a/pkgs/development/python-modules/toggl-cli/default.nix
+++ b/pkgs/development/python-modules/toggl-cli/default.nix
@@ -1,5 +1,6 @@
 { stdenv, buildPythonPackage, fetchPypi, twine, pbr, click, click-completion, validate-email,
-pendulum, ptable, requests, inquirer, pythonOlder, pytest, pytestcov, pytest-mock, faker, factory_boy }:
+pendulum, ptable, requests, inquirer, pythonOlder, pytest, pytestcov, pytest-mock, faker, factory_boy,
+setuptools }:
 
 
 buildPythonPackage rec {
@@ -16,6 +17,7 @@ buildPythonPackage rec {
 
   postPatch = ''
    substituteInPlace requirements.txt \
+     --replace "pendulum==2.0.4" "pendulum>=2.0.4" \
      --replace "click-completion==0.5.0" "click-completion>=0.5.0" \
      --replace "pbr==5.1.2" "pbr>=5.1.2" \
      --replace "inquirer==2.5.1" "inquirer>=2.5.1"
@@ -37,6 +39,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
+    setuptools
     click
     click-completion
     validate-email


### PR DESCRIPTION
###### Motivation for this change
`toggl-cli` fails to build with `pendulum-2.0.5`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
