### PR TITLE
duplicity: 0.7.19 -> 0.8.10, use python3

### DIFF
--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -1,64 +1,90 @@
-{ stdenv, fetchpatch, fetchurl, python2Packages, librsync, ncftp, gnupg
+{ stdenv
+, fetchpatch
+, fetchurl
+, pythonPackages
+, librsync
+, ncftp
+, gnupg
 , gnutar
 , par2cmdline
 , utillinux
 , rsync
-, backblaze-b2, makeWrapper }:
+, backblaze-b2
+, makeWrapper
+}:
 
-python2Packages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication rec {
   pname = "duplicity";
-  version = "0.7.19";
+  version = "0.8.10";
 
   src = fetchurl {
-    url = "https://code.launchpad.net/duplicity/${stdenv.lib.versions.majorMinor version}-series/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "0ag9dknslxlasslwfjhqgcqbkb1mvzzx93ry7lch2lfzcdd91am6";
+    url = "https://code.launchpad.net/duplicity/${stdenv.lib.versions.majorMinor version}-series/${version}/+download/${pname}-${version}fin1558.tar.gz";
+    sha256 = "13apmavdc2cx3wxv2ymy97c575hc37xjhpa6b4sds8fkx2vrb0mh";
   };
-  patches = [
-    ./gnutar-in-test.patch
-    ./use-installed-scripts-in-test.patch
 
-    # The following patches improve the performance of installCheckPhase:
-    # Ensure all duplicity output is captured in tests
-    (fetchpatch {
-      extraPrefix = "";
-      sha256 = "07ay3mmnw8p2j3v8yvcpjsx0rf2jqly9ablwjpmry23dz9f0mxsd";
-      url = "https://bazaar.launchpad.net/~duplicity-team/duplicity/0.8-series/diff/1359.2.1";
+  patches = [
+    # We use the tar binary on all platforms.
+    ./gnutar-in-test.patch
+
+    # Make test respect TMPDIR env var.
+    # https://bugs.launchpad.net/duplicity/+bug/1862672
+    (fetchurl {
+      url = "https://launchpadlibrarian.net/464404371/0001-Make-LogTest-respect-TMPDIR-env-variable.patch";
+      hash = "sha256-wdy8mMurLhBS0ZTXmlIGGrIkS2gGBDwTp7TRxTSXBGo=";
     })
-    # Minimize time spent sleeping between backups
-    (fetchpatch {
-      extraPrefix = "";
-      sha256 = "0v99q6mvikb8sf68gh3s0zg12pq8fijs87fv1qrvdnc8zvs4pmfs";
-      url = "https://bazaar.launchpad.net/~duplicity-team/duplicity/0.8-series/diff/1359.2.2";
-    })
-    # Remove unnecessary sleeping after running backups in tests
-    (fetchpatch {
-      extraPrefix = "";
-      sha256 = "1bmgp4ilq2gwz2k73fxrqplf866hj57lbyabaqpkvwxhr0ch1jiq";
-      url = "https://bazaar.launchpad.net/~duplicity-team/duplicity/0.8-series/diff/1359.2.3";
-    })
+
+    # Our Python infrastructure runs test in installCheckPhase so we need
+    # to make the testing code stop assuming it is run from the source directory.
+    ./use-installed-scripts-in-test.patch
   ] ++ stdenv.lib.optionals stdenv.isLinux [
     ./linux-disable-timezone-test.patch
   ];
 
-  buildInputs = [ librsync makeWrapper python2Packages.wrapPython ];
-  propagatedBuildInputs = [ backblaze-b2 ] ++ (with python2Packages; [
-    boto cffi cryptography ecdsa enum idna pygobject3 fasteners
-    ipaddress lockfile paramiko pyasn1 pycrypto six pydrive
+  buildInputs = [
+    librsync
+    makeWrapper
+    pythonPackages.wrapPython
+  ];
+
+  propagatedBuildInputs = [
+    backblaze-b2
+  ] ++ (with pythonPackages; [
+    boto
+    cffi
+    cryptography
+    ecdsa
+    idna
+    pygobject3
+    fasteners
+    ipaddress
+    lockfile
+    paramiko
+    pyasn1
+    pycrypto
+    pydrive
+    future
+  ] ++ stdenv.lib.optionals (!isPy3k) [
+    enum
   ]);
+
   checkInputs = [
-    gnupg  # Add 'gpg' to PATH.
-    gnutar  # Add 'tar' to PATH.
-    librsync  # Add 'rdiff' to PATH.
-    par2cmdline  # Add 'par2' to PATH.
+    gnupg # Add 'gpg' to PATH.
+    gnutar # Add 'tar' to PATH.
+    librsync # Add 'rdiff' to PATH.
+    par2cmdline # Add 'par2' to PATH.
   ] ++ stdenv.lib.optionals stdenv.isLinux [
-    utillinux  # Add 'setsid' to PATH.
-  ] ++ (with python2Packages; [ lockfile mock pexpect ]);
+    utillinux # Add 'setsid' to PATH.
+  ] ++ (with pythonPackages; [
+    lockfile
+    mock
+    pexpect
+    pytest
+    pytestrunner
+  ]);
 
   postInstall = ''
     wrapProgram $out/bin/duplicity \
       --prefix PATH : "${stdenv.lib.makeBinPath [ gnupg ncftp rsync ]}"
-
-    wrapPythonPrograms
   '';
 
   preCheck = ''
@@ -88,7 +114,7 @@ python2Packages.buildPythonApplication rec {
 
   meta = with stdenv.lib; {
     description = "Encrypted bandwidth-efficient backup using the rsync algorithm";
-    homepage = https://www.nongnu.org/duplicity;
+    homepage = "https://www.nongnu.org/duplicity";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ peti ];
     platforms = platforms.unix;

--- a/pkgs/tools/backup/duplicity/gnutar-in-test.patch
+++ b/pkgs/tools/backup/duplicity/gnutar-in-test.patch
@@ -4,15 +4,15 @@
          https://launchpad.net/bugs/929067
          """
 
--        if platform.system().startswith('Linux'):
--            tarcmd = "tar"
--        elif platform.system().startswith('Darwin'):
--            tarcmd = "gtar"
--        elif platform.system().endswith('BSD'):
--            tarcmd = "gtar"
+-        if platform.system().startswith(u'Linux'):
+-            tarcmd = u"tar"
+-        elif platform.system().startswith(u'Darwin'):
+-            tarcmd = u"gtar"
+-        elif platform.system().endswith(u'BSD'):
+-            tarcmd = u"gtar"
 -        else:
--            raise Exception("Platform %s not supported by tar/gtar." % platform.platform())
-+        tarcmd = "tar"
+-            raise Exception(u"Platform %s not supported by tar/gtar." % platform.platform())
++        tarcmd = u"tar"
 
          # Intial normal backup
          self.backup("full", "testfiles/blocktartest")

--- a/pkgs/tools/backup/duplicity/use-installed-scripts-in-test.patch
+++ b/pkgs/tools/backup/duplicity/use-installed-scripts-in-test.patch
@@ -4,10 +4,46 @@
                  except Exception:
                      pass
 
--        os.environ['PATH'] = "%s:%s" % (
+-        os.environ[u'PATH'] = u"%s:%s" % (
 -            os.path.abspath(build_scripts_cmd.build_dir),
--            os.environ.get('PATH'))
+-            os.environ.get(u'PATH'))
 -
          test.run(self)
 
      def run_tests(self):
+--- a/testing/functional/__init__.py
++++ b/testing/functional/__init__.py
+@@ -107,7 +107,7 @@ class FunctionalTestCase(DuplicityTestCase):
+         if basepython is not None:
+             cmd_list.extend([basepython])
+             cmd_list.extend([u"-m", u"coverage", u"run", u"--source=duplicity", u"-p"])
+-        cmd_list.extend([u"../bin/duplicity"])
++        cmd_list.extend([u"duplicity"])
+         cmd_list.extend(options)
+         cmd_list.extend([u"-v0"])
+         cmd_list.extend([u"--no-print-statistics"])
+--- a/testing/functional/test_log.py
++++ b/testing/functional/test_log.py
+@@ -47,9 +47,9 @@ class LogTest(FunctionalTestCase):
+         # Run actual duplicity command (will fail, because no arguments passed)
+         basepython = os.environ.get(u'TOXPYTHON', None)
+         if basepython is not None:
+-            os.system(u"{} ../bin/duplicity --log-file={} >/dev/null 2>&1".format(basepython, self.logfile))
++            os.system(u"{} duplicity --log-file={} >/dev/null 2>&1".format(basepython, self.logfile))
+         else:
+-            os.system(u"../bin/duplicity --log-file={} >/dev/null 2>&1".format(self.logfile))
++            os.system(u"duplicity --log-file={} >/dev/null 2>&1".format(self.logfile))
+ 
+         # The format of the file should be:
+         # """ERROR 2
+--- a/testing/functional/test_rdiffdir.py
++++ b/testing/functional/test_rdiffdir.py
+@@ -38,7 +38,7 @@ class RdiffdirTest(FunctionalTestCase):
+ 
+     def run_rdiffdir(self, argstring):
+         u"""Run rdiffdir with given arguments"""
+-        self.run_cmd(u"../bin/rdiffdir " + argstring)
++        self.run_cmd(u"rdiffdir " + argstring)
+ 
+     def run_cycle(self, dirname_list):
+         u"""Run diff/patch cycle on directories in dirname_list"""

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2906,7 +2906,7 @@ in
   duplicati = callPackage ../tools/backup/duplicati { };
 
   duplicity = callPackage ../tools/backup/duplicity {
-    gnupg = gnupg1;
+    pythonPackages = python3Packages;
   };
 
   duply = callPackage ../tools/backup/duply { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
