### PR TITLE
nix: build using gcc8

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -2,7 +2,7 @@
 , storeDir ? "/nix/store"
 , stateDir ? "/nix/var"
 , confDir ? "/etc"
-, boehmgc
+, aws-sdk-cpp, boehmgc, boost
 , stdenv, llvmPackages_6
 }:
 
@@ -170,7 +170,7 @@ in rec {
     # Nix1 has the perl bindings by default, so no need to build the manually.
     includesPerl = true;
 
-    inherit storeDir stateDir confDir boehmgc;
+    inherit storeDir stateDir confDir stdenv aws-sdk-cpp boehmgc boost;
   };
 
   nixStable = callPackage common (rec {
@@ -180,7 +180,7 @@ in rec {
       sha256 = "bb6578e9f20eebab6d78469ecc59c450ac54f276e5a86a882015d98fecb1bc7b";
     };
 
-    inherit storeDir stateDir confDir boehmgc;
+    inherit storeDir stateDir confDir stdenv aws-sdk-cpp boehmgc boost;
   } // stdenv.lib.optionalAttrs stdenv.cc.isClang {
     stdenv = llvmPackages_6.stdenv;
   });
@@ -196,7 +196,7 @@ in rec {
     };
     fromGit = true;
 
-    inherit storeDir stateDir confDir boehmgc;
+    inherit storeDir stateDir confDir stdenv aws-sdk-cpp boehmgc boost;
   });
 
   nixFlakes = lib.lowPrio (callPackage common rec {
@@ -210,7 +210,7 @@ in rec {
     };
     fromGit = true;
 
-    inherit storeDir stateDir confDir boehmgc;
+    inherit storeDir stateDir confDir stdenv aws-sdk-cpp boehmgc boost;
   });
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24762,6 +24762,18 @@ in
       storeDir = config.nix.storeDir or "/nix/store";
       stateDir = config.nix.stateDir or "/nix/var";
       boehmgc = boehmgc.override { enableLargeConfig = true; };
+      # Tarball evaluation fails with a gcc9 based nix-env.
+      # $ nix-build pkgs/top-level/release.nix -A tarball
+      stdenv = if stdenv.cc.isGNU then gcc8Stdenv else stdenv;
+      aws-sdk-cpp = aws-sdk-cpp.override {
+        stdenv = if stdenv.cc.isGNU then gcc8Stdenv else stdenv;
+      };
+      boost = boost.override {
+        buildPackages = buildPackages // {
+          stdenv = if stdenv.cc.isGNU then gcc8Stdenv else stdenv;
+        };
+        stdenv = if stdenv.cc.isGNU then gcc8Stdenv else stdenv;
+      };
       })
     nix
     nix1


### PR DESCRIPTION
Workaround for https://github.com/NixOS/nix/issues/3300.

https://hydra.nixos.org/build/109304568

    running tests
    checking Nixpkgs on i686-linux
    error: stack overflow (possible infinite recursion)
    build time elapsed:  0m0.068s 0m0.029s 0m36.549s 0m6.187s
    builder for '/nix/store/dr5kd28msqmqk3hkz0ayx10dww6s8dn9-nixpkgs-tarball-20.03pre207974.16c665911fb.drv' failed with exit code 1

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested tarball evaluation `nix-build pkgs/top-level/release.nix -A tarball`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @edolstra @grahamc
