### PR TITLE
glibc: fix cross compilation build failure (again)

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -97,6 +97,11 @@ stdenv.mkDerivation ({
       ./CVE-2018-11236.patch
       # https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=f51c8367685dc888a02f7304c729ed5277904aff
       ./CVE-2018-11237.patch
+
+      # Remove after upgrading to glibc 2.28+
+      # Change backported from upstream
+      # https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=9c79cec8cd2a6996a73aa83d79b360ffd4bebde6
+      ./fix-out-of-bounds-access-in-findidxwc.patch
     ]
     ++ lib.optionals stdenv.isx86_64 [
       ./fix-x64-abi.patch

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -102,6 +102,10 @@ stdenv.mkDerivation ({
       # Change backported from upstream
       # https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=9c79cec8cd2a6996a73aa83d79b360ffd4bebde6
       ./fix-out-of-bounds-access-in-findidxwc.patch
+
+      # Remove after upgrading to glibc 2.28+
+      # https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=21526a507df8f1b2e37492193a754534d8938c0b
+      ./fix-out-of-bounds-access-in-ibm-1390-converter.patch
     ]
     ++ lib.optionals stdenv.isx86_64 [
       ./fix-x64-abi.patch

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -54,6 +54,11 @@ callPackage ./common.nix { inherit stdenv; } {
         # Fix -Werror build failure when building glibc with musl with GCC >= 8, see:
         # https://github.com/NixOS/nixpkgs/pull/68244#issuecomment-544307798
         (stdenv.lib.optional stdenv.hostPlatform.isMusl "-Wno-error=attribute-alias")
+        (stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+          # Ignore "error: '__EI___errno_location' specifies less restrictive attributes than its target '__errno_location'"
+          # New warning as of GCC 9
+          "-Wno-error=missing-attributes"
+        ])
       ]);
 
     # When building glibc from bootstrap-tools, we need libgcc_s at RPATH for

--- a/pkgs/development/libraries/glibc/fix-out-of-bounds-access-in-findidxwc.patch
+++ b/pkgs/development/libraries/glibc/fix-out-of-bounds-access-in-findidxwc.patch
@@ -1,0 +1,26 @@
+diff -ur glibc-2.27/locale/weightwc.h glibc-2.27-patched/locale/weightwc.h
+--- glibc-2.27/locale/weightwc.h	2018-02-02 01:17:18.000000000 +0900
++++ glibc-2.27-patched/locale/weightwc.h	2020-01-12 04:54:16.044440602 +0900
+@@ -94,19 +94,19 @@
+ 	    if (cp[cnt] != usrc[cnt])
+ 	      break;
+ 
+-	  if (cnt < nhere - 1)
++	  if (cnt < nhere - 1 || cnt == len)
+ 	    {
+ 	      cp += 2 * nhere;
+ 	      continue;
+ 	    }
+ 
+-	  if (cp[nhere - 1] > usrc[nhere -1])
++	  if (cp[nhere - 1] > usrc[nhere - 1])
+ 	    {
+ 	      cp += 2 * nhere;
+ 	      continue;
+ 	    }
+ 
+-	  if (cp[2 * nhere - 1] < usrc[nhere -1])
++	  if (cp[2 * nhere - 1] < usrc[nhere - 1])
+ 	    {
+ 	      cp += 2 * nhere;
+ 	      continue;

--- a/pkgs/development/libraries/glibc/fix-out-of-bounds-access-in-ibm-1390-converter.patch
+++ b/pkgs/development/libraries/glibc/fix-out-of-bounds-access-in-ibm-1390-converter.patch
@@ -1,0 +1,35 @@
+From 21526a507df8f1b2e37492193a754534d8938c0b Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@suse.de>
+Date: Tue, 24 Jul 2018 14:08:34 +0200
+Subject: [PATCH] Fix out-of-bounds access in IBM-1390 converter (bug 23448)
+
+The IBM-1390 converter can consume/produce two UCS4 characters in each
+loop.
+---
+ ChangeLog           | 6 ++++++
+ iconvdata/ibm1364.c | 2 ++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/iconvdata/ibm1364.c b/iconvdata/ibm1364.c
+index b833273..517fe60 100644
+--- a/iconvdata/ibm1364.c
++++ b/iconvdata/ibm1364.c
+@@ -150,6 +150,7 @@ enum
+ #define MIN_NEEDED_INPUT  	MIN_NEEDED_FROM
+ #define MAX_NEEDED_INPUT  	MAX_NEEDED_FROM
+ #define MIN_NEEDED_OUTPUT 	MIN_NEEDED_TO
++#define MAX_NEEDED_OUTPUT 	MAX_NEEDED_TO
+ #define LOOPFCT 		FROM_LOOP
+ #define BODY \
+   {									      \
+@@ -296,6 +297,7 @@ enum
+ 
+ /* Next, define the other direction.  */
+ #define MIN_NEEDED_INPUT	MIN_NEEDED_TO
++#define MAX_NEEDED_INPUT  	MAX_NEEDED_TO
+ #define MIN_NEEDED_OUTPUT	MIN_NEEDED_FROM
+ #define MAX_NEEDED_OUTPUT	MAX_NEEDED_FROM
+ #define LOOPFCT			TO_LOOP
+-- 
+2.9.3
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The backport in #76972 was bad. cc @flokli 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
