### PR TITLE
greybird: 3.22.10 -> 3.22.11

### DIFF
--- a/pkgs/data/themes/greybird/default.nix
+++ b/pkgs/data/themes/greybird/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, which, sassc, glib, libxml2, gdk-pixbuf, librsvg, gtk-engine-murrine }:
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, sassc, gdk-pixbuf, librsvg, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
   pname = "greybird";
-  version = "3.22.10";
+  version = "3.22.11";
 
   src = fetchFromGitHub {
     owner = "shimmerproject";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1g1mnzxqwlbymq8npd2j294f8dzf9fw9nicd4pajmscg2vk71da9";
+    sha256 = "00x7dcjldph9k0nmvc8hyh3k4lhbmwk791rywd89ry6jivrx40pc";
   };
 
   nativeBuildInputs = [
-    autoreconfHook
-    which
+    meson
+    ninja
+    pkgconfig
     sassc
-    glib
-    libxml2
   ];
 
   buildInputs = [
@@ -30,8 +29,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Grey and blue theme from the Shimmer Project for GTK-based environments";
-    homepage = https://github.com/shimmerproject/Greybird;
-    license = with licenses; [ gpl2Plus ]; # or alternatively: cc-by-nc-sa-30
+    homepage = "https://github.com/shimmerproject/Greybird";
+    license = [ licenses.gpl2Plus ]; # or alternatively: cc-by-nc-sa-30 or later
     platforms = platforms.linux;
     maintainers = [ maintainers.romildo ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- update to version [3.22.11](https://github.com/shimmerproject/Greybird/releases/tag/v3.22.11)
- build system ported to meson

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).