### PR TITLE
python-miio: init at 0.4.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2439,6 +2439,12 @@
     githubId = 844574;
     name = "Daniel Austin";
   };
+  flyfloh = {
+    email = "nix@halbmastwurf.de";
+    github = "flyfloh";
+    githubId = 74379;
+    name = "Florian Pester";
+  };
   fmthoma = {
     email = "f.m.thoma@googlemail.com";
     github = "fmthoma";

--- a/pkgs/development/python-modules/python-miio/default.nix
+++ b/pkgs/development/python-modules/python-miio/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, appdirs
+, click
+, construct
+, cryptography
+, pytest
+, zeroconf
+, attrs
+, pytz
+, tqdm
+, netifaces
+}:
+
+buildPythonPackage rec {
+  pname = "python-miio";
+  version = "0.4.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19423b3386b23d2e0fc94a8f6a358bcfbb44eed05376e33fd434d26d168bd18c";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ appdirs click construct cryptography zeroconf attrs pytz tqdm netifaces ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Python library for interfacing with Xiaomi smart appliances";
+    homepage = https://github.com/rytilahti/python-miio;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ flyfloh ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5011,6 +5011,8 @@ in {
 
   python-markdown-math = callPackage ../development/python-modules/python-markdown-math { };
 
+  python-miio = callPackage ../development/python-modules/python-miio { };
+
   python-pipedrive = callPackage ../development/python-modules/python-pipedrive { };
 
   python-ptrace = callPackage ../development/python-modules/python-ptrace { };


### PR DESCRIPTION
###### Motivation for this change

Homeassistant depends on this library, when connected to a Xiaomi Roborock vacuum cleaner.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
