### PR TITLE
nix-prefetch: 0.1.0 -> 0.3.0

### DIFF
--- a/pkgs/tools/package-management/nix-prefetch/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch/default.nix
@@ -2,17 +2,15 @@
 , asciidoc, docbook_xml_dtd_45, docbook_xsl, libxml2, libxslt
 , coreutils, gawk, gnugrep, gnused, jq, nix }:
 
-with stdenv.lib;
-
 stdenv.mkDerivation rec {
   pname = "nix-prefetch";
-  version = "0.1.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "msteen";
     repo = "nix-prefetch";
-    rev = "f9507a655651b51f3a3ebacde85bb40758853615";
-    sha256 = "0ykrbvbwwpz348424yy2452idgw8dffi3klh7n85n96dfflyyd4s";
+    rev = version;
+    sha256 = "0b9gdi7xzmfq0j258x724xsll8gi31m0m4pzfjkqinlm6zwr3sgm";
   };
 
   nativeBuildInputs = [
@@ -40,7 +38,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     makeWrapper $lib/main.sh $out/bin/${pname} \
-      --prefix PATH : '${makeBinPath [ coreutils gawk gnugrep gnused jq nix ]}'
+      --prefix PATH : '${stdenv.lib.makeBinPath [ coreutils gawk gnugrep gnused jq nix ]}'
 
     substitute src/tests.sh $lib/tests.sh \
       --subst-var-by bin $out/bin
@@ -55,13 +53,13 @@ stdenv.mkDerivation rec {
     install -D contrib/nix-prefetch-completion.bash $out/share/bash-completion/completions/nix-prefetch
     install -D contrib/nix-prefetch-completion.zsh $out/share/zsh/site-functions/_nix_prefetch
 
-    mkdir $out/contrib
-    cp -r contrib/hello_rs $out/contrib/
+    mkdir -p $out/share/doc/${pname}/contrib
+    cp -r contrib/hello_rs $out/share/doc/${pname}/contrib/
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Prefetch any fetcher function call, e.g. package sources";
-    homepage = https://github.com/msteen/nix-prefetch;
+    homepage = "https://github.com/msteen/nix-prefetch";
     license = licenses.mit;
     maintainers = with maintainers; [ msteen ];
     platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change

Upstream update + move contrib out of global root environment and into $out/share/doc so as to not pollute global env.

https://github.com/msteen/nix-prefetch/issues/4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
