### PR TITLE
wireguard-tools: 1.0.20191226 -> 1.0.20200102

### DIFF
--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -14,11 +14,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "wireguard-tools";
-  version = "1.0.20191226";
+  version = "1.0.20200102";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${version}.tar.xz";
-    sha256 = "14v5asdjazz0p3bhg8na9w6y66i3jhnn8imxhq8xlix1k4n93l4z";
+    sha256 = "0ry3vbckcbkx43bz0bqinrd1hkll67jbwb72ak0b41wkxjsc8fmv";
   };
 
   sourceRoot = "source/src";


### PR DESCRIPTION
###### Motivation for this change

version bump: https://lists.zx2c4.com/pipermail/wireguard/2020-January/004819.html

*changes:* 

- buildsystem tweaks (we don't appear to be affected)
- documentation updates
- expanded fuzz testsuite

*tests run:*

- `nix build -f . wireguard`
- `nix build -f . nixosTests.wireguard nixosTests.wireguard-generated nixosTests.systemd-networkd-wireguard`
- `nix build -I . -f nixos/tests/wireguard-namespaces`
- `nix review rev 0bf1e65328626e18e7a487b9899717025980c98c`

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @elseym  @ericsagnes  @Mic92  @zx2c4  @globin  @Ma27 
