### PR TITLE
signal-desktop: use autoPatchelfHook, wrap properly

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -2,7 +2,8 @@
 , gnome2, gtk3, atk, at-spi2-atk, cairo, pango, gdk-pixbuf, glib, freetype, fontconfig
 , dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr, libXcomposite
 , libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss, nspr, alsaLib
-, cups, expat, udev, libnotify, libuuid, at-spi2-core, libappindicator-gtk3
+, cups, expat, systemd, libnotify, libuuid, at-spi2-core, libappindicator-gtk3
+, autoPatchelfHook
 # Unfortunately this also overwrites the UI language (not just the spell
 # checking language!):
 , hunspellDicts, spellcheckerLanguage ? null # E.g. "de_DE"
@@ -21,11 +22,32 @@ let
         --set HUNSPELL_DICTIONARIES "${hunspellDicts.${hunspellDict}}/share/hunspell" \
         --set LC_MESSAGES "${spellcheckerLanguage}"''
       else "");
-  rpath = lib.makeLibraryPath [
+in stdenv.mkDerivation rec {
+  pname = "signal-desktop";
+  version = "1.29.6"; # Please backport all updates to the stable channel.
+  # All releases have a limited lifetime and "expire" 90 days after the release.
+  # When releases "expire" the application becomes unusable until an update is
+  # applied. The expiration date for the current release can be extracted with:
+  # $ grep -a "^{\"buildExpiration" "${signal-desktop}/lib/Signal/resources/app.asar"
+  # (Alternatively we could try to patch the asar archive, but that requires a
+  # few additional steps and might not be the best idea.)
+
+  src = fetchurl {
+    url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
+    sha256 = "1s1rc4kyv0nxz5fy5ia7fflphf3izk80ks71q4wd67k1g9lvcw24";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
     alsaLib
-    atk
     at-spi2-atk
     at-spi2-core
+    atk
     cairo
     cups
     dbus
@@ -36,10 +58,6 @@ let
     glib
     gnome2.GConf
     gtk3
-    pango
-    libappindicator-gtk3
-    libnotify
-    libuuid
     libX11
     libXScrnSaver
     libXcomposite
@@ -51,59 +69,44 @@ let
     libXrandr
     libXrender
     libXtst
+    libappindicator-gtk3
+    libnotify
+    libuuid
     nspr
     nss
-    udev
+    pango
+    systemd
     xorg.libxcb
   ];
 
-in stdenv.mkDerivation rec {
-  pname = "signal-desktop";
-  version = "1.29.6"; # Please backport all updates to the stable channel.
-  # All releases have a limited lifetime and "expire" 90 days after the release.
-  # When releases "expire" the application becomes unusable until an update is
-  # applied. The expiration date for the current release can be extracted with:
-  # $ grep -a "^{\"buildExpiration" "${signal-desktop}/libexec/resources/app.asar"
-  # (Alternatively we could try to patch the asar archive, but that requires a
-  # few additional steps and might not be the best idea.)
-
-  src = fetchurl {
-    url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "1s1rc4kyv0nxz5fy5ia7fflphf3izk80ks71q4wd67k1g9lvcw24";
-  };
-
-  phases = [ "unpackPhase" "installPhase" ];
-
-  nativeBuildInputs = [ dpkg wrapGAppsHook ];
+  runtimeDependencies = [
+    systemd.lib
+  ];
 
   unpackPhase = "dpkg-deb -x $src .";
 
-  installPhase = ''
-    mkdir -p $out
-    cp -R opt $out
+  dontBuild = true;
+  dontConfigure = true;
 
-    mv ./usr/share $out/share
-    mv $out/opt/Signal $out/libexec
-    rmdir $out/opt
+  installPhase = ''
+    mkdir -p $out/lib
+
+    mv usr/share $out/share
+    mv opt/Signal $out/lib
 
     chmod -R g-w $out
 
-    # Patch signal
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-             --set-rpath ${rpath}:$out/libexec $out/libexec/signal-desktop
-    wrapProgram $out/libexec/signal-desktop \
-      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-      --prefix LD_LIBRARY_PATH : "${stdenv.cc.cc.lib}/lib" \
-      ${customLanguageWrapperArgs} \
-      "''${gappsWrapperArgs[@]}"
-
     # Symlink to bin
     mkdir -p $out/bin
-    ln -s $out/libexec/signal-desktop $out/bin/signal-desktop
+    ln -s $out/lib/Signal/signal-desktop $out/bin/signal-desktop
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/signal-desktop.desktop \
       --replace /opt/Signal/signal-desktop $out/bin/signal-desktop
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(${customLanguageWrapperArgs})
   '';
 
   meta = {

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -87,6 +87,7 @@ in stdenv.mkDerivation rec {
 
   dontBuild = true;
   dontConfigure = true;
+  dontPatchELF = true;
 
   installPhase = ''
     mkdir -p $out/lib
@@ -94,19 +95,20 @@ in stdenv.mkDerivation rec {
     mv usr/share $out/share
     mv opt/Signal $out/lib
 
-    chmod -R g-w $out
-
     # Symlink to bin
     mkdir -p $out/bin
     ln -s $out/lib/Signal/signal-desktop $out/bin/signal-desktop
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ stdenv.cc.cc ] }"
+      ${customLanguageWrapperArgs}
+    )
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/signal-desktop.desktop \
       --replace /opt/Signal/signal-desktop $out/bin/signal-desktop
-  '';
-
-  preFixup = ''
-    gappsWrapperArgs+=(${customLanguageWrapperArgs})
   '';
 
   meta = {


### PR DESCRIPTION
Most prominently we don't use `phases` because of https://github.com/NixOS/nixpkgs/issues/28910.
This is also problematic when using wrapGAppsHook.
In order to use wrapGAppsHook's automatic wrapping
(this was done manually before because there was no fixupPhase)
we need to install signal at lib/Signal instead of just into libexec.
That's because it would try to wrap .so files.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
