### PR TITLE
[19.09] opensc: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/tools/security/opensc/default.nix
+++ b/pkgs/tools/security/opensc/default.nix
@@ -7,32 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "opensc";
-  version = "0.19.0";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "OpenSC";
     repo = "OpenSC";
     rev = version;
-    sha256 = "10575gb9l38cskq7swyjp0907wlziyxg4ppq33ndz319dsx69d87";
+    sha256 = "0mg8qmhww3li1isfgvn5hang1hq58zra057ilvgci88csfziv5lv";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2019-6502.patch";
-      url = "https://github.com/OpenSC/OpenSC/commit/0d7967549751b7032f22b437106b41444aff0ba9.patch";
-      sha256 = "1y42lmz8i9w99hgpakdncnv8f94cqjfabz0v4xg6wfz9akl3ff7d";
-    })
-    (fetchpatch {
-      name = "CVE-2019-15945.patch";
-      url = "https://github.com/OpenSC/OpenSC/commit/412a6142c27a5973c61ba540e33cdc22d5608e68.patch";
-      sha256 = "088i2i1fkvdxnywmb54bn4283vhbxx6i2632b34ss5dh7k080hp7";
-    })
-    (fetchpatch {
-      name = "CVE-2019-15946.patch";
-      url = "https://github.com/OpenSC/OpenSC/commit/a3fc7693f3a035a8a7921cffb98432944bb42740.patch";
-      sha256 = "1qr9n8cbarrdn4kr5z0ys7flq50hfmcbm8584mhw7r39p08qwmvq";
-    })
-  ];
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/76666.

Closes: https://github.com/NixOS/nixpkgs/issues/76013 https://github.com/NixOS/nixpkgs/pull/76724

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
