### PR TITLE
python.pkgs wide: fix problematic urls

### DIFF
--- a/pkgs/applications/science/biology/xenomapper/default.nix
+++ b/pkgs/applications/science/biology/xenomapper/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ statistics ];
 
   meta = with lib; {
-    homepage = "http://github.com/genomematt/xenomapper";
+    homepage = "https://github.com/genomematt/xenomapper";
     description = "A utility for post processing mapped reads that have been aligned to a primary genome and a secondary genome and binning reads into species specific, multimapping in each species, unmapped and unassigned bins";
     license = licenses.gpl3;
     platforms = platforms.all;

--- a/pkgs/development/python-modules/Pygments/default.nix
+++ b/pkgs/development/python-modules/Pygments/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    homepage = http://pygments.org/;
+    homepage = https://pygments.org/;
     description = "A generic syntax highlighter";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ ];

--- a/pkgs/development/python-modules/pastescript/default.nix
+++ b/pkgs/development/python-modules/pastescript/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A pluggable command-line frontend, including commands to setup package file layouts";
-    homepage = http://pythonpaste.org/script/;
+    homepage = https://github.com/cdent/pastescript/;
     license = licenses.mit;
   };
 

--- a/pkgs/development/python-modules/pathos/default.nix
+++ b/pkgs/development/python-modules/pathos/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Parallel graph management and execution in heterogeneous computing";
-    homepage = http://www.cacr.caltech.edu/~mmckerns/pathos.htm;
+    homepage = https://github.com/uqfoundation/pathos/;
     license = licenses.bsd3;
   };
 

--- a/pkgs/development/python-modules/pivy/default.nix
+++ b/pkgs/development/python-modules/pivy/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://pivy.coin3d.org/;
+    homepage = https://github.com/coin3d/pivy/;
     description = "A Python binding for Coin";
     license = licenses.bsd0;
     maintainers = with maintainers; [ gebner ];

--- a/pkgs/development/python-modules/pox/default.nix
+++ b/pkgs/development/python-modules/pox/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Utilities for filesystem exploration and automated builds";
     license = licenses.bsd3;
-    homepage = http://www.cacr.caltech.edu/~mmckerns/pox.htm;
+    homepage = https://github.com/uqfoundation/pox/;
   };
 
 }

--- a/pkgs/development/python-modules/pvlib/default.nix
+++ b/pkgs/development/python-modules/pvlib/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://pvlib-python.readthedocs.io;
+    homepage = https://pvlib-python.readthedocs.io;
     description = "Simulate the performance of photovoltaic energy systems";
     license = licenses.bsd3;
     maintainers = with maintainers; [ jluttine ];

--- a/pkgs/development/python-modules/pyenchant/default.nix
+++ b/pkgs/development/python-modules/pyenchant/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "pyenchant: Python bindings for the Enchant spellchecker";
-    homepage = https://pythonhosted.org/pyenchant/;
+    homepage = https://github.com/pyenchant/pyenchant;
     license = licenses.lgpl21;
     badPlatforms = [ "x86_64-darwin" ];
   };

--- a/pkgs/development/python-modules/pyftdi/default.nix
+++ b/pkgs/development/python-modules/pyftdi/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "User-space driver for modern FTDI devices";
-    homepage = "http://github.com/eblot/pyftdi";
+    homepage = "https://github.com/eblot/pyftdi";
     license = lib.licenses.lgpl2;
   };
 }

--- a/pkgs/development/python-modules/pyparsing/default.nix
+++ b/pkgs/development/python-modules/pyparsing/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     doCheck = false;
 
     meta = with stdenv.lib; {
-      homepage = http://pyparsing.wikispaces.com/;
+      homepage = https://pyparsing.wikispaces.com/;
       description = "An alternative approach to creating and executing simple grammars, vs. the traditional lex/yacc approach, or the use of regular expressions";
       license = licenses.mit;
     };

--- a/pkgs/development/python-modules/pyramid_exclog/default.nix
+++ b/pkgs/development/python-modules/pyramid_exclog/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A package which logs to a Python logger when an exception is raised by a Pyramid application";
-    homepage = http://docs.pylonsproject.org/;
+    homepage = https://docs.pylonsproject.org/;
     license = licenses.bsd0;
     maintainers = with maintainers; [ domenkozar ];
   };

--- a/pkgs/development/python-modules/pysam/default.nix
+++ b/pkgs/development/python-modules/pysam/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    homepage = http://pysam.readthedocs.io/;
+    homepage = https://pysam.readthedocs.io/;
     description = "A python module for reading, manipulating and writing genome data sets";
     maintainers = with lib.maintainers; [ unode ];
     license = lib.licenses.mit;

--- a/pkgs/development/python-modules/python-sql/default.nix
+++ b/pkgs/development/python-modules/python-sql/default.nix
@@ -3,12 +3,14 @@
 buildPythonPackage rec {
   pname = "python-sql";
   version = "1.0.0";
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "05ni936y0ia9xmryl7mlhbj9i80nnvq1bi4zxhb96rv7yvpb3fqb";
   };
+
   meta = {
-    homepage = http://python-sql.tryton.org/;
+    homepage = https://python-sql.tryton.org/;
     description = "A library to write SQL queries in a pythonic way";
     maintainers = with lib.maintainers; [ johbo ];
     license = lib.licenses.bsd3;

--- a/pkgs/development/python-modules/pyviz-comms/default.nix
+++ b/pkgs/development/python-modules/pyviz-comms/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Launch jobs, organize the output, and dissect the results";
-    homepage = http://pyviz.org/;
+    homepage = https://pyviz.org/;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/quantities/default.nix
+++ b/pkgs/development/python-modules/quantities/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Quantities is designed to handle arithmetic and";
-    homepage = http://python-quantities.readthedocs.io/;
+    homepage = https://python-quantities.readthedocs.io/;
     license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/development/python-modules/relatorio/default.nix
+++ b/pkgs/development/python-modules/relatorio/default.nix
@@ -3,17 +3,20 @@
 buildPythonPackage rec {
   pname = "relatorio";
   version = "0.9.0";
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "0q93sl7ppfvjxylgq9m5n4xdgv4af7d69yxd84zszq10vjmpsg6k";
   };
+
   propagatedBuildInputs = [
     genshi
     lxml
     python_magic
   ];
+
   meta = {
-    homepage = http://relatorio.tryton.org/;
+    homepage = https://relatorio.tryton.org/;
     description = "A templating library able to output odt and pdf files";
     maintainers = with lib.maintainers; [ johbo ];
     license = lib.licenses.gpl3;

--- a/pkgs/development/python-modules/robotframework/default.nix
+++ b/pkgs/development/python-modules/robotframework/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Generic test automation framework";
-    homepage = http://robotframework.org/;
+    homepage = https://robotframework.org/;
     license = licenses.asl20;
     maintainers = with maintainers; [ bjornfor ];
   };

--- a/pkgs/development/python-modules/scikit-image/default.nix
+++ b/pkgs/development/python-modules/scikit-image/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Image processing routines for SciPy";
-    homepage = http://scikit-image.org;
+    homepage = https://scikit-image.org;
     license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/snakebite/default.nix
+++ b/pkgs/development/python-modules/snakebite/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Pure Python HDFS client";
-    homepage = http://github.com/spotify/snakebite;
+    homepage = https://github.com/spotify/snakebite;
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/sympy/default.nix
+++ b/pkgs/development/python-modules/sympy/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "A Python library for symbolic mathematics";
-    homepage    = http://www.sympy.org/;
+    homepage    = https://www.sympy.org/;
     license     = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ lovek323 timokau ];
   };

--- a/pkgs/development/python-modules/threadpool/default.nix
+++ b/pkgs/development/python-modules/threadpool/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://chrisarndt.de/projects/threadpool/;
+    homepage = https://chrisarndt.de/projects/threadpool/;
     description = "Easy to use object-oriented thread pool framework";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/todoist/default.nix
+++ b/pkgs/development/python-modules/todoist/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "The official Todoist Python API library";
-    homepage = http://todoist-python.readthedocs.io/en/latest/;
+    homepage = https://todoist-python.readthedocs.io/en/latest/;
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ the-kenny ];
   };

--- a/pkgs/development/python-modules/translationstring/default.nix
+++ b/pkgs/development/python-modules/translationstring/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://pylonsproject.org/;
+    homepage = https://pylonsproject.org/;
     description = "Utility library for i18n relied on by various Repoze and Pyramid packages";
     license = licenses.bsd0;
     maintainers = with maintainers; [ domenkozar ];

--- a/pkgs/development/python-modules/wget/default.nix
+++ b/pkgs/development/python-modules/wget/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Pure python download utility";
-    homepage = http://bitbucket.org/techtonik/python-wget/;
+    homepage = https://bitbucket.org/techtonik/python-wget/;
     license = with lib.licenses; [ unlicense ];
     maintainers = with lib.maintainers; [ prusnak ];
   };

--- a/pkgs/development/python-modules/xstatic-bootstrap/default.nix
+++ b/pkgs/development/python-modules/xstatic-bootstrap/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib;{
-    homepage = http://getbootstrap.com;
+    homepage = https://getbootstrap.com;
     description = "Bootstrap packaged static files for python";
     license = licenses.mit;
     maintainers = with maintainers; [ makefu ];

--- a/pkgs/development/python-modules/xstatic-pygments/default.nix
+++ b/pkgs/development/python-modules/xstatic-pygments/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib;{
-    homepage = http://pygments.org;
+    homepage = https://pygments.org;
     description = "pygments packaged static files for python";
     license = licenses.mit;
     maintainers = with maintainers; [ makefu ];

--- a/pkgs/development/python-modules/yattag/default.nix
+++ b/pkgs/development/python-modules/yattag/default.nix
@@ -12,6 +12,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Generate HTML or XML in a pythonic way. Pure python alternative to web template engines. Can fill HTML forms with default values and error messages.";
     license = [ licenses.lgpl21 ];
-    homepage = http://www.yattag.org/;
+    homepage = https://www.yattag.org/;
   };
 }

--- a/pkgs/development/python-modules/zope_filerepresentation/default.nix
+++ b/pkgs/development/python-modules/zope_filerepresentation/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ zope_schema ];
 
   meta = with stdenv.lib; {
-    homepage = http://zopefilerepresentation.readthedocs.io/;
+    homepage = https://zopefilerepresentation.readthedocs.io/;
     description = "File-system Representation Interfaces";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];


### PR DESCRIPTION
###### Motivation for this change
noticed a bunch that are problematic on [repology](https://repology.org/repository/nix_unstable/problems)

python packages get a triple hit since there's a unique package per interpreter (2.7, 3.7, 3.8)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


```
Nothing changed
https://github.com/NixOS/nixpkgs/pull/77468
$ nix-shell /home/jon/.cache/nix-review/pr-77468/shell.nix

[nix-shell:~/.cache/nix-review/pr-77468]$
```