### PR TITLE
Telega voip support

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -296,7 +296,10 @@ let
 
         # Telega has a server portion for it's network protocol
         telega = super.telega.overrideAttrs (old: {
-          buildInputs = old.buildInputs ++ [ pkgs.tdlib ];
+          buildInputs = old.buildInputs ++ [
+            pkgs.tdlib
+            (pkgs.callPackage ./telega/libtgvoip.nix {})
+          ];
           nativeBuildInputs = [ pkgs.pkg-config ];
 
           postPatch = ''
@@ -310,6 +313,7 @@ let
           '';
 
           postBuild = ''
+            export WITH_VOIP=t
             cd source/server
             make
             cd -

--- a/pkgs/applications/editors/emacs-modes/telega/libtgvoip.nix
+++ b/pkgs/applications/editors/emacs-modes/telega/libtgvoip.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, libopus
+, openssl
+, libpulseaudio
+, alsaLib
+, patchelf
+}:
+
+let
+  version = "2.4.4";
+
+in stdenv.mkDerivation {
+  pname = "libtgvoip";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "grishka";
+    repo = "libtgvoip";
+    rev = version;
+    sha256 = "122kn3jx6v0kkldlzlpzvlwqxgp6pmzxsjhrhcxw12bx9c08sar5";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkg-config ]
+    ++ lib.optional stdenv.isLinux patchelf;
+  buildInputs = [ libopus openssl  ]
+    ++ lib.optionals stdenv.isLinux [ alsaLib libpulseaudio ];
+
+  # libtgvoip wants to dlopen libpulse and libasound, so tell it where they are.
+  postFixup = lib.optionalString stdenv.isLinux ''
+    so=$(readlink -f $out/lib/libtgvoip.so)
+    patchelf --set-rpath ${lib.makeLibraryPath [ libpulseaudio alsaLib ]}:$(patchelf --print-rpath "$so") "$so"
+  '';
+
+  meta = {
+    description = ''
+      A collection of libraries and header files for implementing telephony functionality into custom Telegram clients.
+    '';
+    license = lib.licenses.unlicense;
+  };
+
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add telega.el VoIP support.

###### Things done
Packaged libtgvoip
Added libtgvoip to telega.el deps
Added a flag to build with voip
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @adisbladis 
