### PR TITLE
opentimestamps-client: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/tools/misc/opentimestamps-client/default.nix
+++ b/pkgs/tools/misc/opentimestamps-client/default.nix
@@ -4,7 +4,7 @@
 
 buildPythonApplication rec {
   pname = "opentimestamps-client";
-  version = "0.6.0";
+  version = "0.7.0";
   disabled = (!isPy3k);
 
   # We can't use the pypi source because it doesn't include README.md which is
@@ -13,17 +13,8 @@ buildPythonApplication rec {
     owner = "opentimestamps";
     repo = "opentimestamps-client";
     rev = "opentimestamps-client-v${version}";
-    sha256 = "05m8nllqad3k69mvby5q08y22i0wrj84gqifdgcldimrrn1i00xp";
+    sha256 = "1aiq9cwr40md54swzm7wkwj0h65psxmvj2japvw79s9x0pp8iwqs";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/opentimestamps/opentimestamps-client/commit/1b328269ceee66916e9a639e8d5d7d13cd70d5d8.patch";
-      sha256 = "0bd3yalyvk5n4sflw9zilpay5k653ybdgkkfppyrk7c8z3i81hbl";
-    })
-  ];
-
-  checkInputs = [ git ];
 
   propagatedBuildInputs = [ opentimestamps appdirs GitPython pysocks ];
 


### PR DESCRIPTION
The extra git check input and the patch aren't needed anymore.