### PR TITLE
python3Packages.skorch: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/skorch/default.nix
+++ b/pkgs/development/python-modules/skorch/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, pytest
+, pytestcov
+, flaky
+, numpy
+, pandas
+, pytorch
+, scikitlearn
+, scipy
+, tabulate
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "skorch";
+  version = "0.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1l576dws9drjakfsn0pfpbr48b21vpxv3vd3dz8lkbn8q71zs22r";
+  };
+
+  propagatedBuildInputs = [ numpy pytorch scikitlearn scipy tabulate tqdm ];
+  checkInputs = [ pytest pytestcov flaky pandas pytestCheckHook ];
+
+  # on CPU, these expect artifacts from previous GPU run
+  disabledTests = [
+    "test_load_cuda_params_to_cpu"
+    "test_pickle_load"
+  ];
+
+  meta = with lib; {
+    description = "Scikit-learn compatible neural net library using Pytorch";
+    homepage = "https://skorch.readthedocs.io";
+    changelog = "https://github.com/skorch-dev/skorch/blob/master/CHANGES.md";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1505,6 +1505,8 @@ in {
 
   sklearn-deap = callPackage ../development/python-modules/sklearn-deap { };
 
+  skorch = callPackage ../development/python-modules/skorch { };
+
   slackclient = callPackage ../development/python-modules/slackclient { };
 
   slicedimage = callPackage ../development/python-modules/slicedimage { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [NA] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
