### PR TITLE
vim-plugins: hashivim/vim-terraform: fix the filetypedetect autocmd

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -402,6 +402,9 @@ self: super: {
     dependencies = with super; [ vim-addon-mw-utils tlib_vim ];
   });
 
+  vim-terraform = super.vim-terraform.overrideAttrs(oa: {
+    patches = (oa.patches or []) ++ lib.singleton ./vim-terraform-fix-event.patch;
+  });
 
   vim-wakatime = super.vim-wakatime.overrideAttrs(old: {
     buildInputs = [ python ];

--- a/pkgs/misc/vim-plugins/vim-terraform-fix-event.patch
+++ b/pkgs/misc/vim-plugins/vim-terraform-fix-event.patch
@@ -1,0 +1,23 @@
+From cad4661952ad7983ece6d6486f0f68d437037015 Mon Sep 17 00:00:00 2001
+From: "Wael M. Nasreddine" <wael.nasreddine@gmail.com>
+Date: Thu, 2 Jan 2020 13:31:13 -0800
+Subject: [PATCH] Put the autocmd filetypedetect in an augroup
+
+---
+ ftdetect/terraform.vim | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/ftdetect/terraform.vim b/ftdetect/terraform.vim
+index 5919422..24bc731 100644
+--- a/ftdetect/terraform.vim
++++ b/ftdetect/terraform.vim
+@@ -1,5 +1,8 @@
+ " By default, Vim associates .tf files with TinyFugue - tell it not to.
+-autocmd! filetypedetect BufRead,BufNewFile *.tf
++augroup filetypedetect
++  au BufRead,BufNewFile *.tf set filetype=terraform
++augroup END
++
+ autocmd BufRead,BufNewFile *.tf set filetype=terraform
+ autocmd BufRead,BufNewFile *.tfvars set filetype=terraform
+ autocmd BufRead,BufNewFile *.tfstate set filetype=json


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I'm using this plugin, and I keep getting the following error at Vim startup

```
Error detected while processing /nix/store/37njws9gkfz3w5q1mm9kf3fcbd58lwqs-vimplugin-vim-terraform-2019-12-16/share/vim-plugins/vim-terraform/ftdetect/terraform.vim:                                                                                                           
line    2:                                                                                                                                                                                                                                                                       
E216: No such group or event: filetypedetect BufRead,BufNewFile *.tf
```

This issue used to block Vim's manifest generation, but that got fixed in https://github.com/NixOS/nixpkgs/pull/66536. That fix was a workaround though, this should fix that as well as Vim's startup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
