### PR TITLE
public-sans: 1.007 -> 1.008

### DIFF
--- a/pkgs/data/fonts/public-sans/default.nix
+++ b/pkgs/data/fonts/public-sans/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 
 let
-  version = "1.007";
+  version = "1.008";
 in fetchzip {
   name = "public-sans-${version}";
 
@@ -16,7 +16,7 @@ in fetchzip {
     unzip -j $downloadedFile binaries/webfonts/\*.woff2 -d $out/share/fonts/woff2
   '';
 
-  sha256 = "1yzraw08qm1ig7ks850b329xp6zv2znjwl610dppax34kwhqghsm";
+  sha256 = "1s4xmliri3r1gcn1ws3wa6davj6giliqjdbcv0bh9ryg3dfpjz74";
 
   meta = with lib; {
     description = "A strong, neutral, principles-driven, open source typeface for text or display";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/uswds/public-sans/releases/tag/v1.008

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @dtzWill