### PR TITLE
fselect: 0.6.7 -> 0.6.8

### DIFF
--- a/pkgs/tools/misc/fselect/default.nix
+++ b/pkgs/tools/misc/fselect/default.nix
@@ -2,22 +2,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "fselect";
-  version = "0.6.7";
+  version = "0.6.8";
 
   src = fetchFromGitHub {
     owner = "jhspetersson";
     repo = "fselect";
     rev = version;
-    sha256 = "0pg3ahx8rmzr585qa4vphd1vxcm1r3sx5iyi8ghg5nn6sibqy0z4";
+    sha256 = "1zccl60l557lhaaqb33myys4vp3jsnjqh3dxb22i46bff28s1w6c";
   };
 
-  cargoSha256 = "0yf3xkxxlb9252r869wbiv3b3kpz4p5gp556sic63bp0acig6a76";
+  cargoSha256 = "1496zjrkwj5bv08k575m064x0hfk0gpci0dmxvvspj6jf8f8bfm6";
 
   meta = with stdenv.lib; {
     description = "Find files with SQL-like queries";
     homepage = "https://github.com/jhspetersson/fselect";
     license = with licenses; [ asl20 mit ];
-    maintainers = [ maintainers.filalex77 ];
+    maintainers = with maintainers; [ filalex77 ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/jhspetersson/fselect/releases/tag/0.6.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/6fnhs4ghx6wvv15fgykma1nipmiyv0za-fselect-0.6.7	  30.2M
/nix/store/mhwx6cyk8s8m10dgzxgmsdxj3mx7h6p4-fselect-0.6.8     30.3M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/77247)
<!-- Reviewable:end -->
