### PR TITLE
soapysdr: add as python module

### DIFF
--- a/pkgs/applications/radio/soapysdr/default.nix
+++ b/pkgs/applications/radio/soapysdr/default.nix
@@ -1,7 +1,8 @@
 { stdenv, lib, lndir, makeWrapper
 , fetchFromGitHub, cmake
 , libusb, pkgconfig
-, python, swig2, numpy, ncurses
+, usePython ? false
+, python, ncurses, swig2
 , extraPackages ? []
 } :
 
@@ -24,12 +25,14 @@ in stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
-  buildInputs = [ libusb ncurses numpy python swig2 ];
+  buildInputs = [ libusb ncurses ]
+    ++ lib.optionals usePython [ python swig2 ];
+
+  propagatedBuildInputs = lib.optional usePython python.pkgs.numpy;
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
-    "-DUSE_PYTHON_CONFIG=ON"
-  ];
+  ] ++ lib.optional usePython "-DUSE_PYTHON_CONFIG=ON";
 
   postFixup = lib.optionalString (lib.length extraPackages != 0) ''
     # Join all plugins via symlinking

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14097,12 +14097,11 @@ in
 
   soapyhackrf = callPackage ../applications/radio/soapyhackrf { };
 
-  soapysdr = callPackage ../applications/radio/soapysdr { inherit (python3Packages) python numpy; };
+  soapysdr = callPackage ../applications/radio/soapysdr { };
 
   soapyremote = callPackage ../applications/radio/soapyremote { };
 
   soapysdr-with-plugins = callPackage ../applications/radio/soapysdr {
-    inherit (python3Packages) python numpy;
     extraPackages = [
       limesuite
       soapyairspy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1325,6 +1325,16 @@ in {
 
   snapcast = callPackage ../development/python-modules/snapcast { };
 
+  soapysdr = toPythonModule (pkgs.soapysdr.override {
+    python = self.python;
+    usePython = true;
+  });
+
+  soapysdr-with-plugins = toPythonModule (pkgs.soapysdr-with-plugins.override {
+    python = self.python;
+    usePython = true;
+  });
+
   sparse = callPackage ../development/python-modules/sparse { };
 
   spglib = callPackage ../development/python-modules/spglib { };
@@ -1953,7 +1963,7 @@ in {
   certifi = callPackage ../development/python-modules/certifi { };
 
   certipy = callPackage ../development/python-modules/certipy {};
- 
+
   characteristic = callPackage ../development/python-modules/characteristic { };
 
   chart-studio = callPackage ../development/python-modules/chart-studio { };


### PR DESCRIPTION
###### Motivation for this change
Use "toPythonModule" function to make python interface available.
So far the python interface was not properly exposed via nixpkgs (closes https://github.com/NixOS/nixpkgs/issues/76808)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @sbourdeauducq 
