### PR TITLE
lib/types: Fix path type check

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -242,8 +242,7 @@ rec {
 
     path = mkOptionType {
       name = "path";
-      # Hacky: there is no ‘isPath’ primop.
-      check = x: builtins.substring 0 1 (toString x) == "/";
+      check = x: isCoercibleToString x && builtins.substring 0 1 (toString x) == "/";
       merge = mergeEqualOption;
     };
 


### PR DESCRIPTION
###### Motivation for this change

Previously when this function was called without a value coercible to a
string it would throw an error instead of returning false. Now it does.

As a result this now allows the use of a type like `either path attrs`
without it erroring out when a definition is an attribute set.

The warning about there not being a isPath primop was removed because
this is not the case anymore, there is `builtins.isPath`. But also there
always was `builtins.typeOf x == "path"` that could've been used
instead. However the path type now stands for more than just path types,
but absolute paths in general.

Fixes https://github.com/NixOS/nixpkgs/issues/76977, relevant for https://github.com/NixOS/nixpkgs/pull/76861

Ping @roberth 

###### Things done

- [x] Tested that it doesn't throw an error anymore with attribute sets