### PR TITLE
bibata-{,extra-}cursors: fix, faster, smaller; bump extra variant from git -> 0.3

### DIFF
--- a/pkgs/data/icons/bibata-cursors/default.nix
+++ b/pkgs/data/icons/bibata-cursors/default.nix
@@ -16,6 +16,11 @@ in stdenvNoCC.mkDerivation rec {
   postPatch = ''
     patchShebangs .
     substituteInPlace build.sh --replace "sudo" ""
+
+    # Don't generate windows cursors,
+    # they aren't used and aren't installed
+    # by the project's install script anyway.
+    echo "exit 0" > w32-make.sh
   '';
 
   nativeBuildInputs  = [
@@ -31,7 +36,9 @@ in stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     install -dm 0755 $out/share/icons
-    cp -pr Bibata_* $out/share/icons/
+    for x in Bibata_*; do
+      cp -pr $x/out/X11/$x $out/share/icons/
+    done
   '';
 
   meta = with stdenvNoCC.lib; {

--- a/pkgs/data/icons/bibata-cursors/extra.nix
+++ b/pkgs/data/icons/bibata-cursors/extra.nix
@@ -1,25 +1,33 @@
-{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen }:
+{ stdenvNoCC, fetchFromGitHub, gnome-themes-extra, inkscape, xcursorgen, python3 }:
 
-stdenvNoCC.mkDerivation rec {
+let
+  py = python3.withPackages(ps: [ ps.pillow ]);
+in stdenvNoCC.mkDerivation rec {
   pname = "bibata-extra-cursors";
-  version = "unstable-2018-10-28";
-  
+  version = "0.3";
+
   src = fetchFromGitHub {
     owner = "KaizIqbal";
     repo = "Bibata_Extra_Cursor";
-    rev = "66fb64b8dbe830e3f7ba2c2bdc4dacae7c438789";
-    sha256 = "1xb7v06sbxbwzd7cnghv9c55lpbbkcaf1nswdrqy87gd0bnpdd2n";
+    rev = "v${version}";
+    sha256 = "1bh945hvakbh985jkr6g6x0myw3k49pvn24m1clvqdv35v65nfxk";
   };
 
   postPatch = ''
     patchShebangs .
-    substituteInPlace build.sh --replace "gksu " ""
+    substituteInPlace build.sh --replace "sudo" ""
+
+    # Don't generate windows cursors,
+    # they aren't used and aren't installed
+    # by the project's install script anyway.
+    echo "exit 0" > w32-make.sh
   '';
 
   nativeBuildInputs  = [
     gnome-themes-extra
     inkscape
     xcursorgen
+    py
   ];
 
   buildPhase = ''
@@ -28,7 +36,9 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     install -dm 0755 $out/share/icons
-    cp -pr Bibata_* $out/share/icons/
+    for x in Bibata_*; do
+      cp -pr $x/out/X11/$x $out/share/icons/
+    done
   '';
 
   meta = with stdenvNoCC.lib; {


### PR DESCRIPTION
###### Motivation for this change

This fixes issue where each theme installed the entire build directory, not
just the final generated 'out/X11' files.

(which was wasteful but also meant they didn't work as the right files were
 two directories deeper)

Avoiding the w32 saves some time and sapce, and more is "saved" by not
shipping non-cursor build intermediates.

Sorry for the bad update, folks!

While visiting these, checked on bibata-extra-cursors and turns out it
has a new release and needed all of the same treatment :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).