### PR TITLE
txr: 225 -> 230

### DIFF
--- a/pkgs/tools/misc/txr/default.nix
+++ b/pkgs/tools/misc/txr/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ bison flex ];
   buildInputs = [ libffi ];
 
+  # fix usage of off_t without include
+  postPatch = ''
+    sed -i '1i#include <sys/types.h>' sysif.h
+  '';
+
   enableParallelBuilding = true;
 
   doCheck = true;

--- a/pkgs/tools/misc/txr/default.nix
+++ b/pkgs/tools/misc/txr/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "txr";
-  version = "225";
+  version = "230";
 
   src = fetchurl {
     url = "http://www.kylheku.com/cgit/txr/snapshot/${pname}-${version}.tar.bz2";
-    sha256 = "07vh0rmvjr2sir15l3ppp2pnp2d849dg17rzykkzqyk3d5rwfxyj";
+    sha256 = "03ab9drdqvkfq240pkrx6197jjvvjizjwfx9psjmm6lixksw0kjx";
   };
 
   nativeBuildInputs = [ bison flex ];


### PR DESCRIPTION
###### Motivation for this change

http://www.kylheku.com/cgit/txr/tree/RELNOTES?id=txr-230
(changes for versions upgraded "through" are included below)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill (:innocent:)