### PR TITLE
parinfer-rust: 0.3.1 -> 0.4.2

### DIFF
--- a/pkgs/development/tools/parinfer-rust/default.nix
+++ b/pkgs/development/tools/parinfer-rust/default.nix
@@ -1,21 +1,29 @@
-{ stdenv, rustPlatform, fetchFromGitHub }:
+{ stdenv, rustPlatform, fetchFromGitHub, llvmPackages }:
 
 rustPlatform.buildRustPackage rec {
   pname = "parinfer-rust";
-  version = "0.3.1";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "eraserhd";
     repo = "parinfer-rust";
     rev = "v${version}";
-    sha256 = "0w7fcg33k8k16q8wzax44ck8csa2dr7bmwcz1g57dz33vhxi8ajc";
+    sha256 = "1k2kr1zlxx3w3kwb634kngzx8vl5iif1yr6zk2xh46gjwqb3223l";
   };
 
-  cargoSha256 = "17fkzpvfaxixllr9nxx7dnpqxkiighggryxf30j3lafghyrx987f";
+  cargoSha256 = "0i5wy15w985nxwl4b6rzb06hchzjwph6ygzjkkmigm9diw9jcycn";
+
+  buildInputs = [ llvmPackages.libclang llvmPackages.clang ];
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
   postInstall = ''
     mkdir -p $out/share/kak/autoload/plugins
     cp rc/parinfer.kak $out/share/kak/autoload/plugins/
+
+    rtpPath=$out/share/vim-plugins/parinfer-rust
+    mkdir -p $rtpPath/plugin
+    sed "s,let s:libdir = .*,let s:libdir = '${placeholder "out"}/lib'," \
+      plugin/parinfer.vim >$rtpPath/plugin/parinfer.vim
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

* New features (Emacs support, unicode support under Kakoune, support for Fennel lang, and Vim packadd).
* Build fix for newer Rust eraserhd/parinfer-rust#57.
* Derivation can be directly installed as a Vim plugin

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Path Info

Before: 29664968
After:  29671616 (+ 6648)

###### Notify maintainers

I'm the maintainer.