### PR TITLE
[WIP] nixpkgs support warnings

### DIFF
--- a/lib/maxtime.nix
+++ b/lib/maxtime.nix
@@ -1,0 +1,2 @@
+# Expose the maximum timestamp for which this Nixpkgs release is supported
+1585692000  # date --date=2020-04-01 +%s

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -1,11 +1,9 @@
 # This file defines the structure of the `config` nixpkgs option.
-
 { lib, ... }:
 
 with lib;
 
 let
-
   mkMassRebuild = args: mkOption (builtins.removeAttrs args [ "feature" ] // {
     type = args.type or (types.uniq types.bool);
     default = args.default or false;
@@ -16,26 +14,32 @@ let
     '';
   });
 
+  supportedTime = import ../../lib/maxtime.nix;
+in
+
+{
   options = {
-
-    /* Internal stuff */
-
     warnings = mkOption {
       type = types.listOf types.str;
       default = [];
       internal = true;
     };
 
-    /* Config options */
-
     doCheckByDefault = mkMassRebuild {
       feature = "run <literal>checkPhase</literal> by default";
     };
-
   };
 
-in {
+  config = {
+    warnings = [
+      (mkIf (builtins ? currentTime && builtins.currentTime > supportedTime) ''
 
-  inherit options;
+        This version of Nixpkgs is no longer supported, please upgrade.
 
+        Backporting of security fixes ended ${toString ((builtins.currentTime - supportedTime) / 86400)} days ago, this means all packages
+        should be considered as potentially vulnerable and insecure. Even if they
+        are not marked explicitly with knownVulnerabilities.
+        '')
+    ];
+  };
 }


### PR DESCRIPTION
Alternative for #23590 based on time instead.

This only partially solves the problems mentioned in https://github.com/NixOS/nixpkgs/pull/23590#issuecomment-410805012, but perhaps it's good enough to create at least some visibility. While something fully dynamic would be more correct, it also requires networking which is undesirable in certain conditions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
