### PR TITLE
bs-platform: don't build a development binary

### DIFF
--- a/pkgs/development/compilers/bs-platform/build-bs-platform.nix
+++ b/pkgs/development/compilers/bs-platform/build-bs-platform.nix
@@ -35,11 +35,12 @@ stdenv.mkDerivation {
   '';
 
   buildPhase = ''
-    node scripts/ninja.js build
+    # This is an unfortunate name, but it's actually how to build a release
+    # binary for BuckleScript
+    node scripts/install.js
   '';
 
   installPhase = ''
-    node scripts/install.js
     mkdir -p $out/bin
     cp -rf jscomp lib vendor odoc_gen native $out
     cp bsconfig.json package.json $out


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It was pointed out in the upstream issue that @turboMaCk opened wrt aarch64 that we are building in devmode ([link](https://github.com/BuckleScript/bucklescript/issues/4091#issuecomment-574514891))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
