### PR TITLE
mdcat: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/tools/text/mdcat/default.nix
+++ b/pkgs/tools/text/mdcat/default.nix
@@ -2,26 +2,28 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mdcat";
-  version = "0.14.0";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "lunaryorn";
     repo = pname;
     rev = "mdcat-${version}";
-    sha256 = "1q8h6pc1i89j1zl4s234inl9v95vsdrry1fzlis89sl2mnbv8ywy";
+    sha256 = "1x9c3cj3y8wvwr74kbz6nrdh61rinr98gcp3hnjpi6c3vg3xx4wh";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ] ++ stdenv.lib.optional stdenv.isDarwin Security;
 
-  cargoSha256 = "1hxsfls6fpllc9yg5ib3qz6pa62j1y1va8a6356j6812csk4ifnn";
+  cargoSha256 = "1kc434pa72n9xll2r4ddmd9xdwv3ls36cwsmdry392j41zmics51";
 
   checkInputs = [ ansi2html ];
   checkPhase = ''
     # Skip tests that use the network and that include files.
-    cargo test -- --skip terminal::iterm2 --skip terminal::resources::tests::remote \
+    cargo test -- --skip terminal::iterm2 \
       --skip magic::tests::detect_mimetype_of_svg_image \
-      --skip magic::tests::detect_mimetype_of_png_image
+      --skip magic::tests::detect_mimetype_of_png_image \
+      --skip resources::tests::read_url_with_http_url_fails_when_status_404 \
+      --skip resources::tests::read_url_with_http_url_returns_content_when_status_200
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Update mdcat to [0.15.0](https://github.com/lunaryorn/mdcat/releases/tag/mdcat-0.15.0).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
