### PR TITLE
rsync: Fix perl-substitution in rrsync

### DIFF
--- a/pkgs/applications/networking/sync/rsync/rrsync.nix
+++ b/pkgs/applications/networking/sync/rsync/rrsync.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace support/rrsync --replace /usr/bin/rsync ${rsync}/bin/rsync
+    substituteInPlace support/rrsync --replace /usr/bin/perl ${perl}/bin/perl
   '';
 
   installPhase = ''


### PR DESCRIPTION
there is no (more) perl in /usr/bin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] working with this on my server since 6 months

you can use #76721 to spare you the back-porting work

###### Notify maintainers

cc @peti @ehmry 
