### PR TITLE
dbvisualizer: 9.5.7 -> 10.0.25

### DIFF
--- a/pkgs/applications/misc/dbvisualizer/default.nix
+++ b/pkgs/applications/misc/dbvisualizer/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, jre, makeWrapper }:
 
-stdenv.mkDerivation {
-  name = "dbvisualizer-9.5.7";
+stdenv.mkDerivation rec {
+  pname = "dbvisualizer";
+  version = "10.0.25";
 
   src = fetchurl {
-    url = https://www.dbvis.com/product_download/dbvis-9.5.7/media/dbvis_unix_9_5_7.tar.gz;
-    sha256 = "1xv4fw7cji2ffvv7z8vjl5lap512pj60s2ynihirrqld7pmklnyr";
+    url = "https://www.dbvis.com/product_download/dbvis-${version}/media/dbvis_unix_${stdenv.lib.strings.replaceChars ["."] ["_"] version}.tar.gz";
+    sha256 = "0f9lqsvyxy0wa6hgdvc9vxvfb44xb46fgcdj5g9y013cj4nsqzf1";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions (Ubuntu 18.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
