### PR TITLE
gns3: Fix python package not being pinned

### DIFF
--- a/pkgs/applications/networking/gns3/default.nix
+++ b/pkgs/applications/networking/gns3/default.nix
@@ -7,8 +7,19 @@ let
     let version = if args.stable then stableVersion else previewVersion;
         branch = if args.stable then "stable" else "preview";
     in args // { inherit version branch; };
-  mkGui = args: callPackage (import ./gui.nix (addVersion args)) { };
-  mkServer = args: callPackage (import ./server.nix (addVersion args)) { };
+  extraArgs = {
+    mkOverride = attrname: version: sha256:
+      self: super: {
+        ${attrname} = super.${attrname}.overridePythonAttrs (oldAttrs: {
+          inherit version;
+          src = oldAttrs.src.override {
+            inherit version sha256;
+          };
+        });
+      };
+  };
+  mkGui = args: callPackage (import ./gui.nix (addVersion args // extraArgs)) { };
+  mkServer = args: callPackage (import ./server.nix (addVersion args // extraArgs)) { };
   guiSrcHash = "1yxwbz93x9hn5y6dir8v7bdfsmfgppvjg4z88l8gx82hhf2476fx";
   serverSrcHash = "1d3m8qrz82g8ii6q6j015wqwp6j0415fbqbjvw43zhdx5mnn962d";
 in {

--- a/pkgs/applications/networking/gns3/gui.nix
+++ b/pkgs/applications/networking/gns3/gui.nix
@@ -1,26 +1,36 @@
+# This package required qt5Full to launch
 { stable, branch, version, sha256Hash }:
 
-{ stdenv, python3, fetchFromGitHub }:
+{ lib, stdenv, python3, fetchFromGitHub 
+, packageOverrides ? self: super: {
+
+}}:
 
 let
-  python = python3.override {
-    packageOverrides = self: super: {
-      psutil = super.psutil.overridePythonAttrs (oldAttrs: rec {
-        version = "5.6.3";
+
+  defaultOverrides = [
+        (mkOverride "psutil" "5.6.3"
+      "1wv31zly44qj0rp2acg58xbnc7bf6ffyadasq093l455q30qafl6")
+        (mkOverride "jsonschema" "5.6.3"
+      "00kf3zmpp9ya4sydffpifn0j0mzm342a2vzh82p6r0vh10cg7xbg")
+  ];
+
+  mkOverride = attrname: version: sha256:
+    self: super: {
+      ${attrname} = super.${attrname}.overridePythonAttrs (oldAttrs: {
+        inherit version;
         src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "1wv31zly44qj0rp2acg58xbnc7bf6ffyadasq093l455q30qafl6";
+          inherit version sha256;
         };
-      });
-      jsonschema = super.jsonschema.overridePythonAttrs (oldAttrs: rec {
-        version = "2.6.0";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "00kf3zmpp9ya4sydffpifn0j0mzm342a2vzh82p6r0vh10cg7xbg";
-        };
+
       });
     };
+
+  python = python3.override {
+    # Put packageOverrides at the start so they are applied after defaultOverrides
+    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([ packageOverrides ] ++ defaultOverrides);
   };
+    
 in python.pkgs.buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "gns3-gui";

--- a/pkgs/applications/networking/gns3/gui.nix
+++ b/pkgs/applications/networking/gns3/gui.nix
@@ -1,36 +1,19 @@
-# This package required qt5Full to launch
-{ stable, branch, version, sha256Hash }:
+{ stable, branch, version, sha256Hash, mkOverride }:
 
-{ lib, stdenv, python3, fetchFromGitHub 
-, packageOverrides ? self: super: {
-
-}}:
+{ lib, stdenv, python3, fetchFromGitHub }:
 
 let
-
+  # TODO: This package requires qt5Full to launch
   defaultOverrides = [
-        (mkOverride "psutil" "5.6.3"
+    (mkOverride "psutil" "5.6.3"
       "1wv31zly44qj0rp2acg58xbnc7bf6ffyadasq093l455q30qafl6")
-        (mkOverride "jsonschema" "5.6.3"
+    (mkOverride "jsonschema" "2.6.0"
       "00kf3zmpp9ya4sydffpifn0j0mzm342a2vzh82p6r0vh10cg7xbg")
   ];
 
-  mkOverride = attrname: version: sha256:
-    self: super: {
-      ${attrname} = super.${attrname}.overridePythonAttrs (oldAttrs: {
-        inherit version;
-        src = oldAttrs.src.override {
-          inherit version sha256;
-        };
-
-      });
-    };
-
   python = python3.override {
-    # Put packageOverrides at the start so they are applied after defaultOverrides
-    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([ packageOverrides ] ++ defaultOverrides);
+    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) defaultOverrides;
   };
-    
 in python.pkgs.buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "gns3-gui";

--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -1,57 +1,18 @@
-{ stable, branch, version, sha256Hash }:
+{ stable, branch, version, sha256Hash, mkOverride }:
 
-{ lib, stdenv, python3, fetchFromGitHub
-, packageOverrides ? self: super: {
-}}:
+{ lib, stdenv, python3, fetchFromGitHub }:
 
 let
   defaultOverrides = [
-        (mkOverride "psutil" "5.6.3"
+    (mkOverride "psutil" "5.6.3"
       "1wv31zly44qj0rp2acg58xbnc7bf6ffyadasq093l455q30qafl6")
-        (mkOverride "jsonschema" "5.6.3"
+    (mkOverride "jsonschema" "2.6.0"
       "00kf3zmpp9ya4sydffpifn0j0mzm342a2vzh82p6r0vh10cg7xbg")
-        (mkOverride "aiohttp" "3.6.2"
-        "09pkw6f1790prnrq0k8cqgnf1qy57ll8lpmc6kld09q7zw4vi6i5")
   ];
 
-  mkOverride = attrname: version: sha256:
-    self: super: {
-      ${attrname} = super.${attrname}.overridePythonAttrs (oldAttrs: {
-        inherit version;
-        src = oldAttrs.src.override {
-          inherit version sha256;
-        };
-        checkPhase = (
-          # Match unstable branch, cookiejar missing from python packages..
-          if attrname == "aiohttp" then ''
-                 cd tests
-                    pytest -k "not get_valid_log_format_exc \
-                    and not test_access_logger_atoms \
-                    and not aiohttp_request_coroutine \
-                    and not server_close_keepalive_connection \
-                    and not connector \
-                    and not client_disconnect \
-                    and not handle_keepalive_on_closed_connection \
-                    and not proxy_https_bad_response \
-                    and not partially_applied_handler \
-                    and not middleware" \
-                  --ignore=test_connector.py \
-                  --ignore=test_cookiejar.py
-            ''
-            else if attrname == "jsonschema" then
-              oldAttrs.checkPhase
-            else 
-              ''''
-        );
-      });
-    };
-
   python = python3.override {
-    # Put packageOverrides at the start so they are applied after defaultOverrides
-    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([ packageOverrides ] ++ defaultOverrides);
+    packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) defaultOverrides;
   };
-    
-
 in python.pkgs.buildPythonPackage {
   pname = "gns3-server";
   inherit version;


### PR DESCRIPTION
Due to https://github.com/NixOS/nixpkgs/issues/44426 the correct psutils
package is not picked up, this commit changes the code so the correct
version is always picked

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
