### PR TITLE
gitAndTools.git-filter-repo: init at 2.24.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -40,6 +40,10 @@ let
 
   git-fame = callPackage ./git-fame {};
 
+  git-filter-repo = callPackage ./git-filter-repo {
+    pythonPackages = python3Packages;
+  };
+
   gita = python3Packages.callPackage ./gita {};
 
   # The full-featured Git.

--- a/pkgs/applications/version-management/git-and-tools/git-filter-repo/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-filter-repo/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+stdenv.mkDerivation rec {
+  pname = "git-filter-repo";
+  version = "2.25.0";
+
+  src = fetchurl {
+    url = "https://github.com/newren/git-filter-repo/releases/download/v${version}/${pname}-${version}.tar.xz";
+    sha256 = "1772if8ajaw80dsdw4ic6vjw24dq0b9w87qlkn0iw4b8r9yxp37a";
+  };
+
+  buildInputs = [ pythonPackages.python ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm755 -t $out/bin git-filter-repo
+    install -Dm644 -t $out/share/man/man1 Documentation/man1/git-filter-repo.1
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/newren/git-filter-repo";
+    description = "Quickly rewrite git repository history (filter-branch replacement)";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/newren/git-filter-repo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
