### PR TITLE
Feature/gpup

### DIFF
--- a/pkgs/development/tools/gpup/default.nix
+++ b/pkgs/development/tools/gpup/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildGoPackage, fetchgit }:
+
+buildGoPackage rec {
+  pname = "gpup";
+  version = "1.6.1";
+  rev = "95727c319393a0c7d2add7cc0f454f158989a966";
+
+  goPackagePath = "github.com/int128/gpup";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "int128";
+    repo = "gpup";
+    sha256 = "0nw9z96x1vk0gm09cz1yy2f870hyn4djb02qhn1f24m58s8mshqj";
+  };
+
+}

--- a/pkgs/development/tools/gpup/default.nix
+++ b/pkgs/development/tools/gpup/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchgit }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   pname = "gpup";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It's my first nixpkg, and I need some help with it :)

Just want to install gpup from the given repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
None of these yet, I'm trying to use nix-build and nix-env to try to install it on my pc.

When I run `nix-env -f . -qaP gpup` I don't see my package (from the root of my local nixpkgs).

When I run `nix-build gpup` from `pkgs/development/tools' I get `can not auto call a function that has an argument without a default vavlue ('stdenv')`

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
