### PR TITLE
ocaml rresult: Add the `result` compatibility package as a build input

### DIFF
--- a/pkgs/development/ocaml-modules/rresult/default.nix
+++ b/pkgs/development/ocaml-modules/rresult/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, result }:
 
 stdenv.mkDerivation rec {
 	name = "ocaml${ocaml.version}-rresult-${version}";
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
 	buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
+  propagatedBuildInputs = [ result ];
+  
 	inherit (topkg) buildPhase installPhase;
 
 	meta = {


### PR DESCRIPTION
cc @vbgl seems like this is an oversight given that it's included in the upstream opam file: https://github.com/dbuenzli/rresult/blob/master/opam