### PR TITLE
firejail: local profile handling fixed

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -36,10 +36,10 @@ stdenv.mkDerivation {
     sed -e "s@/etc/@$out/etc/@g" -e "/chmod u+s/d" -i Makefile
   '';
 
-  # We need to set the directory for the .local override files back to
+  # We need to set the directory for the .local override files to
   # /etc/firejail so we can actually override them
   postInstall = ''
-    sed -E -e 's@^include (.*)(/firejail/.*.local)$@include /etc\2@g' -i $out/etc/firejail/*.profile
+    sed -E -e 's@^include (.*.local)$@include /etc/firejail/\1@g' -i $out/etc/firejail/*.profile
   '';
 
   # At high parallelism, the build sometimes fails with:


### PR DESCRIPTION
The sed expression wasn't really catching anything (as local profiles are included in the provided set of profiles by `include aaa.local` and not by `include xx/firejail/aaa.local` as the sed expression used to expect). As a result, it was not possible to create local profiles in any accessible location. This fix makes it possible to create them in `/etc/firejail/` which seems pretty standard.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
as above

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
