### PR TITLE
ceph: 14.2.4 -> 14.2.5

### DIFF
--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -17,6 +17,11 @@ let
       key = "AQBEEJNac00kExAAXEgy943BGyOpVH1LLlHafQ==";
       uuid = "5e97a838-85b6-43b0-8950-cb56d554d1e5";
     };
+    osd2 = {
+      name = "2";
+      key = "AQAdyhZeIaUlARAAGRoidDAmS6Vkp546UFEf5w==";
+      uuid = "ea999274-13d0-4dd5-9af9-ad25a324f72f";
+    };
   };
   generateCephConfig = { daemonConfig }: {
     enable = true;
@@ -30,7 +35,7 @@ let
   generateHost = { pkgs, cephConfig, networkConfig, ... }: {
     virtualisation = {
       memorySize = 512;
-      emptyDiskImages = [ 20480 20480 ];
+      emptyDiskImages = [ 20480 20480 20480 ];
       vlans = [ 1 ];
     };
 
@@ -65,7 +70,7 @@ let
     };
     osd = {
       enable = true;
-      daemons = [ cfg.osd0.name cfg.osd1.name ];
+      daemons = [ cfg.osd0.name cfg.osd1.name cfg.osd2.name ];
     };
   }; };
 
@@ -104,29 +109,36 @@ let
     monA.wait_until_succeeds("ceph -s | grep 'quorum ${cfg.monA.name}'")
     monA.wait_until_succeeds("ceph -s | grep 'mgr: ${cfg.monA.name}(active,'")
 
-    # Bootstrap both OSDs
+    # Bootstrap OSDs
     monA.succeed(
         "mkfs.xfs /dev/vdb",
         "mkfs.xfs /dev/vdc",
+        "mkfs.xfs /dev/vdd",
         "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd0.name}",
         "mount /dev/vdb /var/lib/ceph/osd/ceph-${cfg.osd0.name}",
         "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd1.name}",
         "mount /dev/vdc /var/lib/ceph/osd/ceph-${cfg.osd1.name}",
+        "mkdir -p /var/lib/ceph/osd/ceph-${cfg.osd2.name}",
+        "mount /dev/vdd /var/lib/ceph/osd/ceph-${cfg.osd2.name}",
         "ceph-authtool --create-keyring /var/lib/ceph/osd/ceph-${cfg.osd0.name}/keyring --name osd.${cfg.osd0.name} --add-key ${cfg.osd0.key}",
         "ceph-authtool --create-keyring /var/lib/ceph/osd/ceph-${cfg.osd1.name}/keyring --name osd.${cfg.osd1.name} --add-key ${cfg.osd1.key}",
+        "ceph-authtool --create-keyring /var/lib/ceph/osd/ceph-${cfg.osd2.name}/keyring --name osd.${cfg.osd2.name} --add-key ${cfg.osd2.key}",
         'echo \'{"cephx_secret": "${cfg.osd0.key}"}\' | ceph osd new ${cfg.osd0.uuid} -i -',
         'echo \'{"cephx_secret": "${cfg.osd1.key}"}\' | ceph osd new ${cfg.osd1.uuid} -i -',
+        'echo \'{"cephx_secret": "${cfg.osd2.key}"}\' | ceph osd new ${cfg.osd2.uuid} -i -',
     )
 
     # Initialize the OSDs with regular filestore
     monA.succeed(
         "ceph-osd -i ${cfg.osd0.name} --mkfs --osd-uuid ${cfg.osd0.uuid}",
         "ceph-osd -i ${cfg.osd1.name} --mkfs --osd-uuid ${cfg.osd1.uuid}",
+        "ceph-osd -i ${cfg.osd2.name} --mkfs --osd-uuid ${cfg.osd2.uuid}",
         "chown -R ceph:ceph /var/lib/ceph/osd",
         "systemctl start ceph-osd-${cfg.osd0.name}",
         "systemctl start ceph-osd-${cfg.osd1.name}",
+        "systemctl start ceph-osd-${cfg.osd2.name}",
     )
-    monA.wait_until_succeeds("ceph osd stat | grep -e '2 osds: 2 up[^,]*, 2 in'")
+    monA.wait_until_succeeds("ceph osd stat | grep -e '3 osds: 3 up[^,]*, 3 in'")
     monA.wait_until_succeeds("ceph -s | grep 'mgr: ${cfg.monA.name}(active,'")
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
 
@@ -161,11 +173,12 @@ let
     monA.wait_for_unit("ceph-mgr-${cfg.monA.name}")
     monA.wait_for_unit("ceph-osd-${cfg.osd0.name}")
     monA.wait_for_unit("ceph-osd-${cfg.osd1.name}")
+    monA.wait_for_unit("ceph-osd-${cfg.osd2.name}")
 
     # Ensure the cluster comes back up again
     monA.succeed("ceph -s | grep 'mon: 1 daemons'")
     monA.wait_until_succeeds("ceph -s | grep 'quorum ${cfg.monA.name}'")
-    monA.wait_until_succeeds("ceph osd stat | grep -e '2 osds: 2 up[^,]*, 2 in'")
+    monA.wait_until_succeeds("ceph osd stat | grep -e '3 osds: 3 up[^,]*, 3 in'")
     monA.wait_until_succeeds("ceph -s | grep 'mgr: ${cfg.monA.name}(active,'")
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
   '';

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -10,6 +10,7 @@
 , cunit, snappy
 , rocksdb, makeWrapper
 , leveldb, oathToolkit
+, libnl, libcap_ng
 
 # Optional Dependencies
 , yasm ? null, fcgi ? null, expat ? null
@@ -88,9 +89,10 @@ let
     ps.webob
     ps.bcrypt
     ps.six
+    ps.pyyaml
   ]);
 
-  version = "14.2.4";
+  version = "14.2.5";
 in rec {
   ceph = stdenv.mkDerivation {
     pname = "ceph";
@@ -98,7 +100,7 @@ in rec {
 
     src = fetchurl {
       url = "http://download.ceph.com/tarballs/ceph-${version}.tar.gz";
-      sha256 = "1y6hixh6srd5aswhzq0sf0dbygwhx0ardx3w3f7qazf5rapvd03i";
+      sha256 = "0wbkdplxs8higmlj57a7rydmx9rq08h0arjrmxmp0s80bn0v5x2c";
     };
 
     patches = [
@@ -116,7 +118,7 @@ in rec {
     buildInputs = cryptoLibsMap.${cryptoStr} ++ [
       boost ceph-python-env libxml2 optYasm optLibatomic_ops optLibs3
       malloc zlib openldap lttng-ust babeltrace gperf gtest cunit
-      snappy rocksdb lz4 oathToolkit leveldb
+      snappy rocksdb lz4 oathToolkit leveldb libnl libcap_ng
     ] ++ optionals stdenv.isLinux [
       linuxHeaders utillinux libuuid udev keyutils optLibaio optLibxfs optZfs
       # ceph 14


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes a critical integrity bug n 14.2.3 and 14.2.4. Adds newly required deps on libnl and libcap_ng.

This needs backporting to 19.09, but I think we should also backport the various fixes to rocksdb etc. before doing so. I can author that.

WIP while my poor laptop chugs away at building it...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
