### PR TITLE
fail2ban: 0.10.4 -> 0.10.5

### DIFF
--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, fetchpatch, python3, gamin }:
+{ stdenv, fetchFromGitHub, python3, gamin }:
 
-let version = "0.10.4"; in
+let version = "0.10.5"; in
 
 python3.pkgs.buildPythonApplication {
   pname = "fail2ban";
@@ -10,17 +10,8 @@ python3.pkgs.buildPythonApplication {
     owner  = "fail2ban";
     repo   = "fail2ban";
     rev    = version;
-    sha256 = "07ik6rm856q0ic2r7vbg6j3hsdcdgkv44hh5ck0c2y21fqwrck3l";
+    sha256 = "1s8g46vkwhqnagj69v4wvcasypzkmq7awhfbxahffrypcpad5ach";
   };
-
-  patches = [
-    # 0.10.3 supports Python 3 but somehow this got into the way
-    # https://github.com/fail2ban/fail2ban/issues/2255
-    (fetchpatch {
-      url = "https://github.com/fail2ban/fail2ban/commit/657b147c0d7830f3600f3dc7feaa4815a7e19fde.patch";
-      sha256 = "1hrk2x7ssrfhab1wrjk5xw1sxhiv2735glfcp6qcj8x4dss3q7f7";
-    })
-  ];
 
   pythonPath = with python3.pkgs;
     stdenv.lib.optionals stdenv.isLinux [


### PR DESCRIPTION
###### Motivation for this change

https://github.com/fail2ban/fail2ban/blob/0.10.5/ChangeLog

Drop included patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).