### PR TITLE
clash: 0.16.0 -> 0.17.1

### DIFF
--- a/pkgs/tools/networking/clash/default.nix
+++ b/pkgs/tools/networking/clash/default.nix
@@ -11,7 +11,13 @@ buildGoModule rec {
     sha256 = "0zhbaw9jzl9wqc7yx8yxqlb6fwkss4pqkv26069qg6nsk584ndnf";
   };
 
+  goPackagePath = "github.com/Dreamacro/clash";
   modSha256 = "0vyd61bin7hmpdqrmrikc776mgif9v25627n8hzi65kiycv40kgx";
+
+  buildFlagsArray = [
+    "-ldflags="
+    "-X ${goPackagePath}/constant.Version=${version}"
+  ];
 
   meta = with stdenv.lib; {
     description = "A rule-based tunnel in Go";

--- a/pkgs/tools/networking/clash/default.nix
+++ b/pkgs/tools/networking/clash/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "clash";
-  version = "0.16.0";
+  version = "0.17.1";
 
   src = fetchFromGitHub {
     owner = "Dreamacro";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1k6afpazggpd7cabbw6ldv77bjj43083d5diy2w0iq5nw69gmwd3";
+    sha256 = "0zhbaw9jzl9wqc7yx8yxqlb6fwkss4pqkv26069qg6nsk584ndnf";
   };
 
-  modSha256 = "1fx53df67mq7p3ampr96x8hd99v2991alb16v8iq36f032raa32f";
+  modSha256 = "0vyd61bin7hmpdqrmrikc776mgif9v25627n8hzi65kiycv40kgx";
 
   meta = with stdenv.lib; {
     description = "A rule-based tunnel in Go";

--- a/pkgs/tools/networking/clash/default.nix
+++ b/pkgs/tools/networking/clash/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
     description = "A rule-based tunnel in Go";
     homepage = "https://github.com/Dreamacro/clash";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ contrun ];
+    maintainers = with maintainers; [ contrun filalex77 ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/Dreamacro/clash/releases/tag/v0.17.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/41p9119if7bljcy9mkvi14149a4i9pjz-clash-0.16.0	  38.9M
/nix/store/agg2xvx5w983bdfa82ks1dhbwn4grspg-clash-0.17.1	  38.9M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @contrun

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/76815)
<!-- Reviewable:end -->
