### PR TITLE
[19.09] opensc: fix CVE-2019-19479, CVE-2019-19480

### DIFF
--- a/pkgs/tools/security/opensc/default.nix
+++ b/pkgs/tools/security/opensc/default.nix
@@ -32,6 +32,26 @@ stdenv.mkDerivation rec {
       url = "https://github.com/OpenSC/OpenSC/commit/a3fc7693f3a035a8a7921cffb98432944bb42740.patch";
       sha256 = "1qr9n8cbarrdn4kr5z0ys7flq50hfmcbm8584mhw7r39p08qwmvq";
     })
+    (fetchpatch {
+      name = "CVE-2019-19479.patch";
+      url = "https://github.com/OpenSC/OpenSC/commit/c3f23b836e5a1766c36617fe1da30d22f7b63de2.patch";
+      sha256 = "0xj6c6wycwynxrn3f8kziwz99z8rjwkrsnk8f0ffx7fj4d97krfw";
+    })
+    # needed for CVE-2019-19480.patch
+    (fetchpatch {
+      name = "opensc-memory-leak-fix.patch";
+      url = "https://github.com/OpenSC/OpenSC/commit/630d6adf32cecaab0ee184618f56497bd50400fb.patch";
+      sha256 = "0cb6fx9pjf7z9zdi2kk1b3zz537xb7dclaqn8z0gy48xg59biwy0";
+    })
+    (fetchpatch {
+      name = "CVE-2019-19480.patch";
+      url = "https://github.com/OpenSC/OpenSC/commit/6ce6152284c47ba9b1d4fe8ff9d2e6a3f5ee02c7.patch";
+      sha256 = "0xm6gl11b4nr436a8al0k8myq6i2xpc9mc24nwf4fhwj3wbzp3dq";
+    })
+
+    # CVE-2019-19481 is on applicable to 0.19
+    # cac1 support was only added after it:
+    # https://github.com/OpenSC/OpenSC/commit/e2b1fb81e0e1339eebaa36fb90635e03f69d4da3#diff-6d5e82180f0ee8125f09f8bedb5cd1cb
   ];
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Closes: #76013

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
