### PR TITLE
bash: enable PGRP_PIPE when building on recent kernels as well #77055

### DIFF
--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -41,9 +41,10 @@ stdenv.mkDerivation rec {
     -DSSH_SOURCE_BASHRC
   '';
 
-  patchFlags = [ "-p0" ];
+  patchFlags = [ "-p0" "-T" ];
 
   patches = upstreamPatches
+    ++ [ ./pgrp-pipe-4.4.patch ]
     ++ optional stdenv.hostPlatform.isCygwin ./cygwin-bash-4.4.11-2.src.patch
     # https://lists.gnu.org/archive/html/bug-bash/2016-10/msg00006.html
     ++ optional stdenv.hostPlatform.isMusl (fetchurl {

--- a/pkgs/shells/bash/5.0.nix
+++ b/pkgs/shells/bash/5.0.nix
@@ -41,9 +41,10 @@ stdenv.mkDerivation rec {
     -DSSH_SOURCE_BASHRC
   '';
 
-  patchFlags = [ "-p0" ];
+  patchFlags = [ "-p0" "-T" ];
 
-  patches = upstreamPatches;
+  patches = upstreamPatches
+    ++ [ ./pgrp-pipe-5.0.patch ];
 
   configureFlags = [
     (if interactive then "--with-installed-readline" else "--disable-readline")

--- a/pkgs/shells/bash/pgrp-pipe-4.4.patch
+++ b/pkgs/shells/bash/pgrp-pipe-4.4.patch
@@ -1,0 +1,29 @@
+diff -u ./configure ../bash-4.4-fixed/configure
+--- ./configure	2016-09-07 22:57:01.000000000 +0200
++++ ../bash-4.4-fixed/configure	2020-01-08 14:10:26.316858174 +0100
+@@ -16064,10 +16064,7 @@
+ solaris2*)	LOCAL_CFLAGS=-DSOLARIS ;;
+ lynxos*)	LOCAL_CFLAGS=-DRECYCLES_PIDS ;;
+ linux*)		LOCAL_LDFLAGS=-rdynamic		 # allow dynamic loading
+-		case "`uname -r`" in
+-		2.[456789]*|[34]*)	$as_echo "#define PGRP_PIPE 1" >>confdefs.h
+- ;;
+-		esac ;;
++		$as_echo "#define PGRP_PIPE 1" >>confdefs.h ;;
+ *qnx6*)		LOCAL_CFLAGS="-Dqnx -Dqnx6" LOCAL_LIBS="-lncurses" ;;
+ *qnx*)		LOCAL_CFLAGS="-Dqnx -F -3s" LOCAL_LDFLAGS="-3s" LOCAL_LIBS="-lunix -lncurses" ;;
+ powerux*)	LOCAL_LIBS="-lgen" ;;
+diff -u ./configure.ac ../bash-4.4-fixed/configure.ac
+--- ./configure.ac	2016-09-07 22:56:28.000000000 +0200
++++ ../bash-4.4-fixed/configure.ac	2016-09-07 22:56:28.000000000 +0200
+@@ -1092,9 +1092,7 @@
+ solaris2*)	LOCAL_CFLAGS=-DSOLARIS ;;
+ lynxos*)	LOCAL_CFLAGS=-DRECYCLES_PIDS ;;
+ linux*)		LOCAL_LDFLAGS=-rdynamic		 # allow dynamic loading
+-		case "`uname -r`" in
+-		2.[[456789]]*|[[34]]*)	AC_DEFINE(PGRP_PIPE) ;;
+-		esac ;;
++		AC_DEFINE(PGRP_PIPE) ;;
+ *qnx6*)		LOCAL_CFLAGS="-Dqnx -Dqnx6" LOCAL_LIBS="-lncurses" ;;
+ *qnx*)		LOCAL_CFLAGS="-Dqnx -F -3s" LOCAL_LDFLAGS="-3s" LOCAL_LIBS="-lunix -lncurses" ;;
+ powerux*)	LOCAL_LIBS="-lgen" ;;

--- a/pkgs/shells/bash/pgrp-pipe-5.0.patch
+++ b/pkgs/shells/bash/pgrp-pipe-5.0.patch
@@ -1,0 +1,31 @@
+diff -u ./configure ../bash-5.0-fixed/configure
+--- ./configure	2019-01-02 15:43:31.000000000 +0100
++++ ../bash-5.0-fixed/configure	2020-01-08 14:18:21.017296179 +0100
+@@ -16312,11 +16312,7 @@
+ solaris2*)	LOCAL_CFLAGS=-DSOLARIS ;;
+ lynxos*)	LOCAL_CFLAGS=-DRECYCLES_PIDS ;;
+ linux*)		LOCAL_LDFLAGS=-rdynamic		 # allow dynamic loading
+-		case "`uname -r`" in
+-		1.*|2.[0123]*)	: ;;
+-		*)	$as_echo "#define PGRP_PIPE 1" >>confdefs.h
+- ;;
+-		esac ;;
++		$as_echo "#define PGRP_PIPE 1" >>confdefs.h ;;
+ netbsd*|openbsd*)	LOCAL_CFLAGS="-DDEV_FD_STAT_BROKEN" ;;
+ *qnx[67]*)	LOCAL_LIBS="-lncurses" ;;
+ *qnx*)		LOCAL_CFLAGS="-Dqnx -F -3s" LOCAL_LDFLAGS="-3s" LOCAL_LIBS="-lunix -lncurses" ;;
+diff -u ./configure.ac ../bash-5.0-fixed/configure.ac
+--- ./configure.ac	2019-01-02 15:39:11.000000000 +0100
++++ ../bash-5.0-fixed/configure.ac	2019-01-02 15:39:11.000000000 +0100
+@@ -1108,10 +1108,7 @@
+ solaris2*)	LOCAL_CFLAGS=-DSOLARIS ;;
+ lynxos*)	LOCAL_CFLAGS=-DRECYCLES_PIDS ;;
+ linux*)		LOCAL_LDFLAGS=-rdynamic		 # allow dynamic loading
+-		case "`uname -r`" in
+-		1.*|2.[[0123]]*)	: ;;
+-		*)	AC_DEFINE(PGRP_PIPE) ;;
+-		esac ;;
++		AC_DEFINE(PGRP_PIPE) ;;
+ netbsd*|openbsd*)	LOCAL_CFLAGS="-DDEV_FD_STAT_BROKEN" ;;
+ *qnx[[67]]*)	LOCAL_LIBS="-lncurses" ;;
+ *qnx*)		LOCAL_CFLAGS="-Dqnx -F -3s" LOCAL_LDFLAGS="-3s" LOCAL_LIBS="-lunix -lncurses" ;;


### PR DESCRIPTION
## Motivation for this change

Hydra currently builds bash 4.4 correctly, but due to a limitation of the configure.ac it would incorrectly omit PGRP_PIPE when building on systems with more recent kernels. This has been fixed upstream in bash 5.0, and this PR pulls in that fix for 4.4 as well. See also #77055

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @matthewbauer 
