### PR TITLE
Fix paperless, python.pkgs.django_extensions

### DIFF
--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -169,17 +169,15 @@ in
     };
 
     users = optionalAttrs (cfg.user == defaultUser) {
-      users = [{
-        name = defaultUser;
+      users.${defaultUser} = {
         group = defaultUser;
         uid = config.ids.uids.paperless;
         home = cfg.dataDir;
-      }];
+      };
 
-      groups = [{
-        name = defaultUser;
+      groups.${defaultUser} = {
         gid = config.ids.gids.paperless;
-      }];
+      };
     };
   };
 }

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -123,9 +123,9 @@ in
   config = mkIf cfg.enable {
 
     systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' - ${cfg.user} ${cfg.user} - -"
+      "d '${cfg.dataDir}' - ${cfg.user} ${config.users.users.${cfg.user}.group} - -"
     ] ++ (optional cfg.consumptionDirIsPublic
-      "d '${cfg.consumptionDir}' 777 ${cfg.user} ${cfg.user} - -"
+      "d '${cfg.consumptionDir}' 777 - - - -"
       # If the consumption dir is not created here, it's automatically created by
       # 'manage' with the default permissions.
     );

--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, pythonOlder
 , six, typing, pygments
 , django, shortuuid, python-dateutil, pytest
 , pytest-django, pytestcov, mock, vobject
@@ -15,6 +15,15 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "0053yqq4vq3mwy7zkfs5vfm3g8j9sfy3vrc6xby83qlj9wz43ipi";
   };
+
+  # This patch fixes a single failing test and can be removed when updating this pkg
+  # to the next version
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/django-extensions/django-extensions/commit/1d21786da2e6868d98ae34c82079e1e03ad1aa97.patch";
+      sha256 = "0d81zpj0f8a7ijrfb12j0b67fgj89k3axaskz1nwqsr4wc6n4bw2";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace setup.py --replace "'tox'," ""


### PR DESCRIPTION
`python.pkgs.django_extensions` is a dependency of `paperless` and `python3Packages.hyperkitty`, which is still broken for other reasons.