### PR TITLE
lib/tests: Fix module tests

### DIFF
--- a/lib/tests/modules/import-from-store.nix
+++ b/lib/tests/modules/import-from-store.nix
@@ -1,17 +1,11 @@
 { lib, ... }:
-let
-  drv = derivation {
-    name = "derivation";
-    system = builtins.currentSystem;
-    builder = "/bin/sh";
-    args = [ "-c" "echo {} > $out" ];
-  };
-in {
+{
 
   imports = [
-    "${drv}"
+    "${builtins.toFile "drv" "{}"}"
     ./declare-enable.nix
     ./define-enable.nix
   ];
 
 }
+


### PR DESCRIPTION
###### Motivation for this change
Fix the broken test in https://github.com/NixOS/nixpkgs/pull/77416

Apparently hydra uses `nix-build lib/tests/release.nix` to run all
tests, where IFD isn't allowed. Fortunately we can get around this with
builtins.toFile, which doesn't require IFD, but still can test the
properties we want.

Ping @LnL7

###### Things done

- [x] Ran `nix-build lib/tests/release.nix`
- [x] Ran the same command after `git revert` e0ea5f4d9ba5d8553fcadde487b57e6dbd1ff746 (the fix for the broken tests) and it fails