### PR TITLE
lib/types: Allow paths as submodule values

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -174,8 +174,7 @@ checkConfigOutput "true" config.submodule.inner ./declare-submoduleWith-modules.
 checkConfigOutput "true" config.submodule.outer ./declare-submoduleWith-modules.nix
 
 ## Paths should be allowed as values and work as expected
-# Temporarily disabled until https://github.com/NixOS/nixpkgs/pull/76861
-#checkConfigOutput "true" config.submodule.enable ./declare-submoduleWith-path.nix
+checkConfigOutput "true" config.submodule.enable ./declare-submoduleWith-path.nix
 
 cat <<EOF
 ====== module tests ======

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -392,14 +392,16 @@ rec {
           else unify (if shorthandOnlyDefinesConfig then { config = value; } else value);
 
         allModules = defs: modules ++ imap1 (n: { value, file }:
-          # Annotate the value with the location of its definition for better error messages
-          coerce (lib.modules.unifyModuleSyntax file "${toString file}-${toString n}") value
+          if isAttrs value || isFunction value then
+            # Annotate the value with the location of its definition for better error messages
+            coerce (lib.modules.unifyModuleSyntax file "${toString file}-${toString n}") value
+          else value
         ) defs;
 
       in
       mkOptionType rec {
         name = "submodule";
-        check = x: isAttrs x || isFunction x;
+        check = x: isAttrs x || isFunction x || path.check x;
         merge = loc: defs:
           (evalModules {
             modules = allModules defs;

--- a/nixos/doc/manual/development/option-types.xml
+++ b/nixos/doc/manual/development/option-types.xml
@@ -257,9 +257,9 @@
     <listitem>
      <para>
       A set of sub options <replaceable>o</replaceable>.
-      <replaceable>o</replaceable> can be an attribute set or a function
-      returning an attribute set. Submodules are used in composed types to
-      create modular options. This is equivalent to
+      <replaceable>o</replaceable> can be an attribute set, a function
+      returning an attribute set, or a path to a file containing such a value. Submodules are used in
+      composed types to create modular options. This is equivalent to
       <literal>types.submoduleWith { modules = toList o; shorthandOnlyDefinesConfig = true; }</literal>.
       Submodules are detailed in
       <xref

--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -391,6 +391,16 @@ users.users.me =
      <link xlink:href="https://github.com/NixOS/nixpkgs/pull/63103">PR #63103</link>.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     For NixOS modules, the types <literal>types.submodule</literal> and <literal>types.submoduleWith</literal> now support
+     paths as allowed values, similar to how <literal>imports</literal> supports paths.
+     Because of this, if you have a module that defines an option of type
+     <literal>either (submodule ...) path</literal>, it will break since a path
+     is now treated as the first type instead of the second. To fix this, change
+     the type to <literal>either path (submodule ...)</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/services/security/certmgr.nix
+++ b/nixos/modules/services/security/certmgr.nix
@@ -113,7 +113,7 @@ in
         otherCert = "/var/certmgr/specs/other-cert.json";
       }
       '';
-      type = with types; attrsOf (either (submodule {
+      type = with types; attrsOf (either path (submodule {
         options = {
           service = mkOption {
             type = nullOr str;
@@ -148,7 +148,7 @@ in
             description = "certmgr spec request object.";
           };
         };
-    }) path);
+    }));
       description = ''
         Certificate specs as described by:
         <link xlink:href="https://github.com/cloudflare/certmgr#certificate-specs" />


### PR DESCRIPTION
###### Motivation for this change
Because allowing paths as submodule values isn't always backwards compatible, that change from https://github.com/NixOS/nixpkgs/pull/75031 had to be [reverted](https://github.com/NixOS/nixpkgs/commit/c7ade6844f4cb4691ad02065e9395b18b3addcda).

This restores that behavior but also fixes the backwards incompatibility in nixpkgs and adds a release note about it.

Ping @roberth @danbst @grahamc 

###### Things done

- [x] Updated docs with this change
- [x] Ran `lib/tests/modules.sh` successfully (again, the revert actually broke a test for this very thing in there)