### PR TITLE
python3Packages.mypy: 0.750 -> 0.761

### DIFF
--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -5,12 +5,12 @@
 
 buildPythonPackage rec {
   pname = "mypy";
-  version = "0.750";
+  version = "0.761";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0k0l74g3jcq7ppzn234sffsaacn6qaq242famckk0cviwgld1jvf";
+    sha256 = "1gw7h84d21wmi267kmgqs9whz0l7rp62pzja2f31wq7cfj6spfl5";
   };
 
   propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];


### PR DESCRIPTION
###### Motivation for this change
noticed it was out of date @r-ryantm in logs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

failures are broken on master
````
[16 built (3 failed), 279 copied (432.5 MiB), 60.1 MiB DL]
error: build of '/nix/store/dcwri69x5ialm1b4cfsy65xjwq7bphmd-env.drv' failed
https://github.com/NixOS/nixpkgs/pull/77039
3 package failed to build:
python38Packages.git-revise python38Packages.ics python38Packages.pyls-mypy

16 package built:
git-revise mypy nix-pin python37Packages.algebraic-data-types python37Packages.ics python37Packages.pyls-mypy python37Packages.pynamodb python37Packages.pytest-mypy python37Packages.tatsu python38Packages.algebraic-data-types python38Packages.mypy python38Packages.pynamodb python38Packages.pytest-mypy python38Packages.tatsu thonny zfs-replicate
```