### PR TITLE
pythonPackages.colormath: init at 3.0.0

### DIFF
--- a/pkgs/development/python-modules/colormath/default.nix
+++ b/pkgs/development/python-modules/colormath/default.nix
@@ -1,0 +1,32 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, networkx
+, nose
+, numpy
+, lib
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "colormath";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gtaylor";
+    rev = "3.0.0";
+    repo = "python-colormath";
+    sha256 = "1nqf5wy8ikx2g684khzvjc4iagkslmbsxxwilbv4jpaznr9lahdl";
+  };
+
+  propagatedBuildInputs = [ networkx numpy ];
+
+  checkInputs = [ nose ];
+  checkPhase = "nosetests";
+
+  meta = with lib; {
+    description = "Color math and conversion library";
+    homepage = "https://github.com/gtaylor/python-colormath";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ jonathanreeve ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1794,6 +1794,8 @@ in {
 
   colour = callPackage ../development/python-modules/colour {};
 
+  colormath = callPackage ../development/python-modules/colormath {};
+
   configshell = callPackage ../development/python-modules/configshell { };
 
   consonance = callPackage ../development/python-modules/consonance { };


### PR DESCRIPTION

###### Motivation for this change

Add a new python package: colormath

###### Things done

Just added the new package. 

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
