### PR TITLE
platformio: 4.0.3 -> 4.1.0

### DIFF
--- a/pkgs/development/arduino/platformio/fix-searchpath.patch
+++ b/pkgs/development/arduino/platformio/fix-searchpath.patch
@@ -1,11 +1,12 @@
---- ./platformio/proc.py-old	2017-09-29 01:20:08.174548250 +0200
-+++ ./platformio/proc.py	2017-09-29 01:19:48.410485308 +0200
-@@ -164,7 +164,7 @@
-                 isdir(join(p, "click")) or isdir(join(p, "platformio")))
+diff -Naur --strip-trailing-cr -r platformio-core-4.1.0.org/platformio/proc.py platformio-core-4.1.0/platformio/proc.py
+--- platformio-core-4.1.0.org/platformio/proc.py	2019-11-07 14:54:20.000000000 +0000
++++ platformio-core-4.1.0/platformio/proc.py	2019-12-31 09:05:47.693515281 +0000
+@@ -167,7 +167,7 @@
+             conditions.append(isdir(join(p, "click")) or isdir(join(p, "platformio")))
          if all(conditions):
              _PYTHONPATH.append(p)
--    os.environ['PYTHONPATH'] = os.pathsep.join(_PYTHONPATH)
+-    os.environ["PYTHONPATH"] = os.pathsep.join(_PYTHONPATH)
 +    os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
  
  
- def get_serialports(filter_hwid=False):
+ def where_is_program(program, envpath=None):

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -59,6 +59,9 @@ let
     (mkOverride "colorlog" "4.0.2"
       "3cf31b25cbc8f86ec01fef582ef3b840950dea414084ed19ab922c8b493f9b42")
 
+    (mkOverride "importlib-metadata" "0.23"
+      "09mdqdfv5rdrwz80jh9m379gxmvk2vhjfz0fg53hid00icvxf65a")
+
     # required by aioesphomeapi
     (self: super: {
       protobuf = super.protobuf.override {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
