### PR TITLE
python3Packages.pycm: init at 2.5

### DIFF
--- a/pkgs/development/python-modules/pycm/default.nix
+++ b/pkgs/development/python-modules/pycm/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy3k, numpy, pytest }:
+
+buildPythonPackage rec {
+  pname = "pycm";
+  version = "2.5";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner  = "sepandhaghighi";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "0zfv20hd7zq95sflsivjk47b0sm7q76w7fv2i2mafn83ficzx0p0";
+  };
+
+  # remove a trivial dependency on the author's `art` Python ASCII art library
+  postPatch = ''
+    rm pycm/__main__.py
+    substituteInPlace setup.py --replace '=get_requires()' '=[]'
+  '';
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ numpy ];
+
+  checkPhase = ''
+    pytest Test/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Multiclass confusion matrix library";
+    homepage = https://pycm.ir;
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1018,6 +1018,8 @@ in {
 
   PyChromecast = callPackage ../development/python-modules/pychromecast { };
 
+  pycm = callPackage ../development/python-modules/pycm { };
+
   py-cpuinfo = callPackage ../development/python-modules/py-cpuinfo { };
 
   py-lru-cache = callPackage ../development/python-modules/py-lru-cache { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [NA] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
