### PR TITLE
pythonPackages.pillow: 6.2.1 -> 7.1.2

### DIFF
--- a/pkgs/development/python-modules/batchgenerators/default.nix
+++ b/pkgs/development/python-modules/batchgenerators/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , isPy27
 , fetchFromGitHub
+, fetchpatch
 , pytest
 , unittest2
 , future
@@ -26,6 +27,13 @@ buildPythonPackage rec {
     sha256 = "0cc3i4wznqb7lk8n6jkprvkpsby6r7khkxqwn75k8f01mxgjfpvf";
     
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/MIC-DKFZ/batchgenerators/pull/59.patch";
+      sha256 = "171b3dm40yn0wi91m9s2nq3j565s1w39jpdf1mvc03rn75i8vdp0";
+    })
+  ];
 
   propagatedBuildInputs = [
     future numpy pillow scipy scikitlearn scikitimage threadpoolctl

--- a/pkgs/development/python-modules/django-versatileimagefield/default.nix
+++ b/pkgs/development/python-modules/django-versatileimagefield/default.nix
@@ -4,6 +4,7 @@
 , django
 , python
 , pillow
+, python_magic
 }:
 
 buildPythonPackage rec {
@@ -14,7 +15,7 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "8322ee9d7bf5ffa5360990320d2cc2efc7017feff35422636d49f625721edf82";
   };
-  propagatedBuildInputs = [ pillow ];
+  propagatedBuildInputs = [ pillow python_magic ];
 
   checkInputs = [ django ];
 

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -1,19 +1,21 @@
 { stdenv, buildPythonPackage, fetchPypi, isPyPy
 , olefile
 , freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11
-, pytestrunner
-, pytest
+, openjpeg, libimagequant
+, pytest, pytestrunner, pyroma, numpy
+, isPy3k
 }:
+
 buildPythonPackage rec {
   pname = "Pillow";
-  version = "6.2.2";
+  version = "7.1.2";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "db9ff0c251ed066d367f53b64827cc9e18ccea001b986d08c265e53625dab950";
+    sha256 = "1pdh1zzdwxilvsjg6rnl4q810pc2p2y16q6lx9gzzihb25h9kd50";
   };
-
-  doCheck = !stdenv.isDarwin && !isPyPy;
 
   # Disable imagefont tests, because they don't work well with infinality:
   # https://github.com/python-pillow/Pillow/issues/1259
@@ -21,12 +23,18 @@ buildPythonPackage rec {
     rm Tests/test_imagefont.py
   '';
 
+  checkPhase = ''
+    runHook preCheck
+    python -m pytest -v -x -W always
+    runHook postCheck
+  '';
+
   propagatedBuildInputs = [ olefile ];
 
-  checkInputs = [ pytest pytestrunner ];
+  checkInputs = [ pytest pytestrunner pyroma numpy ];
 
   buildInputs = [
-    freetype libjpeg zlib libtiff libwebp tcl lcms2 ]
+    freetype libjpeg openjpeg libimagequant zlib libtiff libwebp tcl lcms2 ]
     ++ stdenv.lib.optionals (isPyPy) [ tk libX11 ];
 
   # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.
@@ -45,6 +53,8 @@ buildPythonPackage rec {
     sed -i "setup.py" \
         -e 's|^FREETYPE_ROOT =.*$|FREETYPE_ROOT = ${libinclude freetype}|g ;
             s|^JPEG_ROOT =.*$|JPEG_ROOT = ${libinclude libjpeg}|g ;
+            s|^JPEG2K_ROOT =.*$|JPEG2K_ROOT = ${libinclude openjpeg}|g ;
+            s|^IMAGEQUANT_ROOT =.*$|IMAGEQUANT_ROOT = ${libinclude' libimagequant}|g ;
             s|^ZLIB_ROOT =.*$|ZLIB_ROOT = ${libinclude zlib}|g ;
             s|^LCMS_ROOT =.*$|LCMS_ROOT = ${libinclude lcms2}|g ;
             s|^TIFF_ROOT =.*$|TIFF_ROOT = ${libinclude libtiff}|g ;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
[7.1.2 (2020-04-25)](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#712-2020-04-25)
[7.1.1 (2020-04-02)](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#711-2020-04-02)
[7.1.0 (2020-04-01)](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#710-2020-04-01)
[7.0.0 (2020-01-02)](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#700-2020-01-02)

#### Support for Python 2.7 has been dropped
___
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
___

`python -m PIL` confirms `7.0.0`

```
--------------------------------------------------------------------
Pillow 7.0.0
Python 3.7.6 (default, Dec 18 2019, 19:23:55)
       [GCC 9.2.0]
--------------------------------------------------------------------
...
```

This feature was introduced in https://github.com/python-pillow/Pillow/pull/3870, so running `python -m PIL` before `7.0.0` will print: `python3.7: No module named PIL.__main__; 'PIL' is a package and cannot be directly executed`

`nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` passed, but is there anything more in depth I can do to test reverse dependencies or etc?

The only thing I can think of is any libraries that might depend on this but don't require python2.7, etc.