### PR TITLE
gobetween: init at 0.7.0

### DIFF
--- a/pkgs/servers/gobetween/default.nix
+++ b/pkgs/servers/gobetween/default.nix
@@ -1,0 +1,34 @@
+{ buildGoModule, fetchFromGitHub, lib, enableStatic ? false }:
+
+buildGoModule rec {
+  pname = "gobetween";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "yyyar";
+    repo = "gobetween";
+    rev = version;
+    sha256 = "f01593509ccece063acd47002c4fc52261fbbbcdbf14b088d813b7d8e38fcca8";
+  };
+
+  modSha256 =
+    "dd91838d20c99c73447590e43edd13c87755276f17ef3e53f24c5df3d0908f78";
+
+  buildPhase = ''
+    make build${lib.optionalString enableStatic "-static"}
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/gobetween $out/bin
+    cp -r share $out/share
+    cp -r config $out/share
+  '';
+
+  meta = with lib; {
+    description = "Modern & minimalistic load balancer for the Сloud era";
+    homepage = "http://gobetween.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tomberek ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15196,6 +15196,10 @@ in
 
   grafana_reporter = callPackage ../servers/monitoring/grafana-reporter { };
 
+  gobetween = callPackage ../servers/gobetween {
+    buildGoModule = buildGo112Module;
+  };
+
   h2o = callPackage ../servers/http/h2o { };
 
   haka = callPackage ../tools/security/haka { };


### PR DESCRIPTION
###### Motivation for this change
Include a dynamic proxy into nixpkgs.

###### Things done
Build with buildGo112Module due to errors with go 1.13 (upstream is aware, issues filed).

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
