### PR TITLE
obs-wlrobs: 20191008 -> 20200111

### DIFF
--- a/pkgs/applications/video/obs-studio/wlrobs.nix
+++ b/pkgs/applications/video/obs-studio/wlrobs.nix
@@ -5,27 +5,32 @@
 # nix-env -f . -iA obs-wlrobs
 # mkdir -p ~/.config/obs-studio/plugins/wlrobs/bin/64bit
 # ln -s ~/.nix-profile/share/obs/obs-plugins/wlrobs/bin/64bit/libwlrobs.so ~/.config/obs-studio/plugins/wlrobs/bin/64bit
-{ stdenv, fetchhg, wayland, obs-studio }:
+{ stdenv, fetchhg, wayland, obs-studio
+, meson, ninja, pkgconfig, libX11
+, dmabufSupport ? false, libdrm ? null, libGL ? null}:
+
+assert dmabufSupport -> libdrm != null && libGL != null;
+
 stdenv.mkDerivation {
   pname = "obs-wlrobs";
-  version = "20191008";
+  version = "20200111";
 
   src = fetchhg {
     url = "https://hg.sr.ht/~scoopta/wlrobs";
-    rev = "82e2b93c6f662dfd9d69f7826c0096bef585c3ae";
-    sha256 = "1d2mlybkwyr0jw6paamazla2a1cyj60bs10i0lk9jclxnp780fy6";
+    rev = "8345bf985e390896d89e35e2feae1fa37722f4be";
+    sha256 = "0j01wkhwhhla4qx8mwyrq2qj9cfhxksxaq2k8rskmy2qbdkvvdpb";
   };
 
-  buildInputs = [ wayland obs-studio ];
-
-  preBuild = ''
-    cd Release
-  '';
+  buildInputs = [ libX11 libGL libdrm meson ninja pkgconfig wayland obs-studio ];
 
   installPhase = ''
     mkdir -p $out/share/obs/obs-plugins/wlrobs/bin/64bit
     cp ./libwlrobs.so $out/share/obs/obs-plugins/wlrobs/bin/64bit/
   '';
+
+  mesonFlags = [
+    "-Duse_dmabuf=${if dmabufSupport then "true" else "false"}"
+  ];
 
   meta = with stdenv.lib; {
     description = "An obs-studio plugin that allows you to screen capture on wlroots based wayland compositors";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @grahamc 