### PR TITLE
Reduce closure gnome-shell closure

### DIFF
--- a/pkgs/development/libraries/clutter-gst/default.nix
+++ b/pkgs/development/libraries/clutter-gst/default.nix
@@ -1,13 +1,13 @@
 { fetchurl, stdenv, pkgconfig, clutter, gtk3, glib, cogl, gnome3, gdk-pixbuf }:
 
-let
+stdenv.mkDerivation rec {
   pname = "clutter-gst";
   version = "3.0.27";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+
+  outputs = [ "out" "dev" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "17czmpl92dzi4h3rn5rishk015yi3jwiw29zv8qan94xcmnbssgy";
   };
 

--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -7,6 +7,8 @@ in stdenv.mkDerivation rec {
   pname = "gtkd";
   version = "3.9.0";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchzip {
     url = "https://gtkd.org/Downloads/sources/GtkD-${version}.zip";
     sha256 = "12kc4s5gp6gn456d8pzhww1ggi9qbxldmcpp6855297g2x8xxy5p";
@@ -117,6 +119,15 @@ in stdenv.mkDerivation rec {
     "prefix=${placeholder "out"}"
     "PKG_CONFIG=${pkgconfig}/bin/pkg-config"
   ];
+
+  # The .pc files does not declare an `includedir=`, so the multiple
+  # outputs setup hook misses this.
+  postFixup = ''
+    for pc in $dev/lib/pkgconfig/*; do
+      substituteInPlace $pc \
+        --replace "$out/include" "$dev/include"
+    done
+  '';
 
   meta = with stdenv.lib; {
     description = "D binding and OO wrapper for GTK";

--- a/pkgs/development/libraries/libappindicator/default.nix
+++ b/pkgs/development/libraries/libappindicator/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
   versionMajor = "12.10";
   versionMinor = "0";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "${meta.homepage}/${versionMajor}/${version}/+download/libappindicator-${version}.tar.gz";
     sha256 = "17xlqd60v0zllrxp8bgq3k5a1jkj0svkqn8rzllcyjh8k0gpr46m";

--- a/pkgs/development/libraries/libgnomekbd/default.nix
+++ b/pkgs/development/libraries/libgnomekbd/default.nix
@@ -4,6 +4,8 @@ stdenv.mkDerivation rec {
   pname = "libgnomekbd";
   version = "3.26.1";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0y962ykn3rr9gylj0pwpww7bi20lmhvsw6qvxs5bisbn2mih5jpp";

--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   pname = "libnotify";
   version = "0.7.8";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1371csx0n92g60b5dmai4mmzdnx8081mc3kcgc6a0xipcq5rw839";

--- a/pkgs/development/libraries/liboauth/default.nix
+++ b/pkgs/development/libraries/liboauth/default.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "07w1aq8y8wld43wmbk2q8134p3bfkp2vma78mmsfgw2jn1bh3xhd";
   };
 
+  outputs = [ "out" "dev" ];
+
   nativeBuildInputs = [ pkgconfig ];
 
   propagatedBuildInputs = [ nss nspr ];

--- a/pkgs/development/libraries/libpeas/default.nix
+++ b/pkgs/development/libraries/libpeas/default.nix
@@ -6,6 +6,8 @@ stdenv.mkDerivation rec {
   pname = "libpeas";
   version = "1.24.0";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1yg6r0srz3knhgvplprl3pikrq5c02dmdxgfwcynd6hjih9h16hb";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

Adds a dev output to a few gnome-shell dependencies (and gtkd), preventing their propagated build inputs becoming part of eg. gnome-shell's closure. Specifically reduces gnome-shell's closure size from 1.6GB to 1.1GB.

It seems like it's very common for derivations to specify propagated build inputs without having an extra output, so there's probably some really low hanging fruits here. (Might honestly be good for the propagated-build-inputs files to get a dedicated output which is automatically added?).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
