### PR TITLE
m64py: init at 0.2.4

### DIFF
--- a/pkgs/misc/emulators/m64py/default.nix
+++ b/pkgs/misc/emulators/m64py/default.nix
@@ -1,0 +1,51 @@
+{ lib, fetchFromGitHub, mupen64plus, python3Packages, wrapQtAppsHook }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "m64py";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "mupen64plus";
+    repo = "mupen64plus-ui-python";
+    # As of 2020-01-01, the latest release of m64py is 0.2.4.  However,
+    # this was released in 2017, and there hasn't been a new release since
+    # then.  There have been a few commits to the repo since 0.2.4
+    # improving things, so we use the latest commit from the repo as of
+    # 2020-01-01.
+    rev = "30e05dd9a357bf6e56fc2b23cf64f5d0ada03192";
+    sha256 = "1x5shgg4jrafyb0axk39m3n6p28n0ylniv5hchrh9qbqq6zb1v5r";
+  };
+
+  propagatedBuildInputs =
+    (with python3Packages; [
+      pyqt5
+      pysdl2
+    ]) ++
+    [ mupen64plus
+    ];
+
+  nativeBuildInputs =
+    (with python3Packages; [
+      pyqt5
+    ]) ++
+    [ wrapQtAppsHook
+    ];
+
+  dontWrapQtApps = true;
+
+  postFixup = ''
+    wrapPythonPrograms
+
+    wrapQtApp "$out/bin/m64py" \
+      --prefix PATH : "${mupen64plus}/bin" \
+      --prefix LD_LIBRARY_PATH : "${mupen64plus}/lib" \
+      --run 'cd "${mupen64plus}/lib"'
+  '';
+
+  meta = with lib; {
+    description = "A Qt5 front-end (GUI) for Mupen64Plus";
+    maintainers = with maintainers; [ cdepillabout ];
+    license = licenses.gpl3;
+    homepage = "https://github.com/mupen64plus/mupen64plus-ui-python";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24741,6 +24741,8 @@ in
 
   mupen64plus = callPackage ../misc/emulators/mupen64plus { };
 
+  m64py = libsForQt5.callPackage ../misc/emulators/m64py { };
+
   muse = callPackage ../applications/audio/muse { };
 
   musly = callPackage ../applications/audio/musly { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This adds the package m64py:

https://github.com/mupen64plus/mupen64plus-ui-python

This is a Qt-based GUI for the mupen64plus N64 emulator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
