### PR TITLE
cassowary: init at v0.3.0

### DIFF
--- a/pkgs/tools/networking/cassowary/default.nix
+++ b/pkgs/tools/networking/cassowary/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub, writeText, runtimeShell, ncurses, }:
+
+buildGoModule rec {
+  pname = "cassowary";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "rogerwelin";
+    repo = pname;
+    rev = "33b7e81a5d147980f4ddc689818df2b071f6ab4e";
+    sha256 = "01cdmh2v9rz8rna08hdsddllck6zp9wcrhxdy6hs77zfsbzyfflx";
+  };
+
+  modSha256 = "1iylnnmj5slji89pkb3shp4xqar1zbpl7bzwddbzpp8y52fmsv1c";
+
+  meta = with lib; {
+    homepage = "https://github.com/rogerwelin/cassowary";
+    description = "Modern cross-platform HTTP load-testing tool written in Go ";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hugoreeves ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1381,6 +1381,8 @@ in
 
   ccnet = callPackage ../tools/networking/ccnet { };
 
+  cassowary = callPackage ../tools/networking/cassowary { };
+
   croc = callPackage ../tools/networking/croc { };
 
   cddl = callPackage ../development/tools/cddl { };


### PR DESCRIPTION
###### Motivation for this change

Add [cassowary](https://github.com/rogerwelin/cassowary) a 'Modern cross-platform HTTP load-testing tool written in Go'

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
