### PR TITLE
tiny: init at 0.5.1

### DIFF
--- a/pkgs/applications/networking/irc/tiny/default.nix
+++ b/pkgs/applications/networking/irc/tiny/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, lib
+, rustPlatform
+, fetchpatch
+, fetchFromGitHub
+, pkg-config
+, dbus
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tiny";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "osa1";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1m57xsrc7lzkrm8k1wh3yx3in5bhd0qjzygxdwr8lvigpsiy5caa";
+  };
+
+  cargoSha256 = "1vj6whnx8gd5r66zric9163ddlqc4al4azj0dvhv5sq0r33871kv";
+
+  RUSTC_BOOTSTRAP = 1;
+
+  nativeBuildInputs = lib.optional stdenv.isLinux pkg-config;
+  buildInputs = lib.optionals stdenv.isLinux [ dbus openssl ];
+
+  meta = with lib; {
+    description = "A console IRC client";
+    homepage = "https://github.com/osa1/tiny";
+    license = licenses.mit;
+    maintainers = with maintainers; [ filalex77 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21642,6 +21642,8 @@ in
 
   tint2 = callPackage ../applications/misc/tint2 { };
 
+  tiny = callPackage ../applications/networking/irc/tiny { };
+
   tixati = callPackage ../applications/networking/p2p/tixati { };
 
   tkcvs = callPackage ../applications/version-management/tkcvs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Closes #76848 and closes osa1/tiny#166.

https://github.com/osa1/tiny/releases/tag/0.5.0

###### Things that need to be resolved
- https://github.com/osa1/tiny/commit/b309d1acd7f3d974f522fa55737b4df55723288f needs to be released

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/76868)
<!-- Reviewable:end -->
