### PR TITLE
Add cachix as a blocker for channel updates

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -60,6 +60,7 @@ let
               jobs.stack.x86_64-darwin
               jobs.stdenv.x86_64-darwin
               jobs.vim.x86_64-darwin
+              jobs.cachix.x86_64-darwin
 
               # UI apps
               # jobs.firefox-unwrapped.x86_64-darwin
@@ -105,6 +106,7 @@ let
               # Ensure that X11/GTK are in order.
               jobs.thunderbird.x86_64-linux
               jobs.unar.x86_64-linux
+              jobs.cachix.x86_64-linux
 
               /*
               jobs.tests.cc-wrapper.x86_64-linux


### PR DESCRIPTION
Cachix broke quite a few times in last year and it's really hard to keep up with that. Getting lots of support request (for example see https://discourse.nixos.org/t/cant-build-cachix-0-3-4/5390).

I hope this makes sense since it's a widely used service within community. I'm happy to be pinged when it does break, but I'd like for that to happen before users see the breakage, which is what release critical jobs are for.