### PR TITLE
pythonPackages.browser-cookie3: refactor fix broken package use github src

### DIFF
--- a/pkgs/development/python-modules/browser-cookie3/default.nix
+++ b/pkgs/development/python-modules/browser-cookie3/default.nix
@@ -1,16 +1,34 @@
-{ lib, fetchPypi, buildPythonPackage, isPy3k, keyring, pbkdf2, pyaes}:
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, isPy27
+, keyring
+, pbkdf2
+, pyaes
+, python-lz4
+, configparser
+}:
+
 buildPythonPackage rec {
   pname = "browser-cookie3";
   version = "0.9.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "42e73e0276083ff162080860cd039138760921a56a0f316775cecee37d444c3f";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "borisbabic";
+    repo = "browser_cookie3";
+    rev = version;
+    sha256 = "00967fw9d2zb7kzr7p0lvkhi0vswy1crznxqgq8z2pk229cn4b2s";
   };
 
-  disabled = !isPy3k;
-
-  propagatedBuildInputs = [ keyring pbkdf2 pyaes ];
+  propagatedBuildInputs = [
+    keyring
+    pbkdf2
+    pyaes
+    python-lz4
+    configparser
+  ];
 
   # No tests implemented
   doCheck = false;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
