### PR TITLE
pythonPackages.tablib: 0.12.1 -> 0.14.0 enable tests remove patches

### DIFF
--- a/pkgs/development/python-modules/markuppy/default.nix
+++ b/pkgs/development/python-modules/markuppy/default.nix
@@ -1,0 +1,22 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "markuppy";
+  version = "1.14";
+
+  src = fetchPypi {
+    pname = "MarkupPy";
+    inherit version;
+    sha256 = "1adee2c0a542af378fe84548ff6f6b0168f3cb7f426b46961038a2bcfaad0d5f";
+  };
+
+  meta = with lib; {
+    description = "An HTML/XML generator";
+    homepage = https://github.com/tylerbakke/MarkupPy;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/openpyxl/default.nix
+++ b/pkgs/development/python-modules/openpyxl/default.nix
@@ -1,38 +1,43 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromBitbucket
 , isPy27
 , pytest
 , jdcal
 , et_xmlfile
 , lxml
+, pillow
 }:
 
 buildPythonPackage rec {
   pname = "openpyxl";
-  version = "3.0.2";
+  version = "3.0.1";
   disabled = isPy27; # 2.6.4 was final python2 release
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "eb68c08a72ac6d9812df181e88ebece3a68436364353eb6eda3bed863e3d73a6";
+  src = fetchFromBitbucket {
+    owner = "openpyxl";
+    repo = pname;
+    rev = version;
+    sha256 = "1svmnzby6sfdv1qkb1va8z8krysrcdzfjibnyzvl8jgpydcvi8v5";
   };
 
-  checkInputs = [ pytest ];
-  propagatedBuildInputs = [ jdcal et_xmlfile lxml ];
+  checkInputs = [
+    pytest
+    pillow
+  ];
 
-  postPatch = ''
-    # LICENSE.rst is missing, and setup.cfg currently doesn't contain anything useful anyway
-    # This should likely be removed in the next update
-    rm setup.cfg
+  propagatedBuildInputs = [
+    jdcal
+    et_xmlfile
+    lxml
+  ];
+
+  checkPhase = ''
+    pytest openpyxl
   '';
 
-  # Tests are not included in archive.
-  # https://bitbucket.org/openpyxl/openpyxl/issues/610
-  doCheck = false;
-
   meta = {
-    description = "A Python library to read/write Excel 2007 xlsx/xlsm files";
+    description = "A Python library to read/write Excel 2010 xlsx/xlsm/xltx/xltm files";
     homepage = https://openpyxl.readthedocs.org;
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ lihop sjourdois ];

--- a/pkgs/development/python-modules/tablib/default.nix
+++ b/pkgs/development/python-modules/tablib/default.nix
@@ -1,27 +1,52 @@
-{ buildPythonPackage, stdenv, fetchPypi, pytest, unicodecsv, pandas
-, xlwt, openpyxl, pyyaml, xlrd, odfpy, fetchpatch
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, pytestcov
+, unicodecsv
+, pandas
+, xlwt
+, openpyxl
+, pyyaml
+, xlrd
+, odfpy
+, markuppy
 }:
 
 buildPythonPackage rec {
   pname = "tablib";
-  version = "0.12.1";
+  version = "0.14.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "11wxchj0qz77dn79yiq30k4b4gsm429f4bizk4lm4rb63nk51kxq";
+  src = fetchFromGitHub {
+    owner = "jazzband";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1i50nbr7wxk1m6nh8bx0icci2hr9xc9sqi2ypj3ykkvl66sii2z7";
   };
 
-  checkInputs = [ pytest unicodecsv pandas ];
-  propagatedBuildInputs = [ xlwt openpyxl pyyaml xlrd odfpy ];
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/kennethreitz/tablib/commit/0e51a2d0944022af186d2dcd34c0ab3c47141ba5.patch";
-      sha256 = "0lbbl871zdn5vpgqyjkil0c2ap3b5hz19rmihhyvrx7m4mlh1aij";
-    })
+  checkInputs = [
+    pytest
+    pytestcov
+    unicodecsv
+    pandas
   ];
 
-  meta = with stdenv.lib; {
+  propagatedBuildInputs = [
+    xlwt
+    openpyxl
+    pyyaml
+    xlrd
+    odfpy
+    markuppy
+  ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
     description = "Tablib: format-agnostic tabular dataset library";
     homepage = http://python-tablib.org;
     license = licenses.mit;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -809,6 +809,8 @@ in {
 
   markerlib = callPackage ../development/python-modules/markerlib { };
 
+  markuppy = callPackage ../development/python-modules/markuppy { };
+
   matchpy = callPackage ../development/python-modules/matchpy { };
 
   maxminddb = callPackage ../development/python-modules/maxminddb { };


### PR DESCRIPTION

###### Motivation for this change

Required a backport of openpyxl from 3.0.2 -> 3.0.1. 3.0.2 is broken https://bitbucket.org/openpyxl/openpyxl/issues/1373/broken-writer-with-lxml-defusedxml. Which causes the writer to fail. Enable tests on openpyxl as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
