### PR TITLE
python3Packages.pyspf: 2.0.14pre -> 2.0.14

### DIFF
--- a/pkgs/development/python-modules/pyspf/default.nix
+++ b/pkgs/development/python-modules/pyspf/default.nix
@@ -1,17 +1,20 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pydns }:
+{ lib, python, buildPythonPackage, fetchFromGitHub, pydns }:
 
 buildPythonPackage rec {
   pname = "pyspf";
-  version = "2.0.14pre1";
+  version = "2.0.14";
 
   src = fetchFromGitHub {
     owner = "sdgathman";
     repo = pname;
     rev = "pyspf-${version}";
-    sha256 = "17d8namkrsmmhc6p4226pffgafivn59qqlj42sq3sma10i09r0c2";
+    sha256 = "0bmimlmwrq9glnjc4i6pwch30n3y5wyqmkjfyayxqxkfrixqwydi";
   };
 
   propagatedBuildInputs = [ pydns ];
+
+  # requires /etc/resolv.conf to exist
+  doCheck = false;
 
   meta = with lib; {
     homepage = http://bmsi.com/python/milter.html;


### PR DESCRIPTION
###### Motivation for this change
follow up to: https://github.com/NixOS/nixpkgs/pull/75604
closes https://github.com/NixOS/nixpkgs/pull/77204

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

```
[5 built, 2 copied (0.1 MiB), 0.1 MiB DL]
https://github.com/NixOS/nixpkgs/pull/77208
4 package built:
pypolicyd-spf python27Packages.pyspf python37Packages.pyspf python38Packages.pyspf
```