### PR TITLE
ocamlPackages.npy: init at unstable-2019-04-02

### DIFF
--- a/pkgs/development/ocaml-modules/npy/default.nix
+++ b/pkgs/development/ocaml-modules/npy/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildDunePackage, fetchFromGitHub, numpy, camlzip }:
+
+buildDunePackage rec {
+  pname = "npy";
+  version = "unstable-2019-04-02";
+
+  minimumOCamlVersion = "4.06";
+
+  src = fetchFromGitHub {
+    owner = "LaurentMazare";
+    repo   = "${pname}-ocaml";
+    rev    = "c051086bfea6bee58208098bcf1c2f725a80a1fb";
+    sha256 = "06mgrnm7xiw2lhqvbdv2zmd65sqfdnjd7j4qmcswanmplm17yhvb";
+  };
+
+  propagatedBuildInputs = [ camlzip ];
+  checkInputs = [ numpy ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "OCaml implementation of the Npy format spec";
+    maintainers = [ maintainers.bcdarwin ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -558,6 +558,10 @@ let
       lwt = ocaml_lwt;
     };
 
+    npy = callPackage ../development/ocaml-modules/npy {
+      inherit (pkgs.python3Packages) numpy;
+    };
+
     num = if lib.versionOlder "4.06" ocaml.version
       then callPackage ../development/ocaml-modules/num {}
       else null;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [NA] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
