### PR TITLE
qutebrowser: 1.8.3 -> 1.9.0

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -21,12 +21,12 @@ let
 
 in mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "qutebrowser";
-  version = "1.8.3";
+  version = "1.9.0";
 
   # the release tarballs are different from the git checkout!
   src = fetchurl {
     url = "https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "055zmzk3q0m3hx1742nfy2mdawfllrkvijnbzp1hiv01dj1bxaf8";
+    sha256 = "1y0yq1qfr6g1s7kf3w2crd0b025dv2dfknhlz3v0001ns3rgwj17";
   };
 
   # Needs tox

--- a/pkgs/applications/networking/browsers/qutebrowser/fix-restart.patch
+++ b/pkgs/applications/networking/browsers/qutebrowser/fix-restart.patch
@@ -1,29 +1,20 @@
 diff --git a/qutebrowser/app.py b/qutebrowser/app.py
-index 2b6896b76..ee05f379d 100644
+index a47b5d2f4..f23ee23ef 100644
 --- a/qutebrowser/app.py
 +++ b/qutebrowser/app.py
-@@ -555,22 +555,8 @@ class Quitter:
-                 args: The commandline as a list of strings.
-                 cwd: The current working directory as a string.
+@@ -573,13 +573,8 @@ class Quitter(QObject):
+         Return:
+             The commandline as a list of strings.
          """
 -        if os.path.basename(sys.argv[0]) == 'qutebrowser':
 -            # Launched via launcher script
 -            args = [sys.argv[0]]
--            cwd = None
 -        elif hasattr(sys, 'frozen'):
 -            args = [sys.executable]
--            cwd = os.path.abspath(os.path.dirname(sys.executable))
 -        else:
 -            args = [sys.executable, '-m', 'qutebrowser']
--            cwd = os.path.join(
--                os.path.abspath(os.path.dirname(qutebrowser.__file__)), '..')
--            if not os.path.isdir(cwd):
--                # Probably running from a python egg. Let's fallback to
--                # cwd=None and see if that works out.
--                # See https://github.com/qutebrowser/qutebrowser/issues/323
--                cwd = None
 +        args = ['@qutebrowser@']
 +        cwd = None
  
          # Add all open pages so they get reopened.
-         page_args = []
+         page_args = []  # type: typing.MutableSequence[str]


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version bump for qutebrowser

Closes #77360

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after) 1,691,204,144 -> 1,690,966,528
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
