### PR TITLE
fish: fix systemctl completion

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -3,6 +3,7 @@
   groff, man-db, getent, libiconv, pcre2,
   gettext, ncurses, python3,
   cmake
+  , fetchpatch
 
   , writeText
 
@@ -106,6 +107,15 @@ let
     preConfigure = ''
       patchShebangs ./build_tools/git_version_gen.sh
     '';
+
+    patches = [
+      # Fixes "Integer 243 in '243 (243)' followed by non-digit" error with systemctl completion.
+      # https://github.com/fish-shell/fish-shell/issues/5689 (will be included in fish 3.1.0)
+      (fetchpatch {
+        url = "https://github.com/fish-shell/fish-shell/commit/c6ec4235136e82c709e8d7b455f7c463f9714b48.patch";
+        sha256 = "02m6pkhhx6y21csydznsxkbpnwhcpzyz99xgd9ryh7s03v7wbigw";
+      })
+    ];
 
     # Required binaries during execution
     # Python: Autocompletion generated from manpages and config editing


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Type `systemctl rest<TAB>` in fish and you get the following error message:
```
 archachatina  ~  systemctl restart diInteger 243 in '243 (243)' followed by non-digit           Fri 17 Jan 2020 05:43:35 PM CET
        Integer 243 in '243 (243)' followed by non-digit
```

(The error message is shown twice and messes up the prompt, which drives me crazy.)

Unfortunately it's not clear when the next fish release is going to be (see https://github.com/fish-shell/fish-shell/issues/5934), so I'd like to patch this now.

cc maintainer @ocharles

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
