### PR TITLE
devilutionx: 0.5.0 -> 1.0.0, install font file

### DIFF
--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -10,7 +10,10 @@ stdenv.mkDerivation rec {
     sha256 = "010hxj129zmsynvizk89vm2y29dcxsfi585czh3f03wfr38rxa6b";
   };
 
-  NIX_CFLAGS_COMPILE = "-I${SDL2_ttf}/include/SDL2";
+  NIX_CFLAGS_COMPILE = [
+    "-I${SDL2_ttf}/include/SDL2"
+    ''-DTTF_FONT_PATH="${placeholder "out"}/share/fonts/truetype/CharisSILB.ttf"''
+  ];
 
   nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [ libsodium SDL2 SDL2_mixer SDL2_ttf ];
@@ -22,8 +25,10 @@ stdenv.mkDerivation rec {
     mkdir -p $out/Applications
     mv devilutionx.app $out/Applications
   '' else ''
-    mkdir -p $out/bin
-    cp devilutionx $out/bin
+    install -Dm755 -t $out/bin devilutionx
+    install -Dt $out/share/fonts/truetype ../Packaging/resources/CharisSILB.ttf
+
+    # TODO: icons and .desktop (see Packages/{debian,fedora}/*)
   '') + ''
 
     runHook postInstall

--- a/pkgs/games/devilutionx/default.nix
+++ b/pkgs/games/devilutionx/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, cmake, SDL2, SDL2_mixer, SDL2_ttf, libsodium, pkg-config }:
 stdenv.mkDerivation rec {
-  version = "0.5.0";
+  version = "1.0.0";
   pname = "devilutionx";
 
   src = fetchFromGitHub {
     owner = "diasurgical";
     repo = "devilutionX";
     rev = version;
-    sha256 = "010hxj129zmsynvizk89vm2y29dcxsfi585czh3f03wfr38rxa6b";
+    sha256 = "0lx903gchda4bgr71469yn63rx5ya6xv9j1azx18nrv3sskrphn4";
   };
 
   NIX_CFLAGS_COMPILE = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

Maintainer: `karolchmist` (no github name in maintainer-list.nix)