### PR TITLE
ibus-rime: Init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2914,6 +2914,16 @@
     githubId = 896431;
     name = "Chris Hodapp";
   };
+  holliswu = {
+    name = "Hollis Wu";
+    email = "whyhollis@gmail.com";
+    github = "holi0317";
+    githubId = 6838982;
+    keys = [{
+      longkeyid = "rsa4096/0x93A6D27F21E51CD4";
+      fingerprint = "5EED 66CC 6B4E E911 01C9  2FBD 93A6 D27F 21E5 1CD4";
+    }];
+  };
   hrdinka = {
     email = "c.nix@hrdinka.at";
     github = "hrdinka";

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-rime/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-rime/default.nix
@@ -1,0 +1,80 @@
+{ stdenv
+, fetchFromGitHub
+, wrapGAppsHook
+, gdk-pixbuf
+, pkgconfig
+, cmake
+, librime
+, ibus
+, libnotify
+, brise
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ibus-rime";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "rime";
+    repo = "ibus-rime";
+    rev = version;
+    sha256 = "0zbajz7i18vrqwdyclzywvsjg6qzaih64jhi3pkxp7mbw8jc5vhy";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+    wrapGAppsHook
+  ];
+
+  # FIXME: Replace brise (deprecated) with rime/plum
+  buildInputs = [
+    librime
+    ibus
+    libnotify
+    brise
+    gdk-pixbuf
+  ];
+
+  # cmake cannont automatically find our nonstandard brise install location
+  cmakeFlags = [
+    "-DRIME_DATA_DIR=${brise}/share/rime-data"
+  ];
+
+  # Fix hard-coded paths references on rime-data and icons
+  preBuild = ''
+    sed -i ../rime_config.h -E \
+      -e "s|(IBUS_RIME_SHARED_DATA_DIR).+$|\1 \"${brise}/share/rime-data\"|" \
+      -e "s|(IBUS_RIME_ICONS_DIR).+$|\1 \"$out/share/ibus-rime/icons\"|"
+  '';
+
+  # CMake script does not provide install phrase
+  installPhase = ''
+    install -m 755 -d $out/share/ibus/component
+    install -m 644 -t $out/share/ibus/component/ ${src}/rime.xml
+
+    install -m 755 -d $out/lib/ibus-rime
+    install -m 755 -t $out/lib/ibus-rime/ ibus-engine-rime
+
+    install -m 755 -d $out/share/ibus-rime
+    install -m 755 -d $out/share/ibus-rime/icons
+    install -m 644 -t $out/share/ibus-rime/icons/ ${src}/icons/*.png
+  '';
+
+  # The ibus config rime.xml hard-coded binary path for ibus-engine-rime
+  postFixup = ''
+    sed -i $out/share/ibus/component/rime.xml \
+      -e "s|/usr/lib/ibus-rime|$out/lib/ibus-rime|" \
+      -e "s|/usr/share/ibus-rime|$out/share/ibus-rime|"
+  '';
+
+  meta = with stdenv.lib; {
+    isIbusEngine = true;
+    homepage = https://github.com/rime/ibus-rime;
+    downloadPage = https://github.com/rime/ibus-rime/releases;
+    description = "【中州韻】Rime for Linux/IBus";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ holliswu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2512,6 +2512,8 @@ in
       protobuf = pkgs.protobuf.overrideDerivation (oldAttrs: { stdenv = clangStdenv; });
     };
 
+    rime = callPackage ../tools/inputmethods/ibus-engines/ibus-rime { };
+
     table = callPackage ../tools/inputmethods/ibus-engines/ibus-table { };
 
     table-chinese = callPackage ../tools/inputmethods/ibus-engines/ibus-table-chinese {


### PR DESCRIPTION
##### Motivation for this change

Add ibus binding for rime input method

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] ~~macOS~~ Not applicable
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~ Not applicable
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
