### PR TITLE
tmatrix: 1.1 -> 1.3

### DIFF
--- a/pkgs/applications/misc/tmatrix/default.nix
+++ b/pkgs/applications/misc/tmatrix/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/M4444/TMatrix";
     license = licenses.gpl2;
     platforms = platforms.all;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = with maintainers; [ infinisil filalex77 ];
   };
 }

--- a/pkgs/applications/misc/tmatrix/default.nix
+++ b/pkgs/applications/misc/tmatrix/default.nix
@@ -1,22 +1,27 @@
-{ stdenv, lib, fetchFromGitHub, cmake, ncurses }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, installShellFiles
+, ncurses
+}:
 
 stdenv.mkDerivation rec {
   pname = "tmatrix";
-  version = "1.1";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "M4444";
     repo = "TMatrix";
     rev = "v${version}";
-    sha256 = "1x9drk3wdsd6vzcypk3x068sqcbgis488s9fhcpsv8xgb496rd6y";
+    sha256 = "1cvgxmdpdzpl8w4z3sh4g5pbd15rd8s1kcspi9v95yf9rydyy69s";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake installShellFiles ];
   buildInputs = [ ncurses ];
 
   postInstall = ''
-    mkdir -p $out/share/man/man6
-    install -m 0644 ../tmatrix.6 $out/share/man/man6
+    installManPage ../tmatrix.6
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/M4444/TMatrix/releases/tag/v1.2, https://github.com/M4444/TMatrix/releases/tag/v1.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
/nix/store/a5h01236rxk6p8as0d6ca17zvpnac10m-tmatrix-1.1	  36.3M
/nix/store/d44h8dsqabk912spn53jbsi0h7lyp95l-tmatrix-1.3   36.4M
```
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixpkgs/77825)
<!-- Reviewable:end -->
