### PR TITLE
ms-sys: avoid leaking the build timestamp into the manpage

### DIFF
--- a/pkgs/tools/misc/ms-sys/default.nix
+++ b/pkgs/tools/misc/ms-sys/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/ms-sys/${pname}-${version}.tar.gz";
     sha256 = "06xqpm2s9cg8fj7a1822wmh3p4arii0sifssazg1gr6i7xg7kbjz";
   };
+  # TODO: Remove with next release, see https://sourceforge.net/p/ms-sys/patches/8/
+  patches = [ ./manpages-without-build-timestamps.patch ];
 
   nativeBuildInputs = [ gettext ];
 

--- a/pkgs/tools/misc/ms-sys/manpages-without-build-timestamps.patch
+++ b/pkgs/tools/misc/ms-sys/manpages-without-build-timestamps.patch
@@ -1,0 +1,12 @@
+diff -u ms-sys-2.6.0/Makefile ms-sys-2.6.0-fixed/Makefile
+--- ms-sys-2.6.0/Makefile	2015-09-27 20:39:45.000000000 +0200
++++ ms-sys-2.6.0-fixed/Makefile2020-01-06 16:43:55.181477511 +0100
+@@ -121,7 +121,7 @@
+
+ $(DESTDIR)$(MANDIR)/%: $(MAN)/$(dir $(*D))/$(*F)
+ 	install -D -m 644 $(MAN)/$(dir $(*D))$(*F) $@
+-	gzip -f $@
++	gzip -n -f $@
+
+ #$(DESTDIR)$(MANDIR)/%: $(MAN)/$(*F)
+ #	echo t: $<


### PR DESCRIPTION
Also proposed upstream as https://sourceforge.net/p/ms-sys/patches/8/

###### Motivation for this change

This makes the ms-sys deterministic, so building the same sources always produces the same bits.

Can be verified with `nix-build '<nixpkgs>' -A ms-sys --check`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

