### PR TITLE
wpsoffice: 11.1.0.8865 -> 11.1.0.9080

### DIFF
--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec{
   pname = "wpsoffice";
-  version = "11.1.0.8865";
+  version = "11.1.0.9080";
 
   src = fetchurl {
-    url = "http://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/8865/wps-office_11.1.0.8865_amd64.deb";
-    sha256 = "1hfpj1ayhzlrnnp72yjzrpd60xsbj9y46m345lqysiaj1hnwdbd8";
+    url = "http://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/9080/wps-office_11.1.0.9080.XA_amd64.deb";
+    sha256 = "1731e9aea22ef4e558ad66b1373d863452b4f570aecf09d448ae28a821333454";
   };
   unpackCmd = "dpkg -x $src .";
   sourceRoot = ".";
@@ -75,20 +75,16 @@ stdenv.mkDerivation rec{
     mkdir -p $out
     cp -r opt $out
     cp -r usr/* $out
-
     # Avoid forbidden reference error due use of patchelf
     rm -r *
-
     for i in wps wpp et wpspdf; do
       patchelf \
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --force-rpath --set-rpath "$(patchelf --print-rpath $prefix/office6/$i):${stdenv.cc.cc.lib}/lib64:${libPath}" \
         $prefix/office6/$i
-
       substituteInPlace $out/bin/$i \
         --replace /opt/kingsoft/wps-office $prefix
     done
-
     for i in $out/share/applications/*;do
       substituteInPlace $i \
         --replace /usr/bin $out/bin \


### PR DESCRIPTION
###### Motivation for this change
WpsOffice released a new version a few days ago and I wanted to remove this ugly update message.

###### Things done
I updated version and sha256. I tried the package on nixos 19.09 using callPackage.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
