### PR TITLE
ruby: Revert rubygems to 3.0.6 for ruby 2.6 and earlier

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -12,7 +12,8 @@ let
   opString = lib.optionalString;
   patchSet = import ./rvm-patchsets.nix { inherit fetchFromGitHub; };
   config = import ./config.nix { inherit fetchFromSavannah; };
-  rubygems = import ./rubygems { inherit stdenv lib fetchurl; };
+  inherit (import ./rubygems { inherit stdenv lib fetchurl; })
+    rubygems_3_0 rubygems_3_1;
 
   # Contains the ruby version heuristics
   rubyVersion = import ./ruby-version.nix { inherit lib; };
@@ -23,7 +24,7 @@ let
     then "$out/bin/ruby"
     else "${buildPackages.ruby}/bin/ruby";
 
-  generic = { version, sha256 }: let
+  generic = { version, sha256, rubygems }: let
     ver = version;
     tag = ver.gitTag;
     atLeast25 = lib.versionAtLeast ver.majMin "2.5";
@@ -236,6 +237,7 @@ in {
       src = "1bn6n5b920qy3lsx99jr8495jkc3sg89swgb96d5fgd579g6p6zr";
       git = "066kb1iki7mx7qkm10xhj5b6v8s47wg68v43l3nc36y2hyim1w2c";
     };
+    rubygems = rubygems_3_0;
   };
 
   ruby_2_5 = generic {
@@ -244,6 +246,7 @@ in {
       src = "1m6nmnj9shifp8g3yh7aimac01vl035bzcc19x2spdji6ig0sb8b";
       git = "0wppf82c9ccdbnvj30mppr5a3mc7sxm05diahjdw7hhk29n43knp";
     };
+    rubygems = rubygems_3_0;
   };
 
   ruby_2_6 = generic {
@@ -252,6 +255,7 @@ in {
       src = "0zgdrgylq6avbblf78kpaf0k2xnkpc3jng3wkd7x67ycdrqnp5v6";
       git = "0pay6ic22ag3bnvxffhgwp7z6clkd0p93944a1l4lvc5hxc8v77j";
     };
+    rubygems = rubygems_3_0;
   };
 
   ruby_2_7 = generic {
@@ -260,5 +264,6 @@ in {
       src = "1glc3zpnih6h8mrgfcak0aa7cgmi4zyvxfyi6y2brwg2nn9sm6cc";
       git = "11iz64k95czs273mb10195d1j75mmbcgddfdx1vay5876ffw81dq";
     };
+    rubygems = rubygems_3_1;
   };
 }

--- a/pkgs/development/interpreters/ruby/rubygems/default.nix
+++ b/pkgs/development/interpreters/ruby/rubygems/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchurl }:
 
-stdenv.mkDerivation rec {
+let generic = { version, sha256 }: stdenv.mkDerivation {
   name = "rubygems";
-  version = "3.1.2";
+  inherit version;
 
   src = fetchurl {
     url = "https://rubygems.org/rubygems/rubygems-${version}.tgz";
-    sha256 = "0h7ij4jpj8rgnpkl63cwh2lnav73pw5wpfqra3va7077lsyadlgd";
+    inherit sha256;
   };
 
   patches = [
@@ -26,5 +26,15 @@ stdenv.mkDerivation rec {
     homepage = https://rubygems.org/;
     license = with licenses; [ mit /* or */ ruby ];
     maintainers = with maintainers; [ qyliss zimbatm ];
+  };
+};
+in {
+  rubygems_3_0 = generic {
+    version = "3.0.6";
+    sha256 = "1ca1i4xmggizr59m6p28gprlvshczsbx30q8iyzxb2vj4jn8arzx";
+  };
+  rubygems_3_1 = generic {
+    version = "3.1.2";
+    sha256 = "0h7ij4jpj8rgnpkl63cwh2lnav73pw5wpfqra3va7077lsyadlgd";
   };
 }

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -79,12 +79,7 @@ in buildRubyGem rec {
   '';
 
   installCheckPhase = ''
-    if [[ "$("$out/bin/vagrant" --version)" == "Vagrant ${version}" ]]; then
-      echo 'Vagrant smoke check passed'
-    else
-      echo 'Vagrant smoke check failed'
-      return 1
-    fi
+    HOME="$(mktemp -d)" $out/bin/vagrant init --output - > /dev/null
   '';
 
   # `patchShebangsAuto` patches this one script which is intended to run


### PR DESCRIPTION
###### Motivation for this change

The rubygems upgrade from 3.0.6 to 3.1.2 (#76495) broke vagrant at runtime. Specifically, it

* works with ruby 2.6 and rubygems 3.0.6,
* fails with ruby 2.6 and rubygems 3.1.2,
* works with ruby 2.7 and rubygems 3.1.2,

perhaps because bundler 2.1 vendored by rubygems 3.1 conflicts with bundler 1.17 vendored by ruby 2.6.

Fixes #76629.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vrthra @manveru @alyssais @zimbatm @aneeshusa
