### PR TITLE
fail2ban: fix work with python3

### DIFF
--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -47,6 +47,10 @@ python3.pkgs.buildPythonApplication {
     ${python3.interpreter} setup.py install_data --install-dir=$out --root=$out
   '';
 
+  postPatch = ''
+    ${stdenv.shell} ./fail2ban-2to3
+  '';
+
   postInstall = let
     sitePackages = "$out/${python3.sitePackages}";
   in ''


### PR DESCRIPTION
###### Motivation for this change
Fixed this error - https://github.com/NixOS/nixpkgs/commit/7adbfb1220e158cd62540b2137851f368dc15e77#commitcomment-36634294

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
