### PR TITLE
rsync: Fix perl-substitution in rrsync

### DIFF
--- a/pkgs/applications/networking/sync/rsync/rrsync.nix
+++ b/pkgs/applications/networking/sync/rsync/rrsync.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace support/rrsync --replace /usr/bin/rsync ${rsync}/bin/rsync
+    substituteInPlace support/rrsync --replace /usr/bin/perl ${perl}/bin/perl
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

there is no (more) perl in /usr/bin

###### Notify maintainers

cc @peti @ehmry 
