### PR TITLE
grandorgue: init at 0.3.1-r2333

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5966,6 +5966,12 @@
     githubId = 37715;
     name = "Brian McKenna";
   };
+  puzzlewolf = {
+    email = "nixos@nora.pink";
+    github = "puzzlewolf";
+    githubId = 23097564;
+    name = "Nora Widdecke";
+  };
   pxc = {
     email = "patrick.callahan@latitudeengineering.com";
     name = "Patrick Callahan";

--- a/pkgs/applications/audio/grandorgue/default.nix
+++ b/pkgs/applications/audio/grandorgue/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchsvn, cmake, pkg-config, gcc, pkgconfig, fftwFloat, alsaLib
+, zlib, wavpack, wxGTK31, udev, jackaudioSupport ? false, libjack2
+, includeDemo ? true }:
+
+stdenv.mkDerivation rec {
+  pname = "grandorgue";
+  rev = "2333";
+  version = "0.3.1-r${rev}";
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/ourorgan/svn/trunk";
+    inherit rev;
+    sha256 = "0xzjdc2g4gja2lpmn21xhdskv43qpbpzkbb05jfqv6ma2zwffzz1";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ pkgconfig fftwFloat alsaLib zlib wavpack wxGTK31 udev ]
+    ++ lib.optional jackaudioSupport libjack2;
+
+  cmakeFlags = lib.optional (!jackaudioSupport) [
+    "-DRTAUDIO_USE_JACK=OFF"
+    "-DRTMIDI_USE_JACK=OFF"
+  ] ++ lib.optional (!includeDemo) "-DINSTALL_DEMO=OFF";
+
+  meta = {
+    description = "Virtual Pipe Organ Software";
+    homepage = "https://sourceforge.net/projects/ourorgan";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.puzzlewolf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19450,6 +19450,8 @@ in
       ++ lib.optionals stdenv.isLinux [ gr-gsm gr-limesdr ];
   };
 
+  grandorgue = callPackage ../applications/audio/grandorgue { };
+
   gr-nacl = callPackage ../applications/radio/gnuradio/nacl.nix { };
 
   gr-gsm = callPackage ../applications/radio/gnuradio/gsm.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Create a package for grandorgue, a sample based pipe organ simulator.
https://sourceforge.net/projects/ourorgan/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).