### PR TITLE
stups-pierone: init at 1.1.45

### DIFF
--- a/pkgs/development/python-modules/stups-pierone/default.nix
+++ b/pkgs/development/python-modules/stups-pierone/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, requests
+, stups-cli-support
+, stups-zign
+, pytest
+, pytestcov
+, hypothesis
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "stups-pierone";
+  version = "1.1.45";
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "zalando-stups";
+    repo = "pierone-cli";
+    rev = version;
+    sha256 = "1ggfizw27wpcagbbk15xpfrhq6b250cx4278b5d7y8s438g128cs";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    stups-cli-support
+    stups-zign
+  ];
+
+  preCheck = "
+    export HOME=$TEMPDIR
+  ";
+
+  checkInputs = [
+    pytest
+    pytestcov
+    hypothesis
+  ];
+
+  meta = with lib; {
+    description = "Convenient command line client for STUPS' Pier One Docker registry";
+    homepage = "https://github.com/zalando-stups/pierone-cli";
+    license = licenses.asl20;
+    maintainers = [ maintainers.mschuwalow ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1392,6 +1392,8 @@ in {
 
   stups-fullstop = callPackage ../development/python-modules/stups-fullstop { };
 
+  stups-pierone = callPackage ../development/python-modules/stups-pierone { };
+
   stups-tokens = callPackage ../development/python-modules/stups-tokens { };
 
   stups-zign = callPackage ../development/python-modules/stups-zign { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
