### PR TITLE
samurai: init at 1.0

### DIFF
--- a/pkgs/development/tools/build-managers/samurai/default.nix
+++ b/pkgs/development/tools/build-managers/samurai/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "samurai";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "michaelforney";
+    repo = pname;
+    rev = version;
+    sha256 = "1jsxfpwa6q893x18qlvpsiym29rrw5cj0k805wgmk2n57j9rw4f2";
+  };
+
+  makeFlags = [ "DESTDIR=" "PREFIX=${placeholder "out"}" ];
+
+  meta = with stdenv.lib; {
+    description = "ninja-compatible build tool written in C";
+    homepage = "https://github.com/michaelforney/samurai";
+    license = with licenses; [ mit asl20 ]; # see LICENSE
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10476,6 +10476,8 @@ in
 
   rr = callPackage ../development/tools/analysis/rr { };
 
+  samurai = callPackage ../development/tools/build-managers/samurai { };
+
   saleae-logic = callPackage ../development/tools/misc/saleae-logic { };
 
   sauce-connect = callPackage ../development/tools/sauce-connect { };


### PR DESCRIPTION
###### Motivation for this change

> samurai is a ninja-compatible build tool written in C99 with a focus on
simplicity, speed, and portability.

Will need some plumbing work to be used automagically in nixpkgs like we
do with ninja (setup-hook to start), but still nice to have packaged for
anyone interested in using now that 1.0 has been released.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).