### PR TITLE
lwan: indicate jemalloc should be used, or it won't be

### DIFF
--- a/pkgs/servers/http/lwan/default.nix
+++ b/pkgs/servers/http/lwan/default.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ jemalloc zlib ];
 
+  # Note: tcmalloc and mimalloc are also supported (and normal malloc)
+  cmakeFlags = [ "-DUSE_ALTERNATIVE_MALLOC=jemalloc" ];
+
   meta = with stdenv.lib; {
     description = "Lightweight high-performance multi-threaded web server";
     longDescription = "A lightweight and speedy web server with a low memory


### PR DESCRIPTION
###### Motivation for this change

Since we are kind enough to provide it a custom allocator
(you know how many packages wish they were as lucky?!)
kindly encourage they play together so as not to be rude.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).