### PR TITLE
marktext: init

### DIFF
--- a/pkgs/applications/misc/marktext/default.nix
+++ b/pkgs/applications/misc/marktext/default.nix
@@ -1,0 +1,35 @@
+{ appimageTools, fetchurl, lib }:
+
+let
+  pname = "marktext";
+  version = "v0.16.0-rc.2";
+in
+appimageTools.wrapType2 rec {
+  name = "${pname}-${version}-binary";
+
+  src = fetchurl {
+    url = "https://github.com/marktext/marktext/releases/download/${version}/marktext-x86_64.AppImage";
+    sha256 = "1w1mxa1j94zr36xhvlhzq8d77pi359vdxqb2j8mnz2bib9khxk9k";
+  };
+
+  profile = ''
+    export LC_ALL=C.UTF-8
+  '';
+
+  multiPkgs = null; # no 32bit needed
+  extraPkgs = p: (appimageTools.defaultFhsEnvArgs.multiPkgs p) ++ [
+    p.libsecret
+    p.xlibs.libxkbfile
+  ];
+
+  # Strip version from binary name.
+  extraInstallCommands = "mv $out/bin/${name} $out/bin/${pname}";
+
+  meta = with lib; {
+    description = "A simple and elegant markdown editor, available for Linux, macOS and Windows.";
+    homepage = "https://marktext.app";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nh2 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4906,6 +4906,8 @@ in
 
   mandoc = callPackage ../tools/misc/mandoc { };
 
+  marktext = callPackage ../applications/misc/marktext { };
+
   mawk = callPackage ../tools/text/mawk { };
 
   mb2md = callPackage ../tools/text/mb2md { };


### PR DESCRIPTION
###### Motivation for this change

https://marktext.app is a great editor.

Long-term it would be great to package it without using the AppImage binary release (see https://github.com/marktext/marktext/issues/1647), but until that's done, this is a workaround.

I used the `notable` package by @dtzWill as a template. It is also an AppImage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
