### PR TITLE
hal-hardware-analyzer: init at 2.0.0

### DIFF
--- a/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
+++ b/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub, cmake, ninja, pkgconfig, python3Packages
+, boost, rapidjson, qtbase, qtsvg, igraph, spdlog, wrapQtAppsHook
+, llvmPackages ? null
+}:
+
+stdenv.mkDerivation rec {
+  version = "2.0.0";
+  pname = "hal-hardware-analyzer";
+
+  src = fetchFromGitHub {
+    owner = "emsec";
+    repo = "hal";
+    rev = "v${version}";
+    sha256 = "11xmqxnryksl645wmm1d69k1b5zwvxxf0admk4iblzaa3ggf7cv1";
+  };
+  # make sure bundled dependencies don't get in the way - install also otherwise
+  # copies them in full to the output, bloating the package
+  postPatch = ''
+    rm -rf deps/*/*
+    substituteInPlace cmake/detect_dependencies.cmake \
+      --replace 'spdlog 1.4.2 EXACT' 'spdlog 1.4.2 REQUIRED'
+  '';
+
+  nativeBuildInputs = [ cmake ninja pkgconfig ];
+  buildInputs = [ qtbase qtsvg boost rapidjson igraph spdlog wrapQtAppsHook ]
+    ++ (with python3Packages; [ python pybind11 ])
+    ++ stdenv.lib.optional stdenv.cc.isClang llvmPackages.openmp;
+
+  cmakeFlags = with stdenv.lib.versions; [
+    "-DHAL_VERSION_RETURN=${version}"
+    "-DHAL_VERSION_MAJOR=${major version}"
+    "-DHAL_VERSION_MINOR=${minor version}"
+    "-DHAL_VERSION_PATCH=${patch version}"
+    "-DHAL_VERSION_TWEAK=0"
+    "-DHAL_VERSION_ADDITIONAL_COMMITS=0"
+    "-DHAL_VERSION_DIRTY=false"
+    "-DHAL_VERSION_BROKEN=false"
+    "-DENABLE_INSTALL_LDCONFIG=off"
+    "-DBUILD_ALL_PLUGINS=on"
+  ];
+  # needed for macos build - this is why we use wrapQtAppsHook instead of
+  # the qt mkDerivation - the latter forcibly overrides this.
+  cmakeBuildType = "MinSizeRel";
+
+  meta = {
+    description = "A comprehensive reverse engineering and manipulation framework for gate-level netlists";
+    homepage = "https://github.com/emsec/hal";
+    license = stdenv.lib.licenses.mit;
+    platforms = with stdenv.lib.platforms; unix;
+    maintainers = with stdenv.lib.maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4146,6 +4146,8 @@ in
 
   hal-flash = callPackage ../os-specific/linux/hal-flash { };
 
+  hal-hardware-analyzer = libsForQt5.callPackage ../applications/science/electronics/hal-hardware-analyzer { };
+
   half = callPackage ../development/libraries/half { };
 
   halibut = callPackage ../tools/typesetting/halibut { };


### PR DESCRIPTION
###### Motivation for this change
Neat tool: https://media.ccc.de/v/36c3-10879-hal_-_the_open-source_hardware_analyzer

Works on darwin once #76958 is merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
