### PR TITLE
llvm: use correct version of tablegen when cross compiling _8 and _9

### DIFF
--- a/pkgs/development/compilers/llvm/8/llvm.nix
+++ b/pkgs/development/compilers/llvm/8/llvm.nix
@@ -109,7 +109,7 @@ in stdenv.mkDerivation ({
     "-DCAN_TARGET_i386=false"
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DCMAKE_CROSSCOMPILING=True"
-    "-DLLVM_TABLEGEN=${buildPackages.llvm_7}/bin/llvm-tblgen"
+    "-DLLVM_TABLEGEN=${buildPackages.llvm_8}/bin/llvm-tblgen"
   ];
 
   postBuild = ''

--- a/pkgs/development/compilers/llvm/9/llvm.nix
+++ b/pkgs/development/compilers/llvm/9/llvm.nix
@@ -126,7 +126,7 @@ in stdenv.mkDerivation (rec {
     "-DCAN_TARGET_i386=false"
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DCMAKE_CROSSCOMPILING=True"
-    "-DLLVM_TABLEGEN=${buildPackages.llvm_7}/bin/llvm-tblgen"
+    "-DLLVM_TABLEGEN=${buildPackages.llvm_9}/bin/llvm-tblgen"
   ];
 
   postBuild = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

llvm_8 and llvm_9 were broken in cross compilation because they were using tblgen from llvm_7.

error from `nix-build --arg crossSystem '{ system = "aarch64-linux"; }' -A llvm_9` on `x86_64-linux`:
```
Included from /build/llvm/lib/Transforms/InstCombine/InstCombineTables.td:2:
Included from /build/llvm/include/llvm/IR/Intrinsics.td:1245:
/build/llvm/include/llvm/IR/IntrinsicsNVVM.td:55:25: error: Unknown operator
  list<LLVMType> regs = !cond(
                        ^
Included from /build/llvm/lib/Transforms/InstCombine/InstCombineTables.td:2:
Included from /build/llvm/include/llvm/IR/Intrinsics.td:1245:
/build/llvm/include/llvm/IR/IntrinsicsNVVM.td:55:25: error: Unknown token when parsing a value
  list<LLVMType> regs = !cond(
                        ^
Included from /build/llvm/lib/Transforms/InstCombine/InstCombineTables.td:2:
Included from /build/llvm/include/llvm/IR/Intrinsics.td:1245:
/build/llvm/include/llvm/IR/IntrinsicsNVVM.td:55:25: error: expected ';' after declaration
  list<LLVMType> regs = !cond(
                        ^
make[2]: *** [lib/Transforms/InstCombine/CMakeFiles/InstCombineTableGen.dir/build.make:94: lib/Transforms/InstCombine/InstCombineTables.inc] Error 1
```

error from `nix-build --arg crossSystem '{ system = "aarch64-linux"; }' -A llvm_8`:
```
/build/llvm/include/llvm/IR/Intrinsics.td:95:1: error: Record `IntrCold' does not have a field named `ArgNo'!

def IntrCold : IntrinsicProperty;
^
make[2]: *** [include/llvm/IR/CMakeFiles/intrinsics_gen.dir/build.make:161: include/llvm/IR/IntrinsicEnums.inc] Error 1
```

See #52031

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
