### PR TITLE
lcdf-typetools: init at 2.108

### DIFF
--- a/pkgs/tools/misc/lcdf-typetools/default.nix
+++ b/pkgs/tools/misc/lcdf-typetools/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "lcdf-typetools";
+  version = "2.108";
+
+  src = fetchFromGitHub {
+    owner = "kohler";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0a6jqaqwq43ldjjjlnsh6mczs2la9363qav7v9fyrfzkfj8kw9ad";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  configureFlags = [ "--without-kpathsea" ];
+
+  meta = with stdenv.lib; {
+    description = "Utilities for manipulating OpenType, PostScript Type 1, and Multiple Master fonts";
+    homepage = "https://www.lcdf.org/type";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4691,6 +4691,8 @@ in
 
   latexrun = callPackage ../tools/typesetting/tex/latexrun { };
 
+  lcdf-typetools = callPackage ../tools/misc/lcdf-typetools { };
+
   ldapvi = callPackage ../tools/misc/ldapvi { };
 
   ldns = callPackage ../development/libraries/ldns { };


### PR DESCRIPTION
###### Motivation for this change

"Utilities for manipulating OpenType, PostScript Type 1, and Multiple Master fonts"

For example, `otfinfo`! ...which is available in texlive somewhere
according to `command-not-found`
(unsurprising that it needs to be told "no kpathsea" hehe).

Good for use outside of tex environments, and useful enough to be a
package IMO.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Well, most of them. :innocent:
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).