### PR TITLE
mercurial_4: init at 4.9.1

### DIFF
--- a/pkgs/applications/version-management/mercurial/4.9.nix
+++ b/pkgs/applications/version-management/mercurial/4.9.nix
@@ -1,0 +1,71 @@
+{ stdenv, fetchurl, python2Packages, makeWrapper, unzip
+, guiSupport ? false, tk ? null
+, ApplicationServices
+, mercurialSrc ? fetchurl rec {
+    meta.name = "mercurial-${meta.version}";
+    meta.version = "4.9.1";
+    url = "https://mercurial-scm.org/release/${meta.name}.tar.gz";
+    sha256 = "0iybbkd9add066729zg01kwz5hhc1s6lhp9rrnsmzq6ihyxj3p8v";
+  }
+}:
+
+let
+  inherit (python2Packages) docutils hg-git dulwich python;
+
+in python2Packages.buildPythonApplication {
+
+  inherit (mercurialSrc.meta) name version;
+  src = mercurialSrc;
+
+  format = "other";
+
+  inherit python; # pass it so that the same version can be used in hg2git
+
+  buildInputs = [ makeWrapper docutils unzip ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ ApplicationServices ];
+
+  propagatedBuildInputs = [ hg-git dulwich ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = (stdenv.lib.optionalString guiSupport
+    ''
+      mkdir -p $out/etc/mercurial
+      cp contrib/hgk $out/bin
+      cat >> $out/etc/mercurial/hgrc << EOF
+      [extensions]
+      hgk=$out/lib/${python.libPrefix}/site-packages/hgext/hgk.py
+      EOF
+      # setting HG so that hgk can be run itself as well (not only hg view)
+      WRAP_TK=" --set TK_LIBRARY ${tk}/lib/${tk.libPrefix}
+                --set HG $out/bin/hg
+                --prefix PATH : ${tk}/bin "
+    '') +
+    ''
+      for i in $(cd $out/bin && ls); do
+        wrapProgram $out/bin/$i \
+          $WRAP_TK
+      done
+
+      # copy hgweb.cgi to allow use in apache
+      mkdir -p $out/share/cgi-bin
+      cp -v hgweb.cgi contrib/hgweb.wsgi $out/share/cgi-bin
+      chmod u+x $out/share/cgi-bin/hgweb.cgi
+
+      # install bash/zsh completions
+      install -v -m644 -D contrib/bash_completion $out/share/bash-completion/completions/_hg
+      install -v -m644 -D contrib/zsh_completion $out/share/zsh/site-functions/_hg
+    '';
+
+  meta = {
+    inherit (mercurialSrc.meta) version;
+    description = "A fast, lightweight SCM system for very large distributed projects";
+    homepage = https://www.mercurial-scm.org;
+    downloadPage = https://www.mercurial-scm.org/release/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.eraserhd ];
+    updateWalker = true;
+    platforms = stdenv.lib.platforms.unix;
+  };
+}
+

--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, lib, fetchFromGitHub, fetchurl, fetchzip, fetchgit, mercurial, python27, setJavaClassPath,
+{ stdenv, lib, fetchFromGitHub, fetchurl, fetchzip, fetchgit, mercurial_4, python27, setJavaClassPath,
   zlib, makeWrapper, openjdk, unzip, git, clang, llvm, which, icu, ruby, bzip2, glibc
   # gfortran, readline, bzip2, lzma, pcre, curl, ed, tree ## WIP: fastr deps
 }:
 
 let
   version = "19.1.1";
+  mercurial = mercurial_4;
   truffleMake = ./truffle.make;
   makeMxGitCache = list: out: ''
      mkdir ${out}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20049,6 +20049,9 @@ in
 
   menumaker = callPackage ../applications/misc/menumaker { };
 
+  mercurial_4 = callPackage ../applications/version-management/mercurial/4.9.nix {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices;
+  };
   mercurial = callPackage ../applications/version-management/mercurial {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };


### PR DESCRIPTION
###### Motivation for this change

Commit 88a473fc upgraded mercurial, made it use python3, and removed
support for hg-git, breaking graalvm8.  Since hg-git does not
officially support python3 or the new version of mercurial, this
patch adds back the old version of mercurial, used only by the
graalvm build.

Closes #76527.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @eelco @volth @hlolli

@hlolli I assume the 19.2.1 Graal PR will need to be updated as well?