### PR TITLE
ser2net: init at 4.1.1 (with gensio)

### DIFF
--- a/pkgs/development/libraries/gensio/default.nix
+++ b/pkgs/development/libraries/gensio/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "gensio";
+  version = "1.3.3";
+
+  src = fetchFromGitHub {
+    owner = "cminyard";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "04yrm3kg8m77kh6z0b9yw4h43fm0d54wnyrd8lp5ddn487kawm5g";
+  };
+
+  configureFlags = [
+    "--with-python=no"
+  ];
+
+  buildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
+    description = "General Stream I/O";
+    homepage = "https://sourceforge.net/projects/ser2net/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ emantor ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/servers/ser2net/default.nix
+++ b/pkgs/servers/ser2net/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchFromGitHub, gensio, libyaml, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "ser2net";
+  version = "4.1.1";
+
+  src = fetchFromGitHub {
+    owner = "cminyard";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "1zl68mmd7pp10cjv1jk8rs2dlbwvzskyb58qvc7ph7vc6957lfhc";
+  };
+
+  buildInputs = [ autoreconfHook gensio libyaml ];
+
+  meta = with lib; {
+    description = "Serial to network connection server";
+    homepage = "https://sourceforge.net/projects/ser2net/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ emantor ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11394,6 +11394,8 @@ in
     inherit (darwin.apple_sdk.frameworks) OpenCL;
   };
 
+  gensio = callPackage ../development/libraries/gensio {};
+
   geoclue2 = callPackage ../development/libraries/geoclue {};
 
   geocode-glib = callPackage ../development/libraries/geocode-glib {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25236,6 +25236,8 @@ in
 
   seafile-shared = callPackage ../misc/seafile-shared { };
 
+  ser2net = callPackage ../servers/ser2net {};
+
   serviio = callPackage ../servers/serviio {};
   selinux-python = callPackage ../os-specific/linux/selinux-python { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add the ser2net serial to network server. Also packages the library it depends on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
