### PR TITLE
ocaml-ng.ocamlPackages_4_10.ocaml: init at 4.10.0+beta1

### DIFF
--- a/pkgs/development/compilers/ocaml/4.10.nix
+++ b/pkgs/development/compilers/ocaml/4.10.nix
@@ -1,0 +1,6 @@
+import ./generic.nix {
+  major_version = "4";
+  minor_version = "10";
+  patch_version = "0+beta1";
+  sha256 = "18jrgww98v1famb2x5jhbsnm4ngph2rvq0z4cxpqxfn06yb53jyf";
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1230,6 +1230,8 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_4_09 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.09.nix { });
 
+  ocamlPackages_4_10 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.10.nix { });
+
   ocamlPackages_latest = ocamlPackages_4_09;
 
   ocamlPackages = ocamlPackages_4_07;


### PR DESCRIPTION
###### Motivation for this change

https://inbox.ocaml.org/caml-list/0609233a-ca50-c444-7347-1ab29fce15da@inria.fr/T/#u

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
