### PR TITLE
nixos/systemd: Explicitly put default path packages after othe…

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -240,7 +240,7 @@ let
   serviceConfig = { name, config, ... }: {
     config = mkMerge
       [ { # Default path for systemd services.  Should be quite minimal.
-          path =
+          path = mkAfter
             [ pkgs.coreutils
               pkgs.findutils
               pkgs.gnugrep


### PR DESCRIPTION
###### Motivation for this change

This fixes the dhcpcd issue in https://github.com/NixOS/nixpkgs/issues/76969, which was exposed by https://github.com/NixOS/nixpkgs/pull/75031 introducing changes in the module ordering and therefore option ordering too.

The dhcpcd issue would also be fixable by explicitly putting
dhcpcd's paths before others, however it makes more sense for systemd's
default paths to be after all others by default, since they should only
be a fallback, which is how binary finding will work if they come after.

Ping @demokritos @izuk @karolchmist 

###### Things done

- [x] Tested that this actually fixes the issue (checking `cat /etc/resolv.conf`)