### PR TITLE
ntl: 11.4.1 -> 11.4.2, gf2x: 1.2 -> 1.3.0

### DIFF
--- a/pkgs/development/libraries/gf2x/default.nix
+++ b/pkgs/development/libraries/gf2x/default.nix
@@ -1,19 +1,24 @@
 { stdenv
 , lib
-, fetchurl
+, fetchgit
+, autoreconfHook
 , optimize ? false # impure hardware optimizations
 }:
 stdenv.mkDerivation rec {
   pname = "gf2x";
-  version = "1.2"; # remember to also update the url
+  version = "1.3.0";
 
-  src = fetchurl {
-    # find link to latest version (with file id) here: https://gforge.inria.fr/projects/gf2x/
-    # Requested a predictable link:
-    # https://gforge.inria.fr/tracker/index.php?func=detail&aid=21704&group_id=1874&atid=6982
-    url = "https://gforge.inria.fr/frs/download.php/file/36934/gf2x-${version}.tar.gz";
-    sha256 = "0d6vh1mxskvv3bxl6byp7gxxw3zzpkldrxnyajhnl05m0gx7yhk1";
+  # upstream has plans to move to gitlab:
+  # https://github.com/NixOS/nixpkgs/pull/45299#issuecomment-564477936
+  src = fetchgit {
+    url = "https://scm.gforge.inria.fr/anonscm/git/gf2x/gf2x.git";
+    rev = "gf2x-${version}";
+    sha256 = "04g5jg0i4vz46b4w2dvbmahwzi3k6b8g515mfw7im1inc78s14id";
   };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
 
   # no actual checks present yet (as of 1.2), but can't hurt trying
   # for an indirect test, run ntl's test suite

--- a/pkgs/development/libraries/ntl/default.nix
+++ b/pkgs/development/libraries/ntl/default.nix
@@ -14,11 +14,11 @@ assert withGf2x -> gf2x != null;
 
 stdenv.mkDerivation rec {
   pname = "ntl";
-  version = "11.4.1";
+  version = "11.4.2";
 
   src = fetchurl {
     url = "http://www.shoup.net/ntl/ntl-${version}.tar.gz";
-    sha256 = "03k2hb6yn49d1f9cdig2ci7h5ga0x3nb3li60hh19wdqzg28f1m3";
+    sha256 = "11r3f37psdbjw926kf6bn5bp69aj88f5cchvv1xh2bhrcjdp4r1b";
   };
 
   buildInputs = [
@@ -67,6 +67,8 @@ stdenv.mkDerivation rec {
     # Upstream contact: maintainer is victorshoup on GitHub. Alternatively the
     # email listed on the homepage.
     homepage = http://www.shoup.net/ntl/;
+    # also locally at "${src}/doc/tour-changes.html";
+    changelog = "https://www.shoup.net/ntl/doc/tour-changes.html";
     maintainers = with maintainers; [ timokau ];
     license = licenses.gpl2Plus;
     platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change

gf2x was updated, ntl needs an update for compatibility. See https://github.com/NixOS/nixpkgs/pull/45299.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
