### PR TITLE
nixos/fresh-rss: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -803,6 +803,7 @@
   ./services/web-apps/cryptpad.nix
   ./services/web-apps/documize.nix
   ./services/web-apps/frab.nix
+  ./services/web-apps/fresh-rss.nix
   ./services/web-apps/gotify-server.nix
   ./services/web-apps/icingaweb2/icingaweb2.nix
   ./services/web-apps/icingaweb2/module-monitoring.nix

--- a/nixos/modules/services/web-apps/fresh-rss.nix
+++ b/nixos/modules/services/web-apps/fresh-rss.nix
@@ -1,0 +1,219 @@
+{ config, pkgs, lib, ... }:
+
+let
+
+  inherit (lib) mkDefault mkEnableOption mkForce mkIf mkMerge mkOption;
+  inherit (lib) literalExample optional optionalString types;
+
+  cfg = config.services.fresh-rss;
+  fpm = config.services.phpfpm.pools.fresh-rss;
+
+  user = "freshrss";
+  group = config.services.httpd.group;
+  stateDir = "/var/lib/fresh-rss";
+
+in
+{
+  # interface
+  options = {
+    services.fresh-rss = {
+
+      enable = mkEnableOption "FreshRSS";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.fresh-rss;
+        description = "Which FreshRSS package to use.";
+      };
+
+      initialPassword = mkOption {
+        type = types.str;
+        example = "correcthorsebatterystaple";
+        description = ''
+          Specifies the initial password for the admin, i.e. the password assigned if the user does not already exist.
+          The password specified here is world-readable in the Nix store, so it should be changed promptly.
+        '';
+      };
+
+      database = {
+        host = mkOption {
+          type = types.str;
+          default = "localhost";
+          description = "Database host address.";
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = 3306;
+          description = "Database host port.";
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "freshrss";
+          description = "Database name.";
+        };
+
+        user = mkOption {
+          type = types.str;
+          default = "freshrss";
+          description = "Database user.";
+        };
+
+        passwordFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "/run/keys/freshrss-dbpassword";
+          description = ''
+            A file containing the password corresponding to
+            <option>database.user</option>.
+          '';
+        };
+
+        createLocally = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Create the database and database user locally.
+            This currently only applies if database type "mysql" is selected.
+          '';
+        };
+      };
+
+      virtualHost = mkOption {
+        type = types.submodule (import ../web-servers/apache-httpd/per-server-options.nix);
+        example = literalExample ''
+          {
+            hostName = "fresh-rss.example.org";
+            adminAddr = "webmaster@example.org";
+            forceSSL = true;
+            enableACME = true;
+          }
+        '';
+        description = ''
+          Apache configuration can be done by adapting <option>services.httpd.virtualHosts</option>.
+          See <xref linkend="opt-services.httpd.virtualHosts"/> for further information.
+        '';
+      };
+
+      poolConfig = mkOption {
+        type = with types; attrsOf (oneOf [ str int bool ]);
+        default = {
+          "pm" = "dynamic";
+          "pm.max_children" = 32;
+          "pm.start_servers" = 2;
+          "pm.min_spare_servers" = 2;
+          "pm.max_spare_servers" = 4;
+          "pm.max_requests" = 500;
+        };
+        description = ''
+          Options for the FreshRSS PHP pool. See the documentation on <literal>php-fpm.conf</literal>
+          for details on configuration directives.
+        '';
+      };
+
+    };
+  };
+
+  # implementation
+  config = mkIf cfg.enable {
+
+    assertions = [
+      { assertion = cfg.database.createLocally -> cfg.database.user == user;
+        message = "services.fresh-rss.database.user must be set to ${user} if services.fresh-rss.database.createLocally is set true";
+      }
+      { assertion = cfg.database.createLocally -> cfg.database.passwordFile == null;
+        message = "a password cannot be specified if services.fresh-rss.database.createLocally is set to true";
+      }
+    ];
+
+    services.mysql = mkIf cfg.database.createLocally {
+      enable = true;
+      package = mkDefault pkgs.mariadb;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        { name = cfg.database.user;
+          ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
+        }
+      ];
+    };
+
+    services.phpfpm.pools.fresh-rss = {
+      inherit user group;
+      settings = {
+        "listen.owner" = config.services.httpd.user;
+        "listen.group" = config.services.httpd.group;
+      } // cfg.poolConfig;
+    };
+
+    services.httpd = {
+      enable = true;
+      extraModules = [ "proxy_fcgi" ];
+      virtualHosts.${cfg.virtualHost.hostName} = mkMerge [ cfg.virtualHost {
+        documentRoot = mkForce "${cfg.package}/share/fresh-rss/p";
+        extraConfig = ''
+          <Directory "${cfg.package}/share/fresh-rss/p">
+            <FilesMatch "\.php$">
+              <If "-f %{REQUEST_FILENAME}">
+                SetHandler "proxy:unix:${fpm.socket}|fcgi://localhost/"
+              </If>
+            </FilesMatch>
+
+            AllowOverride AuthConfig FileInfo Indexes Limit
+            Require all granted
+          </Directory>
+
+          <IfModule mod_http2.c>
+            Protocols h2 http/1.1
+          </IfModule>
+
+          # for the API
+          AllowEncodedSlashes On
+        '';
+      } ];
+    };
+
+    systemd.services.fresh-rss-init = {
+      wantedBy = [ "multi-user.target" ];
+      before = [ "phpfpm-fresh-rss.service" ];
+      after = optional cfg.database.createLocally "mysql.service";
+      script = ''
+        cp -r ${cfg.package}/share/fresh-rss/data/. ${stateDir}
+        chmod -R u+w ${stateDir}/
+
+        if [ ! -f "${stateDir}/config.php" ]; then
+          ${pkgs.php}/bin/php ${cfg.package}/share/fresh-rss/cli/do-install.php \
+            --default_user admin \
+            --db-type mysql \
+            --db-host ${cfg.database.host}:${toString cfg.database.port} \
+            --db-user ${cfg.database.user} \
+            --db-base ${cfg.database.name} \
+            ${optionalString (cfg.database.passwordFile != null) "--db-password `cat ${cfg.database.passwordFile}`"} \
+            --disable_update
+
+          ${pkgs.php}/bin/php ${cfg.package}/share/fresh-rss/cli/create-user.php \
+            --user admin \
+            --password '${cfg.initialPassword}'
+        fi
+
+        rm -f ${stateDir}/do-install.txt
+      '';
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = user;
+        Group = group;
+        StateDirectory = "fresh-rss";
+        StateDirectoryMode = "0750";
+        PrivateTmp = true;
+      };
+    };
+
+    systemd.services.httpd.after = optional cfg.database.createLocally "mysql.service";
+
+    users.users.${user} = {
+      group = group;
+      isSystemUser = true;
+    };
+  };
+}

--- a/pkgs/servers/web-apps/fresh-rss/default.nix
+++ b/pkgs/servers/web-apps/fresh-rss/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, writeText }:
+
+stdenv.mkDerivation rec {
+  pname = "fresh-rss";
+  version = "1.15.3";
+
+  src = fetchFromGitHub {
+    owner = "FreshRSS";
+    repo = "FreshRSS";
+    rev = version;
+    sha256 = "0xnflvqhifk0icqqclv4qbs43x77syi3szha5mzqxf2fxyzrs358";
+  };
+
+  phpConfig = writeText "constants.local.php" ''
+  <?php
+    safe_define('DATA_PATH', '/var/lib/fresh-rss');
+  ?>
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fresh-rss
+    cp -r . $out/share/fresh-rss
+    cp ${phpConfig} $out/share/fresh-rss/constants.local.php
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A free, self-hostable aggregator... probably the best!";
+    license = licenses.agpl3;
+    homepage = "https://freshrss.org/";
+
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15159,6 +15159,8 @@ in
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration;
   };
 
+  fresh-rss = callPackage ../servers/web-apps/fresh-rss { };
+
   fusionInventory = callPackage ../servers/monitoring/fusion-inventory { };
 
   gatling = callPackage ../servers/http/gatling { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/77246

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @schmittlauch
