### PR TITLE
calls: unstable-2019-10-29 -> 0.1.1

### DIFF
--- a/pkgs/applications/networking/calls/default.nix
+++ b/pkgs/applications/networking/calls/default.nix
@@ -14,6 +14,7 @@
 , libpeas
 , dbus
 , vala
+, wrapGAppsHook
 , xorg
 , xvfb_run
 , libxml2
@@ -21,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "calls";
-  version = "unstable-2019-10-29";
+  version = "0.1.1";
 
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
     repo = "calls";
-    rev = "9fe575053d8f01c3a76a6c20d39f0816166d5afd";
+    rev = "v${version}";
     sha256 = "01inx4mvrzvklwrfryw5hw9p89v8cn78m3qmv97g7a3v0h5c0n35";
   };
 
@@ -37,6 +38,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     desktop-file-utils
     vala
+    wrapGAppsHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
New upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).