### PR TITLE
google_talk_plugin: sha1 -> sha256

### DIFF
--- a/pkgs/applications/networking/browsers/mozilla-plugins/google-talk-plugin/default.nix
+++ b/pkgs/applications/networking/browsers/mozilla-plugins/google-talk-plugin/default.nix
@@ -48,21 +48,21 @@ in
 stdenv.mkDerivation rec {
   pname = "google-talk-plugin";
 
-  # You can get the upstream version and SHA-1 hash from the following URLs:
-  # curl -s http://dl.google.com/linux/talkplugin/deb/dists/stable/main/binary-amd64/Packages | grep -E 'Version|SHA1'
-  # curl -s http://dl.google.com/linux/talkplugin/deb/dists/stable/main/binary-i386/Packages | grep -E 'Version|SHA1'
+  # You can get the upstream version and SHA-256 hash from the following URLs:
+  # curl -s http://dl.google.com/linux/talkplugin/deb/dists/stable/main/binary-amd64/Packages | grep -E 'Version|SHA256'
+  # curl -s http://dl.google.com/linux/talkplugin/deb/dists/stable/main/binary-i386/Packages | grep -E 'Version|SHA256'
   version = "5.41.3.0";
 
   src =
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "${baseURL}/google-talkplugin_${version}-1_amd64.deb";
-        sha1 = "0bbc3d6997ba22ce712d93e5bc336c894b54fc81";
+        sha256 = "af7e23d2b6215afc547f96615b99f04e0561557cc58c0c9302364b5a3840d97d";
       }
     else if stdenv.hostPlatform.system == "i686-linux" then
       fetchurl {
         url = "${baseURL}/google-talkplugin_${version}-1_i386.deb";
-        sha1 = "6eae0544858f85c68b0cc46d7786e990bd94f139";
+        sha256 = "4c46d2b7f2018640288cd7ac49adc47e309d0beadfd979eb03030e672016b4a7";
       }
     else throw "Google Talk does not support your platform.";
 


### PR DESCRIPTION
related to https://github.com/NixOS/nixpkgs/issues/77238

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
