### PR TITLE
stdenv: make darwin builds reproducable

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -50,6 +50,9 @@ cmakeConfigurePhase() {
     # because we usually do not package the framework
     cmakeFlags="-DCMAKE_FIND_FRAMEWORK=last $cmakeFlags"
 
+    # on macOS i686 was only relevant for 10.5 or earlier.
+    cmakeFlags="-DCMAKE_OSX_ARCHITECTURES=x86_64 $cmakeFlags"
+
     # we never want to use the global macOS SDK
     cmakeFlags="-DCMAKE_OSX_SYSROOT= $cmakeFlags"
 

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -53,10 +53,6 @@ cmakeConfigurePhase() {
     # we never want to use the global macOS SDK
     cmakeFlags="-DCMAKE_OSX_SYSROOT= $cmakeFlags"
 
-    # disable OSX deployment target
-    # we don't want our binaries to have a "minimum" OSX version
-    cmakeFlags="-DCMAKE_OSX_DEPLOYMENT_TARGET= $cmakeFlags"
-
     # correctly detect our clang compiler
     cmakeFlags="-DCMAKE_POLICY_DEFAULT_CMP0025=NEW $cmakeFlags"
 

--- a/pkgs/development/tools/misc/ccls/default.nix
+++ b/pkgs/development/tools/misc/ccls/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DCCLS_VERSION=${version}"
-    "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12"
+    "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.macosVersionMin or ""}"
   ];
 
   preConfigure = ''

--- a/pkgs/development/tools/misc/ccls/default.nix
+++ b/pkgs/development/tools/misc/ccls/default.nix
@@ -15,10 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = with llvmPackages; [ clang-unwrapped llvm rapidjson ];
 
-  cmakeFlags = [
-    "-DCCLS_VERSION=${version}"
-    "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.macosVersionMin or ""}"
-  ];
+  cmakeFlags = [ "-DCCLS_VERSION=${version}" ];
 
   preConfigure = ''
     cmakeFlagsArray+=(-DCMAKE_CXX_FLAGS="-fvisibility=hidden -fno-rtti")

--- a/pkgs/development/tools/misc/cquery/default.nix
+++ b/pkgs/development/tools/misc/cquery/default.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DSYSTEM_CLANG=ON"
     "-DCLANG_CXX=ON"
-    "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.macosVersionMin or ""}"
   ];
 
   shell = runtimeShell;

--- a/pkgs/development/tools/misc/cquery/default.nix
+++ b/pkgs/development/tools/misc/cquery/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DSYSTEM_CLANG=ON"
     "-DCLANG_CXX=ON"
-    "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12"
+    "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.macosVersionMin or ""}"
   ];
 
   shell = runtimeShell;

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -1,10 +1,15 @@
 { stdenv, fetchurl, xar, cpio, pkgs, python3, pbzx, lib }:
 
+let version = "10.12"; in
+
+# Ensure appleSdkVersion is up to date.
+assert stdenv.isDarwin -> stdenv.appleSdkVersion == version;
+
 let
   # sadly needs to be exported because security_tool needs it
   sdk = stdenv.mkDerivation rec {
-    version = "10.12";
     pname = "MacOS_SDK";
+    inherit version;
 
     # This URL comes from https://swscan.apple.com/content/catalogs/others/index-10.12.merged-1.sucatalog, which we found by:
     #  1. Google: site:swscan.apple.com and look for a name that seems appropriate for your version

--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -31,7 +31,7 @@ self = stdenv.mkDerivation rec {
   outputs = [ "out" "static" ];
 
   cmakeFlags = [
-    "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12" # For std::shared_timed_mutex.
+    "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.macosVersionMin or ""}" # For std::shared_timed_mutex.
     "-DCMAKE_SKIP_BUILD_RPATH=OFF" # To run libmysql/libmysql_api_test during build.
     "-DFORCE_UNSUPPORTED_COMPILER=1" # To configure on Darwin.
     "-DWITH_ROUTER=OFF" # It may be packaged separately.

--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -31,7 +31,6 @@ self = stdenv.mkDerivation rec {
   outputs = [ "out" "static" ];
 
   cmakeFlags = [
-    "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.macosVersionMin or ""}" # For std::shared_timed_mutex.
     "-DCMAKE_SKIP_BUILD_RPATH=OFF" # To run libmysql/libmysql_api_test during build.
     "-DFORCE_UNSUPPORTED_COMPILER=1" # To configure on Darwin.
     "-DWITH_ROUTER=OFF" # It may be packaged separately.

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -28,15 +28,20 @@ let
   ];
 in rec {
   commonPreHook = ''
-    export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
-    export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
+    export NIX_ENFORCE_NO_NATIVE=''${NIX_ENFORCE_NO_NATIVE-1}
+    export NIX_ENFORCE_PURITY=''${NIX_ENFORCE_PURITY-1}
     export NIX_IGNORE_LD_THROUGH_GCC=1
-    stripAllFlags=" " # the Darwin "strip" command doesn't know "-s"
-    export MACOSX_DEPLOYMENT_TARGET=10.12
-    export SDKROOT=
     export CMAKE_OSX_ARCHITECTURES=x86_64
+    export SDKROOT=
+
+    # Ensure consistent LC_VERSION_MIN_MACOSX and remove LC_UUID.
+    export MACOSX_DEPLOYMENT_TARGET=10.12
+    export NIX_LDFLAGS+=" -macosx_version_min 10.12 -sdk_version 10.12 -no_uuid"
+
     # Workaround for https://openradar.appspot.com/22671534 on 10.11.
     export gl_cv_func_getcwd_abort_bug=no
+
+    stripAllFlags=" " # the Darwin "strip" command doesn't know "-s"
   '';
 
   bootstrapTools = derivation {

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -34,7 +34,6 @@ in rec {
     export NIX_ENFORCE_NO_NATIVE=''${NIX_ENFORCE_NO_NATIVE-1}
     export NIX_ENFORCE_PURITY=''${NIX_ENFORCE_PURITY-1}
     export NIX_IGNORE_LD_THROUGH_GCC=1
-    export CMAKE_OSX_ARCHITECTURES=x86_64
     export SDKROOT=
 
     # Ensure consistent LC_VERSION_MIN_MACOSX and remove LC_UUID.


### PR DESCRIPTION
###### Motivation for this change

Fixes #21629

Here's an example using hello (without the stdenv changes) https://gist.github.com/LnL7/7e705ea7f4099c074a004c897810bc73

And a run of r13y over the darwin stdenv
https://dgn9s9wft3u6a.cloudfront.net/store/ppm2pvkw1ngvmw063qbkxsg7r0nvdcxi-report/index.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @NixOS/darwin-maintainers