### PR TITLE
nixos/transmisison: Transmission torrent test fix

### DIFF
--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -129,19 +129,23 @@ in
     # It's useful to have transmission in path, e.g. for remote control
     environment.systemPackages = [ pkgs.transmission ];
 
-    users.users = optionalAttrs (cfg.user == "transmission") (singleton
-      { name = "transmission";
+    users.users = optionalAttrs (cfg.user == "transmission") ({
+      transmission = {
+        name = "transmission";
         group = cfg.group;
         uid = config.ids.uids.transmission;
         description = "Transmission BitTorrent user";
         home = homeDir;
         createHome = true;
-      });
+      };
+    });
 
-    users.groups = optionalAttrs (cfg.group == "transmission") (singleton
-      { name = "transmission";
+    users.groups = optionalAttrs (cfg.group == "transmission") ({
+      transmission = {
+        name = "transmission";
         gid = config.ids.gids.transmission;
-      });
+      };
+    });
 
     # AppArmor profile
     security.apparmor.profiles = mkIf apparmor [

--- a/nixos/tests/bittorrent.nix
+++ b/nixos/tests/bittorrent.nix
@@ -38,8 +38,12 @@ in
 
           # We need Apache on the tracker to serve the torrents.
           services.httpd.enable = true;
-          services.httpd.adminAddr = "foo@example.org";
-          services.httpd.documentRoot = "/tmp";
+          services.httpd.virtualHosts = {
+            "torrentserver.org" = {
+              adminAddr = "foo@example.org";
+              documentRoot = "/tmp";
+            };
+          };
 
           networking.firewall.enable = false;
 

--- a/nixos/tests/bittorrent.nix
+++ b/nixos/tests/bittorrent.nix
@@ -18,6 +18,17 @@ let
   externalRouterAddress = "80.100.100.1";
   externalClient2Address = "80.100.100.2";
   externalTrackerAddress = "80.100.100.3";
+
+  transmissionConfig = { ... }: {
+    environment.systemPackages = [ pkgs.transmission ];
+    services.transmission = {
+      enable = true;
+      settings = {
+        dht-enabled = false;
+        message-level = 3;
+      };
+    };
+  };
 in
 
 {
@@ -26,92 +37,79 @@ in
     maintainers = [ domenkozar eelco rob bobvanderlinden ];
   };
 
-  nodes =
-    { tracker =
-        { pkgs, ... }:
-        { environment.systemPackages = [ pkgs.transmission ];
+  nodes = {
+    tracker = { pkgs, ... }: {
+      imports = [ transmissionConfig ];
 
-          virtualisation.vlans = [ 1 ];
-          networking.interfaces.eth1.ipv4.addresses = [
-            { address = externalTrackerAddress; prefixLength = 24; }
-          ];
+      virtualisation.vlans = [ 1 ];
+      networking.firewall.enable = false;
+      networking.interfaces.eth1.ipv4.addresses = [
+        { address = externalTrackerAddress; prefixLength = 24; }
+      ];
 
-          # We need Apache on the tracker to serve the torrents.
-          services.httpd.enable = true;
-          services.httpd.virtualHosts = {
-            "torrentserver.org" = {
-              adminAddr = "foo@example.org";
-              documentRoot = "/tmp";
-            };
-          };
-
-          networking.firewall.enable = false;
-
-          services.opentracker.enable = true;
-
-          services.transmission.enable = true;
-          services.transmission.settings.dht-enabled = false;
-          services.transmission.settings.port-forwaring-enabled = false;
-        };
-
-      router =
-        { pkgs, nodes, ... }:
-        { virtualisation.vlans = [ 1 2 ];
-          networking.nat.enable = true;
-          networking.nat.internalInterfaces = [ "eth2" ];
-          networking.nat.externalInterface = "eth1";
-          networking.firewall.enable = true;
-          networking.firewall.trustedInterfaces = [ "eth2" ];
-          networking.interfaces.eth0.ipv4.addresses = [];
-          networking.interfaces.eth1.ipv4.addresses = [
-            { address = externalRouterAddress; prefixLength = 24; }
-          ];
-          networking.interfaces.eth2.ipv4.addresses = [
-            { address = internalRouterAddress; prefixLength = 24; }
-          ];
-          services.miniupnpd = {
-            enable = true;
-            externalInterface = "eth1";
-            internalIPs = [ "eth2" ];
-            appendConfig = ''
-              ext_ip=${externalRouterAddress}
-            '';
+      # We need Apache on the tracker to serve the torrents.
+      services.httpd = {
+        enable = true;
+        virtualHosts = {
+          "torrentserver.org" = {
+            adminAddr = "foo@example.org";
+            documentRoot = "/tmp";
           };
         };
-
-      client1 =
-        { pkgs, nodes, ... }:
-        { environment.systemPackages = [ pkgs.transmission pkgs.miniupnpc ];
-          virtualisation.vlans = [ 2 ];
-          networking.interfaces.eth0.ipv4.addresses = [];
-          networking.interfaces.eth1.ipv4.addresses = [
-            { address = internalClient1Address; prefixLength = 24; }
-          ];
-          networking.defaultGateway = internalRouterAddress;
-          networking.firewall.enable = false;
-          services.transmission.enable = true;
-          services.transmission.settings.dht-enabled = false;
-          services.transmission.settings.message-level = 3;
-        };
-
-      client2 =
-        { pkgs, ... }:
-        { environment.systemPackages = [ pkgs.transmission ];
-          virtualisation.vlans = [ 1 ];
-          networking.interfaces.eth0.ipv4.addresses = [];
-          networking.interfaces.eth1.ipv4.addresses = [
-            { address = externalClient2Address; prefixLength = 24; }
-          ];
-          networking.firewall.enable = false;
-          services.transmission.enable = true;
-          services.transmission.settings.dht-enabled = false;
-          services.transmission.settings.port-forwaring-enabled = false;
-        };
+      };
+      services.opentracker.enable = true;
     };
 
-  testScript =
-    { nodes, ... }:
-    ''
+    router = { pkgs, nodes, ... }: {
+      virtualisation.vlans = [ 1 2 ];
+      networking.nat.enable = true;
+      networking.nat.internalInterfaces = [ "eth2" ];
+      networking.nat.externalInterface = "eth1";
+      networking.firewall.enable = true;
+      networking.firewall.trustedInterfaces = [ "eth2" ];
+      networking.interfaces.eth0.ipv4.addresses = [];
+      networking.interfaces.eth1.ipv4.addresses = [
+        { address = externalRouterAddress; prefixLength = 24; }
+      ];
+      networking.interfaces.eth2.ipv4.addresses = [
+        { address = internalRouterAddress; prefixLength = 24; }
+      ];
+      services.miniupnpd = {
+        enable = true;
+        externalInterface = "eth1";
+        internalIPs = [ "eth2" ];
+        appendConfig = ''
+          ext_ip=${externalRouterAddress}
+        '';
+      };
+    };
+
+    client1 = { pkgs, nodes, ... }: {
+      imports = [ transmissionConfig ];
+      environment.systemPackages = [ pkgs.miniupnpc ];
+
+      virtualisation.vlans = [ 2 ];
+      networking.interfaces.eth0.ipv4.addresses = [];
+      networking.interfaces.eth1.ipv4.addresses = [
+        { address = internalClient1Address; prefixLength = 24; }
+      ];
+      networking.defaultGateway = internalRouterAddress;
+      networking.firewall.enable = false;
+    };
+
+    client2 = { pkgs, ... }: {
+      imports = [ transmissionConfig ];
+
+      virtualisation.vlans = [ 1 ];
+      networking.interfaces.eth0.ipv4.addresses = [];
+      networking.interfaces.eth1.ipv4.addresses = [
+        { address = externalClient2Address; prefixLength = 24; }
+      ];
+      networking.firewall.enable = false;
+    };
+  };
+
+  testScript = { nodes, ... }: ''
       start_all()
 
       # Wait for network and miniupnpd.
@@ -163,5 +161,4 @@ in
           "cmp /tmp/test.tar.bz2 ${file}"
       )
     '';
-
 })


### PR DESCRIPTION
###### Motivation for this change

The `transmission` NixOS module threw warnings and the `bittorrent` test did not work any longer due to changes in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @flokli @worldofpeace 
