### PR TITLE
Rosie init at unstable 2020-01-11

### DIFF
--- a/pkgs/tools/text/rosie/default.nix
+++ b/pkgs/tools/text/rosie/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, lib
+, fetchgit
+, libbsd
+, readline
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rosie";
+  version = "unstable-2020-01-11";
+  src = fetchgit {
+    url = https://gitlab.com/rosie-pattern-language/rosie;
+    rev = "670e9027563609ba2ea31e14e2621a1302742795";
+    sha256 = "0jc512dbn62a1fniknhbp6q0xa1p7xi3hn5v60is8sy9jgi3afxv";
+    fetchSubmodules = true;
+  };
+
+  postUnpack = ''
+    # The Makefile calls git to update submodules, unless this file exists
+    touch ${src.name}/submodules/~~present~~
+  '';
+
+  preConfigure = ''
+    patchShebangs src/build_info.sh
+    # Part of the same Makefile target which calls git to update submodules
+    ln -s src submodules/lua/include
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/emacs/site-lisp $out/share/vim-plugins $out/share/nvim
+    mv $out/lib/rosie/extra/extra/emacs/* $out/share/emacs/site-lisp/
+    mv $out/lib/rosie/extra/extra/vim $out/share/vim-plugins/rosie
+    ln -s $out/share/vim-plugins/rosie $out/share/nvim/site
+  '';
+
+  makeFlags = [ "DESTDIR=${placeholder "out"}" ];
+
+  buildInputs = [ libbsd readline ];
+
+  meta = with lib; {
+    homepage = https://rosie-lang.org;
+    description = "Tools for searching using parsing expression grammars";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kovirobi ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6116,6 +6116,8 @@ in
 
   rnv = callPackage ../tools/text/xml/rnv { };
 
+  rosie = callPackage ../tools/text/rosie { };
+
   rounded-mgenplus = callPackage ../data/fonts/rounded-mgenplus { };
 
   roundup = callPackage ../tools/misc/roundup { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Packages request #73921. A supercharged alternative to regular expressions (regex), matching patterns against any input text.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

# Notes
- Currently Rosie uses its own Lua, so I don't use luaPackages.callPackage (see https://gitlab.com/rosie-pattern-language/rosie/issues/111)
- Using unstable branch currently, as it contains some fixes for Nix packaging (as a result of previously mentioned gitlab issue).
- Not using fetchFromGitLab but fetchgit as we need to fetch the submodules
- Editor plugins have some bugs:
  - Emacs requires `(require 'rpl-mode)` before being able to `M-x rpl-mode`
  - Not sure how/where vim plugins should be installed, I tried to replicate something like `vimPlugins.syntastic` in the output directory but couldn't get it to auto-load using `vim_configurable.customize` (neovim picks up package from `~/.nix-profile/share/nvim/site` when `nix-env -i`'d)

(It pleases me that this is pull request 77777, just because it's the same digits.)

Edit: fixes #73921 