### PR TITLE
onnxruntime: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchFromGitHub, glibcLocales
-, cmake, python3
+, cmake, python3, libpng, zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "onnxruntime";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "onnxruntime";
     rev = "v${version}";
-    sha256 = "1d28lzrjnq69yl8j9ncxlsxl0bniacn3hnsr9van10zgp527436v";
+    sha256 = "1ryf5v2h07c7b42q2p9id88i270ajyz5rlsradp00dy8in6dn2yr";
     # TODO: use nix-versions of grpc, onnx, eigen, googletest, etc.
     # submodules increase src size and compile times significantly
     # not currently feasible due to how integrated cmake build is with git
@@ -25,12 +25,19 @@ stdenv.mkDerivation rec {
     python3 # for shared-lib or server
   ];
 
+  buildInputs = [
+    # technically optional, but highly recommended
+    libpng
+    zlib
+  ];
+
   cmakeDir = "../cmake";
 
   cmakeFlags = [
     "-Donnxruntime_USE_OPENMP=ON"
     "-Donnxruntime_BUILD_SHARED_LIB=ON"
-    "-Donnxruntime_ENABLE_LTO=ON"
+    # flip back to ON next release
+    "-Donnxruntime_ENABLE_LTO=OFF" # https://github.com/microsoft/onnxruntime/issues/2828
   ];
 
   # ContribOpTest.StringNormalizerTest sets locale to en_US.UTF-8"


### PR DESCRIPTION
###### Motivation for this change
bumping packages I maintain

had to disable LTO due to https://github.com/microsoft/onnxruntime/issues/2828

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
