### PR TITLE
amp: git rev 2c88e8 (2019-06-09) -> 0.6.1

### DIFF
--- a/pkgs/applications/editors/amp/default.nix
+++ b/pkgs/applications/editors/amp/default.nix
@@ -3,17 +3,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "amp";
-  # The latest release (0.5.2) does not compile, so we use a git snapshot instead.
-  version = "unstable-2019-06-09";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "jmacdonald";
     repo = pname;
-    rev = "2c88e82a88ada8a5fd2620ef225192395a4533a2";
-    sha256 = "0ha1xiabq31s687gkrnszf3zc7b3sfdl79iyg5ygbc49mzvarp8c";
+    rev = version;
+    sha256 = "0jhxyl27nwp7rp0lc3kic69g8x55d0azrwlwwhz3z74icqa8f03j";
   };
 
-  cargoSha256 = "1bvj2zg19ak4vi47vjkqlybz011kn5zq1j7zznr76zrryacw4lz1";
+  cargoSha256 = "0rk5c8knx8swqzmj7wd18hq2h5ndkzvcbq4lzggpavkk01a8hlb1";
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ openssl python3 xorg.libxcb libgit2 ] ++ stdenv.lib.optionals stdenv.isDarwin


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
