### PR TITLE
gitstatus: patch fewer characters

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ (callPackage ./romkatv_libgit2.nix {}) ];
   patchPhase = ''
-    sed -i "s|local daemon=\S*|local daemon=$out/bin/gitstatusd|" gitstatus.plugin.zsh
+    sed -i "1i GITSTATUS_DAEMON=$out/bin/gitstatusd" gitstatus.plugin.zsh
   '';
   installPhase = ''
     install -Dm755 gitstatusd $out/bin/gitstatusd

--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ (callPackage ./romkatv_libgit2.nix {}) ];
   patchPhase = ''
-    sed -i "s|local daemon=.*|local daemon=$out/bin/gitstatusd|" gitstatus.plugin.zsh
+    sed -i "s|local daemon=\S*|local daemon=$out/bin/gitstatusd|" gitstatus.plugin.zsh
   '';
   installPhase = ''
     install -Dm755 gitstatusd $out/bin/gitstatusd


### PR DESCRIPTION
This is a followup to https://github.com/NixOS/nixpkgs/pull/76744.

The patch is still too aggressive because it captures additional local
variables declared in the same line. It should stop when it hits
whitespace.

Even better, patching in the `GITSTATUS_DAEMON` variable seems like a more stable
solution than doing inline replacements.

See https://github.com/romkatv/gitstatus/pull/92.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@mmlb 