### PR TITLE
bash-my-aws: init at 20200111

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -96,6 +96,7 @@
   ./programs/atop.nix
   ./programs/autojump.nix
   ./programs/bash/bash.nix
+  ./programs/bash-my-aws.nix
   ./programs/bcc.nix
   ./programs/browserpass.nix
   ./programs/captive-browser.nix

--- a/nixos/modules/programs/bash-my-aws.nix
+++ b/nixos/modules/programs/bash-my-aws.nix
@@ -1,0 +1,25 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  prg = config.programs;
+  cfg = prg.bash-my-aws;
+
+  initScript = ''
+    eval $(${pkgs.bash-my-aws}/bin/bma-init)
+  '';
+in
+  {
+    options = {
+      programs.bash-my-aws = {
+        enable = mkEnableOption "bash-my-aws";
+      };
+    };
+
+    config = mkIf cfg.enable {
+      environment.systemPackages = with pkgs; [ bash-my-aws ];
+
+      programs.bash.interactiveShellInit = initScript;
+    };
+  }

--- a/pkgs/tools/admin/bash-my-aws/default.nix
+++ b/pkgs/tools/admin/bash-my-aws/default.nix
@@ -1,0 +1,72 @@
+{ stdenv
+, awscli
+, jq
+, fetchgit
+, installShellFiles
+, bashInteractive
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bash-my-aws";
+  version = "20191231";
+
+  src = fetchgit {
+    url = "https://github.com/bash-my-aws/bash-my-aws";
+    rev = "ef93bd1bf8692dc2fe9f475e7c8a309eb25ef7a6";
+    sha256 = "c57e8327a3dfa24f0c40b8c94eab55fa232f87044e7d59f7bc4b40e5012e83ed";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  # Why does it propagate packages that are used for testing?
+  propagatedBuildInputs = [
+    awscli
+    jq
+    bashInteractive
+  ];
+  nativeBuildInputs = [ installShellFiles ];
+
+  #Checks are failing due to missing TTY, which won't exist.
+  checkPhase = ''
+    pushd test
+    ./shared-spec.sh
+    ./stack-spec.sh
+    popd
+  '';
+  installPhase=''
+    mkdir -p $out
+    cp -r . $out
+  '';
+  postFixup = ''
+    pushd $out
+    # substituteInPlace scripts/build \
+    #     --replace '~/.bash-my-aws' $out
+    # substituteInPlace scripts/build-completions \
+    #     --replace "{HOME}" $out \
+    #     --replace '~/.bash-my-aws' $out
+    # ./scripts/build
+    # ./scripts/build-completions
+    # substituteInPlace bash_completion.sh \
+    #     --replace "{HOME}" $out \
+    #     --replace .bash-my-aws ""
+    # substituteInPlace bin/bma \
+    #     --replace '~/.bash-my-aws' $out
+    # installShellCompletion --bash --name bash-my-aws.bash bash_completion.sh
+    # chmod +x $out/lib/*
+    # patchShebangs --host $out/lib
+    # cat > $out/bin/bma-init <<EOF
+    # echo source $out/aliases
+    # echo source $out/bash
+    # EOF
+    # chmod +x $out/bin/bma-init
+    popd
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://bash-my-aws.org;
+    description = "CLI commands for AWS";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tomberek ];
+  };
+}

--- a/pkgs/tools/admin/bash-my-aws/default.nix
+++ b/pkgs/tools/admin/bash-my-aws/default.nix
@@ -8,18 +8,17 @@
 
 stdenv.mkDerivation rec {
   pname = "bash-my-aws";
-  version = "20191231";
+  version = "20200111";
 
   src = fetchgit {
     url = "https://github.com/bash-my-aws/bash-my-aws";
-    rev = "ef93bd1bf8692dc2fe9f475e7c8a309eb25ef7a6";
-    sha256 = "c57e8327a3dfa24f0c40b8c94eab55fa232f87044e7d59f7bc4b40e5012e83ed";
+    rev = "5a97ce2c22affca1299022a5afa109d7b62242ba";
+    sha256 = "459bda8b244af059d96c7c8b916cf956b01cb2732d1c2888a3ae06a4d660bea6";
   };
 
   dontConfigure = true;
   dontBuild = true;
 
-  # Why does it propagate packages that are used for testing?
   propagatedBuildInputs = [
     awscli
     jq
@@ -27,7 +26,6 @@ stdenv.mkDerivation rec {
   ];
   nativeBuildInputs = [ installShellFiles ];
 
-  #Checks are failing due to missing TTY, which won't exist.
   checkPhase = ''
     pushd test
     ./shared-spec.sh
@@ -40,26 +38,27 @@ stdenv.mkDerivation rec {
   '';
   postFixup = ''
     pushd $out
-    # substituteInPlace scripts/build \
-    #     --replace '~/.bash-my-aws' $out
-    # substituteInPlace scripts/build-completions \
-    #     --replace "{HOME}" $out \
-    #     --replace '~/.bash-my-aws' $out
-    # ./scripts/build
-    # ./scripts/build-completions
-    # substituteInPlace bash_completion.sh \
-    #     --replace "{HOME}" $out \
-    #     --replace .bash-my-aws ""
-    # substituteInPlace bin/bma \
-    #     --replace '~/.bash-my-aws' $out
-    # installShellCompletion --bash --name bash-my-aws.bash bash_completion.sh
-    # chmod +x $out/lib/*
-    # patchShebangs --host $out/lib
-    # cat > $out/bin/bma-init <<EOF
-    # echo source $out/aliases
-    # echo source $out/bash
-    # EOF
-    # chmod +x $out/bin/bma-init
+    substituteInPlace scripts/build \
+        --replace '~/.bash-my-aws' $out
+    substituteInPlace scripts/build-completions \
+        --replace "{HOME}" $out \
+        --replace '~/.bash-my-aws' $out
+    ./scripts/build
+    ./scripts/build-completions
+    substituteInPlace bash_completion.sh \
+        --replace "{HOME}" $out \
+        --replace .bash-my-aws ""
+    substituteInPlace bin/bma \
+        --replace '~/.bash-my-aws' $out
+    installShellCompletion --bash --name bash-my-aws.bash bash_completion.sh
+    chmod +x $out/lib/*
+    patchShebangs --host $out/lib
+    installShellCompletion --bash --name bash-my-aws.bash bash_completion.sh
+    cat > $out/bin/bma-init <<EOF
+    echo source $out/aliases
+    echo source $out/bash_completion.sh
+    EOF
+    chmod +x $out/bin/bma-init
     popd
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -769,6 +769,8 @@ in
 
   automirror = callPackage ../tools/misc/automirror { };
 
+  bash-my-aws = callPackage ../tools/admin/bash-my-aws { };
+
   bcachefs-tools = callPackage ../tools/filesystems/bcachefs-tools { };
 
   bitwarden = callPackage ../tools/security/bitwarden { };


### PR DESCRIPTION
###### Motivation for this change
Add bash-my-aws to nixpkgs

###### Things done
- add package
- add program module
- tested on NixOS

Note: the package needs to be initialized by sourcing an alias and bash_completions for some features. Otherwise the bma script in `/bin` is still functional. Non-NixOS could use `eval $(bma-init)`  that performs the above actions, but that might be the prerogative of upstream.

Another (perhaps better) option is to incorporate into home-manager so we don't have to patch the hard-coded location away.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
