### PR TITLE
topgrade: fix, add darwin Foundation framework

### DIFF
--- a/pkgs/tools/misc/topgrade/default.nix
+++ b/pkgs/tools/misc/topgrade/default.nix
@@ -20,6 +20,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/r-darwish/topgrade";
     license = licenses.gpl3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ filalex77 ];
+    maintainers = with maintainers; [ filalex77 hugoreeves ];
   };
 }

--- a/pkgs/tools/misc/topgrade/default.nix
+++ b/pkgs/tools/misc/topgrade/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform }:
+{ stdenv, lib, fetchFromGitHub, rustPlatform, Foundation }:
 
 rustPlatform.buildRustPackage rec {
   pname = "topgrade";
@@ -13,7 +13,9 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1y85hl7xl60vsj3ivm6pyd6bvk39wqg25bqxfx00r9myha94iqmd";
 
-  meta = with stdenv.lib; {
+  buildInputs = lib.optional stdenv.isDarwin Foundation;
+
+  meta = with lib; {
     description = "Upgrade all the things";
     homepage = "https://github.com/r-darwish/topgrade";
     license = licenses.gpl3;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6790,7 +6790,9 @@ in
 
   toml2nix = (callPackage ../tools/toml2nix { }).toml2nix { };
 
-  topgrade = callPackage ../tools/misc/topgrade {  };
+  topgrade = callPackage ../tools/misc/topgrade {
+    inherit (darwin.apple_sdk.frameworks) Foundation;
+  };
 
   tor = callPackage ../tools/security/tor {
     # remove this, when libevent's openssl is upgraded to 1_1_0 or newer.


### PR DESCRIPTION
##### Motivation for this change

Resolves an issue introduced at #77250 
The issue is caused by a new dependency in topgrade that relies on the Darwin Foundation framework. This PR resolves the issue, allowing topgrade to build once again on Darwin.
Closer attention needs to be paid to testing builds on MacOS as breaks like this are avoidable. Maybe maintainers should find MacOS users to help maintain/test each PR. @filalex77 if you would like a Darwin tester for topgrade related PR's to nixpkgs, I am available.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
