### PR TITLE
jdupes: 1.13.2 -> 1.14.0

### DIFF
--- a/pkgs/tools/misc/jdupes/default.nix
+++ b/pkgs/tools/misc/jdupes/default.nix
@@ -2,20 +2,25 @@
 
 stdenv.mkDerivation rec {
   pname = "jdupes";
-  version = "1.13.2";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "jbruchon";
     repo  = "jdupes";
     rev   = "v${version}";
-    sha256 = "1dzw1h9x9addkxf7r8lb8y09wmdkx8i61f5m96589r88jjk965xy";
+    sha256 = "18hn25f7cdz1li0vvx74al7a8z2220xhzjp9j6idhldsmjnscgq8";
     # Unicode file names lead to different checksums on HFS+ vs. other
     # filesystems because of unicode normalisation. The testdir
     # directories have such files and will be removed.
     extraPostFetch = "rm -r $out/testdir";
   };
 
-  makeFlags = [ "PREFIX=$(out)" ] ++ stdenv.lib.optional stdenv.isLinux "ENABLE_BTRFS=1";
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ] ++ stdenv.lib.optionals stdenv.isLinux [
+    "ENABLE_DEDUPE=1"
+    "STATIC_DEDUPE_H=1"
+  ];
 
   enableParallelBuilding = true;
 
@@ -32,7 +37,7 @@ stdenv.mkDerivation rec {
       duplicate files. This fork known as 'jdupes' is heavily modified
       from and improved over the original.
     '';
-    homepage = https://github.com/jbruchon/jdupes;
+    homepage = "https://github.com/jbruchon/jdupes";
     license = licenses.mit;
     maintainers = with maintainers; [ romildo ];
     platforms = platforms.all;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Tool update

+ https://github.com/jbruchon/jdupes/releases/tag/v1.13.3
+ https://github.com/jbruchon/jdupes/releases/tag/v1.14.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @romildo as maintainer