### PR TITLE
emacs: 2 minor hotfixes

### DIFF
--- a/pkgs/applications/editors/emacs-modes/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-generated.nix
@@ -3236,10 +3236,10 @@
       elpaBuild {
         pname = "undo-tree";
         ename = "undo-tree";
-        version = "0.7";
+        version = "0.7.2";
         src = fetchurl {
-          url = "https://elpa.gnu.org/packages/undo-tree-0.7.el";
-          sha256 = "0mc5spiqx20z8vh8b24dp9hqj27h5bm5wqk0ga7c6s6mp69r72h4";
+          url = "https://elpa.gnu.org/packages/undo-tree-0.7.2.el";
+          sha256 = "0gdqh5rkgwlancbjx5whgl5gqkdipdkspkl2bqmrq70sgg5ahrcc";
         };
         packageRequires = [];
         meta = {

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -111,6 +111,11 @@ env NIXPKGS_ALLOW_BROKEN=1 nix-instantiate --show-trace ../../../../ -A emacsPac
 
         flycheck-rtags = fix-rtags super.flycheck-rtags;
 
+        gnuplot = super.gnuplot.overrideAttrs (old: {
+          nativeBuildInputs =
+            (old.nativeBuildInputs or []) ++ [ pkgs.autoreconfHook ];
+        });
+
         pdf-tools = super.pdf-tools.overrideAttrs(old: {
           nativeBuildInputs = [ external.pkgconfig ];
           buildInputs = with external; old.buildInputs ++ [ autoconf automake libpng zlib poppler ];


### PR DESCRIPTION
###### Motivation for this change

Without this `evil` and `gnuplot` are broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
