### PR TITLE
python3Packages.tensorly: init at 0.4.5

### DIFF
--- a/pkgs/development/python-modules/sparse/default.nix
+++ b/pkgs/development/python-modules/sparse/default.nix
@@ -35,6 +35,5 @@ buildPythonPackage rec {
     homepage = https://github.com/pydata/sparse/;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/tensorly/default.nix
+++ b/pkgs/development/python-modules/tensorly/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, nose
+, isPy27
+, numpy
+, scipy
+, sparse
+, pytorch
+}:
+
+buildPythonPackage rec {
+  pname = "tensorly";
+  version = "0.4.5";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "1ml91yaxwx4msisxbm92yf22qfrscvk58f3z2r1jhi96pw2k4i7x";
+  };
+
+  propagatedBuildInputs = [ numpy scipy sparse ];
+  checkInputs = [ pytest nose pytorch ];
+  # also has a cupy backend, but the tests are currently broken
+  # (e.g. attempts to access cupy.qr instead of cupy.linalg.qr)
+  # and this backend also adds a non-optional CUDA dependence,
+  # as well as tensorflow and mxnet backends, but the tests don't
+  # seem to exercise these backend by default
+
+  checkPhase = ''
+    runHook preCheck
+    nosetests -e "test_cupy"
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Tensor learning in Python";
+    homepage = https://tensorly.org/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6453,6 +6453,8 @@ in {
     cudaSupport = true;
   };
 
+  tensorly = callPackage ../development/python-modules/tensorly { };
+
   tflearn = callPackage ../development/python-modules/tflearn { };
 
   simpleai = callPackage ../development/python-modules/simpleai { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
