### PR TITLE
x264: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/x264/default.nix
+++ b/pkgs/development/libraries/x264/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, nasm }:
+{ stdenv, lib, fetchurl, nasm }:
 
 stdenv.mkDerivation rec {
   pname = "x264";
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1xv41z04km3rf374xk3ny7v8ibr211ph0j5am0909ln63mphc48f";
   };
 
+  # Upstream ./configure greps for (-mcpu|-march|-mfpu) in CFLAGS, which in nix
+  # is put in the cc wrapper anyway.
+  patches = [ ./disable-arm-neon-default.patch ];
+
   postPatch = ''
     patchShebangs .
   '';
@@ -17,15 +21,16 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "lib" "dev" ];
 
-  preConfigure = ''
+  preConfigure = lib.optionalString (stdenv.buildPlatform.isx86_64 || stdenv.hostPlatform.isi686) ''
     # `AS' is set to the binutils assembler, but we need nasm
     unset AS
   '';
 
   configureFlags = [ "--enable-shared" ]
-    ++ stdenv.lib.optional (!stdenv.isi686) "--enable-pic";
+    ++ stdenv.lib.optional (!stdenv.isi686) "--enable-pic"
+    ++ stdenv.lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "--cross-prefix=${stdenv.cc.targetPrefix}";
 
-  nativeBuildInputs = [ nasm ];
+  nativeBuildInputs = lib.optional (stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isi686) nasm;
 
   meta = with stdenv.lib; {
     description = "Library for encoding H264/AVC video streams";

--- a/pkgs/development/libraries/x264/disable-arm-neon-default.patch
+++ b/pkgs/development/libraries/x264/disable-arm-neon-default.patch
@@ -1,0 +1,13 @@
+diff -Naur x264-snapshot-20190517-2245-stable-orig/configure x264-snapshot-20190517-2245-stable/configure
+--- x264-snapshot-20190517-2245-stable-orig/configure	2020-01-03 19:51:03.041037657 -0500
++++ x264-snapshot-20190517-2245-stable/configure	2020-01-03 19:52:15.075034609 -0500
+@@ -930,9 +930,6 @@
+ fi
+ 
+ if [ $asm = auto -a $ARCH = ARM ] ; then
+-    # set flags so neon is built by default
+-    [ $compiler == CL ] || echo $CFLAGS | grep -Eq '(-mcpu|-march|-mfpu)' || CFLAGS="$CFLAGS -mcpu=cortex-a8 -mfpu=neon"
+-
+     cc_check '' '' '__asm__("add r0, r1, r2");' && define HAVE_ARM_INLINE_ASM
+     if [ $compiler = CL ] && cpp_check '' '' 'defined(_M_ARM) && _M_ARM >= 7' ; then
+         define HAVE_ARMV6


### PR DESCRIPTION
##### Motivation for this change
Fix for cross compilation. Note that nasm is only needed for x86 targets.

Built on `x86_64` and tested on raspberry pi 1 with `pkgsCross.raspberryPi.x264`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @spwhitt @tadeokondrak
