### PR TITLE
ibus-engines.table-others: 1.3.9 -> 1.3.11

### DIFF
--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-others/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-others/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ibus-table-others";
-  version = "1.3.9";
+  version = "1.3.11";
 
   src = fetchurl {
     url = "https://github.com/moebiuscurve/ibus-table-others/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0270a9njyzb1f8nw5w9ghwxcl3m6f13d8p8a01fjm8rnjs04mcb3";
+    sha256 = "0763wnlklcs3d8fk21nkp7dgn4qzqgxh1s24q3kl8gzgng2a88jj";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     isIbusEngine = true;
     description  = "Various table-based input methods for IBus";
-    homepage     = https://github.com/moebiuscurve/ibus-table-others;
+    homepage     = "https://github.com/moebiuscurve/ibus-table-others";
     license      = licenses.gpl3;
     platforms    = platforms.linux;
     maintainers  = with maintainers; [ mudri ];


### PR DESCRIPTION
###### Motivation for this change

Update ibus-table-others to version 1.3.11 with the following changes:

* Add Vietnamese input methods Telex and VNI
* Extend russian translit for latin slavic layouts
* latex: add most of Unicode 9.0 block Mathematical Alphanumeric Symbols
* mathwriter-ibus: add superscript alphabets
* mathwriter-ibus: added Blackboard bold letters

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
