### PR TITLE
pythonPackages.seqnmf: init at 0.1.2

### DIFF
--- a/pkgs/development/python-modules/seqnmf/default.nix
+++ b/pkgs/development/python-modules/seqnmf/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, matplotlib
+, scipy
+, seaborn
+}:
+
+buildPythonPackage rec {
+  pname = "seqnmf";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "75a7bdb5f23de6345625f0d36bb0e42399f270ebe0d411d5a6ee64f6e7325f51";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    matplotlib
+    scipy
+    seaborn
+  ];
+
+  # no tests
+  doCheck=false;
+
+  meta = with lib; {
+    description = "Python implementation of seqNMF";
+    homepage = https://www.context-lab.com;
+    license = licenses.mit;
+    maintainers = [ maintainers.tbenst ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1133,6 +1133,8 @@ in {
     inherit (pkgs) cmake qt5 llvmPackages;
   });
 
+  seqnmf = callPackage ../development/python-modules/seqnmf { };
+
   simplefix = callPackage ../development/python-modules/simplefix { };
 
   pyside2-tools = toPythonModule (callPackage ../development/python-modules/pyside2-tools {


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @