### PR TITLE
ocamlPackages.lwt_ppx: use independent source from lwt

### DIFF
--- a/pkgs/development/ocaml-modules/lwt/ppx.nix
+++ b/pkgs/development/ocaml-modules/lwt/ppx.nix
@@ -1,9 +1,21 @@
-{ buildDunePackage, lwt, ppx_tools_versioned }:
+{ fetchzip, buildDunePackage, lwt, ppx_tools_versioned }:
 
 buildDunePackage {
   pname = "lwt_ppx";
+  version = "1.2.4";
 
-  inherit (lwt) src version;
+  src = fetchzip {
+    # `lwt_ppx` has a different release cycle than Lwt, but it's included in
+    # one of its release bundles.
+    # Because there could exist an Lwt release _without_ a `lwt_ppx` release,
+    # this `src` field doesn't inherit from the Lwt derivation.
+    #
+    # This is particularly useful for overriding Lwt without breaking `lwt_ppx`,
+    # as new Lwt releases may contain broken `lwt_ppx` code.
+    url = "https://github.com/ocsigen/lwt/archive/4.4.0.tar.gz";
+    sha256 = "1l97zdcql7y13fhaq0m9n9xvxf712jg0w70r72fvv6j49xm4nlhi";
+  };
+
 
   propagatedBuildInputs = [ lwt ppx_tools_versioned ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I also added a comment in the packaging code itself, but basically Lwt does sometimes release versions without releasing `lwt_ppx`. In those versions, a broken lwt_ppx package will be in these lwt release tarballs without dev-time helper dependendency declarations stripped (`bisect_ppx`), causing an error building the lwt_ppx package.

Additionally, the versioning scheme for lwt_ppx is different than Lwt's own version; this diff also fixes that.

Tagging Lwt maintainer @aantron for confirmation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vbgl @Zimmi48 (git history)
