### PR TITLE
[r19.09] cyrus_sasl: add patch for CVE-2019-19906

### DIFF
--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, openssl, openldap, kerberos, db, gettext
 , pam, fixDarwinDylibNames, autoreconfHook, enableLdap ? false
-, buildPackages, pruneLibtoolFiles }:
+, buildPackages, pruneLibtoolFiles, fetchpatch }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -27,6 +27,11 @@ stdenv.mkDerivation rec {
   patches = [
     ./missing-size_t.patch # https://bugzilla.redhat.com/show_bug.cgi?id=906519
     ./cyrus-sasl-ac-try-run-fix.patch
+    (fetchpatch {
+      name = "CVE-2019-19906.patch";
+      url = "https://sources.debian.org/data/main/c/cyrus-sasl2/2.1.27+dfsg-1+deb10u1/debian/patches/0021-CVE-2019-19906.patch";
+      sha256 = "1n4c5wg7l9j8rlbvx8i605j5d39xmj5wm618k8acxl4fmglcmfls";
+    })
   ];
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change
Backport of #76662 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
