### PR TITLE
keepassxc: fix darwin build

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, makeWrapper, qttools
+{ stdenv, fetchFromGitHub, cmake, makeWrapper, qttools, darwin
 
 , curl
 , glibcLocales
@@ -7,7 +7,6 @@
 , libargon2
 , libgcrypt
 , libgpgerror
-, libmicrohttpd
 , libsodium
 , libyubikey
 , pkg-config
@@ -93,7 +92,6 @@ stdenv.mkDerivation rec {
     libargon2
     libgcrypt
     libgpgerror
-    libmicrohttpd
     libsodium
     libyubikey
     pkg-config
@@ -105,7 +103,8 @@ stdenv.mkDerivation rec {
     zlib
   ]
   ++ stdenv.lib.optional withKeePassKeeShareSecure quazip
-  ++ stdenv.lib.optional stdenv.isDarwin qtmacextras;
+  ++ stdenv.lib.optional stdenv.isDarwin qtmacextras
+  ++ stdenv.lib.optional (stdenv.isDarwin && withKeePassTouchID) darwin.apple_sdk.frameworks.LocalAuthentication;
 
   preFixup = optionalString stdenv.isDarwin ''
     # Make it work without Qt in PATH.
@@ -118,6 +117,6 @@ stdenv.mkDerivation rec {
     homepage = https://keepassxc.org/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ jonafato ];
-    platforms = with platforms; linux ++ darwin;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
@@ -70,6 +70,7 @@ with frameworks; with libs; {
   Kernel                  = [ IOKit ];
   LDAP                    = [];
   LatentSemanticMapping   = [ Carbon ];
+  LocalAuthentication     = [];
   MapKit                  = [];
   MediaAccessibility      = [ CoreGraphics CoreText QuartzCore ];
   MediaToolbox            = [ AudioToolbox AudioUnit CoreMedia ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This PR allows keepassxc to build on macOS.

- Removed the unnecessary libmicrohttpd dependency, which doesn't build on macOS. KeepassXC removed this dependency in 2.1.2.
- Fixed a compiler error related to the Touch ID feature by adding a dependency on the LocalAuthentication framework. Compiler error that was fixed:

```
[ 64%] Building CXX object src/CMakeFiles/keepassx_core.dir/keys/drivers/YubiKey.cpp.o
[ 64%] Building CXX object src/CMakeFiles/keepassx_core.dir/touchid/TouchID.mm.o
/private/var/folders/qx/jwzr4j413sj76yplz7xqx22h0000gn/T/nix-build-keepassxc-2.5.1.drv-0/source/src/touchid/TouchID.mm:11:10: fatal error: 'LocalAuthentication/LocalAuthentication.h' file not found
#include <LocalAuthentication/LocalAuthentication.h>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [src/CMakeFiles/keepassx_core.dir/build.make:2065: src/CMakeFiles/keepassx_core.dir/touchid/TouchID.mm.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:641: src/CMakeFiles/keepassx_core.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
builder for '/nix/store/a7wrkjifshgxjls99gj344yvi3rwvfzm-keepassxc-2.5.1.drv' failed with exit code 2
error: build of '/nix/store/a7wrkjifshgxjls99gj344yvi3rwvfzm-keepassxc-2.5.1.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jonafato
