### PR TITLE
libvirtd: fix path to ebtables

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -102,6 +102,7 @@ in stdenv.mkDerivation rec {
   ] ++ optionals stdenv.isLinux [
     "QEMU_BRIDGE_HELPER=/run/wrappers/bin/qemu-bridge-helper"
     "QEMU_PR_HELPER=/run/libvirt/nix-helpers/qemu-pr-helper"
+    "EBTABLES_PATH=${ebtables}/bin/ebtables-legacy"
     "--with-attr"
     "--with-apparmor"
     "--with-secdriver-apparmor"


### PR DESCRIPTION
###### Motivation for this change

With the bump of iptables (#75026) ebtables was renamed from `ebtables`
to `ebtables-legacy`. libvirtd requires this binary to be availabe to
configure the host networking.

fixes #75878

cc people involved in the bump/the issue: @dtzwill @TimKlampe @izuk @rembo10 @andersk @kamidon  @d4g @costrouc 

###### Things done


- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
