### PR TITLE
obexfs: add missing bluez dep

### DIFF
--- a/pkgs/tools/bluetooth/obexfs/default.nix
+++ b/pkgs/tools/bluetooth/obexfs/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, pkgconfig, fuse, obexftp }:
-   
+{ stdenv, fetchurl, pkgconfig, bluez, fuse, obexftp }:
+
 stdenv.mkDerivation rec {
   name = "obexfs-0.12";
-   
+
   src = fetchurl {
     url = "mirror://sourceforge/openobex/${name}.tar.gz";
     sha256 = "1g3krpygk6swa47vbmp9j9s8ahqqcl9ra8r25ybgzv2d9pmjm9kj";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ fuse obexftp ];
+  buildInputs = [ fuse obexftp bluez ];
 
   meta = with stdenv.lib; {
     homepage = http://dev.zuckschwerdt.org/openobex/wiki/ObexFs;


### PR DESCRIPTION
###### Motivation for this change
noticed it was failing: https://hydra.nixos.org/build/109940494

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
