### PR TITLE
termius: init at 5.10.1

### DIFF
--- a/pkgs/applications/networking/termius/default.nix
+++ b/pkgs/applications/networking/termius/default.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "termius";
-  version = "5.6.2";
+  version = "5.10.1";
 
   src = fetchurl {
     url = "https://deb.termius.com/pool/main/t/termius-app/termius-app_${version}_amd64.deb";
-    sha256 = "0vgrkb4f9d47vr8dgl6rwjq0q5slxzhwlvrnafdjnxcx8vhy2g54";
+    sha256 = "04zh0zzyp906lf6mz3xzxybn2a55rv3vvrj0m12gnrb8kjb3pk5s";
   };
 
   desktopItem = makeDesktopItem {

--- a/pkgs/applications/networking/termius/default.nix
+++ b/pkgs/applications/networking/termius/default.nix
@@ -1,0 +1,68 @@
+{ atomEnv
+, autoPatchelfHook
+, dpkg
+, fetchurl
+, makeDesktopItem
+, makeWrapper
+, stdenv
+, udev
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "termius";
+  version = "5.6.2";
+
+  src = fetchurl {
+    url = "https://deb.termius.com/pool/main/t/termius-app/termius-app_${version}_amd64.deb";
+    sha256 = "0vgrkb4f9d47vr8dgl6rwjq0q5slxzhwlvrnafdjnxcx8vhy2g54";
+  };
+
+  desktopItem = makeDesktopItem {
+    categories = "Network;";
+    comment = "The SSH client that works on Desktop and Mobile";
+    desktopName = "Termius";
+    exec = "termius-app";
+    genericName = "Cross-platform SSH client";
+    icon = "termius-app";
+    name = "termius-app";
+  };
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontPatchELF = true;
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg makeWrapper wrapGAppsHook ];
+
+  buildInputs = atomEnv.packages;
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp -R "opt" "$out"
+    cp -R "usr/share" "$out/share"
+    chmod -R g-w "$out"
+
+    # Desktop file
+    mkdir -p "$out/share/applications"
+    cp "${desktopItem}/share/applications/"* "$out/share/applications"
+  '';
+
+  runtimeDependencies = [ udev.lib ];
+
+  postFixup = ''
+    makeWrapper $out/opt/Termius/termius-app $out/bin/termius-app \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A cross-platform SSH client with cloud data sync and more";
+    homepage = "https://termius.com/";
+    downloadPage = "https://termius.com/linux/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ filalex77 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6945,6 +6945,8 @@ in
     pythonPackages = python3Packages;
   };
 
+  termius = callPackage ../applications/networking/termius { };
+
   termplay = callPackage ../tools/misc/termplay { };
 
   tewisay = callPackage ../tools/misc/tewisay { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Closes #74777 and closes #76816.
Mostly copied from https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/04p269sdm2hzzgsld4kdrc1x6jw6az3p-termius-5.2.3	 527.7M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Th0rgal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/76891)
<!-- Reviewable:end -->
