### PR TITLE
fluidasserts: init at 20.1.22554

### DIFF
--- a/pkgs/development/python-modules/fluidasserts/default.nix
+++ b/pkgs/development/python-modules/fluidasserts/default.nix
@@ -1,0 +1,187 @@
+{ buildPythonPackage
+, fetchPypi
+, isPy37
+, lib
+
+# pythonPackages
+, aiohttp
+, androguard
+, azure-identity
+, azure-keyvault-keys
+, azure-keyvault-secrets
+, azure-mgmt-compute
+, azure-mgmt-keyvault
+, azure-mgmt-network
+, azure-mgmt-storage
+, azure-mgmt-web
+, azure-storage-file
+, bandit
+, bcrypt
+, beautifulsoup4
+, boto3
+, cfn-flip
+, cython
+, dnspython
+, colorama
+, configobj
+, defusedxml
+, GitPython
+, google_api_python_client
+, kubernetes
+, ldap3
+, mixpanel
+, mysql-connector
+, names
+, ntplib
+, oyaml
+, paramiko
+, pillow
+, psycopg2
+, pycrypto
+, pygments
+, pyjks
+, pynacl
+, pyopenssl
+, pypdf2
+, pysmb
+, python_magic
+, pytz
+, requirements-detector
+, selenium
+, tlslite-ng
+, viewstate
+
+# pythonPackages to test the derivation
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "fluidasserts";
+  version = "20.1.22554";
+  disabled = !isPy37;
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "0j7zppwingi9m58z51phy40d69jlskx1vgyz1gj9miqhbjfdymhi";
+  };
+
+  patchPhase = ''
+    # Version mismatches between current FluidAsserts and Nixpkgs
+    substituteInPlace ./setup.py \
+      --replace 'tlslite-ng==0.8.0-alpha29' 'tlslite-ng==0.7.5' \
+      --replace 'boto3==1.10.17' 'boto3==1.10.1' \
+      --replace 'cfn-flip==1.2.2' 'cfn-flip==1.1.0.post1' \
+      --replace 'azure-mgmt-storage==7.1.0' 'azure-mgmt-storage==7.0.0' \
+
+    # Functionality that will be not present for the momment
+    #   but that we'll work to add in the future
+    # Just a minimal portion of fluidasserts use this
+    substituteInPlace ./setup.py \
+      --replace "'azure-storage-file-share==12.0.0'," "" \
+      --replace "'pymssql==2.1.4'," "" \
+      --replace "'pytesseract==0.3.0'," "" \
+      --replace "'pywinrm==0.4.1'," "" \
+
+  '';
+
+  propagatedBuildInputs = [
+    # pythonPackages
+    aiohttp
+    androguard
+    azure-identity
+    azure-keyvault-keys
+    azure-keyvault-secrets
+    azure-mgmt-compute
+    azure-mgmt-keyvault
+    azure-mgmt-network
+    azure-mgmt-storage
+    azure-mgmt-web
+    azure-storage-file
+    bandit
+    bcrypt
+    beautifulsoup4
+    boto3
+    cfn-flip
+    cython
+    dnspython
+    colorama
+    configobj
+    defusedxml
+    GitPython
+    google_api_python_client
+    kubernetes
+    ldap3
+    mixpanel
+    mysql-connector
+    names
+    ntplib
+    oyaml
+    paramiko
+    pillow
+    psycopg2
+    pycrypto
+    pygments
+    pyjks
+    pynacl
+    pyopenssl
+    pypdf2
+    pysmb
+    python_magic
+    pytz
+    requirements-detector
+    selenium
+    tlslite-ng
+    viewstate
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    # This file launches mock docker containers and servers
+    #   let's remove it to create a custom test environment
+    rm test/conftest.py
+
+    pytest \
+      test/test_cloud_aws_cloudformation_cloudfront.py \
+      test/test_cloud_aws_cloudformation_dynamodb.py \
+      test/test_cloud_aws_cloudformation_ec2.py \
+      test/test_cloud_aws_cloudformation_elb.py \
+      test/test_cloud_aws_cloudformation_elb2.py \
+      test/test_cloud_aws_cloudformation_fsx.py \
+      test/test_cloud_aws_cloudformation_iam.py \
+      test/test_cloud_aws_cloudformation_kms.py \
+      test/test_cloud_aws_cloudformation_rds.py \
+      test/test_cloud_aws_cloudformation_s3.py \
+      test/test_cloud_aws_cloudformation_secretsmanager.py \
+      test/test_format_apk.py \
+      test/test_format_file.py \
+      test/test_format_jks.py \
+      test/test_format_jwt.py \
+      test/test_format_pdf.py \
+      test/test_format_pkcs12.py \
+      test/test_format_string.py \
+      test/test_helper_asynchronous.py \
+      test/test_helper_crypto.py \
+      test/test_lang_core.py \
+      test/test_lang_csharp.py \
+      test/test_lang_docker.py \
+      test/test_lang_dotnetconfig.py \
+      test/test_lang_html.py \
+      test/test_lang_php.py \
+      test/test_lang_python.py \
+      test/test_lang_rpgle.py \
+
+  '';
+
+  meta = with lib; {
+    description = "Assertion Library for Security Assumptions";
+    homepage = "https://gitlab.com/fluidattacks/asserts";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
+  };
+}

--- a/pkgs/development/python-modules/mixpanel/default.nix
+++ b/pkgs/development/python-modules/mixpanel/default.nix
@@ -1,30 +1,46 @@
-{ stdenv
-, buildPythonPackage
-, fetchzip
-, pytest
+
+{ buildPythonPackage
+, fetchFromGitHub
+, isPy37
+, lib
+
+# Python Dependencies
 , mock
+, pytest
 , six
-, isPy3k
 }:
 
 buildPythonPackage rec {
-  version = "4.0.2";
   pname = "mixpanel";
-  disabled = isPy3k;
+  version = "4.5.0";
+  disabled = !isPy37;
 
-  src = fetchzip {
-    url = "https://github.com/mixpanel/mixpanel-python/archive/${version}.zip";
-    sha256 = "0yq1bcsjzsz7yz4rp69izsdn47rvkld4wki2xmapp8gg2s9i8709";
+  src = fetchFromGitHub {
+    owner = "mixpanel";
+    repo = "mixpanel-python";
+    rev = version;
+    sha256 = "1hlc717wcn71i37ngsfb3c605rlyjhsn3v6b5bplq00373r4d39z";
   };
 
-  checkInputs = [ pytest mock ];
-  propagatedBuildInputs = [ six ];
-  checkPhase = "py.test tests.py";
+  propagatedBuildInputs = [
+    six
+  ];
 
-  meta = with stdenv.lib; {
-    homepage = https://github.com/mixpanel/mixpanel-python;
-    description = ''This is the official Mixpanel Python library'';
+  checkInputs = [
+    mock
+    pytest
+  ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/mixpanel/mixpanel-python";
+    description = "Official Mixpanel Python library";
     license = licenses.asl20;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
   };
-
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3242,6 +3242,8 @@ in
     stdenv = gccStdenv;
   };
 
+  fluidasserts = with python37Packages; toPythonApplication fluidasserts;
+
   flux = callPackage ../development/compilers/flux { };
 
   fido2luks = callPackage ../tools/security/fido2luks {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -674,6 +674,8 @@ in {
 
   flufl_lock = callPackage ../development/python-modules/flufl/lock.nix { };
 
+  fluidasserts = callPackage ../development/python-modules/fluidasserts { };
+
   foxdot = callPackage ../development/python-modules/foxdot { };
 
   fsspec = callPackage ../development/python-modules/fsspec { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It's a pretty nice framework that you can use to build 'exploits' (scripts) to verify if previous vulnerabilities found in your systems are still open or closed, the complexity of such scripts is up to the developer, and that's what make it so powerful

It can be used as CLI tool too, to run the exploits, or with predefined (basic) tests like --http or --aws

We use it actively every day and therefore we would like to get it directly from nixpkgs

It's open source https://fluidattacks.com/asserts/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

**nix-linter**

```
$ nix-linter . && echo 'ok' || echo 'fail'
ok
```

**nix-review**

```
kamado:~/Documents/nixpkgs$ nix-review rev HEAD
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nix-review/0
From https://github.com/NixOS/nixpkgs
   f2251b483c0..3b8c2ac0000  master     -> refs/nix-review/0
$ git worktree add /home/kamado/.cache/nix-review/rev-fe32b55afa5923803957e425a9e0fdb7387e1d60/nixpkgs 3b8c2ac00004813e0478715b99caf60a79388314
Preparing worktree (detached HEAD 3b8c2ac0000)
Updating files: 100% (20761/20761), done.
HEAD is now at 3b8c2ac0000 Merge pull request #77776 from dtzWill/update/bibata-cursors-0.4.2
$ nix-env -f /home/kamado/.cache/nix-review/rev-fe32b55afa5923803957e425a9e0fdb7387e1d60/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit fe32b55afa5923803957e425a9e0fdb7387e1d60
Updating 3b8c2ac0000..fe32b55afa5
Fast-forward
 pkgs/development/python-modules/fluidasserts/default.nix           | 142 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 pkgs/development/python-modules/fluidasserts/overlays/mixpanel.nix |  29 +++++++++++++
 pkgs/top-level/all-packages.nix                                    |   2 +
 pkgs/top-level/python-packages.nix                                 |   4 ++
 4 files changed, 177 insertions(+)
 create mode 100644 pkgs/development/python-modules/fluidasserts/default.nix
 create mode 100644 pkgs/development/python-modules/fluidasserts/overlays/mixpanel.nix
$ nix-env -f /home/kamado/.cache/nix-review/rev-fe32b55afa5923803957e425a9e0fdb7387e1d60/nixpkgs -qaP --xml --out-path --show-trace --meta
$ nix build --no-link --keep-going --max-jobs 4 --option build-use-sandbox true -f /home/kamado/.cache/nix-review/rev-fe32b55afa5923803957e425a9e0fdb7387e1d60/build.nix
[1 built, 0.0 MiB DL]
1 package were built:
fluidasserts

$ nix-shell /home/kamado/.cache/nix-review/rev-fe32b55afa5923803957e425a9e0fdb7387e1d60/shell.nix
these paths will be fetched (1.51 MiB download, 8.27 MiB unpacked):
  /nix/store/6lds7pywa1mvay194h6har2cdkhqw2ly-bash-interactive-4.4-p23
  /nix/store/d2iqwqxxq19jyvakh7l4jfvwnbz9rkka-bash-interactive-4.4-p23-dev
  /nix/store/g0wql6lf0ysg7kb6ymmarz6x8glds8if-bash-interactive-4.4-p23-info
  /nix/store/im6sdk69k5s7c8jxzhzfvb2j9nwg7hmg-bash-interactive-4.4-p23-man
  /nix/store/ppa5zzafkz86aaipg5lb3yvyih21p7jd-bash-interactive-4.4-p23-doc
  /nix/store/w95z96r4cb86hnl92xxrnx3m4mk6ixya-readline-7.0p5
copying path '/nix/store/ppa5zzafkz86aaipg5lb3yvyih21p7jd-bash-interactive-4.4-p23-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/g0wql6lf0ysg7kb6ymmarz6x8glds8if-bash-interactive-4.4-p23-info' from 'https://cache.nixos.org'...
copying path '/nix/store/im6sdk69k5s7c8jxzhzfvb2j9nwg7hmg-bash-interactive-4.4-p23-man' from 'https://cache.nixos.org'...
copying path '/nix/store/w95z96r4cb86hnl92xxrnx3m4mk6ixya-readline-7.0p5' from 'https://cache.nixos.org'...
copying path '/nix/store/6lds7pywa1mvay194h6har2cdkhqw2ly-bash-interactive-4.4-p23' from 'https://cache.nixos.org'...
copying path '/nix/store/d2iqwqxxq19jyvakh7l4jfvwnbz9rkka-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...
innovation

[nix-shell:~/.cache/nix-review/rev-fe32b55afa5923803957e425a9e0fdb7387e1d60]$ asserts --help
usage: asserts [-h] [-q] [-k] [-n] [-o] [-c] [-u] [-ms] [-eec] [-mp] [-O FILE]
               [--http URL [URL ...]]
               [--ssl IP_ADDRESS:PORT [IP_ADDRESS:PORT ...]]
               [--dns NS [NS ...]] [--apk APK [APK ...]]
               [--lang FILE/DIR [FILE/DIR ...]]
               [--aws AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY [AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY ...]]
               [--azure AZURE_SUBSCRIPTION_ID:AZURE_CLIENT_ID:AZURE_CLIENT_SECRET:AZURE_TENANT_ID [AZURE_SUBSCRIPTION_ID:AZURE_CLIENT_ID:AZURE_CLIENT_SECRET:AZURE_TENANT_ID ...]]
               [--cloudformation FILE/DIR [FILE/DIR ...]]
               [exploits [exploits ...]]

positional arguments:
  exploits              exploits to execute

optional arguments:
  -h, --help            show this help message and exit
  -q, --quiet           do not show checks output
  -k, --kiss            keep it simple, shows only who and where has been
                        found to be vulnerable
  -n, --no-color        remove colors
  -o, --show-open       show only opened checks
  -c, --show-closed     show only closed checks
  -u, --show-unknown    show only unknown (error) checks
  -ms, --show-method-stats
                        show method-level stats at the end
  -eec, --enrich-exit-codes
                        make the exit codes more expressive
  -mp, --multiprocessing
                        enable multiprocessing over the provided list of
                        exploits.The number of used cpu cores defaults to the
                        local cpu count provided by the OS.
  -O FILE, --output FILE
                        save output in FILE
  --http URL [URL ...]  perform generic HTTP checks over given URL
  --ssl IP_ADDRESS:PORT [IP_ADDRESS:PORT ...]
                        perform generic SSL checks over given IP address and
                        port, if port is not specified it defaults to 443
  --dns NS [NS ...]     perform generic DNS checks over given nameserver
  --apk APK [APK ...]   perform generic APK checks over given APK file(s)
  --lang FILE/DIR [FILE/DIR ...]
                        perform static security checks over given files or
                        directories
  --aws AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY [AWS_ACCESS_KEY_ID:AWS_SECRET_ACCESS_KEY ...]
                        perform AWS checks using the given credentials
  --azure AZURE_SUBSCRIPTION_ID:AZURE_CLIENT_ID:AZURE_CLIENT_SECRET:AZURE_TENANT_ID [AZURE_SUBSCRIPTION_ID:AZURE_CLIENT_ID:AZURE_CLIENT_SECRET:AZURE_TENANT_ID ...]
                        perform Azure checks using the given credentials
  --cloudformation FILE/DIR [FILE/DIR ...]
                        perform AWS checks over CloudFormation templates
                        starting recursively from FILE/DIR

[nix-shell:~/.cache/nix-review/rev-fe32b55afa5923803957e425a9e0fdb7387e1d60]$ asserts --show-open --kiss --multiprocessing --http https://fluidattacks.com
#     ________      _     __   ___                        __
#    / ____/ /_  __(_)___/ /  /   |  _____________  _____/ /______
#   / /_  / / / / / / __  /  / /| | / ___/ ___/ _ \/ ___/ __/ ___/
#  / __/ / / /_/ / / /_/ /  / ___ |(__  |__  )  __/ /  / /_(__  )
# /_/   /_/\__,_/_/\__,_/  /_/  |_/____/____/\___/_/   \__/____/
#
# v. 20.1.21342
#  ___
# | >>|> fluid
# |___|  attacks, we hack your software
#
---
finding: Fluid Asserts - Protocols - HTTP part 1 Module
  check: fluidasserts.proto.http -> has_clear_viewstate
  check: fluidasserts.proto.http -> has_delete_method
  check: fluidasserts.proto.http -> has_dirlisting
  check: fluidasserts.proto.http -> has_host_header_injection
  check: fluidasserts.proto.http -> has_not_subresource_integrity
---
finding: Fluid Asserts - Protocols - HTTP part 2 Module
  check: fluidasserts.proto.http -> has_mixed_content
  check: fluidasserts.proto.http -> has_put_method
  check: fluidasserts.proto.http -> has_reverse_tabnabbing
  check: fluidasserts.proto.http -> has_sqli
  check: fluidasserts.proto.http -> has_trace_method
---
finding: Fluid Asserts - Protocols - HTTP part 3 Module
  check: fluidasserts.proto.http -> is_basic_auth_enabled
  check: fluidasserts.proto.http -> is_date_unsyncd
  check: fluidasserts.proto.http -> is_header_access_control_allow_origin_missing
  check: fluidasserts.proto.http -> is_header_cache_control_missing
  check: fluidasserts.proto.http -> is_header_content_security_policy_missing
  check: fluidasserts.proto.http -> is_header_content_type_missing
  check: fluidasserts.proto.http -> is_header_expires_missing
  check: fluidasserts.proto.http -> is_header_hsts_missing
  check: fluidasserts.proto.http -> is_header_perm_cross_dom_pol_missing
  check: fluidasserts.proto.http -> is_header_pragma_missing
---
finding: Fluid Asserts - Protocols - HTTP part 4 Module
  check: fluidasserts.proto.http -> is_header_server_present
  check: fluidasserts.proto.http -> is_header_x_asp_net_version_present
  check: fluidasserts.proto.http -> is_header_x_content_type_options_missing
  check: fluidasserts.proto.http -> is_header_x_frame_options_missing
  check: fluidasserts.proto.http -> is_header_x_powered_by_present
  check: fluidasserts.proto.http -> is_header_x_xxs_protection_missing
  check: fluidasserts.proto.http -> is_not_https_required
  check: fluidasserts.proto.http -> is_resource_accessible
  check: fluidasserts.proto.http -> is_response_delayed
  check: fluidasserts.proto.http -> is_sessionid_exposed
  check: fluidasserts.proto.http -> is_version_visible
---
finding: Fluid Asserts - Protocols - HTTP part 1 Module
---
check: fluidasserts.proto.http -> has_not_subresource_integrity
description: Check if elements fetched by the provided url have SRI.
status: OPEN
vulnerabilities:
- where: https://fluidattacks.com
  specific: link element has not integrity attributes
- where: https://fluidattacks.com
  specific: script element has not integrity attributes
risk: medium
---
finding: Fluid Asserts - Protocols - HTTP part 2 Module
---
check: fluidasserts.proto.http -> has_mixed_content
description: Check if resource has mixed (HTTP and HTTPS) links.
status: OPEN
vulnerabilities:
- where: https://fluidattacks.com/web/
  specific: Resource has mixed content
risk: low
---
finding: Fluid Asserts - Protocols - HTTP part 3 Module
---
check: fluidasserts.proto.http -> is_header_cache_control_missing
description: Check if Cache-Control HTTP header is properly set.
status: OPEN
vulnerabilities:
- where: https://fluidattacks.com/web/
  specific: Cache-Control header is missing which is insecure
risk: low
---
check: fluidasserts.proto.http -> is_header_content_security_policy_missing
description: Check if Content-Security-Policy HTTP header is properly set.
status: OPEN
vulnerabilities:
- where: https://fluidattacks.com/web/
  specific: Content-Security-Policy header is insecure
risk: medium
---
check: fluidasserts.proto.http -> is_header_content_type_missing
description: Check if Content-Type HTTP header is properly set.
status: OPEN
vulnerabilities:
- where: https://fluidattacks.com/web/
  specific: Content-Type header is insecure
risk: low
---
check: fluidasserts.proto.http -> is_header_hsts_missing
description: Check if Strict-Transport-Security HTTP header is properly set.
status: OPEN
vulnerabilities:
- where: https://fluidattacks.com/web/
  specific: Strict-Transport-Security is secure
risk: medium
---
finding: Fluid Asserts - Protocols - HTTP part 4 Module
---
check: fluidasserts.proto.http -> is_resource_accessible
description: Check if URL is available by checking response code.
status: OPEN
vulnerabilities:
- where: https://fluidattacks.com/web/
  specific: Resource is available
risk: medium
---
summary:
  test time: 5.8919 seconds
  checks:
    total: 31 (100%)
    errors: 0 (0.00%)
    unknown: 1 (3.23%)
    closed: 23 (74.19%)
    opened: 7 (22.58%)
  risk:
    high: 0 (0.00%)
    medium: 4 (57.14%)
    low: 3 (42.86%)
```
