### PR TITLE
httpie: 1.0.3 -> 2.0.0

### DIFF
--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -2,22 +2,18 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "httpie";
-  version = "1.0.3";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "jakubroztocil";
     repo = "httpie";
     rev = version;
-    sha256 = "0y30sp0x3nmgzi4dqw1rc3705hnn36ij0zlyyx7g6fqdq8bd8p5q";
+    sha256 = "0d0rsn5i973l9y0ws3xmnzaw4jwxdlryyjbasnlddph5mvkf7dq0";
   };
 
   propagatedBuildInputs = with python3Packages; [ pygments requests setuptools ];
   dontUseSetuptoolsCheck = true;
-
-  disabledTests = [
-    "test_current_version"
-    "test_error"
-  ];
+  patches = [ ./strip-venv.patch ];
 
   checkInputs = with python3Packages; [
     mock

--- a/pkgs/tools/networking/httpie/strip-venv.patch
+++ b/pkgs/tools/networking/httpie/strip-venv.patch
@@ -1,0 +1,19 @@
+diff --git a/tests/test_docs.py b/tests/test_docs.py
+index 7a41822..720ecf6 100644
+--- a/tests/test_docs.py
++++ b/tests/test_docs.py
+@@ -41,12 +41,10 @@ assert filenames
+ 
+ # HACK: hardcoded paths, venv should be irrelevant, etc.
+ # TODO: replaces the process with Python code
+-VENV_BIN = Path(__file__).parent.parent / 'venv/bin'
+-VENV_PYTHON = VENV_BIN / 'python'
+-VENV_RST2PSEUDOXML = VENV_BIN / 'rst2pseudoxml.py'
++VENV_PYTHON = 'python'
++VENV_RST2PSEUDOXML = 'rst2pseudoxml.py'
+ 
+ 
+-@pytest.mark.skipif(not os.path.exists(VENV_RST2PSEUDOXML), reason='docutils not installed')
+ @pytest.mark.parametrize('filename', filenames)
+ def test_rst_file_syntax(filename):
+     p = subprocess.Popen(


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md)

I only tested http-prompt quickly. A simple GET worked.

$ nix path-info -h -S /nix/store/zakzw9m8pcp1z2lf7i4lvk34naybx9na-httpie-1.0.3
/nix/store/zakzw9m8pcp1z2lf7i4lvk34naybx9na-httpie-1.0.3	 115.8M

$ nix path-info -h -S /nix/store/jscqy7pkcqrj9zhy1rjshhsz7vhj99z2-httpie-2.0.0
/nix/store/jscqy7pkcqrj9zhy1rjshhsz7vhj99z2-httpie-2.0.0	 115.9M