### PR TITLE
rustPackages: make rustc-dev optional

### DIFF
--- a/pkgs/development/compilers/rust/1_38_0.nix
+++ b/pkgs/development/compilers/rust/1_38_0.nix
@@ -1,6 +1,7 @@
 import ./default.nix {
   rustcVersion = "1.38.0";
   rustcSha256 = "101dlpsfkq67p0hbwx4acqq6n90dj4bbprndizpgh1kigk566hk4";
+  enableRustcDev = false;
 
   # Note: the version MUST be one version prior to the version we're
   # building

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -1,5 +1,6 @@
 { rustcVersion
 , rustcSha256
+, enableRustcDev ? true
 , bootstrapVersion
 , bootstrapHashes
 , selectRustPackage
@@ -70,6 +71,7 @@
       rustc = self.callPackage ./rustc.nix ({
         version = rustcVersion;
         sha256 = rustcSha256;
+        inherit enableRustcDev;
 
         # Use boot package set to break cycle
         rustPlatform = bootRustPlatform;

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -4,6 +4,7 @@
 , pkgconfig, openssl
 , which, libffi
 , withBundledLLVM ? false
+, enableRustcDev ? true
 , version
 , sha256
 }:
@@ -132,12 +133,13 @@ in stdenv.mkDerivation rec {
   outputs = [ "out" "man" "doc" ];
   setOutputFlags = false;
 
-  postInstall = ''
+  postInstall = stdenv.lib.optionalString enableRustcDev ''
     # install rustc-dev components. Necessary to build rls, clippy...
     python x.py dist rustc-dev
     tar xf build/dist/rustc-dev*tar.gz
     cp -r rustc-dev*/rustc-dev*/lib/* $out/lib/
 
+  '' + ''
     # remove references to llvm-config in lib/rustlib/x86_64-unknown-linux-gnu/codegen-backends/librustc_codegen_llvm-llvm.so
     # and thus a transitive dependency on ncurses
     find $out/lib -name "*.so" -type f -exec remove-references-to -t ${llvmShared} '{}' '+'


### PR DESCRIPTION
This was only introduced in 1.40.0 and doesn't work on older versions.

    thread 'main' panicked at 'Error: no rules matched rustc-dev.', src/bootstrap/builder.rs:231:21
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
    failed to run: /build/rustc-1.38.0-src/build/bootstrap/debug/bootstrap dist rustc-dev

###### Motivation for this change

Fixes `rustPackages_1_38`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @FRidh
