### PR TITLE
python3Packages.dask: 2.9.0 -> 2.9.1 enable tests, move to github src

### DIFF
--- a/pkgs/development/python-modules/bokeh/default.nix
+++ b/pkgs/development/python-modules/bokeh/default.nix
@@ -1,7 +1,7 @@
 { buildPythonPackage
 , fetchPypi
 , futures
-, isPy3k
+, isPy27
 , isPyPy
 , jinja2
 , lib
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c60d38a41a777b8147ee4134e6142cea8026b5eebf48149e370c44689869dce7";
+    sha256 = "1rywd6c6hi0c6yg18j5zxssjd07a5hafcd21xr3q2yvp3aj3h3f6";
   };
 
   patches = [
@@ -39,7 +39,12 @@ buildPythonPackage rec {
 
   disabled = isPyPy;
 
-  checkInputs = [ mock pytest pillow selenium ];
+  checkInputs = [
+    mock
+    pytest
+    pillow
+    selenium
+  ];
 
   propagatedBuildInputs = [
     pillow
@@ -51,7 +56,9 @@ buildPythonPackage rec {
     numpy
     packaging
   ]
-  ++ lib.optionals ( !isPy3k ) [ futures ];
+  ++ lib.optionals ( isPy27 ) [
+    futures
+  ];
 
   checkPhase = ''
     ${python.interpreter} -m unittest discover -s bokeh/tests

--- a/pkgs/development/python-modules/cma/default.nix
+++ b/pkgs/development/python-modules/cma/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "cma";
+  version = "2.7.0";
+
+  src = fetchFromGitHub {
+    owner = "CMA-ES";
+    repo = "pycma";
+    rev = "r${version}";
+    sha256 = "0c26969pcqj047axksfffd9pj77n16k4r9h6pyid9q3ah5zk0xg3";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  checkPhase = ''
+    ${python.executable} -m cma.test
+  '';
+
+  meta = with lib; {
+    description = "CMA-ES, Covariance Matrix Adaptation Evolution Strategy for non-linear numerical optimization in Python";
+    homepage = https://github.com/CMA-ES/pycma;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -1,7 +1,7 @@
 { lib
 , bokeh
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , fsspec
 , pytest
 , pythonOlder
@@ -19,21 +19,40 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "eec200032922b2249f7f1061f8701eaf3e68488cfa78ff2b47c3262f442bede7";
+  src = fetchFromGitHub {
+    owner = "dask";
+    repo = pname;
+    rev = version;
+    sha256 = "1xayr4gkp4slvmh2ksdr0d196giz3yhknqjjg1vw2j0la9gwfwxs";
   };
 
-  checkInputs = [ pytest ];
-  propagatedBuildInputs = [
-    bokeh cloudpickle dill fsspec numpy pandas partd toolz ];
+  checkInputs = [
+    pytest
+  ];
 
-  checkPhase = ''
-    py.test dask
+  propagatedBuildInputs = [
+    bokeh
+    cloudpickle
+    dill
+    fsspec
+    numpy
+    pandas
+    partd
+    toolz
+  ];
+
+  postPatch = ''
+    # versioneer hack to set version of github package
+    echo "def get_versions(): return {'dirty': False, 'error': None, 'full-revisionid': None, 'version': '${version}'}" > dask/_version.py
+
+    substituteInPlace setup.py \
+      --replace "version=versioneer.get_version()," "version='${version}'," \
+      --replace "cmdclass=versioneer.get_cmdclass()," ""
   '';
 
-  # URLError
-  doCheck = false;
+  checkPhase = ''
+    pytest
+  '';
 
   meta = {
     description = "Minimal task scheduling abstraction";

--- a/pkgs/development/python-modules/optuna/default.nix
+++ b/pkgs/development/python-modules/optuna/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pytest
 , mock
 , bokeh
@@ -13,6 +13,7 @@
 , mxnet
 , scikit-optimize
 , tensorflow
+, cma
 , sqlalchemy
 , numpy
 , scipy
@@ -21,6 +22,7 @@
 , colorlog
 , pandas
 , alembic
+, tqdm
 , typing
 , pythonOlder
 , isPy27
@@ -31,9 +33,11 @@ buildPythonPackage rec {
   version = "0.19.0";
   disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "cbcdc826915dd07f7df723bec0dd3edd5e61e54c40e7a8b023e19d4434eef602";
+  src = fetchFromGitHub {
+    owner = "optuna";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "179x2lsckpmkrkkdnvvbzky86g1ba882z677qwbayhsc835wbp0y";
   };
 
   checkInputs = [
@@ -49,6 +53,7 @@ buildPythonPackage rec {
     mxnet
     scikit-optimize
     tensorflow
+    cma
   ];
 
   propagatedBuildInputs = [
@@ -60,16 +65,22 @@ buildPythonPackage rec {
     colorlog
     pandas
     alembic
-  ] ++ lib.optionals (pythonOlder "3.5") [ typing ];
+    tqdm
+  ] ++ lib.optionals (pythonOlder "3.5") [
+    typing
+  ];
 
   configurePhase = if !(pythonOlder "3.5") then ''
     substituteInPlace setup.py \
-      --replace "'typing'" ""
+      --replace "'typing'," ""
   '' else "";
 
   checkPhase = ''
     pytest --ignore tests/test_cli.py \
-           --ignore tests/integration_tests/test_chainermn.py
+           --ignore tests/integration_tests/test_chainermn.py \
+           --ignore tests/integration_tests/test_pytorch_lightning.py \
+           --ignore tests/integration_tests/test_pytorch_ignite.py \
+           --ignore tests/integration_tests/test_fastai.py
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4355,6 +4355,8 @@ in {
 
   cachetools = callPackage ../development/python-modules/cachetools {};
 
+  cma = callPackage ../development/python-modules/cma { };
+
   cmd2 = callPackage ../development/python-modules/cmd2 {};
 
   warlock = callPackage ../development/python-modules/warlock { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

My goal is to ensure that all the core numeric python packages in nixpkgs have all tests enabled and use github as a src. The motivation for this is that in the long run this will enable us to have value to the python community in being able to easily check current master of a given package vs all dependent packages. Which upon talking with numpy/numba/scipy/matplotlib communities is something they really need. This may need to go into staging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
