### PR TITLE
hakuneko: 1.4.2 -> 5.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5070,6 +5070,12 @@
     githubId = 7588406;
     name = "Andrew R. M.";
   };
+  nloomans = {
+    email = "noah@nixos.noahloomans.com";
+    github = "nloomans";
+    githubId = 7829481;
+    name = "Noah Loomans";
+  };
   nmattia = {
     email = "nicolas@nmattia.com";
     github = "nmattia";

--- a/pkgs/tools/misc/hakuneko/default.nix
+++ b/pkgs/tools/misc/hakuneko/default.nix
@@ -1,28 +1,84 @@
-{ stdenv, fetchurl, wxGTK30, openssl, curl }:
-
+{ atomEnv
+, autoPatchelfHook
+, dpkg
+, fetchurl
+, makeDesktopItem
+, makeWrapper
+, udev
+, stdenv
+, wrapGAppsHook
+}:
+let
+  desktopItem = makeDesktopItem {
+    desktopName = "HakuNeko Desktop";
+    genericName = "Manga & Anime Downloader";
+    categories = "Network;FileTransfer;";
+    exec = "hakuneko";
+    icon = "hakuneko-desktop";
+    name = "hakuneko-desktop";
+    type = "Application";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "hakuneko";
-  version = "1.4.2";
+  version = "5.0.8";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/hakuneko/hakuneko_${version}_src.tar.gz";
-    sha256 = "76a63fa05e91b082cb5a70a8abacef005354e99978ff8b1369f7aa0af7615d52";
-  };
+  src = {
+    "x86_64-linux" = fetchurl {
+      url = "https://github.com/manga-download/hakuneko/releases/download/v${version}/hakuneko-desktop_${version}_linux_amd64.deb";
+      sha256 = "924df1d7a0ab54b918529165317e4428b423c9045548d1e36bd634914f7957f0";
+    };
+    "i686-linux" = fetchurl {
+      url = "https://github.com/manga-download/hakuneko/releases/download/v${version}/hakuneko-desktop_${version}_linux_i386.deb";
+      sha256 = "988d8b0e8447dcd0a8d85927f5877bca9efb8e4b09ed3c80a6788390e54a48d2";
+    };
+  }."${stdenv.hostPlatform.system}";
 
-  preConfigure = ''
-    substituteInPlace ./configure \
-       --replace /bin/bash $shell
-    '';
+  dontBuild = true;
+  dontConfigure = true;
+  dontPatchELF = true;
+  dontWrapGApps = true;
 
-  buildInputs = [ wxGTK30 openssl curl ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeWrapper
+    wrapGAppsHook
+  ];
 
-  meta = {
-    description = "Manga downloader";
-    homepage = https://sourceforge.net/projects/hakuneko/;
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.linux;
+  buildInputs = atomEnv.packages;
 
-    # This project was abandoned upstream.
-    broken = true;
+  unpackPhase = ''
+    # The deb file contains a setuid binary, so 'dpkg -x' doesn't work here
+    dpkg --fsys-tarfile $src | tar --extract
+  '';
+
+  installPhase = ''
+    cp -R usr "$out"
+    # Overwrite existing .desktop file.
+    cp "${desktopItem}/share/applications/hakuneko-desktop.desktop" \
+       "$out/share/applications/hakuneko-desktop.desktop"
+  '';
+
+  runtimeDependencies = [
+    udev.lib
+  ];
+
+  postFixup = ''
+    makeWrapper $out/lib/hakuneko-desktop/hakuneko $out/bin/hakuneko \
+      "''${gappsWrapperArgs[@]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Manga & Anime Downloader";
+    homepage = "https://sourceforge.net/projects/hakuneko/";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [
+      nloomans
+    ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

HakuNeko switched to electron. Since this is the latest release the broken status can be dropped. The original maintainer (@RubenAstudillo) dropped support for the package so I decided to pick it up.

I based this on the simplenote package, and implemented the setuid fix from the slack package.

This is my first contribution to nixpkgs! So all nitpicks are welcome!


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
