### PR TITLE
pythonPackages.capstone: 3.0.5.post1 -> 4.0.1, redesign as wrapper package around main capstone package

### DIFF
--- a/pkgs/development/libraries/capstone/default.nix
+++ b/pkgs/development/libraries/capstone/default.nix
@@ -9,9 +9,23 @@ stdenv.mkDerivation rec {
     sha256 = "1isxw2qwy1fi3m3w7igsr5klzczxc5cxndz0a78dfss6ps6ymfvr";
   };
 
+  # replace faulty macos detection
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i 's/^IS_APPLE := .*$/IS_APPLE := 1/' Makefile
+  '';
+
   configurePhase = '' patchShebangs make.sh '';
-  buildPhase = '' ./make.sh '';
-  installPhase = '' env PREFIX=$out ./make.sh install '';
+  buildPhase = "PREFIX=$out ./make.sh";
+
+  doCheck = true;
+  checkPhase = ''
+    # first remove fuzzing steps from check target
+    substituteInPlace Makefile --replace "fuzztest fuzzallcorp" ""
+    make check
+  '';
+
+  installPhase = (stdenv.lib.optionalString stdenv.isDarwin "HOMEBREW_CAPSTONE=1 ")
+    + "PREFIX=$out ./make.sh install";
   
   nativeBuildInputs = [
     pkgconfig
@@ -23,7 +37,7 @@ stdenv.mkDerivation rec {
     description = "Advanced disassembly library";
     homepage    = "http://www.capstone-engine.org";
     license     = stdenv.lib.licenses.bsd3;
-    platforms   = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ thoughtpolice ris ];
   };
 }

--- a/pkgs/development/python-modules/capstone/default.nix
+++ b/pkgs/development/python-modules/capstone/default.nix
@@ -3,43 +3,33 @@
 , fetchPypi
 , fetchpatch
 , setuptools
+, capstone
 }:
 
 buildPythonPackage rec {
   pname = "capstone";
-  version = "3.0.5.post1";
+  version = stdenv.lib.getVersion capstone;
 
-  setupPyBuildFlags = [
-    "--plat-name x86_64-linux"
-  ];
+  src = capstone.src;
+  sourceRoot = "${capstone.name}/bindings/python";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "3c0f73db9f8392f7048c8a244809f154d7c39f354e2167f6c477630aa517ed04";
-  };
+  postPatch = ''
+    ln -s ${capstone}/lib/libcapstone${stdenv.targetPlatform.extensions.sharedLibrary} prebuilt/
+    ln -s ${capstone}/lib/libcapstone.a prebuilt/
+  '';
 
   propagatedBuildInputs = [ setuptools ];
 
-  patches = [
-    (fetchpatch {
-      stripLen = 2;
-      url = "https://patch-diff.githubusercontent.com/raw/aquynh/capstone/pull/783/commits/23fe9f36622573c747e2bab6119ff245437bf276.patch";
-      sha256 = "0yizqrdlxqxn16873593kdx2vrr7gvvilhgcf9xy6hr0603d3m5r";
-    })
-  ];
-
-  postPatch = ''
-    patchShebangs src/make.sh
-  '';
-
-  preCheck = ''
-    mv src/libcapstone.so capstone
+  checkPhase = ''
+    mv capstone capstone.hidden
+    patchShebangs test_*
+    make check
   '';
 
   meta = with stdenv.lib; {
     homepage = "http://www.capstone-engine.org/";
     license = licenses.bsdOriginal;
-    description = "Capstone disassembly engine";
-    maintainers = with maintainers; [ bennofs ];
+    description = "Python bindings for Capstone disassembly engine";
+    maintainers = with maintainers; [ bennofs ris ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1723,7 +1723,7 @@ in {
     inherit (self) python numpy boost;
   });
 
-  capstone = callPackage ../development/python-modules/capstone { };
+  capstone = callPackage ../development/python-modules/capstone { inherit (pkgs) capstone; };
 
   capturer = callPackage ../development/python-modules/capturer { };
 


### PR DESCRIPTION
##### Motivation for this change
Similar to #76762, this allows us to more easily keep the main package and python bindings in sync.

Again, I've also enabled the main `capstone` package on darwin and enabled its tests too.

Downstream dependency `pwntools` fails to build but that's due to `tox` being broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @thoughtpolice @bennofs 
