### PR TITLE
codeowners: Add infinisil to some more paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 /.github/CODEOWNERS @edolstra
 
 # Libraries
-/lib                        @edolstra @nbp
+/lib                        @edolstra @nbp @infinisil
 /lib/systems                @nbp @ericson2314 @matthewbauer
 /lib/generators.nix         @edolstra @nbp @Profpatsch
 /lib/debug.nix              @edolstra @nbp @Profpatsch
@@ -30,9 +30,9 @@
 /pkgs/build-support/setup-hooks       @Ericson2314
 
 # NixOS Internals
-/nixos/default.nix          @nbp
-/nixos/lib/from-env.nix     @nbp
-/nixos/lib/eval-config.nix  @nbp
+/nixos/default.nix          @nbp @infinisil
+/nixos/lib/from-env.nix     @nbp @infinisil
+/nixos/lib/eval-config.nix  @nbp @infinisil
 /nixos/doc/manual/configuration/abstractions.xml      @nbp
 /nixos/doc/manual/configuration/config-file.xml       @nbp
 /nixos/doc/manual/configuration/config-syntax.xml     @nbp
@@ -62,7 +62,7 @@
 
 # Haskell
 /pkgs/development/compilers/ghc                       @basvandijk @cdepillabout
-/pkgs/development/haskell-modules                     @basvandijk @cdepillabout
+/pkgs/development/haskell-modules                     @basvandijk @cdepillabout @infinisil
 /pkgs/development/haskell-modules/default.nix         @basvandijk @cdepillabout
 /pkgs/development/haskell-modules/generic-builder.nix @basvandijk @cdepillabout
 /pkgs/development/haskell-modules/hoogle.nix          @basvandijk @cdepillabout


### PR DESCRIPTION
###### Motivation for this change
I know stuff about these

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
