### PR TITLE
gcc: keep using gcc8 to work-around failing rpi build

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7831,7 +7831,7 @@ in
   gerbil-unstable = callPackage ../development/compilers/gerbil/unstable.nix { stdenv = gccStdenv; };
 
   gccFun = callPackage (if stdenv.targetPlatform.isVc4 then ../development/compilers/gcc/6 else ../development/compilers/gcc/9);
-  gcc = if stdenv.targetPlatform.isVc4 then gcc6 else gcc9;
+  gcc = if stdenv.targetPlatform.isVc4 then gcc6 else if stdenv.targetPlatform.isAarch32 then gcc8 else gcc9;
   gcc-unwrapped = gcc.cc;
 
   gccStdenv = if stdenv.cc.isGNU then stdenv else stdenv.override {

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -55,7 +55,7 @@ self: super: let
   removeUnknownConfigureFlags = f: with self.lib;
     remove "--disable-shared"
     (remove "--enable-static" f);
-  
+
   ocamlFixPackage = b:
     b.overrideAttrs (o: {
       configurePlatforms = [ ];
@@ -63,7 +63,7 @@ self: super: let
       buildInputs = o.buildInputs ++ o.nativeBuildInputs or [ ];
       propagatedNativeBuildInputs = o.propagatedBuildInputs or [ ];
     });
-  
+
   ocamlStaticAdapter = _: super:
     self.lib.mapAttrs
       (_: p: if p ? overrideAttrs then ocamlFixPackage p else p)
@@ -209,7 +209,7 @@ in {
   kmod = super.kmod.override {
     withStatic = true;
   };
-  
+
   curl = super.curl.override {
     # a very sad story: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=439039
     gssSupport = false;
@@ -241,6 +241,6 @@ in {
   ocaml-ng = self.lib.mapAttrs (_: set:
     if set ? overrideScope' then set.overrideScope' ocamlStaticAdapter else set
   ) super.ocaml-ng;
-  
+
   python27 = super.python27.override { static = true; };
 }


### PR DESCRIPTION
Unless anyone knows how to solve this, keep using gcc8.

https://hydra.nixos.org/build/109284638

```
In file included from <command-line>:
./../include/libc-symbols.h:471:26: error: '__EI___errno_location'
specifies less restrictive attributes than its target
'__errno_location': 'const', 'nothrow' [-Werror=missing-attributes]
  471 |   extern __typeof (name) __EI_##name \
      |                          ^~~~~
./../include/libc-symbols.h:475:29: note: in expansion of macro
'__hidden_ver1'
475 | #  define hidden_def(name)  __hidden_ver1(__GI_##name, name,
name);
      |                             ^~~~~~~~~~~~~
./../include/libc-symbols.h:539:32: note: in expansion of macro
'hidden_def'
  539 | # define libc_hidden_def(name) hidden_def (name)
      |                                ^~~~~~~~~~
errno-loc.c:28:1: note: in expansion of macro 'libc_hidden_def'
   28 | libc_hidden_def (__errno_location)
      | ^~~~~~~~~~~~~~~
errno-loc.c:24:1: note: '__EI___errno_location' target declared here
   24 | __errno_location (void)
      | ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [../o-iterator.mk:9: /build/build/csu/errno-loc.os] Error 1
```

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
