### PR TITLE
vscode, vscodium: ban nixpkgs-update from updating

### DIFF
--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -16,6 +16,8 @@ let
   }.${system};
 in
   callPackage ./generic.nix rec {
+    # The update script doesn't correctly change the hash for darwin, so please:
+    # nixpkgs-update: no auto update
 
     version = "1.41.1";
     pname = "vscode";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -22,6 +22,8 @@ let
 in
   callPackage ./generic.nix rec {
     inherit sourceRoot;
+    # The update script doesn't correctly change the hash for darwin, so please:
+    # nixpkgs-update: no auto update
 
     version = "1.41.1";
     pname = "vscodium";


### PR DESCRIPTION
nixpkgs-update doesn't correctly update the hash for darwin.
There doesn't seem to be a good fix for this.

See also:

  - #76471
  - #76458

CC: @ryantm @eadwu
