### PR TITLE
libretro.snes9x: 29b78d -> 04692e

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -786,10 +786,11 @@ in with stdenv.lib.licenses;
 
   snes9x = (mkLibRetroCore rec {
     core = "snes9x";
-    src = fetchRetro {
+    src = fetchFromGitHub {
+      owner = "snes9xgit";
       repo = core;
-      rev = "29b78df8c9f0f48ed4605d08a187a134b3b316d6";
-      sha256 = "004h1pkxvbn4zlh8bqs6z17k04jw5wzbwklpgvmb7hbxshsi4qid";
+      rev = "04692e1ee45cc647423774ee17c63208c2713638";
+      sha256 = "09p9m85fxwrrrapjb08rcxknpgq5d6a87arrm1jn94r56glxlcfa";
     };
     description = "Port of SNES9x git to libretro";
     license = "Non-commercial";


### PR DESCRIPTION
Upstream has broken git history [1], so the current version cannot be
fetched. The required patches have been upstreamed [2], and we hope
that upstream will be more careful with their git history.

The previous commit can still be viewed on github [3], but is not the
ancestor of any fetchable ref.

[1] https://github.com/libretro/snes9x/issues/199
[2] https://github.com/snes9xgit/snes9x/pull/588
[3] https://github.com/libretro/snes9x/commit/29b78df8c9f0f48ed4605d08a187a134b3b316d6

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixing build for snes9x

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
