### PR TITLE
svxlink: init at 19.09.1

### DIFF
--- a/pkgs/applications/radio/svxlink/default.nix
+++ b/pkgs/applications/radio/svxlink/default.nix
@@ -1,0 +1,71 @@
+{ stdenv, cmake, pkgconfig, fetchFromGitHub, makeDesktopItem, alsaLib, speex
+, libopus, curl, gsm, libgcrypt, libsigcxx, popt, qtbase, qttools
+, wrapQtAppsHook, rtl-sdr, tcl, doxygen, groff }:
+
+let
+  desktopItem = makeDesktopItem rec {
+    name = "Qtel";
+    exec = "qtel";
+    icon = "qtel";
+    desktopName = name;
+    genericName = "EchoLink Client";
+    categories = "HamRadio;Qt;Network;";
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "svxlink";
+  version = "19.09.1";
+
+  src = fetchFromGitHub {
+    owner = "sm0svx";
+    repo = pname;
+    rev = version;
+    sha256 = "0xmbac821w9kl7imlz0mra19mlhi0rlpbyyay26w1y7h98j4g4yp";
+  };
+
+  cmakeFlags = [
+    "-DDO_INSTALL_CHOWN=NO"
+    "-DRTLSDR_LIBRARIES=${rtl-sdr}/lib/librtlsdr.so"
+    "-DRTLSDR_INCLUDE_DIRS=${rtl-sdr}/include"
+    "../src"
+  ];
+  enableParallelBuilding = true;
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [ cmake pkgconfig doxygen groff wrapQtAppsHook ];
+
+  buildInputs = [
+    alsaLib
+    curl
+    gsm
+    libgcrypt
+    libsigcxx
+    libopus
+    popt
+    qtbase
+    qttools
+    rtl-sdr
+    speex
+    tcl
+  ];
+
+  postInstall = ''
+    rm -f $out/share/applications/*
+    cp -v ${desktopItem}/share/applications/* $out/share/applications
+    mv $out/share/icons/link.xpm $out/share/icons/qtel.xpm
+
+    wrapQtApp $out/bin/qtel
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Advanced repeater controller and EchoLink software";
+    longDescription = ''
+      Advanced repeater controller and EchoLink software for Linux including a
+      GUI, Qtel - The Qt EchoLink client
+    '';
+    homepage = "http://www.svxlink.org/";
+    license = with licenses; [ gpl2 ];
+    maintainers = with maintainers; [ zaninime ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14302,6 +14302,8 @@ in
 
   svrcore = callPackage ../development/libraries/svrcore { };
 
+  svxlink = libsForQt5.callPackage ../applications/radio/svxlink { };
+
   swiftclient = python3.pkgs.callPackage ../tools/admin/swiftclient { };
 
   sword = callPackage ../development/libraries/sword { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
