### PR TITLE
pam_gnupg: init at fbd75b7

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -361,15 +361,15 @@ let
           # We use try_first_pass the second time to avoid prompting password twice
           (optionalString (cfg.unixAuth &&
           (config.security.pam.enableEcryptfs
-	    || config.security.pam.enableGnupg
+            || config.security.pam.enableGnupg
             || cfg.pamMount
             || cfg.enableKwallet
             || cfg.enableGnomeKeyring
             || cfg.googleAuthenticator.enable
             || cfg.duoSecurity.enable)) ''
               auth required pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} likeauth
-	      ${optionalString config.security.pam.enableGnupg
-	        "auth optional ${pkgs.pam_gnupg}/lib/security/pam_gnupg.so"}
+              ${optionalString config.security.pam.enableGnupg
+                "auth optional ${pkgs.pam_gnupg}/lib/security/pam_gnupg.so"}
               ${optionalString config.security.pam.enableEcryptfs
                 "auth optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so unwrap"}
               ${optionalString cfg.pamMount
@@ -441,8 +441,8 @@ let
               "session optional ${pkgs.otpw}/lib/security/pam_otpw.so"}
           ${optionalString cfg.startSession
               "session optional ${pkgs.systemd}/lib/security/pam_systemd.so"}
-	  ${optionalString config.security.pam.enableGnupg
-	      "session optional ${pkgs.pam_gnupg}/lib/security/pam_gnupg.so"}
+          ${optionalString config.security.pam.enableGnupg
+              "session optional ${pkgs.pam_gnupg}/lib/security/pam_gnupg.so"}
           ${optionalString cfg.forwardXAuth
               "session optional pam_xauth.so xauthpath=${pkgs.xorg.xauth}/bin/xauth systemuser=99"}
           ${optionalString (cfg.limits != [])

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -361,12 +361,15 @@ let
           # We use try_first_pass the second time to avoid prompting password twice
           (optionalString (cfg.unixAuth &&
           (config.security.pam.enableEcryptfs
+	    || config.security.pam.enableGnupg
             || cfg.pamMount
             || cfg.enableKwallet
             || cfg.enableGnomeKeyring
             || cfg.googleAuthenticator.enable
             || cfg.duoSecurity.enable)) ''
               auth required pam_unix.so ${optionalString cfg.allowNullPassword "nullok"} likeauth
+	      ${optionalString config.security.pam.enableGnupg
+	        "auth optional ${pkgs.pam_gnupg}/lib/security/pam_gnupg.so"}
               ${optionalString config.security.pam.enableEcryptfs
                 "auth optional ${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so unwrap"}
               ${optionalString cfg.pamMount
@@ -438,6 +441,8 @@ let
               "session optional ${pkgs.otpw}/lib/security/pam_otpw.so"}
           ${optionalString cfg.startSession
               "session optional ${pkgs.systemd}/lib/security/pam_systemd.so"}
+	  ${optionalString config.security.pam.enableGnupg
+	      "session optional ${pkgs.pam_gnupg}/lib/security/pam_gnupg.so"}
           ${optionalString cfg.forwardXAuth
               "session optional pam_xauth.so xauthpath=${pkgs.xorg.xauth}/bin/xauth systemuser=99"}
           ${optionalString (cfg.limits != [])
@@ -723,6 +728,13 @@ in
       default = false;
       description = ''
         Enable eCryptfs PAM module (mounting ecryptfs home directory on login).
+      '';
+    };
+
+    security.pam.enableGnupg = mkOption {
+      default = false;
+      description = ''
+        Enable pam_gnupg module to unlock GPG agent on login.
       '';
     };
 

--- a/pkgs/os-specific/linux/pam_gnupg/default.nix
+++ b/pkgs/os-specific/linux/pam_gnupg/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchgit, autoreconfHook, gnupg, pam } :
+
+stdenv.mkDerivation rec {
+  name = "pam_gnupg-fbd75b7";
+  src = fetchgit {
+    url = https://github.com/cruegge/pam-gnupg;
+    rev = "fbd75b720877e4cf94e852ce7e2b811feb330bb5";
+    sha256 = "0kqn6xb85jfmhvvbd2lasnci46p2pcwy0wq233za9h7xwfr49f7d";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ gnupg pam ];
+
+  preAutoreconf = ''
+    mkdir m4
+  '';
+
+  configurePhase = ''
+    ./configure --prefix=$out --with-moduledir=$out/lib/security
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A PAM plugin to preset GPG passphrases on login";
+    homepage = "https://github.com/cruegge/pam-gnupg/";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/pam_gnupg/default.nix
+++ b/pkgs/os-specific/linux/pam_gnupg/default.nix
@@ -13,13 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ gnupg pam ];
 
-  preAutoreconf = ''
-    mkdir m4
-  '';
-
-  configurePhase = ''
-    ./configure --prefix=$out --with-moduledir=$out/lib/security
-  '';
+  configureFlags = [ "--with-moduledir=$\{out\}/lib/security" ];
 
   meta = with stdenv.lib; {
     description = "A PAM plugin to preset GPG passphrases on login";

--- a/pkgs/os-specific/linux/pam_gnupg/default.nix
+++ b/pkgs/os-specific/linux/pam_gnupg/default.nix
@@ -1,7 +1,9 @@
 { stdenv, fetchgit, autoreconfHook, gnupg, pam } :
 
 stdenv.mkDerivation rec {
-  name = "pam_gnupg-fbd75b7";
+  pname = "pam_gnupg";
+  version = "unstable-2019-12-06";
+
   src = fetchgit {
     url = https://github.com/cruegge/pam-gnupg;
     rev = "fbd75b720877e4cf94e852ce7e2b811feb330bb5";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16837,6 +16837,8 @@ in
 
   pam_ccreds = callPackage ../os-specific/linux/pam_ccreds { };
 
+  pam_gnupg = callPackage ../os-specific/linux/pam_gnupg { };
+
   pam_krb5 = callPackage ../os-specific/linux/pam_krb5 { };
 
   pam_ldap = callPackage ../os-specific/linux/pam_ldap { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The [pam_gnupg](https://github.com/cruegge/pam-gnupg) module allows GPG keys to be unlocked during user authentication and session creation in PAM. This request adds a new package for pam_gnupg to nix, and modifies the PAM module in NixOS to add optional support for pam_gnupg to the system PAM configuration. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @prusnak 
