### PR TITLE
python3Packages.google_api_core: 0.15.0 -> 1.16.0

### DIFF
--- a/pkgs/development/python-modules/google_api_core/default.nix
+++ b/pkgs/development/python-modules/google_api_core/default.nix
@@ -1,20 +1,20 @@
 { lib, buildPythonPackage, fetchPypi, pythonOlder, isPy27
-, google_auth, protobuf, googleapis_common_protos, requests, setuptools, grpcio, futures, mock }:
+, google_auth, protobuf, googleapis_common_protos, requests, setuptools, grpcio, mock }:
 
 buildPythonPackage rec {
   pname = "google-api-core";
-  version = "1.15.0";
+  version = "1.16.0";
   disabled = isPy27; # google namespace no longer works on python2
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2d661c8d650a1df5805d0e360121cb55c55d8bd29f858fa62cbe943e59ce89f7";
+    sha256 = "1qh30ji399gngv2j1czzvi3h0mgx3lfdx2n8qp8vii7ihyh65scj";
   };
 
   propagatedBuildInputs = [
     googleapis_common_protos protobuf
     google_auth requests setuptools grpcio
-  ] ++ lib.optional (pythonOlder "3.2") futures;
+  ];
 
   # requires nox
   doCheck = false;

--- a/pkgs/development/python-modules/google_auth/default.nix
+++ b/pkgs/development/python-modules/google_auth/default.nix
@@ -1,29 +1,17 @@
 { stdenv, buildPythonPackage, fetchpatch, fetchPypi
-, pytest, mock, oauth2client, flask, requests, setuptools, urllib3, pytest-localserver, six, pyasn1-modules, cachetools, rsa }:
+, pytest, mock, oauth2client, flask, requests, setuptools, urllib3, pytest-localserver, six, pyasn1-modules, cachetools, rsa, freezegun }:
 
 buildPythonPackage rec {
   pname = "google-auth";
-  version = "1.6.3";
+  version = "1.10.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4";
+    sha256 = "1xs8ch6bz57vs6j0p8061c7wj9ahkvrfpf1y9v7r009979507ckv";
   };
-  patches = [
-    (fetchpatch {
-      name = "use-new-pytest-api-to-keep-building-with-pytest5.patch";
-      url = "https://github.com/googleapis/google-auth-library-python/commit/b482417a04dbbc207fcd6baa7a67e16b1a9ffc77.patch";
-      sha256 = "07jpa7pa6sffbcwlsg5fgcv2vvngil5qpmv6fhjqp7fnvx0674s0";
-    })
-  ];
 
-  checkInputs = [ pytest mock oauth2client flask requests urllib3 pytest-localserver ];
+  checkInputs = [ pytest mock oauth2client flask requests urllib3 pytest-localserver freezegun ];
   propagatedBuildInputs = [ six pyasn1-modules cachetools rsa setuptools ];
-
-  # The removed test tests the working together of google_auth and google's https://pypi.python.org/pypi/oauth2client
-  # but the latter is deprecated. Since it is not currently part of the nixpkgs collection and deprecated it will
-  # probably never be. We just remove the test to make the tests work again.
-  postPatch = ''rm tests/test__oauth2client.py'';
 
   checkPhase = ''
     py.test

--- a/pkgs/development/python-modules/google_cloud_core/default.nix
+++ b/pkgs/development/python-modules/google_cloud_core/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "google-cloud-core";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "49036087c1170c3fad026e45189f17092b8c584a9accb2d73d1854f494e223ae";
+    sha256 = "0vfhvpiiigfldi3vb0730w13md1c90irpdx5kypmnfszrrzg7q2a";
   };
 
   propagatedBuildInputs = [ google_api_core grpcio setuptools ];

--- a/pkgs/development/python-modules/googleapis_common_protos/default.nix
+++ b/pkgs/development/python-modules/googleapis_common_protos/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "googleapis-common-protos";
-  version = "1.6.0";
+  version = "1.51.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e61b8ed5e36b976b487c6e7b15f31bb10c7a0ca7bd5c0e837f4afab64b53a0c6";
+    sha256 = "0vi2kr0daivx2q1692lp3y61bfnvdw471xsfwi8924br89q92g01";
   };
 
   propagatedBuildInputs = [ protobuf setuptools ];


### PR DESCRIPTION
###### Motivation for this change

A new version is available upstream.

`google-api-core` version 1.16.0 requires at least Python 3.5, there is no point in keeping a Python 3.2 check around here.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) (there are none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

CC @vanschelven 
