### PR TITLE
sile: v0.9.5.1 -> v0.10.3; adjust build process

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -6,6 +6,7 @@ basexx,,,,,
 binaryheap,,,,,vcunat
 bit32,,,,lua5_1,lblasc
 busted,,,,,
+cassowary,,,,,marsam
 cjson,lua-cjson,,,,
 compat53,,,,,vcunat
 coxpcall,,,1.17.0-1,,

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -9,6 +9,7 @@ busted,,,,,
 cassowary,,,,,marsam
 cjson,lua-cjson,,,,
 compat53,,,,,vcunat
+cosmo,,,,,marsam
 coxpcall,,,1.17.0-1,,
 cqueues,,,,,vcunat
 cyrussasl,,,,,vcunat

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -214,6 +214,23 @@ compat53 = buildLuarocksPackage {
     };
   };
 };
+cosmo = buildLuarocksPackage {
+  pname = "cosmo";
+  version = "16.06.04-1";
+
+  src = fetchurl {
+    url    = mirror://luarocks/cosmo-16.06.04-1.src.rock;
+    sha256 = "1adrk74j0x1yzhy0xz9k80hphxdjvm09kpwpbx00sk3kic6db0ww";
+  };
+  propagatedBuildInputs = [ lpeg ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://cosmo.luaforge.net";
+    description = "Safe templates for Lua";
+    maintainers = with maintainers; [ marsam ];
+    license.fullName = "MIT/X11";
+  };
+};
 coxpcall = buildLuarocksPackage {
   pname = "coxpcall";
   version = "1.17.0-1";

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -158,6 +158,23 @@ busted = buildLuarocksPackage {
     };
   };
 };
+cassowary = buildLuarocksPackage {
+  pname = "cassowary";
+  version = "2.2-1";
+
+  src = fetchurl {
+    url    = mirror://luarocks/cassowary-2.2-1.src.rock;
+    sha256 = "0laghzk5jbap5rfd8sasnrdrbda649sfciarba8rhygm0qni1azy";
+  };
+  propagatedBuildInputs = [ lua penlight ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/simoncozens/cassowary.lua";
+    description = "The cassowary constraint solver.";
+    maintainers = with maintainers; [ marsam ];
+    license.fullName = "Apache 2";
+  };
+};
 cjson = buildLuarocksPackage {
   pname = "lua-cjson";
   version = "2.1.0.6-1";

--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -1,23 +1,23 @@
 { stdenv, darwin, fetchurl, makeWrapper, pkgconfig
 , harfbuzz, icu
 , fontconfig, lua, libiconv
-, makeFontsConf, gentium, gentium-book-basic, dejavu_fonts
+, makeFontsConf, gentium
 }:
 
 with stdenv.lib;
 
 let
-  luaEnv = lua.withPackages(ps: with ps;[ lpeg luaexpat lua-zlib luafilesystem luasocket luasec]);
+  luaEnv = lua.withPackages(ps: with ps;[cassowary linenoise lpeg lua-zlib lua_cliargs luaepnf luaexpat luafilesystem luarepl luasec luasocket stdlib vstruct]);
 
 in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.9.5.1";
+  version = "0.10.0";
 
   src = fetchurl {
-    url = "https://github.com/simoncozens/sile/releases/download/v${version}/${pname}-${version}.tar.bz2";
-    sha256 = "0fh0jbpsyqyq0hzq4midn7yw2z11hqdgqb9mmgz766cp152wrkb0";
+    url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.bz2";
+    sha256 = "b0353b88793d68bf3e800f87bff51e8161ce39d250e22dff11385712caf332b6";
   };
 
   nativeBuildInputs = [pkgconfig makeWrapper];
@@ -34,8 +34,6 @@ stdenv.mkDerivation rec {
   FONTCONFIG_FILE = makeFontsConf {
     fontDirectories = [
       gentium
-      gentium-book-basic
-      dejavu_fonts
     ];
   };
 
@@ -46,11 +44,12 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   checkPhase = ''
-    make documentation/developers.pdf documentation/sile.pdf
+    make documentation examples
   '';
 
   postInstall = ''
-    install -D -t $out/share/doc/sile documentation/*.pdf
+    install -D -t $out/share/doc/sile documentation/sile.pdf
+    install -D -t $out/share/doc/sile examples
   '';
 
   # Hack to avoid TMPDIR in RPATHs.

--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -13,11 +13,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.10.0";
+  version = "0.10.1";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.bz2";
-    sha256 = "b0353b88793d68bf3e800f87bff51e8161ce39d250e22dff11385712caf332b6";
+    sha256 = "a5ec924bfe8a629ec4b4d09754d822cab1cf48d28bc6ce649faa5c597a108666";
   };
 
   nativeBuildInputs = [pkgconfig makeWrapper];

--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   checkPhase = ''
-    make documentation examples
+    make examples
   '';
 
   postInstall = ''

--- a/pkgs/tools/typesetting/sile/default.nix
+++ b/pkgs/tools/typesetting/sile/default.nix
@@ -7,17 +7,17 @@
 with stdenv.lib;
 
 let
-  luaEnv = lua.withPackages(ps: with ps;[cassowary linenoise lpeg lua-zlib lua_cliargs luaepnf luaexpat luafilesystem luarepl luasec luasocket stdlib vstruct]);
+  luaEnv = lua.withPackages(ps: with ps;[cassowary cosmo linenoise lpeg lua-zlib lua_cliargs luaepnf luaexpat luafilesystem luarepl luasec luasocket stdlib vstruct]);
 
 in
 
 stdenv.mkDerivation rec {
   pname = "sile";
-  version = "0.10.1";
+  version = "0.10.3";
 
   src = fetchurl {
     url = "https://github.com/sile-typesetter/sile/releases/download/v${version}/${pname}-${version}.tar.bz2";
-    sha256 = "a5ec924bfe8a629ec4b4d09754d822cab1cf48d28bc6ce649faa5c597a108666";
+    sha256 = "d89d5ce7d2bf46fb062e5299ffd8b5d821dc3cb3462a0e7c1109edeee111d856";
   };
 
   nativeBuildInputs = [pkgconfig makeWrapper];


### PR DESCRIPTION
#### Motivation for this change

New release of SILE upstream ([announcement](https://sile-typesetter.org/2020/01/sile-0-10-0-is-released)) has new dependencies and a different build system. Overall it should be easier to packages, but for this release cycle there are several changes.

Note I am not a Nix user, I am an upstream maintainer trying to facilitate this update. There are several things _NOT_ done yet that I don't know how to fix:

- [x] The `./configure` command needs to be passed the `--with-system-luarocks` argument if, as in the current package, all the external Lua Rocks are being supplied by the package manager. Alternatively if it would be better for Nix not to bother with those and just have SILE bundle the deps itself, you can just drop all the Lua package deps and _not_ pass this argument and it will bundle everything.
- [ ] The man page should get packaged too, is it?

If there is anything else I can facilitate so this packages easily let me know.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).