### PR TITLE
Fix Python test driver

### DIFF
--- a/nixos/lib/test-driver/test-driver.py
+++ b/nixos/lib/test-driver/test-driver.py
@@ -704,7 +704,8 @@ class Machine:
 
         def process_serial_output() -> None:
             for _line in self.process.stdout:
-                line = _line.decode("unicode_escape").replace("\r", "").rstrip()
+                # Ignore undecodable bytes that may occur in boot menus
+                line = _line.decode(errors="ignore").replace("\r", "").rstrip()
                 eprint("{} # {}".format(self.name, line))
                 self.logger.enqueue({"msg": line, "machine": self.name})
 

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -155,7 +155,7 @@ in rec {
             --add-flags "''${vms[*]}" \
             ${lib.optionalString enableOCR
               "--prefix PATH : '${ocrProg}/bin:${imagemagick_tiff}/bin'"} \
-            --run "export testScript=\"\$(cat $out/test-script)\"" \
+            --run "export testScript=\"\$(${coreutils}/bin/cat $out/test-script)\"" \
             --set VLANS '${toString vlans}'
           ln -s ${testDriver}/bin/nixos-test-driver $out/bin/nixos-run-vms
           wrapProgram $out/bin/nixos-run-vms \


### PR DESCRIPTION
Trigger bug that's fixed by `test-driver.py: specify coreutils dependency`:
```
# Run driver with empty PATH.
# Output: "nixos-test-driver: line 2: cat: command not found"
env -i tests="" $(nix-build --no-out-link "nixpkgs/nixos/tests/haka.nix" -A driver)/bin/nixos-test-driver
# remove vde dir
rm -r vde1.ctl
```

Trigger bug that's fixed by `test-driver.py: fix decoding of VM output`:
```
# Fails with UnicodeDecodeError: 'unicodeescape' codec can't decode bytes in position 15-16: truncated \xXX escape
nix-build --no-out-link - <<'EOF'
import nixpkgs/nixos/tests/make-test-python.nix {
  machine.boot.initrd.preDeviceCommands = "echo 'decoding test: \\\\x λ'";
  testScript = ''
    machine.succeed("true")
  '';
}
EOF
```

cc @tfc 