### PR TITLE
Updates to awscli, botocore, boto3

### DIFF
--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname =  "boto3";
-  version = "1.10.1"; # N.B: if you change this, change botocore too
+  version = "1.10.47"; # N.B: if you change this, change botocore too
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2904bfb928116fea3a83247de6c3687eb9bf942d764e361f5574d5ac11be2ad3";
+    sha256 = "05nqqrmqdsqa9k10v0f72wlk9dd7m91bcfacxdjj9fi5vzc39cdk";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -12,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.13.2"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.13.47"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "8223485841ef4731a5d4943a733295ba69d0005c4ae64c468308cc07f6960d39";
+    sha256 = "0whjfwd8d3l67b8hbnf666pcn4n8fdz3qajjwl68jn4mxk2pq655";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -36,11 +36,11 @@ let
 
 in py.pkgs.buildPythonApplication rec {
   pname = "awscli";
-  version = "1.16.266"; # N.B: if you change this, change botocore to a matching version too
+  version = "1.16.311"; # N.B: if you change this, change botocore to a matching version too
 
   src = py.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "9c59a5ca805f467669d471b29550ecafafb9b380a4a6926a9f8866f71cd4f7be";
+    sha256 = "03rddgn6dw1nppkap1phswhzifrjzap9367pzxl58pbqiq3jn5kj";
   };
 
   # No tests included


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Necessary updates for Python 3.7 support

Previously, the following errors would occur:

```
$ aws eks update-kubeconfig --region eu-west-1 --name myeks
Error in sitecustomize; set PYTHONVERBOSE for traceback:
ImportError: This package should not be accessible on Python 3. Either you are trying to run from the python-future src folder or your installation of python-future is corrupted.
Traceback (most recent call last):
  File "/nix/store/3ghbq3qk5l2bwm0cb67b4cygvwrq2c8y-awscli-1.16.266/bin/.aws-wrapped", line 14, in <module>
    import sys;import site;import functools;sys.argv[0] = '/nix/store/3ghbq3qk5l2bwm0cb67b4cygvwrq2c8y-awscli-1.16.266/bin/aws';functools.reduce(lambda k, p: site.addsitedir(p, k), ['/nix/store/3ghbq3qk5l2bwm0cb67b4cygvwrq2c8y-awscli-1.16.266/lib/python3.7/site-packages','/nix/store/xg8pj5pg4s16kgicfrgxm8fgm628xg5n-python3.7-python-dateutil-2.8.0/lib/python3.7/site-packages','/nix/store/1i37v0b8a6f0pd641piilncn62b5hr3p-python3.7-six-1.12.0/lib/python3.7/site-packages','/nix/store/8cq0n5r6d7rkidifbsxqkap9imnn44rf-python3.7-setuptools_scm-3.3.3/lib/python3.7/site-packages','/nix/store/g1ys9jixq2c7c6pyxyiyj80473b9nd08-python3.7-jmespath-0.9.4/lib/python3.7/site-packages','/nix/store/ilyfy7vlz59nkidykfcbldicx01qqqlm-python3.7-ply-3.11/lib/python3.7/site-packages','/nix/store/05wprk4fbwya0n4gyzkrdy025qshqafn-python3.7-docutils-0.15.2/lib/python3.7/site-packages','/nix/store/vqcrkscy19pjnksjwghwv6fl780l3g7n-python3.7-ordereddict-1.1/lib/python3.7/site-packages','/nix/store/yz636bbhkfgb1rxa409gi9ycz8cf5r64-python3.7-simplejson-3.16.1/lib/python3.7/site-packages','/nix/store/yrjsqxgkdlhx29add6gda94wqsiwxjx3-python3.7-packaging-19.2/lib/python3.7/site-packages','/nix/store/9zy703cqhlyrc5y37i8jlb4346amqwm8-python3.7-pyparsing-2.4.2/lib/python3.7/site-packages','/nix/store/nhmpshasnqqll40qxbggm5pvgngqb8lv-python3.7-pycparser-2.19/lib/python3.7/site-packages','/nix/store/snz1pawsryw17p6cxay3wc51asb5g5f6-python3.7-cffi-1.13.1/lib/python3.7/site-packages','/nix/store/i9fm8y7ndbz0z1n3y303ycmmdmmnf0r1-python3.7-cryptography-2.8/lib/python3.7/site-packages','/nix/store/9fwq2sg80c66ijnk66xjkhyp82riq64k-python3.7-pyasn1-0.4.7/lib/python3.7/site-packages','/nix/store/sg4ygzhfc031fzd8h75jii3mwl1ic591-python3.7-idna-2.8/lib/python3.7/site-packages','/nix/store/dwxqmi066sm6yb5zssm04vj3zqkj08aa-python3.7-pyOpenSSL-19.0.0/lib/python3.7/site-packages','/nix/store/70ryp2dkr8xmcmwl3w4xnfxrqxc9kngf-python3.7-certifi-2019.9.11/lib/python3.7/site-packages','/nix/store/iadmc74iddhvvhkgqanxh2q7pcr07nbm-python3.7-pysocks-1.7.0/lib/python3.7/site-packages','/nix/store/7pwryyy1m8pkvd2y1936m1pzl4frs3sm-python3.7-urllib3-1.25.6/lib/python3.7/site-packages','/nix/store/rn2fknpwcs7dsac20bziyjgs7rnxz2d0-python3.7-botocore-1.13.2/lib/python3.7/site-packages','/nix/store/7c15acqm9ifp6bgx375xpclgs243kxfb-python3.7-bcdoc-0.16.0/lib/python3.7/site-packages','/nix/store/6dg4v631him6nr0cnqagbmj9vrgjp1nb-python3.7-s3transfer-0.2.1/lib/python3.7/site-packages','/nix/store/xj394bh0x3g2szlapc8dyf3wi5za6ql5-python3.7-colorama-0.4.1/lib/python3.7/site-packages','/nix/store/zjwcyd346zbma44mna5s7g1nw8bm640x-python3.7-rsa-3.4.2/lib/python3.7/site-packages','/nix/store/2493yirzz17js8l4byiijqkspshp2s5b-python3.7-PyYAML-5.1.2/lib/python3.7/site-packages'], site._init_pathinfo());
  File "/nix/store/zdh16dcvjw99ybam59zd2ijb6bx138j0-python3-3.7.5/lib/python3.7/functools.py", line 21, in <module>
    from collections import namedtuple
  File "/nix/store/zdh16dcvjw99ybam59zd2ijb6bx138j0-python3-3.7.5/lib/python3.7/collections/__init__.py", line 27, in <module>
    from reprlib import recursive_repr as _recursive_repr
  File "/nix/store/wsp0hvpba4bbk0vwirgibdrs82mfnyvc-python2.7-future-0.18.2/lib/python2.7/site-packages/reprlib/__init__.py", line 7, in <module>
    raise ImportError('This package should not be accessible on Python 3. '
ImportError: This package should not be accessible on Python 3. Either you are trying to run from the python-future src folder or your installation of python-future is corrupted.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

