### PR TITLE
freeswitch: 1.8.7 -> 1.10.2

### DIFF
--- a/pkgs/servers/sip/freeswitch/modules.nix
+++ b/pkgs/servers/sip/freeswitch/modules.nix
@@ -3,6 +3,8 @@
 , gsmlib
 , lua
 , curl
+, libmysqlclient
+, postgresql
 }:
 
 let
@@ -101,6 +103,11 @@ in
     silk = mk "codecs/mod_silk" [];
     siren = mk "codecs/mod_siren" [];
     theora = mk "codecs/mod_theora" [];
+  };
+
+  databases = {
+    mariadb = mk "databases/mod_mariadb" [ libmysqlclient ];
+    pgsql = mk "databases/mod_pgsql" [ postgresql ];
   };
 
   dialplans = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Release notes:
https://github.com/signalwire/freeswitch/releases/tag/v1.10.2
https://freeswitch.org/confluence/display/FREESWITCH/FreeSWITCH+1.10.x+Release+notes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
