### PR TITLE
bluez-alsa: 1.4.0 -> 2.0.0

### DIFF
--- a/pkgs/tools/bluetooth/bluez-alsa/default.nix
+++ b/pkgs/tools/bluetooth/bluez-alsa/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoreconfHook
-, alsaLib, bluez, glib, sbc
+, alsaLib, bluez, glib, sbc, dbus
 
 # optional, but useful utils
 , readline, libbsd, ncurses
@@ -13,31 +13,30 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "bluez-alsa";
-  version = "1.4.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "Arkq";
     repo = "bluez-alsa";
     rev = "v${version}";
-    sha256 = "12kc2896rbir8viywd6bjwcklkwf46j4svh9viryn6kmk084nb49";
+    sha256 = "08mppgnjf1j2733bk9yf0cny6rfxxwiys0s62lz2zd2lpdl6d9lz";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
 
   buildInputs = [
-    alsaLib bluez glib sbc
+    alsaLib bluez glib sbc dbus
     readline libbsd ncurses
   ]
   ++ optional aacSupport fdk_aac;
 
   configureFlags = [
     "--with-alsaplugindir=\$out/lib/alsa-lib"
+    "--with-dbusconfdir=\$out/etc/dbus-1"
     "--enable-rfcomm"
     "--enable-hcitop"
   ]
   ++ optional aacSupport "--enable-aac";
-
-  doCheck = false; # fails 1 of 3 tests, needs access to ALSA
 
   meta = {
     description = "Bluez 5 Bluetooth Audio ALSA Backend";
@@ -63,7 +62,7 @@ stdenv.mkDerivation rec {
     homepage = src.meta.homepage;
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = [ maintainers.oxij ];
+    maintainers = [ maintainers.oxij maintainers.lheckemann ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
New upstream release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
