### PR TITLE
nixos/apropos: init

### DIFF
--- a/nixos/modules/misc/apropos.nix
+++ b/nixos/modules/misc/apropos.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.documentation.apropos;
+
+in
+
+{
+
+  options.documentation.apropos = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to crete an apropos cache for the generated system path.
+        '';
+      };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.tmpfiles.rules = [ "d /var/cache/man 0755 root root -" ];
+
+    system.activationScripts.apropos = ''
+      ${pkgs.mandb}/bin/mandb
+    '';
+
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -79,6 +79,7 @@
   ./i18n/input-method/nabi.nix
   ./i18n/input-method/uim.nix
   ./installer/tools/tools.nix
+  ./misc/apropos.nix
   ./misc/assertions.nix
   ./misc/crashdump.nix
   ./misc/documentation.nix


### PR DESCRIPTION
Fixes #14472

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
