### PR TITLE
dockerTools.*: Assertion against building for Darwin

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -589,6 +589,8 @@ rec {
           if tag == null
           then lib.head (lib.splitString "-" (lib.last (lib.splitString "/" result)))
           else lib.toLower tag;
+        # Docker can't be made to run darwin binaries
+        meta.badPlatforms = lib.platforms.darwin;
       } ''
         ${if (tag == null) then ''
           outName="$(basename "$out")"
@@ -719,6 +721,8 @@ rec {
         layerClosure = writeReferencesToFile layer;
         passthru.buildArgs = args;
         passthru.layer = layer;
+        # Docker can't be made to run darwin binaries
+        meta.badPlatforms = lib.platforms.darwin;
       } ''
         ${lib.optionalString (tag == null) ''
           outName="$(basename "$out")"


### PR DESCRIPTION
###### Motivation for this change

Building a docker image with Darwin binaries just yields a confusing
error when ran:

    standard_init_linux.go:211: exec user process caused "exec format error"

This change prevents people from building such images in the first place

This PR is sponsored by Niteo :sparkles: 

Ping @grahamc @zupo 

###### Things done

- [x] Verified that the assertion is not triggered on Linux
- [x] Verified that the assertion is triggered on macOS