### PR TITLE
imageworsener: init at 1.3.3

### DIFF
--- a/pkgs/tools/graphics/imageworsener/default.nix
+++ b/pkgs/tools/graphics/imageworsener/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchurl
+, zlib
+, libpng
+, libjpeg
+, libwebp
+}:
+
+stdenv.mkDerivation rec {
+  pname = "imageworsener";
+  version = "1.3.3";
+
+  src = fetchurl {
+    url = "https://entropymine.com/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "099ymaqk7gj0plmdx7fxabbdx2n03d25r00ly0vf6cx37mgnwjvw";
+  };
+
+  postPatch = ''
+    patchShebangs tests/runtest
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/doc/imageworsener
+    cp readme.txt technical.txt $out/share/doc/imageworsener
+  '';
+
+  buildInputs = [ zlib libpng libjpeg libwebp ];
+
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A raster image scaling and processing utility";
+    homepage = https://entropymine.com/imageworsener/;
+    changelog = "https://github.com/jsummers/${pname}/blob/${version}/changelog.txt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ emily ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -930,6 +930,8 @@ in
 
   ili2c = callPackage ../tools/misc/ili2c { };
 
+  imageworsener = callPackage ../tools/graphics/imageworsener { };
+
   imgpatchtools = callPackage ../development/mobile/imgpatchtools { };
 
   ipgrep = callPackage ../tools/networking/ipgrep { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[ImageWorsener](https://entropymine.com/imageworsener/) is a high-quality command-line raster image scaling and processing tool, supporting a wide range of algorithms. It's packaged in [Homebrew, Gentoo and FreeBSD](https://repology.org/project/imageworsener/versions).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).