### PR TITLE
luajit: add version with gc64 enabled

### DIFF
--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -65,4 +65,8 @@ in rec {
     inherit callPackage;
   };
 
+  luajit_2_1_gc64 = import ../luajit/2.1-gc64.nix {
+    self = luajit_2_1_gc64;
+    inherit callPackage;
+  };
 }

--- a/pkgs/development/interpreters/luajit/2.1-gc64.nix
+++ b/pkgs/development/interpreters/luajit/2.1-gc64.nix
@@ -1,0 +1,9 @@
+{ self, callPackage }:
+callPackage ./default.nix {
+  inherit self;
+  version = "2.1.0-beta3";
+  name = "2.1.0-beta3-gc64";
+  isStable = false;
+  sha256 = "1hyrhpkwjqsv54hnnx4cl8vk44h9d6c9w0fz1jfjz00w255y7lhs";
+  withGC64 = true;
+}

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -5,6 +5,7 @@
 , version
 , extraMeta ? {}
 , callPackage
+, withGC64 ? false
 , self
 , packageOverrides ? (self: super: {})
 }:
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
     "CROSS=${stdenv.cc.targetPrefix}"
     # TODO: when pointer size differs, we would need e.g. -m32
     "HOST_CC=${buildPackages.stdenv.cc}/bin/cc"
+    (stdenv.lib.optionalString withGC64 "XCFLAGS=-DLUAJIT_ENABLE_GC64")
   ];
   buildFlags = [ "amalg" ]; # Build highly optimized version
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9097,7 +9097,7 @@ in
 
   ### LUA interpreters
   luaInterpreters = callPackage ./../development/interpreters/lua-5 {};
-  inherit (luaInterpreters) lua5_1 lua5_2 lua5_2_compat lua5_3 lua5_3_compat luajit_2_1 luajit_2_0;
+  inherit (luaInterpreters) lua5_1 lua5_2 lua5_2_compat lua5_3 lua5_3_compat luajit_2_1 luajit_2_0 luajit_2_1_gc64;
 
   lua5 = lua5_2_compat;
   lua = lua5;


### PR DESCRIPTION
###### Motivation for this change
Add a build variant of this which helps resolve some issues in Minetest (package coming in later)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
