### PR TITLE
xlayoutdisplay: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/tools/X11/xlayoutdisplay/default.nix
+++ b/pkgs/tools/X11/xlayoutdisplay/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xlayoutdisplay";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "alex-courtis";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0wm6a48ym0wn2w0872mfq40ghajfrg1bccj1g342w899qh5x3bc4";
+    sha256 = "0ldqbwsryy7mqhxywdn2c2yi1mzlnl39sw8p3vx10w6q9drya9iv";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

Very minor (and for our packaging, no functional change AFAICT)
but bumping it anyway to scratch that itch and because we might
as well use the slightly better version if we have to pick one to use
:).

https://github.com/alex-courtis/xlayoutdisplay/releases/tag/v1.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).