### PR TITLE
pythonPackages.dodgy: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/dodgy/default.nix
+++ b/pkgs/development/python-modules/dodgy/default.nix
@@ -1,0 +1,40 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, isPy3k
+, lib
+
+# pythonPackages
+, mock
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "dodgy";
+  version = "0.2.1";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "landscapeio";
+    repo = pname;
+    rev = version;
+    sha256 = "0ywwjpz0p6ls3hp1lndjr9ql6s5lkj7dgpll1h87w04kwan70j0x";
+  };
+
+  checkInputs = [
+    mock
+    nose
+  ];
+
+  checkPhase = ''
+    nosetests tests/test_checks.py
+  '';
+
+  meta = with lib; {
+    description = "Looks at Python code to search for things which look \"dodgy\" such as passwords or diffs";
+    homepage = "https://github.com/landscapeio/dodgy";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15120,6 +15120,8 @@ in
 
   do-agent = callPackage ../servers/monitoring/do-agent { };
 
+  dodgy = with python3Packages; toPythonApplication dodgy;
+
   dovecot = callPackage ../servers/mail/dovecot { };
   dovecot_pigeonhole = callPackage ../servers/mail/dovecot/plugins/pigeonhole { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1852,6 +1852,8 @@ in {
 
   defusedxml = callPackage ../development/python-modules/defusedxml {};
 
+  dodgy = callPackage ../development/python-modules/dodgy { };
+
   dugong = callPackage ../development/python-modules/dugong {};
 
   easysnmp = callPackage ../development/python-modules/easysnmp {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

dodgy is a nice tool to check for secrets in source code

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @

###### nix-review rev HEAD plus bynary test

```
kamado:~/Documents/nixpkgs$ nix-review rev HEAD
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nix-review/0
From https://github.com/NixOS/nixpkgs
   0b7b588de24..7d7d41f7b5e  master     -> refs/nix-review/0
$ git worktree add /home/kamado/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc/nixpkgs 7d7d41f7b5e0e8339384ecd9a1d6837b0df3902a
Preparing worktree (detached HEAD 7d7d41f7b5e)
HEAD is now at 7d7d41f7b5e Merge pull request #74912 from edef1c/pounce
$ nix-env -f /home/kamado/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit f4e8dbce45692e3862c106311630532763bb51fc
Updating 7d7d41f7b5e..f4e8dbce456
Fast-forward
 pkgs/development/python-modules/dodgy/default.nix | 33 +++++++++++++++++++++++++++++++++
 pkgs/top-level/all-packages.nix                   |  2 ++
 pkgs/top-level/python-packages.nix                |  2 ++
 3 files changed, 37 insertions(+)
 create mode 100644 pkgs/development/python-modules/dodgy/default.nix
$ nix-env -f /home/kamado/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc/nixpkgs -qaP --xml --out-path --show-trace --meta
$ nix build --no-link --keep-going --max-jobs 4 --option build-use-sandbox true -f /home/kamado/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc/build.nix
[1 built, 0.0 MiB DL]
2 package were built:
dodgy python38Packages.dodgy

$ nix-shell /home/kamado/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc/shell.nix
these paths will be fetched (1.51 MiB download, 8.27 MiB unpacked):
  /nix/store/6n34bphaagi53sv2zfk3x56z5b5vbccd-bash-interactive-4.4-p23-man
  /nix/store/c3pjljc2ha0jspsban2lfalqkzv2ncn5-readline-7.0p5
  /nix/store/g1fpiz69s4l8yk4gjsly5hwbr3nm64i5-bash-interactive-4.4-p23-info
  /nix/store/ixhlw5k9ziazafxkn74wvg36kbv5vl4f-bash-interactive-4.4-p23-doc
  /nix/store/jw8pwmn1g55pymkmshcwghyv2z13k5n3-bash-interactive-4.4-p23-dev
  /nix/store/nd2irl4gl044zq9dsrb3c3chsr13cb2k-bash-interactive-4.4-p23
copying path '/nix/store/ixhlw5k9ziazafxkn74wvg36kbv5vl4f-bash-interactive-4.4-p23-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/g1fpiz69s4l8yk4gjsly5hwbr3nm64i5-bash-interactive-4.4-p23-info' from 'https://cache.nixos.org'...
copying path '/nix/store/6n34bphaagi53sv2zfk3x56z5b5vbccd-bash-interactive-4.4-p23-man' from 'https://cache.nixos.org'...
copying path '/nix/store/c3pjljc2ha0jspsban2lfalqkzv2ncn5-readline-7.0p5' from 'https://cache.nixos.org'...
copying path '/nix/store/nd2irl4gl044zq9dsrb3c3chsr13cb2k-bash-interactive-4.4-p23' from 'https://cache.nixos.org'...
copying path '/nix/store/jw8pwmn1g55pymkmshcwghyv2z13k5n3-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...
innovation

[nix-shell:~/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc]$ dodgy 
Unable to read '/home/kamado/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc/nixpkgs/pkgs/tools/archivers/zip/natspec-gentoo.patch.bz2': 'utf-8' codec can't decode byte 0xd4 in position 10: invalid continuation byte
Unable to read '/home/kamado/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc/nixpkgs/pkgs/tools/X11/xbindkeys-config/xbindkeys-config-patch1.patch': 'utf-8' codec can't decode byte 0xe9 in position 312: invalid continuation byte
Unable to read '/home/kamado/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc/nixpkgs/pkgs/games/rili/moderinze_cpp.patch': 'utf-8' codec can't decode byte 0xe9 in position 3689: invalid continuation byte
{
  "warnings": [
    {
      "path": "nixpkgs/pkgs/servers/mail/mailman/settings.py",
      "line": 43,
      "code": "secret",
      "message": "Possible hardcoded secret key"
    }
  ]
}

[nix-shell:~/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc]$ dodgy --help
usage: dodgy [-h] [--ignore-paths IGNORE_PATH [IGNORE_PATH ...]] [--zero-exit]

A very basic tool to run against your codebase to search for "dodgy" looking
values. It is a series of simple regular expressions designed to detect things
such as accidental SCM diff checkins, or passwords/secret keys hardcoded into
files.

optional arguments:
  -h, --help            show this help message and exit
  --ignore-paths IGNORE_PATH [IGNORE_PATH ...], -i IGNORE_PATH [IGNORE_PATH ...]
                        Paths to ignore
  --zero-exit, -0       Dodgy will exit with a code of 1 if problems are
                        found. This flag ensures that it always returns with 0
                        unless an exception is raised.

[nix-shell:~/.cache/nix-review/rev-f4e8dbce45692e3862c106311630532763bb51fc]$ 
```