### PR TITLE
Opensnitch: init at 1.0.0b and provide NixOS module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -769,6 +769,7 @@
   ./services/security/nginx-sso.nix
   ./services/security/oauth2_proxy.nix
   ./services/security/oauth2_proxy_nginx.nix
+  ./services/security/opensnitch.nix
   ./services/security/physlock.nix
   ./services/security/shibboleth-sp.nix
   ./services/security/sks.nix

--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -1,0 +1,176 @@
+{ config, lib, pkgs, ... }:
+
+
+let
+  cfg = config.services.opensnitch;
+  inherit (pkgs) opensnitchd opensnitch-ui writeText iptables;
+  inherit (lib) nameValuePair mapAttrsToList;
+  inherit (builtins) listToAttrs replaceStrings concatMap;
+  escapeRuleName = name:
+    replaceStrings [ "*" "." "/" ] [ "all" "-" "-" ] name;
+
+  makeAlwaysRuleFile =  rulePath: name': rule: let name = escapeRuleName name'; in
+    nameValuePair (rulePath + "/${name}.json") {
+      source = writeText name (builtins.toJSON ({
+        inherit name;
+        enabled = true;
+        duration = "always";
+      } // rule));
+    };
+
+  makeAlwaysOperatorFile = rulePath: name: operator:
+    makeAlwaysRuleFile rulePath name {action = "allow"; inherit operator; };
+
+  makePackageRuleFile = rulePath: pkg: let
+    name = "nixos-allow-pkg-${lib.strings.getName pkg}";
+    in makeAlwaysOperatorFile rulePath name {
+          type = "regexp";
+          operand = "process.path";
+          data = "${pkg}/.*";
+    };
+
+  makeHostRuleFile = rulePath: type: value: let
+    name = "nixos-allow-${type}-${value}";
+    in makeAlwaysOperatorFile rulePath name {
+      type = "regexp";
+      operand = "dest.${type}";
+      data = replaceStrings [ "." "*" ] [ "\\." ".*" ] value;
+    };
+
+in
+
+{
+
+  options = {
+    services.opensnitch = with lib; {
+      enable = mkEnableOption "opensnitch";
+
+      uiConfig = mkOption {
+        type = types.attrs;
+        description = "JSON attribute set for opensnitch-ui config file.";
+        default = {
+          default_timeout = 60;
+          default_action = "deny";
+          default_duration = "once";
+        };
+        example = ''
+          {
+            default_timeout = 15;
+            default_action = "allow";
+            default_duration = "until restart";
+          }
+        '';
+      };
+
+      startUserService = mkOption {
+        type = types.bool;
+        description = ''
+          If enabled, run the opensnitch-ui process as a user
+          service in the graphical session.  All users' UI processes
+          share the config specified in uiConfig.  If this is disabled,
+          opensnitch-ui must be run by some other means.
+        '';
+        default = true;
+      };
+
+      whitelistPackages = mkOption {
+        type = types.listOf types.package;
+        description = ''
+          List of packages for which to generate rules to allow connections
+          from all processes that are located below
+          a package's store path.  Intended for process rules
+          which should survive NixOS updates.
+        '';
+        default = with pkgs; [ nix ];
+      };
+
+      whitelistHosts = mkOption {
+        type = types.listOf types.attrs;
+        description = ''
+          List of destination hosts for which to create default (regexp) allow rules,
+          regardless of other connection properties.
+        '';
+        default = [];
+        example = ''[ { host = "*.nixos.org" } { ip = "127.0.0.1" } ]'';
+      };
+
+      extraRules = mkOption {
+        type = types.attrsOf types.attrs;
+        description = ''
+          Set of JSON attribute sets describing default opensnitch rules that are written to
+          /etc/opensnitch/rules.
+        '';
+        default = [];
+        example = ''
+          {
+            kerberos_rule = {
+              action = "allow";
+              operator = {
+                type = "list";
+                list = [
+                  {
+                    type = "simple";
+                    operand = "dest.host";
+                    data = "kerberos.example.domain";
+                  }
+                  {
+                    type = "simple";
+                    operand = "dest.port";
+                    data = "88";
+                  }
+                ];
+              };
+            };
+          }
+        '';
+      };
+    };
+  };
+
+  config =
+    let
+      uiConfig = writeText "ui-config.json" (builtins.toJSON cfg.uiConfig);
+    in
+    lib.mkIf cfg.enable {
+
+      environment.etc = listToAttrs (
+        (map (makePackageRuleFile "opensnitchd/rules") cfg.whitelistPackages)
+        ++ concatMap (x: mapAttrsToList (n: v: makeHostRuleFile "opensnitchd/rules" n v) x) cfg.whitelistHosts
+        ++ mapAttrsToList (makeAlwaysRuleFile "opensnitchd/rules") cfg.extraRules
+      );
+
+      environment.systemPackages = if cfg.startUserService then [] else [ opensnitch-ui ];
+
+      systemd.services.opensnitchd = {
+        description = "opensnitch firewall daemon";
+        after = [ "network.target" ];
+        wants = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        preStart = ''
+          mkdir -p /etc/opensnitchd/rules
+          chown root:root /etc/opensnitchd
+          chmod 700 /etc/opensnitchd
+          # mkdir -p /run/opensnitch
+        '';
+        path = [ iptables ];
+        # For some reason there is a problem with specifying /run for the socket file...
+        # script = "${lib.getBin opensnitch.daemon}/bin/opensnitchd -log-file /var/log/opensnitchd.log -rules-path /etc/opensnitchd/rules -ui-socket unix:///run/opensnitch/osui.sock -debug";
+        script = "${lib.getBin opensnitchd}/bin/opensnitchd -log-file /var/log/opensnitchd.log -rules-path /etc/opensnitchd/rules -ui-socket unix:///tmp/osui.sock";
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "30";
+        };
+      };
+
+
+      systemd.user.services.opensnitch-ui = {
+        description = "opensnitch firewall UI process";
+        wantedBy = [ "graphical-session.target" ];
+        partOf = [ "graphical-session.target" ];
+        script = "${lib.getBin opensnitch-ui}/bin/opensnitch-ui --config ${uiConfig} --socket unix:///tmp/osui.sock";
+        unitConfig.ConditionUser = "!@system";
+        enable = cfg.startUserService;
+      };
+    };
+}

--- a/pkgs/tools/security/opensnitch/default.nix
+++ b/pkgs/tools/security/opensnitch/default.nix
@@ -1,0 +1,57 @@
+{ lib, stdenv, pkgs, python3Packages, fetchFromGitHub, libnetfilter_queue
+, libnfnetlink, libpcap, protobuf, buildGoPackage, pkg-config
+, qt5
+}:
+
+let
+  version = "1.0.0.b-2019-10-09";
+  src = fetchFromGitHub {
+    owner = "evilsocket";
+    repo = "opensnitch";
+    rev = "2b49871a2d1b8346eba169343b29d099a9e5c355";
+    sha256 = "00zgy40crlcx2h42wibg5m6pxjyfaxpkhxyq523i70q7dh4aj2jm";
+  };
+  meta = {
+    description = "GNU/Linux port of the Little Snitch application firewall";
+    license = lib.licenses.gpl3;
+    homepage = "https://github.com/evilsocket/opensnitch";
+    platforms = lib.platforms.unix;
+  };
+in
+
+{
+  opensnitchd = buildGoPackage rec {
+    pname = "opensnitch-daemon";
+    inherit src version meta;
+    goPackagePath = "github.com/evilsocket/opensnitch";
+    subPackages = [ "./daemon" ];
+    goDeps = ./deps.nix;
+    buildInputs = [ pkg-config libnetfilter_queue libnfnetlink libpcap protobuf ];
+    postInstall = "mv $bin/bin/daemon $bin/bin/opensnitchd";
+  };
+
+  opensnitch-ui = python3Packages.buildPythonApplication rec {
+    pname = "opensnitch-ui";
+    inherit src version meta;
+    sourceRoot = "source/ui";
+    dontWrapPythonPrograms = true;
+    nativeBuildInputs = [ qt5.wrapQtAppsHook stdenv python3Packages.pyqt5 ];
+    preBuild = ''
+      pyrcc5 -o opensnitch/resources_rc.py opensnitch/res/resources.qrc
+    '';
+    propagatedBuildInputs = with python3Packages; [
+      grpcio
+      grpcio-tools
+      pyinotify
+      configparser
+      pyqt5
+      unicode-slugify
+    ] ;
+    doCheck = false;
+    postInstall = ''
+      for program in $out/bin/*; do
+      wrapQtApp $program --prefix PYTHONPATH : $PYTHONPATH
+      done
+    '';
+  };
+}

--- a/pkgs/tools/security/opensnitch/deps.nix
+++ b/pkgs/tools/security/opensnitch/deps.nix
@@ -1,0 +1,84 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/evilsocket/ftrace";
+    fetch = {
+      type = "git";
+      url = "https://github.com/evilsocket/ftrace";
+      rev =  "06529699d3b47fd1adae671b6851dd6f7539c841";
+      sha256 = "16njp0j1g8mcw5abw1zwsa7zqfvb01lm2sl0180dy5r37vcp3h54";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev =  "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "925541529c1fa6821df4e44ce2723319eb2be768";
+      sha256 = "1d3zjvhl115l23xakj0014qpjchivlg098h10v5nfirkk1i9f9sa";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/gopacket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/gopacket";
+      rev =  "11c65f1ca9081dfea43b4f9643f5c155583b73ba";
+      sha256 = "07bagq7bf2lx8hmy4wg0j258y67c2ydm0h2d0z70c150557mklvx";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "8d16fa6dc9a85c1cd3ed24ad08ff21cf94f10888";
+      sha256 = "1bb4vkcdspxby2vg72rbpafji3wnpp28i3gwkhivh5xk4kvi9crl";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "b126b21c05a91c856b027c16779c12e3bf236954";
+      sha256 = "01i6izkswkm79ydlkz8nkwvp7f57xf53ffh6pzka16qng4ljy1v9";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-genproto";
+      rev =  "7fd901a49ba6a7f87732eb344f6e3c5b19d1b200";
+      sha256 = "1j5y7md243f8x37fnwwlgpvrpnyliqh2b07hs26dy7655ifay486";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/grpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc/grpc-go";
+      rev =  "d11072e7ca9811b1100b80ca0269ac831f06d024";
+      sha256 = "1b8kjz9cqlf74mp51vdvsh5yg0vpgsc7pd7mq61mn2m3xwcgwzzl";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20314,6 +20314,9 @@ in
     buildGoPackage = buildGo112Package;
   };
 
+  inherit (callPackage ../tools/security/opensnitch { })
+  opensnitchd opensnitch-ui;
+
   oroborus = callPackage ../applications/window-managers/oroborus {};
 
   osm2pgsql = callPackage ../tools/misc/osm2pgsql { };


### PR DESCRIPTION
###### Motivation for this change
Opensnitch seems to be a useful personal firewall application to control (at the moment only outgoing) connections per process/user/destination.
See also: #76610 
###### Things done
The package provides two attributes, the daemon `opensnitchd` and the UI program `opensnitch-ui`, which are built from the same source.

Additionally, a NixOS module is provided which starts the daemon as a system service, and (default behavior) runs the UI process in each user's graphical session as a user service.

Some support is added for generating some predefined rules, as e.g. per-process rules, which have been created via the UI prompt, become obsolete if the store path to a program changes.

Issues:
- Had some problems trying to put the socket file under `/run/...`, so it currently resides under the default `/tmp`
- Permissions of log files, socket file and rules files could be wrong
- Upstream uses version `1.0.0b`, but there seems to be no definitive release.  Since upstream also advertises this as unstable, I added the commit date to the version number

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

*NOTE*:
- Developed and tested the package and the module on 19.09
- Only tested evaluation on master