### PR TITLE
go_1_12, go_1_13: skip TestExtraFiles on 32-bit arm

### DIFF
--- a/pkgs/development/compilers/go/1.12.nix
+++ b/pkgs/development/compilers/go/1.12.nix
@@ -141,8 +141,11 @@ stdenv.mkDerivation rec {
     ./go-1.9-skip-flaky-20072.patch
     ./skip-external-network-tests.patch
     ./skip-nohup-tests.patch
+  ] ++ [
     # breaks under load: https://github.com/golang/go/issues/25628
-    ./skip-test-extra-files-on-386.patch
+    (if stdenv.isAarch32
+    then ./skip-test-extra-files-on-aarch32.patch
+    else ./skip-test-extra-files-on-386.patch)
   ];
 
   postPatch = ''

--- a/pkgs/development/compilers/go/1.13.nix
+++ b/pkgs/development/compilers/go/1.13.nix
@@ -138,8 +138,11 @@ stdenv.mkDerivation rec {
     ./go-1.9-skip-flaky-20072.patch
     ./skip-external-network-tests.patch
     ./skip-nohup-tests.patch
+  ] ++ [
     # breaks under load: https://github.com/golang/go/issues/25628
-    ./skip-test-extra-files-on-386.patch
+    (if stdenv.isAarch32
+    then ./skip-test-extra-files-on-aarch32.patch
+    else ./skip-test-extra-files-on-386.patch)
   ];
 
   postPatch = ''

--- a/pkgs/development/compilers/go/skip-test-extra-files-on-aarch32.patch
+++ b/pkgs/development/compilers/go/skip-test-extra-files-on-aarch32.patch
@@ -1,0 +1,15 @@
+diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
+index 558345ff63..22129bf022 100644
+--- a/src/os/exec/exec_test.go
++++ b/src/os/exec/exec_test.go
+@@ -593,6 +593,10 @@ func TestExtraFiles(t *testing.T) {
+ 		t.Skipf("skipping test on %q", runtime.GOOS)
+ 	}
+ 
++	if runtime.GOOS == "linux" && runtime.GOARCH  == "arm" {
++		t.Skipf("skipping test on %q %q", runtime.GOARCH, runtime.GOOS)
++	}
++
+ 	// Ensure that file descriptors have not already been leaked into
+ 	// our environment.
+ 	if !testedAlreadyLeaked {


### PR DESCRIPTION
###### Motivation for this change

The test is known to be flaky in some environments, and I'm seeing it
consistently in an armv7l-linux vm.

Note that to test this the contents of the following PRs are required:
 - https://github.com/NixOS/nixpkgs/pull/76810
 - https://github.com/NixOS/nixpkgs/pull/76922

And it will likely fail to build due to https://github.com/golang/go/issues/32738, which will be fixed in go 1.14.

The patch to disable the test is duplicated to avoid a mass rebuild on other platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS (armv7l-linux vm)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
