### PR TITLE
bash_unit: init at 1.6.1

### DIFF
--- a/pkgs/tools/misc/bash_unit/default.nix
+++ b/pkgs/tools/misc/bash_unit/default.nix
@@ -1,0 +1,27 @@
+{ fetchFromGitHub
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bash_unit";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "pgrange";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0jcjpcyf569b12vm4jrd53iqrrsjvr8sp9y29w2ls38fm8a16vr6";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bash_unit $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Bash unit testing enterprise edition framework for professionals";
+    maintainers = with maintainers; [ pamplemousse ];
+    platforms = platforms.linux;
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2234,6 +2234,8 @@ in
 
   atool = callPackage ../tools/archivers/atool { };
 
+  bash_unit = callPackage ../tools/misc/bash_unit { };
+
   bsc = callPackage ../tools/compression/bsc {
     inherit (llvmPackages) openmp;
   };


### PR DESCRIPTION
###### Motivation for this change

Make the `bash_unit` testing framework available via Nix.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
