### PR TITLE
gildas: 20191201_a -> 20200101_a 

### DIFF
--- a/pkgs/applications/science/astronomy/gildas/imager-py3.patch
+++ b/pkgs/applications/science/astronomy/gildas/imager-py3.patch
@@ -1,0 +1,12 @@
+diff -ruN gildas-src-jan20a.orig/contrib/imager/pro/define.ima gildas-src-jan20a/contrib/imager/pro/define.ima
+--- gildas-src-jan20a.orig/contrib/imager/pro/define.ima	2020-01-01 02:15:16.000000000 +0100
++++ gildas-src-jan20a/contrib/imager/pro/define.ima	2020-01-14 11:18:46.000000000 +0100
+@@ -9,7 +9,7 @@
+ !
+ ! Patch for a Bug on Mac-OS/X where Python blocks if activated first
+ ! from a script launched by a widget.
+-python print "Starting Python" 
++python print("Starting Python")
+ !
+ ! INPUT, GO and UVT_CONVERT always defined by GreG
+ define command GO "@ p_go.ima" gag_pro:go_greg.hlp  


### PR DESCRIPTION
###### Motivation for this change

Update gildas to the latest upstream, and replace Python 2 by Python 3.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
