### PR TITLE
nixos/roundcube: security improvements

### DIFF
--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -108,6 +108,7 @@ in
       $config['max_message_size'] = '25M';
       $config['plugins'] = [${concatMapStringsSep "," (p: "'${p}'") cfg.plugins}];
       $config['des_key'] = file_get_contents('/var/lib/roundcube/des_key');
+      $config['mime_types'] = '${pkgs.nginx}/conf/mime.types';
       ${cfg.extraConfig}
     '';
 


### PR DESCRIPTION

###### Motivation for this change
* database password is world readable in the store
* php update script is ran as root


###### Things done
* If the database is local, use postgres peer authentication. Otherwise, use a password file.
* Leave database initialisation to `postgresql.ensure*`.
* Leave `/var/lib/roundcube` creation to systemd.
* Run php upgrade script as unpriviledged user.
* initialize the des_key (the installer does it, but nixos bypasses the installer...)
* En passant, fix warning about mime types database

This *should* be backward compatible:
* des_key is only used for cookies apparently. So changing it only logs users out.
* changing the default user: /var/lib/roundcube is chowned by systemd
* database owner does not change, and can still log in with peer auth even if it previously used a password

The nixos test still passes, with no modification.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Ma27 @globin @Vskilet 