### PR TITLE
Zwave fixes

### DIFF
--- a/pkgs/development/libraries/openzwave/default.nix
+++ b/pkgs/development/libraries/openzwave/default.nix
@@ -3,7 +3,7 @@
 , systemd }:
 
 let
-  version = "2018-11-13";
+  version = "2019-12-08";
 
 in stdenv.mkDerivation {
   pname = "openzwave";
@@ -14,8 +14,8 @@ in stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "home-assistant";
     repo = "open-zwave";
-    rev = "0679daef6aa5a39e2441a68f7b45cfe022c4d961";
-    sha256 = "1d13maj93i6h792cbvqpx43ffss44dxmvbwj2777vzvvjib8m4n8";
+    rev = "2cd2137025c529835e4893a7b87c3d56605b2681";
+    sha256 = "04g8fb4f4ihakvvsmzcnncgfdd2ikmki7s22i9c6layzdwavbwf1";
   };
 
   nativeBuildInputs = [ doxygen fontconfig graphviz-nox libxml2 pkgconfig which ];

--- a/pkgs/development/python-modules/homeassistant-pyozw/default.nix
+++ b/pkgs/development/python-modules/homeassistant-pyozw/default.nix
@@ -10,5 +10,6 @@ python_openzwave.overridePythonAttrs (oldAttrs: rec {
     sha256 = "2d500638270ee4f0e7e9e114d9b4402c94c232f314116cdcf88d7c1dc9a44427";
   };
 
+  patches = [];
   meta.homepage = https://github.com/home-assistant/python-openzwave;
 })

--- a/pkgs/development/python-modules/python_openzwave/cython.patch
+++ b/pkgs/development/python-modules/python_openzwave/cython.patch
@@ -1,0 +1,20 @@
+diff --git a/pyozw_setup.py b/pyozw_setup.py
+index b201840..37bf2a8 100644
+--- a/pyozw_setup.py
++++ b/pyozw_setup.py
+@@ -257,13 +257,13 @@ class Template(object):
+         if sys.platform.startswith("win"):
+             return ['Cython']
+         else:
+-            return ['Cython==0.28.6']
++            return ['Cython>=0.28.6']
+ 
+     def build_requires(self):
+         if sys.platform.startswith("win"):
+             return ['Cython']
+         else:
+-            return ['Cython==0.28.6']
++            return ['Cython>=0.28.6']
+ 
+     def build(self):
+         if len(self.ctx['extra_objects']) == 1 and os.path.isfile(self.ctx['extra_objects'][0]):

--- a/pkgs/development/python-modules/python_openzwave/default.nix
+++ b/pkgs/development/python-modules/python_openzwave/default.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPythonPackage, fetchPypi, isPy3k
 , pkgconfig
-, systemd, libyaml, openzwave, cython
+, systemd, libyaml, openzwave, cython, pyserial
 , six, pydispatcher, urwid }:
 
 buildPythonPackage rec {
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ systemd libyaml openzwave cython ];
-  propagatedBuildInputs = [ six urwid pydispatcher ];
+  propagatedBuildInputs = [ six urwid pydispatcher pyserial ];
 
   # primary location for the .xml files is in /etc/openzwave so we override the
   # /usr/local/etc lookup instead as that allows us to dump new .xml files into
@@ -26,6 +26,8 @@ buildPythonPackage rec {
     substituteInPlace src-lib/libopenzwave/libopenzwave.pyx \
       --replace /usr/local/etc/openzwave ${openzwave}/etc/openzwave
   '';
+
+  patches = [ ./cython.patch ];
 
   # no tests available
   doCheck = false;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

python_openzwave was not building. This fixes that and also updates libopenzwave. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @etu 
