### PR TITLE
teeworlds: cmake instead of bam, oh joy! cleanup

### DIFF
--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -37,9 +37,9 @@ stdenv.mkDerivation rec {
       Flag.  You can even design your own maps!
     '';
 
-    homepage = https://teeworlds.com/;
+    homepage = "https://teeworlds.com/";
     license = "BSD-style, see `license.txt'";
     maintainers = with stdenv.lib.maintainers; [ astsmtl ];
-    platforms = ["x86_64-linux" "i686-linux"];
+    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, stdenv, bam, pkgconfig, python, alsaLib
+{ fetchFromGitHub, stdenv, cmake, pkgconfig, python, alsaLib
 , libX11, libGLU, SDL2, lua5_3, zlib, freetype, wavpack
 }:
 
@@ -21,34 +21,11 @@ stdenv.mkDerivation rec {
                 '#define DATA_DIR "${placeholder "out"}/share/teeworlds/data"'
   '';
 
-  nativeBuildInputs = [ bam pkgconfig ];
-
-  configurePhase = ''
-    runHook preConfigure
-    bam config
-    runHook postConfigure
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-    bam conf=release
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin $out/share/teeworlds
-    cp build/x86_64/release/teeworlds{,_srv} $out/bin
-    cp -r build/x86_64/release/data $out/share/teeworlds
-  '';
+  nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
     python alsaLib libX11 libGLU SDL2 lua5_3 zlib freetype wavpack
   ];
-
-  postInstall = ''
-    mkdir -p $out/share/doc/teeworlds
-    cp -v *.txt $out/share/doc/teeworlds/
-  '';
 
   meta = {
     description = "Retro multiplayer shooter game";


### PR DESCRIPTION
###### Motivation for this change

Looks like teeworlds offers cmake support
and since it is mentioned first in their README
I gave it a go and ... :grin: :tada:

This fixes long-standing issues I've had building teeworlds
with more exotic compilers
(including clang? but havne't tried it using nixpkgs-master lately...)
and makes it possible to greatly simplify the expression
with all the same files installed AFAICT.

I noticed bam now has no consumers in-tree,
but I'm content letting it sit there (and maybe bitrot if untested)
as long as it doesn't make things too awkward when we're hanging
and it sees teeworlds expression happier and healthier than ever before
and while that truly brings joy it hurts and is a constant reminder of
its mistakes and weaknesses and what could have been ....
well so I think we can maybe hold off on evicting it for now.
That seems kinda cruel.  Likely teeworlds wouldn't be what it is today
if not for all bam has done for it.

Okay anyway >_> <_<.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I've only tested the client?
And now that there's a build system we're familiar with... if anyone's
curious we might have some options to poke at.

(sorry bam ;3)