### PR TITLE
calibre: 3.48 -> 4.8

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -1,7 +1,27 @@
-{ lib, mkDerivation, fetchurl, poppler_utils, pkgconfig, libpng
-, imagemagick, libjpeg, fontconfig, podofo, qtbase, qmake, icu, sqlite
-, unrarSupport ? false, chmlib, python2Packages, libusb1, libmtp
-, xdg_utils, makeDesktopItem, removeReferencesTo
+{ lib
+, mkDerivation
+, fetchurl
+, poppler_utils
+, pkgconfig
+, libpng
+, imagemagick
+, libjpeg
+, fontconfig
+, podofo
+, qtbase
+, qmake
+, icu
+, sqlite
+, hunspell
+, hyphen
+, unrarSupport ? false
+, chmlib
+, python2Packages
+, libusb1
+, libmtp
+, xdg_utils
+, makeDesktopItem
+, removeReferencesTo
 }:
 
 let
@@ -10,11 +30,11 @@ let
 in
 mkDerivation rec {
   pname = "calibre";
-  version = "3.48.0";
+  version = "4.8.0";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${pname}-${version}.tar.xz";
-    sha256 = "034m89h7j2088p324i1kya33dfldmqyynjxk3w98xiqkz7q2hi82";
+    sha256 = "1lk44qh3hzqhpz2b00iik7cgjg4xm36qjh2pxflkjnbk691gbpqk";
   };
 
   patches = [
@@ -44,17 +64,49 @@ mkDerivation rec {
   CALIBRE_PY3_PORT = builtins.toString pypkgs.isPy3k;
 
   buildInputs = [
-    poppler_utils libpng imagemagick libjpeg
-    fontconfig podofo qtbase chmlib icu sqlite libusb1 libmtp xdg_utils
-  ] ++ (with pypkgs; [
-    apsw cssselect css-parser dateutil dnspython feedparser html5-parser lxml markdown netifaces pillow
-    python pyqt5_with_qtwebkit sip
-    regex msgpack beautifulsoup4 html2text
-    # the following are distributed with calibre, but we use upstream instead
-    odfpy
-  ]) ++ lib.optionals (!pypkgs.isPy3k) (with pypkgs; [
-    mechanize
-  ]);
+    poppler_utils
+    libpng
+    imagemagick
+    libjpeg
+    fontconfig
+    podofo
+    qtbase
+    chmlib
+    icu
+    hunspell
+    hyphen
+    sqlite
+    libusb1
+    libmtp
+    xdg_utils
+  ] ++ (
+    with pypkgs; [
+      apsw
+      cssselect
+      css-parser
+      dateutil
+      dnspython
+      feedparser
+      html5-parser
+      lxml
+      markdown
+      netifaces
+      pillow
+      python
+      pyqt5_with_qtwebkit
+      sip
+      regex
+      msgpack
+      beautifulsoup4
+      html2text
+      # the following are distributed with calibre, but we use upstream instead
+      odfpy
+    ]
+  ) ++ lib.optionals (!pypkgs.isPy3k) (
+    with pypkgs; [
+      mechanize
+    ]
+  );
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
