### PR TITLE
Add Robomongo keyword so users can find it by searching 'robomongo'

### DIFF
--- a/pkgs/applications/misc/robo3t/default.nix
+++ b/pkgs/applications/misc/robo3t/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = https://robomongo.org/;
-    description = "Query GUI for mongodb. Formerly called Robomongo.";
+    description = "Query GUI for mongodb. Formerly called Robomongo";
     platforms = [ "x86_64-linux" ];
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.eperuffo ];

--- a/pkgs/applications/misc/robo3t/default.nix
+++ b/pkgs/applications/misc/robo3t/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = https://robomongo.org/;
-    description = "Query GUI for mongodb";
+    description = "Query GUI for mongodb. Formerly called Robomongo.";
     platforms = [ "x86_64-linux" ];
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.eperuffo ];


### PR DESCRIPTION
###### Motivation for this change

This should make it easier to find robomongo package under robo3t.

I was looking for robomongo and didn't find it. It is annoying to find that robomongo has different name as package and it is not searchable by robomongo. I suspect that I am not alone.

###### Things done

I just added robomongo keyword to description so you can find it when searching for it.


Adding word to string will not break anything. 

