### PR TITLE
evdi: 1.6.4 -> git-2020-01-16

### DIFF
--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -1,37 +1,44 @@
-{ stdenv, fetchFromGitHub, kernel, libdrm }:
+{ stdenv, fetchFromGitHub, fetchpatch, kernel, libdrm }:
 
 stdenv.mkDerivation rec {
   pname = "evdi";
-  version = "1.6.4";
+  version = "-unstable-20190116";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1yrjm8lvvz3v4h5af6m9qzq6z4lbgd7qbvq5rz7sjhdsh7g6qibd";
+    rev = "391f1f71e4c86fc18de27947c78e02b5e3e9f128";
+    sha256 = "147cwmk57ldchvzr06lila6av7jvcdggs9jgifqscklp9x6dc4ny";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   buildInputs = [ kernel libdrm ];
 
+  patches = [
+    (fetchpatch {
+      url    = "https://crazy.dev.frugalware.org/evdi-all-in-one-fixes.patch";
+      sha256 = "03hs68v8c2akf8a4rc02m15fzyp14ay70rcx8kwg2y98qkqh7w30";
+    })
+  ];
+
   makeFlags = [
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "KVER=${kernel.modDirVersion}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 
   hardeningDisable = [ "format" "pic" "fortify" ];
 
   installPhase = ''
     install -Dm755 module/evdi.ko $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/gpu/drm/evdi/evdi.ko
-    install -Dm755 library/libevdi.so $out/lib/libevdi.so
+    install -Dm755 library/libevdi.so.1.6.4 $out/lib/libevdi.so
   '';
 
   meta = with stdenv.lib; {
     description = "Extensible Virtual Display Interface";
-    homepage = "https://www.displaylink.com/";
-    license = with licenses; [ lgpl21 gpl2 ];
     platforms = platforms.linux;
+    license = with licenses; [ lgpl21 gpl2 ];
+    homepage = "https://www.displaylink.com/";
     broken = versionOlder kernel.version "4.9" || stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

EVDI 1.6.4 doesn't compile/work on kernel 5.4.11. A user in the support groups supplied a patch that works on latest git.

It fixes #74698

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
