### PR TITLE
doc: Make callout marks & prompts unselectable

### DIFF
--- a/doc/overrides.css
+++ b/doc/overrides.css
@@ -7,3 +7,10 @@
 .calloutlist img {
     width: 1.5em;
 }
+
+.prompt {
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}

--- a/doc/overrides.css
+++ b/doc/overrides.css
@@ -1,6 +1,8 @@
 .docbook .xref img[src^=images\/callouts\/],
 .screen img,
-.programlisting img {
+.programlisting img,
+.literallayout img,
+.synopsis img {
     width: 1em;
 }
 
@@ -8,7 +10,11 @@
     width: 1.5em;
 }
 
-.prompt {
+.prompt,
+.screen img,
+.programlisting img,
+.literallayout img,
+.synopsis img {
     -moz-user-select: none;
     -webkit-user-select: none;
     -ms-user-select: none;


### PR DESCRIPTION
As [noticed](https://github.com/NixOS/rfcs/pull/64#issuecomment-574168483) by @davidak, this was actually broken.

This will make copying examples easier.