### PR TITLE
pkgsStatic: make OpenSSL 1.1 compile

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -72,7 +72,11 @@ let
       "-DHAVE_CRYPTODEV"
       "-DUSE_CRYPTODEV_DIGESTS"
     ] ++ stdenv.lib.optional enableSSL2 "enable-ssl2"
-      ++ stdenv.lib.optional (versionAtLeast version "1.1.0" && stdenv.hostPlatform.isAarch64) "no-afalgeng";
+      ++ stdenv.lib.optional (versionAtLeast version "1.1.0" && stdenv.hostPlatform.isAarch64) "no-afalgeng"
+      # OpenSSL needs a specific `no-shared` configure flag.
+      # See https://wiki.openssl.org/index.php/Compilation_and_Installation#Configure_Options
+      # for a comprehensive list of configuration options.
+      ++ stdenv.lib.optional (versionAtLeast version "1.1.0" && static) "no-shared";
 
     makeFlags = [
       "MANDIR=$(man)/share/man"

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -161,14 +161,11 @@ in {
   };
   mkl = super.mkl.override { enableStatic = true; };
   nix = super.nix.override { withAWS = false; };
-  # openssl 1.1 doesn't compile
-  openssl = super.openssl_1_0_2.override {
-    static = true;
-
-    # Don’t use new stdenv for openssl because it doesn’t like the
-    # --disable-shared flag
-    stdenv = super.stdenv;
-  };
+  openssl = (super.openssl_1_1.override { static = true; }).overrideAttrs (o: {
+    configureFlags = (removeUnknownConfigureFlags o.configureFlags) ++ [
+      "no-shared"
+    ];
+  });
   arrow-cpp = super.arrow-cpp.override {
     enableShared = false;
     python = { pkgs = { python = null; numpy = null; }; };

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -163,12 +163,7 @@ in {
   nix = super.nix.override { withAWS = false; };
   openssl = (super.openssl_1_1.override { static = true; }).overrideAttrs (o: {
     # OpenSSL doesn't like the `--enable-static` / `--disable-shared` flags.
-    # Instead, there's a specific `no-shared` configure flag.
-    # See https://wiki.openssl.org/index.php/Compilation_and_Installation#Configure_Options
-    # for a comprehensive list.
-    configureFlags = (removeUnknownConfigureFlags o.configureFlags) ++ [
-      "no-shared"
-    ];
+    configureFlags = (removeUnknownConfigureFlags o.configureFlags);
   });
   arrow-cpp = super.arrow-cpp.override {
     enableShared = false;

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -162,6 +162,10 @@ in {
   mkl = super.mkl.override { enableStatic = true; };
   nix = super.nix.override { withAWS = false; };
   openssl = (super.openssl_1_1.override { static = true; }).overrideAttrs (o: {
+    # OpenSSL doesn't like the `--enable-static` / `--disable-shared` flags.
+    # Instead, there's a specific `no-shared` configure flag.
+    # See https://wiki.openssl.org/index.php/Compilation_and_Installation#Configure_Options
+    # for a comprehensive list.
     configureFlags = (removeUnknownConfigureFlags o.configureFlags) ++ [
       "no-shared"
     ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I've been using this in my own overlays and it's working well for me. Opening a PR to get feedback and to have it built by CI in case I'm overlooking something.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
