### PR TITLE
Revert patch: add "doc" to ghc wrapper

### DIFF
--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, ghc, llvmPackages, packages, buildEnv, makeWrapper
+{ lib, stdenv, ghc, llvmPackages, packages, symlinkJoin, makeWrapper
 , withLLVM ? false
 , postBuild ? ""
 , ghcLibdir ? null # only used by ghcjs, when resolving plugins
@@ -51,24 +51,14 @@ let
                    ++ lib.optional stdenv.targetPlatform.isDarwin llvmPackages.clang);
 in
 if paths == [] && !withLLVM then ghc else
-buildEnv {
+symlinkJoin {
   # this makes computing paths from the name attribute impossible;
   # if such a feature is needed, the real compiler name should be saved
   # as a dedicated drv attribute, like `compiler-name`
   name = ghc.name + "-with-packages";
   paths = paths ++ [ghc];
-  extraOutputsToInstall = ["doc"];
   postBuild = ''
     . ${makeWrapper}/nix-support/setup-hook
-
-    # We make changes to ghc binaries in $out/bin. buildEnv gives a
-    # symlink if only one of the paths has the subdirectory. If so,
-    # we need to remove it for our new wrappers.
-
-    if [ -L "$out/bin" ]; then
-      rm -f "$out/bin"
-      mkdir -p "$out/bin"
-    fi
 
     # wrap compiler executables with correct env variables
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#76842. This change breaks `ghcWithHoogle`:

~~~
$ nix-build --no-out-link -E 'with import <nixpkgs> {}; haskellPackages.ghcWithHoogle (pkgs: with pkgs; [aeson cabal-plan])'
these derivations will be built:
  /nix/store/hq66xwgclahnv7qlhqhqxd9n81fv8f5s-ghc-8.6.5-with-packages.drv
building '/nix/store/hq66xwgclahnv7qlhqhqxd9n81fv8f5s-ghc-8.6.5-with-packages.drv'...
collision between `/nix/store/ds8hl24am8gmgx1dlzy7fmpjymdw5q99-uuid-types-1.0.3-doc/share/doc/uuid-types-1.0.3/html/uuid-types.haddock' and `/nix/store/v7lspi47i8xf8wkgqww4k3d1ps871ajd-uuid-types-1.0.3-doc/share/doc/uuid-types-1.0.3/html/uuid-types.haddock'
builder for '/nix/store/hq66xwgclahnv7qlhqhqxd9n81fv8f5s-ghc-8.6.5-with-packages.drv' failed with exit code 255
~~~

Apparently, the change causes file conflicts that did not occur before.

Ping @matthewbauer.