### PR TITLE
flyway: fix jarDirs option

### DIFF
--- a/pkgs/development/tools/flyway/default.nix
+++ b/pkgs/development/tools/flyway/default.nix
@@ -19,8 +19,8 @@
         makeWrapper "${jre_headless}/bin/java" $out/bin/flyway \
           --add-flags "-Djava.security.egd=file:/dev/../dev/urandom" \
           --add-flags "-classpath '$out/share/flyway/lib/*:$out/share/flyway/drivers/*'" \
-          --add-flags "-DjarDirs '$out/share/flyway/jars'" \
-          --add-flags "org.flywaydb.commandline.Main"
+          --add-flags "org.flywaydb.commandline.Main" \
+          --add-flags "-jarDirs='$out/share/flyway/jars'"
       '';
       meta = with stdenv.lib; {
         description = "Evolve your Database Schema easily and reliably across all your instances";


### PR DESCRIPTION
this is not a system property, but rather an argument to
org.flaywaydb.commandline.Main.main().  therefore, it must come after,
rather than before, the name of the main class.  (otherwise it's
interpreted as an argument to the VM itself.)

flyway also expects the option and value to be separated by '=', not ' '.

follows on to #76094

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

was failing like this after #76094:

```
$ ./result/bin/flyway --help
Error: Could not find or load main class .nix.store.mviaqav8f5c80sjxw4r31sqqyn69wb0w-flyway-6.1.2.share.flyway.jars
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @Rakesh4G @CMCDragonkai @teto 
