### PR TITLE
ber_metaocaml: fix install order.

### DIFF
--- a/pkgs/development/compilers/ocaml/ber-metaocaml.nix
+++ b/pkgs/development/compilers/ocaml/ber-metaocaml.nix
@@ -50,10 +50,10 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     make world
-    make -i install
 
     make bootstrap
     make opt.opt
+    make -i install
     make installopt
     mkdir -p $out/include
     ln -sv $out/lib/ocaml/caml $out/include/caml


### PR DESCRIPTION
Indeed, all standard modules with compiler-libs are not included (
eg. Optcompile).

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

All modules bundled with ocaml are not includes (eg. Optcompile in compiler-libs).

```
damien@damien:/tmp/nixpkgs$ nix-shell --pure -E 'with import <nixpkgs> {}; runCommand "dummy" {buildInputs=[pkgs.ber_metaocaml];} ""'  -I nixpkgs=.
[nix-shell:/tmp/nixpkgs]$ ocaml -I +compiler-libs
        OCaml version 4.07.1

# open Optcompile;;
Error: Unbound module Optcompile
#

```


###### Things done

Move install phase after building phase.
Now we have:
```
damien@damien:/tmp/nixpkgs$ nix-shell --pure -E 'with import <nixpkgs> {}; runCommand "dummy" {buildInputs=[pkgs.ber_metaocaml];} ""'  -I nixpkgs=.
[nix-shell:/tmp/nixpkgs]$ ocaml -I +compiler-libs
        OCaml version 4.07.1

# open Optcompile;;
# 
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
