### PR TITLE
corerad: 0.1.4 -> 0.1.8

### DIFF
--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "corerad";
-  version = "0.1.4";
+  version = "0.1.8";
 
   goPackagePath = "github.com/mdlayher/corerad";
 
@@ -10,10 +10,10 @@ buildGoModule rec {
     owner = "mdlayher";
     repo = "corerad";
     rev = "v${version}";
-    sha256 = "0qlmmgdz69gqqn6h5kb3gsjyj7lm6pcfcx9xlmrxhisj914ij76r";
+    sha256 = "13js6p3svx2xp20yjpb5w71rnyrhiiqbbvsck45i756j1lndaqxr";
   };
 
-  modSha256 = "0vim91yvw0cf9bd10hfanz8azq7q19lp2x61rs44ycx9zm3qdhcw";
+  modSha256 = "03x7r392bwchmd3jzwwykdfkr9lfdn77phfwh8xfk2avhzq7qs89";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mdlayher/corerad";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Latest alpha release of CoreRAD which better handles network link state changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Built locally and verified working binary:

```
[matt@routnerr-2:~/src/nixpkgs]$ nix-build -A corerad                                                                                                                    
these derivations will be built:
  /nix/store/yyp7mr1f6m1xax2ws6lmipz79rsc4r9v-corerad-0.1.8.drv
building '/nix/store/yyp7mr1f6m1xax2ws6lmipz79rsc4r9v-corerad-0.1.8.drv'...                                                                                                       
[...]
[matt@routnerr-2:~/src/nixpkgs]$ ./result/bin/corerad -init

[matt@routnerr-2:~/src/nixpkgs]$ ./result/bin/corerad
2020/01/16 15:45:03 CoreRAD v0.1.8 (ALPHA) starting with configuration file "corerad.toml"
2020/01/16 15:45:03 eth0: send advertisements is false, skipping initialization
2020/01/16 15:45:03 starting HTTP debug listener on "localhost:9430": prometheus: false, pprof: false

^C2020/01/16 15:45:14 received interrupt, shutting down
```