### PR TITLE
ocrmypdf: 9.2.0 -> 9.5.0

### DIFF
--- a/pkgs/tools/text/ocrmypdf/default.nix
+++ b/pkgs/tools/text/ocrmypdf/default.nix
@@ -29,14 +29,14 @@ let
 
 in buildPythonApplication rec {
   pname = "ocrmypdf";
-  version = "9.4.0";
+  version = "9.5.0";
   disabled = ! python3Packages.isPy3k;
 
   src = fetchFromGitHub {
     owner = "jbarlow83";
     repo = "OCRmyPDF";
     rev = "v${version}";
-    sha256 = "07356syg7w9m9h4yl5zk2y4s8hsb7kybbm4x9vm7mli4gw9dwv1m";
+    sha256 = "0rvwxykyscpcvfgm8zzyvjgzl9x9ddi9cxmqyxrc031mxpc0lzyy";
   };
 
   nativeBuildInputs = with python3Packages; [

--- a/pkgs/tools/text/ocrmypdf/default.nix
+++ b/pkgs/tools/text/ocrmypdf/default.nix
@@ -70,8 +70,8 @@ in buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace src/ocrmypdf/leptonica.py \
-      --replace "lept = ffi.dlopen(_libpath)" \
-      'lept = ffi.dlopen("${stdenv.lib.makeLibraryPath [leptonica]}/liblept${stdenv.hostPlatform.extensions.sharedLibrary}")'
+      --replace '_libpath = find_library(libname)' \
+                '_libpath = "${stdenv.lib.getLib leptonica}/lib/liblept${stdenv.hostPlatform.extensions.sharedLibrary}"'
   '';
 
   # The tests take potentially 20+ minutes, depending on machine

--- a/pkgs/tools/text/ocrmypdf/default.nix
+++ b/pkgs/tools/text/ocrmypdf/default.nix
@@ -28,14 +28,14 @@ let
 
 in buildPythonApplication rec {
   pname = "ocrmypdf";
-  version = "9.2.0";
+  version = "9.4.0";
   disabled = ! python3Packages.isPy3k;
 
   src = fetchFromGitHub {
     owner = "jbarlow83";
     repo = "OCRmyPDF";
     rev = "v${version}";
-    sha256 = "1mvc6x5nn242z65pxv39ch71vaikgi89bb0sjbfy2jbw91vk41xa";
+    sha256 = "07356syg7w9m9h4yl5zk2y4s8hsb7kybbm4x9vm7mli4gw9dwv1m";
   };
 
   nativeBuildInputs = with python3Packages; [

--- a/pkgs/tools/text/ocrmypdf/default.nix
+++ b/pkgs/tools/text/ocrmypdf/default.nix
@@ -10,6 +10,7 @@
 , stdenv
 , tesseract4
 , unpaper
+, substituteAll
 }:
 
 let
@@ -68,11 +69,12 @@ in buildPythonApplication rec {
     setuptools
   ] ++ runtimeDeps;
 
-  postPatch = ''
-    substituteInPlace src/ocrmypdf/leptonica.py \
-      --replace '_libpath = find_library(libname)' \
-                '_libpath = "${stdenv.lib.getLib leptonica}/lib/liblept${stdenv.hostPlatform.extensions.sharedLibrary}"'
-  '';
+  patches = [
+    (substituteAll {
+      src = ./liblept.patch;
+      liblept = "${stdenv.lib.getLib leptonica}/lib/liblept${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
 
   # The tests take potentially 20+ minutes, depending on machine
   doCheck = false;

--- a/pkgs/tools/text/ocrmypdf/liblept.patch
+++ b/pkgs/tools/text/ocrmypdf/liblept.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ocrmypdf/leptonica.py b/src/ocrmypdf/leptonica.py
+index 328b063..b993cc9 100644
+--- a/src/ocrmypdf/leptonica.py
++++ b/src/ocrmypdf/leptonica.py
+@@ -46,7 +46,7 @@ if os.name == 'nt':
+     os.environ['PATH'] = shim_paths_with_program_files()
+ else:
+     libname = 'lept'
+-_libpath = find_library(libname)
++_libpath = '@liblept@'
+ if not _libpath:
+     raise MissingDependencyError(
+         """


### PR DESCRIPTION
###### Motivation for this change

https://ocrmypdf.readthedocs.io/en/latest/release_notes.html#v9-4-0
https://ocrmypdf.readthedocs.io/en/latest/release_notes.html#v9-3-0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).