### PR TITLE
pre-commit: installed git hook should have full path to binary

### DIFF
--- a/pkgs/development/python-modules/pre-commit/default.nix
+++ b/pkgs/development/python-modules/pre-commit/default.nix
@@ -7,6 +7,7 @@
 , importlib-metadata
 , importlib-resources
 , nodeenv
+, python
 , six
 , toml
 , virtualenv
@@ -21,6 +22,10 @@ buildPythonApplication rec {
     pname = "pre_commit";
     sha256 = "0l5qg1cw4a0670m96s0ryy5mqz5aslfrrnwpriqgmrnsgdixhj4g";
   };
+
+  patches = [
+    ./hook-tmpl-use-the-hardcoded-path-to-pre-commit.patch
+  ];
 
   propagatedBuildInputs = [
     aspy-yaml
@@ -37,6 +42,11 @@ buildPythonApplication rec {
 
   # slow and impure
   doCheck = false;
+
+  preFixup = ''
+    substituteInPlace $out/${python.sitePackages}/pre_commit/resources/hook-tmpl \
+      --subst-var-by pre-commit $out
+  '';
 
   meta = with lib; {
     description = "A framework for managing and maintaining multi-language pre-commit hooks";

--- a/pkgs/development/python-modules/pre-commit/hook-tmpl-use-the-hardcoded-path-to-pre-commit.patch
+++ b/pkgs/development/python-modules/pre-commit/hook-tmpl-use-the-hardcoded-path-to-pre-commit.patch
@@ -1,0 +1,25 @@
+From d9e6999e32112602ec276634cb004eda3ca64ec3 Mon Sep 17 00:00:00 2001
+From: "Wael M. Nasreddine" <wael.nasreddine@gmail.com>
+Date: Mon, 13 Jan 2020 11:04:58 -0800
+Subject: [PATCH] hook-tmpl: use the hardcoded path to pre-commit, if found
+
+---
+ pre_commit/resources/hook-tmpl | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/pre_commit/resources/hook-tmpl b/pre_commit/resources/hook-tmpl
+index 213d16e..3a99211 100755
+--- a/pre_commit/resources/hook-tmpl
++++ b/pre_commit/resources/hook-tmpl
+@@ -107,6 +107,8 @@ def _exe() -> Tuple[str, ...]:
+             except OSError:
+                 pass
+ 
++    if os.path.isfile('@pre-commit@/bin/pre-commit') and os.access('@pre-commit@/bin/pre-commit', os.X_OK):
++        return ('@pre-commit@/bin/pre-commit', 'run')
+     if distutils.spawn.find_executable('pre-commit'):
+         return ('pre-commit', 'run')
+ 
+-- 
+2.23.1
+


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

pre-commit currently install impure Git hooks that look for the `pre-commit` binary in PATH. If the user has `pre-commit` loaded via a nix-shell instead of having it installed then GUI editors, such as Intellij, won't be able to use Git commit because the hook fails trying to look for the `pre-commit` binary in PATH.

This patch updates the hook template to use the hardcoded path to the `pre-commit` binary if it was found, fallback to using the one from PATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @Charg @fmartinho