### PR TITLE
[release-19.09] cawbird: 1.0.2 -> 1.0.4

### DIFF
--- a/pkgs/applications/networking/cawbird/default.nix
+++ b/pkgs/applications/networking/cawbird/default.nix
@@ -3,14 +3,14 @@
 , glib-networking, python3 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.2";
+  version = "1.0.4";
   pname = "cawbird";
 
   src = fetchFromGitHub {
     owner = "IBBoard";
     repo = "cawbird";
     rev = "v${version}";
-    sha256 = "sha256:0b79ngwilicqkgacva93cir4rmk15yzgsih56yb3a4n6bqjispay";
+    sha256 = "sha256:1gqi7bn08b9cjpb0mgs6bk1a2npdfhn56ckps95nck0jyqzfbnir";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

backport of #77583 
/cc @jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).