### PR TITLE
mongodb-tools: use default openssl

### DIFF
--- a/pkgs/tools/misc/mongodb-tools/default.nix
+++ b/pkgs/tools/misc/mongodb-tools/default.nix
@@ -2,7 +2,7 @@
 , lib
 , buildGoPackage
 , fetchFromGitHub
-, openssl_1_0_2
+, openssl
 , pkgconfig
 , libpcap
 }:
@@ -36,7 +36,7 @@ in buildGoPackage {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl_1_0_2 libpcap ];
+  buildInputs = [ openssl libpcap ];
 
   # Mongodb incorrectly names all of their binaries main
   # Let's work around this with our own installer


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/77503

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
