### PR TITLE
libspiro: 0.5.20150702 -> 20190731

### DIFF
--- a/pkgs/development/libraries/libspiro/default.nix
+++ b/pkgs/development/libraries/libspiro/default.nix
@@ -1,18 +1,22 @@
-{stdenv, pkgconfig, fetchurl}:
+{stdenv, pkgconfig, autoreconfHook, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "libspiro";
-  version = "0.5.20150702";
-  src = fetchurl {
-    url = "https://github.com/fontforge/libspiro/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "0z4zpxd3nwwchqdsbmmjbp13aw5jg8v5p1993190bpykkrjlh6nv";
+  version = "20190731";
+
+  src = fetchFromGitHub {
+    owner = "fontforge";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256:1wc6ikjrvcq05jki0ligmxyplgb4nzx6qb5va277qiin8vad9b1v";
   };
 
-  nativeBuildInputs = [pkgconfig];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
 
   meta = with stdenv.lib; {
     description = "A library that simplifies the drawing of beautiful curves";
     homepage = https://github.com/fontforge/libspiro;
     license = licenses.gpl3Plus;
+    maintainers = [ maintainers.erictapen ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
bump libspiro

###### Things done

- Bumped
- Built from git sources.
- Added myself as maintainer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
