### PR TITLE
WIP: networking.services: Add vpnc module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -746,6 +746,7 @@
   ./services/networking/zeronet.nix
   ./services/networking/zerotierone.nix
   ./services/networking/znc/default.nix
+  ./services/networking/vpnc.nix
   ./services/printing/cupsd.nix
   ./services/scheduling/atd.nix
   ./services/scheduling/chronos.nix

--- a/nixos/modules/services/networking/vpnc.nix
+++ b/nixos/modules/services/networking/vpnc.nix
@@ -1,0 +1,97 @@
+{ lib, pkgs, config, ... }:
+
+with lib;
+
+let
+
+  buildVpnc = key: value: {
+    name = "vpnc/${key}.conf";
+    value = {
+      text = ''
+        IPSec gateway ${value.gateway}
+        IPSec ID ${value.id}
+        IPSec secret ${value.secret}
+        Xauth username ${value.username}
+        Password helper ${pkgs.systemd}/bin/systemd-ask-password
+        Script ${pkgs.vpnc}/etc/vpnc/vpnc-script
+        '';
+    };
+  };
+  up = pkgs.writeScript "up" ''
+    #!${pkgs.bash}/bin/bash
+    PATH=${makeBinPath [pkgs.nettools pkgs.iproute]}:$PATH
+
+    LOCAL_GATEWAY=$(ip r | grep "default via" | grep -oE "([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)" | head -n1)
+    ip route del default via $LOCAL_GATEWAY
+    ip route add default dev tun0 proto static scope link metric 50
+    if [ ! -d /var/run/vpnc ]; then
+      mkdir -p /var/run/vpnc
+    fi
+    echo -ne $LOCAL_GATEWAY > /var/run/vpnc/LOCAL_GATEWAY
+  '';
+  down = pkgs.writeScript "down" ''
+    #!${pkgs.bash}/bin/bash
+    PATH=${makeBinPath [pkgs.nettools pkgs.iproute]}:$PATH
+
+    LOCAL_GATEWAY=$(cat /var/run/vpnc/LOCAL_GATEWAY)
+    ip route add default via $LOCAL_GATEWAY
+    ip route del default dev tun0
+  '';
+  buildService = key: value: nameValuePair "vpnc-${key}" {
+    description = "VPNC for ${key}";
+    # No automatic startup, password
+
+    path = [ pkgs.iptables pkgs.nettools pkgs.iproute ];
+    serviceConfig = {
+      ExecStart = "${pkgs.vpnc}/bin/vpnc /etc/vpnc/${key}.conf";
+      ExecStartPost = "${up}";
+      ExecStopPost = "${down}";
+      Type = "forking";
+    };
+  };
+
+  cfg = config.services.networking.vpnc;
+  vpnModule = types.submodule {
+    options = {
+      gateway = mkOption {
+        default = "";
+        type = types.separatedString "";
+        description = "Gateway address";
+      };
+      id = mkOption {
+        default = "linux";
+        type = types.separatedString "";
+        description = "Your group name";
+      };
+      secret = mkOption {
+        default = "";
+        type = types.separatedString "";
+        description = "Your shared secret";
+      };
+      username = mkOption {
+        default = "";
+        type = types.separatedString "";
+        description = "Your username";
+        example = "john.doe@example.com";
+      };
+    };
+  };
+
+in
+
+{
+  options.services.networking.vpnc.servers = mkOption {
+    default = {};
+
+    description = "Each attribute defines a vpn client";
+
+    type = types.attrsOf vpnModule;
+  };
+
+  config = mkIf (cfg.servers != {}) {
+    environment.systemPackages = [ pkgs.vpnc ];
+    boot.kernelModules = [ "tun" ];
+    environment.etc = attrsets.mapAttrs' buildVpnc cfg.servers;
+    systemd.services = listToAttrs (mapAttrsFlatten buildService cfg.servers);
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Related to the issue #77891, we have been using this vpnc module definition for a while now.

This MR creates a new services.networking.vpnc attributeset, for setting up a vpnc service and systemd definition (the latter was missing in the original module definition).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
