### PR TITLE
python3.pkgs.binwalk 2.1.1 -> 2.2.0

### DIFF
--- a/pkgs/development/python-modules/binwalk/default.nix
+++ b/pkgs/development/python-modules/binwalk/default.nix
@@ -10,24 +10,39 @@
 , p7zip
 , cabextract
 , lzma
+, nose
 , pycrypto
 , pyqtgraph ? null }:
 
-let visualizationSupport = (pyqtgraph != null);
+let
+  visualizationSupport = (pyqtgraph != null);
+  version = "2.2.0";
 in
 buildPythonPackage {
   pname = "binwalk";
-  version = "2.1.1";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "devttys0";
     repo = "binwalk";
-    rev = "291a03595d17f848c73b74cb6ca508da782cd8f7";
-    sha256 = "0grid93yz6i6jb2zggrqncp5awdf7qi88j5y2k7dq0k9r6b8zydw";
+    rev = "be738a52e09b0da2a6e21470e0dbcd5beb42ed1b";
+    sha256 = "1bxgj569fzwv6jhcbl864nmlsi9x1k1r20aywjxc8b9b1zgqrlvc";
   };
 
   propagatedBuildInputs = [ zlib xz ncompress gzip bzip2 gnutar p7zip cabextract lzma pycrypto ]
-    ++ stdenv.lib.optional visualizationSupport pyqtgraph;
+  ++ stdenv.lib.optional visualizationSupport pyqtgraph;
+
+  # setup.py only installs version.py during install, not test
+  postPatch = ''
+    echo '__version__ = "${version}"' > src/binwalk/core/version.py
+  '';
+
+  # binwalk wants to access ~/.config/binwalk/magic
+  preCheck = ''
+    HOME=$(mktemp -d)
+  '';
+
+  checkInputs = [ nose ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/ReFirmLabs/binwalk";


### PR DESCRIPTION
###### Motivation for this change
New release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
