### PR TITLE
nixos/zerotierone: prevent systemd from changing MAC address

### DIFF
--- a/nixos/modules/services/networking/zerotierone.nix
+++ b/nixos/modules/services/networking/zerotierone.nix
@@ -63,5 +63,15 @@ in
     networking.firewall.allowedUDPPorts = [ cfg.port ];
 
     environment.systemPackages = [ cfg.package ];
+
+    # Prevent systemd from potentially changing the MAC address
+    environment.etc."systemd/network/50-zerotier.link".text = ''
+      [Match]
+      OriginalName=zt*
+
+      [Link]
+      AutoNegotiation=false
+      MACAddressPolicy=none
+    '';
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
zerotier has been very flaky for me after this commit fe3da83b7e26b6f7cdde7a457a794c215d16e969. Somehow adding `tap` to `boot.kernelModules` was causing issues on cloud hosted instances--as well as in qemu.

While debugging, I found that systemd was sometimes changing the MAC address of the interface after it was brought up by zerotier. This is even without using `systemd-networkd`. This PR disables that behavior from systemd for zerotier interfaces.

Note that i'm not using the `systemd.network.link.<name>` option in my PR since it is only active when `systemd.network.enable` is set. It's not clear to me if this should be the case or not.

I have my own nixos test for zerotier here:
https://github.com/danielfullmer/nixos-config/blob/master/tests/zerotier/default.nix
It only works if this fix is used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @obadz