### PR TITLE
python3Packages.moto: 1.3.13 -> 1.3.14

### DIFF
--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -22,29 +22,16 @@
 , sure
 , werkzeug
 , xmltodict
-, isPy38
 }:
 
 buildPythonPackage rec {
   pname = "moto";
-  version = "1.3.13";
+  version = "1.3.14";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0rhbjvqi1khp80gfnl3x632kwlpq3k7m8f13nidznixdpa78vm4m";
+    sha256 = "0fm09074qic24h8rw9a0paklygyb7xd0ch4890y4v8lj2pnsxbkr";
   };
-
-  # 3.8 is not yet support
-  # https://github.com/spulec/moto/pull/2519
-  disabled = isPy38;
-
-  # Backported fix from 1.3.14.dev for compatibility with botocore >= 1.9.198.
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/spulec/moto/commit/e4a4e6183560489e98b95e815b439c7a1cf3566c.diff";
-      sha256 = "1fixr7riimnldiikv33z4jwjgcsccps0c6iif40x8wmpvgcfs0cb";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace setup.py \
@@ -76,11 +63,18 @@ buildPythonPackage rec {
 
   checkInputs = [ boto3 freezegun nose sure ];
 
-  checkPhase = ''nosetests -v ./tests/ \
-                  -e test_invoke_function_from_sns \
-                  -e test_invoke_requestresponse_function \
-                  -e test_context_manager \
-                  -e test_decorator_start_and_stop'';
+  checkPhase = ''
+    nosetests -v ./tests/ \
+              -e test_invoke_function_from_sns \
+              -e test_invoke_requestresponse_function \
+              -e test_context_manager \
+              -e test_decorator_start_and_stop \
+              -e test_invoke_event_function \
+              -e test_invoke_function_from_dynamodb \
+              -e test_invoke_function_from_sqs \
+              -e test_invoke_lambda_error \
+              -e test_invoke_async_function
+  '';
 
   meta = with lib; {
     description = "Allows your tests to easily mock out AWS Services";


### PR DESCRIPTION
###### Motivation for this change
This update enables python38Packages.moto

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

