### PR TITLE
davfs2: substitute ps command

### DIFF
--- a/pkgs/tools/filesystems/davfs2/0001-umount_davfs-substitute-ps-command.patch
+++ b/pkgs/tools/filesystems/davfs2/0001-umount_davfs-substitute-ps-command.patch
@@ -1,0 +1,25 @@
+From 0cb1321c4cbb2978318ddad73c9ee6f2a19c55c8 Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Sat, 11 Jan 2020 21:06:33 +0100
+Subject: [PATCH] umount_davfs: substitute ps command
+
+---
+ src/umount_davfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/umount_davfs.c b/src/umount_davfs.c
+index b7019c3..a278679 100644
+--- a/src/umount_davfs.c
++++ b/src/umount_davfs.c
+@@ -157,7 +157,7 @@ main(int argc, char *argv[])
+     }
+     fclose(file);
+ 
+-    char *ps_command = ne_concat("ps -p ", pid, NULL);
++    char *ps_command = ne_concat("@ps@ -p ", pid, NULL);
+     FILE *ps_in = popen(ps_command, "r");
+     if (!ps_in) {
+         error(0, 0,
+-- 
+2.24.1
+

--- a/pkgs/tools/filesystems/davfs2/default.nix
+++ b/pkgs/tools/filesystems/davfs2/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, fetchurl, neon, zlib }:
+{ stdenv
+, fetchurl
+, neon
+, procps
+, substituteAll
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   name = "davfs2-1.5.6";
@@ -10,11 +16,21 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ neon zlib ];
 
-  patches = [ ./isdir.patch ./fix-sysconfdir.patch ];
+  patches = [
+    ./isdir.patch
+    ./fix-sysconfdir.patch
+    (substituteAll {
+      src = ./0001-umount_davfs-substitute-ps-command.patch;
+      ps = "${procps}/bin/ps";
+    })
+  ];
 
   configureFlags = [ "--sysconfdir=/etc" ];
 
-  makeFlags = ["sbindir=$(out)/sbin" "ssbindir=$(out)/sbin"];
+  makeFlags = [
+    "sbindir=$(out)/sbin"
+    "ssbindir=$(out)/sbin"
+  ];
 
   meta = {
     homepage = https://savannah.nongnu.org/projects/davfs2;


### PR DESCRIPTION
umount.davfs2 uses ps to get a process list to terminate gracefully.

On NixOS, this currently fails:

```
sh: ps: command not found
/run/current-system/sw/bin/umount.davfs:
  can't find mount.davfs-process with pid 4085;
  trying to unmount anyway.
  you propably have to remove /var/run/mount.davfs/root-x.pid manually
sh: umount: command not found
```

Fix this by patching ${procps}/bin/ps into the ps_command.

Afterwards:

```
umount.davfs: waiting for mount.davfs (pid 4106) to terminate gracefully .. OK
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
