### PR TITLE
gitAndTools.git-workspace: init at 0.4.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -135,6 +135,10 @@ let
 
   git-test = callPackage ./git-test { };
 
+  git-workspace = callPackage ./git-workspace {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   git2cl = callPackage ./git2cl { };
 
   gitFastExport = callPackage ./fast-export { };

--- a/pkgs/applications/version-management/git-and-tools/git-workspace/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-workspace/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-workspace";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "orf";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "01qxm00c5wqpy1clrvjr44v7cg4nqawaf5a6qnvvgswvis4kakzr";
+  };
+
+  cargoSha256 = "16rkmk888alfvq8nsggi26vck1c7ya0fa5j7gv219g5py4gw2n34";
+
+  verifyCargoDeps = true;
+
+  buildInputs = with stdenv; lib.optional isDarwin Security;
+
+  meta = with stdenv.lib; {
+    description = "Sync personal and work git repositories from multiple providers";
+    homepage = "https://github.com/orf/git-workspace";
+    license = with licenses; [ mit ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ misuzu ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/orf/git-workspace/releases/tag/v0.4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

