### PR TITLE
berglas: 0.2.1 -> 0.5.0

### DIFF
--- a/pkgs/tools/admin/berglas/default.nix
+++ b/pkgs/tools/admin/berglas/default.nix
@@ -3,16 +3,16 @@
 buildGoModule rec {
 
   name = "berglas-${version}";
-  version = "0.2.1";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "berglas";
-    rev = "v0.2.1";
-    sha256 = "1m34rxiynmgsris1avjn7am50b8sds77515zlnna9qvsrywbzljc";
+    rev = "v0.5.0";
+    sha256 = "1y5w2czipwj069w4zxnyb9xqv5mx0yjjramykf3vm3q478bk3rm7";
   };
 
-  modSha256 = "0lfcrsb4r5hxxd652cxff23fnbrphp3lgwp5anpaddzcjcd2qyj8";
+  modSha256 = "0y4ajii3pv25s4gjazf6fl0b9wax17cmwhbmiybqhp61annca7kr";
 
   meta = with stdenv.lib; {
     description = "A tool for managing secrets on Google Cloud";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Regular package update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

r? @andir 