### PR TITLE
psi: 0.15 -> 1.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi/default.nix
@@ -1,27 +1,26 @@
-{ stdenv, fetchurl, enchant, qt4, zlib, sox, libX11, xorgproto, libSM
-, libICE, qca2, pkgconfig, which, glib
-, libXScrnSaver
+{ stdenv, fetchFromGitHub, cmake, wrapQtAppsHook
+, qtbase, qtmultimedia, qtx11extras, qttools, qtwebengine
+, libidn, qca2-qt5, libXScrnSaver, hunspell
 }:
-
 stdenv.mkDerivation rec {
-  name = "psi-0.15";
-
-  src = fetchurl {
-    url = "mirror://sourceforge/psi/${name}.tar.bz2";
-    sha256 = "593b5ddd7934af69c245afb0e7290047fd7dedcfd8765baca5a3a024c569c7e6";
+  pname = "psi";
+  version = "1.4";
+  src = fetchFromGitHub {
+    owner = "psi-im";
+    repo = pname;
+    rev = version;
+    sha256 = "09c7cg96vgxzgbpypgcw7yv73gvzppbi1lm4svbpfn2cfxy059d4";
+    fetchSubmodules = true;
   };
-
-  buildInputs =
-    [ enchant qt4 zlib sox libX11 xorgproto libSM libICE
-      qca2 pkgconfig which glib libXScrnSaver
-    ];
-
-  NIX_CFLAGS_COMPILE="-I${qca2}/include/QtCrypto";
-
-  NIX_LDFLAGS="-lqca";
-
+  patches = [
+    ./fix-cmake-hunspell-1.7.patch
+  ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+  buildInputs = [
+    qtbase qtmultimedia qtx11extras qttools qtwebengine
+    libidn qca2-qt5 libXScrnSaver hunspell
+  ];
   enableParallelBuilding = true;
-
   meta = with stdenv.lib; {
     description = "Psi, an XMPP (Jabber) client";
     maintainers = [ maintainers.raskin ];

--- a/pkgs/applications/networking/instant-messengers/psi/fix-cmake-hunspell-1.7.patch
+++ b/pkgs/applications/networking/instant-messengers/psi/fix-cmake-hunspell-1.7.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/modules/FindHunspell.cmake b/cmake/modules/FindHunspell.cmake
+index a2d180b3..3a5aef3a 100644
+--- a/cmake/modules/FindHunspell.cmake
++++ b/cmake/modules/FindHunspell.cmake
+@@ -64,6 +64,7 @@ set(HUNSPELL_NAMES
+ 	hunspell-1.4
+ 	hunspell-1.5
+ 	hunspell-1.6
++	hunspell-1.7
+ 	libhunspell${d}
+ )
+ find_library(

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20804,7 +20804,7 @@ in
 
   ps2client = callPackage ../applications/networking/ps2client { };
 
-  psi = callPackage ../applications/networking/instant-messengers/psi { };
+  psi = libsForQt5.callPackage ../applications/networking/instant-messengers/psi { };
 
   psi-plus = libsForQt5.callPackage ../applications/networking/instant-messengers/psi-plus { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
New version: https://github.com/psi-im/psi/releases/tag/1.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @raskin
