### PR TITLE
csv2odf: init at 2.09

### DIFF
--- a/pkgs/applications/office/csv2odf/default.nix
+++ b/pkgs/applications/office/csv2odf/default.nix
@@ -1,0 +1,28 @@
+{ lib, python3, fetchurl }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "csv2odf";
+  version = "2.09";
+  src = fetchurl {
+    url = "mirror://sourceforge/project/${pname}/${pname}-${version}/${pname}-${version}.tar.gz";
+    sha256 = "09l0yfay89grjdzap2h11f0hcyn49np5zizg2yyp2aqgjs8ki57p";
+  };
+
+  meta = with lib; {
+    homepage = "https://sourceforge.net/p/csv2odf/wiki/Main_Page/";
+    description = "Convert csv files to OpenDocument Format";
+    longDescription = ''
+      csv2odf is a command line tool that can convert a comma separated value
+      (csv) file to an odf, ods, html, xlsx, or docx document that can be viewed in
+      LibreOffice and other office productivity programs. csv2odf is useful for
+      creating reports from databases and other data sources that produce csv files.
+      csv2odf can be combined with cron and shell scripts to automatically generate
+      business reports.
+      
+      The output format (fonts, number formatting, etc.) is controlled by a
+      template file that you can design in your office application of choice.
+    '';
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1508,6 +1508,8 @@ in
 
   crudini = callPackage ../tools/misc/crudini { };
 
+  csv2odf = callPackage ../applications/office/csv2odf { };
+
   csvkit = callPackage ../tools/text/csvkit { };
 
   csvs-to-sqlite = with python3Packages; toPythonApplication csvs-to-sqlite;


### PR DESCRIPTION
###### Motivation for this change

Useful command line tool to insert csv files in ODF spreadsheets.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
