### PR TITLE
imv: 4.0.1 -> 4.1.0

### DIFF
--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -2,18 +2,18 @@
 , freeimage, fontconfig, pkgconfig
 , asciidoc, docbook_xsl, libxslt, cmocka
 , librsvg, pango, libxkbcommon, wayland
-, libGLU
+, libGLU, icu
 }:
 
 stdenv.mkDerivation rec {
   pname = "imv";
-  version = "4.0.1";
+  version = "4.1.0";
 
   src = fetchFromGitHub {
     owner  = "eXeC64";
     repo   = "imv";
     rev    = "v${version}";
-    sha256 = "sha256:01fbkbwwsyr00k3mwans8jfb9p4gl02v6z62vgx0pkgrzxjkcz07";
+    sha256 = "sha256:0gk8g178i961nn3bls75a8qpv6wvfvav6hd9lxca1skaikd33zdx";
   };
 
   preBuild = ''
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
     pango
     pkgconfig
     wayland
+    icu
   ];
 
   installFlags = [ "PREFIX=$(out)" "CONFIGPREFIX=$(out)/etc" ];


### PR DESCRIPTION
#### Motivation for this change

Bump imv.

###### Things done

Bumped version, added icu as dependency, as it [a new mandatory dependency](https://github.com/eXeC64/imv/commit/42a15b157827dbd9c981416c8919ce5f5c907331#diff-04c6e90faac2675aa89e2176d2eec7d8R123).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @rnhmjoj @markus1189 
