### PR TITLE
pythonPackages.cfn-flip: 1.1.0.post1 -> 1.2.2

### DIFF
--- a/pkgs/development/python-modules/cfn-flip/default.nix
+++ b/pkgs/development/python-modules/cfn-flip/default.nix
@@ -1,25 +1,55 @@
-{ lib, buildPythonPackage, fetchPypi, six, pyyaml, click, pytestrunner }:
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+
+# pythonPackages
+, click
+, pytest
+, pytestcov
+, pytestrunner
+, pyyaml
+, six
+}:
 
 buildPythonPackage rec {
   pname = "cfn-flip";
-  version = "1.1.0.post1";
+  version = "1.2.2";
 
-  src = fetchPypi {
-    pname = "cfn_flip";
-    inherit version;
-    sha256 = "16r01ijjwnq06ax5xrv6mq9l00f6sgzw776kr43zjai09xsbwwck";
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "aws-cfn-template-flip";
+    rev = version;
+    sha256 = "05fk725a1i3zl3idik2hxl3w6k1ln0j33j3jdq1gvy1sfyc79ifm";
   };
 
-  propagatedBuildInputs = [ six pyyaml click ];
-  nativeBuildInputs = [ pytestrunner ];
+  propagatedBuildInputs = [
+    click
+    pyyaml
+    six
+  ];
 
-  # No tests in Pypi
-  doCheck = false;
+  checkInputs = [
+    pytest
+    pytestcov
+    pytestrunner
+  ];
+
+  checkPhase = ''
+    py.test \
+      --cov=cfn_clean \
+      --cov=cfn_flip \
+      --cov=cfn_tools \
+      --cov-report term-missing \
+      --cov-report html
+  '';
 
   meta = with lib; {
     description = "Tool for converting AWS CloudFormation templates between JSON and YAML formats";
-    homepage = https://github.com/awslabs/aws-cfn-template-flip;
+    homepage = "https://github.com/awslabs/aws-cfn-template-flip";
     license = licenses.asl20;
-    maintainers = with maintainers; [ psyanticy ];
+    maintainers = with maintainers; [
+      kamadorueda
+      psyanticy
+    ];
   };
 }

--- a/pkgs/development/python-modules/fluidasserts/default.nix
+++ b/pkgs/development/python-modules/fluidasserts/default.nix
@@ -75,7 +75,6 @@ buildPythonPackage rec {
     substituteInPlace ./setup.py \
       --replace 'tlslite-ng==0.8.0-alpha36' 'tlslite-ng==0.7.5' \
       --replace 'boto3==1.11.7' 'boto3==1.10.1' \
-      --replace 'cfn-flip==1.2.2' 'cfn-flip==1.1.0.post1' \
       --replace 'typed-ast==1.4.1' 'typed-ast==1.4.0' \
       --replace 'pillow==7.0.0' 'pillow==6.2.1' \
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

keeping it updated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
