### PR TITLE
protonvpn-cli-ng: init at 2.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3448,6 +3448,16 @@
     githubId = 4611077;
     name = "Raymond Gauthier";
   };
+  jtcoolen = {
+    email = "jtcoolen@pm.me";
+    name = "Julien Coolen";
+    github = "jtcoolen";
+    githubId = 54635632;
+    keys = [{
+      longkeyid = "rsa4096/0x19642151C218F6F5";
+      fingerprint = "4C68 56EE DFDA 20FB 77E8  9169 1964 2151 C218 F6F5";
+    }];
+  };
   jtobin = {
     email = "jared@jtobin.io";
     github = "jtobin";

--- a/pkgs/applications/networking/protonvpn-cli-ng/default.nix
+++ b/pkgs/applications/networking/protonvpn-cli-ng/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchFromGitHub, python3Packages, openvpn, dialog }:
+
+python3Packages.buildPythonApplication rec {
+  name = "protonvpn-cli-ng";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "protonvpn";
+    repo = "protonvpn-cli-ng";
+    rev = "v${version}";
+    sha256 = "11fvnnr5p3qdc4y10815jnydcjvxlxwkkq9kvaajg0yszq84rwkz";
+  };
+
+  propagatedBuildInputs = (with python3Packages; [
+      requests
+      docopt
+      setuptools
+      pythondialog
+    ]) ++ [
+      dialog
+      openvpn
+    ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Linux command-line client for ProtonVPN";
+    homepage = "https://github.com/protonvpn/protonvpn-cli-ng";
+    maintainers = [ maintainers.jtcoolen ];
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20792,6 +20792,8 @@ in
 
   protonvpn-cli = callPackage ../applications/networking/protonvpn-cli { };
 
+  protonvpn-cli-ng = callPackage ../applications/networking/protonvpn-cli-ng { };
+
   ps2client = callPackage ../applications/networking/ps2client { };
 
   psi = callPackage ../applications/networking/instant-messengers/psi { };


### PR DESCRIPTION
###### Motivation for this change
This PR introduces a newer and enhanced version of the protonvpn-cli tool, written in Python (see https://github.com/ProtonVPN/protonvpn-cli-ng). 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).