### PR TITLE
ocamlPackages.uchar: don't depend on opaline at runtime

### DIFF
--- a/pkgs/development/ocaml-modules/uchar/default.nix
+++ b/pkgs/development/ocaml-modules/uchar/default.nix
@@ -8,10 +8,10 @@ stdenv.mkDerivation {
     sha256 = "1w2saw7zanf9m9ffvz2lvcxvlm118pws2x1wym526xmydhqpyfa7";
   };
 
-  nativeBuildInputs = [ ocaml ocamlbuild findlib opaline ];
-  buildInputs = [ findlib ocaml ocamlbuild opaline ];
+  nativeBuildInputs = [ ocaml ocamlbuild findlib ];
+  buildInputs = [ findlib ocaml ocamlbuild ];
   buildPhase = "ocaml pkg/build.ml native=true native-dynlink=${if withShared then "true" else "false"}";
-  installPhase = "opaline -libdir $OCAMLFIND_DESTDIR";
+  installPhase = "${opaline}/bin/opaline -libdir $OCAMLFIND_DESTDIR";
   configurePlatforms = [];
 
   meta = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Took me a long time to track down why I was having to build 2 OCaml compilers (one for host, one for target) in my project when cross-compiling to musl64 static.

`opaline` is only needed during the install phase so it shouldn't end up in either build inputs. These additions are in line with how `buildDunePackage` installs its packages too:

https://github.com/NixOS/nixpkgs/blob/353ea7f3ebd34a989c30cfa714644b86f1fd50ef/pkgs/build-support/ocaml/dune.nix#L24

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc: @vbgl @Zimmi48