### PR TITLE
gflags: fix static musl build

### DIFF
--- a/pkgs/development/libraries/gflags/default.nix
+++ b/pkgs/development/libraries/gflags/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv
+, fetchFromGitHub
+, cmake
+, enableShared ? true
+, enableStatic ? true
+}:
 
 stdenv.mkDerivation rec {
   pname = "gflags";
@@ -17,8 +22,8 @@ stdenv.mkDerivation rec {
   preConfigure = "rm BUILD";
 
   cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_STATIC_LIBS=ON"
+    "-DBUILD_SHARED_LIBS=${if enableShared then "ON" else "OFF"}"
+    "-DBUILD_STATIC_LIBS=${if enableStatic then "ON" else "OFF"}"
   ];
 
   doCheck = false;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -176,6 +176,12 @@ in {
   cdo = super.cdo.override {
     enable_all_static = true;
   };
+
+  gflags = super.gflags.override {
+    enableStatic = true;
+    enableShared = false;
+  };
+
   gsm = super.gsm.override {
     staticSupport = true;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
