### PR TITLE
python3Packages.fints: 2.2.0 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/fints/default.nix
+++ b/pkgs/development/python-modules/fints/default.nix
@@ -7,7 +7,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "2.2.0";
+  version = "3.0.0";
   pname = "fints";
   disabled = isPy27;
 
@@ -15,13 +15,8 @@ buildPythonPackage rec {
     owner = "raphaelm";
     repo = "python-fints";
     rev = "v${version}";
-    sha256 = "1gx173dzdprf3jsc7dss0xax8s6l2hr02qg9m5c4rksb3dl5fl8w";
+    sha256 = "00fqgnmv7z6d792ga4cyzn9lrfjf79jplkssm2jbyb0akfggfj7h";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace 'sepaxml==2.0.*' 'sepaxml~=2.0'
-  '';
 
   propagatedBuildInputs = [ requests mt-940 sepaxml bleach ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Package was outdated.

###### Things done
Updated the package to the latest version.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
