### PR TITLE
stacer: init at 1.1.0

### DIFF
--- a/pkgs/tools/admin/stacer/default.nix
+++ b/pkgs/tools/admin/stacer/default.nix
@@ -1,0 +1,32 @@
+{ lib, mkDerivation, fetchFromGitHub
+, cmake
+, qtcharts
+, qttools
+}:
+
+mkDerivation rec {
+  pname = "stacer";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "oguzhaninan";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0qndzzkbq6abapvwq202kva8j619jdn9977sbqmmfs9zkjz4mbsd";
+  };
+
+  nativeBuildInputs = [ cmake qttools ];
+
+  buildInputs = [ qtcharts ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Linux System Optimizer and Monitoring";
+    homepage = "https://github.com/oguzhaninan/Stacer";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2044,6 +2044,8 @@ in
 
   staccato = callPackage ../tools/text/staccato { };
 
+  stacer = libsForQt5.callPackage ../tools/admin/stacer { };
+
   stagit = callPackage ../development/tools/stagit { };
 
   step-ca = callPackage ../tools/security/step-ca { };


### PR DESCRIPTION
###### Motivation for this change
wanted a nice looking monitoring tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
$ nix path-info -Sh ./result
/nix/store/gagj7l3izf0vs91p42cp312d9lrzigv5-stacer-1.1.0	 283.7M
```