### PR TITLE
isync: enable manpage and reformat

### DIFF
--- a/pkgs/tools/networking/isync/default.nix
+++ b/pkgs/tools/networking/isync/default.nix
@@ -1,14 +1,24 @@
-{ fetchurl, stdenv, openssl, pkgconfig, db, zlib, cyrus_sasl, perl }:
+{ fetchurl
+, stdenv
+, openssl
+, autoreconfHook
+, pkgconfig
+, db
+, zlib
+, cyrus_sasl
+, perl
+}:
 
 stdenv.mkDerivation rec {
-  name = "isync-1.3.1";
+  pname = "isync";
+  version = "1.3.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/isync/${name}.tar.gz";
+    url = "mirror://sourceforge/isync/${pname}-${version}.tar.gz";
     sha256 = "1sphd30jplii58y2zmw365bckm6pszmapcy905zhjll1sm1ldjv8";
   };
 
-  nativeBuildInputs = [ pkgconfig perl ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig perl ];
   buildInputs = [ openssl db cyrus_sasl zlib ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
