### PR TITLE
ums: 6.2.2 -> 9.1.0

### DIFF
--- a/pkgs/servers/ums/default.nix
+++ b/pkgs/servers/ums/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ums";
-  version = "6.2.2";
+  version = "9.1.0";
   
   src = fetchurl {
-    url = "mirror://sourceforge/project/unimediaserver/Official%20Releases/Linux/" + stdenv.lib.toUpper "${pname}-${version}" + "-Java8.tgz";
-    sha256 = "1qa999la9hixy0pdj9phjvr6lwqycgdvm94nc1606vz0ivf95b15";
+    url = "mirror://sourceforge/project/unimediaserver/Official%20Releases/Linux/" + stdenv.lib.toUpper "${pname}-${version}" + ".tgz";
+    sha256 = "07wprjpwqids96v5q5fhwcxqlg8jp1vy585vl2nqbfi1vf5v294s";
     name = "${pname}-${version}.tgz";
   };
 
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
     cp -a . $out/
     mkdir $out/bin
     mv $out/documentation /$out/doc
+
+    # ums >= 9.0.0 ships its own JRE in the package. if we remove it, the `UMS.sh`
+    # script will correctly fall back to the JRE specified by JAVA_HOME
+    rm -rf $out/linux/jre-x64 $out/linux/jre-x86
 
     makeWrapper "$out/UMS.sh" "$out/bin/ums" \
       --prefix LD_LIBRARY_PATH ":" "${stdenv.lib.makeLibraryPath [ libzen libmediainfo] }" \


### PR DESCRIPTION
An upgrade.

Notes:

Removing the packaged JRE so that `jre8` gets used.

Patchelf fails on `tsMuxeR` and `tsMuxeR-new`, but this doesn't make it any worse comparing to 6.2.2 where is also failed, so I am assuming fixing it is out of scope of this pr. The only difference is that the new UMS version correctly identifies that `tsMuxeR` doesn't work, comparing to the previous one.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
