### PR TITLE
python3.pkgs.publicsuffix: fix build

### DIFF
--- a/pkgs/development/python-modules/publicsuffix/default.nix
+++ b/pkgs/development/python-modules/publicsuffix/default.nix
@@ -10,11 +10,8 @@ buildPythonPackage rec {
   };
 
 
-  # fix the ASCII-mode LICENSE file read
   # disable test_fetch and the doctests (which also invoke fetch)
-  patchPhase = stdenv.lib.optionalString isPy3k ''
-    sed -i "s/)\.read(/,encoding='utf-8'\0/" setup.py
-  '' + ''
+  patchPhase = ''
     sed -i -e "/def test_fetch/i\\
     \\t@unittest.skip('requires internet')" -e "/def additional_tests():/,+1d" tests.py
   '';

--- a/pkgs/development/python-modules/publicsuffix/default.nix
+++ b/pkgs/development/python-modules/publicsuffix/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
 
   # disable test_fetch and the doctests (which also invoke fetch)
-  patchPhase = ''
+  postPatch = ''
     sed -i -e "/def test_fetch/i\\
     \\t@unittest.skip('requires internet')" -e "/def additional_tests():/,+1d" tests.py
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This patch has not been necessary since
5425867bfa3e4ba83a3d67aa50b811b5f70d6fe5, and has in fact broken the
build since then.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
