### PR TITLE
gitlab: 12.6.2 -> 12.6.4

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,11 +1,11 @@
 {
-  "version": "12.6.2",
-  "repo_hash": "0bchamvr3f0ph49f7xa76gsp2mjj1ajy4q0wy1hjvr9bayxx94av",
+  "version": "12.6.4",
+  "repo_hash": "0jsww785bxvjdrp1wsz6zkvx9zr69j24bway6nfyjkz8a7vbl9ls",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v12.6.2-ee",
+  "rev": "v12.6.4-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "a4b6c71d4b7c1588587345e2dfe0c6bd7cc63a83",
+    "GITALY_SERVER_VERSION": "1.77.1",
     "GITLAB_PAGES_VERSION": "1.12.0",
     "GITLAB_SHELL_VERSION": "10.3.0",
     "GITLAB_WORKHORSE_VERSION": "8.18.0"

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -17,14 +17,14 @@ let
       };
   };
 in buildGoPackage rec {
-  version = "a4b6c71d4b7c1588587345e2dfe0c6bd7cc63a83";
+  version = "1.77.1";
   pname = "gitaly";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitaly";
-    rev = version;
-    sha256 = "1pxmhq1nrc8q2kk83bz5afx14hshqgzqm6j4vgmyjvbmdvgl80wv";
+    rev = "v${version}";
+    sha256 = "08xc9lxlvga36yq1wdvb1h4zk70c36qspyd7azhkw84kzwfrif1c";
   };
 
   # Fix a check which assumes that hook files are writeable by their

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile
@@ -327,7 +327,7 @@ group :metrics do
   gem 'influxdb', '~> 0.2', require: false
 
   # Prometheus
-  gem 'prometheus-client-mmap', '~> 0.9.10'
+  gem 'prometheus-client-mmap', '~> 0.10.0'
   gem 'raindrops', '~> 0.18'
 end
 

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
@@ -531,8 +531,8 @@ GEM
       regexp_parser (~> 1.1)
       regexp_property_values (~> 0.3)
     json (1.8.6)
-    json-jwt (1.9.4)
-      activesupport
+    json-jwt (1.11.0)
+      activesupport (>= 4.2)
       aes_key_wrap
       bindata
     json-schema (2.8.0)
@@ -746,7 +746,7 @@ GEM
       parser
       unparser
     procto (0.0.3)
-    prometheus-client-mmap (0.9.10)
+    prometheus-client-mmap (0.10.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -1283,7 +1283,7 @@ DEPENDENCIES
   peek (~> 1.1)
   pg (~> 1.1)
   premailer-rails (~> 1.10.3)
-  prometheus-client-mmap (~> 0.9.10)
+  prometheus-client-mmap (~> 0.10.0)
   pry-byebug (~> 3.5.1)
   pry-rails (~> 0.3.4)
   rack (~> 2.0.7)

--- a/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
@@ -2326,10 +2326,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "065k7vffdki73f4nz89lxi6wxmcw5dlf593831pgvlbralll6x3r";
+      sha256 = "18rf9v20i0dk5dblr7m22di959xpch2h7gsx0cl585cryr7apwp3";
       type = "gem";
     };
-    version = "1.9.4";
+    version = "1.11.0";
   };
   json-schema = {
     dependencies = ["addressable"];
@@ -3365,10 +3365,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0immyg4as0isyj2dcjf44n0avg1jv5kx1qk0asrgb5ayzwmjqg1k";
+      sha256 = "00d2c79xhz5k3fcclarjr1ffxbrvc6236f4rrvriad9kwqr7c1mp";
       type = "gem";
     };
-    version = "0.9.10";
+    version = "0.10.0";
   };
   pry = {
     dependencies = ["coderay" "method_source"];


### PR DESCRIPTION
###### Motivation for this change
CVE-2020-6832

Following up on https://gitlab.com/gitlab-org/gitlab/issues/194206, Gitaly seems to have a tag now, but they're now prefixed with `v`. Adressed this in the derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
