### PR TITLE
boomerang: 0.5.1 -> 0.5.2

### DIFF
--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "boomerang";
-  version = "0.5.1";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "BoomerangDecompiler";
     repo = pname;
     rev = "v${version}";
-    sha256 = "046ba4km8c31kbnllx05nbqhjmk7bpi56d3n8md8bsr98nj21a2j";
+    sha256 = "0xncdp0z8ry4lkzmvbj5d7hlzikivghpwicgywlv47spgh8ny0ix";
   };
 
   nativeBuildInputs = [ cmake bison flex ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/BoomerangDecompiler/boomerang/releases/tag/v0.5.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).