### PR TITLE
hfsutils: init at 3.2.6-14

### DIFF
--- a/pkgs/tools/filesystems/hfsutils/default.nix
+++ b/pkgs/tools/filesystems/hfsutils/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "hfsutils";
+  baseversion = "3.2.6";
+  version = "${baseversion}-14";
+
+  srcs = [
+    # Actual source
+    (fetchurl {
+      name = "${pname}-${baseversion}.tar.gz";
+      urls = [
+        "ftp://ftp.mars.org/pub/hfs/${pname}-${baseversion}.tar.gz"
+        "http://deb.debian.org/debian/pool/main/h/${pname}/${pname}_${baseversion}.orig.tar.gz"
+      ];
+      sha256 = "0h4q51bjj5dvsmc2xx1l7ydii9jmfq5y066zkkn21fajsbb257dw";
+    })
+
+    # Debian packaging files, for the patches
+    (fetchurl {
+      name = "patches-${baseversion}.tar.xz";
+      url = "http://deb.debian.org/debian/pool/main/h/${pname}/${pname}_${version}.debian.tar.xz";
+      sha256 = "1b67vfcf679yk8yp1msyzsjfswpqh8mllkcrgbiy7l7a9ynvsp45";
+    })
+  ];
+
+  sourceRoot = "${pname}-${baseversion}";
+
+  # Apply patches from debian
+  prePatch = ''
+    for p in $(cat ../debian/patches/series); do
+      patches+=" ../debian/patches/$p"
+    done
+  '';
+
+  postPatch = ''
+    touch .stamp/*
+
+    substituteInPlace Makefile.in \
+      --replace '"$(BINDEST)/."' \
+                '-Dt "$(BINDEST)"' \
+      --replace '"$(MANDEST)' \
+                '-DT "$(MANDEST)'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "HFS utilities";
+    maintainers = with maintainers; [ dtzWill ];
+    license = licenses.gpl2Plus;
+    homepage = "https://www.mars.org/home/rob/proj/hfs";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4008,6 +4008,8 @@ in
 
   hfsprogs = callPackage ../tools/filesystems/hfsprogs { };
 
+  hfsutils = callPackage ../tools/filesystems/hfsutils { };
+
   highlight = callPackage ../tools/text/highlight ({
     lua = lua5;
   });


### PR DESCRIPTION
###### Motivation for this change

HFS utilities.

* init at 3.2.6-14.  "-14" is debian patchset used.
* touch timestamp files to avoid autoconf
  after patches, which is good because that fails.
  (patches fix the generated files too so all good)
* hfsutils: fix installation commands, fix build

These are especially useful as hfsprogs long since
stopped supporting HFS (as did Apple).

(ours still do, only because they're so very very ancient ;)).

I tackle updating those in 88bf051a78dd774370fade57dbb268633861a34f
(and likely a PR coming shortly after this) but I'm not entirely sure
it's worth upgrading those or not.

But will probably PR it for visibility and in case that does seem
like a good idea to anyone :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Superficially they appear okay :).
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).