### PR TITLE
aview:  new at 1.3.0rc1-debian4

### DIFF
--- a/pkgs/applications/graphics/aview/default.nix
+++ b/pkgs/applications/graphics/aview/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, aalib, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "aview";
+  version = "1.3.0rc1-debian4";
+
+  src = fetchFromGitHub {
+    owner = "deepfire";
+    repo = "aview";
+    rev = "c128170199aa3516649ad9ed806af30849f19ffc";
+    sha256 = "1gikxn2z12rfbb9vdf7pgrjk2kvr83bk1hycmijvdnbls6l87cyp";
+  };
+
+  buildInputs = [
+    aalib ncurses
+  ];
+
+  meta = {
+    homepage = http://aa-project.sourceforge.net/;
+    description = "Aview is a high quality ascii-art image(pnm) browser and animation(fli/flc) player.";
+    license = stdenv.lib.licenses.gpl2;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ lib.maintainers.deepfire ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18082,6 +18082,8 @@ in
 
   autotrace = callPackage ../applications/graphics/autotrace {};
 
+  aview = callPackage ../applications/graphics/aview { };
+
   avocode = callPackage ../applications/graphics/avocode {};
 
   azpainter = callPackage ../applications/graphics/azpainter { };


### PR DESCRIPTION
###### Motivation for this change

Add `aview` -- the ASCII art viewer accompanying `aalib`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
