### PR TITLE
xorg.libXpm: 3.5.12 -> 3.5.13

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -950,11 +950,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   libXpm = callPackage ({ stdenv, pkgconfig, fetchurl, libX11, libXext, xorgproto, libXt, gettext }: stdenv.mkDerivation {
-    name = "libXpm-3.5.12";
+    name = "libXpm-3.5.13";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/lib/libXpm-3.5.12.tar.bz2;
-      sha256 = "1v5xaiw4zlhxspvx76y3hq4wpxv7mpj6parqnwdqvpj8vbinsspx";
+      url = mirror://xorg/individual/lib/libXpm-3.5.13.tar.bz2;
+      sha256 = "09dc6nwlb2122h02vl64k9x56mxnyqz2gwpga0abfv4bb1bxmlcw";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig gettext ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -261,11 +261,6 @@ self: super:
   });
 
   libXpm = super.libXpm.overrideAttrs (attrs: {
-    name = "libXpm-3.5.12";
-    src = fetchurl {
-      url = mirror://xorg/individual/lib/libXpm-3.5.12.tar.bz2;
-      sha256 = "1v5xaiw4zlhxspvx76y3hq4wpxv7mpj6parqnwdqvpj8vbinsspx";
-    };
     outputs = [ "bin" "dev" "out" ]; # tiny man in $bin
     patchPhase = "sed -i '/USE_GETTEXT_TRUE/d' sxpm/Makefile.in cxpm/Makefile.in";
   });

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -195,7 +195,7 @@ mirror://xorg/individual/lib/libXinerama-1.1.4.tar.bz2
 mirror://xorg/individual/lib/libxkbfile-1.1.0.tar.bz2
 mirror://xorg/individual/lib/libXmu-1.1.3.tar.bz2
 mirror://xorg/individual/lib/libXp-1.0.3.tar.bz2
-mirror://xorg/individual/lib/libXpm-3.5.12.tar.bz2
+mirror://xorg/individual/lib/libXpm-3.5.13.tar.bz2
 mirror://xorg/individual/lib/libXpresent-1.0.0.tar.bz2
 mirror://xorg/individual/lib/libXrandr-1.5.2.tar.bz2
 mirror://xorg/individual/lib/libXrender-0.9.10.tar.bz2


### PR DESCRIPTION
###### Motivation for this change

Update, mostly (minor).

Don't set `src` in override (?!), or name.

Didn't chase down why override was used, might be worth doing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).