### PR TITLE
precice: fix output and cmake

### DIFF
--- a/pkgs/development/libraries/precice/0001-Fix-the-install-target-dirs-to-use-the-CMAKE-flags.patch
+++ b/pkgs/development/libraries/precice/0001-Fix-the-install-target-dirs-to-use-the-CMAKE-flags.patch
@@ -1,0 +1,112 @@
+From 078cc28a3ece0dcc4033961090a6e5d6e63b3ec5 Mon Sep 17 00:00:00 2001
+From: Scriptkiddi <fritz@otlinghaus.it>
+Date: Sat, 4 Jan 2020 17:59:32 +0100
+Subject: [PATCH] Fix the install target dirs to use the CMAKE flags
+
+---
+ CMakeLists.txt | 27 ++++++++++++++-------------
+ 1 file changed, 14 insertions(+), 13 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 96b9d1b5..ff8191ae 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,7 +5,7 @@ project(preCICE VERSION 1.6.1 LANGUAGES CXX)
+ 
+ #
+ # Overview of this configuration
+-# 
++#
+ # PREAMBLE
+ # Setup Options
+ # Find Mandatory Dependencies
+@@ -30,6 +30,7 @@ include(CheckCXX11Library)
+ include(CopyTargetProperty)
+ include(XSDKMacros)
+ include(Validation)
++include(GNUInstallDirs)
+ 
+ # CMake Policies
+ 
+@@ -197,7 +198,7 @@ if(CMAKE_VERSION VERSION_LESS "3.11")
+   endif()
+ endif()
+ 
+-# Add precice as an empty target 
++# Add precice as an empty target
+ add_library(precice ${preCICE_DUMMY})
+ set_target_properties(precice PROPERTIES
+   # precice is a C++11 project
+@@ -267,7 +268,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/DetectGitRevision.cmake)
+ configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.hpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.hpp" @ONLY)
+ 
+ # Includes Configuration
+-target_include_directories(precice PUBLIC 
++target_include_directories(precice PUBLIC
+   $<BUILD_INTERFACE:${preCICE_SOURCE_DIR}/src>
+   $<BUILD_INTERFACE:${preCICE_BINARY_DIR}/src>
+   $<INSTALL_INTERFACE:include>
+@@ -282,7 +283,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
+ #
+ 
+ add_executable(binprecice "src/drivers/main.cpp")
+-target_link_libraries(binprecice 
++target_link_libraries(binprecice
+   PRIVATE
+   Threads::Threads
+   precice
+@@ -365,18 +366,18 @@ include(${CMAKE_CURRENT_LIST_DIR}/src/tests.cmake)
+ # binprecice - the precice binary
+ install(TARGETS precice binprecice
+   EXPORT preciceTargets
+-  LIBRARY DESTINATION lib
+-  ARCHIVE DESTINATION lib
+-  RUNTIME DESTINATION bin
+-  PUBLIC_HEADER DESTINATION include/precice
+-  INCLUDES DESTINATION include/precice
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/static
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/precice
++  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/precice
+   )
+ 
+ if(PRECICE_InstallTest)
+   # Install the testprecice target
+   install(TARGETS testprecice
+     EXPORT preciceTargets
+-    RUNTIME DESTINATION bin
++    RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR}
+     )
+ 
+   # Install the resources necessary for the tests
+@@ -396,7 +397,7 @@ endif()
+ install(EXPORT preciceTargets
+   FILE preciceTargets.cmake
+   NAMESPACE precice::
+-  DESTINATION lib/cmake/precice
++  DESTINATION  ${CMAKE_INSTALL_LIBDIR}/cmake/precice
+   )
+ 
+ # Generate a Package Config File for precice
+@@ -408,7 +409,7 @@ write_basic_package_version_file("preciceConfigVersion.cmake"
+ 
+ # Install the Config and the ConfigVersion files
+ install(FILES "cmake/preciceConfig.cmake" "${preCICE_BINARY_DIR}/preciceConfigVersion.cmake"
+-  DESTINATION lib/cmake/precice
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/precice
+   )
+ 
+ # Setup the config in the build directory
+@@ -477,7 +478,7 @@ configure_file(
+   "lib/pkgconfig/libprecice.pc"
+   @ONLY
+   )
+-install(DIRECTORY "${preCICE_BINARY_DIR}/lib/pkgconfig" 
++install(DIRECTORY "${preCICE_BINARY_DIR}/lib/pkgconfig"
+   DESTINATION lib
+ )
+ 
+-- 
+2.23.1
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
