### PR TITLE
home-assistant: upgrade to 0.104.1, add support for zwave/zha adapters, add various python modules for components

### DIFF
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -251,6 +251,7 @@ in {
       home = cfg.configDir;
       createHome = true;
       group = "hass";
+      extraGroups = [ "dialout" ];
       uid = config.ids.uids.hass;
     };
 

--- a/pkgs/development/python-modules/braviarc-homeassistant/default.nix
+++ b/pkgs/development/python-modules/braviarc-homeassistant/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, requests }:
+
+buildPythonPackage rec {
+  pname = "braviarc-homeassistant";
+  version = "0.3.7.dev0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ylv76xc7a538m5520y32daglcysnpxxbvff2kh179jzp78k27qb";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://pypi.org/project/braviarc-homeassistant";
+    description = "(braviarc pkged for pypi?)";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/development/python-modules/denonavr/default.nix
+++ b/pkgs/development/python-modules/denonavr/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, requests }:
+
+buildPythonPackage rec {
+  pname = "denonavr";
+  version = "0.7.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15f2bln3j3z2abanzhi2xdizsvcpirba0lnfwh1m3z2k1483y3vs";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/scarface-4711/denonavr";
+    description = "Automation Library for Denon AVR receivers.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/development/python-modules/flux-led/default.nix
+++ b/pkgs/development/python-modules/flux-led/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, aiohttp, zigpy
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "flux_led";
+  version = "0.22";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ilmz2jfpgh08v7bm4fy7mp06vkg6a6zwqr8cr0dqbrn6jylr6x6";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A Python library to communicate with the flux_led smart bulbs";
+    homepage = "https://github.com/Danielhiversen/flux_led";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ colemickens ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/getmac/default.nix
+++ b/pkgs/development/python-modules/getmac/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "getmac";
+  version = "0.8.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0s6ka96nr549k9jqpyqaj5vi18465qcmi1vsl37lhql5f45x40fm";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/GhostofGoes/getmac";
+    description = "Pure-Python package to get the MAC address of network interfaces and hosts on the local network.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/development/python-modules/plexapi/default.nix
+++ b/pkgs/development/python-modules/plexapi/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, requests, tqdm, websocket_client }:
+
+buildPythonPackage rec {
+  pname = "PlexAPI";
+  version = "3.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "18iflcjrc9n7j1x19hfrkmxq08008w08cjrzwvgaaip8crlyp7z8";
+  };
+
+  propagatedBuildInputs = [ requests tqdm websocket_client ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/pkkid/python-plexapi";
+    description = "Python bindings for the Plex API";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/development/python-modules/plexauth/default.nix
+++ b/pkgs/development/python-modules/plexauth/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, aiohttp }:
+
+buildPythonPackage rec {
+  pname = "plexauth";
+  version = "0.0.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gzf5w1z5p24x08fincicbbi358i6ngjw5rc8k8nwy69bjrbk7r8";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/jjlawren/python-plexauth/";
+    description = "Handles the authorization flow to obtain tokens from Plex.tv via external redirection";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/development/python-modules/plexwebsocket/default.nix
+++ b/pkgs/development/python-modules/plexwebsocket/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, aiohttp }:
+
+buildPythonPackage rec {
+  pname = "plexwebsocket";
+  version = "0.0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sp1ky6sy0d23h71sl3zkvy7vlif1rs8w51dlh3n8q9c44px42h0";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/jjlawren/python-plexwebsocket/";
+    description = "Async library to react to events issued over Plex websockets";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.103.6";
+  version = "0.104.1";
   components = {
     "abode" = ps: with ps; [  ];
     "acer_projector" = ps: with ps; [ pyserial ];
@@ -22,7 +22,7 @@
     "almond" = ps: with ps; [ aiohttp-cors ];
     "alpha_vantage" = ps: with ps; [  ];
     "amazon_polly" = ps: with ps; [ boto3 ];
-    "ambiclimate" = ps: with ps; [  ];
+    "ambiclimate" = ps: with ps; [ aiohttp-cors ];
     "ambient_station" = ps: with ps; [  ];
     "amcrest" = ps: with ps; [ ha-ffmpeg ];
     "ampio" = ps: with ps; [  ];
@@ -85,8 +85,9 @@
     "bme680" = ps: with ps; [  ];
     "bmw_connected_drive" = ps: with ps; [  ];
     "bom" = ps: with ps; [  ];
-    "braviatv" = ps: with ps; [  ];
+    "braviatv" = ps: with ps; [ getmac ];
     "broadlink" = ps: with ps; [ broadlink ];
+    "brother" = ps: with ps; [  ];
     "brottsplatskartan" = ps: with ps; [  ];
     "browser" = ps: with ps; [  ];
     "brunt" = ps: with ps; [  ];
@@ -164,7 +165,7 @@
     "dnsip" = ps: with ps; [ aiodns ];
     "dominos" = ps: with ps; [ aiohttp-cors ];
     "doods" = ps: with ps; [ pillow ];
-    "doorbird" = ps: with ps; [  ];
+    "doorbird" = ps: with ps; [ aiohttp-cors ];
     "dovado" = ps: with ps; [  ];
     "downloader" = ps: with ps; [  ];
     "dsmr" = ps: with ps; [  ];
@@ -189,6 +190,7 @@
     "efergy" = ps: with ps; [  ];
     "egardia" = ps: with ps; [  ];
     "eight_sleep" = ps: with ps; [  ];
+    "elgato" = ps: with ps; [  ];
     "eliqonline" = ps: with ps; [  ];
     "elkm1" = ps: with ps; [  ];
     "elv" = ps: with ps; [  ];
@@ -228,7 +230,7 @@
     "fido" = ps: with ps; [  ];
     "file" = ps: with ps; [  ];
     "filesize" = ps: with ps; [  ];
-    "filter" = ps: with ps; [  ];
+    "filter" = ps: with ps; [ aiohttp-cors sqlalchemy ];
     "fints" = ps: with ps; [ fints ];
     "fitbit" = ps: with ps; [ aiohttp-cors fitbit ];
     "fixer" = ps: with ps; [  ];
@@ -239,7 +241,7 @@
     "flume" = ps: with ps; [  ];
     "flunearyou" = ps: with ps; [  ];
     "flux" = ps: with ps; [  ];
-    "flux_led" = ps: with ps; [  ];
+    "flux_led" = ps: with ps; [ flux-led ];
     "folder" = ps: with ps; [  ];
     "folder_watcher" = ps: with ps; [ watchdog ];
     "foobot" = ps: with ps; [  ];
@@ -272,6 +274,7 @@
     "geofency" = ps: with ps; [ aiohttp-cors ];
     "geonetnz_quakes" = ps: with ps; [  ];
     "geonetnz_volcano" = ps: with ps; [  ];
+    "gios" = ps: with ps; [  ];
     "github" = ps: with ps; [ PyGithub ];
     "gitlab_ci" = ps: with ps; [ python-gitlab ];
     "gitter" = ps: with ps; [  ];
@@ -331,7 +334,7 @@
     "html5" = ps: with ps; [ aiohttp-cors pywebpush ];
     "http" = ps: with ps; [ aiohttp-cors ];
     "htu21d" = ps: with ps; [  ];
-    "huawei_lte" = ps: with ps; [ stringcase ];
+    "huawei_lte" = ps: with ps; [ getmac stringcase ];
     "huawei_router" = ps: with ps; [  ];
     "hue" = ps: with ps; [ aiohue ];
     "hunterdouglas_powerview" = ps: with ps; [  ];
@@ -359,6 +362,7 @@
     "integration" = ps: with ps; [  ];
     "intent" = ps: with ps; [ aiohttp-cors ];
     "intent_script" = ps: with ps; [  ];
+    "intesishome" = ps: with ps; [  ];
     "ios" = ps: with ps; [ aiohttp-cors zeroconf ];
     "iota" = ps: with ps; [  ];
     "iperf3" = ps: with ps; [  ];
@@ -378,6 +382,7 @@
     "kankun" = ps: with ps; [  ];
     "keba" = ps: with ps; [  ];
     "keenetic_ndms2" = ps: with ps; [  ];
+    "kef" = ps: with ps; [ getmac ];
     "keyboard" = ps: with ps; [  ];
     "keyboard_remote" = ps: with ps; [ evdev ];
     "kira" = ps: with ps; [  ];
@@ -410,13 +415,14 @@
     "liveboxplaytv" = ps: with ps; [  ];
     "llamalab_automate" = ps: with ps; [  ];
     "local_file" = ps: with ps; [  ];
+    "local_ip" = ps: with ps; [  ];
     "locative" = ps: with ps; [ aiohttp-cors ];
     "lock" = ps: with ps; [  ];
     "lockitron" = ps: with ps; [  ];
     "logbook" = ps: with ps; [ aiohttp-cors sqlalchemy ];
     "logentries" = ps: with ps; [  ];
     "logger" = ps: with ps; [  ];
-    "logi_circle" = ps: with ps; [ ha-ffmpeg ];
+    "logi_circle" = ps: with ps; [ aiohttp-cors ha-ffmpeg ];
     "london_air" = ps: with ps; [  ];
     "london_underground" = ps: with ps; [  ];
     "loopenergy" = ps: with ps; [  ];
@@ -505,7 +511,7 @@
     "niko_home_control" = ps: with ps; [  ];
     "nilu" = ps: with ps; [  ];
     "nissan_leaf" = ps: with ps; [  ];
-    "nmap_tracker" = ps: with ps; [  ];
+    "nmap_tracker" = ps: with ps; [ getmac ];
     "nmbs" = ps: with ps; [  ];
     "no_ip" = ps: with ps; [  ];
     "noaa_tides" = ps: with ps; [  ];
@@ -571,7 +577,7 @@
     "pjlink" = ps: with ps; [  ];
     "plaato" = ps: with ps; [ aiohttp-cors ];
     "plant" = ps: with ps; [  ];
-    "plex" = ps: with ps; [ aiohttp-cors ];
+    "plex" = ps: with ps; [ aiohttp-cors plexapi plexauth plexwebsocket ];
     "plugwise" = ps: with ps; [  ];
     "plum_lightpad" = ps: with ps; [  ];
     "pocketcasts" = ps: with ps; [  ];
@@ -601,7 +607,7 @@
     "qrcode" = ps: with ps; [ pillow ];
     "quantum_gateway" = ps: with ps; [  ];
     "qwikswitch" = ps: with ps; [  ];
-    "rachio" = ps: with ps; [  ];
+    "rachio" = ps: with ps; [ aiohttp-cors ];
     "radarr" = ps: with ps; [  ];
     "radiotherm" = ps: with ps; [  ];
     "rainbird" = ps: with ps; [  ];
@@ -655,6 +661,7 @@
     "sensehat" = ps: with ps; [  ];
     "sensibo" = ps: with ps; [  ];
     "sensor" = ps: with ps; [  ];
+    "sentry" = ps: with ps; [ sentry-sdk ];
     "serial" = ps: with ps; [ pyserial-asyncio ];
     "serial_pm" = ps: with ps; [  ];
     "sesame" = ps: with ps; [  ];
@@ -666,6 +673,7 @@
     "shopping_list" = ps: with ps; [ aiohttp-cors ];
     "sht31" = ps: with ps; [  ];
     "sigfox" = ps: with ps; [  ];
+    "signal_messenger" = ps: with ps; [  ];
     "simplepush" = ps: with ps; [  ];
     "simplisafe" = ps: with ps; [  ];
     "simulated" = ps: with ps; [  ];
@@ -718,6 +726,7 @@
     "statsd" = ps: with ps; [ statsd ];
     "steam_online" = ps: with ps; [  ];
     "stiebel_eltron" = ps: with ps; [  ];
+    "stookalert" = ps: with ps; [  ];
     "stream" = ps: with ps; [ aiohttp-cors av ];
     "streamlabswater" = ps: with ps; [  ];
     "stt" = ps: with ps; [ aiohttp-cors ];
@@ -725,6 +734,7 @@
     "sun" = ps: with ps; [  ];
     "supervisord" = ps: with ps; [  ];
     "supla" = ps: with ps; [  ];
+    "surepetcare" = ps: with ps; [  ];
     "swiss_hydrological_data" = ps: with ps; [  ];
     "swiss_public_transport" = ps: with ps; [  ];
     "swisscom" = ps: with ps; [  ];
@@ -770,6 +780,7 @@
     "tile" = ps: with ps; [  ];
     "time_date" = ps: with ps; [  ];
     "timer" = ps: with ps; [  ];
+    "tmb" = ps: with ps; [  ];
     "tod" = ps: with ps; [  ];
     "todoist" = ps: with ps; [ todoist ];
     "tof" = ps: with ps; [  ];
@@ -848,11 +859,11 @@
     "weather" = ps: with ps; [  ];
     "webhook" = ps: with ps; [ aiohttp-cors ];
     "weblink" = ps: with ps; [  ];
-    "webostv" = ps: with ps; [ websockets ];
+    "webostv" = ps: with ps; [  ];
     "websocket_api" = ps: with ps; [ aiohttp-cors ];
     "wemo" = ps: with ps; [  ];
     "whois" = ps: with ps; [  ];
-    "wink" = ps: with ps; [  ];
+    "wink" = ps: with ps; [ aiohttp-cors ];
     "wirelesstag" = ps: with ps; [  ];
     "withings" = ps: with ps; [ aiohttp-cors ];
     "wled" = ps: with ps; [  ];
@@ -870,7 +881,7 @@
     "xfinity" = ps: with ps; [  ];
     "xiaomi" = ps: with ps; [ ha-ffmpeg ];
     "xiaomi_aqara" = ps: with ps; [  ];
-    "xiaomi_miio" = ps: with ps; [ construct ];
+    "xiaomi_miio" = ps: with ps; [ construct python-miio ];
     "xiaomi_tv" = ps: with ps; [  ];
     "xmpp" = ps: with ps; [ slixmpp ];
     "xs1" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -27,9 +27,6 @@ let
     (mkOverride "colorlog" "4.0.2"
       "3cf31b25cbc8f86ec01fef582ef3b840950dea414084ed19ab922c8b493f9b42")
 
-    (mkOverride "pyyaml" "5.1.2"
-      "1r5faspz73477hlbjgilw05xsms0glmsa371yqdd26znqsvg1b81")
-
     # required by aioesphomeapi
     (self: super: {
       protobuf = super.protobuf.override {
@@ -70,7 +67,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.103.6";
+  hassVersion = "0.104.1";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -85,7 +82,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "1492q4icyhvz30fw5ysrwlnsls4iy5pv62ay3vq1ygcfnlapkqhl";
+    sha256 = "139pfcnnhi9hr6y3fyd2qaf7cmiili5alqwm4i9gpx6lwxibvyiz";
   };
 
   propagatedBuildInputs = [
@@ -99,14 +96,6 @@ in with py.pkgs; buildPythonApplication rec {
 
   checkInputs = [
     asynctest pytest pytest-aiohttp requests-mock pydispatcher aiohue netdisco hass-nabucasa
-  ];
-
-  patches = [
-    # newer importlib-metadata version
-    (fetchpatch {
-      url = "https://github.com/home-assistant/home-assistant/commit/63c6b803dc2d835d57b97ed833ee5cd8318bf7ae.patch";
-      sha256 = "16q3qdnmgsw5415f70zvsv1z63dljp3c9glv06cyj4s6qsl13xdc";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2942,6 +2942,8 @@ in {
 
   plexauth = callPackage ../development/python-modules/plexauth { };
 
+  plexwebsocket = callPackage ../development/python-modules/plexwebsocket { };
+
   plotly = callPackage ../development/python-modules/plotly { };
 
   plyfile = callPackage ../development/python-modules/plyfile { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2583,6 +2583,8 @@ in {
 
   fluent-logger = callPackage ../development/python-modules/fluent-logger {};
 
+  flux-led = callPackage ../development/python-modules/flux-led { };
+
   python-forecastio = callPackage ../development/python-modules/python-forecastio { };
 
   fpdf = callPackage ../development/python-modules/fpdf { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -560,6 +560,8 @@ in {
 
   dendropy = callPackage ../development/python-modules/dendropy { };
 
+  denonavr = callPackage ../development/python-modules/denonavr { };
+
   dependency-injector = callPackage ../development/python-modules/dependency-injector { };
 
   btchip = callPackage ../development/python-modules/btchip { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2938,6 +2938,8 @@ in {
 
   plaster-pastedeploy = callPackage ../development/python-modules/plaster-pastedeploy {};
 
+  plexapi = callPackage ../development/python-modules/plexapi { };
+
   plotly = callPackage ../development/python-modules/plotly { };
 
   plyfile = callPackage ../development/python-modules/plyfile { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -690,6 +690,8 @@ in {
 
   geoip2 = callPackage ../development/python-modules/geoip2 { };
 
+  getmac = callPackage ../development/python-modules/getmac { };
+
   gidgethub = callPackage ../development/python-modules/gidgethub { };
 
   gin-config = callPackage ../development/python-modules/gin-config { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -492,6 +492,8 @@ in {
 
   boltons = callPackage ../development/python-modules/boltons { };
 
+  braviarc = callPackage ../development/python-modules/braviarc-homeassistant { };
+
   braintree = callPackage ../development/python-modules/braintree { };
 
   django-sesame = callPackage ../development/python-modules/django-sesame { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2940,6 +2940,8 @@ in {
 
   plexapi = callPackage ../development/python-modules/plexapi { };
 
+  plexauth = callPackage ../development/python-modules/plexauth { };
+
   plotly = callPackage ../development/python-modules/plotly { };
 
   plyfile = callPackage ../development/python-modules/plyfile { };


### PR DESCRIPTION

###### Motivation for this change
* Upgrade home-assistant to latest (`0.104.1`)
* Add the `home-assistant` service user to the `dialout` group so that it can access certain zwave/zha adapters
* Add the following modules:
  * `denonavr`: (denon component)
  * `braviarc-homeassistant`: (bravia component)
  * `plexauth`, `plexapi`, `plexwebsocket`: (plex component)
  * `flux_led`, `getmac`: (magichome/fluxled component)

cc: @Mic92

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
