### PR TITLE
python3Packages.google_auth: 1.6.3 -> 1.10.0

### DIFF
--- a/pkgs/development/python-modules/google_auth/default.nix
+++ b/pkgs/development/python-modules/google_auth/default.nix
@@ -1,29 +1,17 @@
 { stdenv, buildPythonPackage, fetchpatch, fetchPypi
-, pytest, mock, oauth2client, flask, requests, setuptools, urllib3, pytest-localserver, six, pyasn1-modules, cachetools, rsa }:
+, pytest, mock, oauth2client, flask, requests, setuptools, urllib3, pytest-localserver, six, pyasn1-modules, cachetools, rsa, freezegun }:
 
 buildPythonPackage rec {
   pname = "google-auth";
-  version = "1.6.3";
+  version = "1.10.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4";
+    sha256 = "1xs8ch6bz57vs6j0p8061c7wj9ahkvrfpf1y9v7r009979507ckv";
   };
-  patches = [
-    (fetchpatch {
-      name = "use-new-pytest-api-to-keep-building-with-pytest5.patch";
-      url = "https://github.com/googleapis/google-auth-library-python/commit/b482417a04dbbc207fcd6baa7a67e16b1a9ffc77.patch";
-      sha256 = "07jpa7pa6sffbcwlsg5fgcv2vvngil5qpmv6fhjqp7fnvx0674s0";
-    })
-  ];
 
-  checkInputs = [ pytest mock oauth2client flask requests urllib3 pytest-localserver ];
+  checkInputs = [ pytest mock oauth2client flask requests urllib3 pytest-localserver freezegun ];
   propagatedBuildInputs = [ six pyasn1-modules cachetools rsa setuptools ];
-
-  # The removed test tests the working together of google_auth and google's https://pypi.python.org/pypi/oauth2client
-  # but the latter is deprecated. Since it is not currently part of the nixpkgs collection and deprecated it will
-  # probably never be. We just remove the test to make the tests work again.
-  postPatch = ''rm tests/test__oauth2client.py'';
 
   checkPhase = ''
     py.test


### PR DESCRIPTION
###### Motivation for this change

A new version is available upstream.

It builds fine without the test-related patches now, so let's remove those patches. Also, a new dependency is required to run the tests.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) (there are none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @vanschelven (Hah, did not expect to find you here!)