### PR TITLE
jitterentropy: make man pages reproducible

### DIFF
--- a/pkgs/development/libraries/jitterentropy/default.nix
+++ b/pkgs/development/libraries/jitterentropy/default.nix
@@ -9,6 +9,10 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0n2l1fxr7bynnarpwdjifb2fvlsq8w5wmfh31yk5nrc756cjlgyw";
   };
+  patches = [
+    # Can be removed when upgrading beyond 2.2.0
+    ./reproducible-manpages.patch
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/jitterentropy/reproducible-manpages.patch
+++ b/pkgs/development/libraries/jitterentropy/reproducible-manpages.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 4ff069b..3b8714a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -58,7 +58,7 @@ cppcheck:
+ install:
+ 	install -d -m 0755 $(DESTDIR)$(PREFIX)/share/man/man3
+ 	install -m 644 doc/$(NAME).3 $(DESTDIR)$(PREFIX)/share/man/man3/
+-	gzip -9 $(DESTDIR)$(PREFIX)/share/man/man3/$(NAME).3
++	gzip -n -9 $(DESTDIR)$(PREFIX)/share/man/man3/$(NAME).3
+ 	install -d -m 0755 $(DESTDIR)$(PREFIX)/$(LIBDIR)
+ 	install -m 0755 -s lib$(NAME).so.$(LIBVERSION) $(DESTDIR)$(PREFIX)/$(LIBDIR)/
+ 	install -d -m 0755 $(DESTDIR)$(PREFIX)/$(INCDIR)


### PR DESCRIPTION
###### Motivation for this change

Makes the package reproducible in the `nix-build '<nixpkgs>' -A jitterentropy --check` sense

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @JohnAZoidberg 
