### PR TITLE
ocamlPackages.ocaml-migrate-parsetree: 1.4.0 → 1.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchFromGitHub, buildDunePackage, result, ppx_derivers }:
+{ lib, fetchFromGitHub, buildDunePackage, result, ppx_derivers }:
 
 buildDunePackage rec {
    pname = "ocaml-migrate-parsetree";
-   version = "1.4.0";
+   version = "1.5.0";
 
    src = fetchFromGitHub {
      owner = "ocaml-ppx";
      repo = pname;
      rev = "v${version}";
-     sha256 = "0sv1p4615l8gpbah4ya2c40yr6fbvahvv3ks7zhrsgcwcq2ljyr2";
+     sha256 = "0ms7nx7x16nkbm9rln3sycbzg6ad8swz8jw6bjndrill8bg3fipv";
    };
 
    propagatedBuildInputs = [ ppx_derivers result ];
 
    meta = {
      description = "Convert OCaml parsetrees between different major versions";
-     license = stdenv.lib.licenses.lgpl21;
-     maintainers = [ stdenv.lib.maintainers.vbgl ];
+     license = lib.licenses.lgpl21;
+     maintainers = [ lib.maintainers.vbgl ];
      inherit (src.meta) homepage;
    };
 }

--- a/pkgs/development/ocaml-modules/stdint/default.nix
+++ b/pkgs/development/ocaml-modules/stdint/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, fetchFromGitHub, buildDunePackage }:
+{ lib, fetchFromGitHub, buildDunePackage }:
 
 buildDunePackage rec {
   pname = "stdint";
   version = "0.6.0";
+
+  minimumOCamlVersion = "4.07";
 
   src = fetchFromGitHub {
     owner = "andrenth";
@@ -14,7 +16,7 @@ buildDunePackage rec {
   meta = {
     description = "Various signed and unsigned integers for OCaml";
     homepage = "https://github.com/andrenth/ocaml-stdint";
-    license = stdenv.lib.licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.gebner ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gebner ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
