### PR TITLE
buildRustCrate: fixup usage of `builtins.filterSource`

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/helpers.nix
+++ b/pkgs/build-support/rust/build-rust-crate/helpers.nix
@@ -11,14 +11,14 @@
      else
        features
    ) [] (lib.attrNames feat);
-  include = includedFiles: src: lib.filterSource (path: type:
+  include = includedFiles: src: builtins.filterSource (path: type:
      lib.any (f:
        let p = toString (src + ("/" + f));
        in
        p == path || (lib.strings.hasPrefix (p + "/") path)
      ) includedFiles
   ) src;
-  exclude = excludedFiles: src: lib.filterSource (path: type:
+  exclude = excludedFiles: src: builtins.filterSource (path: type:
     lib.all (f:
        !lib.strings.hasPrefix (toString (src + ("/" + f))) path
     ) excludedFiles


### PR DESCRIPTION
###### Motivation for this change
While unifying most of the lib function calls I accidentially changed
the filterSource functions as well. Since there were no tests I ended
up forgetting about this case (even thought I ran into it…).

https://github.com/NixOS/nixpkgs/pull/75563/files/0aac0e8d2c9c129bf1ed868bdc735b738b17b44e#r363462659

@xzfc Can you verify that this solves your problem?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers
