### PR TITLE
blender: fix on darwin

### DIFF
--- a/pkgs/applications/graphics/openimageio/default.nix
+++ b/pkgs/applications/graphics/openimageio/default.nix
@@ -39,6 +39,5 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.unix;
-    badPlatforms = [ "x86_64-darwin" ];
   };
 }

--- a/pkgs/applications/misc/blender/darwin.patch
+++ b/pkgs/applications/misc/blender/darwin.patch
@@ -1,0 +1,105 @@
+diff a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake/platform/platform_apple.cmake
+--- a/build_files/cmake/platform/platform_apple.cmake
++++ b/build_files/cmake/platform/platform_apple.cmake
+@@ -35,7 +35,6 @@ else()
+   message(STATUS "Using pre-compiled LIBDIR: ${LIBDIR}")
+ endif()
+ if(NOT EXISTS "${LIBDIR}/")
+-  message(FATAL_ERROR "Mac OSX requires pre-compiled libs at: '${LIBDIR}'")
+ endif()
+ 
+ if(WITH_OPENAL)
+@@ -79,7 +78,7 @@ endif()
+ if(WITH_CODEC_SNDFILE)
+   set(LIBSNDFILE ${LIBDIR}/sndfile)
+   set(LIBSNDFILE_INCLUDE_DIRS ${LIBSNDFILE}/include)
+-  set(LIBSNDFILE_LIBRARIES sndfile FLAC ogg vorbis vorbisenc)
++  set(LIBSNDFILE_LIBRARIES sndfile)
+   set(LIBSNDFILE_LIBPATH ${LIBSNDFILE}/lib ${LIBDIR}/ffmpeg/lib)  # TODO, deprecate
+ endif()
+ 
+@@ -90,7 +89,7 @@ if(WITH_PYTHON)
+     # normally cached but not since we include them with blender
+     set(PYTHON_INCLUDE_DIR "${LIBDIR}/python/include/python${PYTHON_VERSION}m")
+     set(PYTHON_EXECUTABLE "${LIBDIR}/python/bin/python${PYTHON_VERSION}m")
+-    set(PYTHON_LIBRARY ${LIBDIR}/python/lib/libpython${PYTHON_VERSION}m.a)
++    set(PYTHON_LIBRARY "${LIBDIR}/python/lib/libpython${PYTHON_VERSION}m.dylib")
+     set(PYTHON_LIBPATH "${LIBDIR}/python/lib/python${PYTHON_VERSION}")
+     # set(PYTHON_LINKFLAGS "-u _PyMac_Error")  # won't  build with this enabled
+   else()
+@@ -155,10 +154,7 @@ if(WITH_CODEC_FFMPEG)
+   set(FFMPEG_INCLUDE_DIRS ${FFMPEG}/include)
+   set(FFMPEG_LIBRARIES
+     avcodec avdevice avformat avutil
+-    mp3lame swscale x264 xvidcore
+-    theora theoradec theoraenc
+-    vorbis vorbisenc vorbisfile ogg opus
+-    vpx swresample)
++    swscale swresample)
+   set(FFMPEG_LIBPATH ${FFMPEG}/lib)
+ endif()
+ 
+@@ -199,14 +195,14 @@ if(WITH_OPENCOLLADA)
+   set(OPENCOLLADA ${LIBDIR}/opencollada)
+ 
+   set(OPENCOLLADA_INCLUDE_DIRS
+-    ${LIBDIR}/opencollada/include/COLLADAStreamWriter
+-    ${LIBDIR}/opencollada/include/COLLADABaseUtils
+-    ${LIBDIR}/opencollada/include/COLLADAFramework
+-    ${LIBDIR}/opencollada/include/COLLADASaxFrameworkLoader
+-    ${LIBDIR}/opencollada/include/GeneratedSaxParser
++    ${LIBDIR}/opencollada/include/opencollada/COLLADAStreamWriter
++    ${LIBDIR}/opencollada/include/opencollada/COLLADABaseUtils
++    ${LIBDIR}/opencollada/include/opencollada/COLLADAFramework
++    ${LIBDIR}/opencollada/include/opencollada/COLLADASaxFrameworkLoader
++    ${LIBDIR}/opencollada/include/opencollada/GeneratedSaxParser
+   )
+ 
+-  set(OPENCOLLADA_LIBPATH ${OPENCOLLADA}/lib)
++  set(OPENCOLLADA_LIBPATH ${OPENCOLLADA}/lib/opencollada)
+   set(OPENCOLLADA_LIBRARIES
+     OpenCOLLADASaxFrameworkLoader
+     -lOpenCOLLADAFramework
+@@ -215,7 +211,7 @@ if(WITH_OPENCOLLADA)
+     -lMathMLSolver
+     -lGeneratedSaxParser
+     -lbuffer -lftoa -lUTF
+-    ${OPENCOLLADA_LIBPATH}/libxml2.a
++    xml2
+   )
+   # PCRE is bundled with openCollada
+   # set(PCRE ${LIBDIR}/pcre)
+@@ -276,14 +272,13 @@ if(WITH_BOOST)
+ endif()
+ 
+ if(WITH_INTERNATIONAL OR WITH_CODEC_FFMPEG)
+-  set(PLATFORM_LINKFLAGS "${PLATFORM_LINKFLAGS} -liconv") # boost_locale and ffmpeg needs it !
+ endif()
+ 
+ if(WITH_OPENIMAGEIO)
+   set(OPENIMAGEIO ${LIBDIR}/openimageio)
+   set(OPENIMAGEIO_INCLUDE_DIRS ${OPENIMAGEIO}/include)
+   set(OPENIMAGEIO_LIBRARIES
+-    ${OPENIMAGEIO}/lib/libOpenImageIO.a
++    ${OPENIMAGEIO}/lib/libOpenImageIO.dylib
+     ${PNG_LIBRARIES}
+     ${JPEG_LIBRARIES}
+     ${TIFF_LIBRARY}
+@@ -306,7 +301,7 @@ endif()
+ if(WITH_OPENCOLORIO)
+   set(OPENCOLORIO ${LIBDIR}/opencolorio)
+   set(OPENCOLORIO_INCLUDE_DIRS ${OPENCOLORIO}/include)
+-  set(OPENCOLORIO_LIBRARIES OpenColorIO tinyxml yaml-cpp)
++  set(OPENCOLORIO_LIBRARIES OpenColorIO)
+   set(OPENCOLORIO_LIBPATH ${OPENCOLORIO}/lib)
+ endif()
+ 
+@@ -443,7 +438,7 @@ else()
+   set(CMAKE_CXX_FLAGS_RELEASE "-mdynamic-no-pic -fno-strict-aliasing")
+ endif()
+ 
+-if(${XCODE_VERSION} VERSION_EQUAL 5 OR ${XCODE_VERSION} VERSION_GREATER 5)
++if(FALSE)
+   # Xcode 5 is always using CLANG, which has too low template depth of 128 for libmv
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-depth=1024")
+ endif()

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -1,7 +1,7 @@
 { config, stdenv, lib, fetchurl, boost, cmake, ffmpeg, gettext, glew
 , ilmbase, libXi, libX11, libXext, libXrender
 , libjpeg, libpng, libsamplerate, libsndfile
-, libtiff, libGLU, libGL, openal, opencolorio, openexr, openimageio, openjpeg_1, python3Packages
+, libtiff, libGLU, libGL, openal, opencolorio, openexr, openimageio, openjpeg, python3Packages
 , openvdb, libXxf86vm, tbb
 , zlib, fftw, opensubdiv, freetype, jemalloc, ocl-icd, addOpenGLRunpath
 , jackaudioSupport ? false, libjack2
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     [ boost ffmpeg gettext glew ilmbase
       libXi libX11 libXext libXrender
       freetype libjpeg libpng libsamplerate libsndfile libtiff libGLU libGL openal
-      opencolorio openexr openimageio openjpeg_1 python zlib fftw jemalloc
+      opencolorio openexr openimageio openjpeg python zlib fftw jemalloc
       (opensubdiv.override { inherit cudaSupport; })
       openvdb libXxf86vm tbb
       makeWrapper

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -8,6 +8,7 @@
 , cudaSupport ? config.cudaSupport or false, cudatoolkit
 , colladaSupport ? true, opencollada
 , enableNumpy ? false, makeWrapper
+, pugixml, SDL, Cocoa, CoreGraphics, ForceFeedback, OpenAL, OpenGL
 }:
 
 with lib;
@@ -23,22 +24,53 @@ stdenv.mkDerivation rec {
     sha256 = "1zl0ar95qkxsrbqw9miz2hrjijlqjl06vg3clfk9rm7krr2l3b2j";
   };
 
+  patches = lib.optional stdenv.isDarwin ./darwin.patch;
+
   nativeBuildInputs = [ cmake ] ++ optional cudaSupport addOpenGLRunpath;
   buildInputs =
     [ boost ffmpeg gettext glew ilmbase
-      libXi libX11 libXext libXrender
-      freetype libjpeg libpng libsamplerate libsndfile libtiff libGLU libGL openal
+      freetype libjpeg libpng libsamplerate libsndfile libtiff
       opencolorio openexr openimageio openjpeg python zlib fftw jemalloc
       (opensubdiv.override { inherit cudaSupport; })
-      openvdb libXxf86vm tbb
+      tbb
       makeWrapper
     ]
+    ++ (if (!stdenv.isDarwin) then [
+      libXi libX11 libXext libXrender
+      libGLU libGL openal
+      libXxf86vm
+      # OpenVDB currently doesn't build on darwin
+      openvdb
+    ]
+    else [
+      pugixml SDL Cocoa CoreGraphics ForceFeedback OpenAL OpenGL
+    ])
     ++ optional jackaudioSupport libjack2
     ++ optional cudaSupport cudatoolkit
     ++ optional colladaSupport opencollada;
 
   postPatch =
-    ''
+    if stdenv.isDarwin then ''
+      : > build_files/cmake/platform/platform_apple_xcode.cmake
+      substituteInPlace source/creator/CMakeLists.txt \
+        --replace '${"$"}{LIBDIR}/python' \
+                  '${python}'
+      substituteInPlace build_files/cmake/platform/platform_apple.cmake \
+        --replace '${"$"}{LIBDIR}/python' \
+                  '${python}' \
+        --replace '${"$"}{LIBDIR}/opencollada' \
+                  '${opencollada}' \
+        --replace '${"$"}{PYTHON_LIBPATH}/site-packages/numpy' \
+                  '${python3Packages.numpy}/${python.sitePackages}/numpy' \
+        --replace 'set(OPENJPEG_INCLUDE_DIRS ' \
+                  'set(OPENJPEG_INCLUDE_DIRS "'$(echo ${openjpeg.dev}/include/openjpeg-*)'") #' \
+        --replace 'set(OPENJPEG_LIBRARIES ' \
+                  'set(OPENJPEG_LIBRARIES "${openjpeg}/lib/libopenjp2.dylib") #' \
+        --replace 'set(OPENIMAGEIO ' \
+                  'set(OPENIMAGEIO "${openimageio.out}") #' \
+        --replace 'set(OPENEXR_INCLUDE_DIRS ' \
+                  'set(OPENEXR_INCLUDE_DIRS "${openexr.dev}/include/OpenEXR") #'
+    '' else ''
       substituteInPlace extern/clew/src/clew.c --replace '"libOpenCL.so"' '"${ocl-icd}/lib/libOpenCL.so"'
     '';
 
@@ -48,7 +80,7 @@ stdenv.mkDerivation rec {
       "-DWITH_CODEC_SNDFILE=ON"
       "-DWITH_INSTALL_PORTABLE=OFF"
       "-DWITH_FFTW3=ON"
-      #"-DWITH_SDL=ON"
+      "-DWITH_SDL=OFF"
       "-DWITH_OPENCOLORIO=ON"
       "-DWITH_OPENSUBDIV=ON"
       "-DPYTHON_LIBRARY=${python.libPrefix}m"
@@ -61,10 +93,18 @@ stdenv.mkDerivation rec {
       "-DWITH_OPENVDB=ON"
       "-DWITH_TBB=ON"
       "-DWITH_IMAGE_OPENJPEG=ON"
+      "-DWITH_OPENCOLLADA=${if colladaSupport then "ON" else "OFF"}"
     ]
+    ++ optionals stdenv.isDarwin [
+      "-DWITH_CYCLES_OSL=OFF" # requires LLVM
+      "-DWITH_OPENVDB=OFF" # OpenVDB currently doesn't build on darwin
+
+      "-DLIBDIR=/does-not-exist"
+    ]
+    # Clang doesn't support "-export-dynamic"
+    ++ optional stdenv.cc.isClang "-DPYTHON_LINKFLAGS="
     ++ optional jackaudioSupport "-DWITH_JACK=ON"
-    ++ optional cudaSupport "-DWITH_CYCLES_CUDA_BINARIES=ON"
-    ++ optional colladaSupport "-DWITH_OPENCOLLADA=ON";
+    ++ optional cudaSupport "-DWITH_CYCLES_CUDA_BINARIES=ON";
 
   NIX_CFLAGS_COMPILE = "-I${ilmbase.dev}/include/OpenEXR -I${python}/include/${python.libPrefix}";
 
@@ -95,7 +135,7 @@ stdenv.mkDerivation rec {
     # They comment two licenses: GPLv2 and Blender License, but they
     # say: "We've decided to cancel the BL offering for an indefinite period."
     license = licenses.gpl2Plus;
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = [ maintainers.goibhniu ];
   };
 }

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -1,7 +1,7 @@
 { config, stdenv, lib, fetchurl, boost, cmake, ffmpeg, gettext, glew
 , ilmbase, libXi, libX11, libXext, libXrender
 , libjpeg, libpng, libsamplerate, libsndfile
-, libtiff, libGLU, libGL, openal, opencolorio, openexr, openimageio, openjpeg, python3Packages
+, libtiff, libGLU, libGL, openal, opencolorio, openexr, openimageio2, openjpeg, python3Packages
 , openvdb, libXxf86vm, tbb
 , zlib, fftw, opensubdiv, freetype, jemalloc, ocl-icd, addOpenGLRunpath
 , jackaudioSupport ? false, libjack2
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [ boost ffmpeg gettext glew ilmbase
       freetype libjpeg libpng libsamplerate libsndfile libtiff
-      opencolorio openexr openimageio openjpeg python zlib fftw jemalloc
+      opencolorio openexr openimageio2 openjpeg python zlib fftw jemalloc
       (opensubdiv.override { inherit cudaSupport; })
       tbb
       makeWrapper
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
         --replace 'set(OPENJPEG_LIBRARIES ' \
                   'set(OPENJPEG_LIBRARIES "${openjpeg}/lib/libopenjp2.dylib") #' \
         --replace 'set(OPENIMAGEIO ' \
-                  'set(OPENIMAGEIO "${openimageio.out}") #' \
+                  'set(OPENIMAGEIO "${openimageio2.out}") #' \
         --replace 'set(OPENEXR_INCLUDE_DIRS ' \
                   'set(OPENEXR_INCLUDE_DIRS "${openexr.dev}/include/OpenEXR") #'
     '' else ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18210,7 +18210,9 @@ in
 
   bleachbit = callPackage ../applications/misc/bleachbit { };
 
-  blender = callPackage  ../applications/misc/blender { };
+  blender = callPackage  ../applications/misc/blender {
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics ForceFeedback OpenAL OpenGL;
+  };
 
   bluefish = callPackage ../applications/editors/bluefish {
     gtk = gtk3;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Enable blender on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
