### PR TITLE
glibc: fix cross with gcc9

### DIFF
--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -49,7 +49,9 @@ callPackage ./common.nix { inherit stdenv; } {
       ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "pie";
 
     NIX_CFLAGS_COMPILE = stdenv.lib.concatStringsSep " "
-      (if !stdenv.hostPlatform.isMusl
+      (stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform)
+        [ "-Wno-error=missing-attributes" "-Wno-error=array-bounds" ]
+      ++ (if !stdenv.hostPlatform.isMusl
         # TODO: This (returning a string or `null`, instead of a list) is to
         #       not trigger a mass rebuild due to the introduction of the
         #       musl-specific flags below.
@@ -62,7 +64,7 @@ callPackage ./common.nix { inherit stdenv; } {
             # Fix -Werror build failure when building glibc with musl with GCC >= 8, see:
             # https://github.com/NixOS/nixpkgs/pull/68244#issuecomment-544307798
             (stdenv.lib.optional stdenv.hostPlatform.isMusl "-Wno-error=attribute-alias")
-          ]));
+          ])));
 
     # When building glibc from bootstrap-tools, we need libgcc_s at RPATH for
     # any program we run, because the gcc will have been placed at a new


### PR DESCRIPTION
Added -Wno-error flags for new warnings in GCC 9.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
