### PR TITLE
Clarify error message of 'assigning to top-level attribute'

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -123,7 +123,7 @@ rec {
     if m ? config || m ? options then
       let badAttrs = removeAttrs m ["_file" "key" "disabledModules" "imports" "options" "config" "meta"]; in
       if badAttrs != {} then
-        throw "Module `${key}' has an unsupported attribute `${head (attrNames badAttrs)}'. This is caused by assignments to the top-level attributes `config' or `options'."
+        throw "Module `${key}' has an unsupported attribute `${head (attrNames badAttrs)}'. This is caused by introducing a top-level `config' or `options' attribute. Add configuration attributes immediately on the top level instead, or move all of them (namely: ${toString (attrNames badAttrs)}) into the explicit `config' attribute."
       else
         { file = m._file or file;
           key = toString m.key or key;


### PR DESCRIPTION
If I understand correctly, the problem isn't so much that you're assigning to
that top-level attribute, but that the assignment to the attribute (or any
child of the attribute) introduces the 'config' object and prevents 'lifting'
all settings to a generated 'config' object.

###### Motivation for this change

I think this would improve the new-user experience, where you're not yet so
sure where configuration options should go.