### PR TITLE
frescobaldi: 3.0.0 -> 3.1

### DIFF
--- a/pkgs/misc/frescobaldi/default.nix
+++ b/pkgs/misc/frescobaldi/default.nix
@@ -1,23 +1,31 @@
-{ lib, fetchFromGitHub, python3Packages, lilypond }:
+{ lib, buildPythonApplication, fetchFromGitHub, python3Packages, pyqtwebengine, lilypond }:
 
-python3Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   name = "frescobaldi-${version}";
-  version = "3.0.0";
+  version = "3.1";
 
   src = fetchFromGitHub {
     owner = "wbsoft";
     repo = "frescobaldi";
     rev = "v${version}";
-    sha256 = "1yn18pwsjxpxz5j3yfysmaif8k0vqahj5c7ays9cxsylpg9hl7jd";
+    sha256 = "0sv6dc1l34rrhfbn1wqkl9zs9hiacmmbviw87d0d03987s1iirb1";
   };
 
   propagatedBuildInputs = with python3Packages; [
     lilypond pygame python-ly sip
-    pyqt5_with_qtwebkit (poppler-qt5.override { pyqt5 = pyqt5_with_qtwebkit; })
+    pyqt5 poppler-qt5
+    pyqtwebengine
   ];
+
+  nativeBuildInputs = [ pyqtwebengine.wrapQtAppsHook ];
 
   # no tests in shipped with upstream
   doCheck = false;
+
+  dontWrapQtApps = true;
+  makeWrapperArgs = [
+      "\${qtWrapperArgs[@]}"
+  ];
 
   meta = with lib; {
     homepage = http://frescobaldi.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3358,7 +3358,7 @@ in
 
   freetds = callPackage ../development/libraries/freetds { };
 
-  frescobaldi = callPackage ../misc/frescobaldi {};
+  frescobaldi = python3Packages.callPackage ../misc/frescobaldi {};
 
   frostwire = callPackage ../applications/networking/p2p/frostwire { };
   frostwire-bin = callPackage ../applications/networking/p2p/frostwire/frostwire-bin.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Closes: #76847

3.0.0 does not work #76847 because it needs `wrapQtAppsHook`.

Also, [version 3.1](https://github.com/frescobaldi/frescobaldi/releases/tag/v3.1). is available, which replaces QtWebKit with QtWebEngine  #53079.

###### Things done
I modeled the changes after #66796, which fixed the same problem for anki. That change uses pyqtwebengine, so I decided to move frescobaldi to 3.1.

I do not really understand these lines:
```
  dontWrapQtApps = true;
  makeWrapperArgs = [
      "\${qtWrapperArgs[@]}"
  ];
```
Without `makeWrapperArgs ...`, startup fails with the same error as before,
```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
```
Without `dontWrapQtApps = true`, frescobaldi starts. But anki has this line, so, what is it needed for?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
cc @sepi 
