### PR TITLE
corerad: init at v0.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4399,6 +4399,12 @@
     githubId = 4378377;
     name = "Matthias Devlamynck";
   };
+  mdlayher = {
+    email = "mdlayher@gmail.com";
+    github = "mdlayher";
+    githubId = 1926905;
+    name = "Matt Layher";
+  };
   meditans = {
     email = "meditans@gmail.com";
     github = "meditans";

--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "corerad";
+  version = "0.1.4";
+
+  goPackagePath = "github.com/mdlayher/corerad";
+
+  src = fetchFromGitHub {
+    owner = "mdlayher";
+    repo = "corerad";
+    rev = "v${version}";
+    sha256 = "0qlmmgdz69gqqn6h5kb3gsjyj7lm6pcfcx9xlmrxhisj914ij76r";
+  };
+
+  modSha256 = "0vim91yvw0cf9bd10hfanz8azq7q19lp2x61rs44ycx9zm3qdhcw";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mdlayher/corerad";
+    description = "CoreRAD extensible and observable IPv6 NDP RA daemon";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mdlayher ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15959,6 +15959,8 @@ in
 
   coredns = callPackage ../servers/dns/coredns { };
 
+  corerad = callPackage ../tools/networking/corerad { };
+
   cpufrequtils = callPackage ../os-specific/linux/cpufrequtils { };
 
   cpuset = callPackage ../os-specific/linux/cpuset { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[CoreRAD](https://github.com/mdlayher/corerad) is a new project I'm working on to create an extensible radvd replacement. I'm running it as of now on my NixOS home router via an overlay, but would like to get it packaged upstream as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

(none as of now)

cc @danderson, per our conversation last night about packaging this