### PR TITLE
morph: 1.3.1 -> 1.4.0

### DIFF
--- a/pkgs/tools/package-management/morph/default.nix
+++ b/pkgs/tools/package-management/morph/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   pname = "morph";
-  version = "1.3.1";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "dbcdk";
     repo = "morph";
     rev = "v${version}";
-    sha256 = "0nwl9n5b0lnil96573wa3hyr3vyvfiwvmpkla3pmwkpmriac4xrg";
+    sha256 = "1y6clzi8sfnrv4an26b44r24nnxds1kj9aw3lmjbgxl9yrxxsj1k";
   };
 
   goPackagePath = "github.com/dbcdk/morph";


### PR DESCRIPTION
###### Motivation for this change
```
Here's finally another major release. It's been a while, but now is the time! We've compiled a good collection of nice features and bugfixes for you.

The "special thanks" of this release goes out to @fooker and @flokli . Thank you both for your contributions! :1st_place_medal: 

Breaking changes - read carefully:

    The default build targets have been reduced to include only the target NixOS system, not its derivation. (#69, #91)
    nixpkgs.* NixOS options are no longer special-cased by morph eval-machines.nix, meaning that everything except from nixpkgs.overlays will not work, if either network.pkgs or nixpkgs.pkgs is set. (#96)

Other notable changes/fixes:

    morph push now supports substitute-on-destination (#73, #83)
    morph deploy .. dry-activate and deployment.targetHost now actually works as expected. (#81, #86)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
