### PR TITLE
pythonPackages.unicorn: redesign to become a wrapper package around unicorn-emu

### DIFF
--- a/pkgs/development/libraries/unicorn-emu/default.nix
+++ b/pkgs/development/libraries/unicorn-emu/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   configurePhase = '' patchShebangs make.sh '';
-  buildPhase = '' ./make.sh '';
+  buildPhase = '' ./make.sh '' + stdenv.lib.optionalString stdenv.isDarwin "macos-universal-no";
   installPhase = '' env PREFIX=$out ./make.sh install '';
 
   nativeBuildInputs = [ pkgconfig python ];
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     description = "Lightweight multi-platform CPU emulator library";
     homepage    = "http://www.unicorn-engine.org";
     license     = stdenv.lib.licenses.bsd3;
-    platforms   = stdenv.lib.platforms.linux;
+    platforms   = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
   };
 }

--- a/pkgs/development/python-modules/unicorn/default.nix
+++ b/pkgs/development/python-modules/unicorn/default.nix
@@ -1,23 +1,23 @@
-{ stdenv, buildPackages, buildPythonPackage, fetchPypi }:
+{ stdenv, buildPythonPackage, setuptools, unicorn-emu }:
 
 buildPythonPackage rec {
   pname = "unicorn";
-  version = "1.0.1";
+  version = stdenv.lib.getVersion unicorn-emu;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0a5b4vh734b3wfkgapzzf8x18rimpmzvwwkly56da84n27wfw9bg";
-  };
+  src = unicorn-emu.src;
+  sourceRoot = "unicorn-${version}/bindings/python";
 
-  # needs python2 at build time
-  PYTHON=buildPackages.python2.interpreter;
+  prePatch = ''
+    ln -s ${unicorn-emu}/lib/libunicorn${stdenv.targetPlatform.extensions.sharedLibrary} prebuilt/
+    ln -s ${unicorn-emu}/lib/libunicorn.a prebuilt/
+  '';
 
-  setupPyBuildFlags = [ "--plat-name" "linux" ];
+  propagatedBuildInputs = [ setuptools ];
 
   meta = with stdenv.lib; {
-    description = "Unicorn CPU emulator engine";
+    description = "Python bindings for Unicorn CPU emulator engine";
     homepage = "http://www.unicorn-engine.org/";
     license = [ licenses.gpl2 ];
-    maintainers = [ maintainers.bennofs ];
+    maintainers = with maintainers; [ bennofs ris ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Currently the python package is totally separate from the `unicorn-emu` package ending up performing almost the same compilation, while actually the "bindings" are really just a subdirectory of the main `unicorn` source. Re-using the compilation result will allow us to keep the two in sync and should allow more flexibility in creating overridden versions (which I'll have to do when I add unicorn support to the `aflplusplus` package in #76645).

At the same time I've fixed & enabled `unicorn-emu` on darwin.

Only reverse dependency rebuilds that fail seem already broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @bennofs @thoughtpolice 
