### PR TITLE
cupy: Move cudatoolkit to propagatedNativeBuildInputs to fix Thrust

### DIFF
--- a/pkgs/development/python-modules/cupy/default.nix
+++ b/pkgs/development/python-modules/cupy/default.nix
@@ -18,8 +18,11 @@ buildPythonPackage rec {
     mock
   ];
 
-  propagatedBuildInputs = [
+  propagatedNativeBuildInputs = [
     cudatoolkit
+  ];
+
+  propagatedBuildInputs = [
     cudnn
     linuxPackages.nvidia_x11
     nccl


### PR DESCRIPTION
###### Motivation for this change

The `nvcc` binary needs to be found in `PATH` at build time for Thrust support to be enabled.

Test case: check the `cupy.cuda.thrust_enabled` boolean, or try to use `cupy.sort`, which doesn’t work without Thrust.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @hyphon81