### PR TITLE
python3Packages.livelossplot: init at v0.5.0

### DIFF
--- a/pkgs/development/python-modules/livelossplot/default.nix
+++ b/pkgs/development/python-modules/livelossplot/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, isPy27
+, pytest
+, bokeh
+, ipython
+, matplotlib
+, numpy
+, nbconvert
+, nbformat
+}:
+
+buildPythonPackage rec {
+  pname = "livelossplot";
+  version = "0.5.0";
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner  = "stared";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "164v65qglgyg38q9ajnas99rp14mvrk5hn8x76b8iy81vszmx1c0";
+  };
+
+  propagatedBuildInputs = [ bokeh ipython matplotlib numpy ];
+
+  checkInputs = [ pytest nbconvert nbformat ];
+  checkPhase = ''
+    pytest tests tests/external_test_examples.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Live training loss plot in Jupyter for Keras, PyTorch, and others";
+    homepage = "https://github.com/stared/livelossplot";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -891,6 +891,8 @@ in {
 
   limitlessled = callPackage ../development/python-modules/limitlessled { };
 
+  livelossplot = callPackage ../development/python-modules/livelossplot { };
+
   lmtpd = callPackage ../development/python-modules/lmtpd { };
 
   logster = callPackage ../development/python-modules/logster { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [NA] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
