### PR TITLE
minetest: update to 5.1.0 and build on Darwin

### DIFF
--- a/pkgs/development/libraries/irrlicht/common.nix
+++ b/pkgs/development/libraries/irrlicht/common.nix
@@ -1,0 +1,11 @@
+{ fetchzip }:
+
+rec {
+  pname = "irrlicht";
+  version = "1.8.4";
+
+  src = fetchzip {
+    url = "mirror://sourceforge/irrlicht/${pname}-${version}.zip";
+    sha256 = "02sq067fn4xpf0lcyb4vqxmm43qg2nxx770bgrl799yymqbvih5f";
+  };
+}

--- a/pkgs/development/libraries/irrlicht/default.nix
+++ b/pkgs/development/libraries/irrlicht/default.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation rec {
     homepage = http://irrlicht.sourceforge.net/;
     license = stdenv.lib.licenses.zlib;
     description = "Open source high performance realtime 3D engine written in C++";
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/irrlicht/default.nix
+++ b/pkgs/development/libraries/irrlicht/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchzip, libGLU, libGL, unzip, libXrandr, libX11, libXxf86vm }:
 
+let
+  common = import ./common.nix { inherit fetchzip; };
+in
 
 stdenv.mkDerivation rec {
-  pname = "irrlicht";
-  version = "1.8.4";
+  pname = common.pname;
+  version = common.version;
 
-  src = fetchzip {
-    url = "mirror://sourceforge/irrlicht/${pname}-${version}.zip";
-    sha256 = "02sq067fn4xpf0lcyb4vqxmm43qg2nxx770bgrl799yymqbvih5f";
-  };
+  src = common.src;
 
   preConfigure = ''
     cd source/Irrlicht

--- a/pkgs/development/libraries/irrlicht/mac.nix
+++ b/pkgs/development/libraries/irrlicht/mac.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchzip, libGLU, libGL, unzip, fetchFromGitHub, cmake, Cocoa, OpenGL, IOKit }:
+
+let
+  version = "1.8.4";
+
+  irrlichtZip = fetchzip {
+    name = "irrlichtZip";
+    url = "mirror://sourceforge/irrlicht/irrlicht-${version}.zip";
+    sha256 = "02sq067fn4xpf0lcyb4vqxmm43qg2nxx770bgrl799yymqbvih5f";
+  };
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "irrlicht-mac";
+  inherit version;
+
+  src = fetchFromGitHub {
+		owner = "quiark";
+		repo = "IrrlichtCMake";
+		rev = "523a5e6ef84be67c3014f7b822b97acfced536ce";
+		sha256 = "10ahnry2zl64wphs233gxhvs6c0345pyf5nwa29mc6yn49x7bidi";
+  };
+
+  postUnpack = ''
+    cp -r ${irrlichtZip}/* $sourceRoot/
+    chmod -R 777 $sourceRoot
+	'';
+
+  patches = [ ./mac_device.patch ];
+  dontFixCmake = true;
+
+  cmakeFlags = [
+    "-DIRRLICHT_STATIC_LIBRARY=ON"
+    "-DIRRLICHT_BUILD_EXAMPLES=OFF"
+    "-DIRRLICHT_INSTALL_MEDIA_FILES=OFF"
+    "-DIRRLICHT_ENABLE_X11_SUPPORT=OFF"
+    "-DIRRLICHT_BUILD_TOOLS=OFF"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ unzip OpenGL Cocoa IOKit ];
+
+  meta = {
+    homepage = http://irrlicht.sourceforge.net/;
+    license = stdenv.lib.licenses.zlib;
+    description = "Open source high performance realtime 3D engine written in C++";
+    platforms = stdenv.lib.platforms.darwin;
+  };
+}

--- a/pkgs/development/libraries/irrlicht/mac.nix
+++ b/pkgs/development/libraries/irrlicht/mac.nix
@@ -1,19 +1,12 @@
 { stdenv, fetchzip, libGLU, libGL, unzip, fetchFromGitHub, cmake, Cocoa, OpenGL, IOKit }:
 
 let
-  version = "1.8.4";
-
-  irrlichtZip = fetchzip {
-    name = "irrlichtZip";
-    url = "mirror://sourceforge/irrlicht/irrlicht-${version}.zip";
-    sha256 = "02sq067fn4xpf0lcyb4vqxmm43qg2nxx770bgrl799yymqbvih5f";
-  };
-
+  common = import ./common.nix { inherit fetchzip; };
 in
 
 stdenv.mkDerivation rec {
   pname = "irrlicht-mac";
-  inherit version;
+  version = common.version;
 
   src = fetchFromGitHub {
 		owner = "quiark";
@@ -23,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   postUnpack = ''
-    cp -r ${irrlichtZip}/* $sourceRoot/
+    cp -r ${common.src}/* $sourceRoot/
     chmod -R 777 $sourceRoot
 	'';
 

--- a/pkgs/development/libraries/irrlicht/mac_device.patch
+++ b/pkgs/development/libraries/irrlicht/mac_device.patch
@@ -1,0 +1,20 @@
+--- a/source/Irrlicht/MacOSX/CIrrDeviceMacOSX.mm
++++ b/source/Irrlicht/MacOSX/CIrrDeviceMacOSX.mm
+@@ -39,7 +39,7 @@
+ #include <IOKit/hidsystem/IOHIDUsageTables.h>
+ #else
+ /* The header was moved here in Mac OS X 10.1 */
+-#include <Kernel/IOKit/hidsystem/IOHIDUsageTables.h>
++#include <IOKit/hid/IOHIDUsageTables.h>
+ #endif
+ #include <IOKit/hid/IOHIDLib.h>
+ #include <IOKit/hid/IOHIDKeys.h>
+@@ -496,7 +496,7 @@
+ 		{
+ 			[[NSAutoreleasePool alloc] init];
+ 			[NSApplication sharedApplication];
+-			[NSApp setDelegate:(id<NSFileManagerDelegate>)[[[AppDelegate alloc] initWithDevice:this] autorelease]];
++			[NSApp setDelegate:(id<NSApplicationDelegate>)[[[AppDelegate alloc] initWithDevice:this] autorelease]];
+ 			[NSBundle loadNibNamed:@"MainMenu" owner:[NSApp delegate]];
+ 			[NSApp finishLaunching];
+ 		}

--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = (stdenv.lib.optionalString stdenv.isDarwin ''
-    for file in out-shared/*.dylib*; do
-      install_name_tool -id $out/lib/$file $file
+    for file in out-shared/*.dylib.*.*; do
+      install_name_tool -id $out/lib/$(basename $file) $file
     done
   '') + # XXX consider removing above after transition to cmake in the next release
   "

--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   pname = "leveldb";
@@ -11,16 +11,14 @@ stdenv.mkDerivation rec {
     sha256 = "01kxga1hv4wp94agx5vl3ybxfw5klqrdsrb6p6ywvnjmjxm8322y";
   };
 
+  nativeBuildInputs = []
+    ++ stdenv.lib.optional stdenv.isDarwin [ fixDarwinDylibNames ];
+
   buildPhase = ''
     make all
   '';
 
-  installPhase = (stdenv.lib.optionalString stdenv.isDarwin ''
-    for file in out-shared/*.dylib.*.*; do
-      install_name_tool -id $out/lib/$(basename $file) $file
-    done
-  '') + # XXX consider removing above after transition to cmake in the next release
-  "
+  installPhase = "
     mkdir -p $out/{bin,lib,include}
 
     cp -r include $out

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, irrlicht, libpng, bzip2, curl, libogg, jsoncpp
 , libjpeg, libXxf86vm, libGLU, libGL, openal, libvorbis, sqlite, luajit
 , freetype, gettext, doxygen, ncurses, graphviz, xorg, gmp, libspatialindex
-, leveldb, postgresql, hiredis
+, leveldb, postgresql, hiredis, libiconv, OpenGL, OpenAL ? openal, Carbon, Cocoa
 }:
 
 with stdenv.lib;
@@ -39,6 +39,8 @@ let
     ] ++ optionals buildClient [
       "-DOpenGL_GL_PREFERENCE=GLVND"
     ];
+    
+    patches = [ ./fix_wordsize_confusion.patch ];
 
     NIX_CFLAGS_COMPILE = "-DluaL_reg=luaL_Reg"; # needed since luajit-2.1.0-beta3
 
@@ -47,6 +49,8 @@ let
     buildInputs = [
       irrlicht luajit jsoncpp gettext freetype sqlite curl bzip2 ncurses
       gmp libspatialindex
+    ] ++ optionals stdenv.isDarwin [ 
+      libiconv OpenGL OpenAL Carbon Cocoa
     ] ++ optionals buildClient [
       libpng libjpeg libGLU libGL openal libogg libvorbis xorg.libX11 libXxf86vm
     ] ++ optionals buildServer [
@@ -62,7 +66,7 @@ let
       homepage = http://minetest.net/;
       description = "Infinite-world block sandbox game";
       license = licenses.lgpl21Plus;
-      platforms = platforms.linux;
+      platforms = platforms.linux ++ platforms.darwin;
       maintainers = with maintainers; [ pyrolagus fpletz ];
     };
   };

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -40,8 +40,6 @@ let
       "-DOpenGL_GL_PREFERENCE=GLVND"
     ];
     
-    patches = [ ./fix_wordsize_confusion.patch ];
-
     NIX_CFLAGS_COMPILE = "-DluaL_reg=luaL_Reg"; # needed since luajit-2.1.0-beta3
 
     nativeBuildInputs = [ cmake doxygen graphviz ];

--- a/pkgs/games/minetest/disable_fixup.patch
+++ b/pkgs/games/minetest/disable_fixup.patch
@@ -1,0 +1,10 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -802,7 +802,6 @@
+ 		install(CODE "
+ 			set(BU_CHMOD_BUNDLE_ITEMS ON)
+ 			include(BundleUtilities)
+-			fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/${BUNDLE_PATH}\" \"\" \"\${CMAKE_INSTALL_PREFIX}/${BINDIR}\")
+ 		" COMPONENT Runtime)
+ 	endif()
+ 

--- a/pkgs/games/minetest/fix_wordsize_confusion.patch
+++ b/pkgs/games/minetest/fix_wordsize_confusion.patch
@@ -1,0 +1,10 @@
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -17,6 +17,7 @@
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+ 
++#include <cstdint>
+ #include "irrlicht.h" // createDevice
+ #include "irrlichttypes_extrabloated.h"
+ #include "chat_interface.h"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12047,7 +12047,11 @@ in
 
   ip2location-c = callPackage ../development/libraries/ip2location-c { };
 
-  irrlicht = callPackage ../development/libraries/irrlicht { };
+  irrlicht = if !stdenv.isDarwin then
+    callPackage ../development/libraries/irrlicht { }
+  else callPackage ../development/libraries/irrlicht/mac.nix {
+    inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL IOKit;
+  };
 
   isocodes = callPackage ../development/libraries/iso-codes { };
 
@@ -23210,7 +23214,10 @@ in
 
   multimc = libsForQt5.callPackage ../games/multimc { };
 
-  inherit (callPackages ../games/minetest { })
+  inherit (callPackages ../games/minetest {
+	inherit (darwin) libiconv;
+    inherit (darwin.apple_sdk.frameworks) OpenGL OpenAL Carbon Cocoa;
+  })
     minetestclient_4 minetestserver_4
     minetestclient_5 minetestserver_5;
 


### PR DESCRIPTION
###### Motivation for this change
Build minetest and irrlicht on Darwin.
Update minetest to 5.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
