### PR TITLE
gnustep/base: add libiberty to linker flags

### DIFF
--- a/pkgs/desktops/gnustep/base/default.nix
+++ b/pkgs/desktops/gnustep/base/default.nix
@@ -9,6 +9,7 @@
 , libobjc, libgcrypt
 , icu
 , pkgconfig, portaudio
+, libiberty
 }:
 let
   version = "1.26.0";
@@ -30,8 +31,14 @@ gsmakeDerivation {
     libobjc libgcrypt
     icu
     portaudio
+    libiberty
   ];
   patches = [ ./fixup-paths.patch ];
+
+  # Bump to gcc9 has give missing xmemdup symbols. Need libiberty here
+  # to resolve it, unclear why. See #76927 for more info
+  NIX_LDFLAGS = "-liberty";
+
   meta = {
     description = "An implementation of AppKit and Foundation libraries of OPENSTEP and Cocoa";
   };


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/issues/76927, we found that
xmemdup is missing when compiling some conftest for gnustep-base. It’s
unclear why this happens but it appears to be from the update to gcc9.
Adding libiberty gives us that symbol and fixes things. What’s less
clear is why this happens to begin with.

Fixes #76927

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
