### PR TITLE
{python{Full,Packages},pypyPackages}: move unversioned aliases to aliases.nix

### DIFF
--- a/pkgs/applications/audio/clerk/default.nix
+++ b/pkgs/applications/audio/clerk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper, rofi, mpc_cli, perl,
-utillinux, pythonPackages, libnotify }:
+utillinux, python2Packages, libnotify }:
 
 stdenv.mkDerivation {
   name = "clerk-2016-10-14";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "0y045my65hr3hjyx13jrnyg6g3wb41phqb1m7azc4l6vx6r4124b";
   };
 
-  buildInputs = [ makeWrapper pythonPackages.mpd2 ];
+  buildInputs = [ makeWrapper python2Packages.mpd2 ];
 
   dontBuild = true;
 

--- a/pkgs/applications/audio/gtklick/default.nix
+++ b/pkgs/applications/audio/gtklick/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages, gettext, klick}:
+{ stdenv, fetchurl, python2Packages, gettext, klick}:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "gtklick";
   version = "0.6.4";
 
@@ -9,7 +9,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "7799d884126ccc818678aed79d58057f8cf3528e9f1be771c3fa5b694d9d0137";
   };
 
-  pythonPath = with pythonPackages; [
+  pythonPath = with python2Packages; [
     pyliblo
     pyGtkGlade
   ];

--- a/pkgs/applications/audio/ingen/default.nix
+++ b/pkgs/applications/audio/ingen/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, boost, ganv, glibmm, gtkmm2, libjack2, lilv
-, lv2Unstable, makeWrapper, pkgconfig, python, raul, rdflib, serd, sord, sratom
+, lv2Unstable, makeWrapper, pkgconfig, python2, raul, rdflib, serd, sord, sratom
 , wafHook
 , suil
 }:
@@ -18,7 +18,7 @@ stdenv.mkDerivation  rec {
   nativeBuildInputs = [ pkgconfig wafHook ];
   buildInputs = [
     boost ganv glibmm gtkmm2 libjack2 lilv lv2Unstable makeWrapper
-    python raul serd sord sratom suil
+    python2 raul serd sord sratom suil
   ];
 
   preConfigure = ''
@@ -31,7 +31,7 @@ stdenv.mkDerivation  rec {
     for program in ingenams ingenish
     do
       wrapProgram $out/bin/$program \
-        --prefix PYTHONPATH : $out/${python.sitePackages}:$PYTHONPATH
+        --prefix PYTHONPATH : $out/${python2.sitePackages}:$PYTHONPATH
     done
   '';
 

--- a/pkgs/applications/audio/jalv/default.nix
+++ b/pkgs/applications/audio/jalv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk2, libjack2, lilv, lv2, pkgconfig, python
+{ stdenv, fetchurl, gtk2, libjack2, lilv, lv2, pkgconfig, python2
 , serd, sord , sratom, suil, wafHook }:
 
 stdenv.mkDerivation  rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation  rec {
 
   nativeBuildInputs = [ pkgconfig wafHook ];
   buildInputs = [
-    gtk2 libjack2 lilv lv2 python serd sord sratom suil
+    gtk2 libjack2 lilv lv2 python2 serd sord sratom suil
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/kid3/default.nix
+++ b/pkgs/applications/audio/kid3/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, pkgconfig, cmake, python, ffmpeg, phonon, automoc4
+, pkgconfig, cmake, python2, ffmpeg, phonon, automoc4
 , chromaprint, docbook_xml_dtd_45, docbook_xsl, libxslt
 , id3lib, taglib, mp4v2, flac, libogg, libvorbis
 , zlib, readline , qtbase, qttools, qtmultimedia, qtquickcontrols
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ wrapQtAppsHook ];
   buildInputs = with stdenv.lib;
-  [ pkgconfig cmake python ffmpeg phonon automoc4
+  [ pkgconfig cmake python2 ffmpeg phonon automoc4
     chromaprint docbook_xml_dtd_45 docbook_xsl libxslt
     id3lib taglib mp4v2 flac libogg libvorbis zlib readline
     qtbase qttools qtmultimedia qtquickcontrols ];

--- a/pkgs/applications/audio/lastfmsubmitd/default.nix
+++ b/pkgs/applications/audio/lastfmsubmitd/default.nix
@@ -1,6 +1,6 @@
-{ lib, fetchurl, pythonPackages }:
+{ lib, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "lastfmsubmitd";
   version = "1.0.6";
 

--- a/pkgs/applications/editors/bluefish/default.nix
+++ b/pkgs/applications/editors/bluefish/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, intltool, wrapGAppsHook, pkgconfig , gtk, libxml2
-, enchant, gucharmap, python, gnome3
+, enchant, gucharmap, python2, gnome3
 }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ intltool pkgconfig wrapGAppsHook ];
   buildInputs = [ gnome3.adwaita-icon-theme gtk libxml2
-    enchant gucharmap python ];
+    enchant gucharmap python2 ];
 
   meta = with stdenv.lib; {
     description = "A powerful editor targeted towards programmers and webdevelopers";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, callPackage, fetchurl
-, python
+, python2
 , jdk, cmake, libxml2, zlib, python3, ncurses5
 }:
 
@@ -179,7 +179,7 @@ let
         platforms = platforms.linux;
       };
     }).override {
-      propagatedUserEnvPkgs = [ python ];
+      propagatedUserEnvPkgs = [ python2 ];
     };
 
   buildRider = { name, version, src, license, description, wmClass, ... }:

--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, autoconf, automake, libtool, gtk2, pkgconfig, perlPackages,
-libxml2, gettext, python, libxml2Python, docbook5, docbook_xsl,
+libxml2, gettext, python2, libxml2Python, docbook5, docbook_xsl,
 libxslt, intltool, libart_lgpl, withGNOME ? false, libgnomeui,
 gtk-mac-integration-gtk2 }:
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs =
-    [ gtk2 libxml2 gettext python libxml2Python docbook5
+    [ gtk2 libxml2 gettext python2 libxml2Python docbook5
       libxslt docbook_xsl libart_lgpl ]
       ++ stdenv.lib.optional withGNOME libgnomeui
       ++ stdenv.lib.optional stdenv.isDarwin gtk-mac-integration-gtk2;

--- a/pkgs/applications/graphics/jbrout/default.nix
+++ b/pkgs/applications/graphics/jbrout/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchsvn, pythonPackages, makeWrapper, fbida, which }:
+{ stdenv, fetchsvn, python2Packages, makeWrapper, fbida, which }:
 
 let
-  inherit (pythonPackages) python;
-in pythonPackages.buildPythonApplication rec {
+  inherit (python2Packages) python;
+in python2Packages.buildPythonApplication rec {
   pname = "jbrout";
   version = "338";
 
@@ -31,7 +31,7 @@ in pythonPackages.buildPythonApplication rec {
   '';
 
   buildInputs = [ python makeWrapper which ];
-  propagatedBuildInputs = with pythonPackages; [ pillow lxml pyGtkGlade pyexiv2 fbida ];
+  propagatedBuildInputs = with python2Packages; [ pillow lxml pyGtkGlade pyexiv2 fbida ];
 
   meta = {
     homepage = https://manatlan.com/jbrout/;

--- a/pkgs/applications/graphics/k3d/default.nix
+++ b/pkgs/applications/graphics/k3d/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchpatch, ftgl, glew, asciidoc
-, cmake, ninja, libGLU, libGL, zlib, python, expat, libxml2, libsigcxx, libuuid, freetype
+, cmake, ninja, libGLU, libGL, zlib, python2, expat, libxml2, libsigcxx, libuuid, freetype
 , libpng, boost, doxygen, cairomm, pkgconfig, libjpeg, libtiff
 , gettext, intltool, perl, gtkmm2, glibmm, gtkglext, libXmu }:
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ninja gettext intltool doxygen pkgconfig perl asciidoc ];
 
   buildInputs = [
-     libGLU libGL zlib python expat libxml2 libsigcxx libuuid freetype libpng
+     libGLU libGL zlib python2 expat libxml2 libsigcxx libuuid freetype libpng
      boost cairomm libjpeg libtiff
      ftgl glew gtkmm2 glibmm gtkglext libXmu
     ];

--- a/pkgs/applications/kde/kcachegrind.nix
+++ b/pkgs/applications/kde/kcachegrind.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib,
   extra-cmake-modules, kdoctools,
-  karchive, ki18n, kio, perl, python, php, qttools
+  karchive, ki18n, kio, perl, python2, php, qttools
   , kdbusaddons
 }:
 
@@ -12,5 +12,5 @@ mkDerivation {
     maintainers = with lib.maintainers; [ orivej ];
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
-  buildInputs = [ karchive ki18n kio perl python php qttools kdbusaddons ];
+  buildInputs = [ karchive ki18n kio perl python2 php qttools kdbusaddons ];
 }

--- a/pkgs/applications/kde/kdebugsettings.nix
+++ b/pkgs/applications/kde/kdebugsettings.nix
@@ -3,7 +3,7 @@
   extra-cmake-modules, kdoctools,
   gettext,
   kcoreaddons, kconfig, kdbusaddons, kwidgetsaddons, kitemviews, kcompletion,
-  python
+  python2
 }:
 
 mkDerivation {
@@ -14,7 +14,7 @@ mkDerivation {
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    gettext kcoreaddons kconfig kdbusaddons kwidgetsaddons kitemviews kcompletion python
+    gettext kcoreaddons kconfig kdbusaddons kwidgetsaddons kitemviews kcompletion python2
   ];
   propagatedUserEnvPkgs = [ ];
 }

--- a/pkgs/applications/kde/minuet.nix
+++ b/pkgs/applications/kde/minuet.nix
@@ -1,5 +1,5 @@
 { mkDerivation
-, lib, extra-cmake-modules, gettext, python
+, lib, extra-cmake-modules, gettext, python2
 , drumstick, fluidsynth
 , kcoreaddons, kcrash, kdoctools
 , qtquickcontrols2, qtsvg, qttools, qtdeclarative
@@ -12,7 +12,7 @@ mkDerivation {
     maintainers = with maintainers; [ peterhoeg HaoZeke ];
   };
 
-  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python qtdeclarative ];
+  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python2 qtdeclarative ];
 
   propagatedBuildInputs = [
     drumstick fluidsynth

--- a/pkgs/applications/misc/bashSnippets/default.nix
+++ b/pkgs/applications/misc/bashSnippets/default.nix
@@ -1,10 +1,10 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper
-, curl, python, bind, iproute, bc, gitMinimal }:
+, curl, python2, bind, iproute, bc, gitMinimal }:
 let
   version = "1.17.3";
   deps = lib.makeBinPath [
     curl
-    python
+    python2
     bind.dnsutils
     iproute
     bc

--- a/pkgs/applications/misc/bleachbit/default.nix
+++ b/pkgs/applications/misc/bleachbit/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, pythonPackages
+, python2Packages
 , fetchurl
 , gettext
 , gobject-introspection
@@ -9,7 +9,7 @@
 , libnotify
 }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "bleachbit";
   version = "3.0";
 
@@ -32,7 +32,7 @@ pythonPackages.buildPythonApplication rec {
     libnotify
   ];
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     chardet
     pygobject3
     requests

--- a/pkgs/applications/misc/cherrytree/default.nix
+++ b/pkgs/applications/misc/cherrytree/default.nix
@@ -1,6 +1,6 @@
-{ lib, fetchurl, pythonPackages, gettext }:
+{ lib, fetchurl, python2Packages, gettext }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "cherrytree";
   version = "0.38.10";
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
 
   nativeBuildInputs = [ gettext ];
 
-  propagatedBuildInputs = with pythonPackages; [ pygtk dbus-python pygtksourceview ];
+  propagatedBuildInputs = with python2Packages; [ pygtk dbus-python2 pygtksourceview ];
 
   patches = [ ./subprocess.patch ];
 

--- a/pkgs/applications/misc/curabydagoma/default.nix
+++ b/pkgs/applications/misc/curabydagoma/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runtimeShell, lib, fetchurl, python, pythonPackages, unzip }:
+{ stdenv, runtimeShell, lib, fetchurl, python2, python2Packages, unzip }:
 
 # This package uses a precompiled "binary" distribution of CuraByDagoma,
 # distributed by the editor.
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   };
   unpackCmd = "unzip $curSrc && tar zxf CuraByDagoma_amd64.tar.gz";
   nativeBuildInputs = [ unzip ];
-  buildInputs = [ python pythonPackages.pyopengl pythonPackages.wxPython pythonPackages.pyserial pythonPackages.numpy ];
+  buildInputs = [ python2 python2Packages.pyopengl python2Packages.wxPython python2Packages.pyserial python2Packages.numpy ];
 
   # Compile all pyc files because the included pyc files may be older than the
   # py files. However, Python doesn't realize that because the packages
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     cat > $out/bin/curabydago <<EOF
     #!${runtimeShell}
     export PYTHONPATH=$PYTHONPATH
-    ${python.out}/bin/python $out/curabydago/cura.py
+    ${python2.out}/bin/python $out/curabydago/cura.py
     EOF
     chmod a+x $out/bin/curabydago
 

--- a/pkgs/applications/misc/direwolf/default.nix
+++ b/pkgs/applications/misc/direwolf/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , espeak, alsaLib, perl
-, python }:
+, python2 }:
 
 with stdenv.lib;
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    espeak perl python
+    espeak perl python2
   ] ++ (optional stdenv.isLinux alsaLib);
 
   postPatch = ''

--- a/pkgs/applications/misc/dockbarx/default.nix
+++ b/pkgs/applications/misc/dockbarx/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, gnome2, keybinder }:
+{ stdenv, fetchFromGitHub, python2Packages, gnome2, keybinder }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   ver = "0.93";
   name = "dockbarx-${ver}";
 
@@ -24,8 +24,8 @@ pythonPackages.buildPythonApplication rec {
     substituteInPlace dockx_applets/volume-control.py         --replace /usr/share/             $out/share/
   '';
 
-  propagatedBuildInputs = (with pythonPackages; [ pygtk pyxdg dbus-python pillow xlib ])
-    ++ (with gnome2; [ gnome_python gnome_python_desktop ])
+  propagatedBuildInputs = (with python2Packages; [ pygtk pyxdg dbus-python2 pillow xlib ])
+    ++ (with gnome2; [ gnome_python2 gnome_python2_desktop ])
     ++ [ keybinder ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/dotfiles/default.nix
+++ b/pkgs/applications/misc/dotfiles/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, pythonPackages }:
+{ stdenv, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "dotfiles";
   version = "0.6.4";
 
-  src = pythonPackages.fetchPypi {
+  src = python2Packages.fetchPypi {
     inherit version pname;
     sha256 = "03qis6m9r2qh00sqbgwsm883s4bj1ibwpgk86yh4l235mdw8jywv";
   };
@@ -12,8 +12,8 @@ pythonPackages.buildPythonApplication rec {
   # No tests in archive
   doCheck = false;
 
-  checkInputs = with pythonPackages; [ pytest ];
-  propagatedBuildInputs = with pythonPackages; [ click ];
+  checkInputs = with python2Packages; [ pytest ];
+  propagatedBuildInputs = with python2Packages; [ click ];
 
   meta = with stdenv.lib; {
     description = "Easily manage your dotfiles";

--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python, pkgconfig, cmake, bluez, libusb1, curl
+{ stdenv, fetchFromGitHub, python2, pkgconfig, cmake, bluez, libusb1, curl
 , libiconv, gettext, sqlite
 , dbiSupport ? false, libdbi ? null, libdbiDrivers ? null
 , postgresSupport ? false, postgresql ? null
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake ];
 
-  buildInputs = [ python bluez libusb1 curl gettext sqlite libiconv ]
+  buildInputs = [ python2 bluez libusb1 curl gettext sqlite libiconv ]
   ++ optionals dbiSupport [ libdbi libdbiDrivers ]
   ++ optionals postgresSupport [ postgresql ];
 

--- a/pkgs/applications/misc/haxor-news/default.nix
+++ b/pkgs/applications/misc/haxor-news/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, python, fetchpatch }:
+{ stdenv, python2, fetchpatch }:
 
-with python.pkgs;
+with python2.pkgs;
 
 buildPythonApplication rec {
   pname = "haxor-news";
@@ -31,7 +31,7 @@ buildPythonApplication rec {
   checkInputs = [ mock ];
 
   checkPhase = ''
-    ${python.interpreter} -m unittest discover -s tests -v
+    ${python2.interpreter} -m unittest discover -s tests -v
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, makeWrapper, pkgconfig
-, zip, python, zlib, which, icu, libmicrohttpd, lzma, aria2, wget, bc
+, zip, python2, zlib, which, icu, libmicrohttpd, lzma, aria2, wget, bc
 , libuuid, libX11, libXext, libXt, libXrender, glib, dbus, dbus-glib
 , gtk2, gdk-pixbuf, pango, cairo, freetype, fontconfig, alsaLib, atk, cmake
 , xapian, ctpp2, zimlib
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    zip python zlib xapian which icu libmicrohttpd
+    zip python2 zlib xapian which icu libmicrohttpd
     lzma zimlib ctpp2 aria2 wget bc libuuid makeWrapper pugixml
   ];
 

--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, fetchpatch, stdenv, gnutls, glib, pkgconfig, check, libotr, python
+{ fetchurl, fetchpatch, stdenv, gnutls, glib, pkgconfig, check, libotr, python2
 , enableLibPurple ? false, pidgin ? null
 , enablePam ? false, pam ? null
 }:
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ] ++ optional doCheck check;
 
-  buildInputs = [ gnutls glib libotr python ]
+  buildInputs = [ gnutls glib libotr python2 ]
     ++ optional enableLibPurple pidgin
     ++ optional enablePam pam;
 

--- a/pkgs/applications/networking/instant-messengers/blink/default.nix
+++ b/pkgs/applications/networking/instant-messengers/blink/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchdarcs, pythonPackages, libvncserver, zlib
+{ stdenv, fetchdarcs, python2Packages, libvncserver, zlib
 , gnutls, libvpx, makeDesktopItem, mkDerivationWith }:
 
-mkDerivationWith pythonPackages.buildPythonApplication rec {
+mkDerivationWith python2Packages.buildPythonApplication rec {
 
   pname = "blink";
   version = "3.2.0";
@@ -12,21 +12,21 @@ mkDerivationWith pythonPackages.buildPythonApplication rec {
     sha256 = "19rcwr5scw48qnj79q1pysw95fz9h98nyc3161qy2kph5g7dwkc3";
   };
 
-  patches = [ ./pythonpath.patch ];
+  patches = [ ./python2path.patch ];
   postPatch = ''
     sed -i 's|@out@|'"''${out}"'|g' blink/resources.py
   '';
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     pyqt5_with_qtwebkit
     cjson
     sipsimple
     twisted
-    google_api_python_client
+    google_api_python2_client
   ];
 
   buildInputs = [
-    pythonPackages.cython
+    python2Packages.cython
     zlib
     libvncserver
     libvpx

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,7 +1,7 @@
 { config, fetchurl, stdenv, wrapGAppsHook, autoreconfHook
 , curl, dbus, dbus-glib, enchant, gtk2, gnutls, gnupg, gpgme
 , libarchive, libcanberra-gtk2, libetpan, libnotify, libsoup, libxml2, networkmanager
-, openldap, perl, pkgconfig, poppler, python, shared-mime-info
+, openldap, perl, pkgconfig, poppler, python2, shared-mime-info
 , glib-networking, gsettings-desktop-schemas, libSM, libytnef, libical
 # Build options
 # TODO: A flag to build the manual.
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     # autotools check tries to dlopen libpython as a requirement for the python plugin
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${python}/lib
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${python2}/lib
   '';
 
   postPatch = ''
@@ -51,8 +51,8 @@ stdenv.mkDerivation rec {
         --subst-var-by MIMEROOTDIR ${shared-mime-info}/share
   '';
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook python.pkgs.wrapPython ];
-  propagatedBuildInputs = with python.pkgs; [ python ] ++ optionals enablePluginPython [ pygtk pygobject2 ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook python2.pkgs.wrapPython ];
+  propagatedBuildInputs = with python2.pkgs; [ python2 ] ++ optionals enablePluginPython [ pygtk pygobject2 ];
 
   buildInputs =
     [ curl dbus dbus-glib gtk2 gnutls gsettings-desktop-schemas
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  pythonPath = with python.pkgs; [ pygobject2 pygtk ];
+  pythonPath = with python2.pkgs; [ pygobject2 pygtk ];
 
   preFixup = ''
     buildPythonPath "$out $pythonPath"

--- a/pkgs/applications/office/gnumeric/default.nix
+++ b/pkgs/applications/office/gnumeric/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, pkgconfig, intltool, perlPackages
-, goffice, gnome3, wrapGAppsHook, gtk3, bison, pythonPackages
+, goffice, gnome3, wrapGAppsHook, gtk3, bison, python2Packages
 , itstool
 }:
 
 let
-  inherit (pythonPackages) python pygobject3;
+  inherit (python2Packages) python2 pygobject3;
 in stdenv.mkDerivation rec {
   pname = "gnumeric";
   version = "1.12.46";
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
   # ToDo: optional libgda, introspection?
   buildInputs = [
     goffice gtk3 gnome3.adwaita-icon-theme
-    python pygobject3
+    python2 pygobject3
   ] ++ (with perlPackages; [ perl XMLParser ]);
 
   enableParallelBuilding = true;

--- a/pkgs/applications/office/ledger/default.nix
+++ b/pkgs/applications/office/ledger/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, boost, gmp, mpfr, libedit, python
+{ stdenv, fetchFromGitHub, cmake, boost, gmp, mpfr, libedit, python2
 , texinfo, gnused, usePython ? true }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     (boost.override { enablePython = usePython; })
-    gmp mpfr libedit python texinfo gnused
+    gmp mpfr libedit python2 texinfo gnused
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/radio/gnss-sdr/default.nix
+++ b/pkgs/applications/radio/gnss-sdr/default.nix
@@ -9,7 +9,7 @@
 , gnuradio
 , orc
 , pkgconfig
-, pythonPackages
+, python2Packages
 , uhd
 , log4cpp
 , openblas
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     gnuradio
     orc
     pkgconfig
-    pythonPackages.Mako
+    python2Packages.Mako
 
     # UHD support is optional, but gnuradio is built with it, so there's
     # nothing to be gained by leaving it out.

--- a/pkgs/applications/radio/gnuradio/ais.nix
+++ b/pkgs/applications/radio/gnuradio/ais.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
 , makeWrapper, cppunit, gr-osmosdr
-, pythonSupport ? true, python, swig
+, pythonSupport ? true, python2, swig
 }:
 
-assert pythonSupport -> python != null && swig != null;
+assert pythonSupport -> python2 != null && swig != null;
 
 stdenv.mkDerivation {
   pname = "gr-ais";
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     cmake boost gnuradio makeWrapper cppunit gr-osmosdr
-  ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
+  ] ++ stdenv.lib.optionals pythonSupport [ python2 swig ];
 
   postInstall = ''
     for prog in "$out"/bin/*; do

--- a/pkgs/applications/radio/gnuradio/gsm.nix
+++ b/pkgs/applications/radio/gnuradio/gsm.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
 , makeWrapper, cppunit, libosmocore, gr-osmosdr
-, pythonSupport ? true, python, swig
+, pythonSupport ? true, python2, swig
 }:
 
-assert pythonSupport -> python != null && swig != null;
+assert pythonSupport -> python2 != null && swig != null;
 
 stdenv.mkDerivation {
   pname = "gr-gsm";
@@ -19,11 +19,11 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     cmake boost gnuradio makeWrapper cppunit libosmocore gr-osmosdr
-  ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
+  ] ++ stdenv.lib.optionals pythonSupport [ python2 swig ];
 
   postInstall = ''
     for prog in "$out"/bin/*; do
-        wrapProgram "$prog" --set PYTHONPATH $PYTHONPATH:${gr-osmosdr}/lib/${python.libPrefix}/site-packages:$(toPythonPath "$out")
+        wrapProgram "$prog" --set PYTHONPATH $PYTHONPATH:${gr-osmosdr}/lib/${python2.libPrefix}/site-packages:$(toPythonPath "$out")
     done
   '';
 

--- a/pkgs/applications/radio/gnuradio/limesdr.nix
+++ b/pkgs/applications/radio/gnuradio/limesdr.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
-, pythonSupport ? true, python, swig, limesuite
+, pythonSupport ? true, python2, swig, limesuite
 } :
 
-assert pythonSupport -> python != null && swig != null;
+assert pythonSupport -> python2 != null && swig != null;
 
 let
   version = "2.0.0";
@@ -25,7 +25,7 @@ in stdenv.mkDerivation {
 
   buildInputs = [
     boost gnuradio limesuite
-  ] ++ stdenv.lib.optionals pythonSupport [ python ];
+  ] ++ stdenv.lib.optionals pythonSupport [ python2 ];
 
 
   enableParallelBuilding = true;

--- a/pkgs/applications/radio/gnuradio/nacl.nix
+++ b/pkgs/applications/radio/gnuradio/nacl.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio, uhd
 , makeWrapper, libsodium, cppunit
-, pythonSupport ? true, python, swig
+, pythonSupport ? true, python2, swig
 }:
 
-assert pythonSupport -> python != null && swig != null;
+assert pythonSupport -> python2 != null && swig != null;
 
 stdenv.mkDerivation {
   pname = "gr-nacl";
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     cmake boost gnuradio uhd makeWrapper libsodium cppunit
-  ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
+  ] ++ stdenv.lib.optionals pythonSupport [ python2 swig ];
 
   postInstall = ''
     for prog in "$out"/bin/*; do

--- a/pkgs/applications/radio/gnuradio/osmosdr.nix
+++ b/pkgs/applications/radio/gnuradio/osmosdr.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, cmake, pkgconfig, makeWrapper
 , boost
-, pythonSupport ? true, python, swig
+, pythonSupport ? true, python2, swig
 , airspy
 , gnuradio
 , hackrf
@@ -10,7 +10,7 @@
 , uhd
 }:
 
-assert pythonSupport -> python != null && swig != null;
+assert pythonSupport -> python2 != null && swig != null;
 
 stdenv.mkDerivation rec {
   pname = "gr-osmosdr";
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     cmake makeWrapper boost
     airspy gnuradio hackrf libbladeRF rtl-sdr uhd
   ] ++ stdenv.lib.optionals stdenv.isLinux [ soapysdr-with-plugins ]
-    ++ stdenv.lib.optionals pythonSupport [ python swig ];
+    ++ stdenv.lib.optionals pythonSupport [ python2 swig ];
 
   postInstall = ''
     for prog in "$out"/bin/*; do

--- a/pkgs/applications/radio/gnuradio/rds.nix
+++ b/pkgs/applications/radio/gnuradio/rds.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
-, makeWrapper, pythonSupport ? true, python, swig
+, makeWrapper, pythonSupport ? true, python2, swig
 }:
 
-assert pythonSupport -> python != null && swig != null;
+assert pythonSupport -> python2 != null && swig != null;
 
 stdenv.mkDerivation rec {
   pname = "gr-rds";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     cmake boost gnuradio makeWrapper
-  ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
+  ] ++ stdenv.lib.optionals pythonSupport [ python2 swig ];
 
   postInstall = ''
     for prog in "$out"/bin/*; do

--- a/pkgs/applications/science/biology/bcftools/default.nix
+++ b/pkgs/applications/science/biology/bcftools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, htslib, zlib, bzip2, lzma, curl, perl, python, bash }:
+{ stdenv, fetchurl, htslib, zlib, bzip2, lzma, curl, perl, python2, bash }:
 
 stdenv.mkDerivation rec {
   pname = "bcftools";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0b2f6lqhxdlrvfjqxv7a4nzqj68c1j4avn16iqxwwm80kn302wzm";
   };
 
-  buildInputs = [ htslib zlib bzip2 lzma curl perl python ];
+  buildInputs = [ htslib zlib bzip2 lzma curl perl python2 ];
 
   makeFlags = [
     "HSTDIR=${htslib}"

--- a/pkgs/applications/science/biology/bedtools/default.nix
+++ b/pkgs/applications/science/biology/bedtools/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, zlib, python, bzip2, lzma}:
+{stdenv, fetchFromGitHub, zlib, python2, bzip2, lzma}:
 
 stdenv.mkDerivation rec {
   pname = "bedtools";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "015qq3pwrwgnyxyi959niijjlswl231b3wxlsm3l8msv6fdhmkz8";
   };
 
-  buildInputs = [ zlib python bzip2 lzma ];
+  buildInputs = [ zlib python2 bzip2 lzma ];
   cxx = if stdenv.cc.isClang then "clang++" else "g++";
   cc = if stdenv.cc.isClang then "clang" else "gcc";
   buildPhase = "make prefix=$out SHELL=${stdenv.shell} CXX=${cxx} CC=${cc} -j $NIX_BUILD_CORES";

--- a/pkgs/applications/science/biology/bowtie2/default.nix
+++ b/pkgs/applications/science/biology/bowtie2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, zlib, tbb, python, perl }:
+{ stdenv, fetchFromGitHub, zlib, tbb, python2, perl }:
 
 stdenv.mkDerivation rec {
   pname = "bowtie2";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1l1f0yhjqqvy4lpxfml1xwv7ayimwbpzazvp0281gb4jb5f5mr1a";
   };
 
-  buildInputs = [ zlib tbb python perl ];
+  buildInputs = [ zlib tbb python2 perl ];
 
   installFlags = [ "prefix=$(out)" ];
 

--- a/pkgs/applications/science/biology/hisat2/default.nix
+++ b/pkgs/applications/science/biology/hisat2/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, unzip, which, python, perl}:
+{stdenv, fetchurl, unzip, which, python2, perl}:
 
 stdenv.mkDerivation rec {
   pname = "hisat2";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ unzip which ];
-  buildInputs = [ python perl ];
+  buildInputs = [ python2 perl ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/applications/science/logic/lean2/default.nix
+++ b/pkgs/applications/science/logic/lean2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, gmp, mpfr, python
+{ stdenv, fetchFromGitHub, cmake, gmp, mpfr, python2
 , gperftools, ninja, makeWrapper }:
 
 stdenv.mkDerivation {
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     sha256 = "1xv3j487zhh1zf2b4v19xzw63s2sgjhg8d62a0kxxyknfmdf3khl";
   };
 
-  buildInputs = [ gmp mpfr cmake python gperftools ninja makeWrapper ];
+  buildInputs = [ gmp mpfr cmake python2 gperftools ninja makeWrapper ];
   enableParallelBuilding = true;
 
   preConfigure = ''

--- a/pkgs/applications/science/math/ginac/default.nix
+++ b/pkgs/applications/science/math/ginac/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cln, pkgconfig, readline, gmp, python }:
+{ stdenv, fetchurl, cln, pkgconfig, readline, gmp, python2 }:
 
 stdenv.mkDerivation rec {
   name = "ginac-1.7.8";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ readline ] ++ stdenv.lib.optional stdenv.isDarwin gmp;
 
-  nativeBuildInputs = [ pkgconfig python ];
+  nativeBuildInputs = [ pkgconfig python2 ];
 
   preConfigure = "patchShebangs ginsh";
 

--- a/pkgs/applications/science/math/gurobi/default.nix
+++ b/pkgs/applications/science/math/gurobi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoPatchelfHook, python }:
+{ stdenv, lib, fetchurl, autoPatchelfHook, python2 }:
 
 let
   majorVersion = "8.1";
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
   sourceRoot = "gurobi${builtins.replaceStrings ["."] [""] version}/linux64";
 
   nativeBuildInputs = [ autoPatchelfHook ];
-  buildInputs = [ (python.withPackages (ps: [ ps.gurobipy ])) ];
+  buildInputs = [ (python2.withPackages (ps: [ ps.gurobipy ])) ];
 
   buildPhase = ''
     cd src/build

--- a/pkgs/applications/science/robotics/gazebo/default.nix
+++ b/pkgs/applications/science/robotics/gazebo/default.nix
@@ -2,7 +2,7 @@
   , boost-build, boost_process
   , xorg_sys_opengl, tbb, ogre, tinyxml-2
   , libtar, glxinfo,  libusb, libxslt, ignition
-  , pythonPackages, utillinux
+  , python2Packages, utillinux
 
   # these deps are hidden; cmake doesn't catch them
   , gazeboSimulator, sdformat ? gazeboSimulator.sdformat, curl, tinyxml, qt4
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     libxslt
     ignition.math2
     sdformat
-    pythonPackages.pyopengl
+    python2Packages.pyopengl
 
     # TODO: add these hidden deps to cmake configuration & submit upstream
     curl

--- a/pkgs/applications/version-management/git-and-tools/git-bz/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bz/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit
 , asciidoc, docbook_xml_dtd_45, docbook_xsl, libxslt, makeWrapper, xmlto
-, pythonPackages }:
+, python2Packages }:
 
 stdenv.mkDerivation {
   pname = "git-bz";
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     asciidoc docbook_xml_dtd_45 docbook_xsl libxslt makeWrapper xmlto
   ];
   buildInputs = []
-    ++ (with pythonPackages; [ python pysqlite ]);
+    ++ (with python2Packages; [ python2 pysqlite ]);
 
   postPatch = ''
     patchShebangs configure
@@ -27,8 +27,8 @@ stdenv.mkDerivation {
 
   postInstall = ''
     wrapProgram $out/bin/git-bz \
-      --prefix PYTHONPATH : "$(toPythonPath "${pythonPackages.pycrypto}")" \
-      --prefix PYTHONPATH : "$(toPythonPath "${pythonPackages.pysqlite}")"
+      --prefix PYTHONPATH : "$(toPythonPath "${python2Packages.pycrypto}")" \
+      --prefix PYTHONPATH : "$(toPythonPath "${python2Packages.pysqlite}")"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/git-and-tools/git-imerge/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-imerge/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
 stdenv.mkDerivation rec {
   pname = "git-imerge";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0vi1w3f0yk4gqhxj2hzqafqq28rihyhyfnp8x7xzib96j2si14a4";
   };
 
-  buildInputs = [ pythonPackages.python pythonPackages.wrapPython ];
+  buildInputs = [ python2Packages.python2 python2Packages.wrapPython ];
 
   makeFlags = [ "PREFIX=" "DESTDIR=$(out)" ] ; 
  

--- a/pkgs/applications/version-management/git-crecord/default.nix
+++ b/pkgs/applications/version-management/git-crecord/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "git-crecord";
   version = "20161216.0";
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0v3y90zi43myyi4k7q3892dcrbyi9dn2q6xgk12nw9db9zil269i";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ docutils ];
+  propagatedBuildInputs = with python2Packages; [ docutils ];
 
   meta = {
     homepage = https://github.com/andrewshadura/git-crecord;

--- a/pkgs/applications/version-management/git-review/default.nix
+++ b/pkgs/applications/version-management/git-review/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages} :
+{ stdenv, fetchFromGitHub, python2Packages} :
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "git-review";
   version = "1.28.0";
 
@@ -15,7 +15,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1hgw1dkl94m3idv4izc7wf2j7al2c7nnsqywy7g53nzkv9pfv47s";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ pbr requests setuptools ];
+  propagatedBuildInputs = with python2Packages; [ pbr requests setuptools ];
 
   # Don't do tests because they require gerrit which is not packaged
   doCheck = false;

--- a/pkgs/applications/version-management/gitstats/default.nix
+++ b/pkgs/applications/version-management/gitstats/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, perl, python, gnuplot, coreutils, gnugrep }:
+{ stdenv, fetchzip, perl, python2, gnuplot, coreutils, gnugrep }:
 
 stdenv.mkDerivation rec {
   pname = "gitstats";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     name = "${pname}-${version}" + "-src";
   };
 
-  buildInputs = [ perl python ];
+  buildInputs = [ perl python2 ];
 
   postPatch = ''
     sed -e "s|gnuplot_cmd = .*|gnuplot_cmd = '${gnuplot}/bin/gnuplot'|" \

--- a/pkgs/applications/video/bomi/default.nix
+++ b/pkgs/applications/video/bomi/default.nix
@@ -1,5 +1,5 @@
 { config, stdenv, fetchFromGitHub
-, fetchpatch, pkgconfig, perl, python, which
+, fetchpatch, pkgconfig, perl, python2, which
 , libX11, libxcb, libGLU, libGL
 , qtbase, qtdeclarative, qtquickcontrols, qttools, qtx11extras, qmake, makeWrapper
 , libchardet
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
                    ++ optional cddaSupport "--enable-cdda"
                    ;
 
-  nativeBuildInputs = [ makeWrapper pkgconfig perl python which qttools qmake ];
+  nativeBuildInputs = [ makeWrapper pkgconfig perl python2 which qttools qmake ];
 
   meta = with stdenv.lib; {
     description = "Powerful and easy-to-use multimedia player";

--- a/pkgs/applications/virtualization/charliecloud/default.nix
+++ b/pkgs/applications/virtualization/charliecloud/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python }:
+{ stdenv, fetchFromGitHub, python2 }:
 
 stdenv.mkDerivation rec {
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "177rcf1klcxsp6x9cw75cmz3y2izgd1hvi1rb9vc6iz9qx1nmk3v";
   };
 
-  buildInputs = [ python ];
+  buildInputs = [ python2 ];
 
   preConfigure = ''
     substituteInPlace Makefile --replace '/bin/bash' '${stdenv.shell}'

--- a/pkgs/applications/virtualization/seabios/default.nix
+++ b/pkgs/applications/virtualization/seabios/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, iasl, python }:
+{ stdenv, fetchurl, iasl, python2 }:
 
 stdenv.mkDerivation rec {
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1xwvp77djxbxbxg82hzj26pv6zka3556vkdcp09hnfwapcp46av2";
   };
 
-  buildInputs = [ iasl python ];
+  buildInputs = [ iasl python2 ];
 
   hardeningDisable = [ "pic" "stackprotector" "fortify" ];
 

--- a/pkgs/data/documentation/bgnet/default.nix
+++ b/pkgs/data/documentation/bgnet/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, python, zip, fop }:
+{ stdenv, lib, fetchurl, python2, zip, fop }:
 
 stdenv.mkDerivation {
   pname = "bgnet";
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "00ggr5prc5i3w9gaaw2sadfq6haq7lmh0vdilaxx8xz9z5znxvyv";
   };
 
-  buildInputs = [ python zip fop ];
+  buildInputs = [ python2 zip fop ];
 
   preBuild = ''
     sed -i "s/#disable=1/disable=1/" bin/bgvalidate

--- a/pkgs/data/misc/conway_polynomials/default.nix
+++ b/pkgs/data/misc/conway_polynomials/default.nix
@@ -1,13 +1,13 @@
 { stdenv
 , fetchurl
-, python
+, python2
 }:
 
 stdenv.mkDerivation rec {
   pname = "conway_polynomials";
   version = "0.5";
 
-  pythonEnv = python.withPackages (ps: with ps; [ six ]);
+  pythonEnv = python2.withPackages (ps: with ps; [ six ]);
 
   src = fetchurl {
     url = "mirror://sageupstream/conway_polynomials/conway_polynomials-${version}.tar.bz2";

--- a/pkgs/data/misc/elliptic_curves/default.nix
+++ b/pkgs/data/misc/elliptic_curves/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , fetchurl
-, python
+, python2
 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     export SAGE_SHARE="$out/share"
     export PYTHONPATH=$PWD
 
-    ${python.interpreter} ${spkg-install}
+    ${python2.interpreter} ${spkg-install}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/deepin/dtkcore/default.nix
+++ b/pkgs/desktops/deepin/dtkcore/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, gsettings-qt, pythonPackages, deepin }:
+{ stdenv, mkDerivation, fetchFromGitHub, pkgconfig, qmake, gsettings-qt, python2Packages, deepin }:
 
 mkDerivation rec {
   pname = "dtkcore";
@@ -14,7 +14,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig
     qmake
-    pythonPackages.wrapPython
+    python2Packages.wrapPython
     deepin.setupHook
   ];
 

--- a/pkgs/desktops/plasma-5/discover.nix
+++ b/pkgs/desktops/plasma-5/discover.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation,
-  extra-cmake-modules, gettext, kdoctools, python,
+  extra-cmake-modules, gettext, kdoctools, python2,
   appstream-qt, discount, flatpak, fwupd, ostree, packagekit-qt, pcre, utillinux,
   qtquickcontrols2,
   karchive, kconfig, kcrash, kdbusaddons, kdeclarative, kio, kirigami2, kitemmodels,
@@ -9,7 +9,7 @@
 
 mkDerivation {
   name = "discover";
-  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python ];
+  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python2 ];
   buildInputs = [
     # discount is needed for libmarkdown
     appstream-qt discount flatpak fwupd ostree packagekit-qt pcre utillinux

--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, python, fetchFromGitHub, emscriptenRev ? null }:
+{ stdenv, cmake, python2, fetchFromGitHub, emscriptenRev ? null }:
 
 let
   defaultVersion = "89";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     inherit rev;
   };
 
-  nativeBuildInputs = [ cmake python ];
+  nativeBuildInputs = [ cmake python2 ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/WebAssembly/binaryen;

--- a/pkgs/development/compilers/clasp/default.nix
+++ b/pkgs/development/compilers/clasp/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchFromGitLab
 , llvmPackages
 , cmake, boehmgc, gmp, zlib, ncurses, boost, libelf
-, python, git, sbcl
+, python2, git, sbcl
 , wafHook
 }:
 let
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake python git sbcl wafHook ] ++
+  nativeBuildInputs = [ cmake python2 git sbcl wafHook ] ++
     (with llvmPackages; [ llvm clang ]);
 
   buildInputs = with llvmPackages;

--- a/pkgs/development/compilers/cmdstan/default.nix
+++ b/pkgs/development/compilers/cmdstan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, runtimeShell }:
+{ stdenv, fetchurl, python2, runtimeShell }:
 
 stdenv.mkDerivation {
   name = "cmdstan-2.17.1";
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   doCheck = true;
-  checkInputs = [ python ];
+  checkInputs = [ python2 ];
   checkPhase = "python ./runCmdStanTests.py src/test/interface"; # see #5368
 
   installPhase = ''

--- a/pkgs/development/compilers/dtc/default.nix
+++ b/pkgs/development/compilers/dtc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchgit, flex, bison, pkgconfig, which
-, pythonSupport ? stdenv.buildPlatform == stdenv.hostPlatform, python, swig
+, pythonSupport ? stdenv.buildPlatform == stdenv.hostPlatform, python2, swig
 }:
 
 stdenv.mkDerivation rec {
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1jhhfrg22h53lvm2lqhd66pyk20pil08ry03wcwyx1c3ln27k73z";
   };
 
-  nativeBuildInputs = [ flex bison pkgconfig which ] ++ lib.optionals pythonSupport [ python swig ];
-  buildInputs = lib.optionals pythonSupport [ python ];
+  nativeBuildInputs = [ flex bison pkgconfig which ] ++ lib.optionals pythonSupport [ python2 swig ];
+  buildInputs = lib.optionals pythonSupport [ python2 ];
 
   postPatch = ''
     patchShebangs pylibfdt/

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -1,4 +1,4 @@
-{ emscriptenVersion, stdenv, fetchFromGitHub, emscriptenfastcomp, python, nodejs, closurecompiler
+{ emscriptenVersion, stdenv, fetchFromGitHub, emscriptenfastcomp, python2, nodejs, closurecompiler
 , jre, binaryen, enableWasm ? true ,  cmake
 }:
 
@@ -18,13 +18,13 @@ stdenv.mkDerivation {
     inherit rev;
   };
 
-  buildInputs = [ nodejs cmake python ];
+  buildInputs = [ nodejs cmake python2 ];
 
   buildCommand = ''
     mkdir -p $out/${appdir}
     cp -r $src/* $out/${appdir}
     chmod -R +w $out/${appdir}
-    grep -rl '^#!/usr.*python' $out/${appdir} | xargs sed -i -s 's@^#!/usr.*python.*@#!${python}/bin/python@'
+    grep -rl '^#!/usr.*python' $out/${appdir} | xargs sed -i -s 's@^#!/usr.*python.*@#!${python2}/bin/python@'
     sed -i -e "s,EM_CONFIG = '~/.emscripten',EM_CONFIG = '$out/${appdir}/config'," $out/${appdir}/tools/shared.py
     sed -i -e 's,^.*did not see a source tree above the LLVM.*$,      return True,' $out/${appdir}/tools/shared.py
     sed -i -e 's,def check_sanity(force=False):,def check_sanity(force=False):\n  return,' $out/${appdir}/tools/shared.py
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
 
     echo "EMSCRIPTEN_ROOT = '$out/${appdir}'" > $out/${appdir}/config
     echo "LLVM_ROOT = '${emscriptenfastcomp}/bin'" >> $out/${appdir}/config
-    echo "PYTHON = '${python}/bin/python'" >> $out/${appdir}/config
+    echo "PYTHON = '${python2}/bin/python'" >> $out/${appdir}/config
     echo "NODE_JS = '${nodejs}/bin/node'" >> $out/${appdir}/config
     echo "JS_ENGINES = [NODE_JS]" >> $out/${appdir}/config
     echo "COMPILER_ENGINE = NODE_JS" >> $out/${appdir}/config
@@ -55,8 +55,8 @@ stdenv.mkDerivation {
     cp $out/${appdir}/config $HOME/.emscripten
     export PATH=$PATH:$out/bin
 
-    #export EMCC_DEBUG=2  
-    ${python}/bin/python $src/tests/runner.py test_hello_world
+    #export EMCC_DEBUG=2
+    ${python2}/bin/python $src/tests/runner.py test_hello_world
     echo "--------------- /running test -----------------"
   '';
 

--- a/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
+++ b/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
@@ -1,4 +1,4 @@
-{ emscriptenVersion, stdenv, fetchFromGitHub, cmake, python, gtest, ... }:
+{ emscriptenVersion, stdenv, fetchFromGitHub, cmake, python2, gtest, ... }:
 
 let
   rev = emscriptenVersion;
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     inherit rev;
   };
 
-  nativeBuildInputs = [ cmake python gtest ];
+  nativeBuildInputs = [ cmake python2 gtest ];
   preConfigure = ''
     cp -Lr ${srcFL} tools/clang
     chmod +w -R tools/clang

--- a/pkgs/development/compilers/intel-graphics-compiler/default.nix
+++ b/pkgs/development/compilers/intel-graphics-compiler/default.nix
@@ -7,7 +7,7 @@
 , flex
 , llvmPackages_8
 , opencl-clang
-, python
+, python2
 , spirv-llvm-translator
 
 , buildWithPatches ? true
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     sha256 = "1d3vxq4v8jdjgl5jdm9qpxzgaw98r84dzs9lk9ph02khfkajqhjm";
   };
 
-  nativeBuildInputs = [ clang cmake bison flex llvm python ];
+  nativeBuildInputs = [ clang cmake bison flex llvm python2 ];
 
   buildInputs = [ clang opencl-clang spirv-llvm-translator ];
 

--- a/pkgs/development/compilers/ispc/default.nix
+++ b/pkgs/development/compilers/ispc/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, which, m4, python, bison, flex, llvmPackages,
+{stdenv, fetchFromGitHub, which, m4, python2, bison, flex, llvmPackages,
 testedTargets ? ["sse2"] # the default test target is sse4, but that is not supported by all Hydra agents
 }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = with llvmPackages; [
     which
     m4
-    python
+    python2
     bison
     flex
     llvm

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, ninja, llvm_5, llvm_8, curl, tzdata
-, python, libconfig, lit, gdb, unzip, darwin, bash
+, python2, libconfig, lit, gdb, unzip, darwin, bash
 , callPackage, makeWrapper, runCommand, targetPackages
 , bootstrapVersion ? false
 , version ? "1.17.0"
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ninja makeWrapper unzip ]
     ++ stdenv.lib.optionals (!bootstrapVersion) [
-      bootstrapLdc python lit
+      bootstrapLdc python2 lit
     ]
     ++ stdenv.lib.optional (!bootstrapVersion && stdenv.hostPlatform.isDarwin)
       # https://github.com/NixOS/nixpkgs/issues/57120

--- a/pkgs/development/compilers/llvm/3.9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python }:
+{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python2 }:
 
 let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
@@ -18,7 +18,7 @@ let
 
     nativeBuildInputs = [ cmake ];
 
-    buildInputs = [ libxml2 llvm python ];
+    buildInputs = [ libxml2 llvm python2 ];
 
     cmakeFlags = [
       "-DCMAKE_CXX_FLAGS=-std=c++11"

--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, llvm, version, release_version, clang-tools-extra_src, python
+{ stdenv, fetch, cmake, libxml2, llvm, version, release_version, clang-tools-extra_src, python2
 , fixDarwinDylibNames
 , enableManpages ? false
 }:
@@ -19,8 +19,8 @@ let
       mv clang-tools-extra-* $sourceRoot/tools/extra
     '';
 
-    nativeBuildInputs = [ cmake python ]
-      ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+    nativeBuildInputs = [ cmake python2 ]
+      ++ stdenv.lib.optional enableManpages python2.pkgs.sphinx;
 
     buildInputs = [ libxml2 llvm ]
       ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;

--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -1,5 +1,5 @@
 { lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
-, libxml2, python, isl, fetchurl, overrideCC, wrapCCWith
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 }:
@@ -17,7 +17,7 @@ let
   clang-tools-extra_src = fetch "clang-tools-extra" "1dhmp7ccfpr42bmvk3kp37ngjpf3a9m5d4kkpsn7d00hzi7fdl9m";
 
   tools = stdenv.lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
     llvm = callPackage ./llvm.nix {
@@ -29,12 +29,12 @@ let
 
     llvm-manpages = lowPrio (tools.llvm.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python2;  # don't use python2-boot
     });
 
     clang-manpages = lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python2;  # don't use python2-boot
     });
 
     libclang = tools.clang-unwrapped.lib;
@@ -57,7 +57,7 @@ let
   });
 
   libraries = stdenv.lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
     stdenv = overrideCC stdenv buildLlvmTools.clang;

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python
+{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python2
 , fixDarwinDylibNames
 , enableManpages ? false
 }:
@@ -19,8 +19,8 @@ let
       mv clang-tools-extra-* $sourceRoot/tools/extra
     '';
 
-    nativeBuildInputs = [ cmake python ]
-      ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+    nativeBuildInputs = [ cmake python2 ]
+      ++ stdenv.lib.optional enableManpages python2.pkgs.sphinx;
 
     buildInputs = [ libxml2 llvm ]
       ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -1,5 +1,5 @@
 { lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
-, libxml2, python, isl, fetchurl, overrideCC, wrapCCWith
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 }:
@@ -16,7 +16,7 @@ let
   clang-tools-extra_src = fetch "clang-tools-extra" "018b3fiwah8f8br5i26qmzh6sjvzchpn358sn8v079m49f2jldm3";
 
   tools = stdenv.lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
     mkExtraBuildCommands = cc: ''
       rsrc="$out/resource-root"
       mkdir "$rsrc"
@@ -36,12 +36,12 @@ let
 
     llvm-manpages = lowPrio (tools.llvm.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python2;  # don't use python2-boot
     });
 
     clang-manpages = lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python2;  # don't use python2-boot
     });
 
     libclang = tools.clang-unwrapped.lib;
@@ -74,7 +74,7 @@ let
   });
 
   libraries = stdenv.lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
     compiler-rt = callPackage ./compiler-rt.nix {};

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python
+{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python2
 , fixDarwinDylibNames
 , enableManpages ? false
 }:
@@ -19,8 +19,8 @@ let
       mv clang-tools-extra-* $sourceRoot/tools/extra
     '';
 
-    nativeBuildInputs = [ cmake python ]
-      ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+    nativeBuildInputs = [ cmake python2 ]
+      ++ stdenv.lib.optional enableManpages python2.pkgs.sphinx;
 
     buildInputs = [ libxml2 llvm ]
       ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -1,5 +1,5 @@
 { lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
-, libxml2, python, isl, fetchurl, overrideCC, wrapCCWith
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 }:
@@ -16,7 +16,7 @@ let
   clang-tools-extra_src = fetch "clang-tools-extra" "1w8ml7fyn4vyxmy59n2qm4r1k1kgwgwkaldp6m45fdv4g0kkfbhd";
 
   tools = stdenv.lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
     mkExtraBuildCommands = cc: ''
       rsrc="$out/resource-root"
       mkdir "$rsrc"
@@ -36,12 +36,12 @@ let
 
     llvm-manpages = lowPrio (tools.llvm.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python2;  # don't use python2-boot
     });
 
     clang-manpages = lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python2;  # don't use python2-boot
     });
 
     libclang = tools.clang-unwrapped.lib;
@@ -74,7 +74,7 @@ let
   });
 
   libraries = stdenv.lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
     compiler-rt = callPackage ./compiler-rt.nix {};

--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python
+{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python2
 , fixDarwinDylibNames
 , enableManpages ? false
 , enablePolly ? false # TODO: get this info from llvm (passthru?)
@@ -19,8 +19,8 @@ let
       mv clang-tools-extra-* $sourceRoot/tools/extra
     '';
 
-    nativeBuildInputs = [ cmake python ]
-      ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+    nativeBuildInputs = [ cmake python2 ]
+      ++ stdenv.lib.optional enableManpages python2.pkgs.sphinx;
 
     buildInputs = [ libxml2 llvm ]
       ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;

--- a/pkgs/development/compilers/llvm/7/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/7/compiler-rt.nix
@@ -1,10 +1,10 @@
-{ stdenv, version, fetch, cmake, python, llvm, libcxxabi }:
+{ stdenv, version, fetch, cmake, python2, llvm, libcxxabi }:
 stdenv.mkDerivation {
   pname = "compiler-rt";
   inherit version;
   src = fetch "compiler-rt" "1n48p8gjarihkws0i2bay5w9bdwyxyxxbpwyng7ba58jb30dlyq5";
 
-  nativeBuildInputs = [ cmake python llvm ];
+  nativeBuildInputs = [ cmake python2 llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;
 
   NIX_CFLAGS_COMPILE = [

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -1,5 +1,5 @@
 { lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
-, libxml2, python, isl, fetchurl, overrideCC, wrapCCWith, wrapBintoolsWith
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith, wrapBintoolsWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 }:
@@ -16,7 +16,7 @@ let
   clang-tools-extra_src = fetch "clang-tools-extra" "0lb4kdh7j2fhfz8kd6iv5df7m3pikiryk1vvwsf87spc90n09q0w";
 
   tools = stdenv.lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
     mkExtraBuildCommands = cc: ''
       rsrc="$out/resource-root"
       mkdir "$rsrc"
@@ -42,12 +42,12 @@ let
 
     llvm-manpages = lowPrio (tools.llvm.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python;  # don't use python-boot
     });
 
     clang-manpages = lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python;  # don't use python-boot
     });
 
     libclang = tools.clang-unwrapped.lib;
@@ -126,7 +126,7 @@ let
   });
 
   libraries = stdenv.lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
     compiler-rt = callPackage ./compiler-rt.nix {

--- a/pkgs/development/compilers/llvm/7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/7/libc++/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetch, cmake, python, libcxxabi, fixDarwinDylibNames, version
+{ lib, stdenv, fetch, cmake, python2, libcxxabi, fixDarwinDylibNames, version
 , enableShared ? ! stdenv.hostPlatform.isMusl }:
 
 stdenv.mkDerivation {
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   '' + lib.optionalString stdenv.hostPlatform.isMusl ''
     patchShebangs utils/cat_files.py
   '';
-  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl python;
+  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl python2;
 
   buildInputs = [ libcxxabi ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 

--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -2,7 +2,7 @@
 , fetch
 , fetchpatch
 , cmake
-, python
+, python2
 , libffi
 , libbfd
 , libpfm
@@ -48,8 +48,8 @@ in stdenv.mkDerivation ({
   outputs = [ "out" "python" ]
     ++ optional enableSharedLibraries "lib";
 
-  nativeBuildInputs = [ cmake python ]
-    ++ optional enableManpages python.pkgs.sphinx;
+  nativeBuildInputs = [ cmake python2 ]
+    ++ optional enableManpages python2.pkgs.sphinx;
 
   buildInputs = [ libxml2 libffi ]
     ++ optional enablePFM libpfm; # exegesis

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python
+{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python2
 , fixDarwinDylibNames
 , enableManpages ? false
 , enablePolly ? false # TODO: get this info from llvm (passthru?)
@@ -19,8 +19,8 @@ let
       mv clang-tools-extra-* $sourceRoot/tools/extra
     '';
 
-    nativeBuildInputs = [ cmake python ]
-      ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+    nativeBuildInputs = [ cmake python2 ]
+      ++ stdenv.lib.optional enableManpages python2.pkgs.sphinx;
 
     buildInputs = [ libxml2 llvm ]
       ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -1,5 +1,5 @@
 { lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
-, libxml2, python, isl, fetchurl, overrideCC, wrapCCWith, wrapBintoolsWith
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith, wrapBintoolsWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 }:
@@ -16,7 +16,7 @@ let
   clang-tools-extra_src = fetch "clang-tools-extra" "1qf3097bc5ia8p6cpmbx985rjr3yaah5s8fc0nv7pw742yv7jw8q";
 
   tools = stdenv.lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
     mkExtraBuildCommands = cc: ''
       rsrc="$out/resource-root"
       mkdir "$rsrc"
@@ -42,12 +42,12 @@ let
 
     llvm-manpages = lowPrio (tools.llvm.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python2;  # don't use python2-boot
     });
 
     clang-manpages = lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python2;  # don't use python2-boot
     });
 
     libclang = tools.clang-unwrapped.lib;
@@ -162,7 +162,7 @@ let
   });
 
   libraries = stdenv.lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
     compiler-rt = callPackage ./compiler-rt.nix ({} //

--- a/pkgs/development/compilers/llvm/9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/9/clang/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python
+{ stdenv, fetch, cmake, libxml2, llvm, version, clang-tools-extra_src, python2
 , fixDarwinDylibNames
 , enableManpages ? false
 , enablePolly ? false # TODO: get this info from llvm (passthru?)
@@ -19,8 +19,8 @@ let
       mv clang-tools-extra-* $sourceRoot/tools/extra
     '';
 
-    nativeBuildInputs = [ cmake python ]
-      ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+    nativeBuildInputs = [ cmake python2 ]
+      ++ stdenv.lib.optional enableManpages python2.pkgs.sphinx;
 
     buildInputs = [ libxml2 llvm ]
       ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;

--- a/pkgs/development/compilers/llvm/9/default.nix
+++ b/pkgs/development/compilers/llvm/9/default.nix
@@ -1,5 +1,5 @@
 { lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
-, libxml2, python, isl, fetchurl, overrideCC, wrapCCWith, wrapBintoolsWith
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith, wrapBintoolsWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 }:
@@ -16,7 +16,7 @@ let
   clang-tools-extra_src = fetch "clang-tools-extra" "01vgzd4k1q93nfs8gyl83mjlc4x0qsgfqw32lacbjzdxg0mdfvxj";
 
   tools = stdenv.lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
     mkExtraBuildCommands = cc: ''
       rsrc="$out/resource-root"
       mkdir "$rsrc"
@@ -42,12 +42,12 @@ let
 
     llvm-manpages = lowPrio (tools.llvm.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python2;  # don't use python-boot
     });
 
     clang-manpages = lowPrio (tools.clang-unwrapped.override {
       enableManpages = true;
-      python = pkgs.python;  # don't use python-boot
+      python2 = pkgs.python2;  # don't use python-boot
     });
 
     libclang = tools.clang-unwrapped.lib;
@@ -162,7 +162,7 @@ let
   });
 
   libraries = stdenv.lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
     compiler-rt = callPackage ./compiler-rt.nix ({} //

--- a/pkgs/development/compilers/llvm/9/llvm.nix
+++ b/pkgs/development/compilers/llvm/9/llvm.nix
@@ -1,7 +1,7 @@
 { stdenv
 , fetch
 , cmake
-, python
+, python2
 , libffi
 , libbfd
 , libpfm
@@ -43,11 +43,11 @@ in stdenv.mkDerivation (rec {
     mv polly-* $sourceRoot/tools/polly
   '';
 
-  outputs = [ "out" "python" ]
+  outputs = [ "out" "python2" ]
     ++ optional enableSharedLibraries "lib";
 
-  nativeBuildInputs = [ cmake python ]
-    ++ optionals enableManpages [ python.pkgs.sphinx python.pkgs.recommonmark ];
+  nativeBuildInputs = [ cmake python2 ]
+    ++ optionals enableManpages [ python2.pkgs.sphinx python2.pkgs.recommonmark ];
 
   buildInputs = [ libxml2 libffi ]
     ++ optional enablePFM libpfm; # exegesis

--- a/pkgs/development/em-modules/generic/default.nix
+++ b/pkgs/development/em-modules/generic/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, emscripten, python }:
+{ pkgs, lib, emscripten, python2 }:
 
 { buildInputs ? [], nativeBuildInputs ? []
 
@@ -12,8 +12,8 @@ pkgs.stdenv.mkDerivation (
 
   pname = "emscripten-${lib.getName args}";
   version = lib.getVersion args;
-  buildInputs = [ emscripten python ] ++ buildInputs;
-  nativeBuildInputs = [ emscripten python ] ++ nativeBuildInputs;
+  buildInputs = [ emscripten python2 ] ++ buildInputs;
+  nativeBuildInputs = [ emscripten python2 ] ++ nativeBuildInputs;
 
   # fake conftest results with emscripten's python magic
   EMCONFIGURE_JS=2;

--- a/pkgs/development/libraries/arrayfire/default.nix
+++ b/pkgs/development/libraries/arrayfire/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig
 , cudatoolkit, opencl-clhpp, ocl-icd, fftw, fftwFloat, mkl
 , blas, openblas, boost, mesa, libGLU, libGL
-, freeimage, python, clfft, clblas
+, freeimage, python2, clfft, clblas
 , doxygen, buildDocs ? false
 }:
 
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkgconfig
-    python
+    python2
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, fetchFromGitHub, fixDarwinDylibNames, autoconf, boost
 , brotli, cmake, double-conversion, flatbuffers, gflags, glog, gtest, lz4, perl
-, python, rapidjson, snappy, thrift, uriparser, which, zlib, zstd
+, python2, rapidjson, snappy, thrift, uriparser, which, zlib, zstd
 , enableShared ? true }:
 
 let
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
   };
 
   patches = [
-    # patch to fix python-test
+    # patch to fix python2-test
     ./darwin.patch
   ] ++ lib.optionals (!enableShared) [
     # The shared jemalloc lib is unused and breaks in static mode due to missing -fpic.
@@ -60,8 +60,8 @@ in stdenv.mkDerivation rec {
     uriparser
     zlib
     zstd
-    python.pkgs.python
-    python.pkgs.numpy
+    python2.pkgs.python
+    python2.pkgs.numpy
   ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/aubio/default.nix
+++ b/pkgs/development/libraries/aubio/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, alsaLib, fftw, libjack2, libsamplerate
-, libsndfile, pkgconfig, python, wafHook
+, libsndfile, pkgconfig, python2, wafHook
 }:
 
 stdenv.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1npks71ljc48w6858l9bq30kaf5nph8z0v61jkfb70xb9np850nl";
   };
 
-  nativeBuildInputs = [ pkgconfig python wafHook ];
+  nativeBuildInputs = [ pkgconfig python2 wafHook ];
   buildInputs = [ alsaLib fftw libjack2 libsamplerate libsndfile ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, icu, expat, zlib, bzip2, python, fixDarwinDylibNames, libiconv
+{ stdenv, icu, expat, zlib, bzip2, python2, fixDarwinDylibNames, libiconv
 , which
 , buildPackages
 , toolset ? /**/ if stdenv.cc.isClang  then "clang"
@@ -89,7 +89,7 @@ let
   ] ++ optional (link != "static") "runtime-link=${runtime-link}"
     ++ optional (variant == "release") "debug-symbols=off"
     ++ optional (toolset != null) "toolset=${toolset}"
-    ++ optional (!enablePython) "--without-python"
+    ++ optional (!enablePython) "--without-python2"
     ++ optional (mpi != null || stdenv.hostPlatform != stdenv.buildPlatform) "--user-config=user-config.jam"
     ++ optionals (stdenv.hostPlatform.libc == "msvcrt") [
     "threadapi=win32"
@@ -146,15 +146,15 @@ stdenv.mkDerivation {
   buildInputs = [ expat zlib bzip2 libiconv ]
     ++ optional (stdenv.hostPlatform == stdenv.buildPlatform) icu
     ++ optional stdenv.isDarwin fixDarwinDylibNames
-    ++ optional enablePython python
-    ++ optional enableNumpy python.pkgs.numpy;
+    ++ optional enablePython python2
+    ++ optional enableNumpy python2.pkgs.numpy;
 
   configureScript = "./bootstrap.sh";
   configurePlatforms = [];
   configureFlags = [
     "--includedir=$(dev)/include"
     "--libdir=$(out)/lib"
-  ] ++ optional enablePython "--with-python=${python.interpreter}"
+  ] ++ optional enablePython "--with-python2=${python2.interpreter}"
     ++ [ (if stdenv.hostPlatform == stdenv.buildPlatform then "--with-icu=${icu.dev}" else "--without-icu") ]
     ++ optional (toolset != null) "--with-toolset=${toolset}";
 

--- a/pkgs/development/libraries/botan/generic.nix
+++ b/pkgs/development/libraries/botan/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, bzip2, zlib, gmp, openssl, boost
+{ stdenv, fetchurl, python2, bzip2, zlib, gmp, openssl, boost
 # Passed by version specific builders
 , baseVersion, revision, sha256
 , extraConfigureFlags ? ""
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
   inherit postPatch;
 
-  buildInputs = [ python bzip2 zlib gmp openssl boost ]
+  buildInputs = [ python2 bzip2 zlib gmp openssl boost ]
              ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 
   configurePhase = ''

--- a/pkgs/development/libraries/clearsilver/default.nix
+++ b/pkgs/development/libraries/clearsilver/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, python }:
+{ stdenv, fetchurl, fetchpatch, python2 }:
 
 stdenv.mkDerivation rec {
   name = "clearsilver-0.10.5";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   PYTHON_SITE = "$(out)/site-packages";
 
   configureFlags = [
-    "--with-python=${python}/bin/python"
+    "--with-python=${python2}/bin/python"
     "--disable-apache"
     "--disable-perl"
     "--disable-ruby"

--- a/pkgs/development/libraries/cppcms/default.nix
+++ b/pkgs/development/libraries/cppcms/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pcre, zlib, python, openssl }:
+{ stdenv, fetchurl, cmake, pcre, zlib, python2, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "cppcms";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ cmake pcre zlib python openssl ];
+  buildInputs = [ cmake pcre zlib python2 openssl ];
 
   cmakeFlags = [
     "--no-warn-unused-cli"

--- a/pkgs/development/libraries/docopt_cpp/default.nix
+++ b/pkgs/development/libraries/docopt_cpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, python }:
+{ stdenv, fetchFromGitHub, cmake, python2 }:
 
 stdenv.mkDerivation rec {
   version = "0.6.2";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1rgkc8nsc2zz2lkyai0y68vrd6i6kbq63hm3vdza7ab6ghq0n1dd";
   };
 
-  nativeBuildInputs = [ cmake python ];
+  nativeBuildInputs = [ cmake python2 ];
 
   cmakeFlags = ["-DWITH_TESTS=ON"];
 

--- a/pkgs/development/libraries/flann/default.nix
+++ b/pkgs/development/libraries/flann/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, unzip, cmake, python }:
+{ stdenv, fetchFromGitHub, fetchpatch, unzip, cmake, python2 }:
 
 stdenv.mkDerivation {
   name = "flann-1.9.1";
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     })
   ];
 
-  buildInputs = [ unzip cmake python ];
+  buildInputs = [ unzip cmake python2 ];
 
   meta = {
     homepage = http://people.cs.ubc.ca/~mariusm/flann/;

--- a/pkgs/development/libraries/folks/default.nix
+++ b/pkgs/development/libraries/folks/default.nix
@@ -21,7 +21,7 @@
 , libsecret
 , db
 , python3
-, python
+, python2
 , readline
 , gtk3
 }:
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkgconfig
-    python
+    python2
     python3
     vala
   ];

--- a/pkgs/development/libraries/gaia/default.nix
+++ b/pkgs/development/libraries/gaia/default.nix
@@ -8,7 +8,7 @@
 , wafHook
 , makeWrapper
 , qt4
-, pythonPackages
+, python2Packages
 , pythonSupport ? false
 # Default to false since it breaks the build, see https://github.com/MTG/gaia/issues/11
 , stlfacadeSupport ? false
@@ -16,7 +16,7 @@
 , cyclopsSupport ? true
 }:
 
-assert pythonSupport -> pythonPackages != null;
+assert pythonSupport -> python2Packages != null;
 
 stdenv.mkDerivation rec {
   pname = "gaia";
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     # The gaiafusion binary inside $out/bin needs a shebangs patch, and
     # wrapping with the appropriate $PYTHONPATH
     ++ lib.optionals (pythonSupport) [
-      pythonPackages.wrapPython
+      python2Packages.wrapPython
     ]
   ;
 
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals (pythonSupport) [
       # This is not exactly specified in upstream's README but it's needed by the
       # resulting $out/bin/gaiafusion script
-      pythonPackages.pyyaml
+      python2Packages.pyyaml
     ]
   ;
 

--- a/pkgs/development/libraries/ganv/default.nix
+++ b/pkgs/development/libraries/ganv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, graphviz, gtk2, gtkmm2, pkgconfig, python, wafHook }:
+{ stdenv, fetchgit, graphviz, gtk2, gtkmm2, pkgconfig, python2, wafHook }:
 
 stdenv.mkDerivation rec {
   name = "ganv-unstable-${rev}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig wafHook ];
-  buildInputs = [ graphviz gtk2 gtkmm2 python ];
+  buildInputs = [ graphviz gtk2 gtkmm2 python2 ];
 
   meta = with stdenv.lib; {
     description = "An interactive Gtk canvas widget for graph-based interfaces";

--- a/pkgs/development/libraries/gdal/2.4.0.nix
+++ b/pkgs/development/libraries/gdal/2.4.0.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, unzip, libjpeg, libtiff, zlib
-, postgresql, libmysqlclient, libgeotiff, pythonPackages, proj, geos, openssl
+, postgresql, libmysqlclient, libgeotiff, python2Packages, proj, geos, openssl
 , libpng, sqlite, libspatialite, poppler, hdf4, qhull, giflib, expat
 , libiconv, libxml2
 , netcdfSupport ? true, netcdf, hdf5, curl
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ unzip libjpeg libtiff libgeotiff libpng proj openssl sqlite
     libspatialite poppler hdf4 qhull giflib expat libxml2 proj ]
-  ++ (with pythonPackages; [ python numpy wrapPython ])
+  ++ (with python2Packages; [ python2 numpy wrapPython ])
   ++ stdenv.lib.optional stdenv.isDarwin libiconv
   ++ stdenv.lib.optionals netcdfSupport [ netcdf hdf5 curl ];
 

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchpatch, unzip, libjpeg, libtiff, zlib
-, postgresql, libmysqlclient, libgeotiff, pythonPackages, proj, geos, openssl
+, postgresql, libmysqlclient, libgeotiff, python2Packages, proj, geos, openssl
 , libpng, sqlite, libspatialite, poppler, hdf4, qhull, giflib, expat
 , libiconv, libxml2, autoreconfHook
 , netcdfSupport ? true, netcdf, hdf5, curl
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ unzip libjpeg libtiff libpng proj openssl sqlite
     libspatialite libgeotiff poppler hdf4 qhull giflib expat libxml2 ]
-  ++ (with pythonPackages; [ python numpy wrapPython ])
+  ++ (with python2Packages; [ python2 numpy wrapPython ])
   ++ stdenv.lib.optional stdenv.isDarwin libiconv
   ++ stdenv.lib.optionals netcdfSupport [ netcdf hdf5 curl ];
 

--- a/pkgs/development/libraries/gdal/gdal-1_11.nix
+++ b/pkgs/development/libraries/gdal/gdal-1_11.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, unzip, libjpeg, libtiff, zlib
-, postgresql, mysql57, libgeotiff, python, pythonPackages, proj, geos, openssl
+, postgresql, mysql57, libgeotiff, python2, python2Packages, proj, geos, openssl
 , libpng }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0hphxzvy23v3vqxx1y22hhhg4cypihrb8555y12nb4mrhzlw7zfl";
   };
 
-  buildInputs = [ unzip libjpeg libtiff libgeotiff libpng python pythonPackages.numpy proj openssl ];
+  buildInputs = [ unzip libjpeg libtiff libgeotiff libpng python2 python2Packages.numpy proj openssl ];
 
   patches = [
     # This ensures that the python package is installed into gdal's prefix,
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   #   TEST FAILED: /nix/store/xkrmb8xnvqxzjwsdmasqmsdh1a5y2y99-gdal-1.11.2/lib/python2.7/site-packages/ does NOT support .pth files
   #   error: bad install directory or PYTHONPATH
   preBuild = ''
-    pythonInstallDir=$out/lib/${python.libPrefix}/site-packages
+    pythonInstallDir=$out/lib/${python2.libPrefix}/site-packages
     mkdir -p $pythonInstallDir
     export PYTHONPATH=''${PYTHONPATH:+''${PYTHONPATH}:}$pythonInstallDir
   '';

--- a/pkgs/development/libraries/geos/default.nix
+++ b/pkgs/development/libraries/geos/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python }:
+{ stdenv, fetchurl, python2 }:
 
 stdenv.mkDerivation rec {
   name = "geos-3.7.3";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ python ];
+  buildInputs = [ python2 ];
 
   meta = with stdenv.lib; {
     description = "C++ port of the Java Topology Suite (JTS)";

--- a/pkgs/development/libraries/grib-api/default.nix
+++ b/pkgs/development/libraries/grib-api/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, fetchpatch, stdenv,
   cmake, netcdf, gfortran, libpng, openjpeg,
-  enablePython ? false, pythonPackages }:
+  enablePython ? false, python2Packages }:
 
 stdenv.mkDerivation rec{
   pname = "grib-api";
@@ -29,11 +29,11 @@ stdenv.mkDerivation rec{
                   libpng
                   openjpeg
                 ] ++ stdenv.lib.optionals enablePython [
-                  pythonPackages.python
+                  python2Packages.python2
                 ];
 
   propagatedBuildInputs = stdenv.lib.optionals enablePython [
-                  pythonPackages.numpy
+                  python2Packages.numpy
                 ];
 
   cmakeFlags = [ "-DENABLE_PYTHON=${if enablePython then "ON" else "OFF"}"

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -4,7 +4,7 @@
 , meson
 , ninja
 , pkgconfig
-, python
+, python2
 , gst-plugins-base
 , libxml2
 , flex
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     gettext
     gobject-introspection
-    python
+    python2
     flex
     perl
   ];

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -3,7 +3,7 @@
 , meson
 , ninja
 , pkgconfig
-, python
+, python2
 , gst-plugins-base
 , orc
 , gettext
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     ninja
     gettext
     pkgconfig
-    python
+    python2
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -16,7 +16,7 @@
 , gst-plugins-bad
 , nasm
 , libvpx
-, python
+, python2
 }:
 
 stdenv.mkDerivation rec {
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     libGLU
     nasm
     libvpx
-    python
+    python2
   ];
 
   mesonFlags = [

--- a/pkgs/development/libraries/gstreamer/validate/default.nix
+++ b/pkgs/development/libraries/gstreamer/validate/default.nix
@@ -3,7 +3,7 @@
 , pkgconfig
 , gstreamer
 , gst-plugins-base
-, python
+, python2
 , gobject-introspection
 , json-glib
 }:
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    python
+    python2
     json-glib
   ];
 

--- a/pkgs/development/libraries/harfbuzz/default.nix
+++ b/pkgs/development/libraries/harfbuzz/default.nix
@@ -4,7 +4,7 @@
 , withCoreText ? false
 , withIcu ? false # recommended by upstream as default, but most don't needed and it's big
 , withGraphite2 ? true # it is small and major distros do include it
-, python
+, python2
 }:
 
 let
@@ -48,7 +48,7 @@ stdenv.mkDerivation {
     ++ optional withGraphite2 graphite2
     ++ optionals withIcu [ icu harfbuzz ];
 
-  checkInputs = [ python ];
+  checkInputs = [ python2 ];
   doInstallCheck = false; # fails, probably a bug
 
   # Slightly hacky; some pkgs expect them in a single directory.

--- a/pkgs/development/libraries/hpx/default.nix
+++ b/pkgs/development/libraries/hpx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, boost, cmake, hwloc, gperftools, pkgconfig, python }:
+{ stdenv, fetchFromGitHub, boost, cmake, hwloc, gperftools, pkgconfig, python2 }:
 
 stdenv.mkDerivation rec {
   pname = "hpx";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ boost hwloc gperftools ];
-  nativeBuildInputs = [ cmake pkgconfig python ];
+  nativeBuildInputs = [ cmake pkgconfig python2 ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, python, fetchpatch }:
+{ stdenv, fetchFromGitHub, cmake, python2, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "jsoncpp";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     export LD_LIBRARY_PATH="`pwd`/src/lib_json:$LD_LIBRARY_PATH"
   '';
 
-  nativeBuildInputs = [ cmake python ];
+  nativeBuildInputs = [ cmake python2 ];
 
   # fix inverted sense in isAnyCharRequiredQuoting on aarch64. See: https://github.com/open-source-parsers/jsoncpp/pull/1120
   patches = stdenv.lib.optionals stdenv.isAarch64 [

--- a/pkgs/development/libraries/jxrlib/default.nix
+++ b/pkgs/development/libraries/jxrlib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python }:
+{ stdenv, fetchFromGitHub, python2 }:
 
 stdenv.mkDerivation rec {
   pname = "jxrlib";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0rk3hbh00nw0wgbfbqk1szrlfg3yq7w6ar16napww3nrlm9cj65w";
   };
 
-  nativeBuildInputs = [ python ];
+  nativeBuildInputs = [ python2 ];
 
   makeFlags = [ "DIR_INSTALL=$(out)" "SHARED=1" ];
 

--- a/pkgs/development/libraries/kde-frameworks/kapidox.nix
+++ b/pkgs/development/libraries/kde-frameworks/kapidox.nix
@@ -1,9 +1,9 @@
-{ mkDerivation, lib, extra-cmake-modules, python }:
+{ mkDerivation, lib, extra-cmake-modules, python2 }:
 
 mkDerivation {
   name = "kapidox";
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
-  nativeBuildInputs = [ extra-cmake-modules python ];
+  nativeBuildInputs = [ extra-cmake-modules python2 ];
   postFixup = ''
     moveToOutput bin $bin
   '';

--- a/pkgs/development/libraries/kmsxx/default.nix
+++ b/pkgs/development/libraries/kmsxx/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, libdrm
-, withPython ? false, python }:
+, withPython ? false, python2 }:
 
 stdenv.mkDerivation {
   pname = "kmsxx";
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   cmakeFlags = stdenv.lib.optional (!withPython) "-DKMSXX_ENABLE_PYTHON=OFF";
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ libdrm python ];
+  buildInputs = [ libdrm python2 ];
 
   meta = with stdenv.lib; {
     description = "C++11 library, utilities and python bindings for Linux kernel mode setting";

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -19,7 +19,7 @@
 
 , enableUnfree    ? false
 , enableIpp       ? false
-, enablePython    ? false, pythonPackages
+, enablePython    ? false, python2Packages
 , enableGtk2      ? false, gtk2
 , enableGtk3      ? false, gtk3
 , enableVtk       ? false, vtk
@@ -176,7 +176,7 @@ stdenv.mkDerivation {
   buildInputs =
        [ zlib pcre hdf5 glog boost gflags ]
     ++ lib.optional useSystemProtobuf protobuf
-    ++ lib.optional enablePython pythonPackages.python
+    ++ lib.optional enablePython python2Packages.python2
     ++ lib.optional enableGtk2 gtk2
     ++ lib.optional enableGtk3 gtk3
     ++ lib.optional enableVtk vtk
@@ -204,7 +204,7 @@ stdenv.mkDerivation {
     ++ lib.optionals stdenv.isDarwin [ bzip2 AVFoundation Cocoa VideoDecodeAcceleration ]
     ++ lib.optionals enableDocs [ doxygen graphviz-nox ];
 
-  propagatedBuildInputs = lib.optional enablePython pythonPackages.numpy;
+  propagatedBuildInputs = lib.optional enablePython python2Packages.numpy;
 
   nativeBuildInputs = [ cmake pkgconfig unzip ];
 

--- a/pkgs/development/libraries/physics/geant4/g4py/default.nix
+++ b/pkgs/development/libraries/physics/geant4/g4py/default.nix
@@ -4,14 +4,14 @@
 , geant4
 
 # Python (obviously) and boost::python for wrapping.
-, python
+, python2
 , boost
 }:
 
 let
   # g4py does not support MT and will fail to build against MT geant
   geant4_nomt = geant4.override { enableMultiThreading = false; };
-  boost_python = boost.override { enablePython = true; inherit python; };
+  boost_python = boost.override { enablePython = true; inherit python2; };
 in
 
 stdenv.mkDerivation {
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   sourceRoot = "geant4.10.05.p01/environments/g4py";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ geant4_nomt xercesc boost_python python ];
+  buildInputs = [ geant4_nomt xercesc boost_python python2 ];
 
   GEANT4_INSTALL = geant4_nomt;
 

--- a/pkgs/development/libraries/physics/geant4/g4py/default.nix
+++ b/pkgs/development/libraries/physics/geant4/g4py/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   preConfigure = ''
     # Fix for boost 1.67+
     substituteInPlace CMakeLists.txt \
-    --replace "find_package(Boost)" "find_package(Boost 1.40 REQUIRED COMPONENTS python${builtins.replaceStrings ["."] [""] python.pythonVersion})"
+    --replace "find_package(Boost)" "find_package(Boost 1.40 REQUIRED COMPONENTS python${builtins.replaceStrings ["."] [""] python2.pythonVersion})"
     for f in `find . -name CMakeLists.txt`; do
       substituteInPlace "$f" \
         --replace "boost_python" "\''${Boost_LIBRARIES}"

--- a/pkgs/development/libraries/science/biology/elastix/default.nix
+++ b/pkgs/development/libraries/science/biology/elastix/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, itk, python }:
+{ stdenv, fetchFromGitHub, cmake, itk, python2 }:
 
 stdenv.mkDerivation rec {
   pname    = "elastix";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     rev    = version;
     sha256 = "1zrl7rz4lwsx88b2shnl985f3a97lmp4ksbd437h9y0hfjq8l0lj";
   };
-  nativeBuildInputs = [ cmake python ];
+  nativeBuildInputs = [ cmake python2 ];
   buildInputs = [ itk ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/science/math/clblas/default.nix
+++ b/pkgs/development/libraries/science/math/clblas/default.nix
@@ -4,7 +4,7 @@
 , gfortran
 , blas
 , boost
-, python
+, python2
 , ocl-icd
 , opencl-headers
 , Accelerate, CoreGraphics, CoreVideo, OpenCL
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     cmake
     gfortran
     blas
-    python
+    python2
     boost
   ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
     ocl-icd

--- a/pkgs/development/libraries/silgraphite/graphite2.nix
+++ b/pkgs/development/libraries/silgraphite/graphite2.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, freetype, cmake, python }:
+{ stdenv, fetchurl, pkgconfig, freetype, cmake, python2 }:
 
 stdenv.mkDerivation rec {
   version = "1.3.13";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   patches = stdenv.lib.optionals stdenv.isDarwin [ ./macosx.patch ];
 
-  checkInputs = [ python ];
+  checkInputs = [ python2 ];
   doCheck = false; # fails, probably missing something
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -17,7 +17,7 @@
 # This seperates "what to build" (the exact gem versions) from "how to build"
 # (to make gems behave if necessary).
 
-{ lib, fetchurl, writeScript, ruby, kerberos, libxml2, libxslt, python, stdenv, which
+{ lib, fetchurl, writeScript, ruby, kerberos, libxml2, libxslt, python2, stdenv, which
 , libiconv, postgresql, v8, clang, sqlite, zlib, imagemagick
 , pkgconfig , ncurses, xapian, gpgme, utillinux, tzdata, icu, libffi
 , cmake, libssh2, openssl, libmysqlclient, darwin, git, perl, pcre, gecode_3, curl
@@ -292,7 +292,7 @@ in
   # otherwise the gem will fail to link to the libv8 binary.
   # see: https://github.com/cowboyd/libv8/pull/161
   libv8 = attrs: {
-    buildInputs = [ which v8 python ];
+    buildInputs = [ which v8 python2 ];
     buildFlags = [ "--with-system-v8=true" ];
   };
 

--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -3,7 +3,7 @@
 , fetchpatch
 , git
 , go
-, python
+, python2
 , stdenv
 }:
 
@@ -33,7 +33,7 @@ buildBazelPackage rec {
     sha256 = "17z4nqqsdrainbh8fmhf6sgrxwf7aknadmn94z1yqpxa7kb9x33v";
   };
 
-  nativeBuildInputs = [ go git python ];
+  nativeBuildInputs = [ go git python2 ];
 
   bazelTarget = "//ibazel";
 

--- a/pkgs/development/tools/build-managers/bam/default.nix
+++ b/pkgs/development/tools/build-managers/bam/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, lua5_3, python }:
+{ stdenv, fetchFromGitHub, lua5_3, python2 }:
 
 stdenv.mkDerivation rec {
   pname = "bam";
@@ -11,11 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "13br735ig7lygvzyfd15fc2rdygrqm503j6xj5xkrl1r7w2wipq6";
   };
 
-  buildInputs = [ lua5_3 python ];
+  buildInputs = [ lua5_3 python2 ];
 
   buildPhase = ''${stdenv.shell} make_unix.sh'';
 
-  checkPhase = ''${python.interpreter} scripts/test.py'';
+  checkPhase = ''${python2.interpreter} scripts/test.py'';
 
   installPhase = ''
     mkdir -p "$out/share/bam"

--- a/pkgs/development/tools/build-managers/bear/default.nix
+++ b/pkgs/development/tools/build-managers/bear/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, python }:
+{ stdenv, fetchFromGitHub, cmake, python2 }:
 
 stdenv.mkDerivation rec {
   pname = "bear";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ python ]; # just for shebang of bin/bear
+  buildInputs = [ python2 ]; # just for shebang of bin/bear
 
   doCheck = false; # all fail
 

--- a/pkgs/development/tools/build-managers/bloop/default.nix
+++ b/pkgs/development/tools/build-managers/bloop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, coursier, python, makeWrapper }:
+{ stdenv, lib, fetchurl, coursier, python2, makeWrapper }:
 
 let
   baseName = "bloop";
@@ -66,7 +66,7 @@ stdenv.mkDerivation {
     cp ${client} $out/bloop
     chmod +x $out/bloop
     makeWrapper $out/bloop $out/bin/bloop \
-      --prefix PATH : ${lib.makeBinPath [ python ]}
+      --prefix PATH : ${lib.makeBinPath [ python2 ]}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/build-managers/ninja/default.nix
+++ b/pkgs/development/tools/build-managers/ninja/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, python, buildDocs ? true, asciidoc, docbook_xml_dtd_45, docbook_xsl, libxslt, re2c }:
+{ stdenv, fetchFromGitHub, fetchpatch, python2, buildDocs ? true, asciidoc, docbook_xml_dtd_45, docbook_xsl, libxslt, re2c }:
 
 with stdenv.lib;
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ python re2c ] ++ optionals buildDocs [ asciidoc docbook_xml_dtd_45 docbook_xsl libxslt.bin ];
+  nativeBuildInputs = [ python2 re2c ] ++ optionals buildDocs [ asciidoc docbook_xml_dtd_45 docbook_xsl libxslt.bin ];
 
   buildPhase = ''
     python configure.py --bootstrap

--- a/pkgs/development/tools/cask/default.nix
+++ b/pkgs/development/tools/cask/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, emacsPackages }:
+{ stdenv, fetchurl, python2, emacsPackages }:
 
 stdenv.mkDerivation rec {
   pname = "cask";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     s f dash ansi ecukes servant ert-runner el-mock
     noflet ert-async shell-split-string git package-build
   ] ++ [
-    python
+    python2
   ];
 
   buildPhase = ''

--- a/pkgs/development/tools/casperjs/default.nix
+++ b/pkgs/development/tools/casperjs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fontsConf, phantomjs2, python, nodePackages }:
+{ stdenv, fetchFromGitHub, fontsConf, phantomjs2, python2, nodePackages }:
 
 let version = "1.1.1";
 
@@ -14,10 +14,10 @@ in stdenv.mkDerivation {
     sha256 = "187prrm728xpn0nx9kxfxa4fwd7w25z78nsxfk6a6kl7c5656jpz";
   };
 
-  buildInputs = [ phantomjs2 python nodePackages.eslint ];
+  buildInputs = [ phantomjs2 python2 nodePackages.eslint ];
 
   patchPhase = ''
-    substituteInPlace bin/casperjs --replace "/usr/bin/env python" "${python}/bin/python" \
+    substituteInPlace bin/casperjs --replace "/usr/bin/env python" "${python2}/bin/python2" \
                                    --replace "'phantomjs'" "'${phantomjs2}/bin/phantomjs'"
   '';
 

--- a/pkgs/development/tools/castxml/default.nix
+++ b/pkgs/development/tools/castxml/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub
-, pythonPackages
+, python2Packages
 , cmake
 , llvmPackages
 , libffi, libxml2, zlib
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "1qpgr5hyb692h7l5igmq53m6a6vi4d9qp8ks893cflfx9955h3ip";
   };
 
-  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optionals withMan [ pythonPackages.sphinx ];
+  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optionals withMan [ python2Packages.sphinx ];
 
   clangVersion = lib.getVersion llvmPackages.clang;
 

--- a/pkgs/development/tools/erlang/cuter/default.nix
+++ b/pkgs/development/tools/erlang/cuter/default.nix
@@ -1,5 +1,5 @@
 { stdenv, autoreconfHook, which, writeText, makeWrapper, fetchFromGitHub, erlang
-, z3, python }:
+, z3, python2 }:
 
 stdenv.mkDerivation rec {
   pname = "cuter";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ autoreconfHook makeWrapper which ];
-  buildInputs = [ python python.pkgs.setuptools z3.python erlang ];
+  buildInputs = [ python2 python2.pkgs.setuptools z3.python erlang ];
 
   buildFlags = [ "PWD=$(out)/lib/erlang/lib/cuter-${version}" "cuter_target" ];
   configurePhase = ''
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
     cp -r * "$out/lib/erlang/lib/cuter-${version}"
     cp cuter "$out/bin/cuter"
     wrapProgram $out/bin/cuter \
-      --prefix PATH : "${python}/bin" \
-      --suffix PYTHONPATH : "${z3}/${python.sitePackages}" \
+      --prefix PATH : "${python2}/bin" \
+      --suffix PYTHONPATH : "${z3}/${python2.sitePackages}" \
       --suffix ERL_LIBS : "$out/lib/erlang/lib"
   '';
 

--- a/pkgs/development/tools/grabserial/default.nix
+++ b/pkgs/development/tools/grabserial/default.nix
@@ -1,6 +1,6 @@
-{ lib, fetchFromGitHub, pythonPackages }:
+{ lib, fetchFromGitHub, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "grabserial";
   version = "1.9.9";
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0cwrajkh605gfhshrlpbc32gmx86a8kv3pq7cv713k60sgqrgpqx";
   };
 
-  propagatedBuildInputs = [ pythonPackages.pyserial ];
+  propagatedBuildInputs = [ python2Packages.pyserial ];
 
   meta = with lib; {
     description = "Python based serial dump and timing program";

--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub
 , gcc-arm-embedded, libftdi1
-, python, pythonPackages
+, python2, python2Packages
 }:
 
 with lib;
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libftdi1
-    python
-    pythonPackages.intelhex
+    python2
+    python2Packages.intelhex
   ];
 
   postPatch = ''

--- a/pkgs/development/tools/misc/cli11/default.nix
+++ b/pkgs/development/tools/misc/cli11/default.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   cmake,
   gtest,
-  python,
+  python2,
   boost
 }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  checkInputs = [ boost python ];
+  checkInputs = [ boost python2 ];
 
   doCheck = true;
 

--- a/pkgs/development/tools/misc/coccinelle/default.nix
+++ b/pkgs/development/tools/misc/coccinelle/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, python, ncurses, ocamlPackages, pkgconfig }:
+{ fetchurl, stdenv, python2, ncurses, ocamlPackages, pkgconfig }:
 
 stdenv.mkDerivation rec {
   pname = "coccinelle";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = with ocamlPackages; [
     ocaml findlib menhir
     ocaml_pcre pycaml
-    python ncurses pkgconfig
+    python2 ncurses pkgconfig
   ];
 
   doCheck = !stdenv.isDarwin;

--- a/pkgs/development/tools/misc/distcc/default.nix
+++ b/pkgs/development/tools/misc/distcc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, popt, avahi, pkgconfig, python, gtk2, runCommand
+{ stdenv, fetchFromGitHub, popt, avahi, pkgconfig, python2, gtk2, runCommand
 , gcc, autoconf, automake, which, procps, libiberty_static
 , runtimeShell
 , sysconfDir ? ""   # set this parameter to override the default value $out/etc
@@ -18,7 +18,7 @@ let
     };
 
   nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [popt avahi pkgconfig python gtk2 autoconf automake which procps libiberty_static];
+    buildInputs = [popt avahi pkgconfig python2 gtk2 autoconf automake which procps libiberty_static];
     preConfigure =
     ''
       export CPATH=$(ls -d ${gcc.cc}/lib/gcc/*/${gcc.cc.version}/plugin/include)

--- a/pkgs/development/tools/misc/doclifter/default.nix
+++ b/pkgs/development/tools/misc/doclifter/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, python}:
+{stdenv, fetchurl, python2}:
 
 stdenv.mkDerivation {
   name = "doclifter-2.19";
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
     url = http://www.catb.org/~esr/doclifter/doclifter-2.19.tar.gz;
     sha256 = "1as6z7mdjrrkw2kism41q5ybvyzvwcmj9qzla2fz98v9f4jbj2s2";
   };
-  buildInputs = [ python ];
+  buildInputs = [ python2 ];
   
   makeFlags = [ "PREFIX=$(out)" ];
   

--- a/pkgs/development/tools/misc/gede/default.nix
+++ b/pkgs/development/tools/misc/gede/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchurl, makeWrapper, python, qmake, ctags, gdb }:
+{ mkDerivation, lib, fetchurl, makeWrapper, python2, qmake, ctags, gdb }:
 
 mkDerivation rec {
   pname = "gede";
@@ -9,7 +9,7 @@ mkDerivation rec {
     sha256 = "0n67fiks7lbylgda8n06wfwcvl5qnb70rabk2b39g05byz7jcdcn";
   };
 
-  nativeBuildInputs = [ qmake makeWrapper python ];
+  nativeBuildInputs = [ qmake makeWrapper python2 ];
 
   buildInputs = [ ctags ];
 

--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, libtool, makeWrapper
-, coreutils, ctags, ncurses, pythonPackages, sqlite, universal-ctags
+, coreutils, ctags, ncurses, python2Packages, sqlite, universal-ctags
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses ];
 
-  propagatedBuildInputs = [ pythonPackages.pygments ];
+  propagatedBuildInputs = [ python2Packages.pygments ];
 
   configureFlags = [
     "--with-ltdl-include=${libtool}/include"
@@ -34,9 +34,9 @@ stdenv.mkDerivation rec {
     cp -v *.el "$out/share/emacs/site-lisp"
 
     wrapProgram $out/bin/gtags \
-      --prefix PYTHONPATH : "$(toPythonPath ${pythonPackages.pygments})"
+      --prefix PYTHONPATH : "$(toPythonPath ${python2Packages.pygments})"
     wrapProgram $out/bin/global \
-      --prefix PYTHONPATH : "$(toPythonPath ${pythonPackages.pygments})"
+      --prefix PYTHONPATH : "$(toPythonPath ${python2Packages.pygments})"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/games/20kly/default.nix
+++ b/pkgs/games/20kly/default.nix
@@ -1,12 +1,12 @@
 { stdenv
 , fetchurl
-, python }:
+, python2 }:
 
-python.pkgs.buildPythonApplication rec {
+python2.pkgs.buildPythonApplication rec {
   pname = "20kly";
   version = "1.4";
   format = "other";
-  disabled = !(python.isPy2 or false);
+  disabled = !(python2.isPy2 or false);
 
   src = fetchurl {
     url = "http://jwhitham.org.uk/20kly/lightyears-${version}.tar.bz2";
@@ -20,9 +20,9 @@ python.pkgs.buildPythonApplication rec {
         "LIGHTYEARS_DIR = \"$out/share\""
   '';
 
-  propagatedBuildInputs = with python.pkgs; [ pygame ];
+  propagatedBuildInputs = with python2.pkgs; [ pygame ];
 
-  buildPhase = "python -O -m compileall .";
+  buildPhase = "python2 -O -m compileall .";
 
   installPhase = ''
     mkdir -p "$out/share"

--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, lua5_3, pkgconfig, python
+{ stdenv, fetchFromGitHub, autoreconfHook, lua5_3, pkgconfig, python2
 , zlib, bzip2, curl, lzma, gettext, libiconv
 , sdlClient ? true, SDL, SDL_mixer, SDL_image, SDL_ttf, SDL_gfx, freetype, fluidsynth
 , gtkClient ? false, gtk3
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
   postPatch = ''
     for f in {common,utility}/*.py; do
       substituteInPlace $f \
-        --replace '/usr/bin/env python' ${python.interpreter}
+        --replace '/usr/bin/env python' ${python2.interpreter}
     done
   '';
 

--- a/pkgs/games/gemrb/default.nix
+++ b/pkgs/games/gemrb/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake
-, freetype, SDL2, SDL2_mixer, openal, zlib, libpng, python, libvorbis
+, freetype, SDL2, SDL2_mixer, openal, zlib, libpng, python2, libvorbis
 , libiconv }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   # TODO: make libpng, libvorbis, sdl_mixer, freetype, vlc, glew (and other gl reqs) optional
-  buildInputs = [ freetype python openal SDL2 SDL2_mixer zlib libpng libvorbis libiconv ];
+  buildInputs = [ freetype python2 openal SDL2 SDL2_mixer zlib libpng libvorbis libiconv ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/games/gnubg/default.nix
+++ b/pkgs/games/gnubg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib, python, gtk2, readline }:
+{ stdenv, fetchurl, pkgconfig, glib, python2, gtk2, readline }:
 
 let version = "1.06.002"; in
 stdenv.mkDerivation {
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ python glib gtk2 readline ];
+  buildInputs = [ python2 glib gtk2 readline ];
 
   configureFlags = [ "--with-gtk" "--with--board3d" ];
 

--- a/pkgs/misc/emulators/blastem/default.nix
+++ b/pkgs/misc/emulators/blastem/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub, pkgconfig, SDL2, glew, xcftools, python, pillow, makeWrapper }:
+{ stdenv, fetchurl, fetchFromGitHub, pkgconfig, SDL2, glew, xcftools, python2, pillow, makeWrapper }:
 
 let
   vasm =
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     url = "https://www.retrodev.com/repos/blastem/archive/3d48cb0c28be.tar.gz";
     sha256 = "07wzbmzp0y8mh59jxg81q17gqagz3psxigxh8dmzsipgg68y6a8r";
   };
-  buildInputs = [ pkgconfig SDL2 glew xcftools python pillow vasm makeWrapper ];
+  buildInputs = [ pkgconfig SDL2 glew xcftools python2 pillow vasm makeWrapper ];
   preBuild = ''
     patchShebangs img2tiles.py
   '';

--- a/pkgs/misc/gnuk/generic.nix
+++ b/pkgs/misc/gnuk/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, gcc-arm-embedded, binutils-arm-embedded, makeWrapper
-, python, pythonPackages
+, python2, python2Packages
 
 # Extra options
 , device ? "fsij", vid ? "234b", pid ? "0000"
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   inherit src;
 
   nativeBuildInputs = [ gcc-arm-embedded binutils-arm-embedded makeWrapper ];
-  buildInputs = [ python ] ++ (with pythonPackages; [ pyusb colorama ]);
+  buildInputs = [ python2 ] ++ (with python2Packages; [ pyusb colorama ]);
 
   configurePhase = ''
     cd src

--- a/pkgs/os-specific/linux/anbox/default.nix
+++ b/pkgs/os-specific/linux/anbox/default.nix
@@ -14,7 +14,7 @@
 , properties-cpp
 , protobuf
 , protobufc
-, python
+, python2
 , lxc
 , writeText
 , writeScript
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cmake pkgconfig dbus boost libcap gtest systemd mesa glib
-    SDL2 SDL2_image protobuf protobufc properties-cpp lxc python
+    SDL2 SDL2_image protobuf protobufc properties-cpp lxc python2
     libGL
   ];
 

--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, protobuf, protobufc, asciidoc, iptables
 , xmlto, docbook_xsl, libpaper, libnl, libcap, libnet, pkgconfig
-, which, python, makeWrapper, docbook_xml_dtd_45 }:
+, which, python2, makeWrapper, docbook_xml_dtd_45 }:
 
 stdenv.mkDerivation rec {
   pname = "criu";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
   nativeBuildInputs = [ pkgconfig docbook_xsl which makeWrapper docbook_xml_dtd_45 ];
-  buildInputs = [ protobuf protobufc asciidoc xmlto libpaper libnl libcap libnet python iptables ];
+  buildInputs = [ protobuf protobufc asciidoc xmlto libpaper libnl libcap libnet python2 iptables ];
 
   postPatch = ''
     substituteInPlace ./Documentation/Makefile --replace "2>/dev/null" ""

--- a/pkgs/os-specific/linux/dmtcp/default.nix
+++ b/pkgs/os-specific/linux/dmtcp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, bash, perl, python }:
+{ stdenv, fetchFromGitHub, bash, perl, python2 }:
 
 stdenv.mkDerivation rec {
   pname = "dmtcp";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     substituteInPlace test/autotest.py \
       --replace /bin/bash ${bash}/bin/bash \
       --replace /usr/bin/perl ${perl}/bin/perl \
-      --replace /usr/bin/python ${python}/bin/python \
+      --replace /usr/bin/python ${python2}/bin/python \
       --replace "os.environ['USER']" "\"nixbld1\"" \
       --replace "os.getenv('USER')" "\"nixbld1\""
   '';

--- a/pkgs/servers/dico/default.nix
+++ b/pkgs/servers/dico/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, libtool, gettext, zlib, readline, gsasl
-, guile, python, pcre, libffi, groff }:
+, guile, python2, pcre, libffi, groff }:
 
 stdenv.mkDerivation rec {
   pname = "dico";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   buildInputs =
-    [ libtool gettext zlib readline gsasl guile python pcre libffi groff ];
+    [ libtool gettext zlib readline gsasl guile python2 pcre libffi groff ];
 
   doCheck = true;
 

--- a/pkgs/servers/dict/dictd-wiktionary.nix
+++ b/pkgs/servers/dict/dictd-wiktionary.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, python, dict, glibcLocales, writeScript}:
+{stdenv, fetchurl, python2, dict, glibcLocales, writeScript}:
 
 stdenv.mkDerivation rec {
   version = "20161001";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   convert = ./wiktionary2dict.py;
-  buildInputs = [python dict glibcLocales];
+  buildInputs = [python2 dict glibcLocales];
 
   builder = writeScript "wiktionary-builder.sh" ''
     source $stdenv/setup

--- a/pkgs/servers/dict/dictd-wordnet.nix
+++ b/pkgs/servers/dict/dictd-wordnet.nix
@@ -1,10 +1,10 @@
-{stdenv, python, wordnet, writeScript}:
+{stdenv, python2, wordnet, writeScript}:
 
 stdenv.mkDerivation rec {
   version = "542";
   pname = "dict-db-wordnet";
 
-  buildInputs = [python wordnet];
+  buildInputs = [python2 wordnet];
   convert = ./wordnet_structures.py;
 
   builder = writeScript "builder.sh" ''

--- a/pkgs/servers/foundationdb/default.nix
+++ b/pkgs/servers/foundationdb/default.nix
@@ -2,7 +2,7 @@
 , lib, fetchurl, fetchpatch, fetchFromGitHub
 
 , cmake, ninja, which, findutils, m4, gawk
-, python3, openjdk, mono, libressl, boost
+, python2, python3, openjdk, mono, libressl, boost
 }@args:
 
 let

--- a/pkgs/servers/foundationdb/default.nix
+++ b/pkgs/servers/foundationdb/default.nix
@@ -2,7 +2,7 @@
 , lib, fetchurl, fetchpatch, fetchFromGitHub
 
 , cmake, ninja, which, findutils, m4, gawk
-, python, python3, openjdk, mono, libressl, boost
+, python3, openjdk, mono, libressl, boost
 }@args:
 
 let

--- a/pkgs/servers/foundationdb/vsmake.nix
+++ b/pkgs/servers/foundationdb/vsmake.nix
@@ -4,7 +4,7 @@
 { stdenv49, lib, fetchurl, fetchFromGitHub
 
 , which, findutils, m4, gawk
-, python, openjdk, mono, libressl
+, python2, openjdk, mono, libressl
 , ...
 }:
 
@@ -55,7 +55,7 @@ let
           inherit rev sha256;
         };
 
-        nativeBuildInputs = [ python openjdk gawk which m4 findutils mono ];
+        nativeBuildInputs = [ python2 openjdk gawk which m4 findutils mono ];
         buildInputs = [ libressl boost ];
 
         inherit patches;

--- a/pkgs/servers/ldap/389/default.nix
+++ b/pkgs/servers/ldap/389/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, autoreconfHook, pkgconfig, doxygen, perl, pam, nspr, nss, openldap
-, db, cyrus_sasl, svrcore, icu, net-snmp, kerberos, pcre, perlPackages, libevent, openssl, python
+, db, cyrus_sasl, svrcore, icu, net-snmp, kerberos, pcre, perlPackages, libevent, openssl, python2
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig doxygen ];
   buildInputs = [
     perl pam nspr nss openldap db cyrus_sasl svrcore icu
-    net-snmp kerberos pcre libevent openssl python
+    net-snmp kerberos pcre libevent openssl python2
   ] ++ (with perlPackages; [ MozillaLdap NetAddrIP DBFile ]);
 
   patches = [

--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, makeWrapper, gawk, bash, getopt, procps
+{ stdenv, fetchurl, python2, makeWrapper, gawk, bash, getopt, procps
 , which, jre, version, sha256, coreutils, ...
 }:
 
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
       fi
     done
 
-    wrapProgram $out/bin/cqlsh --prefix PATH : ${python}/bin
+    wrapProgram $out/bin/cqlsh --prefix PATH : ${python2}/bin
     '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1157,7 +1157,7 @@ lib.makeScope newScope (self: with self; {
     meta.platforms = stdenv.lib.platforms.unix;
   }) {};
 
-  libxcb = callPackage ({ stdenv, pkgconfig, fetchurl, libxslt, libpthreadstubs, libXau, xcbproto, libXdmcp, python }: stdenv.mkDerivation {
+  libxcb = callPackage ({ stdenv, pkgconfig, fetchurl, libxslt, libpthreadstubs, libXau, xcbproto, libXdmcp, python3 }: stdenv.mkDerivation {
     name = "libxcb-1.13.1";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1165,7 +1165,7 @@ lib.makeScope newScope (self: with self; {
       sha256 = "1i27lvrcsygims1pddpl5c4qqs6z715lm12ax0n3vx0igapvg7x8";
     };
     hardeningDisable = [ "bindnow" "relro" ];
-    nativeBuildInputs = [ pkgconfig python ];
+    nativeBuildInputs = [ pkgconfig python3 ];
     buildInputs = [ libxslt libpthreadstubs libXau xcbproto libXdmcp ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) {};
@@ -1430,7 +1430,7 @@ lib.makeScope newScope (self: with self; {
     meta.platforms = stdenv.lib.platforms.unix;
   }) {};
 
-  xcbproto = callPackage ({ stdenv, pkgconfig, fetchurl, python }: stdenv.mkDerivation {
+  xcbproto = callPackage ({ stdenv, pkgconfig, fetchurl, python3 }: stdenv.mkDerivation {
     name = "xcb-proto-1.13";
     builder = ./builder.sh;
     src = fetchurl {
@@ -1438,7 +1438,7 @@ lib.makeScope newScope (self: with self; {
       sha256 = "1qdxw9syhbvswiqj5dvj278lrmfhs81apzmvx6205s4vcqg7563v";
     };
     hardeningDisable = [ "bindnow" "relro" ];
-    nativeBuildInputs = [ pkgconfig python ];
+    nativeBuildInputs = [ pkgconfig python3 ];
     buildInputs = [ ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) {};

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -72,9 +72,7 @@ self: super:
 
   mkfontdir = self.mkfontscale;
 
-  libxcb = (super.libxcb.override {
-    python = python3;
-  }).overrideAttrs (attrs: {
+  libxcb = super.libxcb.overrideAttrs (attrs: {
     configureFlags = [ "--enable-xkb" "--enable-xinput" ];
     outputs = [ "out" "dev" "man" "doc" ];
   });
@@ -306,10 +304,6 @@ self: super:
   x11perf = super.x11perf.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [ freetype fontconfig ];
   });
-
-  xcbproto = super.xcbproto.override {
-    python = python3;
-  };
 
   xcbutil = super.xcbutil.overrideAttrs (attrs: {
     outputs = [ "out" "dev" ];

--- a/pkgs/tools/admin/chkcrontab/default.nix
+++ b/pkgs/tools/admin/chkcrontab/default.nix
@@ -1,6 +1,6 @@
-{ python, stdenv }:
+{ python2, stdenv }:
 
-with python.pkgs;
+with python2.pkgs;
 
 buildPythonApplication rec {
   pname = "chkcrontab";

--- a/pkgs/tools/admin/gixy/default.nix
+++ b/pkgs/tools/admin/gixy/default.nix
@@ -1,11 +1,11 @@
-{ lib, fetchFromGitHub, python }:
+{ lib, fetchFromGitHub, python2 }:
 
-python.pkgs.buildPythonApplication rec {
+python2.pkgs.buildPythonApplication rec {
   pname = "gixy";
   version = "0.1.20";
 
-  # package is only compatible with python 2.7 and 3.5+
-  disabled = with python.pkgs; !(pythonAtLeast "3.5" || isPy27);
+  # package is only compatible with python2 2.7 and 3.5+
+  disabled = with python2.pkgs; !(pythonAtLeast "3.5" || isPy27);
 
   # fetching from GitHub because the PyPi source is missing the tests
   src = fetchFromGitHub {
@@ -19,7 +19,7 @@ python.pkgs.buildPythonApplication rec {
     sed -ie '/argparse/d' setup.py
   '';
 
-  propagatedBuildInputs = with python.pkgs; [
+  propagatedBuildInputs = with python2.pkgs; [
     cached-property
     ConfigArgParse
     pyparsing

--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -7,10 +7,10 @@
 #   3) used by `google-cloud-sdk` only on GCE guests
 #
 
-{ stdenv, lib, fetchurl, makeWrapper, python, openssl, with-gce ? false }:
+{ stdenv, lib, fetchurl, makeWrapper, python2, openssl, with-gce ? false }:
 
 let
-  pythonEnv = python.withPackages (p: with p; [
+  pythonEnv = python2.withPackages (p: with p; [
     cffi
     cryptography
     pyopenssl
@@ -36,7 +36,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl (sources "${pname}-${version}" stdenv.hostPlatform.system);
 
-  buildInputs = [ python makeWrapper ];
+  buildInputs = [ python2 makeWrapper ];
 
   patches = [
     ./gcloud-path.patch
@@ -56,7 +56,7 @@ in stdenv.mkDerivation rec {
         binaryPath="$out/bin/$program"
         wrapProgram "$programPath" \
             --set CLOUDSDK_PYTHON "${pythonEnv}/bin/python" \
-            --prefix PYTHONPATH : "${pythonEnv}/${python.sitePackages}" \
+            --prefix PYTHONPATH : "${pythonEnv}/${python2.sitePackages}" \
             --prefix PATH : "${openssl.bin}/bin"
 
         mkdir -p $out/bin

--- a/pkgs/tools/compression/dtrx/default.nix
+++ b/pkgs/tools/compression/dtrx/default.nix
@@ -1,4 +1,4 @@
-{stdenv, lib, fetchurl, pythonPackages
+{stdenv, lib, fetchurl, python2Packages
 , gnutar, unzip, lhasa, rpm, binutils, cpio, gzip, p7zip, cabextract, unrar, unshield
 , bzip2, xz, lzip
 # unzip is handled by p7zip
@@ -11,7 +11,7 @@ let
   ++ lib.optional (unrarSupport) unrar
   ++ [ bzip2 xz lzip ]);
 
-in pythonPackages.buildPythonApplication rec {
+in python2Packages.buildPythonApplication rec {
   pname = "dtrx";
   version = "7.1";
 

--- a/pkgs/tools/filesystems/bees/default.nix
+++ b/pkgs/tools/filesystems/bees/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand, fetchFromGitHub, bash, btrfs-progs, coreutils, pythonPackages, utillinux }:
+{ stdenv, runCommand, fetchFromGitHub, bash, btrfs-progs, coreutils, python2Packages, utillinux }:
 
 let
 
@@ -22,7 +22,7 @@ let
     ];
 
     nativeBuildInputs = [
-      pythonPackages.markdown   # documentation build
+      python2Packages.markdown   # documentation build
     ];
 
     preBuild = ''

--- a/pkgs/tools/filesystems/cryfs/default.nix
+++ b/pkgs/tools/filesystems/cryfs/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchpatch
-, cmake, pkgconfig, python, gtest
+, cmake, pkgconfig, python2, gtest
 , boost, cryptopp, curl, fuse, openssl
 }:
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       --replace "(4.5L*1024*1024*1024)" "(0.5L*1024*1024*1024)"
   '';
 
-  nativeBuildInputs = [ cmake gtest pkgconfig python ];
+  nativeBuildInputs = [ cmake gtest pkgconfig python2 ];
 
   buildInputs = [ boost cryptopp curl fuse openssl ];
 

--- a/pkgs/tools/graphics/appleseed/default.nix
+++ b/pkgs/tools/graphics/appleseed/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, boost165, pkgconfig, guile,
-eigen, libpng, python, libGLU, qt4, openexr, openimageio,
+eigen, libpng, python2, libGLU, qt4, openexr, openimageio,
 opencolorio, xercesc, ilmbase, osl, seexpr, makeWrapper
 }:
 
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1sq9s0rzjksdn8ayp1g17gdqhp7fqks8v1ddd3i5rsl96b04fqx5";
   };
   buildInputs = [
-    cmake pkgconfig boost_static guile eigen libpng python
+    cmake pkgconfig boost_static guile eigen libpng python2
     libGLU qt4 openexr openimageio opencolorio xercesc
     osl seexpr makeWrapper
   ];
@@ -59,7 +59,7 @@ in stdenv.mkDerivation rec {
   # Work around a bug in the CMake build:
   postInstall = ''
     chmod a+x $out/bin/*
-    wrapProgram $out/bin/appleseed.studio --set PYTHONHOME ${python}
+    wrapProgram $out/bin/appleseed.studio --set PYTHONHOME ${python2}
   '';
 }
 

--- a/pkgs/tools/graphics/blockhash/default.nix
+++ b/pkgs/tools/graphics/blockhash/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python, pkgconfig, imagemagick, wafHook }:
+{ stdenv, fetchFromGitHub, python2, pkgconfig, imagemagick, wafHook }:
 
 stdenv.mkDerivation rec {
   pname = "blockhash";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0m7ikppl42iicgmwsb7baajmag7v0p1ab06xckifvrr0zm21bq9p";
   };
 
-  nativeBuildInputs = [ python pkgconfig wafHook ];
+  nativeBuildInputs = [ python2 pkgconfig wafHook ];
   buildInputs = [ imagemagick ];
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/autojump/default.nix
+++ b/pkgs/tools/misc/autojump/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python, bash }:
+{ stdenv, fetchFromGitHub, python2, bash }:
 
 stdenv.mkDerivation rec {
   pname = "autojump";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1rgpsh70manr2dydna9da4x7p8ahii7dgdgwir5fka340n1wrcws";
   };
 
-  buildInputs = [ python bash ];
+  buildInputs = [ python2 bash ];
   dontBuild = true;
 
   installPhase = ''

--- a/pkgs/tools/misc/disper/default.nix
+++ b/pkgs/tools/misc/disper/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python, xorg, makeWrapper }:
+{ stdenv, fetchFromGitHub, python2, xorg, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "disper";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ python ];
+  buildInputs = [ python2 ];
 
   preConfigure = ''
     export makeFlags="PREFIX=$out"

--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, flex, bison, python, autoconf, automake, gnulib, libtool
+{ stdenv, fetchgit, flex, bison, python2, autoconf, automake, gnulib, libtool
 , gettext, ncurses, libusb, freetype, qemu, lvm2, unifont, pkgconfig
 , fuse # only needed for grub-mount
 , zfs ? null
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     ./fix-bash-completion.patch
   ];
 
-  nativeBuildInputs = [ bison flex python pkgconfig autoconf automake ];
+  nativeBuildInputs = [ bison flex python2 pkgconfig autoconf automake ];
   buildInputs = [ ncurses libusb freetype gettext lvm2 fuse libtool ]
     ++ optional doCheck qemu
     ++ optional zfsSupport zfs;

--- a/pkgs/tools/networking/bud/default.nix
+++ b/pkgs/tools/networking/bud/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchgit, python, gyp, utillinux }:
+{ stdenv, lib, fetchgit, python2, gyp, utillinux }:
 
 stdenv.mkDerivation {
   pname = "bud";
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    python gyp
+    python2 gyp
   ] ++ lib.optional stdenv.isLinux utillinux;
 
   buildPhase = ''

--- a/pkgs/tools/networking/carddav-util/default.nix
+++ b/pkgs/tools/networking/carddav-util/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, python, pythonPackages, makeWrapper }:
+{ stdenv, fetchgit, python2, python2Packages, makeWrapper }:
 
 stdenv.mkDerivation {
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   buildInputs = [makeWrapper];
 
-  propagatedBuildInputs = with pythonPackages; [ requests vobject lxml ];
+  propagatedBuildInputs = with python2Packages; [ requests vobject lxml ];
 
   doCheck = false; # no test
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     cp $src/carddav-util.py $out/bin
 
-    pythondir="$out/lib/${python.libPrefix}/site-packages"
+    pythondir="$out/lib/${python2.libPrefix}/site-packages"
     mkdir -p "$pythondir"
     cp $src/carddav.py "$pythondir"
   '';

--- a/pkgs/tools/networking/ccnet/default.nix
+++ b/pkgs/tools/networking/ccnet/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, which, autoreconfHook, pkgconfig, vala, python, libsearpc, libzdb, libuuid, libevent, sqlite, openssl}:
+{stdenv, fetchurl, which, autoreconfHook, pkgconfig, vala, python2, libsearpc, libzdb, libuuid, libevent, sqlite, openssl}:
 
 stdenv.mkDerivation rec {
   version = "6.1.8";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0qlpnrz30ldrqnvbj59d54qdghxpxc5lsq6kf3dw2b93jnzkcmmm";
   };
 
-  nativeBuildInputs = [ pkgconfig which autoreconfHook vala python ];
+  nativeBuildInputs = [ pkgconfig which autoreconfHook vala python2 ];
   propagatedBuildInputs = [ libsearpc libzdb libuuid libevent sqlite openssl ];
 
   configureFlags = [ "--enable-server" ];

--- a/pkgs/tools/networking/dd-agent/5.nix
+++ b/pkgs/tools/networking/dd-agent/5.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, python
+{ stdenv, fetchFromGitHub, python2
 , unzip, makeWrapper }:
 let
-  python' = python.override {
+  python2' = python2.override {
     packageOverrides = self: super: {
       docker = self.buildPythonPackage rec {
         name = "docker-${version}";
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     unzip
     makeWrapper
-  ] ++ (with python'.pkgs; [
+  ] ++ (with python2'.pkgs; [
     requests
     psycopg2
     psutil
@@ -66,7 +66,7 @@ in stdenv.mkDerivation rec {
     consul
     docker
   ]);
-  propagatedBuildInputs = with python'.pkgs; [ python tornado ];
+  propagatedBuildInputs = with python2'.pkgs; [ python2 tornado ];
 
   buildCommand = ''
     mkdir -p $out/bin
@@ -83,7 +83,7 @@ in stdenv.mkDerivation rec {
 
     cat > $out/bin/dd-jmxfetch <<EOF
     #!/usr/bin/env bash
-    exec ${python}/bin/python $out/agent/jmxfetch.py $@
+    exec ${python2}/bin/python $out/agent/jmxfetch.py $@
     EOF
     chmod a+x $out/bin/dd-jmxfetch
 

--- a/pkgs/tools/networking/gmvault/default.nix
+++ b/pkgs/tools/networking/gmvault/default.nix
@@ -1,6 +1,6 @@
-{ pkgs, fetchurl, pythonPackages }:
+{ pkgs, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   version = "1.9.1";
   pname = "gmvault";
 
@@ -12,7 +12,7 @@ pythonPackages.buildPythonApplication rec {
 
   doCheck = false;
 
-  propagatedBuildInputs = with pythonPackages; [ gdata IMAPClient Logbook chardet ];
+  propagatedBuildInputs = with python2Packages; [ gdata IMAPClient Logbook chardet ];
 
   startScript = ./gmvault.py;
 

--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, pythonPackages, nasm, libelf
+{ stdenv, lib, fetchFromGitHub, python2Packages, nasm, libelf
 , kernel ? null, withDriver ? false }:
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "chipsec-${version}";
   version = "1.4.1";
 

--- a/pkgs/tools/security/cipherscan/default.nix
+++ b/pkgs/tools/security/cipherscan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, openssl, makeWrapper, python, coreutils }:
+{ stdenv, lib, fetchFromGitHub, openssl, makeWrapper, python2, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "cipherscan";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ python ];
+  buildInputs = [ python2 ];
 
   buildPhase = ''
     substituteInPlace cipherscan --replace '$0' 'cipherscan'

--- a/pkgs/tools/security/gen-oath-safe/default.nix
+++ b/pkgs/tools/security/gen-oath-safe/default.nix
@@ -1,4 +1,4 @@
-{ coreutils, fetchFromGitHub, libcaca, makeWrapper, python, openssl, qrencode, stdenv, yubikey-manager }:
+{ coreutils, fetchFromGitHub, libcaca, makeWrapper, python2, openssl, qrencode, stdenv, yubikey-manager }:
 
 stdenv.mkDerivation rec {
   pname = "gen-oath-safe";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
         coreutils
         libcaca.bin
         openssl.bin
-        python
+        python2
         qrencode
         yubikey-manager
       ];

--- a/pkgs/tools/system/evemu/default.nix
+++ b/pkgs/tools/system/evemu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, autoreconfHook, pkgconfig, pythonPackages
+{ stdenv, fetchgit, autoreconfHook, pkgconfig, python2Packages
 , libevdev
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
 
-  buildInputs = [ pythonPackages.python pythonPackages.evdev libevdev ];
+  buildInputs = [ python2Packages.python2 python2Packages.evdev libevdev ];
 
   meta = with stdenv.lib; {
     description = "Records and replays device descriptions and events to emulate input devices through the kernel's input system";

--- a/pkgs/tools/system/fio/default.nix
+++ b/pkgs/tools/system/fio/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper
-, libaio, python, zlib
+, libaio, python2, zlib
 , withGnuplot ? false, gnuplot ? null }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "1s37w8bhg23ml1f89x0bkaifywlkgh31305vmip4xfvh3j3vjbym";
   };
 
-  buildInputs = [ python zlib ]
+  buildInputs = [ python2 zlib ]
     ++ stdenv.lib.optional (!stdenv.isDarwin) libaio;
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -4,7 +4,7 @@
 */
 { stdenv, lib, fetchurl, runCommand, writeText, buildEnv
 , callPackage, ghostscriptX, harfbuzz, poppler_min
-, makeWrapper, python, ruby, perl
+, makeWrapper, python2, ruby, perl
 , useFixedHashes ? true
 , recurseIntoAttrs
 }:
@@ -25,7 +25,7 @@ let
   # function for creating a working environment from a set of TL packages
   combine = import ./combine.nix {
     inherit bin combinePkgs buildEnv lib makeWrapper writeText
-      stdenv python ruby perl;
+      stdenv python2 ruby perl;
     ghostscript = ghostscriptX; # could be without X, probably, but we use X above
   };
 

--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -1,8 +1,8 @@
-{ lib, pythonPackages, fetchurl, cloud-utils }:
+{ lib, python2Packages, fetchurl, cloud-utils }:
 
 let version = "0.7.9";
 
-in pythonPackages.buildPythonApplication {
+in python2Packages.buildPythonApplication {
   pname = "cloud-init";
   inherit version;
   namePrefix = "";
@@ -29,10 +29,10 @@ in pythonPackages.buildPythonApplication {
     sed -i s/argparse// requirements.txt
     '';
 
-  propagatedBuildInputs = with pythonPackages; [ cheetah jinja2 prettytable
+  propagatedBuildInputs = with python2Packages; [ cheetah jinja2 prettytable
     oauthlib pyserial configobj pyyaml requests jsonpatch ];
 
-  checkInputs = with pythonPackages; [ contextlib2 httpretty mock unittest2 ];
+  checkInputs = with python2Packages; [ contextlib2 httpretty mock unittest2 ];
 
   doCheck = false;
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -340,6 +340,10 @@ mapAliases ({
   procps-ng = procps; # added 2018-06-08
   pygmentex = texlive.bin.pygmentex; # added 2019-12-15
   pyo3-pack = maturin;
+  python = python2;
+  pythonFull = python.override{x11Support=true;};
+  pythonPackages = python.pkgs;
+  pypyPackages = pypy.pkgs;
   pmenu = throw "pmenu has been removed from nixpkgs, as its maintainer is no longer interested in the package."; # added 2019-12-10
   pulseaudioLight = pulseaudio; # added 2018-04-25
   phonon-backend-gstreamer = throw "Please use libsForQt5.phonon-backend-gstreamer, as Qt4 support in this package has been removed."; # added 2019-11-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1084,7 +1084,7 @@ in
 
   azureus = callPackage ../tools/networking/p2p/azureus { };
 
-  backblaze-b2 = python.pkgs.callPackage ../development/tools/backblaze-b2 { };
+  backblaze-b2 = python2.pkgs.callPackage ../development/tools/backblaze-b2 { };
 
   bandwhich = callPackage ../tools/networking/bandwhich {
     inherit (darwin.apple_sdk.frameworks) Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9973,7 +9973,7 @@ in
 
   dolt = callPackage ../servers/sql/dolt { };
 
-  dot2tex = pythonPackages.dot2tex;
+  dot2tex = python2Packages.dot2tex;
 
   doxygen = callPackage ../development/tools/documentation/doxygen {
     qt4 = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3091,7 +3091,7 @@ in
   epsxe = callPackage ../misc/emulators/epsxe { };
 
   escrotum = callPackage ../tools/graphics/escrotum {
-    inherit (pythonPackages) buildPythonApplication pygtk numpy;
+    inherit (python2Packages) buildPythonApplication pygtk numpy;
   };
 
   etcher = callPackage ../tools/misc/etcher { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10059,7 +10059,7 @@ in
 
   jdepend = callPackage ../development/tools/analysis/jdepend { };
 
-  fedpkg = pythonPackages.callPackage ../development/tools/fedpkg { };
+  fedpkg = python2Packages.callPackage ../development/tools/fedpkg { };
 
   flex_2_5_35 = callPackage ../development/tools/parsing/flex/2.5.35.nix { };
   flex = callPackage ../development/tools/parsing/flex { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9272,7 +9272,6 @@ in
   # Python interpreters. All standard library modules are included except for tkinter, which is
   # available as `pythonPackages.tkinter` and can be used as any other Python package.
   # When switching these sets, please update docs at ../../doc/languages-frameworks/python.md
-  python = python2;
   python2 = python27;
   python3 = python37;
   pypy = pypy2;
@@ -9281,7 +9280,6 @@ in
 
   # Python interpreter that is build with all modules, including tkinter.
   # These are for compatibility and should not be used inside Nixpkgs.
-  pythonFull = python.override{x11Support=true;};
   python2Full = python2.override{x11Support=true;};
   python27Full = python27.override{x11Support=true;};
   python3Full = python3.override{x11Support=true;};
@@ -9292,7 +9290,7 @@ in
   python39Full = python38.override{x11Support=true;};
 
   # pythonPackages further below, but assigned here because they need to be in sync
-  pythonPackages = python.pkgs;
+
   python2Packages = python2.pkgs;
   python3Packages = python3.pkgs;
 
@@ -9306,7 +9304,6 @@ in
   python37Packages = recurseIntoAttrs python37.pkgs;
   python38Packages = recurseIntoAttrs python38.pkgs;
   python39Packages = python39.pkgs;
-  pypyPackages = pypy.pkgs;
   pypy2Packages = pypy2.pkgs;
   pypy27Packages = pypy27.pkgs;
   pypy3Packages = pypy3.pkgs;

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -53,7 +53,7 @@ let
               jobs.openssl.x86_64-darwin
               jobs.pandoc.x86_64-darwin
               jobs.postgresql.x86_64-darwin
-              jobs.python.x86_64-darwin
+              jobs.python2.x86_64-darwin
               jobs.python3.x86_64-darwin
               jobs.ruby.x86_64-darwin
               jobs.rustc.x86_64-darwin
@@ -96,7 +96,7 @@ let
               jobs.stdenv.x86_64-linux
               jobs.linux.x86_64-linux
               jobs.pandoc.x86_64-linux
-              jobs.python.x86_64-linux
+              jobs.python2.x86_64-linux
               jobs.python3.x86_64-linux
               # Needed by contributors to test PRs (by inclusion of the PR template)
               jobs.nixpkgs-review.x86_64-linux
@@ -134,7 +134,7 @@ let
             ++ lib.collect lib.isDerivation jobs.stdenvBootstrapTools
             ++ lib.optionals supportDarwin [
               jobs.stdenv.x86_64-darwin
-              jobs.python.x86_64-darwin
+              jobs.python2.x86_64-darwin
               jobs.python3.x86_64-darwin
               jobs.nixpkgs-review.x86_64-darwin
               jobs.nix-info.x86_64-darwin


### PR DESCRIPTION
###### Motivation for this change

Require in-nixpkgs packages to use versioned names.

:snake: :2nd_place_medal: :chart_with_downwards_trend: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
