### PR TITLE
firefox: Apply a IndexDB Patch

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -110,7 +110,12 @@ let
       url = "https://raw.githubusercontent.com/archlinuxarm/PKGBUILDs/09c7fa0dc1d87922e3b464c0fa084df1227fca79/extra/firefox/build-arm-libopus.patch";
       sha256 = "1zg56v3lc346fkzcjjx21vjip2s9hb2xw4pvza1dsfdnhsnzppfp";
     })
-  ] ++ lib.optional (lib.versionAtLeast ffversion "71") ./fix-ff71-lto.patch
+  ]
+  ++ lib.optional (lib.versionAtLeast ffversion "71") (fetchpatch {
+      name = "fix-temporary-lifetimes-in-lifetimes.patch";
+      url = "https://phabricator.services.mozilla.com/D56876?download=true";
+      sha256 = "02pb035w26rfbidl81z96gp9i23b3nrmds97li4fwi4s5abqwhlx";
+    })
   ++ patches;
 
 in


### PR DESCRIPTION
I tried the fix from https://bugzilla.mozilla.org/show_bug.cgi?id=1601707
but it didn‘t solve my problem https://github.com/vector-im/riot-web/issues/11711

Therefore I instead applied
https://salsa.debian.org/mozilla-team/firefox/commit/e888ce1578d68116949782035f8149cdbc5e832c

which is supposedly a patch for the same problem.

I admit I don‘t know why this helps. I just tried it out because I
heard that the bug does not exist under debian.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @andir 
