### PR TITLE
kernel/update.sh: always use -e

### DIFF
--- a/pkgs/os-specific/linux/kernel/update.sh
+++ b/pkgs/os-specific/linux/kernel/update.sh
@@ -15,7 +15,7 @@ fi
 # Inspect each file and see if it has the latest version
 NIXPKGS="$(git rev-parse --show-toplevel)"
 ls $NIXPKGS/pkgs/os-specific/linux/kernel | while read FILE; do
-  KERNEL="$(sed -n $LINUXSED <<< "$FILE")"
+  KERNEL="$(sed -n -e $LINUXSED <<< "$FILE")"
   [ -z "$KERNEL" ] && continue
 
   # Find the matching new kernel version
@@ -45,11 +45,11 @@ ls $NIXPKGS/pkgs/os-specific/linux/kernel | while read FILE; do
     echo "Failed to get hash of $URL"
     continue
   fi
-  sed -i "s/sha256 = \".*\"/sha256 = \"$HASH\"/g" $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
+  sed -i -e "s/sha256 = \".*\"/sha256 = \"$HASH\"/g" $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
 
   # Rewrite the expression
   sed -i -e '/version = /d' $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
-  sed -i "\#buildLinux (args // rec {#a \  version = \"$V\";" $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
+  sed -i -e "\#buildLinux (args // rec {#a \  version = \"$V\";" $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE
 
   # Commit the changes
   git add -u $NIXPKGS/pkgs/os-specific/linux/kernel/$FILE


### PR DESCRIPTION
###### Motivation for this change

Minor, but makes it explicit when argument is the expression
and seems better to be consistent to use it instead of mixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).