### PR TITLE
texlive: touchup documentation

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/UPGRADING.md
+++ b/pkgs/tools/typesetting/tex/texlive/UPGRADING.md
@@ -28,15 +28,15 @@ To upgrade the package snapshot, follow this process:
 ### Snapshot sources and texlive package database
 
 Mirror the current CTAN archive to our mirror(s) and IPFS (URLs in `default.nix`).
-See <https://tug.org/texlive/acquire-mirror.html> for instructions.
+See https://tug.org/texlive/acquire-mirror.html for instructions.
 
 
 ### Upgrade package information from texlive package database
 
 
-```
-$ curl -L http://mirror.ctan.org/tex-archive/systems/texlive/tlnet/tlpkg/texlive.tlpdb.xz \
-           | xzcat | uniq -u | sed -rn -f ./tl2nix.sed > ./pkgs.nix
+```bash
+curl -L http://mirror.ctan.org/tex-archive/systems/texlive/tlnet/tlpkg/texlive.tlpdb.xz \
+         | xzcat | uniq -u | sed -rn -f ./tl2nix.sed > ./pkgs.nix
 ```
 
 This will download a current snapshot of the CTAN package database `texlive.tlpdb.xz`
@@ -52,17 +52,18 @@ Updating the list of fixed hashes requires a local build of *all* packages,
 which is a resource-intensive process:
 
 
-```
+```bash
 # move fixedHashes away, otherwise build will fail on updated packages
-$ mv fixedHashes.nix fixedHashes-old.nix
+mv fixedHashes.nix fixedHashes-old.nix
 # start with empty fixedHashes
-$ echo '{}' > fixedHashes.nix
-$ nix-build ../../../../.. -Q --no-out-link -A texlive.scheme-full.pkgs | ./fixHashes.sh > ./fixedHashes-new.nix
+echo '{}' > fixedHashes.nix
+
+nix-build ../../../../.. -Q --no-out-link -A texlive.scheme-full.pkgs | ./fixHashes.sh > ./fixedHashes-new.nix
+
 # The script wrongly includes the nix store path to `biber`, which is a separate nixpkgs package
-$ grep -v -F '/nix/store/' fixedHashes-new.nix > fixedHashes.nix 
+grep -v -F '/nix/store/' fixedHashes-new.nix > fixedHashes.nix
 ```
 
 ### Commit changes
 
 Commit the updated `pkgs.nix` and `fixedHashes.nix` to the repository.
-


### PR DESCRIPTION
The `bash` pragma gives syntax highlighting on the file, and removing the
prompts allows a user to just copy-paste the entire block into the terminal to
run the update.

CC @xeji @veprbl


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).