### PR TITLE
python.pkgs.tensorflow: fix build with cudatoolkit 10.2

### DIFF
--- a/pkgs/development/python-modules/tensorflow/cuda-10.2-no-bin2c-path.patch
+++ b/pkgs/development/python-modules/tensorflow/cuda-10.2-no-bin2c-path.patch
@@ -1,0 +1,10 @@
+--- a/third_party/nccl/build_defs.bzl.tpl
++++ b/third_party/nccl/build_defs.bzl.tpl
+@@ -113,7 +113,6 @@ def _device_link_impl(ctx):
+             "--cmdline=--compile-only",
+             "--link",
+             "--compress-all",
+-            "--bin2c-path=%s" % bin2c.dirname,
+             "--create=%s" % tmp_fatbin.path,
+             "--embedded-fatbin=%s" % fatbin_h.path,
+         ] + images,

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -124,6 +124,10 @@ let
         sha256 = "077cpj0kzyqxzdya1dwh8df17zfzhqn7c685hx6iskvw2979zg2n";
       })
       ./lift-gast-restriction.patch
+
+      # cuda 10.2 does not have "-bin2c-path" option anymore
+      # https://github.com/tensorflow/tensorflow/issues/34429
+      ./cuda-10.2-no-bin2c-path.patch
     ];
 
     # On update, it can be useful to steal the changes from gentoo


### PR DESCRIPTION
###### Motivation for this change

This fixes the tensorflow package build failure.

Before the change the build with cudatoolkit 10.2 (now default) fails with the following error:

```
ERROR: /build/output/external/nccl_archive/BUILD.bazel:53:1: fatbinary external/nccl_archive/device_dlink_hdrs.fatbin failed (Exit 1)
fatbinary fatal   : Unknown option '-bin2c-path'
```

As https://github.com/tensorflow/tensorflow/issues/34429 suggests, the fix is to drop the option from the build_defs.bzl.tpl script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @timokau