### PR TITLE
spectral: unstable 2019-08-30 -> 817, olm: cmake+clean

### DIFF
--- a/pkgs/applications/networking/instant-messengers/spectral/default.nix
+++ b/pkgs/applications/networking/instant-messengers/spectral/default.nix
@@ -7,34 +7,32 @@
 , qtgraphicaleffects
 , qtdeclarative
 , qtmacextras
-, olm, cmark
+, olm, libsecret, cmark
 }:
 
 let qtkeychain-qt5 = qtkeychain.override {
   inherit qtbase qttools;
   withQt5 = true;
 };
-in stdenv.mkDerivation {
+in stdenv.mkDerivation rec {
   pname = "spectral";
-  version = "unstable-2019-08-30";
+  version = "817";
 
   src = fetchgit {
-    url = "https://gitlab.com/b0/spectral.git";
-    rev = "ee86c948aec5fe72979fc6df97f4a6ef711bdf94";
-    sha256 = "1mqabdkvzq48wki92wm2r79kj8g8m7ganpl47sh60qfsk4bxa8b2";
+    url = "https://gitlab.com/spectral-im/spectral.git";
+    rev = version;
+    sha256 = "0lg0bkz621cmqb67kz1zmn4xwbspcqalz68byll5iszqz9y4gnp1";
     fetchSubmodules = true;
   };
 
-  #qmakeFlags = [ "CONFIG+=qtquickcompiler" "BUNDLE_FONT=true" ];
-
   nativeBuildInputs = [ pkgconfig cmake wrapQtAppsHook ];
-  buildInputs = [ qtbase qtkeychain-qt5 qtquickcontrols2 qtmultimedia qtgraphicaleffects qtdeclarative olm cmark ]
+  buildInputs = [ qtbase qtkeychain-qt5 qtquickcontrols2 qtmultimedia qtgraphicaleffects qtdeclarative olm libsecret cmark ]
     ++ stdenv.lib.optional stdenv.hostPlatform.isLinux libpulseaudio
     ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin qtmacextras;
 
   meta = with stdenv.lib; {
     description = "A glossy cross-platform Matrix client.";
-    homepage = "https://gitlab.com/b0/spectral";
+    homepage = "https://spectral.im";
     license = licenses.gpl3;
     platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ dtzWill ];

--- a/pkgs/development/libraries/olm/default.nix
+++ b/pkgs/development/libraries/olm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "olm";
@@ -9,17 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "0f7azjxc77n4ib9nj3cwyk3vhk8r2dsyf7id6nvqyxqxwxn95a8w";
   };
 
+  nativeBuildInputs = [ cmake ];
+
   doCheck = true;
-  checkTarget = "test";
-
-  # requires optimisation but memory operations are compiled with -O0
-  hardeningDisable = ["fortify"];
-
-  makeFlags = stdenv.lib.optional stdenv.cc.isClang "CC=cc";
-
-  installFlags = [
-    "PREFIX=${placeholder ''out''}"
-  ];
 
   meta = {
     description = "Implements double cryptographic ratchet and Megolm ratchet";


### PR DESCRIPTION
###### Motivation for this change

Update!

If crashes on launch, and you've previously used spectral,
I've found sometimes nuking paths like
`~/.cache/ENCOM/Spectral/qmlcache` or even
`~/.cache/ENCOM/Spectral` seems to fix things.

Not sure what is going on that would cause that, just a heads-up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill (me :innocent:)