### PR TITLE
gnunet-gtk: init at 0.12.0

### DIFF
--- a/pkgs/applications/networking/p2p/gnunet-gtk/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet-gtk/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchgit, pkgconfig
+, autoreconfHook, wrapGAppsHook
+, libgcrypt, libextractor, libxml2
+, gnome3, gnunet, gnutls, gtk3 }:
+
+stdenv.mkDerivation rec {
+  pname = "gnunet-gtk";
+  version = "0.12.0";
+
+  src = fetchgit {
+    url = "https://git.gnunet.org/gnunet-gtk.git";
+    rev = "v${version}";
+    sha256 = "1ccasng1b4bj0kqhbfhiv0j1gnc4v2ka5f7wxvka3iwp90g7rax6";
+  };
+
+  nativeBuildInputs= [ autoreconfHook wrapGAppsHook pkgconfig ];
+  buildInputs = [ libgcrypt libextractor libxml2 gnunet gnome3.glade gnutls gtk3 ];
+
+  patchPhase = "patchShebangs pixmaps/icon-theme-installer";
+
+  meta = with stdenv.lib; {
+    description = "GNUnet GTK User Interface";
+    homepage = "https://git.gnunet.org/gnunet-gtk.git";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pstn ];
+    platforms = platforms.gnu ++ platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19989,6 +19989,8 @@ in
 
   gnunet_git = lowPrio (callPackage ../applications/networking/p2p/gnunet/git.nix { });
 
+  gnunet-gtk = callPackage ../applications/networking/p2p/gnunet-gtk { };
+
   gocr = callPackage ../applications/graphics/gocr { };
 
   gobby5 = callPackage ../applications/editors/gobby { };


### PR DESCRIPTION
I worked on top of  #77785 for a newer gnunet version, so please only merge after that PR.

###### Motivation for this change
Fixes #76754 and I want it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
