### PR TITLE
libev: Add statically linked `libev` to `pkgsStatic`

### DIFF
--- a/pkgs/development/libraries/libev/default.nix
+++ b/pkgs/development/libraries/libev/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, static ? false }:
 
 stdenv.mkDerivation rec {
   pname = "libev";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     url = "http://dist.schmorp.de/libev/Attic/${pname}-${version}.tar.gz";
     sha256 = "0kil23cgsp0r5shvnwwbsy7fzxb62sxqzqbkbkfp5w54ipy2cm9d";
   };
+
+  configureFlags = stdenv.lib.optional (static) "LDFLAGS=-static";
 
   meta = {
     description = "A high-performance event loop/event model with lots of features";

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -197,4 +197,6 @@ in {
   };
 
   python27 = super.python27.override { static = true; };
+
+  libev = super.libev.override { static = true; };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I have a use case for compiling a fully static binary with `libev`. I added this my project and it worked nicely.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @r-ryantm 
