### PR TITLE
lorri: unstable-2019-10-30 -> unstable-2020-01-09 (backport to release-19.09)

### DIFF
--- a/pkgs/tools/misc/lorri/default.nix
+++ b/pkgs/tools/misc/lorri/default.nix
@@ -15,7 +15,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lorri";
-  version = "unstable-2019-10-30";
+  version = "unstable-2020-01-09";
 
   meta = with stdenv.lib; {
     description = "Your project's nix-env";
@@ -28,17 +28,17 @@ rustPlatform.buildRustPackage rec {
     owner = "target";
     repo = pname;
     # Run `eval $(nix-build -A lorri.updater)` after updating the revision!
-    rev = "03f10395943449b1fc5026d3386ab8c94c520ee3";
-    sha256 = "0fcl79ndaziwd8d74mk1lsijz34p2inn64b4b4am3wsyk184brzq";
+    rev = "7b84837b9988d121dd72178e81afd440288106c5";
+    sha256 = "0rkga944jl6i0051vbsddfqbvzy12168cbg4ly2ng1rk0x97dbr8";
   };
 
-  cargoSha256 = "1daff4plh7hwclfp21hkx4fiflh9r80y2c7k2sd3zm4lmpy0jpfz";
+  cargoSha256 = "0k7l0zhk2vzf4nlwv4xr207irqib2dqjxfdjk1fprff84c4kblx8";
   doCheck = false;
 
   BUILD_REV_COUNT = src.revCount or 1;
   RUN_TIME_CLOSURE = pkgs.callPackage ./runtime.nix {};
 
-  nativeBuildInputs = with pkgs; [ nix direnv which ];
+  nativeBuildInputs = with pkgs; [ rustPackages.rustfmt ];
   buildInputs =
     stdenv.lib.optionals stdenv.isDarwin [ CoreServices Security cf-private ];
 

--- a/pkgs/tools/misc/lorri/runtime.nix
+++ b/pkgs/tools/misc/lorri/runtime.nix
@@ -1,9 +1,13 @@
 {
   # Plumbing tools:
-  closureInfo, runCommand, writeText, buildEnv,
-
-  # Actual dependencies to propagate:
-  bash, coreutils }:
+  closureInfo
+, runCommand
+, writeText
+, buildEnv
+, # Actual dependencies to propagate:
+  bash
+, coreutils
+}:
 let
   tools = buildEnv {
     name = "lorri-runtime-tools";
@@ -15,19 +19,20 @@ let
   };
 
   closureToNix = runCommand "closure.nix" {}
-  ''
-    (
-      echo '{ dep, ... }: ['
-      sed -E 's/^(.*)$/    (dep \1)/' ${runtimeClosureInfo}/store-paths
-      echo ']'
-    ) > $out
-  '';
+    ''
+      (
+        echo '{ dep, ... }: ['
+        sed -E 's/^(.*)$/    (dep \1)/' ${runtimeClosureInfo}/store-paths
+        echo ']'
+      ) > $out
+    '';
 
   runtimeClosureInfoAsNix = runCommand "runtime-closure.nix" {
     runtime_closure_list = closureToNix;
     tools_build_host = tools;
   }
-  ''
-    substituteAll ${./runtime-closure.nix.template} $out
-  '';
-in runtimeClosureInfoAsNix
+    ''
+      substituteAll ${./runtime-closure.nix.template} $out
+    '';
+in
+runtimeClosureInfoAsNix


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of https://github.com/NixOS/nixpkgs/pull/77380 via `git cherry-pick -x c976dc165b69c30f54d8fd42ec541285c598a345`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
