### PR TITLE
nixos/transmission: fix from where service loads config

### DIFF
--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -118,7 +118,7 @@ in
       # 1) Only the "transmission" user and group have access to torrents.
       # 2) Optionally update/force specific fields into the configuration file.
       serviceConfig.ExecStartPre = preStart;
-      serviceConfig.ExecStart = "${pkgs.transmission}/bin/transmission-daemon -f --port ${toString config.services.transmission.port}";
+      serviceConfig.ExecStart = "${pkgs.transmission}/bin/transmission-daemon -f --port ${toString config.services.transmission.port} --config-dir ${settingsDir}";
       serviceConfig.ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
       serviceConfig.User = cfg.user;
       serviceConfig.Group = cfg.group;


### PR DESCRIPTION
### Why

Currently if you specify `home` to be someplace else than `~/` for `user` then Transmissions always attempts to load the config from the default location which is `$HOME/.config/transmission-daemon` based on documentation:
https://github.com/transmission/transmission/wiki/Configuration-Files

Which means that the changes done to the config under `settingsDir` in `ExecPreStart` have no effect because they are modifying a file that is never loaded.

### Changes

I've added an explicit `--config-dir ${settingsDir}` to make sure that Transmission loads the correct config file even when `home` is changed.

### Notify maintainers

cc @edolstra @bjornfor @thoughtpolice @coreyoconnor 