### PR TITLE
cpp-netlib: remove insecure openssl dependency and unnecessary asio

### DIFF
--- a/pkgs/development/libraries/cpp-netlib/default.nix
+++ b/pkgs/development/libraries/cpp-netlib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, boost, openssl, asio }:
+{ stdenv, fetchFromGitHub, cmake, boost, openssl }:
 
 stdenv.mkDerivation rec {
   pname = "cpp-netlib";
@@ -14,18 +14,22 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ cmake boost openssl ];
 
-  # This can be removed when updating to 0.13, see https://github.com/cpp-netlib/cpp-netlib/issues/629
-  propagatedBuildInputs = [ asio ];
-
   cmakeFlags = [
     "-DCPP-NETLIB_BUILD_SHARED_LIBS=ON"
   ];
 
   enableParallelBuilding = true;
 
+  # The test driver binary lacks an RPath to the library's libs
+  preCheck = ''
+    export LD_LIBRARY_PATH=$PWD/libs/network/src
+  '';
+
+  # Most tests make network GET requests to various websites
+  doCheck = false;
+
   meta = with stdenv.lib; {
-    description =
-      "Collection of open-source libraries for high level network programming";
+    description = "Collection of open-source libraries for high level network programming";
     homepage    = https://cpp-netlib.org;
     license     = licenses.boost;
     platforms   = platforms.all;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11065,9 +11065,8 @@ in
 
   cpp-ipfs-api = callPackage ../development/libraries/cpp-ipfs-api { };
 
-  cpp-netlib = callPackage ../development/libraries/cpp-netlib {
-    openssl = openssl_1_0_2;
-  };
+  cpp-netlib = callPackage ../development/libraries/cpp-netlib {};
+
   uri = callPackage ../development/libraries/uri { };
 
   cppcms = callPackage ../development/libraries/cppcms { };


### PR DESCRIPTION
Upstream openssl has dropped support for 1.0.2; see #77503 for details. This
also cleans up the old `asio` dependency, which now comes from `boost`, and
documents why the test driver fails.

CC @vcunat


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).