### PR TITLE
sway: 1.2 -> 1.4, wlroots: 0.8.1 -> 0.10.0

### DIFF
--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -87,7 +87,8 @@ in {
       type = with types; listOf package;
       default = with pkgs; [
         swaylock swayidle
-        xwayland rxvt_unicode dmenu
+        xwayland alacritty dmenu
+        rxvt_unicode # For backward compatibility (old default terminal)
       ];
       defaultText = literalExample ''
         with pkgs; [ swaylock swayidle xwayland rxvt_unicode dmenu ];

--- a/pkgs/applications/window-managers/cage/default.nix
+++ b/pkgs/applications/window-managers/cage/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchFromGitHub, fetchpatch
 , meson, ninja, pkgconfig, makeWrapper
 , wlroots, wayland, wayland-protocols, pixman, libxkbcommon
 , systemd, libGL, libX11
@@ -6,14 +6,20 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "cage";
-  version = "0.1.1";
+  pname = "cage-unstable";
+  version = "2020-01-18";
+  # The last stable release (0.1.1) would require at least the following 3 patches:
+  # - https://github.com/Hjdskes/cage/commit/33bb3c818c5971777b6f09d8821e7f078d38d262.patch
+  # - https://github.com/Hjdskes/cage/commit/51e6c760da51e2b885737d61a61cdc965bb9269d.patch
+  # - https://github.com/Hjdskes/cage/commit/84216ca2a417b237ad61c11e2f3ebbcb91681ece.patch
+  # Which need to be adapted due to other changes. At this point it seems
+  # better to use the current master version until the next stable release.
 
   src = fetchFromGitHub {
     owner = "Hjdskes";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "1vp4mfkflrjmlgyx5mkbzdi3iq58m76q7l9dfrsk85xn0642d6q1";
+    repo = "cage";
+    rev = "cc1f975c442ebd691b70196d76aa120ead717810";
+    sha256 = "1gkqx26pvlw00b3fgx6sh87yyjfzyj51jwxvbf9k117npkrf4b2g";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig makeWrapper ];

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sway-unwrapped";
-  version = "1.2";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "sway";
     rev = version;
-    sha256 = "0vch2zm5afc76ia78p3vg71zr2fyda67l9hd2h0x1jq3mnvfbxnd";
+    sha256 = "11qf89y3q92g696a6f4d23qb44gqixg6qxq740vwv2jw59ms34ja";
   };
 
   patches = [

--- a/pkgs/applications/window-managers/sway/idle.nix
+++ b/pkgs/applications/window-managers/sway/idle.nix
@@ -5,14 +5,19 @@
 
 stdenv.mkDerivation rec {
   pname = "swayidle";
-  version = "1.5";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "swayidle";
     rev = version;
-    sha256 = "05qi96j58xqxjiighay1d39rfanxcpn6vlynj23mb5dymxvlaq9n";
+    sha256 = "1nd3v8r9549lykdwh4krldfl59lzaspmmai5k1icy7dvi6kkr18r";
   };
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "version: '1.5'" "version: '${version}'"
+  '';
 
   nativeBuildInputs = [ meson ninja pkgconfig scdoc ];
   buildInputs = [ wayland wayland-protocols systemd ];

--- a/pkgs/applications/window-managers/sway/lock.nix
+++ b/pkgs/applications/window-managers/sway/lock.nix
@@ -5,17 +5,18 @@
 
 stdenv.mkDerivation rec {
   pname = "swaylock";
-  version = "1.4";
+  version = "1.5";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "swaylock";
     rev = version;
-    sha256 = "1ii9ql1mxkk2z69dv6bg1x22nl3a46iww764wqjiv78x08xpk982";
+    sha256 = "0r95p4w11dwm5ra614vddz83r8j7z6gd120z2vcchy7m9b0f15kf";
   };
 
   postPatch = ''
-    sed -iE "s/version: '1\.3',/version: '${version}',/" meson.build
+    substituteInPlace meson.build \
+      --replace "version: '1.4'" "version: '${version}'"
   '';
 
   nativeBuildInputs = [ meson ninja pkgconfig scdoc ];

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "wlroots";
     rev = version;
-    sha256 = "0sifcrqs82kg9zxqnlr1pl4cw9v9qqakyg3rkysywc9svbikd1g3";
+    sha256 = "0lh0m5wmr5a73zgqnnrrcnrywy7wjsrs839agiq9hf1yrgav3m8z";
   };
 
   # $out for the library and $examples for the example programs (in examples):

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -6,23 +6,14 @@
 
 stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.8.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "wlroots";
     rev = version;
-    sha256 = "1ak86kx617c81dy85wg9rldy1z3n8ch93cjc05a4j6sifv0nkyfm";
+    sha256 = "0sifcrqs82kg9zxqnlr1pl4cw9v9qqakyg3rkysywc9svbikd1g3";
   };
-
-  patches = [
-    # add missing header that changed in mesa-19.2.2
-    # https://github.com/swaywm/wlroots/issues/1862
-    (fetchpatch {
-      url = "https://github.com/swaywm/wlroots/commit/d113e48a2a32542fe6e12f1759f07888364609bf.diff";
-      sha256 = "1h09j1gmnzlz4py92a92chgy8xzsd8h8xn5irq9s2hq4cla66h87";
-    })
-  ];
 
   # $out for the library and $examples for the example programs (in examples):
   outputs = [ "out" "examples" ];

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchFromGitHub, meson, ninja, pkgconfig, fetchpatch
 , wayland, libGL, wayland-protocols, libinput, libxkbcommon, pixman
 , xcbutilwm, libX11, libcap, xcbutilimage, xcbutilerrors, mesa
-, libpng, ffmpeg_4, freerdp
+, libpng, ffmpeg_4
 }:
 
 stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.9.1";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "wlroots";
     rev = version;
-    sha256 = "0lh0m5wmr5a73zgqnnrrcnrywy7wjsrs839agiq9hf1yrgav3m8z";
+    sha256 = "0c0q1p9yss5kx4430ik3n89drqpmm2bvgl8fjlf6prac1a7xzqn8";
   };
 
   # $out for the library and $examples for the example programs (in examples):
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     wayland libGL wayland-protocols libinput libxkbcommon pixman
     xcbutilwm libX11 libcap xcbutilimage xcbutilerrors mesa
-    libpng ffmpeg_4 freerdp
+    libpng ffmpeg_4
   ];
 
   mesonFlags = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Ready for final testing :)
On my setup I've successfully tested `sway`, `swayidle`, `swaylock`, and `cage`.

`nix-review`:
```
8 package were build:
cage sway sway-unwrapped swayidle swaylock swaylock-fancy waybar wlroots
```

TODOs:
- [x] Testing (also e.g. waybar and cage)
- [x] Squash the RC commits before merging
- [x] The default terminal was replaced with Alacritty (needs to be reflected in the module, we probably have to keep urxvt for backwards compatibility)
- [x] Check compatibility with wayfire (https://github.com/NixOS/nixpkgs/pull/76759)
  - **Doesn't build with wlroots 0.9.1 yet**
- [x] Fix the cage build / request a new upstream release:
  ```
  builder for '/nix/store/2az706idl7hd63yfhlvr66vsn6q75yp1-cage-0.1.1.drv' failed with exit code 1; last 10 log lines:
      wlr_data_device_manager_destroy(data_device_mgr);
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      wlr_data_device_manager_create
    ../cage.c:385:2: error: implicit declaration of function 'wlr_compositor_destroy'; did you mean 'wlr_cursor_destroy'? [-Werror=implicit-function-declaration]
      wlr_compositor_destroy(compositor);
      ^~~~~~~~~~~~~~~~~~~~~~
      wlr_cursor_destroy
    cc1: all warnings being treated as errors
    [4/9] Compiling C object 'cage@exe/output.c.o'.
    ninja: build stopped: subcommand failed.
  ```
  WIP: `master` is fine and I've requested a new release: https://github.com/Hjdskes/cage/issues/107
  -> Will use master for now.


Will be done late in a separate PR:
- [ ] [Grimshot](https://github.com/swaywm/sway/blob/8ffa3cf43906fa95c127c01b751590e77c7bf695/contrib/grimshot) (should we ship the dependencies by default?)
  - Extra tools in `contrib/` aren't installed by default but we could e.g. create an additional package like `sway-contrib`. (or sway-tools, sway-extras, etc.).
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @