### PR TITLE
mupen64plus: 2.5 -> 2.5.9

### DIFF
--- a/pkgs/misc/emulators/mupen64plus/default.nix
+++ b/pkgs/misc/emulators/mupen64plus/default.nix
@@ -1,15 +1,15 @@
-{stdenv, fetchurl, boost, dash, freetype, libpng, pkgconfig, SDL, which, zlib }:
+{stdenv, fetchurl, boost, dash, freetype, libpng, pkgconfig, SDL, which, zlib, nasm }:
 
 stdenv.mkDerivation rec {
   pname = "mupen64plus";
-  version = "2.5";
+  version = "2.5.9";
 
   src = fetchurl {
     url = "https://github.com/mupen64plus/mupen64plus-core/releases/download/${version}/mupen64plus-bundle-src-${version}.tar.gz";
-    sha256 = "0rmsvfn4zfvbhz6gf1xkb7hnwflv6sbklwjz2xk4dlpj4vcbjxcw";
+    sha256 = "1a21n4gqdvag6krwcjm5bnyw5phrlxw6m0mk73jy53iq03f3s96m";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig nasm ];
   buildInputs = [ boost dash freetype libpng SDL which zlib ];
 
   buildPhase = ''
@@ -19,11 +19,11 @@ stdenv.mkDerivation rec {
     dash m64p_install.sh DESTDIR="$out" PREFIX=""
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A Nintendo 64 Emulator";
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
     homepage = http://www.mupen64plus.org/;
-    maintainers = [ stdenv.lib.maintainers.sander ];
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ maintainers.sander ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
noticed update fail in @r-ryantm logs

was able to load up game and play some

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
