### PR TITLE
Merge pull request #77772 from x123/x123-add-qt-wrap-xygrib

### DIFF
--- a/pkgs/applications/misc/xygrib/default.nix
+++ b/pkgs/applications/misc/xygrib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, bzip2, qtbase, qttools, libnova, proj, libpng, openjpeg } :
+{ stdenv, fetchFromGitHub, wrapQtAppsHook, cmake, bzip2, qtbase, qttools, libnova, proj, libpng, openjpeg } :
 
 stdenv.mkDerivation rec {
   version = "1.2.6.1";
@@ -11,13 +11,14 @@ stdenv.mkDerivation rec {
     sha256 = "0xzsm8pr0zjk3f8j880fg5n82jyxn8xf1330qmmq1fqv7rsrg9ia";
   };
 
-  nativeBuildInputs = [ cmake qttools ];
+  nativeBuildInputs = [ cmake qttools wrapQtAppsHook ];
   buildInputs = [ bzip2 qtbase libnova proj openjpeg libpng ];
   cmakeFlags = [ "-DOPENJPEG_INCLUDE_DIR=${openjpeg.dev}/include/openjpeg-2.3" ];
 
   postInstall = ''
-    mkdir $out/bin
-    ln -s $out/XyGrib/XyGrib $out/bin/XyGrib
+    wrapQtApp $out/XyGrib/XyGrib
+    mkdir -p $out/bin
+    ln -s $out/XyGrib/XyGrib $out/bin/xygrib
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
XyGrib does not currently work on `19.09.1840.f7d050ed4e3` without Qt, this type of behavior was also addressed in a larger pull request https://github.com/NixOS/nixpkgs/pull/54525
```
% XyGrib                                                                                                                                                                                                                                                                 !7565
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

###### Things done
Added `wrapQtAppsHook` to the `xygrib` derivation and also ensured the output binary has a sensible lowercased name rather than some silly camelcase thing (xygrib and zygrib have never actually used CamelCased names on any other distributions I'm familiar with).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
