### PR TITLE
nixos/activation: add types to options

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -4,6 +4,11 @@ with lib;
 
 let
 
+  childConfigType = mkOptionType {
+    name = "NixOS config module";
+    # merging is not implemented because this type is only
+    # found inside lists.
+  };
 
   # This attribute is responsible for creating boot entries for
   # child configuration. They are only (directly) accessible
@@ -155,6 +160,7 @@ in
 
     nesting.children = mkOption {
       default = [];
+      type = types.listOf childConfigType;
       description = ''
         Additional configurations to build.
       '';
@@ -162,6 +168,7 @@ in
 
     nesting.clone = mkOption {
       default = [];
+      type = types.listOf childConfigType;
       description = ''
         Additional configurations to build based on the current
         configuration which then has a lower priority.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
In response to #76184.

###### Things done
Create a type for the elements of `nesting.clone` and `nesting.children` and slap it on.
The new type doesn't do any validation. However, a type error will now be raised if the user forgets that both options expect lists.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS **inapplicable**
   - [ ] other Linux distributions **inapplicable**
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) **inapplicable**
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` **inapplicable**
- [ ] Tested execution of all binary files (usually in `./result/bin/`) **inapplicable**
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after) **inapplicable**
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
