### PR TITLE
gegl: remove flaky test

### DIFF
--- a/pkgs/development/libraries/gegl/4.0.nix
+++ b/pkgs/development/libraries/gegl/4.0.nix
@@ -63,6 +63,9 @@ stdenv.mkDerivation rec {
       url = "https://salsa.debian.org/gnome-team/gegl/raw/9b7520b38d87cd8ad4b39bf0b8c62d011da25169/debian/patches/increase_test_timeout.patch";
       sha256 = "1prc1h1aipjd9db0i1j7nzga4zvk3vl8qsjpz1jzv1wwvz02isly";
     })
+
+    # Remove gegl:simple / backend-file test that times out frequently
+    ./patches/no-simple-backend-file-test.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/gegl/patches/no-simple-backend-file-test.patch
+++ b/pkgs/development/libraries/gegl/patches/no-simple-backend-file-test.patch
@@ -1,0 +1,10 @@
+diff --git a/tests/simple/meson.build b/tests/simple/meson.build
+index 2c735d80a..ae4d50f2a 100644
+--- a/tests/simple/meson.build
++++ b/tests/simple/meson.build
+@@ -1,5 +1,4 @@
+ testnames = [
+-  'backend-file',
+   'buffer-cast',
+   'buffer-changes',
+   'buffer-extract',


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Following https://github.com/NixOS/nixpkgs/pull/75773 this adds to the Debian patch with our own that removes the flaky `backend-file` test. This should allow for a new `nixos-unstable` release, since `trunk-combined/tested` [has been failing for days](https://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents) due to this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @worldofpeace @jtojnar 
