### PR TITLE
onedrive: 2.3.12 -> 2.3.13

### DIFF
--- a/pkgs/applications/networking/sync/onedrive/default.nix
+++ b/pkgs/applications/networking/sync/onedrive/default.nix
@@ -1,35 +1,27 @@
-{ stdenv
-, fetchFromGitHub
-, dmd
-, pkgconfig
-, curl
-, sqlite
-}:
+{ stdenv, fetchFromGitHub, dmd, pkgconfig, curl, sqlite, libnotify }:
 
 stdenv.mkDerivation rec {
   pname = "onedrive";
-  version = "2.3.12";
+  version = "2.3.13";
 
   src = fetchFromGitHub {
     owner = "abraunegg";
-    repo = "onedrive";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0605nb3blvnncjx09frg2liarrd6pw8ph5jhnh764qcx0hyxcgs6";
+    sha256 = "0bcsrfh1g7bdlcp0zjn6np88qzpn5frv61lzxz9b2ayxf7wyybvi";
   };
 
-  nativeBuildInputs = [
-    dmd
-    pkgconfig
-  ];
-  buildInputs = [
-    curl
-    sqlite
-  ];
+  nativeBuildInputs = [ dmd pkgconfig ];
+
+  buildInputs = [ curl sqlite libnotify ];
+
+  configureFlags = [ "--enable-notifications" ];
+
   meta = with stdenv.lib; {
     description = "A complete tool to interact with OneDrive on Linux";
     homepage = "https://github.com/abraunegg/onedrive";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ doronbehar srgom ];
+    maintainers = with maintainers; [ srgom ianmjones ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Upgrade OneDrive to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

@doronbehar Hope this is ok to submit as a PR and add myself as a maintainer.

I've been using OneDrive with an almost identical Nix file for a couple of months via an overlay, and just as I went to add it to nixpkgs found your version!

This is an update to the latest release, adds in the ability to possibly get notifications by compiling with that option, and runs the `default.nix` file through `nixfmt` to help standardise the format.
