### PR TITLE
victor-mono: 1.2.7 -> 1.3.0

### DIFF
--- a/pkgs/data/fonts/victor-mono/default.nix
+++ b/pkgs/data/fonts/victor-mono/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "victor-mono";
-  version = "1.2.7";
+  version = "1.3.0";
 in fetchFromGitHub rec {
   name = "${pname}-${version}";
 
@@ -26,7 +26,7 @@ in fetchFromGitHub rec {
     unzip -j VictorMonoAll.zip \*.otf -d $out/share/fonts/opentype/${pname}
   '';
 
-  sha256 = "0x4ydp11ry94wkkspnmy1xpzqq3m45xg60z1hq4ll9gmlccaknj0";
+  sha256 = "1lv2x7kfspabnhvm8z79n165fw3awvzj1r8f0g5zn26wgdalgw69";
 
   meta = with lib; {
     description = "Free programming font with cursive italics and ligatures";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/rubjo/victor-mono/releases/tag/v1.3.0
https://github.com/rubjo/victor-mono/releases/tag/v1.2.9
https://github.com/rubjo/victor-mono/releases/tag/v1.2.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jpotier @dtzWill