### PR TITLE
docbook-xsl: Fix reproducibility when building docs

### DIFF
--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -22,6 +22,15 @@ let
           stripLen = "1";
         })
 
+        # Fix reproducibility by respecting generate.consistent.ids in indexes
+        # https://github.com/docbook/xslt10-stylesheets/pull/88
+        # https://sourceforge.net/p/docbook/bugs/1385/
+        (fetchpatch {
+          url = "https://github.com/docbook/xslt10-stylesheets/commit/07631601e6602bc49b8eac3aab9d2b35968d3e7a.patch";
+          sha256 = "0igfhcr6hzcydqsnjsd181h5yl3drjnrwdmxcybr236m8255vkq3";
+          stripLen = "1";
+        })
+
         # Add legacy sourceforge.net URIs to the catalog
         (substituteAll {
           src = ./catalog-legacy-uris.patch;


### PR DESCRIPTION
When building docs generate.consistent.ids was not respected for indexes.

https://github.com/docbook/xslt10-stylesheets/pull/88
https://sourceforge.net/p/docbook/bugs/1385/

This lead to r13y failures in `udisks2.devdoc`.

- [x] Verified that `docbook-xsl` and `docbook-xsl-nons` build with the patch.