### PR TITLE
wayfire: init at 0.3.1

### DIFF
--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkgconfig
+, wayland
+, wlroots
+, wayland-protocols
+, cairo
+, libdrm
+, glm
+, libinput
+, libxkbcommon
+, libevdev
+, libjpeg
+, wf-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wayfire";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = pname;
+    rev = version;
+    sha256 = "0sgcna258f6ccnyg4fm1vwvi9fk88dv8m7jpka1npvkk7c0bjc51";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+  ];
+
+  buildInputs = [
+    wayland
+    wlroots
+    wayland-protocols
+    cairo
+    libdrm
+    glm
+    libinput
+    libxkbcommon
+    libjpeg
+    wf-config
+  ];
+
+  postInstall = ''
+    cp ../wayfire.ini.default $out/share/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "3D wayland compositor";
+    homepage = https://wayfire.org/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Thra11 ];
+  };
+}

--- a/pkgs/applications/window-managers/wayfire/wf-config.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-config.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkgconfig
+, wlroots
+, libevdev
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wf-config";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = "wf-config";
+    rev = version;
+    sha256 = "100b78wvnb3qwd2lrhnh5d0llvn71lfjpkjryry5gbz5v20a63z7";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+  ];
+
+  buildInputs = [
+    wlroots
+    libevdev
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A library for managing configuration files, written for wayfire";
+    homepage = https://wayfire.org/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Thra11 ];
+  };
+}

--- a/pkgs/applications/window-managers/wayfire/wf-shell.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-shell.nix
@@ -1,0 +1,72 @@
+{ stdenv
+, fetchFromGitHub
+, fetchFromGitLab
+, meson
+, ninja
+, pkgconfig
+, wayland
+, wayland-protocols
+, wf-config
+, gtkmm3
+, gobject-introspection
+, libpulseaudio
+, alsaLib
+, libjpeg
+, gtk-layer-shell
+}:
+
+let
+  # fetch submodule
+  libgnome-volume-control = fetchFromGitLab {
+    rev = "468022b708fc1a56154f3b0cc5af3b938fb3e9fb";
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "libgnome-volume-control";
+    sha256 = "01wrl875r52v7f12yrx3qdn2d2s3h2xz7jx1dswydypd9b6qss0d";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "wf-shell";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "WayfireWM";
+    repo = pname;
+    rev = version;
+    sha256 = "0xgr5lgrhdab3qm24z0ws1b7xz1mhf6m1gxzgj5wpr4pc7iwc7lw";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    wf-config
+    gtkmm3
+    gobject-introspection
+    libpulseaudio
+    alsaLib
+    libjpeg
+    gtk-layer-shell
+  ];
+
+  postUnpack = ''
+    cp -r ${libgnome-volume-control}/* source/subprojects/gvc/
+  '';
+
+  postInstall = ''
+    cp ../wf-shell.ini.example $out/share/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A GTK3-based panel for wayfire";
+    homepage = https://wayfire.org/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Thra11 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22090,6 +22090,10 @@ in
   way-cooler = throw ("way-cooler is abandoned by its author: " +
     "https://way-cooler.org/blog/2020/01/09/way-cooler-post-mortem.html");
 
+  wf-config = callPackage ../applications/window-managers/wayfire/wf-config.nix { };
+  wayfire = callPackage ../applications/window-managers/wayfire { };
+  wf-shell = callPackage ../applications/window-managers/wayfire/wf-shell.nix { };
+
   waypipe = callPackage ../applications/networking/remote/waypipe { };
 
   wayv = callPackage ../tools/X11/wayv {};


### PR DESCRIPTION
###### Motivation for this change

Package the wayfire 3D wayland compositor, including its config library and shell (panel, background). Seems to work fairly well using the default/example config files.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
