### PR TITLE
pythonPackages.svgwrite: refactor fix broken build

### DIFF
--- a/pkgs/development/python-modules/svgwrite/default.nix
+++ b/pkgs/development/python-modules/svgwrite/default.nix
@@ -1,7 +1,6 @@
-{ stdenv
+{ lib
 , buildPythonPackage
-, fetchPypi
-, setuptools
+, fetchFromGitHub
 , pyparsing
 , pytest
 }:
@@ -10,21 +9,27 @@ buildPythonPackage rec {
   pname = "svgwrite";
   version = "1.3.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "11e47749b159ed7004721e11d380b4642a26154b8cb2f7b0102fea9c71a3dfa1";
+  src = fetchFromGitHub {
+    owner = "mozman";
+    repo = "svgwrite";
+    rev = "v${version}";
+    sha256 = "14wz0y118a5wwfzin6cirr9254p4y825lnrnackihdbpw22gcw11";
   };
 
-  buildInputs = [ setuptools ];
-  propagatedBuildInputs = [ pyparsing ];
-  checkInputs = [ pytest ];
+  propagatedBuildInputs = [
+    pyparsing
+  ];
 
-  checkPhase = ''
+  checkInputs = [
     pytest
+  ];
+
+  # embed_google_web_font test tried to pull font from internet
+  checkPhase = ''
+    pytest -k "not test_embed_google_web_font"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A Python library to create SVG drawings";
     homepage = https://github.com/mozman/svgwrite;
     license = licenses.mit;


### PR DESCRIPTION
There was a single test in the build that tries to download a google
font.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
