### PR TITLE
firefoxPackages.tor-browser: 8.5.6 -> 9.0.4

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -166,8 +166,8 @@ stdenv.mkDerivation (rec {
   ++ lib.optionals (!isTorBrowserLike) [
     "-I${nss.dev}/include/nss"
   ]
-  ++ lib.optional (pname == "firefox-esr" && lib.versionAtLeast ffversion "68"
-                                          && lib.versionOlder ffversion "69")
+  ++ lib.optional (lib.versionAtLeast ffversion "68"
+                  && lib.versionOlder ffversion "69")
     "-Wno-error=format-security");
 
   postPatch = lib.optionalString (lib.versionAtLeast ffversion "63.0" && !isTorBrowserLike) ''

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -282,6 +282,11 @@ stdenv.mkDerivation (rec {
     "--enable-bundled-fonts"
   ])
 
+  ++ lib.optionals (isTorBrowserLike && lib.versionAtLeast tbversion "9") ([
+      "--enable-proxy-bypass-protection"
+      "MOZ_TELEMETRY_REPORTING="
+  ])
+
   ++ flag alsaSupport "alsa"
   ++ flag pulseaudioSupport "pulseaudio"
   ++ flag ffmpegSupport "ffmpeg"

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -206,12 +206,12 @@ in {
     unpackPhase = ''
       # fetchFromGitHub produces ro sources, root dir gets a name that
       # is too long for shebangs. fixing
-      cp -a $src tor-browser
+      cp -R --no-dereference --preserve=mode $src tor-browser
       chmod -R +w tor-browser
       cd tor-browser
 
       # set times for xpi archives
-      find . -exec touch -d'2010-01-01 00:00' {} \;
+      find . -print0 | xargs -0 -n 1024 -- touch -d'2010-01-01 00:00'
     '';
 
     meta = (args.meta or {}) // {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -305,6 +305,7 @@ in rec {
 
     # tor-browser versions > 9.0 integrate tor-launcher and tor-button, which this derivation does not need
     # but disabling it with the following configure flag does not actually work, hence the rather hacky patch
+    # https://trac.torproject.org/projects/tor/ticket/33135
     patches = [
       (fetchpatch {
         url = "https://github.com/SLNOS/tor-browser/commit/87c24c7709e2c7657f8a304635e7fb18429229de.patch";

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -263,6 +263,8 @@ in rec {
       rev   = "95bb92d552876a1f4260edf68fda5faa3eb36ad8";
       sha256 = "1ykn3yg4s36g2cpzxbz7s995c33ij8kgyvghx38z4i8siaqxdddy";
     };
+
+    meta.knownVulnerabilities = [ "Support ended in August 2018." ];
   }).override {
     gtk3Support = false;
   };
@@ -283,6 +285,8 @@ in rec {
     patches = [
       missing-documentation-patch
     ];
+
+    meta.knownVulnerabilities = [ "Support ended around October 2019." ];
   };
 
   tor-browser = tor-browser-8-5;

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, fetchurl, fetchFromGitHub, overrideCC, gccStdenv, gcc6 }:
+{ lib, callPackage, fetchurl, fetchpatch, fetchFromGitHub, overrideCC, gccStdenv, gcc6 }:
 
 let
 
@@ -289,6 +289,35 @@ in rec {
     meta.knownVulnerabilities = [ "Support ended around October 2019." ];
   };
 
-  tor-browser = tor-browser-8-5;
+  tor-browser-9-0 = tbcommon {
+    ffversion = "68.4.1esr";
+    tbversion = "9.0.4";
+
+    # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
+    src = fetchFromGitHub {
+      owner = "SLNOS";
+      repo  = "tor-browser";
+      # branch "tor-browser-68.4.1esr-9.0-1-slnos"
+      rev   = "04e6899d28554656b18be5e02bfe58d4e430161b";
+      fetchSubmodules = true;
+      sha256 = "0vzkrs69agq4v89hz05mbz70hdh05qjf5z5j5i0ynkvn5n4a1w9f";
+    };
+
+    # tor-browser versions > 9.0 integrate tor-launcher and tor-button, which this derivation does not need
+    # but disabling it with the following configure flag does not actually work, hence the rather hacky patch
+    patches = [
+      (fetchpatch {
+        url = "https://github.com/SLNOS/tor-browser/commit/87c24c7709e2c7657f8a304635e7fb18429229de.patch";
+        sha256 = "1x5w3854w8ngms8kip8pwf621r1b4z4jm03s3j50nxi382gpdmn0";
+      })
+    ];
+
+    extraConfigureFlags = [
+      "--disable-tor-launcher"
+    ];
+
+  };
+
+  tor-browser = tor-browser-9-0;
 
 })

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -197,8 +197,94 @@ in {
     meta.knownVulnerabilities = [ "Support ended in August 2018." ];
   };
 
-  tor-browser-7-5 = throw "firefoxPackages.tor-browser-7-5 was removed because it was out of date and inadequately maintained. Please use tor-browser-bundle-bin instead. See #77452.";
-  tor-browser-8-5 = throw "firefoxPackages.tor-browser-8-5 was removed because it was out of date and inadequately maintained. Please use tor-browser-bundle-bin instead. See #77452.";
-  tor-browser = throw "firefoxPackages.tor-browser was removed because it was out of date and inadequately maintained. Please use tor-browser-bundle-bin instead. See #77452.";
+}) // (let
+
+  tbcommon = args: common (args // {
+    pname = "tor-browser";
+    isTorBrowserLike = true;
+
+    unpackPhase = ''
+      # fetchFromGitHub produces ro sources, root dir gets a name that
+      # is too long for shebangs. fixing
+      cp -a $src tor-browser
+      chmod -R +w tor-browser
+      cd tor-browser
+
+      # set times for xpi archives
+      find . -exec touch -d'2010-01-01 00:00' {} \;
+    '';
+
+    meta = (args.meta or {}) // {
+      description = "A web browser built from TorBrowser source tree";
+      longDescription = ''
+        This is a version of TorBrowser with bundle-related patches
+        reverted.
+
+        I.e. it's a variant of Firefox with less fingerprinting and
+        some isolation features you can't get with any extensions.
+
+        Or, alternatively, a variant of TorBrowser that works like any
+        other UNIX program and doesn't expect you to run it from a
+        bundle.
+
+        It will use your default Firefox profile if you're not careful
+        even! Be careful!
+
+        It will clash with firefox binary if you install both. But it
+        should not be a problem because you should run browsers in
+        separate users/VMs anyway.
+
+        Create new profile by starting it as
+
+        $ firefox -ProfileManager
+
+        and then configure it to use your tor instance.
+
+        Or just use `tor-browser-bundle` package that packs this
+        `tor-browser` back into a sanely-built bundle.
+      '';
+      homepage = "https://www.torproject.org/projects/torbrowser.html";
+      platforms = lib.platforms.unix;
+      license = with lib.licenses; [ mpl20 bsd3 ];
+    };
+  });
+
+in rec {
+
+  tor-browser-7-5 = (tbcommon {
+    ffversion = "52.9.0esr";
+    tbversion = "7.5.6";
+
+    # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
+    src = fetchFromGitHub {
+      owner = "SLNOS";
+      repo  = "tor-browser";
+      # branch "tor-browser-52.9.0esr-7.5-2-slnos"
+      rev   = "95bb92d552876a1f4260edf68fda5faa3eb36ad8";
+      sha256 = "1ykn3yg4s36g2cpzxbz7s995c33ij8kgyvghx38z4i8siaqxdddy";
+    };
+  }).override {
+    gtk3Support = false;
+  };
+
+  tor-browser-8-5 = tbcommon rec {
+    ffversion = "60.9.0esr";
+    tbversion = "8.5.6";
+
+    # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
+    src = fetchFromGitHub {
+      owner = "SLNOS";
+      repo  = "tor-browser";
+      # branch "tor-browser-60.9.0esr-8.5-2-slnos"
+      rev   = "0489ae3158cd8c0e16c2e78b94083d8cbf0209dc";
+      sha256 = "0y5s7d8pg8ak990dp8d801j9823igaibfhv9hsa79nib5yllifzs";
+    };
+
+    patches = [
+      missing-documentation-patch
+    ];
+  };
+
+  tor-browser = tor-browser-8-5;
 
 })

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -54,6 +54,9 @@
 
 # Extra preferences
 , extraPrefs ? ""
+
+# For meta
+, tor-browser-bundle
 }:
 
 with stdenv.lib;
@@ -391,15 +394,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Tor Browser Bundle built by torproject.org";
-    longDescription = ''
-      Tor Browser Bundle is a bundle of the Tor daemon, Tor Browser (heavily patched version of
-      Firefox), several essential extensions for Tor Browser, and some tools that glue those
-      together with a convenient UI.
-
-      `tor-browser-bundle-bin` package is the official version built by torproject.org patched with
-      `patchelf` to work under nix and with bundled scripts adapted to the read-only nature of
-      the `/nix/store`.
-    '';
+    longDescription = tor-browser-bundle.meta.longDescription;
     homepage = "https://www.torproject.org/";
     platforms = attrNames srcs;
     maintainers = with maintainers; [ offline matejc doublec thoughtpolice joachifm hax404 cap ];

--- a/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
@@ -1,0 +1,345 @@
+{ stdenv
+, fetchgit
+, fetchurl
+, symlinkJoin
+
+, tor
+, tor-browser-unwrapped
+
+# Wrapper runtime
+, coreutils
+, hicolor-icon-theme
+, shared-mime-info
+, noto-fonts
+, noto-fonts-emoji
+
+# Audio support
+, audioSupport ? mediaSupport
+, apulse
+
+# Media support (implies audio support)
+, mediaSupport ? false
+, ffmpeg
+
+# Extensions, common
+, zip
+
+# HTTPS Everywhere
+, git
+, libxml2 # xmllint
+, python27
+, python27Packages
+, rsync
+
+# Pluggable transports
+, obfs4
+
+# Customization
+, extraPrefs ? ""
+, extraExtensions ? [ ]
+}:
+
+with stdenv.lib;
+
+let
+  tor-browser-build_src = fetchgit {
+    url = "https://git.torproject.org/builders/tor-browser-build.git";
+    rev = "refs/tags/tbb-7.5a5-build5";
+    sha256 = "0j37mqldj33fnzghxifvy6v8vdwkcz0i4z81prww64md5s8qcsa9";
+  };
+
+  firefoxExtensions = import ./extensions.nix {
+    inherit stdenv fetchurl fetchgit zip
+      git libxml2 python27 python27Packages rsync;
+  };
+
+  bundledExtensions = with firefoxExtensions; [
+    https-everywhere
+    noscript
+    torbutton
+    tor-launcher
+  ] ++ extraExtensions;
+
+  fontsEnv = symlinkJoin {
+    name = "tor-browser-fonts";
+    paths = [ noto-fonts noto-fonts-emoji ];
+  };
+
+  fontsDir = "${fontsEnv}/share/fonts";
+
+  mediaLibPath = makeLibraryPath [
+    ffmpeg
+  ];
+in
+stdenv.mkDerivation {
+  pname = "tor-browser-bundle";
+  version = tor-browser-unwrapped.version;
+
+  buildInputs = [ tor-browser-unwrapped tor ];
+
+  dontUnpack = true;
+
+  buildPhase = ":";
+
+  # The following creates a customized firefox distribution.  For
+  # simplicity, we copy the entire base firefox runtime, to work around
+  # firefox's annoying insistence on resolving the installation directory
+  # relative to the real firefox executable.  A little tacky and
+  # inefficient but it works.
+  installPhase = ''
+    TBBUILD=${tor-browser-build_src}/projects/tor-browser
+    TBDATA_PATH=TorBrowser-Data
+
+    self=$out/lib/tor-browser
+    mkdir -p $self && cd $self
+
+    TBDATA_IN_STORE=$self/$TBDATA_PATH
+
+    cp -dR ${tor-browser-unwrapped}/lib"/"*"/"* .
+    chmod -R +w .
+
+    # Prepare for autoconfig
+    cat >defaults/pref/autoconfig.js <<EOF
+    pref("general.config.filename", "mozilla.cfg");
+    pref("general.config.obscure_value", 0);
+    EOF
+
+    # Hardcoded configuration
+    cat >mozilla.cfg <<EOF
+    // First line must be a comment
+
+    // Always update via Nixpkgs
+    lockPref("app.update.auto", false);
+    lockPref("app.update.enabled", false);
+    lockPref("extensions.update.autoUpdateDefault", false);
+    lockPref("extensions.update.enabled", false);
+    lockPref("extensions.torbutton.updateNeeded", false);
+    lockPref("extensions.torbutton.versioncheck_enabled", false);
+
+    // Where to find the Nixpkgs tor executable & config
+    lockPref("extensions.torlauncher.tor_path", "${tor}/bin/tor");
+    lockPref("extensions.torlauncher.torrc-defaults_path", "$TBDATA_IN_STORE/torrc-defaults");
+
+    // Captures store paths
+    clearPref("extensions.xpiState");
+    clearPref("extensions.bootstrappedAddons");
+
+    // Insist on using IPC for communicating with Tor
+    lockPref("extensions.torlauncher.control_port_use_ipc", true);
+    lockPref("extensions.torlauncher.socks_port_use_ipc", true);
+
+    // Allow sandbox access to sound devices if using ALSA directly
+    ${if audioSupport then ''
+      pref("security.sandbox.content.write_path_whitelist", "/dev/snd/");
+    '' else ''
+      clearPref("security.sandbox.content.write_path_whitelist");
+    ''}
+
+    // User customization
+    ${extraPrefs}
+    EOF
+
+    # Preload extensions
+    find ${toString bundledExtensions} -name '*.xpi' -exec ln -s -t browser/extensions '{}' '+'
+
+    # Copy bundle data
+    bundlePlatform=linux
+    bundleData=$TBBUILD/Bundle-Data
+
+    mkdir -p $TBDATA_PATH
+    cat \
+      $bundleData/$bundlePlatform/Data/Tor/torrc-defaults \
+      >> $TBDATA_PATH/torrc-defaults
+    cat \
+      $bundleData/$bundlePlatform/Data/Browser/profile.default/preferences/extension-overrides.js \
+      $bundleData/PTConfigs/bridge_prefs.js \
+      >> defaults/pref/extension-overrides.js
+
+    # Configure geoip
+    #
+    # tor-launcher insists on resolving geoip data relative to torrc-defaults
+    # (and passes them directly on the tor command-line).
+    #
+    # Write the paths into torrc-defaults anyway, otherwise they'll be
+    # captured in the runtime torrc.
+    ln -s -t $TBDATA_PATH ${tor.geoip}/share/tor/geoip{,6}
+    cat >>$TBDATA_PATH/torrc-defaults <<EOF
+    GeoIPFile $TBDATA_IN_STORE/geoip
+    GeoIPv6File $TBDATA_IN_STORE/geoip6
+    EOF
+
+    # Configure pluggable transports
+    substituteInPlace $TBDATA_PATH/torrc-defaults \
+      --replace "./TorBrowser/Tor/PluggableTransports/obfs4proxy" \
+                "${obfs4}/bin/obfs4proxy"
+
+    # Hard-code path to TBB fonts; xref: FONTCONFIG_FILE in the wrapper below
+    sed $bundleData/$bundlePlatform/Data/fontconfig/fonts.conf \
+        -e "s,<dir>fonts</dir>,<dir>${fontsDir}</dir>," \
+        > $TBDATA_PATH/fonts.conf
+
+    # Generate a suitable wrapper
+    wrapper_PATH=${makeBinPath [ coreutils ]}
+    wrapper_XDG_DATA_DIRS=${concatMapStringsSep ":" (x: "${x}/share") [
+      hicolor-icon-theme
+      shared-mime-info
+    ]}
+
+    ${optionalString audioSupport ''
+      # apulse uses a non-standard library path ...
+      wrapper_LD_LIBRARY_PATH=${apulse}/lib/apulse''${wrapper_LD_LIBRARY_PATH:+:$wrapper_LD_LIBRARY_PATH}
+    ''}
+
+    ${optionalString mediaSupport ''
+      wrapper_LD_LIBRARY_PATH=${mediaLibPath}''${wrapper_LD_LIBRARY_PATH:+:$wrapper_LD_LIBRARY_PATH}
+    ''}
+
+    mkdir -p $out/bin
+    cat >$out/bin/tor-browser <<EOF
+    #! ${stdenv.shell} -eu
+
+    umask 077
+
+    PATH=$wrapper_PATH
+
+    readonly THE_HOME=\$HOME
+    TBB_HOME=\''${TBB_HOME:-\''${XDG_DATA_HOME:-\$HOME/.local/share}/tor-browser}
+    if [[ \''${TBB_HOME:0:1} != / ]] ; then
+      TBB_HOME=\$PWD/\$TBB_HOME
+    fi
+    readonly TBB_HOME
+
+    # Basic sanity check: never want to vomit directly onto user's homedir
+    if [[ "\$TBB_HOME" = "\$THE_HOME" ]] ; then
+      echo 'TBB_HOME=\$HOME; refusing to run' >&2
+      exit 1
+    fi
+
+    mkdir -p "\$TBB_HOME"
+
+    HOME=\$TBB_HOME
+    cd "\$HOME"
+
+    # Re-init XDG basedir envvars
+    XDG_CACHE_HOME=\$HOME/.cache
+    XDG_CONFIG_HOME=\$HOME/.config
+    XDG_DATA_HOME=\$HOME/.local/share
+
+    # Initialize empty TBB runtime state directory hierarchy.  Mirror the
+    # layout used by the official TBB, to avoid the hassle of working
+    # against the assumptions made by tor-launcher & co.
+    mkdir -p "\$HOME/TorBrowser" "\$HOME/TorBrowser/Data"
+
+    # Initialize the Tor data directory.
+    mkdir -p "\$HOME/TorBrowser/Data/Tor"
+
+    # TBB fails if ownership is too permissive
+    chmod 0700 "\$HOME/TorBrowser/Data/Tor"
+
+    # Initialize the browser profile state.  Expect TBB to generate all data.
+    mkdir -p "\$HOME/TorBrowser/Data/Browser/profile.default"
+
+    # Files that capture store paths; re-generated by firefox at startup
+    rm -rf "\$HOME/TorBrowser/Data/Browser/profile.default"/{compatibility.ini,extensions.ini,extensions.json,startupCache}
+
+    # Clear out fontconfig caches
+    rm -f "\$HOME/.cache/fontconfig/"*.cache-*
+
+    # Lift-off!
+    #
+    # TZ is set to avoid stat()ing /etc/localtime over and over ...
+    #
+    # DBUS_SESSION_BUS_ADDRESS is inherited to avoid auto-launching a new
+    # dbus instance; to prevent using the session bus, set the envvar to
+    # an empty/invalid value prior to running tor-browser.
+    #
+    # FONTCONFIG_FILE is required to make fontconfig read the TBB
+    # fonts.conf; upstream uses FONTCONFIG_PATH, but FC_DEBUG=1024
+    # indicates the system fonts.conf being used instead.
+    #
+    # HOME, TMPDIR, XDG_*_HOME are set as a form of soft confinement;
+    # ideally, tor-browser should not write to any path outside TBB_HOME
+    # and should run even under strict confinement to TBB_HOME.
+    #
+    # XDG_DATA_DIRS is set to prevent searching system directories for
+    # mime and icon data.
+    #
+    # PULSE_{SERVER,COOKIE} is necessary for audio playback w/pulseaudio
+    #
+    # APULSE_PLAYBACK_DEVICE is for audio playback w/o pulseaudio (no capture yet)
+    #
+    # TOR_* is for using an external tor instance
+    #
+    # Parameters lacking a default value below are *required* (enforced by
+    # -o nounset).
+    exec env -i \
+      LD_LIBRARY_PATH=$wrapper_LD_LIBRARY_PATH \
+      \
+      TZ=":" \
+      \
+      DISPLAY="\$DISPLAY" \
+      XAUTHORITY="\''${XAUTHORITY:-}" \
+      DBUS_SESSION_BUS_ADDRESS="\$DBUS_SESSION_BUS_ADDRESS" \
+      \
+      HOME="\$HOME" \
+      TMPDIR="\$XDG_CACHE_HOME/tmp" \
+      XDG_CONFIG_HOME="\$XDG_CONFIG_HOME" \
+      XDG_DATA_HOME="\$XDG_DATA_HOME" \
+      XDG_CACHE_HOME="\$XDG_CACHE_HOME" \
+      XDG_RUNTIME_DIR="\$HOME/run" \
+      \
+      XDG_DATA_DIRS="$wrapper_XDG_DATA_DIRS" \
+      \
+      FONTCONFIG_FILE="$TBDATA_IN_STORE/fonts.conf" \
+      \
+      APULSE_PLAYBACK_DEVICE="\''${APULSE_PLAYBACK_DEVICE:-plug:dmix}" \
+      \
+      TOR_SKIP_LAUNCH="\''${TOR_SKIP_LAUNCH:-}" \
+      TOR_CONTROL_PORT="\''${TOR_CONTROL_PORT:-}" \
+      TOR_SOCKS_PORT="\''${TOR_SOCKS_PORT:-}" \
+      \
+      $self/firefox \
+        -no-remote \
+        -profile "\$HOME/TorBrowser/Data/Browser/profile.default" \
+        "\$@"
+    EOF
+    chmod +x $out/bin/tor-browser
+
+    echo "Syntax checking wrapper ..."
+    bash -n $out/bin/tor-browser
+
+    echo "Checking wrapper ..."
+    DISPLAY="" XAUTHORITY="" DBUS_SESSION_BUS_ADDRESS="" TBB_HOME=$(mktemp -d) \
+    $out/bin/tor-browser -version >/dev/null
+  '';
+
+  passthru.execdir = "/bin";
+  meta = with stdenv.lib; {
+    description = "An unofficial version of the Tor Browser Bundle, built from source";
+    longDescription = ''
+      Tor Browser Bundle is a bundle of the Tor daemon, Tor Browser (heavily patched version of
+      Firefox), several essential extensions for Tor Browser, and some tools that glue those
+      together with a convenient UI.
+
+      `tor-browser-bundle-bin` package is the official version built by torproject.org patched with
+      `patchelf` to work under nix and with bundled scripts adapted to the read-only nature of
+      the `/nix/store`.
+
+      `tor-browser-bundle` package is the version built completely from source. It reuses the `tor`
+      package for the tor daemon, `firefoxPackages.tor-browser` package for the tor-browser, and
+      builds all the extensions from source.
+
+      Note that `tor-browser-bundle` package is not only built from source, but also bundles Tor
+      Browser differently from the official `tor-browser-bundle-bin` implementation. The official
+      Tor Browser is not a normal UNIX program and is heavily patched for its use in the Tor Browser
+      Bundle (which `tor-browser-bundle-bin` package then has to work around for the read-only
+      /nix/store). Meanwhile, `firefoxPackages.tor-browser` reverts all those patches, allowing
+      `firefoxPackages.tor-browser` to be used independently of the bundle, and then implements what
+      `tor-browser-bundle` needs for the bundling using a much simpler patch. See the
+      longDescription and expression of the `firefoxPackages.tor-browser` package for more info.
+    '';
+    inherit (tor-browser-unwrapped.meta) homepage platforms license;
+    hydraPlatforms = [ ];
+    maintainers = with maintainers; [ joachifm ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -537,11 +537,6 @@ mapAliases ({
   # added 2019-10-28
   gnatsd = nats-server;
 
-  # added 2020-01-10
-  tor-browser-bundle = throw "tor-browser-bundle was removed because it was out of date and inadequately maintained. Please use tor-browser-bundle-bin instead. See #77452.";
-  # added 2020-01-10
-  tor-browser-unwrapped = throw "tor-browser-unwrapped was removed because it was out of date and inadequately maintained. Please use tor-browser-bundle-bin instead. See #77452.";
-
     /* Cleanup before 20.09 */
   llvm_4 = throw ''
     The LLVM versions 3.5, 3.9 and 4.0 have been removed in NixOS 20.03

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6849,6 +6849,11 @@ in
 
   tor-browser-bundle-bin = callPackage ../applications/networking/browsers/tor-browser-bundle-bin { };
 
+  tor-browser-bundle = callPackage ../applications/networking/browsers/tor-browser-bundle {
+    stdenv = stdenvNoCC;
+    tor-browser-unwrapped = firefoxPackages.tor-browser;
+  };
+
   touchegg = callPackage ../tools/inputmethods/touchegg { };
 
   torsocks = callPackage ../tools/security/tor/torsocks.nix { };
@@ -19131,6 +19136,7 @@ in
   firefox-esr-52-unwrapped = firefoxPackages.firefox-esr-52;
   firefox-esr-60-unwrapped = firefoxPackages.firefox-esr-60;
   firefox-esr-68-unwrapped = firefoxPackages.firefox-esr-68;
+  tor-browser-unwrapped = firefoxPackages.tor-browser;
   icecat-unwrapped = firefoxPackages.icecat;
 
   firefox = wrapFirefox firefox-unwrapped { };


### PR DESCRIPTION
It builds. It works. Should be ready to merge.

# `git log`

- Revert "firefoxPackages.tor-browser*, tor-browser-bundle: remove"

  This reverts commit 1efaa03d95ec5c8080c0e5bff91c41e4b3acf0a0.

  Reverts #77452. /cc @flokli @alyssais

- firefoxPackages.tor-browser: unpack sources much more efficiently

  We don't need to spend time tracking hardlinks in `cp`,
  `find ... -exec ...` is also very very very very sloooooooooooooooooooooooooooooow,
  `find` followed by `xargs` with batching is equivalent, but much faster.

- firefoxPackages.tor-browser: mark older versions as insecure

- firefoxPackages.tor-browser: 8.5.6 -> 9.0.4

- firefoxPackages.tor-browser: fix build ("only" warnings)

- firefoxPackages.tor-browser: add a reference to the upstream ticket

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.09
- Nix: nix-env (Nix) 2.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - New (2):
    - firefoxPackages.tor-browser
    - tor-browser-bundle
- On aarch64-linux: ditto
- On x86_64-darwin:
  - New (1):
    - firefoxPackages.tor-browser

`tor-browser-bundle` now needs to be reworked for tor-browser with internalized tor-launcher. /cc @joachifm