### PR TITLE
vit: fix check phase

### DIFF
--- a/pkgs/applications/misc/vit/default.nix
+++ b/pkgs/applications/misc/vit/default.nix
@@ -1,5 +1,6 @@
 { lib
 , python3Packages
+, glibcLocales
 , taskwarrior }:
 
 with python3Packages;
@@ -20,6 +21,7 @@ buildPythonApplication rec {
     tzlocal
     urwid
   ];
+  checkInputs = [ glibcLocales ];
 
   makeWrapperArgs = [ "--suffix" "PATH" ":" "${taskwarrior}/bin" ];
 


### PR DESCRIPTION
###### Motivation for this change

It broke. See a6d0b81d28dcbd08d32f178d91fa8cdb97f5fa3f for a similar fix for a different package affected by the same issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
