### PR TITLE
pythonPackages.pycodestyle: improve tests

### DIFF
--- a/pkgs/development/python-modules/pycodestyle/default.nix
+++ b/pkgs/development/python-modules/pycodestyle/default.nix
@@ -1,4 +1,7 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ buildPythonPackage
+, fetchPypi
+, lib
+}:
 
 buildPythonPackage rec {
   pname = "pycodestyle";
@@ -6,13 +9,23 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c";
+    sha256 = "0v4prb05n21bm8650v0a01k1nyqjdmkrsm3zycfxh2j5k9n962p4";
   };
+
+  # https://github.com/PyCQA/pycodestyle/blob/2.5.0/tox.ini#L14
+  checkPhase = ''
+    python pycodestyle.py --max-doc-length=72 --testsuite testsuite
+    python pycodestyle.py --statistics pycodestyle.py
+    python pycodestyle.py --max-doc-length=72 --doctest
+    python setup.py test
+  '';
 
   meta = with lib; {
     description = "Python style guide checker (formerly called pep8)";
     homepage = https://pycodestyle.readthedocs.io;
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
   };
 }


### PR DESCRIPTION
- This commit adjust the tests to the ones that are found in the
  tox.ini file for the specified version of the module
- This means we'll have 3 tests in adition to the default one

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

found it while doing other things and wanted to contribute it

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
