### PR TITLE
anarchism: init at 15.3-1

### DIFF
--- a/pkgs/data/documentation/anarchism/default.nix
+++ b/pkgs/data/documentation/anarchism/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitLab, xdg_utils }:
+
+stdenv.mkDerivation rec {
+  pname = "anarchism";
+  version = "15.3-1";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = pname;
+    rev = "debian%2F${version}"; # %2F = urlquote("/")
+    sha256 = "04ylk0y5b3jml2awmyz7m1hnymni8y1n83m0k6ychdh0px8frhm5";
+  };
+
+  phases = [ "unpackPhase" "postPatch" "installPhase" ];
+
+  postPatch = ''
+    substituteInPlace debian/anarchism.desktop \
+      --replace "/usr/bin/xdg-open" "${xdg_utils}/bin/xdg-open"
+    substituteInPlace debian/anarchism.desktop \
+      --replace "file:///usr" "file://$out"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/doc/anarchism $out/share/applications $out/share/icons/hicolor/scalable/apps 
+    cp -r {html,markdown} $out/share/doc/anarchism
+    cp debian/anarchism.svg $out/share/icons/hicolor/scalable/apps
+    cp debian/anarchism.desktop $out/share/applications
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.anarchistfaq.org/";
+    changelog = "http://anarchism.pageabode.com/afaq/new.html";
+    description = "Exhaustive exploration of Anarchist theory and practice";
+    longDescription = ''
+      The Anarchist FAQ is an excellent source of information regarding Anarchist
+      (libertarian socialist) theory and practice. It covers all major topics,
+      from the basics of Anarchism to very specific discussions of politics,
+      social organization, and economics.
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ davidak ];
+    platforms = with platforms; all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17163,6 +17163,8 @@ in
 
   amiri = callPackage ../data/fonts/amiri { };
 
+  anarchism = callPackage ../data/documentation/anarchism { };
+
   andagii = callPackage ../data/fonts/andagii { };
 
   andika = callPackage ../data/fonts/andika { };


### PR DESCRIPTION
###### Motivation for this change

I talked to someone about NixOS at the 36C3 and we discovered that this package is missing.

It is a FAQ about anarchism that was originally packaged for debian and can be found in many debian derivations and AUR. https://repology.org/project/anarchism/versions

Ever wanted to install anarchism on your system? Now you can also on NixOS!

It includes HTML and Markdown files, an icon and desktop file. So you can open it in your browser from the menu.

![Screenshot from 2020-01-06 05-47-23](https://user-images.githubusercontent.com/91113/71796145-ab207b80-3049-11ea-91e2-b4efb6b2394a.png)

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
