### PR TITLE
lwan: fix w/musl re:secure_getenv (fix build)

### DIFF
--- a/pkgs/servers/http/lwan/default.nix
+++ b/pkgs/servers/http/lwan/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ jemalloc zlib ];
 
+  # Workaround bad detection of secure_getenv, a recent musl addition.
+  # This breaks the build as they provide their own definition which conflicts.
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.hostPlatform.isMusl "-DHAVE_SECURE_GETENV=1";
+
   meta = with stdenv.lib; {
     description = "Lightweight high-performance multi-threaded web server";
     longDescription = "A lightweight and speedy web server with a low memory


### PR DESCRIPTION
###### Motivation for this change

Fix lwan build braek w/musl due to secure_getenv
being detected as unavailable and conflicts from
the lwan-provided version.

###### Things done

(I've tested this fixes lwan and produces a maybe-working lwan
(well, it runs?) but haven't checked on this tree yet and
don't have it built for musl yet...)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).