### PR TITLE
parallel-full: init SQL and CSV support

### DIFF
--- a/pkgs/tools/misc/parallel/default.nix
+++ b/pkgs/tools/misc/parallel/default.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gnu.org/software/parallel/";
     license = licenses.gpl3Plus;
     platforms = platforms.all;
-    maintainers = with maintainers; [ pSub vrthra ];
+    maintainers = with maintainers; [ pSub vrthra tomberek ];
   };
 }

--- a/pkgs/tools/misc/parallel/wrapper.nix
+++ b/pkgs/tools/misc/parallel/wrapper.nix
@@ -1,0 +1,13 @@
+{ parallel, makeWrapper , runCommand
+, perlPackages
+, extraPerlPackages ?
+    with perlPackages; [ DBI DBDPg DBDSQLite DBDCSV TextCSV ]
+}:
+
+runCommand "parallel-full" {
+  nativeBuildInputs = [ makeWrapper ];
+  } ''
+      mkdir -p $out/bin
+      makeWrapper ${parallel}/bin/parallel $out/bin/parallel \
+        --set PERL5LIB "${perlPackages.makeFullPerlPath extraPerlPackages}"
+  ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5730,6 +5730,8 @@ in
 
   parallel = callPackage ../tools/misc/parallel { };
 
+  parallel-full = callPackage ../tools/misc/parallel/wrapper.nix { };
+
   parastoo-fonts = callPackage ../data/fonts/parastoo-fonts { };
 
   parcellite = callPackage ../tools/misc/parcellite { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4998,6 +4998,16 @@ let
     };
   };
 
+  DBDCSV = buildPerlPackage {
+    pname = "DBD-CSV";
+    version = "0.54";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/H/HM/HMBRAND/DBD-CSV-0.54.tgz;
+      sha256 = "bc597cd7195e5a023e2b3413d8dc614602b9b3f279f436027881796464d4f0be";
+    };
+    propagatedBuildInputs = [ DBI TextCSV_XS SQLStatement ModuleRuntime ParamsUtil ];
+  };
+
   DBDMock = buildPerlModule {
     pname = "DBD-Mock";
     version = "1.55";
@@ -11137,6 +11147,15 @@ let
     };
   };
 
+  MathBaseConvert = buildPerlPackage {
+    pname = "Math-Base-Convert";
+    version = "0.11";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/M/MI/MIKER/Math-Base-Convert-0.11.tar.gz;
+      sha256 = "8c0971355f24c93b79e77ad54a4570090a1a598fcb9b86f5c17eba42f38b40e0";
+    };
+  };
+
   MathLibm = buildPerlPackage {
     pname = "Math-Libm";
     version = "1.00";
@@ -16618,6 +16637,17 @@ let
     };
     buildInputs = [ TestException ];
     propagatedBuildInputs = [ ClassAccessor ListMoreUtils RegexpCommon SQLTokenizer ];
+  };
+
+  SQLStatement = buildPerlPackage {
+    pname = "SQL-Statement";
+    version = "1.412";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/R/RE/REHSACK/SQL-Statement-1.412.tar.gz;
+      sha256 = "65c870883379c11b53f19ead10aaac241ccc86a90bbab77f6376fe750720e5c8";
+    };
+    buildInputs = [ TestDeep ];
+    propagatedBuildInputs = [ Clone ModuleRuntime ParamsUtil TextSoundex MathBaseConvert ];
   };
 
   SQLTokenizer = buildPerlPackage {


### PR DESCRIPTION
###### Motivation for this change
Allow using parallel's SQL features. `--sqlmaster` and `--sqlworker`

###### Things done
Created parallel-extra to prevent adding dependencies to existing users.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): increased by 14.7M to add SQL support (93.2M -> 107.9M)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
