### PR TITLE
Replace short URL from #63103 with full URL.

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -406,7 +406,7 @@ rec {
                 In file ${def.file}
                 a list is being assigned to the option config.${option}.
                 This will soon be an error as type loaOf is deprecated.
-                See https://git.io/fj2zm for more information.
+                See https://github.com/NixOS/nixpkgs/pull/63103 for more information.
                 Do
                   ${option} =
                     { ${set}${more}}


### PR DESCRIPTION
It's polite to show a user where a URL is taking them before they follow it. Also, the message is already (helpfully) verbose, so there's not much benefit in using a shortener in the first place.

This change also makes the documentation consistent with existing practice when referring to GitHub pull requests in user-visible strings; see, for example:

https://github.com/NixOS/nixpkgs/blob/cd6ac55fb1b4dc75418550cdd75edc8522bf1e9b/pkgs/top-level/all-packages.nix#L25036

https://github.com/NixOS/nixpkgs/blob/273ec2332283bab059e1c665a65effe48ed59aa1/pkgs/development/libraries/jasper/default.nix#L47

https://github.com/NixOS/nixpkgs/blob/0107ee8c322e57cdb2ebcc1c9c4286ff7db53d5c/pkgs/applications/networking/mailreaders/mailpile/default.nix#L49

