### PR TITLE
ocaml-lens: () -> 1.2.3

### DIFF
--- a/pkgs/development/ocaml-modules/lens/default.nix
+++ b/pkgs/development/ocaml-modules/lens/default.nix
@@ -1,12 +1,12 @@
-{ lib, fetchurl, ppx_deriving, ppxfind, buildDunePackage }:
+{ lib, fetchzip, ppx_deriving, ppxfind, buildDunePackage }:
 
 buildDunePackage rec {
   pname = "lens";
   version = "1.2.3";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/pdonadeo/ocaml-lens/archive/v${version}.tar.gz";
-    sha256 = "0mg4lfjp3c5fy68j822kbw4i1jz82msfwxxbb7jklga7jvfpcs95";
+    sha256 = "09k2vhzysx91syjhgv6w1shc9mgzi0l4bhwpx1g5pi4r4ghjp07y";
   };
 
   minimumOCamlVersion = "4.04.1";

--- a/pkgs/development/ocaml-modules/lens/default.nix
+++ b/pkgs/development/ocaml-modules/lens/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchurl, ppx_deriving, ppxfind, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "lens";
+  version = "1.2.3";
+
+  src = fetchurl {
+    url = "https://github.com/pdonadeo/ocaml-lens/archive/v${version}.tar.gz";
+    sha256 = "0mg4lfjp3c5fy68j822kbw4i1jz82msfwxxbb7jklga7jvfpcs95";
+  };
+
+  minimumOCamlVersion = "4.04.1";
+  buildInputs = [ ppx_deriving ppxfind ];
+
+  meta = with lib; {
+    homepage = https://github.com/pdonadeo/ocaml-lens;
+    description = "Functional lenses";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [
+      kazcw
+    ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -468,6 +468,8 @@ let
 
     lambdaTerm = callPackage ../development/ocaml-modules/lambda-term { };
 
+    lens = callPackage ../development/ocaml-modules/lens { };
+
     linenoise = callPackage ../development/ocaml-modules/linenoise { };
 
     llvm = callPackage ../development/ocaml-modules/llvm {


### PR DESCRIPTION
###### Motivation for this change
Package an OPAM module.

###### Things done

Tested with ocamlPackages_latest; the OPAM file says it works with 4.04.1+ so I put that as minimum version.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).