### PR TITLE
idris2: init at 0.0.0 (bf5b229)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4057,6 +4057,12 @@
     githubId = 169170;
     name = "Mathias Schreck";
   };
+  lodi = {
+    email = "anthony.lodi@gmail.com";
+    github = "lodi";
+    githubId = 918448;
+    name = "Anthony Lodi";
+  };
   loewenheim = {
     email = "loewenheim@mailbox.org";
     github = "loewenheim";

--- a/pkgs/development/compilers/chicken/4/eggs.nix
+++ b/pkgs/development/compilers/chicken/4/eggs.nix
@@ -101,7 +101,21 @@ rec {
     };
 
     buildInputs = [
-      
+
+    ];
+  };
+
+  numbers = eggDerivation {
+    name = "numbers-4.6.3";
+
+    src = fetchegg {
+      name = "numbers";
+      version = "4.6.3";
+      sha256 = "0aczzpq6f31lk1919aiywknaci69m1apyx905m2ln2qw8zwmwibq";
+    };
+
+    buildInputs = [
+
     ];
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8265,6 +8265,11 @@ in
 
   idris = idrisPackages.with-packages [ idrisPackages.base ] ;
 
+  idris2 = callPackage ../development/compilers/idris2 {
+    idris = with idrisPackages; with-packages [ base contrib ]; # add contrib module
+    chickenPkgs = chickenPackages_4; # currently expects chicken4
+  };
+
   intel-graphics-compiler = callPackage ../development/compilers/intel-graphics-compiler { };
 
   intercal = callPackage ../development/compilers/intercal { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Added Idris2 compiler.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).