### PR TITLE
krop: Add wrapQtAppsHook.

### DIFF
--- a/pkgs/applications/graphics/krop/default.nix
+++ b/pkgs/applications/graphics/krop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3Packages, libsForQt5, ghostscript }:
+{ stdenv, fetchFromGitHub, python3Packages, libsForQt5, ghostscript, qt5}:
 
 python3Packages.buildPythonApplication rec {
   pname = "krop";
@@ -17,6 +17,11 @@ python3Packages.buildPythonApplication rec {
     poppler-qt5
     libsForQt5.poppler
     ghostscript
+  ];
+
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+  makeWrapperArgs = [
+   "\${qtWrapperArgs[@]}"
   ];
 
   # Disable checks because of interference with older Qt versions // xcb


### PR DESCRIPTION
###### Motivation for this change
`krop` segfaults, because it was missing the QT plugin wrapper. Closes #77339

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @leenaars 
