### PR TITLE
raft-canonical: 0.9.6 -> 0.9.17, dqlite: 1.0.0 -> 1.4.0, lxd: 3.18 -> 3.22

### DIFF
--- a/pkgs/development/libraries/dqlite/default.nix
+++ b/pkgs/development/libraries/dqlite/default.nix
@@ -5,13 +5,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "dqlite";
-  version = "1.0.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "canonical";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0670c1c84lcf5vl3h6mlff00fz2fnm766bzlk526sjjzysx3zjya";
+    sha256 = "19snm6cicxagcw9ys2jmjf6fchzs6pwm7h4jmyr0pn6zks2yjf1i";
   };
 
   nativeBuildInputs = [ autoreconfHook file pkgconfig ];
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = https://github.com/CanonicalLtd/dqlite/;
     license = licenses.asl20;
-    maintainers = with maintainers; [ joko ];
+    maintainers = with maintainers; [ joko wucke13 ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/raft-canonical/default.nix
+++ b/pkgs/development/libraries/raft-canonical/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "raft-canonical";
-  version = "0.9.6";
+  version = "0.9.17";
 
   src = fetchFromGitHub {
     owner = "canonical";
     repo = "raft";
     rev = "v${version}";
-    sha256 = "083il7b5kw3pc7m5p9xjpb9dlvfarc51sni92mkgm9ckc32x9vpp";
+    sha256 = "0q444wd6wz85g4zjkdsrf8z7chkjq9rxzq8l6fh37mgf7c23hv09";
   };
 
   nativeBuildInputs = [ autoreconfHook file pkgconfig ];
@@ -18,11 +18,13 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace /usr/bin/ " "
   '';
 
-  doCheck = false;
-  # Due to
-  #io_uv_recv/success/first                                    [ ERROR ]
-  #Error: test/lib/dir.c:97: No such file or directory
+  # test fails
+  #
+  #append/finalizeSegment                                      [ ERROR ]
+  #Error: test/integration/test_uv_append.c:264: assertion failed: test_dir_has_file(f->dir, "0000000000000001-0000000000000004") is not true
   #Error: child killed by signal 6 (Aborted)
+
+  doCheck = false;
 
   outputs = [ "dev" "out" ];
 
@@ -39,6 +41,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/canonical/raft";
     license = licenses.asl20;
-    maintainers = [ maintainers.wucke13 ];
+    maintainers = with maintainers; [ wucke13 ];
   };
 }

--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -1,7 +1,7 @@
 { stdenv, pkgconfig, lxc, buildGoPackage, fetchurl
 , makeWrapper, acl, rsync, gnutar, xz, btrfs-progs, gzip, dnsmasq
 , squashfsTools, iproute, iptables, ebtables, libcap, libco-canonical, dqlite
-, raft-canonical, sqlite-replication
+, raft-canonical, sqlite-replication, udev
 , writeShellScriptBin, apparmor-profiles, apparmor-parser
 , criu
 , bash
@@ -9,13 +9,13 @@
 
 buildGoPackage rec {
   pname = "lxd";
-  version = "3.18";
+  version = "3.22";
 
   goPackagePath = "github.com/lxc/lxd";
 
   src = fetchurl {
     url = "https://github.com/lxc/lxd/releases/download/${pname}-${version}/${pname}-${version}.tar.gz";
-    sha256 = "1p8g2gbwgn3kln5rxddpc2fxk8bvf026wjiqip2b0vvpi7h3955h";
+    sha256 = "1j60xajcycqnnkasbghcvx3dvb5iadvvq2l3hh9i0sw3dk1wx4hn";
   };
 
   preBuild = ''
@@ -45,7 +45,7 @@ buildGoPackage rec {
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
   buildInputs = [ lxc acl libcap libco-canonical.dev dqlite.dev
-                  raft-canonical.dev sqlite-replication ];
+                  raft-canonical.dev sqlite-replication udev.dev ];
 
   meta = with stdenv.lib; {
     description = "Daemon based on liblxc offering a REST API to manage containers";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
