### PR TITLE
pythonPackages.hydra: init at 0.11.3

### DIFF
--- a/pkgs/development/python-modules/hydra/default.nix
+++ b/pkgs/development/python-modules/hydra/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27, pytest, omegaconf, pathlib2 }:
+
+buildPythonPackage rec {
+  pname = "hydra";
+  version = "0.11.3";
+
+  src = fetchFromGitHub {
+    owner = "facebookresearch";
+    repo = pname;
+    rev = version;
+    sha256 = "0plbls65qfrvvigza3qvy0pwjzgkz8ylpgb1im14k3b125ny41ad";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ omegaconf ] ++ lib.optional isPy27 pathlib2;
+
+  checkPhase = ''
+    runHook preCheck
+    pytest tests/
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "A framework for configuring complex applications";
+    homepage = https://hydra.cc;
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/omegaconf/default.nix
+++ b/pkgs/development/python-modules/omegaconf/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder
+, pytest, pytestrunner, pyyaml, six, pathlib2, isPy27 }:
+
+buildPythonPackage rec {
+  pname = "omegaconf";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "omry";
+    repo = pname;
+    rev = version;
+    sha256 = "1vpcdjlq54pm8xmkv2hqm2n1ysvz2a9iqgf55x0w6slrb4595cwb";
+  };
+
+  checkInputs = [ pytest ];
+  buildInputs = [ pytestrunner ];
+  propagatedBuildInputs = [ pyyaml six ] ++ stdenv.lib.optional isPy27 pathlib2;
+
+  meta = with stdenv.lib; {
+    description = "A framework for configuring complex applications";
+    homepage = "https://github.com/omry/omegaconf";
+    license = licenses.free;  # prior bsd license (1988)
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3737,6 +3737,8 @@ in {
 
   hvac = callPackage ../development/python-modules/hvac { };
 
+  hydra = callPackage ../development/python-modules/hydra { };
+
   hypothesis = callPackage ../development/python-modules/hypothesis { };
 
   colored = callPackage ../development/python-modules/colored { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4402,6 +4402,8 @@ in {
 
   od = callPackage ../development/python-modules/od { };
 
+  omegaconf = callPackage ../development/python-modules/omegaconf { };
+
   orderedset = callPackage ../development/python-modules/orderedset { };
 
   python-multipart = callPackage ../development/python-modules/python-multipart { };


### PR DESCRIPTION
pythonPackages.omegaconf: init at 1.4.1

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [NA] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
