### PR TITLE
elfinfo: 0.7.6 -> 1.0.1

### DIFF
--- a/pkgs/development/tools/misc/elfinfo/default.nix
+++ b/pkgs/development/tools/misc/elfinfo/default.nix
@@ -2,14 +2,14 @@
 
 buildGoPackage rec {
   pname = "elfinfo";
-  version = "0.7.6";
+  version = "1.0.1";
 
   goPackagePath = "github.com/xyproto/elfinfo";
   src = fetchFromGitHub {
     rev = version;
     owner = "xyproto";
     repo = "elfinfo";
-    sha256 = "0f6ik4d157assxdfslnyc91mg70kfh396rapikfv473znx2v2pg9";
+    sha256 = "1iahivc1jm9gv1dijykw2pryjdwb896bv42xmq9v6ax86rsnzqww";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/xyproto/elfinfo/releases/tag/1.0.0
https://github.com/xyproto/elfinfo/releases/tag/1.0.1

Pointing it at itself, as built in this commit:

```
$ ./result-bin/bin/elfinfo ./result-bin/bin/elfinfo
Go 1.13.6
$ nix eval -f . elfinfo.go.version
1.13.6
$ # :D
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).