### PR TITLE
zfs: 0.8.2 -> 0.8.3

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -40,9 +40,18 @@ let
         inherit rev sha256;
       };
 
-      patches = extraPatches;
+      patches = [ ./null-systemd.patch ] ++ extraPatches;
 
-      postPatch = optionalString buildKernel ''
+      postPatch = ''
+        substituteInPlace ./contrib/initramfs/Makefile.am \
+          --replace "/usr/share/initramfs-tools" "$out/share/initramfs-tools"
+        substituteInPlace ./contrib/initramfs/hooks/Makefile.am \
+          --replace "/usr/share/initramfs-tools/hooks" "$out/share/initramfs-tools/hooks"
+        substituteInPlace ./contrib/initramfs/scripts/Makefile.am \
+          --replace "/usr/share/initramfs-tools/scripts" "$out/share/initramfs-tools/scripts"
+        substituteInPlace ./contrib/initramfs/scripts/local-top/Makefile.am \
+          --replace "/usr/share/initramfs-tools/scripts/local-top" "$out/share/initramfs-tools/scripts/local-top"
+      '' + optionalString buildKernel ''
         patchShebangs scripts
         # The arrays must remain the same length, so we repeat a flag that is
         # already part of the command and therefore has no effect.
@@ -56,6 +65,7 @@ let
         substituteInPlace ./config/zfs-build.m4       --replace "\$sysconfdir/init.d"     "$out/etc/init.d"
         substituteInPlace ./etc/zfs/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
         substituteInPlace ./cmd/zed/Makefile.am       --replace "\$(sysconfdir)"          "$out/etc"
+
         substituteInPlace ./etc/systemd/system/zfs-share.service.in \
           --replace "/bin/rm " "${coreutils}/bin/rm "
 
@@ -163,9 +173,9 @@ in {
     # incompatibleKernelVersion = "4.20";
 
     # this package should point to the latest release.
-    version = "0.8.2";
+    version = "0.8.3";
 
-    sha256 = "0miax0h2wg4b2kn8n93804faajy2n1sh25knyy2hg3k77nlr4pni";
+    sha256 = "0viql8rnqr32diapkpdsrwm6xj8vw5vi4dk2x2m7s7g0q2zdkahw";
   };
 
   zfsUnstable = common {
@@ -173,9 +183,9 @@ in {
     # incompatibleKernelVersion = "4.19";
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "0.8.2";
+    version = "0.8.3";
 
-    sha256 = "0miax0h2wg4b2kn8n93804faajy2n1sh25knyy2hg3k77nlr4pni";
+    sha256 = "0viql8rnqr32diapkpdsrwm6xj8vw5vi4dk2x2m7s7g0q2zdkahw";
     isUnstable = true;
   };
 }

--- a/pkgs/os-specific/linux/zfs/null-systemd.patch
+++ b/pkgs/os-specific/linux/zfs/null-systemd.patch
@@ -1,0 +1,14 @@
+diff --git a/etc/systemd/system/Makefile.am b/etc/systemd/system/Makefile.am
+index 130c6c757..9249f15eb 100644
+--- a/etc/systemd/system/Makefile.am
++++ b/etc/systemd/system/Makefile.am
+@@ -31,9 +31,5 @@ $(systemdunit_DATA) $(systemdpreset_DATA):%:%.in
+		-e 's,@sysconfdir\@,$(sysconfdir),g' \
+		$< >'$@'
+
+-install-data-hook:
+-	$(MKDIR_P) "$(DESTDIR)$(systemdunitdir)"
+-	ln -sf /dev/null "$(DESTDIR)$(systemdunitdir)/zfs-import.service"
+-
+ distclean-local::
+	-$(RM) $(systemdunit_DATA) $(systemdpreset_DATA)


### PR DESCRIPTION
###### Motivation for this change
Just trying the patchset that may become zfs 0.8.3 (see zfsonlinux/zfs#9776)

Since there was a minor change in our derivation, I figured I'd send the change up.
For the moment, do not merge, this is beyond unstable :D

I am running this right now with kernel `4.19.95-hardened` and things seem smooth.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
