### PR TITLE
fido2luks: init at unstable-2020-1-2

### DIFF
--- a/pkgs/tools/security/fido2luks/default.nix
+++ b/pkgs/tools/security/fido2luks/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, rustPlatform
+, cryptsetup
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "fido2luks";
+  version = "unstable-2020-1-2";
+
+  src = fetchFromGitHub {
+    owner = "shimunn";
+    repo = pname;
+    rev = "e7049a281a63e3f72f83b720eb44ccb0c65ed4e1";
+    sha256 = "007ay6y3hpha72b9dffr6if8164l5k26341ra83cq754jnh72s54";
+  };
+
+  cargoSha256 = "0393r7qglfqym1264ggr0kr9952wjc031gggs1rrqzl3rm3pmgsc";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ cryptsetup ];
+
+  meta = with stdenv.lib; {
+    description = "Decrypt your LUKS partition using a FIDO2 compatible authenticator";
+    homepage = "https://github.com/shimunn/fido2luks";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.mmahut ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15121,6 +15121,8 @@ in
 
   felix_remoteshell = callPackage ../servers/felix/remoteshell.nix { };
 
+  fido2luks = callPackage ../tools/security/fido2luks { };
+
   fingerd_bsd = callPackage ../servers/fingerd/bsd-fingerd { };
 
   firebird = callPackage ../servers/firebird { icu = null; stdenv = gcc5Stdenv; };


### PR DESCRIPTION
###### Motivation for this change

Init.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).