### PR TITLE
rx: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/applications/graphics/rx/default.nix
+++ b/pkgs/applications/graphics/rx/default.nix
@@ -1,22 +1,22 @@
 { stdenv, rustPlatform, fetchFromGitHub, makeWrapper
 , cmake, pkgconfig
 , xorg ? null
-, vulkan-loader ? null }:
+, libGL ? null }:
 
 with stdenv.lib;
 
 rustPlatform.buildRustPackage rec {
   pname = "rx";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "cloudhead";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0mhpq9x54d884ydmfv1358sgc4jc7bghfx2y0k7p879hyyxr52v1";
+    sha256 = "1byaxbhd3q49473kcdd52rvn3xq7bmy8bdx3pz0jiw96bclzhcgq";
   };
 
-  cargoSha256 = "0fnrgijfkvapj1yyy9grnqh2vkciisf029af0gfwyzsxzdi62gg5";
+  cargoSha256 = "173jfjvdag97f6jvfg366hjk9v3cz301cbzpcahy51rbf1cip1w1";
 
   nativeBuildInputs = [ cmake pkgconfig makeWrapper ];
 
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
   postInstall = optional stdenv.isLinux ''
     mkdir -p $out/share/applications
     cp $src/rx.desktop $out/share/applications
-    wrapProgram $out/bin/rx --prefix LD_LIBRARY_PATH : ${vulkan-loader}/lib
+    wrapProgram $out/bin/rx --prefix LD_LIBRARY_PATH : ${libGL}/lib
   '';
 
   meta = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changes: https://github.com/cloudhead/rx/compare/v0.3.0...v0.3.1

Renderer switched from Vulkan to OpenGL, but I'm not sure why.

Not sure if the runtime dependency to libGL should be extended to MacOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @filalex77 