### PR TITLE
psi-plus: 1.4.904 -> 1.4.983

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake
+{ stdenv, fetchFromGitHub, cmake, wrapQtAppsHook
 , qtbase, qtmultimedia, qtx11extras, qttools, qtwebengine
 , libidn, qca2-qt5, qtkeychain, libXScrnSaver, hunspell
 , libgcrypt, libotr, html-tidy, libgpgerror, libsignal-protocol-c
@@ -6,20 +6,20 @@
 
 stdenv.mkDerivation rec {
   pname = "psi-plus";
-  version = "1.4.904";
+  version = "1.4.983";
 
   src = fetchFromGitHub {
     owner = "psi-plus";
     repo = "psi-plus-snapshots";
     rev = version;
-    sha256 = "1bs7yk3qp91sm8nb9gna8vm59381afn1wfs7aii9yi29bhx6fw9h";
+    sha256 = "0i28i3f41m57fyxcv6bwsq30k4921sxgxxd59cwqknl1vf094gya";
   };
 
   resources = fetchFromGitHub {
     owner = "psi-plus";
     repo = "resources";
-    rev = "182c92ca0bcc055579d8c91bccba9efe157e77a9";
-    sha256 = "06k7q63cxpifpzjnlw1snclkr2mwf9fh71cgfd40n7jgzswzwhpb";
+    rev = "2f1c12564f7506bf902a26040fdb47ead4df6b73";
+    sha256 = "1dgm9k052fq7f2bpx13kchg7sxb227dkn115lyspzvhnhprnypz2";
   };
 
   postUnpack = ''
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_PLUGINS=ON"
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
 
   buildInputs = [
     qtbase qtmultimedia qtx11extras qttools qtwebengine


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
New snapshot: https://github.com/psi-plus/psi-plus-snapshots/releases/tag/1.4.983

Also fix ```This application failed to start because no Qt platform plugin could be initialized``` error on startup by including ```wrapQtAppsHook``` in ```nativeBuildInputs```.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @orivej