### PR TITLE
microcom: init at 2019.01.0

### DIFF
--- a/pkgs/applications/misc/microcom/default.nix
+++ b/pkgs/applications/misc/microcom/default.nix
@@ -1,0 +1,29 @@
+{ stdenv,
+  lib,
+  fetchFromGitHub,
+  readline,
+  autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "microcom";
+  version = "2019.01.0";
+
+  src = fetchFromGitHub {
+    owner = "pengutronix";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "056v28hvagnzns6p8i3bq8609k82d3w1ab2lab5dr4cdfwhs4pqj";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ readline ];
+
+  meta = with lib; {
+    description = "A minimalistic terminal program for communicating
+    with devices over a serial connection";
+    inherit (src.meta) homepage;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ emantor ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5118,6 +5118,8 @@ in
 
   mgba = libsForQt5.callPackage ../misc/emulators/mgba { };
 
+  microcom = callPackage ../applications/misc/microcom { };
+
   midisheetmusic = callPackage ../applications/audio/midisheetmusic { };
 
   mikutter = callPackage ../applications/networking/instant-messengers/mikutter { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A minimalistic terminal program which supports serial connections and RFC2217 telnet connections.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
