### PR TITLE
ldc: fix build and skip impure test

### DIFF
--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, cmake, ninja, llvm_5, llvm_8, curl, tzdata
 , python, libconfig, lit, gdb, unzip, darwin, bash
-, callPackage, makeWrapper, targetPackages
+, callPackage, makeWrapper, runCommand, targetPackages
 , bootstrapVersion ? false
 , version ? "1.17.0"
 , ldcSha256 ? "1aag5jfrng6p4ms0fs90hjbv9bcj3hj8h52r68c3cm6racdajbva"
@@ -18,6 +18,11 @@ let
   else
     "";
 
+  pathConfig = runCommand "ldc-lib-paths" {} ''
+    mkdir $out
+    echo ${tzdata}/share/zoneinfo/ > $out/TZDatabaseDirFile
+    echo ${curl.out}/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} > $out/LibcurlPathFile
+  '';
 in
 
 stdenv.mkDerivation rec {
@@ -42,17 +47,14 @@ stdenv.mkDerivation rec {
       rm ldc-${version}-src/tests/d2/dmd-testsuite/fail_compilation/mixin_gc.d
       rm ldc-${version}-src/tests/d2/dmd-testsuite/runnable/xtest46_gc.d
       rm ldc-${version}-src/tests/d2/dmd-testsuite/runnable/testptrref_gc.d
+
+      # test depends on current year
+      rm ldc-${version}-src/tests/d2/dmd-testsuite/compilable/ddocYear.d
   ''
 
   + stdenv.lib.optionalString (!bootstrapVersion && stdenv.hostPlatform.isDarwin) ''
       # https://github.com/NixOS/nixpkgs/issues/34817
       rm -r ldc-${version}-src/tests/plugins/addFuncEntryCall
-  ''
-
-  + stdenv.lib.optionalString (!bootstrapVersion) ''
-      echo ${tzdata}/share/zoneinfo/ > ldc-${version}-src/TZDatabaseDirFile
-
-      echo ${curl.out}/lib/libcurl${stdenv.hostPlatform.extensions.sharedLibrary} > ldc-${version}-src/LibcurlPathFile
   '';
 
   postPatch = ''
@@ -98,7 +100,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ curl tzdata ];
 
   cmakeFlags = stdenv.lib.optionals (!bootstrapVersion) [
-    "-DD_FLAGS=-d-version=TZDatabaseDir;-d-version=LibcurlPath;-J$PWD"
+    "-DD_FLAGS=-d-version=TZDatabaseDir;-d-version=LibcurlPath;-J${pathConfig}"
     "-DCMAKE_BUILD_TYPE=Release"
   ];
 


### PR DESCRIPTION
Fixes #76973

This moves the path configuration to a separate derivation and skips
an impure test that depends on the current year.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is part of my system closure, so I'm keen to see it fixed.

I've naively applied the recommendations from https://github.com/NixOS/nixpkgs/issues/76973#issuecomment-571489444. but my understanding of D is very superficial. Are the `-d-version=` flags still appropriate?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ThomasMader 
