### PR TITLE
plex-mpv-shim: init at 1.7.12

### DIFF
--- a/pkgs/applications/video/plex-mpv-shim/default.nix
+++ b/pkgs/applications/video/plex-mpv-shim/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, mpv, requests, python-mpv-jsonipc }:
+
+buildPythonApplication rec {
+  pname = "plex-mpv-shim";
+  version = "1.7.12";
+
+  src = fetchFromGitHub {
+    owner = "iwalton3";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0l13g4vkvcd1q4lkdkbgv4hgkx5pql6ym2fap35581z7rzy9jhkq";
+  };
+
+  propagatedBuildInputs = [ mpv requests python-mpv-jsonipc ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/iwalton3/plex-mpv-shim";
+    description = "Allows casting of videos to MPV via the Plex mobile and web app.";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/python-mpv-jsonipc/default.nix
+++ b/pkgs/development/python-modules/python-mpv-jsonipc/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchFromGitHub, requests
+, tqdm, websocket_client, pythonOlder }:
+
+buildPythonPackage rec {
+  pname = "python-mpv-jsonipc";
+  version = "1.1.6";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "iwalton3";
+    repo = "python-mpv-jsonipc";
+    rev = "v${version}";
+    sha256 = "08bs6qrcf5fi72jijmr2w7zs6aa5976dwv04f11ajwhj6i8kfq35";
+  };
+
+  # 'mpv-jsonipc' does not have any tests
+  doCheck = false;
+
+  propagatedBuildInputs = [ requests tqdm websocket_client ];
+
+  pythonImportsCheck = [ "python_mpv_jsonipc" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/iwalton3/python-mpv-jsonipc";
+    description = "Python API to MPV using JSON IPC";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21053,6 +21053,8 @@ in
 
   plex-media-player = libsForQt512.callPackage ../applications/video/plex-media-player { };
 
+  plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };
+
   plover = recurseIntoAttrs (libsForQt5.callPackage ../applications/misc/plover { });
 
   plugin-torture = callPackage ../applications/audio/plugin-torture { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -869,6 +869,8 @@ in {
     mpi = pkgs.openmpi;
   };
 
+  python-mpv-jsonipc = callPackage ../development/python-modules/python-mpv-jsonipc { };
+
   msal = callPackage ../development/python-modules/msal { };
 
   msal-extensions = callPackage ../development/python-modules/msal-extensions { };


### PR DESCRIPTION
Tested. Working as best as it can, I think.

(Specifically on an RPi4 with Sway)
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
