### PR TITLE
facetimehd: unstable-2016-10-09 -> unstable-2019-12-10 for kernels > 4.8

### DIFF
--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -16,9 +16,9 @@ let
   #       still works.
   srcParams = if (stdenv.lib.versionAtLeast kernel.version "4.8") then
     { # Use mainline branch
-      version = "unstable-2016-10-09";
-      rev = "887d0f531ef7b91457be519474136c3355c5132b";
-      sha256 = "0bayahnxar1q6wvf9cb6p8gsfw98w0wqp715hs4r7apmddwk9v7n";
+      version = "unstable-2019-12-10";
+      rev = "ea832ac486afb6dac9ef59aa37e90f332ab7f05a";
+      sha256 = "1dg2i558hjnjnyk53xyg0ayykqaial9bm420v22s9a3khzzjnwq3";
     }
   else
     { # Use master branch (broken on 4.8)


### PR DESCRIPTION
###### Motivation for this change

Facetimehd driver wouldn't load correctly when running the latest stable kernel as per https://github.com/patjak/bcwc_pcie/issues/143

If `boot.kernelPackages = pkgs.linuxPackages_latest;` is set I'd get this dmesg output:
```
[   62.729904] facetimehd: probe of 0000:02:00.0 failed with error -22
```
on a Macbook Pro 12,1

###### Things done
Bumped the https://github.com/patjak/bcwc_pcie driver to latest commit in said repo.
This enabled my facetime webcam to function again.

###### Other
I've tried to follow the rules for contributing. Please tell me if there's anything I need to change/do differently :)

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
