### PR TITLE
nota: init at 1.0

### DIFF
--- a/pkgs/applications/science/math/nota/default.nix
+++ b/pkgs/applications/science/math/nota/default.nix
@@ -1,0 +1,40 @@
+{ mkDerivation, haskellPackages, fetchurl, lib }:
+
+mkDerivation rec {
+  pname = "nota";
+  version = "1.0";
+
+  # Can't use fetchFromGitLab since codes.kary.us doesn't support https
+  src = fetchurl {
+    url = "http://codes.kary.us/nota/nota/-/archive/V${version}/nota-V${version}.tar.bz2";
+    sha256 = "0bbs6bm9p852hvqadmqs428ir7m65h2prwyma238iirv42pk04v8";
+  };
+
+  postUnpack = ''
+    export sourceRoot=$sourceRoot/source
+  '';
+
+  isLibrary = false;
+  isExecutable = true;
+
+  libraryHaskellDepends = with haskellPackages; [
+    base
+    bytestring
+    array
+    split
+    scientific
+    parsec
+    ansi-terminal
+    regex-compat
+    containers
+    terminal-size
+    numbers
+    text
+    time
+  ];
+
+  description = "The most beautiful command line calculator";
+  homepage = "https://kary.us/nota";
+  license = lib.licenses.mpl20;
+  maintainers = with lib.maintainers; [ dtzWill ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23915,6 +23915,8 @@ in
 
   nasc = callPackage ../applications/science/math/nasc { };
 
+  nota = haskellPackages.callPackage ../applications/science/math/nota { };
+
   openblas = callPackage ../development/libraries/science/math/openblas { };
 
   # A version of OpenBLAS using 32-bit integers on all platforms for compatibility with
@@ -25799,5 +25801,4 @@ in
   sentencepiece = callPackage ../development/libraries/sentencepiece {};
 
   kcli = callPackage ../development/tools/kcli {};
-
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes #77590.

(see issue for more details)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).