### PR TITLE
schismtracker: 20120105 -> 20190805

### DIFF
--- a/pkgs/applications/audio/schismtracker/default.nix
+++ b/pkgs/applications/audio/schismtracker/default.nix
@@ -1,30 +1,29 @@
-{ stdenv, fetchurl, alsaLib, python, SDL }:
+{ stdenv, fetchFromGitHub
+, autoreconfHook
+, alsaLib, python, SDL }:
 
 stdenv.mkDerivation rec {
-  version = "20120105";
   pname = "schismtracker";
+  version = "20190805";
 
-  src = fetchurl {
-    url = "http://schismtracker.org/dl/${pname}-${version}.tar.bz2";
-    sha256 = "1ny7wv2wxm1av299wvpskall6438wjjpadphmqc7c0h6d0zg5kii";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "0qqps20vvn3rgpg8174bjrrm38gqcci2z5z4c1r1vhbccclahgsd";
   };
-
-  preConfigure = ''
-    # Build fails on Linux with windres.
-    export ac_cv_prog_ac_ct_WINDRES=
-  '';
 
   configureFlags = [ "--enable-dependency-tracking" ];
 
-  buildInputs = [ alsaLib python SDL ];
+  nativeBuildInputs = [ autoreconfHook python ];
 
-  enableParallelBuilding = true;
+  buildInputs = [ alsaLib SDL ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Music tracker application, free reimplementation of Impulse Tracker";
     homepage = "http://schismtracker.org/";
-    license = stdenv.lib.licenses.gpl2;
+    license = licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
-    maintainers = [ stdenv.lib.maintainers.ftrvxmtrx ];
+    maintainers = with maintainers; [ ftrvxmtrx ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Schismtracker was severely out of date. (not touched since it was added)

###### Things done
Updated version, switched to GitHub repository and dropped obsolete workaround.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
(72814208 -> 73078200)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ftrvxmtrx 
