### PR TITLE
pythonPackages.pytorch-lightning: init at 0.5.3.2

### DIFF
--- a/pkgs/development/python-modules/pytorch-lightning/default.nix
+++ b/pkgs/development/python-modules/pytorch-lightning/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, scikitlearn
+, tqdm
+, numpy
+, pytorch
+, torchvision
+, pandas
+, test-tube
+, future
+, coverage
+, pytest
+, mlflow
+}:
+
+buildPythonPackage rec {
+  pname = "pytorch-lightning";
+  version = "0.5.3.2";
+
+  disabled = !isPy3k; # requires python version >=3.6
+
+  src = fetchFromGitHub {
+    owner = "williamFalcon";
+    repo = pname;
+    rev = version;
+    sha256 = "0vws85dkw2df243fgsh7c8vz9l33a57gvf6lchzb0h2v16q4h2hm";
+  };
+
+
+  # comet_ml not currently available in nixpkgs
+  # not required for pytorch-lightning
+  patchPhase = ''
+    substituteInPlace requirements.txt \
+      --replace "tqdm==4.35.0" "tqdm" \
+      --replace "numpy==1.16.4" "numpy" \
+      --replace "scikit-learn==0.20.2" "scikit-learn" \
+      --replace "torchvision>=0.3.0" "torchvision"
+    substituteInPlace pytorch_lightning/logging/__init__.py \
+      --replace "from .comet_logger import CometLogger" ""
+    rm pytorch_lightning/logging/comet_logger.py
+  '';
+    
+  propagatedBuildInputs = [
+    scikitlearn
+    tqdm
+    numpy
+    pytorch
+    torchvision
+    pandas
+    test-tube
+    future
+  ];
+  
+  # lots of network access needed: https://gist.github.com/09b804918e5ca4b7dc55bb28ca4597f5
+  doCheck = true;
+
+  checkPhase = ''
+    py.test pytorch_lightning tests pl_examples -v --doctest-modules -k not test_running_test_pretrained_model -k not test_cpu_restore_training
+  '';
+
+  
+  checkInputs = [
+    # mlflow
+    coverage
+    pytest
+  ];
+
+  meta = with lib; {
+    description = "PyTorch Lightning is the lightweight PyTorch wrapper for ML researchers";
+    homepage = https://github.com/williamFalcon/pytorch-lightning;
+    license = licenses.asl20;
+    maintainers = [ maintainers.tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/test-tube/default.nix
+++ b/pkgs/development/python-modules/test-tube/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, pandas
+, imageio
+, tensorflow-tensorboard
+, pytorch
+, future
+, tensorflow
+}:
+
+buildPythonPackage rec {
+  pname = "test-tube";
+  version = "0.7.5";
+
+  disabled = !isPy3k; # requires python version >=3.6
+
+  src = fetchFromGitHub {
+    owner = "williamFalcon";
+    repo = pname;
+    rev = version;
+    sha256 = "0zpvlp1ybp2dhgap8jsalpfdyg8ycjhlfi3xrdf5dqffqvh2yhp2";
+  };
+
+  doCheck = false;
+  checkInputs = [
+      tensorflow
+  ];
+
+  propagatedBuildInputs = [
+    pandas
+    imageio
+    tensorflow-tensorboard
+    pytorch
+    future
+  ];
+
+  meta = with lib; {
+    description = "PyTorch Lightning is the lightweight PyTorch wrapper for ML researchers. Scale your models. Write less boilerplate";
+    homepage = https://github.com/williamFalcon/pytorch-lightning;
+    license = licenses.asl20;
+    # maintainers = [ maintainers. ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5623,6 +5623,8 @@ in {
 
   testtools = callPackage ../development/python-modules/testtools { };
 
+  test-tube = callPackage ../development/python-modules/test-tube { };
+
   traitlets = callPackage ../development/python-modules/traitlets { };
 
   transitions = callPackage ../development/python-modules/transitions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1309,6 +1309,8 @@ in {
 
   pytimeparse =  callPackage ../development/python-modules/pytimeparse { };
 
+  pytorch-lightning = callPackage ../development/python-modules/pytorch-lightning { };
+
   pytricia =  callPackage ../development/python-modules/pytricia { };
 
   pytrends = callPackage ../development/python-modules/pytrends { };


### PR DESCRIPTION
###### Motivation for this change
Add PyTorch Lightning, the lightweight PyTorch wrapper for ML researchers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
