### PR TITLE
sxiv: 25 -> 26, minor cleanup

### DIFF
--- a/pkgs/applications/graphics/sxiv/default.nix
+++ b/pkgs/applications/graphics/sxiv/default.nix
@@ -4,28 +4,24 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "sxiv";
-  version = "25";
+  version = "26";
 
   src = fetchFromGitHub {
     owner = "muennich";
     repo = pname;
     rev = "v${version}";
-    sha256 = "13s1lfar142hq1j7xld0ri616p4bqs57b17yr4d0b9a9w7liz4hp";
+    sha256 = "0xaawlfdy7b277m38mgg4423kd7p1ffn0dq4hciqs6ivbb3q9c4f";
   };
-
-  postUnpack = ''
-    substituteInPlace $sourceRoot/Makefile \
-      --replace /usr/local $out
-  '';
 
   configFile = optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
   preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
 
   buildInputs = [ libXft imlib2 giflib libexif ];
 
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
   postInstall = ''
-    mkdir -p $out/share/applications/
-    cp -v sxiv.desktop $out/share/applications/
+    install -Dt $out/share/applications sxiv.desktop
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Upstream's changelog for this is reproduced below:

> Maintenance release

:grin:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).