### PR TITLE
diffoscope: enable on darwin

### DIFF
--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -35,11 +35,14 @@ python3Packages.buildPythonApplication rec {
   #
   # Still missing these tools: abootimg docx2txt dumpxsb enjarify js-beautify lipo oggDump otool procyon-decompiler Rscript wasm2wat zipnode
   # Also these libraries: python3-guestfs
-  pythonPath = with python3Packages; [ debian libarchive-c python_magic tlsh rpm pyxattr ] ++ [
-      acl binutils-unwrapped bzip2 cdrkit colordiff coreutils cpio db diffutils
+  pythonPath = [
+      binutils-unwrapped bzip2 colordiff coreutils cpio db diffutils
       dtc e2fsprogs file findutils fontforge-fonttools gettext gnutar gzip
-      libarchive libcaca lz4 pgpdump progressbar33 sng sqlite squashfsTools unzip xxd xz
-    ] ++ lib.optionals enableBloat [
+      libarchive libcaca lz4 pgpdump sng sqlite squashfsTools unzip xxd xz
+    ]
+    ++ (with python3Packages; [ debian libarchive-c python_magic tlsh rpm progressbar33 ])
+    ++ lib.optionals stdenv.isLinux [ python3Packages.pyxattr acl cdrkit ]
+    ++ lib.optionals enableBloat [
       apktool cbfstool colord fpc ghc ghostscriptX giflib gnupg gnumeric imagemagick
       llvm jdk mono openssh pdftk poppler_utils tcpdump unoconv
       python3Packages.guestfs
@@ -69,6 +72,6 @@ python3Packages.buildPythonApplication rec {
     homepage    = https://wiki.debian.org/ReproducibleBuilds;
     license     = licenses.gpl3Plus;
     maintainers = with maintainers; [ dezgeg ];
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
