### PR TITLE
rxv: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/rxv/default.nix
+++ b/pkgs/development/python-modules/rxv/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, defusedxml
+, requests
+, pytest
+, requests-mock
+, mock
+, pytestcov
+, pytest-timeout
+, testtools
+}:
+
+buildPythonPackage rec {
+  pname = "rxv";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "wuub";
+    repo = pname;
+    # Releases are not tagged
+    rev = "9b586203665031f93960543a272bb1a8f541ed37";
+    sha256 = "1dw3ayrzknai2279bhkgzcapzw06rhijlny33rymlbp7irp0gvnj";
+  };
+
+  propagatedBuildInputs = [ defusedxml requests ];
+
+  checkInputs = [ pytest requests-mock mock pytestcov pytest-timeout testtools ];
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Automation Library for Yamaha RX-V473, RX-V573, RX-V673, RX-V773 receivers";
+    homepage = https://github.com/wuub/rxv;
+    license = licenses.mit;
+    maintainers = with maintainers; [ flyfloh ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6857,6 +6857,8 @@ in {
 
   pony = callPackage ../development/python-modules/pony { };
 
+  rxv     = callPackage ../development/python-modules/rxv     { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

Home Assistant uses this library if you configure a Yamaha Receiver.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
