### PR TITLE
pythonPackages.elementpath: 1.3.3 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/elementpath/default.nix
+++ b/pkgs/development/python-modules/elementpath/default.nix
@@ -1,18 +1,27 @@
-{ lib, buildPythonPackage, fetchFromGitHub }:
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27 }:
 
 buildPythonPackage rec {
-  version = "1.3.3";
+  version = "1.4.0";
   pname = "elementpath";
+  disabled = isPy27; # uses incompatible class syntax
 
   src = fetchFromGitHub {
     owner = "sissaschool";
     repo = "elementpath";
     rev = "v${version}";
-    sha256 = "05wplh836ffwhncf5rpdnz4g1b3mqw7jiy83352nw4x3aak4ifbr";
+    sha256 = "1fmwy7plcgxam09cx3z11068k0c98wcsgclmxdq8chsd6id3632y";
   };
 
   # avoid circular dependency with xmlschema which directly depends on this
   doCheck = false;
+
+  pythonImportsCheck = [
+    "elementpath.xpath1_parser"
+    "elementpath.xpath2_parser"
+    "elementpath.xpath2_functions"
+    "elementpath.xpath_context"
+    "elementpath.xpath_selectors"
+  ];
 
   meta = with lib; {
     description = "XPath 1.0/2.0 parsers and selectors for ElementTree and lxml";

--- a/pkgs/development/python-modules/xmlschema/default.nix
+++ b/pkgs/development/python-modules/xmlschema/default.nix
@@ -4,19 +4,24 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.0.17";
+  version = "1.0.18";
   pname = "xmlschema";
 
   src = fetchFromGitHub {
     owner = "sissaschool";
     repo = "xmlschema";
     rev = "v${version}";
-    sha256 = "0wbz243q8028ljnh6nq3kxawiwpg5p2bwg1b23ibf7zbrhazcj4k";
+    sha256 = "1pwq2sfh7klcxismsqzgw80cp3cdkq9wv8x9g3h1zx1p66xpas9p";
   };
 
   propagatedBuildInputs = [ elementpath ];
 
   checkInputs = [ pytest ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "elementpath~=1.3.0" "elementpath~=1.3"
+  '';
 
   # Ignore broken fixtures, and tests for files which don't exist.
   # For darwin, we need to explicity say we can't reach network


### PR DESCRIPTION
###### Motivation for this change
Updating packages I maintain

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[7 built, 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/76908
8 package were built:
python37Packages.elementpath python37Packages.fints python37Packages.sepaxml python37Packages.xmlschema python38Packages.elementpath python38Packages.fints python38Packages.sepaxml python38Packages.xmlschema
```