### PR TITLE
pythonPackages.pybind11: fix for clang/darwin

### DIFF
--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -1,4 +1,5 @@
-{ lib
+{ stdenv
+, lib
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
@@ -28,7 +29,7 @@ buildPythonPackage rec {
 
   cmakeFlags = [
     "-DEIGEN3_INCLUDE_DIR=${eigen}/include/eigen3"
-  ] ++ lib.optionals (python.isPy3k) [
+  ] ++ lib.optionals (python.isPy3k && !stdenv.cc.isClang) [
   # Enable some tests only on Python 3. The "test_string_view" test
   # 'testTypeError: string_view16_chars(): incompatible function arguments'
   # fails on Python 2.


### PR DESCRIPTION
###### Motivation for this change
Fixes `pybind11` on darwin among others, looks like default clang is still not happy with c++17's sized and aligned deallocations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
