### PR TITLE
python3Packages.dash: init at 1.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -517,6 +517,12 @@
     githubId = 5327697;
     name = "Anatolii Prylutskyi";
   };
+  antoinerg = {
+    email = "roygobeil.antoine@gmail.com";
+    github = "antoinerg";
+    githubId = 301546;
+    name = "Antoine Roy-Gobeil";
+  };
   anton-dessiatov = {
     email = "anton.dessiatov@gmail.com";
     github = "anton-dessiatov";

--- a/pkgs/development/python-modules/dash-core-components/default.nix
+++ b/pkgs/development/python-modules/dash-core-components/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "dash_core_components";
+  version = "1.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16jjanq4glj6c2cwyw94954hrqqv49fknisbxj03lfmflg61j32k";
+  };
+
+  # No tests in archive
+  doCheck = false;
+
+  meta = {
+    description = "A dash component starter pack";
+    homepage = https://dash.plot.ly/dash-core-components;
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/pkgs/development/python-modules/dash-core-components/default.nix
+++ b/pkgs/development/python-modules/dash-core-components/default.nix
@@ -15,9 +15,10 @@ buildPythonPackage rec {
   # No tests in archive
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "A dash component starter pack";
     homepage = https://dash.plot.ly/dash-core-components;
-    license = with lib.licenses; [ mit ];
+    license = licenses.mit;
+    maintainers = [ maintainers.antoinerg ];
   };
 }

--- a/pkgs/development/python-modules/dash-html-components/default.nix
+++ b/pkgs/development/python-modules/dash-html-components/default.nix
@@ -15,9 +15,10 @@ buildPythonPackage rec {
   # No tests in archive
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "HTML components for Dash";
     homepage = https://dash.plot.ly/dash-html-components;
-    license = with lib.licenses; [ mit ];
+    license = licenses.mit;
+    maintainers = [ maintainers.antoinerg ];
   };
 }

--- a/pkgs/development/python-modules/dash-html-components/default.nix
+++ b/pkgs/development/python-modules/dash-html-components/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "dash_html_components";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "166agkrl52j5qin2npsdl2a96jccxz5f1jvcz0hxsnjg0ix0k4l9";
+  };
+
+  # No tests in archive
+  doCheck = false;
+
+  meta = {
+    description = "HTML components for Dash";
+    homepage = https://dash.plot.ly/dash-html-components;
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/pkgs/development/python-modules/dash-renderer/default.nix
+++ b/pkgs/development/python-modules/dash-renderer/default.nix
@@ -15,9 +15,10 @@ buildPythonPackage rec {
   # No tests in archive
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "Renderer for the Dash framework";
     homepage = https://dash.plot.ly/;
-    license = with lib.licenses; [ mit ];
+    license = licenses.mit;
+    maintainers = [ maintainers.antoinerg ];
   };
 }

--- a/pkgs/development/python-modules/dash-renderer/default.nix
+++ b/pkgs/development/python-modules/dash-renderer/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "dash_renderer";
+  version = "1.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ccsykv24dz9xj24106aaj7f0w7x7sv7mamjbx0m6k0wyhh58vw1";
+  };
+
+  # No tests in archive
+  doCheck = false;
+
+  meta = {
+    description = "Renderer for the Dash framework";
+    homepage = https://dash.plot.ly/;
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/pkgs/development/python-modules/dash-table/default.nix
+++ b/pkgs/development/python-modules/dash-table/default.nix
@@ -15,9 +15,10 @@ buildPythonPackage rec {
   # No tests in archive
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "A First-Class Interactive DataTable for Dash";
     homepage = https://dash.plot.ly/datatable;
-    license = with lib.licenses; [ mit ];
+    license = licenses.mit;
+    maintainers = [ maintainers.antoinerg ];
   };
 }

--- a/pkgs/development/python-modules/dash-table/default.nix
+++ b/pkgs/development/python-modules/dash-table/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "dash_table";
+  version = "4.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "01wzac09ac6nr27if1liaxafzdf67x00vw1iq5vaad1147rdh36k";
+  };
+
+  # No tests in archive
+  doCheck = false;
+
+  meta = {
+    description = "A First-Class Interactive DataTable for Dash";
+    homepage = https://dash.plot.ly/datatable;
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/pkgs/development/python-modules/dash/default.nix
+++ b/pkgs/development/python-modules/dash/default.nix
@@ -57,6 +57,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python framework for building analytical web applications";
     homepage = https://dash.plot.ly/;
-    license = with lib.licenses; [ mit ];
+    license = licenses.mit;
+    maintainers = [ maintainers.antoinerg ];
   };
 }

--- a/pkgs/development/python-modules/dash/default.nix
+++ b/pkgs/development/python-modules/dash/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, plotly
+, flask
+, flask-compress
+, future
+, dash-core-components
+, dash-renderer
+, dash-html-components
+, dash-table
+, pytest
+, pytest-mock
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "dash";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "plotly";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "11skbvjlj93aw1pqx6j56h73sy9r06jwq7z5h64fd1a3d4z2gsvy";
+  };
+
+  propagatedBuildInputs = [
+    plotly
+    flask
+    flask-compress
+    future
+    dash-core-components
+    dash-renderer
+    dash-html-components
+    dash-table
+  ];
+
+  checkInputs = [
+    pytest
+    pytest-mock
+    mock
+  ];
+
+  checkPhase = ''
+    pytest tests/unit/test_configs.py
+    pytest tests/unit/test_fingerprint.py
+    pytest tests/unit/test_import.py
+    pytest tests/unit/test_resources.py
+    pytest tests/unit/dash/
+  '';
+
+  pythonImportsCheck = [
+    "dash"
+  ];
+
+  meta = with lib; {
+    description = "Python framework for building analytical web applications";
+    homepage = https://dash.plot.ly/;
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2440,6 +2440,8 @@ in {
 
   dash-renderer = callPackage ../development/python-modules/dash-renderer { };
 
+  dash-table = callPackage ../development/python-modules/dash-table { };
+
   dateparser = callPackage ../development/python-modules/dateparser { };
 
   # Actual name of package

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2438,6 +2438,8 @@ in {
 
   dash-html-components = callPackage ../development/python-modules/dash-html-components { };
 
+  dash-renderer = callPackage ../development/python-modules/dash-renderer { };
+
   dateparser = callPackage ../development/python-modules/dateparser { };
 
   # Actual name of package

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2434,6 +2434,8 @@ in {
 
   daphne = callPackage ../development/python-modules/daphne { };
 
+  dash = callPackage ../development/python-modules/dash { };
+
   dash-core-components = callPackage ../development/python-modules/dash-core-components { };
 
   dash-html-components = callPackage ../development/python-modules/dash-html-components { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2434,6 +2434,8 @@ in {
 
   daphne = callPackage ../development/python-modules/daphne { };
 
+  dash-core-components = callPackage ../development/python-modules/dash-core-components { };
+
   dateparser = callPackage ../development/python-modules/dateparser { };
 
   # Actual name of package

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2436,6 +2436,8 @@ in {
 
   dash-core-components = callPackage ../development/python-modules/dash-core-components { };
 
+  dash-html-components = callPackage ../development/python-modules/dash-html-components { };
+
   dateparser = callPackage ../development/python-modules/dateparser { };
 
   # Actual name of package


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Dash is an open-source framework that creates analytical web apps from Python without writing a single line of javascript (https://dash.plot.ly/). It would be awesome to package it in NixOS!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Manual test
I tested that I could start a simple Dash app:
```shell
$ nix-shell -I nixpkgs=$(pwd) -p python3Packages.dash
$ python app.py
```