### PR TITLE
Agda cubical

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6703,6 +6703,7 @@
   ryanorendorff = {
     email = "12442942+ryanorendorff@users.noreply.github.com";
     github = "ryanorendorff";
+    githubId = 12442942;
     name = "Ryan Orendorff";
   };
   ryansydnor = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6700,6 +6700,11 @@
     githubId = 889991;
     name = "Ryan Artecona";
   };
+  ryanorendorff = {
+    email = "12442942+ryanorendorff@users.noreply.github.com";
+    github = "ryanorendorff";
+    name = "Ryan Orendorff";
+  };
   ryansydnor = {
     email = "ryan.t.sydnor@gmail.com";
     github = "ryansydnor";

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -27,7 +27,7 @@ mkDerivation rec {
     description =
       "A cubical type theory library for use with the Agda compiler";
     license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.unix;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ ryanorendorff ];
   };
 }

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -28,6 +28,6 @@ mkDerivation rec {
       "A cubical type theory library for use with the Agda compiler";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ ryanorendorff ];
+    maintainers = with maintainers; [ alexarice ryanorendorff ];
   };
 }

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, mkDerivation, fetchFromGitHub, ghcWithPackages }:
+
+mkDerivation rec {
+
+  # Version 0.2 is meant to be used with the Agda 2.6.1 compiler.
+  pname = "cubical";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "agda";
+    rev = "v${version}";
+    sha256 = "07qlp2f189jvzbn3aqvpqk2zxpkmkxhhkjsn62iq436kxqj3z6c2";
+  };
+
+  # The cubical library has several `Everything.agda` files, which are
+  # compiled through the make file they provide.
+  nativeBuildInputs = [ (ghcWithPackages (self: [ ])) ];
+  buildPhase = ''
+    patchShebangs
+    make
+  '';
+
+  sourceDirectories = [ "." ];
+
+  meta = with stdenv.lib; {
+    description =
+      "A cubical type theory library for use with the Agda compiler";
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with maintainers; [ ryanorendorff ];
+  };
+}

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -17,7 +17,6 @@ mkDerivation rec {
   # compiled through the make file they provide.
   nativeBuildInputs = [ (ghcWithPackages (self: [ ])) ];
   buildPhase = ''
-    patchShebangs
     make
   '';
 

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -23,7 +23,7 @@ mkDerivation rec {
 
   sourceDirectories = [ "." ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description =
       "A cubical type theory library for use with the Agda compiler";
     license = stdenv.lib.licenses.mit;

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -21,8 +21,6 @@ mkDerivation rec {
     make
   '';
 
-  sourceDirectories = [ "." ];
-
   meta = with lib; {
     description =
       "A cubical type theory library for use with the Agda compiler";

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitHub, ghcWithPackages }:
+{ lib, mkDerivation, fetchFromGitHub, ghc }:
 
 mkDerivation rec {
 
@@ -15,7 +15,7 @@ mkDerivation rec {
 
   # The cubical library has several `Everything.agda` files, which are
   # compiled through the make file they provide.
-  nativeBuildInputs = [ (ghcWithPackages (self: [ ])) ];
+  nativeBuildInputs = [ ghc ];
   buildPhase = ''
     make
   '';

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchFromGitHub, ghcWithPackages }:
+{ lib, mkDerivation, fetchFromGitHub, ghcWithPackages }:
 
 mkDerivation rec {
 

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -23,6 +23,7 @@ mkDerivation rec {
   meta = with lib; {
     description =
       "A cubical type theory library for use with the Agda compiler";
+    homepage = src.meta.homepage;
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ alexarice ryanorendorff ];

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -1,4 +1,4 @@
-{ lib, mkDerivation, fetchFromGitHub, ghc }:
+{ lib, mkDerivation, fetchFromGitHub, ghc, glibcLocales }:
 
 mkDerivation rec {
 
@@ -13,9 +13,11 @@ mkDerivation rec {
     sha256 = "07qlp2f189jvzbn3aqvpqk2zxpkmkxhhkjsn62iq436kxqj3z6c2";
   };
 
+  LC_ALL = "en_US.UTF-8";
+
   # The cubical library has several `Everything.agda` files, which are
   # compiled through the make file they provide.
-  nativeBuildInputs = [ ghc ];
+  nativeBuildInputs = [ ghc glibcLocales ];
   buildPhase = ''
     make
   '';

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -26,7 +26,7 @@ mkDerivation rec {
   meta = with lib; {
     description =
       "A cubical type theory library for use with the Agda compiler";
-    license = stdenv.lib.licenses.mit;
+    license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ryanorendorff ];
   };

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -24,7 +24,6 @@ let
     agda-categories = callPackage ../development/libraries/agda/agda-categories { };
 
     cubical = callPackage ../development/libraries/agda/cubical {
-      inherit (pkgs.haskellPackages) ghcWithPackages;
     };
   };
 in mkAgdaPackages Agda

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -23,7 +23,6 @@ let
 
     agda-categories = callPackage ../development/libraries/agda/agda-categories { };
 
-    cubical = callPackage ../development/libraries/agda/cubical {
-    };
+    cubical = callPackage ../development/libraries/agda/cubical { };
   };
 in mkAgdaPackages Agda

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -22,5 +22,9 @@ let
     agda-prelude = callPackage ../development/libraries/agda/agda-prelude { };
 
     agda-categories = callPackage ../development/libraries/agda/agda-categories { };
+
+    cubical = callPackage ../development/libraries/agda/cubical {
+      inherit (pkgs.haskellPackages) ghcWithPackages;
+    };
   };
 in mkAgdaPackages Agda


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
 
Adds the cubical type theory library to nixpkgs. I asked the maintainers and @Saizan gave approval to add this library to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (checked for any tests, there do not appear to be).
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (all agda files compile)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date (I cannot find a place in the documentation for Agda things)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @jwiegley @laMudri 
