### PR TITLE
Update Haskell package set to LTS 14.20 (plus other fixes)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1261,7 +1261,7 @@ self: super: {
 
   # The LTS-14.x version of their dependencies are too old.
   cabal-plan = super.cabal-plan.overrideScope (self: super: { optparse-applicative = self.optparse-applicative_0_15_1_0; ansi-terminal = self.ansi-terminal_0_10_2; base-compat = self.base-compat_0_11_0; semialign = self.semialign_1_1; time-compat = doJailbreak super.time-compat; });
-  hoogle = super.hoogle.override { haskell-src-exts = self.haskell-src-exts_1_22_0; };
+  hoogle = (doJailbreak super.hoogle).override { haskell-src-exts = self.haskell-src-exts_1_23_0; };    # https://github.com/ndmitchell/hoogle/issues/334
 
   # Version bounds for http-client are too strict:
   # https://github.com/bitnomial/prometheus/issues/34
@@ -1325,7 +1325,7 @@ self: super: {
   });
 
   # Needs the corresponding version of haskell-src-exts.
-  haskell-src-exts-simple = super.haskell-src-exts-simple.override { haskell-src-exts = self.haskell-src-exts_1_22_0; };
+  haskell-src-exts-simple = super.haskell-src-exts-simple.override { haskell-src-exts = self.haskell-src-exts_1_23_0; };
 
   # https://github.com/Daniel-Diaz/HaTeX/issues/144
   HaTeX = dontCheck super.HaTeX;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1365,4 +1365,8 @@ self: super: {
   ormolu = doJailbreak (super.ormolu.override {
     ghc-lib-parser = self.ghc-lib-parser_8_8_1_20191204;
   });
+
+  # krank-0.1.0 does not accept PyF-0.9.0.0.
+  krank = doJailbreak super.krank;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -74,7 +74,7 @@ self: super: {
       name = "git-annex-${super.git-annex.version}-src";
       url = "git://git-annex.branchable.com/";
       rev = "refs/tags/" + super.git-annex.version;
-      sha256 = "1i4arhwbc05iz8hl7kk843m2f49i3ysby1kxcm9qfhpk7z9nyzj4";
+      sha256 = "0s8sv6h90l2a9xdabj0nirhpr6d2k8s5cddjdkm50x395i014w31";
     };
   }).override {
     dbus = if pkgs.stdenv.isLinux then self.dbus else null;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1261,7 +1261,7 @@ self: super: {
 
   # The LTS-14.x version of their dependencies are too old.
   cabal-plan = super.cabal-plan.overrideScope (self: super: { optparse-applicative = self.optparse-applicative_0_15_1_0; ansi-terminal = self.ansi-terminal_0_10_2; base-compat = self.base-compat_0_11_0; semialign = self.semialign_1_1; time-compat = doJailbreak super.time-compat; });
-  hoogle = (doJailbreak super.hoogle).override { haskell-src-exts = self.haskell-src-exts_1_23_0; };    # https://github.com/ndmitchell/hoogle/issues/334
+  hoogle = super.hoogle.override { haskell-src-exts = self.haskell-src-exts_1_23_0; };
 
   # Version bounds for http-client are too strict:
   # https://github.com/bitnomial/prometheus/issues/34

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -16,6 +16,7 @@ self: super: {
   containers = null;
   deepseq = null;
   directory = null;
+  exceptions = null;
   filepath = null;
   ghc-boot = null;
   ghc-boot-th = null;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -107,7 +107,7 @@ self: super: {
   sop-core = self.sop-core_0_5_0_0;
   texmath = self.texmath_0_12;
   th-desugar = self.th-desugar_1_10;
-  tls = self.tls_1_5_2;
+  tls = self.tls_1_5_3;
   trifecta = self.trifecta_2_1;
   vty = self.vty_5_26;
   xml-conduit = overrideCabal super.xml-conduit (drv: { version = "1.9.0.0"; sha256 = "1p57v127882rxvvmwjmvnqdmk3x2wg1z4d8y03849h0xaz1vid0w"; });

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -91,7 +91,7 @@ self: super: {
   microlens-th = self.microlens-th_0_4_3_2;
   network = self.network_3_1_1_1;
   optparse-applicative = self.optparse-applicative_0_15_1_0;
-  pandoc = self.pandoc_2_9_1;
+  pandoc = self.pandoc_2_9_1_1;
   pandoc-types = self.pandoc-types_1_20;
   prettyprinter = self.prettyprinter_1_5_1;
   primitive = dontCheck super.primitive_0_7_0_0;  # evaluating the test suite gives an infinite recursion

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -42,6 +42,28 @@ core-packages:
   # of this library are marked as "broken".
   - ghcjs-base-0
 
+# This is a list of packages with versions from the latest Stackage LTS release.
+#
+# The packages and versions in this list cause the `hackage2nix` tool to
+# generate the package at the given version.
+#
+# For instance, with a line like the following:
+#
+# - aeson ==1.4.6.0
+#
+# `hackage2nix` will generate the `aeson` package at version 1.4.6.0 in the
+# ./hackage-packages.nix file.
+#
+# Since the packages in the LTS package set are sometimes older than the latest
+# on Hackage, `hackage2nix` is smart enough to also generate the latest version
+# of a given package.
+#
+# In the above example with aeson, if there was version 1.5.0.0 of aeson
+# available on Hackage, `hackage2nix` would generate two packages, `aeson`
+# at version 1.4.6.0 and `aeson_1_5_0_0` at version 1.5.0.0.
+#
+# WARNING: This list is generated semiautomatically based on the most recent
+# LTS package set.  DO NOT EDIT BY HAND!
 default-package-overrides:
   # LTS Haskell 14.20
   - abstract-deque ==0.3

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -63,7 +63,9 @@ core-packages:
 # at version 1.4.6.0 and `aeson_1_5_0_0` at version 1.5.0.0.
 #
 # WARNING: This list is generated semiautomatically based on the most recent
-# LTS package set.  DO NOT EDIT BY HAND!
+# LTS package set. If you want to add entries to it, you must do so before the
+# comment saying "# LTS Haskell x.y". Any changes after that commend will be
+# lost the next time `update-stackage.sh` runs.
 default-package-overrides:
   # LTS Haskell 14.20
   - abstract-deque ==0.3

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -5316,7 +5316,6 @@ broken-packages:
   - hakyll-filestore
   - hakyll-ogmarkup
   - hakyll-R
-  - hakyll-sass
   - hakyll-series
   - hakyll-shakespeare
   - hakyll-shortcode

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -10111,7 +10111,6 @@ broken-packages:
   - WebBits
   - WebBits-Html
   - WebBits-multiplate
-  - webby
   - webcloud
   - WebCont
   - webcrank

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -43,7 +43,7 @@ core-packages:
   - ghcjs-base-0
 
 default-package-overrides:
-  # LTS Haskell 14.18
+  # LTS Haskell 14.20
   - abstract-deque ==0.3
   - abstract-deque-tests ==0.3
   - abstract-par ==0.3.3
@@ -73,7 +73,7 @@ default-package-overrides:
   - alarmclock ==0.7.0.2
   - alerts ==0.1.2.0
   - alex ==3.2.5
-  - alg ==0.2.13.0
+  - alg ==0.2.13.1
   - algebraic-graphs ==0.4
   - Allure ==0.9.5.0
   - almost-fix ==0.0.2
@@ -263,10 +263,9 @@ default-package-overrides:
   - bzlib-conduit ==0.3.0.2
   - c2hs ==0.28.6
   - Cabal ==2.4.1.0
-  - cabal2spec ==2.2.2.1
   - cabal-doctest ==1.0.8
   - cabal-file-th ==0.2.6
-  - cabal-rpm ==1.0.2
+  - cabal-rpm ==1.0.3
   - cache ==0.1.3.0
   - cacophony ==0.10.1
   - calendar-recycling ==0.0.0.1
@@ -283,10 +282,10 @@ default-package-overrides:
   - cassava-records ==0.1.0.4
   - cast ==0.1.0.2
   - caster ==0.0.3.0
-  - category ==0.2.4.2
+  - category ==0.2.5.0
   - cayley-client ==0.4.9
-  - cborg ==0.2.2.0
-  - cborg-json ==0.2.1.0
+  - cborg ==0.2.2.1
+  - cborg-json ==0.2.2.0
   - cereal ==0.5.8.1
   - cereal-conduit ==0.8.0
   - cereal-text ==0.1.0.2
@@ -399,7 +398,7 @@ default-package-overrides:
   - convertible ==1.1.1.0
   - cookie ==0.4.5
   - core-data ==0.2.1.4
-  - core-text ==0.2.2.4
+  - core-text ==0.2.2.6
   - countable ==1.0
   - country ==0.1.6
   - courier ==0.1.1.5
@@ -537,7 +536,7 @@ default-package-overrides:
   - direct-sqlite ==2.3.24
   - discount ==0.1.1
   - disk-free-space ==0.1.0.1
-  - distributed-closure ==0.4.1.1
+  - distributed-closure ==0.4.2.0
   - distribution-opensuse ==1.1.1
   - distributive ==0.6.1
   - dl-fedora ==0.5
@@ -562,7 +561,7 @@ default-package-overrides:
   - download ==0.3.2.7
   - drinkery ==0.4
   - dsp ==0.2.5
-  - dual ==0.1.0.2
+  - dual ==0.1.0.3
   - dual-tree ==0.2.2.1
   - dublincore-xml-conduit ==0.1.0.2
   - dunai ==0.5.1
@@ -630,7 +629,7 @@ default-package-overrides:
   - exact-pi ==0.5.0.1
   - exceptional ==0.3.0.0
   - exception-mtl ==0.4.0.1
-  - exceptions ==0.10.3
+  - exceptions ==0.10.4
   - exception-transformers ==0.4.0.8
   - executable-hash ==0.2.0.4
   - executable-path ==0.0.3.1
@@ -698,7 +697,7 @@ default-package-overrides:
   - focuslist ==0.1.0.2
   - foldable1 ==0.1.0.0
   - fold-debounce ==0.2.0.9
-  - fold-debounce-conduit ==0.2.0.3
+  - fold-debounce-conduit ==0.2.0.4
   - foldl ==1.4.5
   - folds ==0.7.5
   - follow-file ==0.0.3
@@ -804,7 +803,7 @@ default-package-overrides:
   - gitrev ==1.3.1
   - gi-vte ==2.91.25
   - gl ==0.9
-  - glabrous ==2.0.0
+  - glabrous ==2.0.1
   - glaze ==0.3.0.1
   - glazier ==1.0.0.0
   - GLFW-b ==3.2.1.1
@@ -818,7 +817,7 @@ default-package-overrides:
   - GLUT ==2.7.0.15
   - gnuplot ==0.5.6
   - google-isbn ==1.0.3
-  - google-oauth2-jwt ==0.3.1
+  - google-oauth2-jwt ==0.3.2
   - gpolyline ==0.1.0.1
   - graph-core ==0.3.0.0
   - graphite ==0.10.0.1
@@ -828,8 +827,8 @@ default-package-overrides:
   - gravatar ==0.8.0
   - graylog ==0.1.0.1
   - greskell ==0.2.3.1
-  - greskell-core ==0.1.2.7
-  - greskell-websocket ==0.1.1.2
+  - greskell-core ==0.1.3.1
+  - greskell-websocket ==0.1.2.1
   - groom ==0.1.2.1
   - groundhog ==0.10.0
   - groundhog-inspector ==0.10.0
@@ -853,7 +852,7 @@ default-package-overrides:
   - HandsomeSoup ==0.4.2
   - hapistrano ==0.3.10.0
   - happy ==1.19.12
-  - hasbolt ==0.1.4.0
+  - hasbolt ==0.1.4.1
   - hashable ==1.2.7.0
   - hashable-time ==0.2.0.2
   - hashids ==1.0.2.4
@@ -874,7 +873,7 @@ default-package-overrides:
   - haskell-src-meta ==0.8.3
   - haskey-btree ==0.3.0.1
   - haskintex ==0.8.0.0
-  - haskoin-core ==0.9.7
+  - haskoin-core ==0.9.8
   - hasql ==1.4.0.1
   - hasql-optparse-applicative ==0.3.0.5
   - hasql-pool ==0.5.1
@@ -984,7 +983,7 @@ default-package-overrides:
   - hspec-leancheck ==0.0.3
   - hspec-megaparsec ==2.0.1
   - hspec-meta ==2.6.0
-  - hspec-need-env ==0.1.0.3
+  - hspec-need-env ==0.1.0.4
   - hspec-pg-transact ==0.1.0.2
   - hspec-smallcheck ==0.5.2
   - hspec-wai ==0.9.2
@@ -1013,7 +1012,7 @@ default-package-overrides:
   - http-conduit ==2.3.7.3
   - http-date ==0.0.8
   - http-directory ==0.1.5
-  - http-download ==0.1.0.0
+  - http-download ==0.1.0.1
   - httpd-shed ==0.4.1.1
   - http-link-header ==1.0.3.1
   - http-media ==0.8.0.0
@@ -1122,9 +1121,9 @@ default-package-overrides:
   - io-streams ==1.5.1.0
   - io-streams-haproxy ==1.0.1.0
   - ip ==1.5.1
-  - ip6addr ==1.0.0
+  - ip6addr ==1.0.1
   - iproute ==1.7.8
-  - IPv6Addr ==1.1.2
+  - IPv6Addr ==1.1.3
   - ipynb ==0.1
   - ipython-kernel ==0.10.1.0
   - irc ==0.6.1.0
@@ -1148,7 +1147,7 @@ default-package-overrides:
   - json-alt ==1.0.0
   - json-feed ==1.0.7
   - jsonpath ==0.1.0.2
-  - json-rpc ==1.0.0
+  - json-rpc ==1.0.1
   - json-rpc-client ==0.2.5.0
   - json-rpc-generic ==0.2.1.5
   - json-rpc-server ==0.2.6.0
@@ -1323,7 +1322,7 @@ default-package-overrides:
   - mime-mail-ses ==0.4.1
   - mime-types ==0.1.0.9
   - minimorph ==0.2.1.0
-  - minio-hs ==1.5.1
+  - minio-hs ==1.5.2
   - miniutter ==0.5.0.0
   - mintty ==0.1.2
   - miso ==1.2.0.0
@@ -1372,11 +1371,10 @@ default-package-overrides:
   - monoid-extras ==0.5.1
   - monoid-subclasses ==0.4.6.1
   - monoid-transformer ==0.0.4
-  - mono-traversable ==1.0.13.0
+  - mono-traversable ==1.0.15.1
   - mono-traversable-instances ==0.1.0.0
   - mono-traversable-keys ==0.1.0
   - more-containers ==0.2.2.0
-  - morpheus-graphql ==0.8.0
   - mountpoints ==1.0.2
   - mpi-hs ==0.5.3.0
   - msgpack ==1.0.1.0
@@ -1681,7 +1679,6 @@ default-package-overrides:
   - pure-zlib ==0.6.6
   - pushbullet-types ==0.4.1.0
   - pusher-http-haskell ==1.5.1.11
-  - PyF ==0.8.1.2
   - qchas ==1.1.0.1
   - qm-interpolated-string ==0.3.0.0
   - qnap-decrypt ==0.3.5
@@ -1702,7 +1699,7 @@ default-package-overrides:
   - quickcheck-text ==0.1.2.1
   - quickcheck-transformer ==0.3.1
   - quickcheck-unicode ==1.0.1.0
-  - radius ==0.6.0.3
+  - radius ==0.6.1.0
   - rainbow ==0.30.0.2
   - rainbox ==0.20.0.0
   - ramus ==0.1.2
@@ -1839,7 +1836,7 @@ default-package-overrides:
   - sdl2-image ==2.0.0
   - sdl2-mixer ==1.1.0
   - sdl2-ttf ==2.1.0
-  - secp256k1-haskell ==0.1.5
+  - secp256k1-haskell ==0.1.6
   - securemem ==0.1.10
   - selda ==0.4.0.0
   - selda-json ==0.1.1.0
@@ -1856,11 +1853,11 @@ default-package-overrides:
   - sendfile ==0.7.11.1
   - seqalign ==0.2.0.4
   - serf ==0.1.1.0
-  - serialise ==0.2.1.0
+  - serialise ==0.2.2.0
   - servant ==0.16.2
   - servant-auth ==0.3.2.0
   - servant-auth-docs ==0.2.10.0
-  - servant-auth-server ==0.4.4.0
+  - servant-auth-server ==0.4.5.0
   - servant-auth-swagger ==0.2.10.0
   - servant-auth-wordpress ==1.0.0.1
   - servant-blaze ==0.9
@@ -2030,7 +2027,7 @@ default-package-overrides:
   - stripe-wreq ==1.0.1.0
   - strive ==5.0.9
   - structs ==0.1.2
-  - structured-cli ==2.5.1.0
+  - structured-cli ==2.5.2.0
   - summoner ==1.3.0.1
   - sum-type-boilerplate ==0.1.1
   - sundown ==0.6
@@ -2139,7 +2136,7 @@ default-package-overrides:
   - thread-hierarchy ==0.3.0.1
   - thread-local-storage ==0.2
   - threads ==0.5.1.6
-  - threepenny-gui ==0.8.3.0
+  - threepenny-gui ==0.8.3.1
   - th-reify-compat ==0.0.1.5
   - th-reify-many ==0.1.9
   - throttle-io-stream ==0.2.0.1
@@ -2148,7 +2145,6 @@ default-package-overrides:
   - th-test-utils ==1.0.1
   - th-utilities ==0.2.3.1
   - thyme ==0.3.5.5
-  - tidal ==1.4.5
   - tile ==0.3.0.0
   - time-compat ==1.9.2.2
   - timeit ==2.0
@@ -2177,11 +2173,11 @@ default-package-overrides:
   - tomland ==1.1.0.1
   - tonalude ==0.1.1.0
   - tonaparser ==0.1.0.0
-  - tonatona ==0.1.0.1
+  - tonatona ==0.1.1.0
   - tonatona-logger ==0.2.0.0
   - tonatona-persistent-postgresql ==0.1.0.1
   - tonatona-persistent-sqlite ==0.1.0.1
-  - tonatona-servant ==0.1.0.2
+  - tonatona-servant ==0.1.0.3
   - torsor ==0.1
   - tostring ==0.2.1.1
   - TotalMap ==0.1.1.1
@@ -2237,7 +2233,7 @@ default-package-overrides:
   - uncertain ==0.3.1.0
   - unconstrained ==0.1.0.2
   - unicode ==0.0.1.1
-  - unicode-show ==0.1.0.3
+  - unicode-show ==0.1.0.4
   - unicode-transforms ==0.3.6
   - unification-fd ==0.10.0.1
   - union ==0.1.2
@@ -2279,7 +2275,7 @@ default-package-overrides:
   - users-test ==0.5.0.1
   - utf8-light ==0.4.2
   - utf8-string ==1.0.1.1
-  - util ==0.1.15.0
+  - util ==0.1.17.0
   - utility-ht ==0.0.14
   - uuid ==1.3.13
   - uuid-types ==1.0.3
@@ -2356,13 +2352,13 @@ default-package-overrides:
   - web-routes-hsp ==0.24.6.1
   - web-routes-wai ==0.24.3.1
   - webrtc-vad ==0.1.0.3
-  - websockets ==0.12.6.1
+  - websockets ==0.12.7.0
   - websockets-snap ==0.10.3.1
   - weigh ==0.0.16
   - wide-word ==0.1.0.9
   - wikicfp-scraper ==0.1.0.11
-  - wild-bind ==0.1.2.4
-  - wild-bind-x11 ==0.2.0.8
+  - wild-bind ==0.1.2.5
+  - wild-bind-x11 ==0.2.0.9
   - Win32 ==2.6.1.0
   - Win32-notify ==0.3.0.3
   - windns ==0.1.0.1
@@ -2444,7 +2440,7 @@ default-package-overrides:
   - yesod-gitrev ==0.2.1
   - yesod-newsfeed ==1.6.1.0
   - yesod-paginator ==1.1.0.2
-  - yesod-persistent ==1.6.0.3
+  - yesod-persistent ==1.6.0.4
   - yesod-recaptcha2 ==0.3.0
   - yesod-sitemap ==1.6.0
   - yesod-static ==1.6.0.1

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2751,6 +2751,7 @@ broken-packages:
   - accelerate-arithmetic
   - accelerate-fftw
   - accelerate-fourier
+  - accelerate-kullback-liebler
   - accelerate-llvm-native
   - accelerate-random
   - accelerate-typelits
@@ -3347,6 +3348,7 @@ broken-packages:
   - boolexpr
   - boombox
   - boomslang
+  - boopadoop
   - boots-app
   - boots-cloud
   - boots-web
@@ -5648,6 +5650,7 @@ broken-packages:
   - hdr-histogram
   - HDRUtils
   - headergen
+  - heart-app
   - heartbeat-streams
   - heatitup
   - heatitup-complete
@@ -6928,6 +6931,7 @@ broken-packages:
   - llvm-base-types
   - llvm-base-util
   - llvm-data-interop
+  - llvm-extension
   - llvm-extra
   - llvm-ffi
   - llvm-general
@@ -7248,6 +7252,8 @@ broken-packages:
   - mmsyn4
   - mmsyn6ukr
   - mmsyn7h
+  - mmsyn7l
+  - mmsyn7s
   - mmsyn7ukr
   - mmtf
   - mmtl
@@ -8270,6 +8276,7 @@ broken-packages:
   - quicktest
   - quickwebapp
   - quipper
+  - quipper-all
   - quipper-core
   - quipper-rendering
   - quiver-binary
@@ -8413,6 +8420,7 @@ broken-packages:
   - refresht
   - refurb
   - reg-alloc
+  - reg-alloc-graph-color
   - regex-deriv
   - regex-dfa
   - regex-generator
@@ -9802,6 +9810,7 @@ broken-packages:
   - typedquery
   - typehash
   - TypeIlluminator
+  - typelevel-rewrite-rules
   - typelevel-tensor
   - TypeNat
   - typeparams

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -8069,7 +8069,6 @@ broken-packages:
   - postgresql-simple-queue
   - postgresql-simple-sop
   - postgresql-simple-typed
-  - postgresql-typed
   - postgresql-typed-lifted
   - postgrest
   - postgrest-ws

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -695,4 +695,8 @@ self: super: builtins.intersectAttrs super {
       spagoWithoutChecks = dontCheck spagoFixHpack;
     in
     spagoWithoutChecks;
+
+  # checks SQL statements at compile time, and so requires a running PostgreSQL
+  # database to run it's test suite
+  postgresql-typed = dontCheck super.postgresql-typed;
 }

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -24,6 +24,7 @@ in
 , doCheck ? !isCross && stdenv.lib.versionOlder "7.4" ghc.version
 , doBenchmark ? false
 , doHoogle ? true
+, doHaddockQuickjump ? doHoogle && stdenv.lib.versionAtLeast ghc.version "8.6"
 , editedCabalFile ? null
 , enableLibraryProfiling ? !(ghc.isGhcjs or false)
 , enableExecutableProfiling ? false
@@ -402,6 +403,7 @@ stdenv.mkDerivation ({
     ${optionalString (doHaddock && isLibrary) ''
       ${setupCommand} haddock --html \
         ${optionalString doHoogle "--hoogle"} \
+        ${optionalString doHaddockQuickjump "--quickjump"} \
         ${optionalString (isLibrary && hyperlinkSource) "--hyperlink-source"} \
         ${stdenv.lib.concatStringsSep " " haddockFlags}
     ''}


### PR DESCRIPTION
This PR is test-built by Hydra at https://hydra.nixos.org/jobset/nixpkgs/haskell-updates. I'll fix up the remaining errors and merge it on Friday, 2020-01-10 [20:00 CET](http://www.thetimezoneconverter.com/?t=20:00&tz=Berlin). You can watch this live on Twitch: https://www.twitch.tv/peti343. If you'd like to chat with me (and others) during the stream, you're welcome to use the Twitch chat or join the [`#haskell4nix` voice conference](https://discord.gg/YTEa3XR).

TODO:

- [x] https://github.com/ndmitchell/hoogle/issues/334
- [x] https://github.com/NixOS/nixpkgs/pull/77311
- [x] https://github.com/NixOS/nixpkgs/pull/77442