### PR TITLE
joplin-desktop: 1.0.167 -> 1.0.177

### DIFF
--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -2,12 +2,12 @@
 
 let
   pname = "joplin-desktop";
-  version = "1.0.167";
+  version = "1.0.177";
 in appimageTools.wrapType2 rec {
   name = "${pname}-${version}";
   src = fetchurl {
-    url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}-x86_64.AppImage";
-    sha256 = "062f2av60490ffrml0q8zv68yir6zaqif0g3d32c985gcvmgn9lw";
+    url = "https://github.com/laurent22/joplin/releases/download/v${version}/Joplin-${version}.AppImage";
+    sha256 = "023q3yxqsv0vd76bvfhyhh0pnfia01rflfpyv0i6w6xnb5hm2jp7";
   };
 
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/laurent22/joplin/releases/tag/v1.0.177
https://github.com/laurent22/joplin/releases/tag/v1.0.176
https://github.com/laurent22/joplin/releases/tag/v1.0.175
https://github.com/laurent22/joplin/releases/tag/v1.0.174
https://github.com/laurent22/joplin/releases/tag/v1.0.173
https://github.com/laurent22/joplin/releases/tag/v1.0.172
https://github.com/laurent22/joplin/releases/tag/v1.0.171
https://github.com/laurent22/joplin/releases/tag/v1.0.170
https://github.com/laurent22/joplin/releases/tag/v1.0.169
https://github.com/laurent22/joplin/releases/tag/v1.0.168

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @