### PR TITLE
Update sha256 in python-hypothesis

### DIFF
--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchFromGitHub
-, isPy3k, attrs, coverage, enum34, pexpect
+, isPy3k, attrs, coverage, sortedcontainers, enum34, pexpect
 , doCheck ? true, pytest, pytest_xdist, flaky, mock
 }:
 buildPythonPackage rec {
@@ -17,12 +17,12 @@ buildPythonPackage rec {
     owner = "HypothesisWorks";
     repo = "hypothesis-python";
     rev = "hypothesis-python-${version}";
-    sha256 = "09bpwp4kdywkmzci969m57w0yy8c31kzwg60vg4mvrmmgyi2cfzv";
+    sha256 = "04n1237cqrkka5sy6vzs4yb9vwz85vi4l1bwjddq8isxkid3grwz";
   };
 
   postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";
 
-  propagatedBuildInputs = [ attrs coverage ] ++ lib.optional (!isPy3k) enum34;
+  propagatedBuildInputs = [ attrs coverage sortedcontainers ] ++ lib.optional (!isPy3k) enum34;
 
   checkInputs = [ pytest pytest_xdist flaky mock pexpect ];
   inherit doCheck;


### PR DESCRIPTION
it looks like the version bump in
046c4020a5ab572371f3beed1951455fe0d6198f did not update the sha256

Also there was a dependency missing.