### PR TITLE
font-manager: 0.7.5 -> 0.7.7

### DIFF
--- a/pkgs/applications/misc/font-manager/default.nix
+++ b/pkgs/applications/misc/font-manager/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "font-manager";
-  version = "0.7.5";
+  version = "0.7.7";
 
   src = fetchFromGitHub {
     owner = "FontManager";
     repo = "master";
     rev = version;
-    sha256 = "16hma8rrkam6ngn5vbdaryn31vdixvii6920g9z928gylz9xkd3g";
+    sha256 = "1bzqvspplp1zj0n0869jqbc60wgbjhf0vdrn5bj8dfawxynh8s5f";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/font-manager/default.nix
+++ b/pkgs/applications/misc/font-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, meson, ninja, gettext, python3, fetchpatch,
+{ stdenv, fetchFromGitHub, meson, ninja, gettext, python3,
   pkgconfig, libxml2, json-glib , sqlite, itstool, librsvg, yelp-tools,
   vala, gtk3, gnome3, desktop-file-utils, wrapGAppsHook, gobject-introspection
 }:
@@ -36,19 +36,6 @@ stdenv.mkDerivation rec {
     librsvg
     gtk3
     gnome3.adwaita-icon-theme
-  ];
-
-  mesonFlags = [
-    "-Ddisable_pycompile=true"
-  ];
-
-  patches = [
-    # fix build with Vala 0.46
-    (fetchpatch {
-      url = "https://github.com/FontManager/font-manager/commit/c73b40de11f376f4515a0edfe97fb3721a264b35.patch";
-      sha256 = "0lacwsifgvda2r3z6j2a0svdqr6mgav7zkvih35xa8155y8wfpnw";
-      excludes = [ "fedora/font-manager.spec" ];
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

https://github.com/FontManager/font-manager/releases/tag/0.7.6 
https://github.com/FontManager/font-manager/releases/tag/0.7.7

Touchups:
* drop included patch
* drop meson flag, no longer recognized/needed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).