### PR TITLE
lorri: set version correctly

### DIFF
--- a/pkgs/tools/misc/lorri/default.nix
+++ b/pkgs/tools/misc/lorri/default.nix
@@ -12,29 +12,39 @@
 , Security
 }:
 
-rustPlatform.buildRustPackage rec {
+let
   pname = "lorri";
+  owner = "target";
+  homepage = "https://github.com/${owner}/${pname}";
+  repoUrl = "${homepage}.git";
+
+  # Run `eval $(nix-build -A lorri.updater)` after updating the revision!
+  rev = "03f10395943449b1fc5026d3386ab8c94c520ee3";
+in
+rustPlatform.buildRustPackage rec {
+  inherit pname;
   version = "unstable-2019-10-30";
 
   meta = with stdenv.lib; {
+    inherit homepage;
     description = "Your project's nix-env";
-    homepage = "https://github.com/target/lorri";
     license = licenses.asl20;
     maintainers = with maintainers; [ grahamc Profpatsch ];
   };
 
   src = fetchFromGitHub {
-    owner = "target";
+    inherit rev owner;
     repo = pname;
-    # Run `eval $(nix-build -A lorri.updater)` after updating the revision!
-    rev = "03f10395943449b1fc5026d3386ab8c94c520ee3";
     sha256 = "0fcl79ndaziwd8d74mk1lsijz34p2inn64b4b4am3wsyk184brzq";
   };
 
   cargoSha256 = "1daff4plh7hwclfp21hkx4fiflh9r80y2c7k2sd3zm4lmpy0jpfz";
   doCheck = false;
 
-  BUILD_REV_COUNT = src.revCount or 1;
+  # Run `eval $(nix-build -A lorri.updater)` after updating the revision to
+  # update BUILD_REV_COUNT.
+  BUILD_REV_COUNT = 310;
+
   RUN_TIME_CLOSURE = pkgs.callPackage ./runtime.nix {};
 
   nativeBuildInputs = with pkgs; [ nix direnv which ];
@@ -47,6 +57,18 @@ rustPlatform.buildRustPackage rec {
       set -euo pipefail
       cp ${src}/nix/runtime.nix ${toString ./runtime.nix}
       cp ${src}/nix/runtime-closure.nix.template ${toString ./runtime-closure.nix.template}
+
+      TMP=$(mktemp -d)
+      pushd $TMP > /dev/null
+      git clone ${repoUrl} > /dev/null 2> /dev/null
+      cd lorri
+      git checkout ${rev} > /dev/null 2> /dev/null
+      REV_COUNT="$(git log --pretty=%h | wc -l)"
+      popd > /dev/null
+      rm -rf $TMP
+
+      echo "BUILD_REV_COUNT = $REV_COUNT"
+      sed -i -e "s/^  BUILD_REV_COUNT = .\+;$/  BUILD_REV_COUNT = $REV_COUNT;/" ${toString ./default.nix}
     '';
     tests = {
       nixos = nixosTests.lorri;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Currently the lorri version is always reported as "1" because the result of `fetchFromGitHub` does not have a `revCount` field. This is a problem when we're trying to support lorri users because we don't know which version they are on.

More context: https://github.com/target/lorri/issues/219.

Before this change:

```console
$ ~/Code/nixpkgs/result/bin/lorri info
lorri version: 1
Lorri Project Configuration

expression: <path>/shell.nix
```

After this change:

```console
$ ~/Code/nixpkgs/result/bin/lorri info
lorri version: 310
Lorri Project Configuration

expression: <path>/shell.nix
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
