### PR TITLE
python2Packages.ihatemoney: fix python2 test deps

### DIFF
--- a/pkgs/development/python-modules/ihatemoney/default.nix
+++ b/pkgs/development/python-modules/ihatemoney/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, lib, fetchFromGitHub, nixosTests
+{ buildPythonPackage, lib, fetchFromGitHub, isPy27, nixosTests
 , alembic
 , aniso8601
 , Babel
@@ -20,6 +20,7 @@
 , jinja2
 , Mako
 , markupsafe
+, mock
 , python-dateutil
 , pytz
 , six
@@ -74,7 +75,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     flask_testing
-  ];
+  ] ++ lib.optionals isPy27 [ mock ];
 
   passthru.tests = {
     inherit (nixosTests) ihatemoney;


### PR DESCRIPTION
###### Motivation for this change
noticed it failing https://hydra.nixos.org/build/109940007

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
