### PR TITLE
ocamlPackages.ppxfind: dontStrip for all versions

### DIFF
--- a/pkgs/development/ocaml-modules/ppxfind/default.nix
+++ b/pkgs/development/ocaml-modules/ppxfind/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchurl, ocaml, ocaml-migrate-parsetree }:
+{ stdenv, lib, buildDunePackage, fetchurl, ocaml, ocaml-migrate-parsetree }:
 
 buildDunePackage (rec {
 	pname = "ppxfind";
@@ -11,6 +11,9 @@ buildDunePackage (rec {
 	minimumOCamlVersion = "4.03";
 
 	buildInputs = [ ocaml-migrate-parsetree ];
+
+  # Don't run the native `strip' when cross-compiling.
+  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
 
 	meta = {
 		homepage = "https://github.com/diml/ppxfind";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I had to add `dontStrip` to support ppx_deriving (which uses ppxfind) when doing cross compilation to a static musl64 binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @vbgl
