### PR TITLE
h3: init at 3.6.2; pythonPackages.h3: init at 3.4.3

### DIFF
--- a/pkgs/development/misc/h3/default.nix
+++ b/pkgs/development/misc/h3/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, cmake
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "h3";
+  version = "3.4.4";
+
+  src = fetchFromGitHub {
+    owner = "uber";
+    repo = "h3";
+    rev = "v${version}";
+    sha256 = "0d0730iwz290qcryj0ij1mnvmx89plcrg21czw5y4k63wlq8ppfg";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/uber/h3";
+    description = "Hexagonal hierarchical geospatial indexing system";
+    license = licenses.asl20;
+    maintainers = [ maintainers.kalbasit ];
+  };
+}

--- a/pkgs/development/misc/h3/default.nix
+++ b/pkgs/development/misc/h3/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
+    "-DENABLE_LINTING=OFF"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/misc/h3/default.nix
+++ b/pkgs/development/misc/h3/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "h3";
-  version = "3.4.4";
+  version = "3.6.2";
 
   src = fetchFromGitHub {
     owner = "uber";
     repo = "h3";
     rev = "v${version}";
-    sha256 = "0d0730iwz290qcryj0ij1mnvmx89plcrg21czw5y4k63wlq8ppfg";
+    sha256 = "0mlv3jk0j340l0bhr3brxm3hbdcfmyp86h7d85537c81cl64y7kg";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/python-modules/h3/default.nix
+++ b/pkgs/development/python-modules/h3/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, cmake
+, fetchPypi
+, h3
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "h3";
+  version = "3.4.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07dlqpr1r4kzb3gci395plpss8gxvvrij40l6w0mylyg7fkab4m2";
+  };
+
+  patches = [
+    ./disable-custom-install.patch
+    ./hardcode-h3-path.patch
+  ];
+
+  preBuild = ''
+    substituteInPlace h3/h3.py \
+      --subst-var-by libh3_path ${h3}/lib/libh3${stdenv.hostPlatform.extensions.sharedLibrary}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/uber/h3-py";
+    description = "This library provides Python bindings for the H3 Core Library.";
+    license = licenses.asl20;
+    platforms = platforms.unix ++ platforms.darwin;
+    maintainers = [ maintainers.kalbasit ];
+  };
+}

--- a/pkgs/development/python-modules/h3/disable-custom-install.patch
+++ b/pkgs/development/python-modules/h3/disable-custom-install.patch
@@ -1,0 +1,41 @@
+diff --git a/setup.py b/setup.py
+index 8e1c220..45297b6 100644
+--- a/setup.py
++++ b/setup.py
+@@ -25,20 +25,6 @@ class CustomBuildExtCommand(build_ext):
+         install_h3(h3_version)
+
+
+-# Tested with wheel v0.29.0
+-class BinaryDistribution(Distribution):
+-    def __init__(self, attrs=None):
+-        Distribution.__init__(self, attrs)
+-        # The values used for the name and sources in the Extension below are
+-        # not important, because we override the build_ext command above.
+-        # The normal C extension building logic is never invoked, and is
+-        # replaced with our own custom logic. However, ext_modules cannot be
+-        # empty, because this signals to other parts of distutils that our
+-        # package contains C extensions and thus needs to be built for
+-        # different platforms separately.
+-        self.ext_modules = [Extension('h3c', [])]
+-
+-
+ long_description = open('README.rst').read()
+
+ setup(
+@@ -52,14 +38,10 @@ setup(
+     url='https://github.com/uber/h3-py.git',
+     packages=find_packages(exclude=['tests', 'tests.*']),
+     install_requires=[],
+-    cmdclass={
+-        'build_ext': CustomBuildExtCommand,
+-    },
+     package_data={
+         'h-py':
+         ['out/*.dylib' if platform.system() == 'Darwin' else (
+             'out/*.dll' if platform.system() == 'Windows' else
+             'out/*.so.*')]
+     },
+-    license='Apache License 2.0',
+-    distclass=BinaryDistribution)
++    license='Apache License 2.0')

--- a/pkgs/development/python-modules/h3/hardcode-h3-path.patch
+++ b/pkgs/development/python-modules/h3/hardcode-h3-path.patch
@@ -1,0 +1,19 @@
+diff --git a/h3/h3.py b/h3/h3.py
+index 18cf168..2cc7812 100644
+--- a/h3/h3.py
++++ b/h3/h3.py
+@@ -34,13 +34,7 @@ from ctypes import (
+     POINTER,
+ )
+
+-_dirname = os.path.dirname(__file__)
+-libh3_path = ('{}/{}'.format(_dirname, 'out/libh3.1.dylib')
+-              if platform.system() == 'Darwin' else (
+-              '{}/{}'.format(_dirname, 'out/h3.dll') if platform.system() == 'Windows' else
+-              '{}/{}'.format(_dirname, 'out/libh3.so.1')))
+-
+-libh3 = cdll.LoadLibrary(libh3_path)
++libh3 = cdll.LoadLibrary('@libh3_path@')
+
+ # Type of an H3 index
+ H3Index = c_ulonglong

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9462,6 +9462,8 @@ in
     samples = true;
   };
 
+  h3 = callPackage ../development/misc/h3 { };
+
   amtk = callPackage ../development/libraries/amtk { };
 
   avrlibc      = callPackage ../development/misc/avr/libc {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -713,6 +713,8 @@ in {
 
   gumath = callPackage ../development/python-modules/gumath { };
 
+  h3 = callPackage ../development/python-modules/h3 { inherit (pkgs) h3; };
+
   h5py = callPackage ../development/python-modules/h5py {
     hdf5 = pkgs.hdf5;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Extracting this from #64962.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
