### PR TITLE
glibc: fix cross compilation build failure

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -97,6 +97,11 @@ stdenv.mkDerivation ({
       ./CVE-2018-11236.patch
       # https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=f51c8367685dc888a02f7304c729ed5277904aff
       ./CVE-2018-11237.patch
+
+      # Remove after upgrading to glibc 2.28+
+      # Change backported from upstream
+      # https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=9c79cec8cd2a6996a73aa83d79b360ffd4bebde6
+      ./fix-out-of-bounds-access-in-findidxwc.patch
     ]
     ++ lib.optionals stdenv.isx86_64 [
       ./fix-x64-abi.patch

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -49,20 +49,12 @@ callPackage ./common.nix { inherit stdenv; } {
       ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "pie";
 
     NIX_CFLAGS_COMPILE = stdenv.lib.concatStringsSep " "
-      (if !stdenv.hostPlatform.isMusl
-        # TODO: This (returning a string or `null`, instead of a list) is to
-        #       not trigger a mass rebuild due to the introduction of the
-        #       musl-specific flags below.
-        #       At next change to non-musl glibc builds, remove this `then`
-        #       and the above condition, instead keeping only the `else` below.
-        then (stdenv.lib.optionals withGd gdCflags)
-        else
-          (builtins.concatLists [
-            (stdenv.lib.optionals withGd gdCflags)
-            # Fix -Werror build failure when building glibc with musl with GCC >= 8, see:
-            # https://github.com/NixOS/nixpkgs/pull/68244#issuecomment-544307798
-            (stdenv.lib.optional stdenv.hostPlatform.isMusl "-Wno-error=attribute-alias")
-          ]));
+      (builtins.concatLists [
+        (stdenv.lib.optionals withGd gdCflags)
+        # Fix -Werror build failure when building glibc with musl with GCC >= 8, see:
+        # https://github.com/NixOS/nixpkgs/pull/68244#issuecomment-544307798
+        (stdenv.lib.optional stdenv.hostPlatform.isMusl "-Wno-error=attribute-alias")
+      ]);
 
     # When building glibc from bootstrap-tools, we need libgcc_s at RPATH for
     # any program we run, because the gcc will have been placed at a new

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -54,6 +54,11 @@ callPackage ./common.nix { inherit stdenv; } {
         # Fix -Werror build failure when building glibc with musl with GCC >= 8, see:
         # https://github.com/NixOS/nixpkgs/pull/68244#issuecomment-544307798
         (stdenv.lib.optional stdenv.hostPlatform.isMusl "-Wno-error=attribute-alias")
+        (stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+          # Ignore "error: '__EI___errno_location' specifies less restrictive attributes than its target '__errno_location'"
+          # New warning as of GCC 9
+          "-Wno-error=missing-attributes"
+        ])
       ]);
 
     # When building glibc from bootstrap-tools, we need libgcc_s at RPATH for

--- a/pkgs/development/libraries/glibc/fix-out-of-bounds-access-in-findidxwc.patch
+++ b/pkgs/development/libraries/glibc/fix-out-of-bounds-access-in-findidxwc.patch
@@ -1,0 +1,28 @@
+diff -ur glibc-2.27/locale/weightwc.h glibc-2.27-patched/locale/weightwc.h
+--- glibc-2.27/locale/weightwc.h	2018-02-02 01:17:18.000000000 +0900
++++ glibc-2.27-patched/locale/weightwc.h	2020-01-12 03:33:41.519720579 +0900
+@@ -73,7 +73,7 @@
+ 	      break;
+ 	  DIAG_POP_NEEDS_COMMENT;
+ 
+-	  if (cnt == nhere)
++	  if (cnt == nhere || cnt == len)
+ 	    {
+ 	      /* Found it.  */
+ 	      *cpp += nhere;
+@@ -100,13 +100,13 @@
+ 	      continue;
+ 	    }
+ 
+-	  if (cp[nhere - 1] > usrc[nhere -1])
++	  if (cp[nhere - 1] > usrc[nhere - 1])
+ 	    {
+ 	      cp += 2 * nhere;
+ 	      continue;
+ 	    }
+ 
+-	  if (cp[2 * nhere - 1] < usrc[nhere -1])
++	  if (cp[2 * nhere - 1] < usrc[nhere - 1])
+ 	    {
+ 	      cp += 2 * nhere;
+ 	      continue;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix cross compiled glibc which fails due to warnings. I don't know why these warnings only show up in cross compilation, but it lets us avoid a mass rebuild of glibc.

Tested on an x86_64 builder
- [x] pkgsCross.riscv64.hello
- [x] pkgsCross.aarch64-multiplatform.hello
- [x] pkgsCross.armv7l-hf-multiplatform.hello

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
