### PR TITLE
freeswitch: fix gsmopen build and enable by default for linux

### DIFF
--- a/pkgs/development/libraries/gsmlib/default.nix
+++ b/pkgs/development/libraries/gsmlib/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+stdenv.mkDerivation rec {
+  pname = "gsmlib";
+  version = "unstable-2017-10-06";
+  src = fetchFromGitHub {
+    owner = "x-logLT";
+    repo = "gsmlib";
+    rev = "4f794b14450132f81673f7d3570c5a859aecf7ae";
+    sha256 = "16v8aj914ac1ipf14a867ljib3gy7fhzd9ypxnsg9l0zi8mm3ml5";
+  };
+  nativeBuildInputs = [ autoreconfHook ];
+  meta = with stdenv.lib; {
+    description = "Library to access GSM mobile phones through GSM modems";
+    homepage = "https://github.com/x-logLT/gsmlib";
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.misuzu ];
+  };
+}

--- a/pkgs/development/libraries/libctb/default.nix
+++ b/pkgs/development/libraries/libctb/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl }:
+stdenv.mkDerivation rec {
+  pname = "libctb";
+  version = "0.16";
+  src = fetchurl {
+    url = "https://iftools.com/download/files/legacy/${pname}-${version}.tar.gz";
+    sha256 = "027wh89d0qyly3d9m6rg4x7x1gqz3y3cnxlgk0k8xgygcrm05c0w";
+  };
+  patches = [
+    ./include-kbhit.patch
+  ];
+  sourceRoot = "${pname}-${version}/build";
+  makeFlags = [
+    "prefix=$(out)"
+  ];
+  meta = with stdenv.lib; {
+    description = "Communications toolbox";
+    homepage = "https://iftools.com";
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.misuzu ];
+  };
+}

--- a/pkgs/development/libraries/libctb/include-kbhit.patch
+++ b/pkgs/development/libraries/libctb/include-kbhit.patch
@@ -1,0 +1,13 @@
+diff --git a/GNUmakefile b/GNUmakefile
+index e39a687..026f9c4 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -140,7 +140,7 @@ all: ../lib/libctb$(LIBFLAG)$(GPIBFLAG)-0.16.a ../lib/libctb$(LIBFLAG)$(GPIBFLAG
+
+ install: install_ctb_lib install_ctb_dll
+ 	$(INSTALL) -d $(DESTDIR)$(prefix)/include/ctb-0.16
+-	for f in ctb.h fifo.h getopt.h $(GPIBINC) iobase.h linux/serport.h linux/timer.h portscan.h serport.h serportx.h timer.h; do \
++	for f in ctb.h fifo.h getopt.h $(GPIBINC) iobase.h kbhit.h linux/serport.h linux/timer.h portscan.h serport.h serportx.h timer.h; do \
+ 	if test ! -d $(DESTDIR)$(prefix)/include/ctb-0.16/`dirname $$f` ; then \
+ 	$(INSTALL) -d $(DESTDIR)$(prefix)/include/ctb-0.16/`dirname $$f`; \
+ 	fi; \

--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -1,4 +1,18 @@
+{ fetchurl, stdenv, lib, ncurses, curl, pkgconfig, gnutls, readline
+, openssl, perl, sqlite, libjpeg, speex, pcre
+, ldns, libedit, yasm, which, lua, libopus, libsndfile, libtiff
+, libctb, gsmlib
+
+, modules ? null
+, postgresql
+, enablePostgres ? true
+
+, SystemConfiguration
+}:
+
 let
+
+availableModules = import ./modules.nix { inherit curl lua libopus libctb gsmlib; };
 
 # the default list from v1.8.7, except with applications/mod_signalwire also disabled
 defaultModules = mods: with mods; [
@@ -57,26 +71,9 @@ defaultModules = mods: with mods; [
   xml_int.cdr
   xml_int.rpc
   xml_int.scgi
-];
+] ++ lib.optionals stdenv.isLinux [ endpoints.gsmopen ];
 
-in
-
-{ fetchurl, stdenv, lib, ncurses, curl, pkgconfig, gnutls, readline
-, openssl, perl, sqlite, libjpeg, speex, pcre
-, ldns, libedit, yasm, which, lua, libopus, libsndfile, libtiff
-
-, modules ? defaultModules
-, postgresql
-, enablePostgres ? true
-
-, SystemConfiguration
-}:
-
-let
-
-availableModules = import ./modules.nix { inherit curl lua libopus; };
-
-enabledModules = modules availableModules;
+enabledModules = (if modules != null then modules else defaultModules) availableModules;
 
 modulesConf = let
   lst = builtins.map (mod: mod.path) enabledModules;
@@ -127,7 +124,7 @@ stdenv.mkDerivation rec {
     description = "Cross-Platform Scalable FREE Multi-Protocol Soft Switch";
     homepage = https://freeswitch.org/;
     license = stdenv.lib.licenses.mpl11;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = with stdenv.lib.maintainers; [ misuzu ];
     platforms = with stdenv.lib.platforms; unix;
   };
 }

--- a/pkgs/servers/sip/freeswitch/modules.nix
+++ b/pkgs/servers/sip/freeswitch/modules.nix
@@ -1,4 +1,6 @@
 { libopus
+, libctb
+, gsmlib
 , lua
 , curl
 }:
@@ -114,7 +116,7 @@ in
   endpoints = {
     alsa = mk "endpoints/mod_alsa" [];
     dingaling = mk "endpoints/mod_dingaling" [];
-    gsmopen = mk "endpoints/mod_gsmopen" [];
+    gsmopen = mk "endpoints/mod_gsmopen" [ gsmlib libctb ];
     h323 = mk "endpoints/mod_h323" [];
     khomp = mk "endpoints/mod_khomp" [];
     loopback = mk "endpoints/mod_loopback" [];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12216,6 +12216,8 @@ in
 
   libcredis = callPackage ../development/libraries/libcredis { };
 
+  libctb = callPackage ../development/libraries/libctb { };
+
   libctemplate = callPackage ../development/libraries/libctemplate { };
 
   libcouchbase = callPackage ../development/libraries/libcouchbase { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3798,6 +3798,8 @@ in
 
   gsmartcontrol = callPackage ../tools/misc/gsmartcontrol { };
 
+  gsmlib = callPackage ../development/libraries/gsmlib { };
+
   gssdp = callPackage ../development/libraries/gssdp { };
 
   gt5 = callPackage ../tools/system/gt5 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Out-of-box support for USB GSM modems in FreeSWITCH on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @pmahoney