### PR TITLE
mesa: 19.2.7 -> 19.3.1

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -27,7 +27,7 @@
 with stdenv.lib;
 
 let
-  version = "19.2.7";
+  version = "19.3.1";
   branch  = versions.major version;
 in
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
     ];
-    sha256 = "17jp8ghipgz62vqqz5llskxypkcmgf8gnlgnj0pyvnbgi6vryyg3";
+    sha256 = "0ndfpqry08s74yw4x3ydyhim6v4ywg0b4yhaazq7zaankjv1v5fd";
   };
 
   prePatch = "patchShebangs .";

--- a/pkgs/development/libraries/mesa/disk_cache-include-dri-driver-path-in-cache-key.patch
+++ b/pkgs/development/libraries/mesa/disk_cache-include-dri-driver-path-in-cache-key.patch
@@ -1,4 +1,4 @@
-From 2a1e32b4105fe95413a615a44d40938920ea1a19 Mon Sep 17 00:00:00 2001
+From 6d22383149e4cdc646c68e29238f41d895a4705b Mon Sep 17 00:00:00 2001
 From: David McFarland <corngood@gmail.com>
 Date: Mon, 6 Aug 2018 15:52:11 -0300
 Subject: [PATCH] disk_cache: include dri driver path in cache key
@@ -12,10 +12,10 @@ timestamps in /nix/store are zero.
  3 files changed, 15 insertions(+), 1 deletion(-)
 
 diff --git a/meson_options.txt b/meson_options.txt
-index a723b5406cf..65a8954291f 100644
+index 626baf3..579c15b 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -330,3 +330,9 @@ option(
+@@ -341,6 +341,12 @@ option(
    value : true,
    description : 'Enable direct rendering in GLX and EGL for DRI',
  )
@@ -25,11 +25,14 @@ index a723b5406cf..65a8954291f 100644
 +  value : '',
 +  description : 'Mesa cache key.'
 +)
+ option(
+   'I-love-half-baked-turnips',
+   type : 'boolean',
 diff --git a/src/util/disk_cache.c b/src/util/disk_cache.c
-index 0aa2646a9bb..bd784d38e21 100644
+index 0cd92ca..fc1c173 100644
 --- a/src/util/disk_cache.c
 +++ b/src/util/disk_cache.c
-@@ -389,8 +389,10 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
+@@ -395,8 +395,10 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
  
     /* Create driver id keys */
     size_t id_size = strlen(driver_id) + 1;
@@ -40,7 +43,7 @@ index 0aa2646a9bb..bd784d38e21 100644
     cache->driver_keys_blob_size += gpu_name_size;
  
     /* We sometimes store entire structs that contains a pointers in the cache,
-@@ -411,6 +413,7 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
+@@ -417,6 +419,7 @@ disk_cache_create(const char *gpu_name, const char *driver_id,
     uint8_t *drv_key_blob = cache->driver_keys_blob;
     DRV_KEY_CPY(drv_key_blob, &cache_version, cv_size)
     DRV_KEY_CPY(drv_key_blob, driver_id, id_size)
@@ -49,13 +52,13 @@ index 0aa2646a9bb..bd784d38e21 100644
     DRV_KEY_CPY(drv_key_blob, &ptr_size, ptr_size_size)
     DRV_KEY_CPY(drv_key_blob, &driver_flags, driver_flags_size)
 diff --git a/src/util/meson.build b/src/util/meson.build
-index 397c2228129..77013563e5d 100644
+index f69ebe9..e2bd8e2 100644
 --- a/src/util/meson.build
 +++ b/src/util/meson.build
-@@ -120,7 +120,12 @@ libmesa_util = static_library(
+@@ -158,7 +158,12 @@ _libmesa_util = static_library(
    [files_mesa_util, format_srgb],
    include_directories : inc_common,
-   dependencies : [dep_zlib, dep_clock, dep_thread, dep_atomic, dep_m],
+   dependencies : deps_for_libmesa_util,
 -  c_args : [c_msvc_compat_args, c_vis_args],
 +  c_args : [
 +    c_msvc_compat_args, c_vis_args,
@@ -67,5 +70,5 @@ index 397c2228129..77013563e5d 100644
  )
  
 -- 
-2.19.2
+2.24.1
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
