### PR TITLE
gcolor2: sha1 -> sha256

### DIFF
--- a/pkgs/applications/graphics/gcolor2/default.nix
+++ b/pkgs/applications/graphics/gcolor2/default.nix
@@ -8,8 +8,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/project/gcolor2/gcolor2/${version}/gcolor2-${version}.tar.bz2";
-    sha1 = "e410a52dcff3d5c6c3d448b68a026d04ccd744be";
-
+    sha256 = "1siv54vwx9dbfcflklvf7pkp5lk6h3nn63flg6jzifz9wp0c84q6";
   };
 
   preConfigure = ''


### PR DESCRIPTION
related to: https://github.com/NixOS/nixpkgs/issues/77238

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
