### PR TITLE
openexr: fix non-cross-compilation

### DIFF
--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "doc" ];
 
   # Needed because there are some generated sources. Solution: just run them under QEMU.
-  postPatch = ''
+  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     for file in b44ExpLogTable dwaLookups
     do
       # Ecape for both sh and Automake


### PR DESCRIPTION
cross-compilation support introduced in https://github.com/NixOS/nixpkgs/pull/61245 resulted in failed non-cross-compilation build:
```
.../bash ./b44ExpLogTable > b44ExpLogTable.h
./b44ExpLogTable: ./b44ExpLogTable: cannot execute binary file
```

because on non-cross-compilation `stdenv.hostPlatform.emulator` is `bash` and `bash` does not run ELF-binaries