### PR TITLE
kdeFrameworks: 5.64.0 -> 5.65.0

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/nix-lib-path.patch
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/nix-lib-path.patch
@@ -1,12 +1,12 @@
 diff --git a/kde-modules/KDEInstallDirs.cmake b/kde-modules/KDEInstallDirs.cmake
-index 0acd33f..c04b0a5 100644
+index c1d056b..d9e19f0 100644
 --- a/kde-modules/KDEInstallDirs.cmake
 +++ b/kde-modules/KDEInstallDirs.cmake
-@@ -236,35 +236,6 @@
+@@ -242,35 +242,6 @@
  # GNUInstallDirs code deals with re-configuring, but that is dealt with
  # by the _define_* macros in this module).
  set(_LIBDIR_DEFAULT "lib")
--# Override this default 'lib' with 'lib64' iff:
+-# Override this default 'lib' with 'lib64' if:
 -#  - we are on a Linux, kFreeBSD or Hurd system but NOT cross-compiling
 -#  - we are NOT on debian
 -#  - we are NOT on flatpak

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.64/ )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.65/ )

--- a/pkgs/development/libraries/kde-frameworks/kinit/kdeinit-extra_libs.patch
+++ b/pkgs/development/libraries/kde-frameworks/kinit/kdeinit-extra_libs.patch
@@ -38,10 +38,9 @@ Index: kinit-5.32.0/src/kdeinit/kinit.cpp
      static void secondary_child_handler(int)
 @@ -1692,7 +1676,7 @@ int main(int argc, char **argv)
      if (!d.suicide && qEnvironmentVariableIsEmpty("KDE_IS_PRELINKED")) {
-         const int extrasCount = sizeof(extra_libs) / sizeof(extra_libs[0]);
-         for (int i = 0; i < extrasCount; i++) {
--            const QString extra = findSharedLib(QString::fromLatin1(extra_libs[i]));
-+            const QString extra = QString::fromLatin1(extra_libs[i]);
+         for (const char *extra_lib : extra_libs) {
+-            const QString extra = findSharedLib(QString::fromLatin1(extra_lib));
++            const QString extra = QString::fromLatin1(extra_lib);
              if (!extra.isEmpty()) {
                  QLibrary l(extra);
                  l.setLoadHints(QLibrary::ExportExternalSymbolsHint);

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,651 +3,659 @@
 
 {
   attica = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/attica-5.64.0.tar.xz";
-      sha256 = "c9b060693656a458f92905091e12d800be020abbf47bb68b9f769a191aa368d9";
-      name = "attica-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/attica-5.65.0.tar.xz";
+      sha256 = "a62908517f9cf44fd13c2cb37868f6484710284bc85bd85b532c3b8b7fc2b9ea";
+      name = "attica-5.65.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/baloo-5.64.0.tar.xz";
-      sha256 = "adaaef1aeec07ccc210210a2e67f4d12c0275226bb05d0220da0281f1a3984c2";
-      name = "baloo-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/baloo-5.65.0.tar.xz";
+      sha256 = "c24c53838d57b40a1f099cb40240cad86fb9ebbf09fd0f811d9ce14a9cf5f3bf";
+      name = "baloo-5.65.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/bluez-qt-5.64.0.tar.xz";
-      sha256 = "7d6c7ba913cea6059327726325b8af4cf2baa7594b8be3143e0649eaa36f8384";
-      name = "bluez-qt-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/bluez-qt-5.65.0.tar.xz";
+      sha256 = "ad60bd7ee5d46bcee838d3c36031ccd4d427cd6ac93286831695f89198a5f143";
+      name = "bluez-qt-5.65.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/breeze-icons-5.64.0.tar.xz";
-      sha256 = "08c2f7efc5f1550668dd2e0cff1641b1b6ec8a91f01614ee14c6abc4d975672f";
-      name = "breeze-icons-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/breeze-icons-5.65.0.tar.xz";
+      sha256 = "166c0a7d49524313c5355e763f6561075ef33cae968ddf6da3174d2788dd7da3";
+      name = "breeze-icons-5.65.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/extra-cmake-modules-5.64.0.tar.xz";
-      sha256 = "1865efc6254bed44e0a6918c5af3da62be4008ba7a197a47f35251f298041a69";
-      name = "extra-cmake-modules-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/extra-cmake-modules-5.65.0.tar.xz";
+      sha256 = "41634536ca1165a758acd85aa11112177616019e2d3974693a92d1d9bc91c105";
+      name = "extra-cmake-modules-5.65.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/frameworkintegration-5.64.0.tar.xz";
-      sha256 = "6c1880f8300a014bb835ce29fd68651bfd38400de8044fe5914cb4392df48a26";
-      name = "frameworkintegration-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/frameworkintegration-5.65.0.tar.xz";
+      sha256 = "3170f99d4418b25225813822e22a1bdf8d73af87cd00b696089b696b151d43be";
+      name = "frameworkintegration-5.65.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kactivities-5.64.0.tar.xz";
-      sha256 = "5afbd0785c04127c91f1ad7402c95ce3f994fb94b216baf56cd802a3a230a3f9";
-      name = "kactivities-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kactivities-5.65.0.tar.xz";
+      sha256 = "00a64654861cdff809be5f78931bfd671fe81841380b9c3926f75957c18f139b";
+      name = "kactivities-5.65.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kactivities-stats-5.64.0.tar.xz";
-      sha256 = "ca1c07b1250735372a4f6aa6b493536d420a902de0d7a8c9777b437fb6ab0bf9";
-      name = "kactivities-stats-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kactivities-stats-5.65.0.tar.xz";
+      sha256 = "5a7ae4c43610ac6d6ce084d639a9a3b6db58ac14a61b56be53a9282573b296c0";
+      name = "kactivities-stats-5.65.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kapidox-5.64.0.tar.xz";
-      sha256 = "f75eedfa1af51f5224b14d8bc4c229c2c2d27f607e00172d24bdcede1c899fb4";
-      name = "kapidox-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kapidox-5.65.0.tar.xz";
+      sha256 = "3748814024088e72a510bde782f47235fded41835ee4dcc130a441a814af7a68";
+      name = "kapidox-5.65.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/karchive-5.64.0.tar.xz";
-      sha256 = "135fbfb2dfe107e4487723a5f887d1d074e13258a4583d592639366094aafe1a";
-      name = "karchive-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/karchive-5.65.0.tar.xz";
+      sha256 = "9e6cdb2cf10407fd435b97eb284ac56ad1bca95f0b1789a8bc26c9cee7edcc52";
+      name = "karchive-5.65.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kauth-5.64.0.tar.xz";
-      sha256 = "ac95525bf1430868c8f54dbdc986478cf7b21192ad3b486381485b429eadddcc";
-      name = "kauth-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kauth-5.65.0.tar.xz";
+      sha256 = "277821947090e806f5850983e110134480915bf8e9609e0f24eaf34f7ca00c5f";
+      name = "kauth-5.65.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kbookmarks-5.64.0.tar.xz";
-      sha256 = "51343a57b50032d60ffae123f426cdd67cd290ce306ae494c1956d0b899d4ff2";
-      name = "kbookmarks-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kbookmarks-5.65.0.tar.xz";
+      sha256 = "c00a04d77ce2b4744feb5ae43f50f8ae5c18b752eae52a8f4d9db47046daf18a";
+      name = "kbookmarks-5.65.0.tar.xz";
     };
   };
   kcalendarcore = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kcalendarcore-5.64.0.tar.xz";
-      sha256 = "983f240a7478a780dc403d577827f027856f9f67e8c3bfe8b69d56093e5bb80e";
-      name = "kcalendarcore-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kcalendarcore-5.65.0.tar.xz";
+      sha256 = "fb79dc1bd1153c7fc38242c577a324462b8913e151bc33b74f7997e48d494cb8";
+      name = "kcalendarcore-5.65.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kcmutils-5.64.0.tar.xz";
-      sha256 = "f55938c566669e9fcdd786ebfd89edfc11b0c283532aed04cfe4162b58a8b649";
-      name = "kcmutils-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kcmutils-5.65.0.tar.xz";
+      sha256 = "fbb525cb21afbf9752d171ceb333a805c40d4722b98da6fce0243e37b8398ec3";
+      name = "kcmutils-5.65.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kcodecs-5.64.0.tar.xz";
-      sha256 = "24cbffb123179cf4386500ae7bc7c99f65c4422cd7b91f314152f11cd596402a";
-      name = "kcodecs-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kcodecs-5.65.0.tar.xz";
+      sha256 = "eca1642a559aad9aed57ea3ad5c7a62a2b20ad13969b6fcba671f5bc7c9782fd";
+      name = "kcodecs-5.65.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kcompletion-5.64.0.tar.xz";
-      sha256 = "4fe5b9254e038e654d55167163b2812582f31fe550c977979d692b69424c2508";
-      name = "kcompletion-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kcompletion-5.65.0.tar.xz";
+      sha256 = "bdd7201940fa47ac1b62f6fcf7a12883abed44876ff729cb430c11d3868eb8ae";
+      name = "kcompletion-5.65.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kconfig-5.64.0.tar.xz";
-      sha256 = "112c1db9f038dbacf357d08645c83ca103d8c3e7fb0c880ac16f665fdf7d9157";
-      name = "kconfig-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kconfig-5.65.0.tar.xz";
+      sha256 = "8dfa064effdf559e1179e9d7e5ec12ff9d79fcfef1859bd1793557261e94a6ed";
+      name = "kconfig-5.65.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kconfigwidgets-5.64.0.tar.xz";
-      sha256 = "e84d590c064f2a86d5b9d2fb5d8aa7abc8ac8752125f5d3197cca6dc7e115c56";
-      name = "kconfigwidgets-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kconfigwidgets-5.65.0.tar.xz";
+      sha256 = "210a694aacd0d6bd26a5a6b78986d180960ddb7e26933b127a0107ae4995a120";
+      name = "kconfigwidgets-5.65.0.tar.xz";
     };
   };
   kcontacts = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kcontacts-5.64.0.tar.xz";
-      sha256 = "0bf0a1ba6ebedd400bed7a490093962cde6a2b26c49627d6770a71524db63058";
-      name = "kcontacts-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kcontacts-5.65.0.tar.xz";
+      sha256 = "84dd287010c8daa6865337df39ce14b44f8f7c14c810fe095d264d5bafa7b306";
+      name = "kcontacts-5.65.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kcoreaddons-5.64.0.tar.xz";
-      sha256 = "3f0cb3273debf9791dda3f1ad135b6b1a20d88fed1e21890c4b70bac64fdb188";
-      name = "kcoreaddons-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kcoreaddons-5.65.0.tar.xz";
+      sha256 = "0f334b123b307829d11a39f639845f2f74d290490b264d9b188f1a785e16bf41";
+      name = "kcoreaddons-5.65.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kcrash-5.64.0.tar.xz";
-      sha256 = "9e9ad5e7a6a3e9a128128a7863204f8c4a555bd8659d8ed4ef4cc6bb2fc48290";
-      name = "kcrash-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kcrash-5.65.0.tar.xz";
+      sha256 = "6b05608507dd2f8821399c4596021bcf9da79a284726a093c8b81b6d3cc4e034";
+      name = "kcrash-5.65.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kdbusaddons-5.64.0.tar.xz";
-      sha256 = "74a6eb443a74eb74a859238b555a3b16be1d6367c4db2a7af5b16da528d57f62";
-      name = "kdbusaddons-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kdbusaddons-5.65.0.tar.xz";
+      sha256 = "e2777538c6d1f0dd5956b3bc2c9cfe34fe360655c188e658f52f926ff8cb3fcc";
+      name = "kdbusaddons-5.65.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kdeclarative-5.64.0.tar.xz";
-      sha256 = "1bf199aebabe63880babc364572de44f6b0a94ffbbffd955bc85916c2be7701d";
-      name = "kdeclarative-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kdeclarative-5.65.0.tar.xz";
+      sha256 = "a0274de8c84d73dd17b1bc0faf64a9e0d0655035c0574148ba64986e367cd881";
+      name = "kdeclarative-5.65.0.tar.xz";
     };
   };
   kded = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kded-5.64.0.tar.xz";
-      sha256 = "2e8bda93918ac174254c8f70a71c9d6966a4721e14a631760e1b912d108001be";
-      name = "kded-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kded-5.65.0.tar.xz";
+      sha256 = "14ba21ffed8b425be7550c8b7e3ba78d3f208b800bba7db6c950e02c06d1f032";
+      name = "kded-5.65.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/portingAids/kdelibs4support-5.64.0.tar.xz";
-      sha256 = "8c9e23e0e22ccec8b46b4c4b160adb8c8765c1dc308bf297f6f72ccc97c7b682";
-      name = "kdelibs4support-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/portingAids/kdelibs4support-5.65.0.tar.xz";
+      sha256 = "c7ebd744c1c8dbc1b8adcf815a7a019b73e5f85653dda3e19dc9f31cab4e7701";
+      name = "kdelibs4support-5.65.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/portingAids/kdesignerplugin-5.64.0.tar.xz";
-      sha256 = "1ca638ec822d9882f4a865d599ce8ad94785fa890ce73bccd5e78210c4a3d95b";
-      name = "kdesignerplugin-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/portingAids/kdesignerplugin-5.65.0.tar.xz";
+      sha256 = "e6ba152df5848789cd35f1734dfd3d20f439a21ebba8b96caf747654de42c515";
+      name = "kdesignerplugin-5.65.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kdesu-5.64.0.tar.xz";
-      sha256 = "f4644b0ee91c55473589909c20a7fa1cfbd3d466f1c72b330d53871a2346d4f0";
-      name = "kdesu-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kdesu-5.65.0.tar.xz";
+      sha256 = "a39a727db863a45969cca2736b321257a2a6c0f2db7e0c70cbe9cf8b3f180d40";
+      name = "kdesu-5.65.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/portingAids/kdewebkit-5.64.0.tar.xz";
-      sha256 = "882801a1fd944b08918cb7d9341985e4330e7adac00ae4e6dddcea5343393ac1";
-      name = "kdewebkit-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/portingAids/kdewebkit-5.65.0.tar.xz";
+      sha256 = "82525a8fda1e9e2e7cde348b6e7227b0747f93d75a7648f4863e0e6889640586";
+      name = "kdewebkit-5.65.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kdnssd-5.64.0.tar.xz";
-      sha256 = "92d9a4947c45e56ea15e417eaf87121b4b3a4f1f81dfd154d2ee968a9797f46b";
-      name = "kdnssd-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kdnssd-5.65.0.tar.xz";
+      sha256 = "e7f684580f3f6060a73da33439b463ed0f47f72e7129c142b09b4b642331969f";
+      name = "kdnssd-5.65.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kdoctools-5.64.0.tar.xz";
-      sha256 = "3e669c9bdf8822c262d834a9fbe9250ffdc91ea49c916b2c16ac8483b62f8fce";
-      name = "kdoctools-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kdoctools-5.65.0.tar.xz";
+      sha256 = "0ff2b70bc46ffc7b62dba9476163ed26ba7fddb8be0ba34ecf48055bcabb649b";
+      name = "kdoctools-5.65.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kemoticons-5.64.0.tar.xz";
-      sha256 = "0b586957bfe26ce0fe44eca305992f99e3c31fbeb19a9d369c4abfdf9cc0400f";
-      name = "kemoticons-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kemoticons-5.65.0.tar.xz";
+      sha256 = "923853ef4fd472369f9d5ec3732d6d03dc55b6ba1dd79146f24551d642e09e51";
+      name = "kemoticons-5.65.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kfilemetadata-5.64.0.tar.xz";
-      sha256 = "4b581e4d659defe4db595a984ed4c037bc80e0bf7b298ec79e6aa5061fa56e23";
-      name = "kfilemetadata-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kfilemetadata-5.65.0.tar.xz";
+      sha256 = "9df372bcc1f910a332b4f5f8b34f5cfeb453c002bec93cdb4004e36157883a75";
+      name = "kfilemetadata-5.65.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kglobalaccel-5.64.0.tar.xz";
-      sha256 = "6863515428988c129acfcceaa3518f90d72c590aff2c295a958a68d0c4cd02ab";
-      name = "kglobalaccel-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kglobalaccel-5.65.0.tar.xz";
+      sha256 = "48fc4678ad28aaba07056b2e6f4b8cc7b8e9522cad8dbed43980a0b38ad9b8df";
+      name = "kglobalaccel-5.65.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kguiaddons-5.64.0.tar.xz";
-      sha256 = "4caac79b7341c7796f3ca5e1d88cef57ecab2eefcac9ab654fd977706c89bae4";
-      name = "kguiaddons-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kguiaddons-5.65.0.tar.xz";
+      sha256 = "f6b34db7c21ced8179351f2bf38c7c073fa4e0f6de2f9d03986aedba4f87488d";
+      name = "kguiaddons-5.65.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kholidays-5.64.0.tar.xz";
-      sha256 = "65b847ba7a00e1a42c0048fe05a400f584e1d9e746edb5d935331ffcb1f5d4ab";
-      name = "kholidays-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kholidays-5.65.0.tar.xz";
+      sha256 = "613f9050c4970a22680c72680dc76d45b270fb5b76129a994a375ad158ab832c";
+      name = "kholidays-5.65.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/portingAids/khtml-5.64.0.tar.xz";
-      sha256 = "00d3a3e8c8b8072f4894d74f91d963cfefbd681e47da0b8e80e1297224c5af85";
-      name = "khtml-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/portingAids/khtml-5.65.0.tar.xz";
+      sha256 = "cfbfda470b4aecd189489e44983aa3c725ef0d234992afd38701273663d7ccba";
+      name = "khtml-5.65.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/ki18n-5.64.0.tar.xz";
-      sha256 = "ccd2c2f8b14251701f902c9e7d046da1582e544d31edae743911f3554022d024";
-      name = "ki18n-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/ki18n-5.65.0.tar.xz";
+      sha256 = "303c3ef4fc7e417233211373a21759332f39a9ae45c9ce7b407eaba412d2caa4";
+      name = "ki18n-5.65.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kiconthemes-5.64.0.tar.xz";
-      sha256 = "f89a97e9501d841d4543249776783ebd1fc4d7f69e114f8a56027f59ad32000a";
-      name = "kiconthemes-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kiconthemes-5.65.0.tar.xz";
+      sha256 = "6549774254705861654e0393ab53b7a06b62415644d6bbe5479f7458b22895c5";
+      name = "kiconthemes-5.65.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kidletime-5.64.0.tar.xz";
-      sha256 = "8287e958a8a2a9538bec1038f5e31ebba338ff522de9c51265ca1d63030581d0";
-      name = "kidletime-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kidletime-5.65.0.tar.xz";
+      sha256 = "10b12437efb42c66956a728dad3a04d84dab5a081536a3b7029393a0ae3f1722";
+      name = "kidletime-5.65.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kimageformats-5.64.0.tar.xz";
-      sha256 = "48c6a7026854127fc83698ab11e6639a525d387cf384f2558db6c7478bceae4c";
-      name = "kimageformats-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kimageformats-5.65.0.tar.xz";
+      sha256 = "51ed246d07e33b5214a5594566955c2b1eff44e009998e74d7f2fe8011f82d13";
+      name = "kimageformats-5.65.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kinit-5.64.0.tar.xz";
-      sha256 = "5298b783499cedb681c334b20234a511cb3377e66d140e7df6b7c1899186263d";
-      name = "kinit-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kinit-5.65.0.tar.xz";
+      sha256 = "bbff3999f40d67284e7f90118f29dbedc9fdd673ce74f29f82a9115f4b5efbc1";
+      name = "kinit-5.65.0.tar.xz";
     };
   };
   kio = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kio-5.64.0.tar.xz";
-      sha256 = "e38c8dcf634989f0f7ec95b68bdd936b9e05f7d242e4050b01f79b7021108f59";
-      name = "kio-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kio-5.65.0.tar.xz";
+      sha256 = "7d3cc0c82e83c082b424a2fe4c796c4c46f233ccd565775babbf6b434fce851b";
+      name = "kio-5.65.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kirigami2-5.64.0.tar.xz";
-      sha256 = "c394360e2323c55cf654d09ec762a03c47db0027e6a992646ea32d27ce8b228e";
-      name = "kirigami2-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kirigami2-5.65.0.tar.xz";
+      sha256 = "034222e4beec5c5b142cdbdd35304fe5374097367237af1feb5252dabe87e261";
+      name = "kirigami2-5.65.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kitemmodels-5.64.0.tar.xz";
-      sha256 = "1bae70e4c6a033eea649efc17f0a060aba89144f4c469f235fbf5023dba5abc4";
-      name = "kitemmodels-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kitemmodels-5.65.0.tar.xz";
+      sha256 = "01980a8b518cdb442ace10f7a61dacec1cb61ff708d86edf83ee079cb6451d41";
+      name = "kitemmodels-5.65.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kitemviews-5.64.0.tar.xz";
-      sha256 = "0b3f8a0116c042ae187b67f35ffd40872352b91f5f236d19dd26ffad8db83fee";
-      name = "kitemviews-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kitemviews-5.65.0.tar.xz";
+      sha256 = "689f2517432861932a05b5c71e1c8c1378bee6773850e8a13a5907d0af58d5cb";
+      name = "kitemviews-5.65.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kjobwidgets-5.64.0.tar.xz";
-      sha256 = "3b39fc5dfc0f1a9cc9bffed3d05b90ba46c52c63cbbeffa0666f5f09e7093ce0";
-      name = "kjobwidgets-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kjobwidgets-5.65.0.tar.xz";
+      sha256 = "2b68d848b086f274020334cadd28d212125e05a7fdd97ff97ac801aed80ec852";
+      name = "kjobwidgets-5.65.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/portingAids/kjs-5.64.0.tar.xz";
-      sha256 = "93855cde810feb7208443a93f81c952bdb42f9886154959bc7a6509c9863e503";
-      name = "kjs-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/portingAids/kjs-5.65.0.tar.xz";
+      sha256 = "d7c9f86a500049a3aa940be469e86e5dbe00d41de9c9488916958ef1a1037df0";
+      name = "kjs-5.65.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/portingAids/kjsembed-5.64.0.tar.xz";
-      sha256 = "939226116cb47fd66dc45a41baa3c0f45b7ab904ec7674088ced3df5c7bae62e";
-      name = "kjsembed-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/portingAids/kjsembed-5.65.0.tar.xz";
+      sha256 = "e6d919e6c87f7a38df623a4f5061cafa50b61fe10f9d4769f61f116f4e920d21";
+      name = "kjsembed-5.65.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/portingAids/kmediaplayer-5.64.0.tar.xz";
-      sha256 = "ce4816a14134c4968559ff5030895ab69b63b66e9b541b74595ce05e4fe68d1d";
-      name = "kmediaplayer-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/portingAids/kmediaplayer-5.65.0.tar.xz";
+      sha256 = "bbab29b71d07ec736b842abc54a67441cb89b25b81e957bd8a95c1550f95c673";
+      name = "kmediaplayer-5.65.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/knewstuff-5.64.0.tar.xz";
-      sha256 = "91334c95a1082ae402ee869da399e5bdbac986c8b30a85d0a899b30de1f3be72";
-      name = "knewstuff-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/knewstuff-5.65.0.tar.xz";
+      sha256 = "0ec8ab4d7f52c94fb479c0c56ed762748832c76e88b495694b7485e79d9797d9";
+      name = "knewstuff-5.65.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/knotifications-5.64.0.tar.xz";
-      sha256 = "5f0c3b158ba253e8df81016c8921d689836ecac063a39766c0290352c9f71bc1";
-      name = "knotifications-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/knotifications-5.65.0.tar.xz";
+      sha256 = "9d766c1566ea7cab83e6cd9c57f76583b3404f9864ed1ba1bc65535ea4c98087";
+      name = "knotifications-5.65.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/knotifyconfig-5.64.0.tar.xz";
-      sha256 = "f496ed0728e688347da360f7aad7f2666cb0310ab669c6006ce9661233218b27";
-      name = "knotifyconfig-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/knotifyconfig-5.65.0.tar.xz";
+      sha256 = "a0eb8a27b545d7cc9c61bef6630b9f6d68da76e49c2c8ac8b4ae03d8f89b1e54";
+      name = "knotifyconfig-5.65.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kpackage-5.64.0.tar.xz";
-      sha256 = "c39c80317c75206ec347edf6d301cb66c2117489f37725374fcfe3b1459aaed6";
-      name = "kpackage-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kpackage-5.65.0.tar.xz";
+      sha256 = "5ac5f6a687c244709487bc47d7aeca276ad7a925d7618fdf04a7af0e1e3fa581";
+      name = "kpackage-5.65.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kparts-5.64.0.tar.xz";
-      sha256 = "61338a37015c2df787b8e0fe49f0ef320474a82831b4f110fb5aefd1635b1d9f";
-      name = "kparts-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kparts-5.65.0.tar.xz";
+      sha256 = "f0fb059a21c744fd5da8e201e4fe329ed1bccaf586541fecd55ddb48191e725f";
+      name = "kparts-5.65.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kpeople-5.64.0.tar.xz";
-      sha256 = "b5bc8d037dab124ea65be1c480b25943e789a403176f8b31599383dcdec20a0e";
-      name = "kpeople-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kpeople-5.65.0.tar.xz";
+      sha256 = "e12ab7b8b02369a505f2f408b9ffba6742369e9f8b9fa7cafed9b23a49526eac";
+      name = "kpeople-5.65.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kplotting-5.64.0.tar.xz";
-      sha256 = "f38f65c97d199077c88213bce84c6162ba254c443f06ccfaf62088ff0e217f7b";
-      name = "kplotting-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kplotting-5.65.0.tar.xz";
+      sha256 = "967d483cba446a2fb734cd1bcc5340349b62f38f41b3759cc58bf8970ac3b719";
+      name = "kplotting-5.65.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kpty-5.64.0.tar.xz";
-      sha256 = "c2ece8c6b336ee85973e005969f1228bbfac87cbace6853e9d01a7b5c5fe319e";
-      name = "kpty-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kpty-5.65.0.tar.xz";
+      sha256 = "b7607cac36ef58aca675a2d90445f1152670c513d6992112ab01ade5400d4554";
+      name = "kpty-5.65.0.tar.xz";
+    };
+  };
+  kquickcharts = {
+    version = "5.65.0";
+    src = fetchurl {
+      url = "${mirror}/stable/frameworks/5.65/kquickcharts-5.65.0.tar.xz";
+      sha256 = "f9ab7697845c872d25e998f2b213d4c32c0b2ccdef99de018dc486d1c4a98388";
+      name = "kquickcharts-5.65.0.tar.xz";
     };
   };
   kross = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/portingAids/kross-5.64.0.tar.xz";
-      sha256 = "d8a7e9fbeba4d16d6288d13d72a5f7581aa8be5894b06f83dbc6068b04551ebd";
-      name = "kross-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/portingAids/kross-5.65.0.tar.xz";
+      sha256 = "c7414c2d6bb959920c2dca01c2b50131a5715629e0229283f8e6dfcfae1a64a5";
+      name = "kross-5.65.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/krunner-5.64.0.tar.xz";
-      sha256 = "e056635f347eb4d8b2a1545de993b28ead1af4e8e4acc43f1dd1637b528fe0b2";
-      name = "krunner-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/krunner-5.65.0.tar.xz";
+      sha256 = "0806c1d9ade246348e952e538cc75dc303c27728a887b67dbf27edac6cffffe6";
+      name = "krunner-5.65.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kservice-5.64.0.tar.xz";
-      sha256 = "60e0c111485158f89211a62403697714dfe141e3539c1c7e1bf04550db74f02f";
-      name = "kservice-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kservice-5.65.0.tar.xz";
+      sha256 = "663ca1539929e9d1188de3732fc8d1353bc5714b434fdf2fa37c4769e4b26fa3";
+      name = "kservice-5.65.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/ktexteditor-5.64.0.tar.xz";
-      sha256 = "0fe12c57a7428d78c46d3367bdae47a0b9fbbd762be4f57f0c52dcd76e309ed5";
-      name = "ktexteditor-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/ktexteditor-5.65.0.tar.xz";
+      sha256 = "830aed1f7d181bf79e57a11373046baf762507a30fe1adc19cb2fc13d9be60c0";
+      name = "ktexteditor-5.65.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/ktextwidgets-5.64.0.tar.xz";
-      sha256 = "0e94c36c7d836450d4c52bd933c492235ea0071b15702c302aed003e8400bbfd";
-      name = "ktextwidgets-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/ktextwidgets-5.65.0.tar.xz";
+      sha256 = "dedad270e03688f937b72e683a249bad464a22df3f97a1cd1bc3be400ec31a11";
+      name = "ktextwidgets-5.65.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kunitconversion-5.64.0.tar.xz";
-      sha256 = "6783d6180b132a80dce2a4cc6c793dae0f5859b0709207c5fc6f4501ef53a822";
-      name = "kunitconversion-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kunitconversion-5.65.0.tar.xz";
+      sha256 = "aa751f4b5d9648656120e9e99b0e28560e468daa01156c85865fbfca42de683d";
+      name = "kunitconversion-5.65.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kwallet-5.64.0.tar.xz";
-      sha256 = "16ff5bb5724105c3d59404f292232c03c6003f6229b483509e395e1171ccabde";
-      name = "kwallet-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kwallet-5.65.0.tar.xz";
+      sha256 = "93822bded2273e21be16d8c34c5f33939afeba0dd9d4f2f3ff3ae93029f71eb0";
+      name = "kwallet-5.65.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kwayland-5.64.0.tar.xz";
-      sha256 = "1540d4ff62afd0bff234e08618fc77d2c54b5cd69bf9c478c45a08a6e69349d3";
-      name = "kwayland-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kwayland-5.65.0.tar.xz";
+      sha256 = "75b22e59dd6d3d70ce7a46b8d431050e2f00f6094ae25e969af90ae535037b12";
+      name = "kwayland-5.65.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kwidgetsaddons-5.64.0.tar.xz";
-      sha256 = "a2d4a47489621d095c4979ea25d5d8304cf4004b10a892a2b314d74cd30cb5da";
-      name = "kwidgetsaddons-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kwidgetsaddons-5.65.0.tar.xz";
+      sha256 = "f5124ae8beb1da1ec5cca979b862c398635ee84e87283a7f528978df928a971d";
+      name = "kwidgetsaddons-5.65.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kwindowsystem-5.64.0.tar.xz";
-      sha256 = "77c2e6b0032a79547f80bcd36682aa72c0e901e3b5acc83a58f69d644ce03dab";
-      name = "kwindowsystem-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kwindowsystem-5.65.0.tar.xz";
+      sha256 = "9745aebe1d0fdcdede623b9a7cd55b86520e3122278a6c4f82ebb83e0cf514c2";
+      name = "kwindowsystem-5.65.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kxmlgui-5.64.0.tar.xz";
-      sha256 = "faa95b92b3b03130022841a6797d5beb3efb6a0d757afaefe038889af76a1dd1";
-      name = "kxmlgui-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kxmlgui-5.65.0.tar.xz";
+      sha256 = "1de343bd51ba57053fd30eefb2237fb022b7cc274be6132fb9064bec64c39e95";
+      name = "kxmlgui-5.65.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/kxmlrpcclient-5.64.0.tar.xz";
-      sha256 = "8c36472cb69a2d5eeb88c437907f7b0b46703ef34d04df7b45a8c90eb95fd6b0";
-      name = "kxmlrpcclient-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/kxmlrpcclient-5.65.0.tar.xz";
+      sha256 = "2b29df46f16c606488238c7936b8cfc198f06549e01ad4b52cae0cb66fa85282";
+      name = "kxmlrpcclient-5.65.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/modemmanager-qt-5.64.0.tar.xz";
-      sha256 = "a9d8554b3720cf46aaaa70da87c79688afc5baa155ffd19ea00e4cae2a1caa21";
-      name = "modemmanager-qt-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/modemmanager-qt-5.65.0.tar.xz";
+      sha256 = "21cd64acbe50d402ea5c3636e628acbc8c73ee32021a6e184c449380216380c2";
+      name = "modemmanager-qt-5.65.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/networkmanager-qt-5.64.0.tar.xz";
-      sha256 = "369d0391e199d059dd2faa554324cbd45334f7864ccfc462699b06c89af04bbf";
-      name = "networkmanager-qt-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/networkmanager-qt-5.65.0.tar.xz";
+      sha256 = "171bac57c2f965b893a70e8bbeab5e1ed80d7d6df97cc52b0a830acdf0c1b82a";
+      name = "networkmanager-qt-5.65.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/oxygen-icons5-5.64.0.tar.xz";
-      sha256 = "41d415b4bd9cca0d9abc43b187059d833ce92b3fff3da66eb8ff4004215e91ef";
-      name = "oxygen-icons5-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/oxygen-icons5-5.65.0.tar.xz";
+      sha256 = "a0e6868aa905f2ca784164fc80b2cb85b1dcebf12588bc4a023c46550923d665";
+      name = "oxygen-icons5-5.65.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/plasma-framework-5.64.0.tar.xz";
-      sha256 = "3f1311a48826ab0a76f47d05b02f9a9486f821cc1ad757b895b570e371acfd09";
-      name = "plasma-framework-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/plasma-framework-5.65.0.tar.xz";
+      sha256 = "794616029509897bdf1685fc1fd0b6cfb66f4edd3627aa69138f100a4615c826";
+      name = "plasma-framework-5.65.0.tar.xz";
     };
   };
   prison = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/prison-5.64.0.tar.xz";
-      sha256 = "31e136dd33940f32fdb87699b113c57aab566112bb9649f20a057c4eee20db2e";
-      name = "prison-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/prison-5.65.0.tar.xz";
+      sha256 = "8dd4400817b4863597eb87fafce27f6cb11ad8a1f4da7491e4c9e4dcaa2fdff1";
+      name = "prison-5.65.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/purpose-5.64.0.tar.xz";
-      sha256 = "004794dfa2d0bcef316d582f37e5691e3980c99240ef570313a98a8d44235b0d";
-      name = "purpose-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/purpose-5.65.0.tar.xz";
+      sha256 = "680700a330cee3a82e9cba02a511cd2963aa20875c99e863b4b93998efc81e24";
+      name = "purpose-5.65.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/qqc2-desktop-style-5.64.0.tar.xz";
-      sha256 = "b0e6ad1ccbd01b6974c3222c6098b6c1ae1fe594c26fe0e2817c35dd90b6013a";
-      name = "qqc2-desktop-style-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/qqc2-desktop-style-5.65.0.tar.xz";
+      sha256 = "a583e4ed8a4513fdd287d432d9a68fa30941803c7a77ce58f2a08b9d77d9628c";
+      name = "qqc2-desktop-style-5.65.0.tar.xz";
     };
   };
   solid = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/solid-5.64.0.tar.xz";
-      sha256 = "fcbbfd124759854bde2da74e1768da818361f61f2839877b4efbcd38b825da6b";
-      name = "solid-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/solid-5.65.0.tar.xz";
+      sha256 = "e94cf8e434b49b8a70318a41219e18b6d2d3b1912a2c3050b69cd66773cc3d00";
+      name = "solid-5.65.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/sonnet-5.64.0.tar.xz";
-      sha256 = "3af364858f76c0206136ae8f3c03da5442ea5e42d2560877f5e00f33850c84dc";
-      name = "sonnet-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/sonnet-5.65.0.tar.xz";
+      sha256 = "1f63ccfa8266e167fd996a253a3d1933a913c12e829056c74fe335fbfb327cbc";
+      name = "sonnet-5.65.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/syndication-5.64.0.tar.xz";
-      sha256 = "bffcd673a70646c8cb683ed7b26f6ef251a2ffe439fc78123ccee4332b567b57";
-      name = "syndication-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/syndication-5.65.0.tar.xz";
+      sha256 = "1be1bd32b4c75c6bb1b35d67cc7643089e0c525cb30e392220c1ac88240e7694";
+      name = "syndication-5.65.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/syntax-highlighting-5.64.0.tar.xz";
-      sha256 = "9655fa79d99fb7d585ae1a11c03d204c83263fe19391e7610575fb0436052b5f";
-      name = "syntax-highlighting-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/syntax-highlighting-5.65.0.tar.xz";
+      sha256 = "5ac5cffeed055adb7f1ef734bab41268dcfbf5e0abdefcf82df2be4479dfc97b";
+      name = "syntax-highlighting-5.65.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.64.0";
+    version = "5.65.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.64/threadweaver-5.64.0.tar.xz";
-      sha256 = "4a3ec0b2b45a5997b24d60059d95006fca5fd86f5d619d8fb1fd30d7510f5a02";
-      name = "threadweaver-5.64.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.65/threadweaver-5.65.0.tar.xz";
+      sha256 = "19d74c5feb15903047d8bdf7fd1c94b4b6d0d22f3c860ff99ed1ef00a1f4b8b0";
+      name = "threadweaver-5.65.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://kde.org/announcements/kde-frameworks-5.65.0.php

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ttuegel