### PR TITLE
kcli: init at 1.8.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1471,6 +1471,12 @@
     githubId = 143982;
     name = "Charles Strahan";
   };
+  cswank = {
+    email = "craigswank@gmail.com";
+    github = "cswank";
+    githubId = 490965;
+    name = "Craig Swank";
+  };
   cwoac = {
     email = "oliver@codersoffortune.net";
     github = "cwoac";

--- a/pkgs/development/tools/kcli/default.nix
+++ b/pkgs/development/tools/kcli/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kcli";
+  version = "1.8.2";
+
+  src = fetchFromGitHub {
+    owner = "cswank";
+    repo = "kcli";
+    rev = version;
+    sha256 = "1m9967f9wk1113ap2qmqinqg7gvpmg5y2g1ji0q818qbandzlh23";
+  };
+
+  modSha256 = "1wcqh3306q9wxb6pnl8cpk73vmy36bjv2gil03j7j4pajs1f2lwn";
+
+  subPackages = [ "." ];
+
+  meta = with stdenv.lib; {
+    description = "A kafka command line browser";
+    homepage = "https://github.com/cswank/kcli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cswank ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25718,4 +25718,6 @@ in
 
   sentencepiece = callPackage ../development/libraries/sentencepiece {};
 
+  kcli = callPackage ../development/tools/kcli {};
+
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
