### PR TITLE
rust: 1.39.0 -> 1.40.0

### DIFF
--- a/pkgs/development/compilers/rust/1_40_0.nix
+++ b/pkgs/development/compilers/rust/1_40_0.nix
@@ -1,0 +1,29 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+# 3. Firefox and Thunderbird should still build on x86_64-linux.
+import ./default.nix {
+  rustcVersion = "1.40.0";
+  rustcSha256 = "1ba9llwhqm49w7sz3z0gqscj039m53ky9wxzhaj11z6yg1ah15yx";
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapVersion = "1.39.0";
+
+  # fetch hashes by running `print-hashes.sh 1.39.0`
+  bootstrapHashes = {
+    i686-unknown-linux-gnu = "36e31b3069c5be4b1fe3c8f7588ca787f13f91ab7170d2b24c6b07285816d0e5";
+    x86_64-unknown-linux-gnu = "b10a73e5ba90034fe51f0f02cb78f297ed3880deb7d3738aa09dc5a4d9704a25";
+    arm-unknown-linux-gnueabihf = "ea08d78a718cd34e67733526c70f3be460605dec8284bdeda36e0c6dd6222eca";
+    armv7-unknown-linux-gnueabihf = "41186745a97e6b76fb7a3a049882fb4869b526e98a66c05a133518515037f0d7";
+    aarch64-unknown-linux-gnu = "e27dc8112fe577012bd88f30e7c92dffd8c796478ce386c49465c03b6db8209f";
+    i686-apple-darwin = "0ada2ed87cc449ed470dce3b57b15bfd5c8c52b01d6116e6b1edc9a3e97836aa";
+    x86_64-apple-darwin = "3736d49c5e9592844e1a5d5452883aeaf8f1e25d671c1bc8f01e81c1766603b5";
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_40_0;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8654,17 +8654,21 @@ in
     inherit (darwin) apple_sdk;
   };
 
+  rust_1_40_0 = callPackage ../development/compilers/rust/1_40_0.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
   rust_1_39_0 = callPackage ../development/compilers/rust/1_39_0.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
   rust_1_38_0 = callPackage ../development/compilers/rust/1_38_0.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
-  rust = rust_1_39_0;
+  rust = rust_1_40_0;
 
+  rustPackages_1_40_0 = rust_1_40_0.packages.stable;
   rustPackages_1_39_0 = rust_1_39_0.packages.stable;
   rustPackages_1_38_0 = rust_1_38_0.packages.stable;
-  rustPackages = rustPackages_1_39_0;
+  rustPackages = rustPackages_1_40_0;
 
   inherit (rustPackages) cargo rustc rustPlatform;
   inherit (rust) makeRustPlatform;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update rustc stable to be 1.40.0.

###### Things done

`firefox` and `thunderbird` still lock on rust 1.38.0, which are not affected. 

**Not sure whether the version of llvm matches.**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - rustc: 796,307,712 -> 419,829,488 (rlibs of dependent crates in `lib/rustlib/{triple}/lib/` now no longer exists)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edolstra 
