### PR TITLE
lib/types: prioritise coercedType in coercedTo

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -590,7 +590,7 @@ rec {
         tail' = tail ts;
       in foldl' either head' tail';
 
-    # Either value of type `finalType` or `coercedType`, the latter is
+    # Either value of type `coercedType` or `finalType`, the former is
     # converted to `finalType` using `coerceFunc`.
     coercedTo = coercedType: coerceFunc: finalType:
       assert lib.assertMsg (coercedType.getSubModules == null)
@@ -599,12 +599,12 @@ rec {
       mkOptionType rec {
         name = "coercedTo";
         description = "${finalType.description} or ${coercedType.description} convertible to it";
-        check = x: finalType.check x || (coercedType.check x && finalType.check (coerceFunc x));
+        check = x: (coercedType.check x && finalType.check (coerceFunc x)) || finalType.check x;
         merge = loc: defs:
           let
             coerceVal = val:
-              if finalType.check val then val
-              else coerceFunc val;
+              if coercedType.check val then coerceFunc val
+              else val;
           in finalType.merge loc (map (def: def // { value = coerceVal def.value; }) defs);
         emptyValue = finalType.emptyValue;
         getSubOptions = finalType.getSubOptions;


### PR DESCRIPTION
This more intuitively matches `types.either` and allows paths to be coerced to submodules again.

###### Motivation for this change

#76861's changes allowed strings to typecheck as submodules when they appear to be a path (start with a slash). A somewhat common use of `coercedTo` is to turn single values into an attrset/submodule: `with types; coercedTo str (value: { inherit value; }) valueSubmodule`. `coercedTo` currently will prioritise the final type if possible, and now that submodules can be set from paths this causes havoc when the module system tries to import what was previously meant to be just a config value.

A similar issue occurs with `types.either`, and #76861 suggests changing the order of the types as a solution. That approach isn't possible here and `coercedTo` feels backward in comparison, so this change reverses its behaviour.

cc @Infinisil who made the original submodule change and suggested this patch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
