### PR TITLE
WIP: pypyInterpreters.pypy{27,36}_prebuilt: fix builds

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -182,13 +182,12 @@ in {
     self = pythonInterpreters.pypy27_prebuilt;
     sourceVersion = {
       major = "7";
-      minor = "1";
-      patch = "1";
+      minor = "3";
+      patch = "0";
     };
-    sha256 = "0rlx4x9xy9h989w6sy4h7lknm00956r30c5gjxwsvf8fhvq9xc3k"; # linux64
+    sha256 = "09lq7j439f1g33hp8pfd5zqnmngydwnsbvvd5bd3gila6xa0m5gl"; # linux64
     pythonVersion = "2.7";
     inherit passthruFun;
-    ncurses = ncurses5;
   };
 
   pypy36_prebuilt = callPackage ./pypy/prebuilt.nix {
@@ -196,13 +195,12 @@ in {
     self = pythonInterpreters.pypy36_prebuilt;
     sourceVersion = {
       major = "7";
-      minor = "1";
-      patch = "1";
+      minor = "3";
+      patch = "0";
     };
-    sha256 = "1c1xx6dm1n4xvh1vd3rcvyyixm5jm9rvzisji1a5bc9l38xzc540"; # linux64
+    sha256 = "0ml8mlk1wwsz256f6gygsrylv6x57yw9idl56fn21s1xykl4kmfk"; # linux64
     pythonVersion = "3.6";
     inherit passthruFun;
-    ncurses = ncurses5;
   };
 
   graalpython37 = callPackage ./graalpython/default.nix {

--- a/pkgs/development/interpreters/python/pypy/prebuilt.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt.nix
@@ -6,7 +6,7 @@
 # Dependencies
 , bzip2
 , zlib
-, openssl_1_0_2
+, openssl
 , expat
 , libffi
 , ncurses
@@ -44,13 +44,21 @@ let
   deps = [
     bzip2
     zlib
-    openssl_1_0_2
+    openssl
     expat
-    libffi
+    libffi6
     ncurses
     tcl
     tk
   ];
+
+  libffi6 = libffi.overrideAttrs(oldAttrs: rec {
+    name = "libffi-3.2.1";
+    src = fetchurl {
+      url = "https://sourceware.org/pub/libffi/${name}.tar.gz";
+      sha256 = "0dya49bnhianl0r65m65xndz6ls2jn1xngyn72gd28ls3n7bnvnh";
+    };
+  });
 
 in with passthru; stdenv.mkDerivation {
   inherit pname version;
@@ -60,7 +68,7 @@ in with passthru; stdenv.mkDerivation {
     inherit sha256;
   };
 
-  buildInputs = [ which ];
+  nativeBuildInputs = [ which ];
 
   installPhase = ''
     mkdir -p $out/lib

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -112,18 +112,18 @@ stdenv.mkDerivation rec {
             if [ "ncurses" = "$library" ]
             then
               # make libtinfo symlinks
-              ln -svf lib''${library}$suffix.$dylibtype $out/lib/libtinfo$newsuffix.$dylibtype
-              ln -svf lib''${library}$suffix.${abiVersion-extension} $out/lib/libtinfo$newsuffix.${abiVersion-extension}
+              ln -svf lib''${library}$suffix.$dylibtype $out/lib/libtinfo${if unicode then "w" else ""}$newsuffix.$dylibtype
+              ln -svf lib''${library}$suffix.${abiVersion-extension} $out/lib/libtinfo${if unicode then "w" else ""}$newsuffix.${abiVersion-extension}
             fi
           fi
         done
         for statictype in a dll.a la; do
           if [ -e "$out/lib/lib''${library}$suffix.$statictype" ]; then
-            ln -svf lib''${library}$suffix.$statictype $out/lib/lib$library$newsuffix.$statictype
+            ln -svf lib''${library}$suffix.$statictype $out/lib/lib$library${if unicode then "w" else ""}$newsuffix.$statictype
             if [ "ncurses" = "$library" ]
             then
               # make libtinfo symlinks
-              ln -svf lib''${library}$suffix.$statictype $out/lib/libtinfo$newsuffix.$statictype
+              ln -svf lib''${library}$suffix.$statictype $out/lib/libtinfo${if unicode then "w" else ""}$newsuffix.$statictype
             fi
           fi
         done


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
