### PR TITLE
nixos/usbmuxd: Fix users.groups assignment

### DIFF
--- a/nixos/modules/services/hardware/usbmuxd.nix
+++ b/nixos/modules/services/hardware/usbmuxd.nix
@@ -51,7 +51,7 @@ in
       };
     };
 
-    users.groups = optional (cfg.group == defaultUserGroup) {
+    users.groups = optionalAttrs (cfg.group == defaultUserGroup) {
       ${cfg.group} = { };
     };
 


### PR DESCRIPTION

###### Motivation for this change
A mistake was introduced in https://github.com/NixOS/nixpkgs/pull/63103

Ping @rnhmjoj 

###### Things done

- [x] Tested evaluation of a nixos configuration with usbmuxd enabled, now succeeds again