### PR TITLE
python3Packages.caldav: unbreak now that xandikos is packaged, touchups

### DIFF
--- a/pkgs/development/python-modules/caldav/default.nix
+++ b/pkgs/development/python-modules/caldav/default.nix
@@ -1,11 +1,12 @@
 { lib, buildPythonPackage, fetchPypi
-, tzlocal, requests, vobject, lxml, nose }:
+, tzlocal, requests, vobject, lxml, nose, xandikos }:
 
 buildPythonPackage rec {
   pname = "caldav";
   version = "0.6.2";
 
   propagatedBuildInputs = [ tzlocal requests vobject lxml nose ];
+  checkInputs = [ xandikos ];
 
   src = fetchPypi {
     inherit pname version;
@@ -17,6 +18,5 @@ buildPythonPackage rec {
     homepage = "https://pythonhosted.org/caldav/";
     license = licenses.asl20;
     maintainers = with maintainers; [ marenz ];
-    broken = true; # missing xandikos package
   };
 }

--- a/pkgs/development/python-modules/caldav/default.nix
+++ b/pkgs/development/python-modules/caldav/default.nix
@@ -5,8 +5,8 @@ buildPythonPackage rec {
   pname = "caldav";
   version = "0.6.2";
 
-  propagatedBuildInputs = [ tzlocal requests vobject lxml nose ];
-  checkInputs = [ xandikos ];
+  propagatedBuildInputs = [ requests vobject lxml ];
+  checkInputs = [ xandikos tzlocal nose ];
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6837,6 +6837,9 @@ in {
 
   pony = callPackage ../development/python-modules/pony { };
 
+  xandikos = disabledIf (!isPy3k) (toPythonModule (pkgs.xandikos.override {
+    python3Packages = self;
+  }));
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

* add python xandikos module based on packaged xandikos application
* unbreak caldav with xandikos
* move packages only needed for testing to checkInputs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).