### PR TITLE
WIP: dracut: init at 049

### DIFF
--- a/pkgs/os-specific/linux/dracut/default.nix
+++ b/pkgs/os-specific/linux/dracut/default.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
   '';
   meta = with lib; {
     description = "dracut is an event driven initramfs infrastructure";
-    homepage = https://dracut.wiki.kernel.org;
+    homepage = "https://dracut.wiki.kernel.org";
     license = licenses.gpl2;
     maintainers = with maintainers; [ cmcdragonkai ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/dracut/default.nix
+++ b/pkgs/os-specific/linux/dracut/default.nix
@@ -1,0 +1,100 @@
+{ stdenv
+, lib
+, fetchurl
+, makeWrapper
+, pkg-config
+, kmod
+, asciidoc
+, libxslt
+, docbook5
+, docbook_xsl
+, docbook_xsl_ns
+, coreutils
+, utillinux
+, gnused
+, gnugrep
+, squashfsTools
+, cpio
+, binutils
+, gzip
+, bzip2
+, lz4
+, lzop
+, zstd
+, xz
+}:
+
+stdenv.mkDerivation rec {
+  name = "dracut";
+  version = "049";
+  src = fetchurl {
+    url = "https://github.com/dracutdevs/dracut/archive/${version}.tar.gz";
+    sha256 = "07jz3qlby4npgqgmzxjrp9977r8vhy1igyr3hgvxy0nqj5cx0lvw";
+  };
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+    kmod
+    asciidoc
+    libxslt
+    docbook5
+    docbook_xsl
+    docbook_xsl_ns
+  ];
+  preConfigure = ''
+    patchShebangs ./configure
+  '';
+  postPatch = ''
+    substituteInPlace dracut.sh \
+      --replace 'dracutbasedir=/usr/lib/dracut' "dracutbasedir=$out/lib/dracut"
+    substituteInPlace lsinitrd.sh \
+      --replace 'dracutbasedir=/usr/lib/dracut' "dracutbasedir=$out/lib/dracut"
+  '';
+  postFixup = ''
+    wrapProgram $out/bin/dracut --set PATH ${lib.makeBinPath [
+      coreutils
+      utillinux
+      gnugrep
+      squashfsTools
+      cpio
+      binutils
+      gzip
+      bzip2
+      lz4
+      lzop
+      zstd
+      xz
+    ]}
+    wrapProgram $out/bin/dracut-catimages --set PATH ${lib.makeBinPath [
+      coreutils
+      cpio
+      gzip
+    ]}
+    wrapProgram $out/bin/lsinitrd --set PATH ${lib.makeBinPath [
+      coreutils
+      utillinux
+      gnused
+      squashfsTools
+      cpio
+      binutils
+      gzip
+      bzip2
+      lz4
+      lzop
+      zstd
+      xz
+    ]}
+    wrapProgram $out/bin/mkinitrd --set PATH ${lib.makeBinPath [
+      coreutils
+      gnused
+      gnugrep
+    ]}
+  '';
+  meta = with lib; {
+    description = "dracut is an event driven initramfs infrastructure";
+    homepage = https://dracut.wiki.kernel.org;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ cmcdragonkai ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -215,6 +215,8 @@ in
 
   dotnet-sdk = callPackage ../development/compilers/dotnet/sdk { };
 
+  dracut = callPackage ../os-specific/linux/dracut { };
+
   dumb-init = callPackage ../applications/virtualization/dumb-init {};
 
   umoci = callPackage ../applications/virtualization/umoci {};


### PR DESCRIPTION
## Motivation for this change

Fixes #77858

This derivation still has some problems. In particular `realpath` is not found in the dracut command. And also the `dracutbasedir` has shell scripts there that have not been properly wrapped as well. And also I need to wrap the bin scripts with a PATH to itself, but not sure if that means I need to add `$out` to the `lib.makeBinPath`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
