### PR TITLE
pulumi: 1.4.0 -> 1.8.1

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,50 +1,50 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "1.4.0";
+  version = "1.8.1";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.4.0-linux-x64.tar.gz";
-        sha256 = "00ywy2ba4xha6gwd42i3fdrk1myivkd1r6ijdr2vkianmg524k6f";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.8.1-linux-x64.tar.gz";
+        sha256 = "00ksdz45464hyxlpyfrby5g3b4d5ma4ww3qshrawvyk2bq9a311a";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v0.2.0-linux-amd64.tar.gz";
         sha256 = "1hj4gysjipd091f106a7xz02g9cail5d11rn6j08m0xphg9cf3fn";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v1.4.1-linux-amd64.tar.gz";
-        sha256 = "0r6xpsb2riqmxwxw28lbi3xd7w4ds510gw99j1rr57h5b9bq19jj";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v2.2.0-linux-amd64.tar.gz";
+        sha256 = "0snwhk9jng3lkh8z1fam9ydnky0myn4wdc3mi3xqxiwy40552vx8";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.2.3-linux-amd64.tar.gz";
-        sha256 = "0m7fajy3cy1agsz787ak548khwj8rwahs1ibaswqfyyw092iyzb9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.4.3-linux-amd64.tar.gz";
+        sha256 = "054bzkmrirrprcanhqqs4gbf4g760l6j1z76fsjyv1ysz3gss2m3";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.7.0-linux-amd64.tar.gz";
-        sha256 = "1qw90l7h8yn06bz2l2995nbrc3svs223dm3ys1807amj4n2jyfwb";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.18.0-linux-amd64.tar.gz";
+        sha256 = "1y6rbm9hil77kbrr937pwm8d49h21h3269s8m6g646banphamj4f";
       }
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.4.0-darwin-x64.tar.gz";
-        sha256 = "02vqw9gn17dy3rfh0j00k9f827l42g3nl3rhlcbc8jbgx3n9c9qy";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v1.8.1-darwin-x64.tar.gz";
+        sha256 = "1cxiglmscz42jaz3mlhq8ia0vk3ap8whps3ppp56fmqyzpb04d0j";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-random-v0.2.0-darwin-amd64.tar.gz";
         sha256 = "077j9fp8ix00rcqrq8qxk3kvz6gz6sknzb2iv3qjvkh6yh292mz3";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v1.4.1-darwin-amd64.tar.gz";
-        sha256 = "1i2vf3bxwf8awvw183hq9bbnmznda1jpv1zqghgz2ybx4s0915nx";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v2.2.0-darwin-amd64.tar.gz";
+        sha256 = "0x3ihq8fqyf3b2mdrn675c94r4yhqbbb74d7kc2lk0vmcsk7b2yf";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.2.3-darwin-amd64.tar.gz";
-        sha256 = "123czx1c31r5r91k2jhdgmnffypnl8w1a6h9mr2rdhwgbx8hzq40";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v1.4.3-darwin-amd64.tar.gz";
+        sha256 = "10rmnn2v7zazylnvjhppy9wagjg7d044g5kn138b30fg9pqf4n6p";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.7.0-darwin-amd64.tar.gz";
-        sha256 = "0cl0vakppxi0v8ym8b4fzhzb10nl84wd0vfik8gpfwsg7zwdzhlp";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v1.18.0-darwin-amd64.tar.gz";
+        sha256 = "02ddp4dmvj7jb71pmcmdzmiicf941pjhn1wpkkydwjml64i8dp07";
       }
     ];
   };

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-VERSION="1.4.0"
+VERSION="1.8.1"
 
 declare -A plugins
 plugins=(
-    ["aws"]="1.7.0"
-    ["gcp"]="1.4.1"
-    ["kubernetes"]="1.2.3"
+    ["aws"]="1.18.0"
+    ["gcp"]="2.2.0"
+    ["kubernetes"]="1.4.3"
     ["random"]="0.2.0"
 )
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
