### PR TITLE
mrsh: init at 2020-01-08

### DIFF
--- a/pkgs/shells/mrsh/default.nix
+++ b/pkgs/shells/mrsh/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchFromGitHub, meson, ninja, pkgconfig, readline }:
+
+stdenv.mkDerivation rec {
+  pname   = "mrsh";
+  version = "2020-01-08";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = "mrsh";
+    rev = "ef21854fc9ce172fb1f7f580b19a89d030d67c65";
+    sha256 = "1iyxmwl61p2x9v9b22416n4lnrlwjqyxybq35x8bcbjxkwypp943";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [ readline ];
+
+  meta = with stdenv.lib; {
+    description = "A minimal POSIX shell";
+    homepage = "https://mrsh.sh";
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthiasbeyer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5059,6 +5059,8 @@ in
 
   mr = callPackage ../applications/version-management/mr { };
 
+  mrsh = callPackage ../shells/mrsh { };
+
   mrtg = callPackage ../tools/misc/mrtg { };
 
   mscgen = callPackage ../tools/graphics/mscgen { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

