### PR TITLE
rippled: 1.2.1 -> 1.4.0

### DIFF
--- a/pkgs/servers/rippled/default.nix
+++ b/pkgs/servers/rippled/default.nix
@@ -1,34 +1,28 @@
-{ stdenv, fetchFromGitHub, fetchgit, fetchurl, git, cmake, pkgconfig
+{ stdenv, fetchFromGitHub, fetchgit, fetchurl, runCommand, git, cmake, pkgconfig
 , openssl, boost, zlib }:
 
 let
-  sqlite3 = fetchurl {
+  sqlite3 = fetchurl rec {
     url = "https://www.sqlite.org/2018/sqlite-amalgamation-3260000.zip";
     sha256 = "0vh9aa5dyvdwsyd8yp88ss300mv2c2m40z79z569lcxa6fqwlpfy";
-  };
-
-  beast = fetchgit {
-    url = "https://github.com/boostorg/beast.git";
-    rev = "2f9a8440c2432d8a196571d6300404cb76314125";
-    sha256 = "1n9ms5cn67b0p0mhldz5psgylds22sm5x22q7knrsf20856vlk5a";
-    fetchSubmodules = false;
-    leaveDotGit = true;
+    passthru.url = url;
   };
 
   docca = fetchgit {
     url = "https://github.com/vinniefalco/docca.git";
     rev = "335dbf9c3613e997ed56d540cc8c5ff2e28cab2d";
-    sha256 = "09cb90k0ygmnlpidybv6nzf6is51i80lnwlvad6ijc3gf1z6i1yh";
-    fetchSubmodules = false;
+    sha256 = "1yisdg7q2p9q9gz0c446796p3ggx9s4d6g8w4j1pjff55655805h";
     leaveDotGit = true;
+    fetchSubmodules = false;
   };
 
-  rocksdb = fetchgit {
+  rocksdb = fetchgit rec {
     url = "https://github.com/facebook/rocksdb.git";
-    rev = "a297643f2e327a8bc7061bfc838fdf11935a2cf2";
-    sha256 = "00z8i4fwr27j9d4ymnls7rcgfvm6xh36a4hy2m2njx4x513pgyzw";
-    fetchSubmodules = false;
+    rev = "v5.17.2";
+    sha256 = "0d9ssggjls1hc4zhng65yg8slqlcw0lr23qr6f39shg42lzr227p";
     leaveDotGit = true;
+    fetchSubmodules = false;
+    postFetch = "cd $out && git tag ${rev}";
   };
 
   lz4 = fetchgit rec {
@@ -51,8 +45,8 @@ let
 
   soci = fetchgit {
     url = "https://github.com/SOCI/soci.git";
-    rev = "3a1f602b3021b925d38828e3ff95f9e7f8887ff7";
-    sha256 = "0lnps42cidlrn43h13b9yc8cs3fwgz7wb6a1kfc9rnw7swkh757f";
+    rev = "04e1870294918d20761736743bb6136314c42dd5";
+    sha256 = "0w3b7qi3bwn8bxh4qbqy6c1fw2bbwh7pxvk8b3qb6h4qgsh6kx89";
     leaveDotGit = true;
     fetchSubmodules = false;
   };
@@ -67,11 +61,11 @@ let
   };
 
   nudb = fetchgit rec {
-    url = "https://github.com/vinniefalco/NuDB.git";
-    rev = "1.0.0";
-    sha256 = "142bxicv25xaw4fmpw8bbblb1grdw30wyj181xl4a5734zw3qgmz";
+    url = "https://github.com/CPPAlliance/NuDB.git";
+    rev = "2.0.1";
+    sha256 = "0h7hmwavrxzj1v547h3z0031ckwphjayfpv1mgcr6q86wm9p5468";
     leaveDotGit = true;
-    fetchSubmodules = false;
+    fetchSubmodules = true; # submodules are needed, rocksdb is dependency
     postFetch = "cd $out && git tag ${rev}";
   };
 
@@ -88,40 +82,54 @@ let
     url = "https://github.com/google/googletest.git";
     rev = "c3bb0ee2a63279a803aaad956b9b26d74bf9e6e2";
     sha256 = "0pj5b6jnrj5lrccz2disr8hklbnzd8hwmrwbfqmvhiwb9q9p0k2k";
-    leaveDotGit = true;
     fetchSubmodules = false;
+    leaveDotGit = true;
   };
 
   google-benchmark = fetchgit {
     url = "https://github.com/google/benchmark.git";
     rev = "5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8";
     sha256 = "0qg70j47zqnrbszlgrzmxpr4g88kq0gyq6v16bhaggfm83c6mg6i";
-    leaveDotGit = true;
     fetchSubmodules = false;
+    leaveDotGit = true;
   };
+
+  # hack to merge rocksdb revisions from rocksdb and nudb, so build process
+  # will find both
+  rocksdb-merged = runCommand "rocksdb-merged" {
+    buildInputs = [ git ];
+  } ''
+    commit=$(cd ${nudb} && git ls-tree HEAD extras/rocksdb | awk '{ print $3  }')
+    git clone ${rocksdb} $out && cd $out
+    git fetch ${nudb}/extras/rocksdb $commit
+    git checkout $commit
+  '';
 in stdenv.mkDerivation rec {
   pname = "rippled";
-  version = "1.2.1";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "ripple";
     repo = "rippled";
     rev = version;
-    sha256 = "1lm0zzz0hi2sh2f4iqq3scapzdjbxcjgr700fgham9wqgaj2ash5";
+    sha256 = "1z04378bg8lcyrnn7sl3j2zfxbwwy2biasg1d4fbaq4snxg5d1pq";
   };
 
   hardeningDisable = ["format"];
-  cmakeFlags = ["-Dstatic=OFF"];
+  cmakeFlags = [
+    "-Dstatic=OFF"
+    "-DBOOST_LIBRARYDIR=${boost.out}/lib"
+    "-DBOOST_INCLUDEDIR=${boost.dev}/include"
+  ];
 
   nativeBuildInputs = [ pkgconfig cmake git ];
-  buildInputs = [ openssl openssl.dev boost zlib ];
+  buildInputs = [ openssl openssl.dev zlib ];
 
   preConfigure = ''
     export HOME=$PWD
 
-    git config --global url."file://${beast}".insteadOf "https://github.com/vinniefalco/Beast.git"
-    git config --global url."file://${docca}".insteadOf "https://github.com/vinniefalco/docca.git"
-    git config --global url."file://${rocksdb}".insteadOf "https://github.com/facebook/rocksdb.git"
+    git config --global url."file://${docca}".insteadOf "${docca.url}"
+    git config --global url."file://${rocksdb-merged}".insteadOf "${rocksdb.url}"
     git config --global url."file://${lz4}".insteadOf "${lz4.url}"
     git config --global url."file://${libarchive}".insteadOf "${libarchive.url}"
     git config --global url."file://${soci}".insteadOf "${soci.url}"
@@ -131,7 +139,7 @@ in stdenv.mkDerivation rec {
     git config --global url."file://${google-benchmark}".insteadOf "${google-benchmark.url}"
     git config --global url."file://${google-test}".insteadOf "${google-test.url}"
 
-    substituteInPlace CMakeLists.txt --replace "URL https://www.sqlite.org/2018/sqlite-amalgamation-3260000.zip" "URL ${sqlite3}"
+    substituteInPlace Builds/CMake/deps/Sqlite.cmake --replace "URL ${sqlite3.url}" "URL ${sqlite3}"
   '';
 
   doCheck = true;
@@ -141,7 +149,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Ripple P2P payment network reference server";
-    homepage = https://ripple.com;
+    homepage = https://github.com/ripple/rippled;
     maintainers = with maintainers; [ ehmry offline ];
     license = licenses.isc;
     platforms = [ "x86_64-linux" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15645,7 +15645,9 @@ in
     libtool = darwin.cctools;
   };
 
-  rippled = callPackage ../servers/rippled { };
+  rippled = callPackage ../servers/rippled {
+    boost = boost17x;
+  };
 
   rippled-validator-keys-tool = callPackage ../servers/rippled/validator-keys-tool.nix {
     boost = boost167.override {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
