### PR TITLE
package etesync-dav

### DIFF
--- a/pkgs/applications/misc/etesync-dav/default.nix
+++ b/pkgs/applications/misc/etesync-dav/default.nix
@@ -1,0 +1,33 @@
+{ lib, python3Packages, radicale2 }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "etesync-dav";
+  version = "0.14.2";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "05kzy74r2hd44sqjgd0bc588ganrzbz5brpiginb8sh8z38igb60";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    etesync
+    flask
+    flask_wtf
+    radicale2
+  ];
+
+  checkInputs = with python3Packages; [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.etesync.com/";
+    description = "Secure, end-to-end encrypted, and privacy respecting sync for contacts, calendars and tasks";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ valodim ];
+  };
+}

--- a/pkgs/development/python-modules/etesync/default.nix
+++ b/pkgs/development/python-modules/etesync/default.nix
@@ -1,0 +1,55 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27,
+  appdirs, asn1crypto, cffi, cryptography, furl, idna, orderedmultidict,
+  packaging, peewee, py, pyasn1, pycparser, pyparsing, pyscrypt,
+  python-dateutil, pytz, requests, six, vobject,
+  pytest
+}:
+
+buildPythonPackage rec {
+  pname = "etesync";
+  version = "0.9.3";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1i6v7i4xmbpkc1pgpzq8gyl2kvg3a1kpdwp8q6l3l0vf9p5qm06w";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+    asn1crypto
+    cffi
+    cryptography
+    furl
+    idna
+    orderedmultidict
+    packaging
+    peewee
+    py
+    pyasn1
+    pycparser
+    pyparsing
+    pyscrypt
+    python-dateutil
+    pytz
+    requests
+    six
+    vobject
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest tests/test_collections.py
+    pytest tests/test_crypto.py
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.etesync.com/";
+    description = "A python API to interact with an EteSync server.";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ valodim ];
+  };
+}

--- a/pkgs/development/python-modules/furl/default.nix
+++ b/pkgs/development/python-modules/furl/default.nix
@@ -1,22 +1,27 @@
-{ stdenv, buildPythonPackage, fetchPypi, flake8, six, orderedmultidict }:
+{ stdenv, buildPythonPackage, fetchPypi, flake8, six, orderedmultidict, pytest }:
 
 buildPythonPackage rec {
   pname = "furl";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1v2lakx03d5w8954a39ki44xv5mllnq0a0avhxykv9hrzg0yvjpx";
+    sha256 = "08dnw3bs1mk0f1ccn466a5a7fi1ivwrp0jspav9arqpf3wd27q60";
   };
 
-  checkInputs = [ flake8 ];
+  checkInputs = [ flake8 pytest ];
 
   propagatedBuildInputs = [ six orderedmultidict ];
 
+  # see https://github.com/gruns/furl/issues/121
+  checkPhase = ''
+    pytest -k 'not join'
+  '';
+
   meta = with stdenv.lib; {
-    description = "URL manipulation made simple.";
-    homepage = https://github.com/gruns/furl;
-    license = licenses.publicDomain;
+    description = "furl is a small Python library that makes parsing and manipulating URLs easy";
+    homepage = "https://github.com/gruns/furl";
+    license = licenses.unlicense;
     maintainers = with maintainers; [ vanzef ];
   };
 }

--- a/pkgs/development/python-modules/pyscrypt/default.nix
+++ b/pkgs/development/python-modules/pyscrypt/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, python }:
+
+buildPythonPackage rec {
+  pname = "pyscrypt";
+  version = "1.6.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sd5pd5fpcdnpp4h58kdnvkf0s3afh4ssfqky2ap6z0gy6ax3zds";
+  };
+
+  checkPhase = ''
+    ${python.interpreter} tests/run-tests-hash.py
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/ricmoo/pyscrypt/";
+    description = "Pure-Python implementation of Scrypt PBKDF and scrypt file format library";
+    license = licenses.mit;
+    maintainers = with maintainers; [ valodim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18932,6 +18932,8 @@ in
 
   eteroj.lv2 = libsForQt5.callPackage ../applications/audio/eteroj.lv2 { };
 
+  etesync-dav = callPackage ../applications/misc/etesync-dav {};
+
   etherape = callPackage ../applications/networking/sniffers/etherape { };
 
   evilvte = callPackage ../applications/misc/evilvte (config.evilvte or {});

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3451,6 +3451,8 @@ in {
 
   et_xmlfile = callPackage ../development/python-modules/et_xmlfile { };
 
+  etesync = callPackage ../development/python-modules/etesync { };
+
   eventlet = callPackage ../development/python-modules/eventlet { };
 
   exifread = callPackage ../development/python-modules/exifread { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1203,6 +1203,8 @@ in {
 
   simplefix = callPackage ../development/python-modules/simplefix { };
 
+  pyscrypt = callPackage ../development/python-modules/pyscrypt { };
+
   pyside2-tools = toPythonModule (callPackage ../development/python-modules/pyside2-tools {
     inherit (pkgs) cmake qt5;
   });


### PR DESCRIPTION
###### Motivation for this change

Packaged the etesync-dav component of [etesync](https://www.etesync.com/) :)

This PR includes python library dependencies pyscrypt, orderedmultidict, and furl.

The furl package had a failing unit test, which I filed a bug report for: https://github.com/gruns/furl/issues/121

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @tasn (etesync), @ricmoo (pyscrypt), @gruns (orderedmultidict, furl)