### PR TITLE
python: fix buildEnv passthru when using .override

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -10,7 +10,6 @@
 , sqlite
 , tcl ? null, tk ? null, tix ? null, xlibsWrapper ? null, libX11 ? null, x11Support ? false
 , zlib
-, self
 , CF, configd, coreutils
 , python-setup-hook
 # Some proprietary libs assume UCS2 unicode, especially on darwin :(
@@ -197,7 +196,7 @@ let
   # Build the basic Python interpreter without modules that have
   # external dependencies.
 
-in with passthru; stdenv.mkDerivation ({
+  self = with passthru; stdenv.mkDerivation ({
     pname = "python";
     inherit version;
 
@@ -281,4 +280,6 @@ in with passthru; stdenv.mkDerivation ({
       # in case both 2 and 3 are installed.
       priority = -100;
     };
-  } // crossCompileEnv)
+  } // crossCompileEnv);
+
+in self

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -10,7 +10,6 @@
 , sqlite
 , tcl ? null, tk ? null, tix ? null, libX11 ? null, xorgproto ? null, x11Support ? false
 , zlib
-, self
 , CF, configd
 , python-setup-hook
 , nukeReferences
@@ -70,226 +69,228 @@ let
     "$out/bin/python"
   else pythonForBuild.interpreter;
 
-in with passthru; stdenv.mkDerivation {
-  pname = "python3";
-  inherit version;
+  self = with passthru; stdenv.mkDerivation {
+    pname = "python3";
+    inherit version;
 
-  inherit buildInputs nativeBuildInputs;
+    inherit buildInputs nativeBuildInputs;
 
-  src = fetchurl {
-    url = with sourceVersion; "https://www.python.org/ftp/python/${major}.${minor}.${patch}/Python-${version}.tar.xz";
-    inherit sha256;
-  };
+    src = fetchurl {
+      url = with sourceVersion; "https://www.python.org/ftp/python/${major}.${minor}.${patch}/Python-${version}.tar.xz";
+      inherit sha256;
+    };
 
-  prePatch = optionalString stdenv.isDarwin ''
-    substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
-    substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '
-  '' + optionalString (stdenv.isDarwin && x11Support) ''
-    substituteInPlace setup.py --replace /Library/Frameworks /no-such-path
-  '';
-
-  patches = [
-    # Disable the use of ldconfig in ctypes.util.find_library (since
-    # ldconfig doesn't work on NixOS), and don't use
-    # ctypes.util.find_library during the loading of the uuid module
-    # (since it will do a futile invocation of gcc (!) to find
-    # libuuid, slowing down program startup a lot).
-    (./. + "/${sourceVersion.major}.${sourceVersion.minor}/no-ldconfig.patch")
-  ] ++ optionals (isPy35 || isPy36) [
-    # Determinism: Write null timestamps when compiling python files.
-    ./3.5/force_bytecode_determinism.patch
-  ] ++ optionals isPy35 [
-    # Backports support for LD_LIBRARY_PATH from 3.6
-    ./3.5/ld_library_path.patch
-  ] ++ optionals (isPy37 || isPy38) [
-    # Fix darwin build https://bugs.python.org/issue34027
-    (fetchpatch {
-      url = https://bugs.python.org/file47666/darwin-libutil.patch;
-      sha256 = "0242gihnw3wfskl4fydp2xanpl8k5q7fj4dp7dbbqf46a4iwdzpa";
-    })
-  ] ++ optionals (isPy3k && hasDistutilsCxxPatch) [
-    # Fix for http://bugs.python.org/issue1222585
-    # Upstream distutils is calling C compiler to compile C++ code, which
-    # only works for GCC and Apple Clang. This makes distutils to call C++
-    # compiler when needed.
-    (
-      if isPy35 then
-        ./3.5/python-3.x-distutils-C++.patch
-      else if isPy37 || isPy38 then
-        ./3.7/python-3.x-distutils-C++.patch
-      else
-        fetchpatch {
-          url = "https://bugs.python.org/file48016/python-3.x-distutils-C++.patch";
-          sha256 = "1h18lnpx539h5lfxyk379dxwr8m2raigcjixkf133l4xy3f4bzi2";
-        }
-    )
-  ];
-
-  postPatch = ''
-  '' + optionalString (x11Support && (tix != null)) ''
-    substituteInPlace "Lib/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
-  '';
-
-  CPPFLAGS = concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs);
-  LDFLAGS = concatStringsSep " " (map (p: "-L${getLib p}/lib") buildInputs);
-  LIBS = "${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}";
-  NIX_LDFLAGS = optionalString stdenv.isLinux "-lgcc_s";
-  # Determinism: We fix the hashes of str, bytes and datetime objects.
-  PYTHONHASHSEED=0;
-
-  configureFlags = [
-    "--enable-shared"
-    "--with-threads"
-    "--without-ensurepip"
-    "--with-system-expat"
-    "--with-system-ffi"
-  ] ++ optionals (sqlite != null && isPy3k) [
-    "--enable-loadable-sqlite-extensions"
-  ] ++ optionals (openssl != null) [
-    "--with-openssl=${openssl.dev}"
-  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "ac_cv_buggy_getaddrinfo=no"
-    # Assume little-endian IEEE 754 floating point when cross compiling
-    "ac_cv_little_endian_double=yes"
-    "ac_cv_big_endian_double=no"
-    "ac_cv_mixed_endian_double=no"
-    "ac_cv_x87_double_rounding=yes"
-    "ac_cv_tanh_preserves_zero_sign=yes"
-    # Generally assume that things are present and work
-    "ac_cv_posix_semaphores_enabled=yes"
-    "ac_cv_broken_sem_getvalue=no"
-    "ac_cv_wchar_t_signed=yes"
-    "ac_cv_rshift_extends_sign=yes"
-    "ac_cv_broken_nice=no"
-    "ac_cv_broken_poll=no"
-    "ac_cv_working_tzset=yes"
-    "ac_cv_have_long_long_format=yes"
-    "ac_cv_have_size_t_format=yes"
-    "ac_cv_computed_gotos=yes"
-    "ac_cv_file__dev_ptmx=yes"
-    "ac_cv_file__dev_ptc=yes"
-  ] ++ optionals stdenv.hostPlatform.isLinux [
-    # Never even try to use lchmod on linux,
-    # don't rely on detecting glibc-isms.
-    "ac_cv_func_lchmod=no"
-  ];
-
-  preConfigure = ''
-    for i in /usr /sw /opt /pkg; do	# improve purity
-      substituteInPlace ./setup.py --replace $i /no-such-path
-    done
-  '' + optionalString stdenv.isDarwin ''
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -msse2"
-    export MACOSX_DEPLOYMENT_TARGET=10.6
-  '' + optionalString (isPy3k && pythonOlder "3.7") ''
-    # Determinism: The interpreter is patched to write null timestamps when compiling Python files
-    #   so Python doesn't try to update the bytecode when seeing frozen timestamps in Nix's store.
-    export DETERMINISTIC_BUILD=1;
-  '' + optionalString stdenv.hostPlatform.isMusl ''
-    export NIX_CFLAGS_COMPILE+=" -DTHREAD_STACK_SIZE=0x100000"
-  '';
-
-  setupHook = python-setup-hook sitePackages;
-
-  postInstall = ''
-    # needed for some packages, especially packages that backport functionality
-    # to 2.x from 3.x
-    for item in $out/lib/${libPrefix}/test/*; do
-      if [[ "$item" != */test_support.py*
-         && "$item" != */test/support
-         && "$item" != */test/libregrtest
-         && "$item" != */test/regrtest.py* ]]; then
-        rm -rf "$item"
-      else
-        echo $item
-      fi
-    done
-    touch $out/lib/${libPrefix}/test/__init__.py
-
-    ln -s "$out/include/${executable}m" "$out/include/${executable}"
-
-    # Determinism: Windows installers were not deterministic.
-    # We're also not interested in building Windows installers.
-    find "$out" -name 'wininst*.exe' | xargs -r rm -f
-
-    # Use Python3 as default python
-    ln -s "$out/bin/idle3" "$out/bin/idle"
-    ln -s "$out/bin/pydoc3" "$out/bin/pydoc"
-    ln -s "$out/bin/python3" "$out/bin/python"
-    ln -s "$out/bin/python3-config" "$out/bin/python-config"
-    ln -s "$out/lib/pkgconfig/python3.pc" "$out/lib/pkgconfig/python.pc"
-
-    # Get rid of retained dependencies on -dev packages, and remove
-    # some $TMPDIR references to improve binary reproducibility.
-    # Note that the .pyc file of _sysconfigdata.py should be regenerated!
-    for i in $out/lib/${libPrefix}/_sysconfigdata*.py $out/lib/${libPrefix}/config-${sourceVersion.major}${sourceVersion.minor}*/Makefile; do
-       sed -i $i -e "s|$TMPDIR|/no-such-path|g"
-    done
-
-    # Further get rid of references. https://github.com/NixOS/nixpkgs/issues/51668
-    find $out/lib/python*/config-* -type f -print -exec nuke-refs -e $out '{}' +
-    find $out/lib -name '_sysconfigdata*.py*' -print -exec nuke-refs -e $out '{}' +
-
-    '' + optionalString stripConfig ''
-    rm -R $out/bin/python*-config $out/lib/python*/config-*
-    '' + optionalString stripIdlelib ''
-    # Strip IDLE (and turtledemo, which uses it)
-    rm -R $out/bin/idle* $out/lib/python*/{idlelib,turtledemo}
-    '' + optionalString stripTkinter ''
-    rm -R $out/lib/python*/tkinter
-    '' + optionalString stripTests ''
-    # Strip tests
-    rm -R $out/lib/python*/test $out/lib/python*/**/test{,s}
-    '' + ''
-    # Include a sitecustomize.py file
-    cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
-    '' + optionalString rebuildBytecode ''
-
-    # Determinism: rebuild all bytecode
-    # We exclude lib2to3 because that's Python 2 code which fails
-    # We rebuild three times, once for each optimization level
-    # Python 3.7 implements PEP 552, introducing support for deterministic bytecode.
-    # This is automatically used when `SOURCE_DATE_EPOCH` is set.
-    find $out -name "*.py" | ${pythonForBuildInterpreter}     -m compileall -q -f -x "lib2to3" -i -
-    find $out -name "*.py" | ${pythonForBuildInterpreter} -O  -m compileall -q -f -x "lib2to3" -i -
-    find $out -name "*.py" | ${pythonForBuildInterpreter} -OO -m compileall -q -f -x "lib2to3" -i -
-    '' + optionalString stripBytecode ''
-    find $out -type d -name __pycache__ -print0 | xargs -0 -I {} rm -rf "{}"
-  '';
-
-  preFixup = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
-    # Ensure patch-shebangs uses shebangs of host interpreter.
-    export PATH=${stdenv.lib.makeBinPath [ "$out" bash ]}:$PATH
-  '';
-
-  # Enforce that we don't have references to the OpenSSL -dev package, which we
-  # explicitly specify in our configure flags above.
-  disallowedReferences =
-    stdenv.lib.optionals (openssl != null) [ openssl.dev ]
-    ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    # Ensure we don't have references to build-time packages.
-    # These typically end up in shebangs.
-    pythonForBuild buildPackages.bash
-  ];
-
-  inherit passthru;
-
-  enableParallelBuilding = true;
-
-  meta = {
-    homepage = http://python.org;
-    description = "A high-level dynamically-typed programming language";
-    longDescription = ''
-      Python is a remarkably powerful dynamic programming language that
-      is used in a wide variety of application domains. Some of its key
-      distinguishing features include: clear, readable syntax; strong
-      introspection capabilities; intuitive object orientation; natural
-      expression of procedural code; full modularity, supporting
-      hierarchical packages; exception-based error handling; and very
-      high level dynamic data types.
+    prePatch = optionalString stdenv.isDarwin ''
+      substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
+      substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '
+    '' + optionalString (stdenv.isDarwin && x11Support) ''
+      substituteInPlace setup.py --replace /Library/Frameworks /no-such-path
     '';
-    license = licenses.psfl;
-    platforms = with platforms; linux ++ darwin;
-    maintainers = with maintainers; [ fridh ];
+
+    patches = [
+      # Disable the use of ldconfig in ctypes.util.find_library (since
+      # ldconfig doesn't work on NixOS), and don't use
+      # ctypes.util.find_library during the loading of the uuid module
+      # (since it will do a futile invocation of gcc (!) to find
+      # libuuid, slowing down program startup a lot).
+      (./. + "/${sourceVersion.major}.${sourceVersion.minor}/no-ldconfig.patch")
+    ] ++ optionals (isPy35 || isPy36) [
+      # Determinism: Write null timestamps when compiling python files.
+      ./3.5/force_bytecode_determinism.patch
+    ] ++ optionals isPy35 [
+      # Backports support for LD_LIBRARY_PATH from 3.6
+      ./3.5/ld_library_path.patch
+    ] ++ optionals (isPy37 || isPy38) [
+      # Fix darwin build https://bugs.python.org/issue34027
+      (fetchpatch {
+        url = https://bugs.python.org/file47666/darwin-libutil.patch;
+        sha256 = "0242gihnw3wfskl4fydp2xanpl8k5q7fj4dp7dbbqf46a4iwdzpa";
+      })
+    ] ++ optionals (isPy3k && hasDistutilsCxxPatch) [
+      # Fix for http://bugs.python.org/issue1222585
+      # Upstream distutils is calling C compiler to compile C++ code, which
+      # only works for GCC and Apple Clang. This makes distutils to call C++
+      # compiler when needed.
+      (
+        if isPy35 then
+          ./3.5/python-3.x-distutils-C++.patch
+        else if isPy37 || isPy38 then
+          ./3.7/python-3.x-distutils-C++.patch
+        else
+          fetchpatch {
+            url = "https://bugs.python.org/file48016/python-3.x-distutils-C++.patch";
+            sha256 = "1h18lnpx539h5lfxyk379dxwr8m2raigcjixkf133l4xy3f4bzi2";
+          }
+      )
+    ];
+
+    postPatch = ''
+    '' + optionalString (x11Support && (tix != null)) ''
+      substituteInPlace "Lib/tkinter/tix.py" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
+    '';
+
+    CPPFLAGS = concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs);
+    LDFLAGS = concatStringsSep " " (map (p: "-L${getLib p}/lib") buildInputs);
+    LIBS = "${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}";
+    NIX_LDFLAGS = optionalString stdenv.isLinux "-lgcc_s";
+    # Determinism: We fix the hashes of str, bytes and datetime objects.
+    PYTHONHASHSEED=0;
+
+    configureFlags = [
+      "--enable-shared"
+      "--with-threads"
+      "--without-ensurepip"
+      "--with-system-expat"
+      "--with-system-ffi"
+    ] ++ optionals (sqlite != null && isPy3k) [
+      "--enable-loadable-sqlite-extensions"
+    ] ++ optionals (openssl != null) [
+      "--with-openssl=${openssl.dev}"
+    ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "ac_cv_buggy_getaddrinfo=no"
+      # Assume little-endian IEEE 754 floating point when cross compiling
+      "ac_cv_little_endian_double=yes"
+      "ac_cv_big_endian_double=no"
+      "ac_cv_mixed_endian_double=no"
+      "ac_cv_x87_double_rounding=yes"
+      "ac_cv_tanh_preserves_zero_sign=yes"
+      # Generally assume that things are present and work
+      "ac_cv_posix_semaphores_enabled=yes"
+      "ac_cv_broken_sem_getvalue=no"
+      "ac_cv_wchar_t_signed=yes"
+      "ac_cv_rshift_extends_sign=yes"
+      "ac_cv_broken_nice=no"
+      "ac_cv_broken_poll=no"
+      "ac_cv_working_tzset=yes"
+      "ac_cv_have_long_long_format=yes"
+      "ac_cv_have_size_t_format=yes"
+      "ac_cv_computed_gotos=yes"
+      "ac_cv_file__dev_ptmx=yes"
+      "ac_cv_file__dev_ptc=yes"
+    ] ++ optionals stdenv.hostPlatform.isLinux [
+      # Never even try to use lchmod on linux,
+      # don't rely on detecting glibc-isms.
+      "ac_cv_func_lchmod=no"
+    ];
+
+    preConfigure = ''
+      for i in /usr /sw /opt /pkg; do	# improve purity
+        substituteInPlace ./setup.py --replace $i /no-such-path
+      done
+    '' + optionalString stdenv.isDarwin ''
+      export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -msse2"
+      export MACOSX_DEPLOYMENT_TARGET=10.6
+    '' + optionalString (isPy3k && pythonOlder "3.7") ''
+      # Determinism: The interpreter is patched to write null timestamps when compiling Python files
+      #   so Python doesn't try to update the bytecode when seeing frozen timestamps in Nix's store.
+      export DETERMINISTIC_BUILD=1;
+    '' + optionalString stdenv.hostPlatform.isMusl ''
+      export NIX_CFLAGS_COMPILE+=" -DTHREAD_STACK_SIZE=0x100000"
+    '';
+
+    setupHook = python-setup-hook sitePackages;
+
+    postInstall = ''
+      # needed for some packages, especially packages that backport functionality
+      # to 2.x from 3.x
+      for item in $out/lib/${libPrefix}/test/*; do
+        if [[ "$item" != */test_support.py*
+           && "$item" != */test/support
+           && "$item" != */test/libregrtest
+           && "$item" != */test/regrtest.py* ]]; then
+          rm -rf "$item"
+        else
+          echo $item
+        fi
+      done
+      touch $out/lib/${libPrefix}/test/__init__.py
+
+      ln -s "$out/include/${executable}m" "$out/include/${executable}"
+
+      # Determinism: Windows installers were not deterministic.
+      # We're also not interested in building Windows installers.
+      find "$out" -name 'wininst*.exe' | xargs -r rm -f
+
+      # Use Python3 as default python
+      ln -s "$out/bin/idle3" "$out/bin/idle"
+      ln -s "$out/bin/pydoc3" "$out/bin/pydoc"
+      ln -s "$out/bin/python3" "$out/bin/python"
+      ln -s "$out/bin/python3-config" "$out/bin/python-config"
+      ln -s "$out/lib/pkgconfig/python3.pc" "$out/lib/pkgconfig/python.pc"
+
+      # Get rid of retained dependencies on -dev packages, and remove
+      # some $TMPDIR references to improve binary reproducibility.
+      # Note that the .pyc file of _sysconfigdata.py should be regenerated!
+      for i in $out/lib/${libPrefix}/_sysconfigdata*.py $out/lib/${libPrefix}/config-${sourceVersion.major}${sourceVersion.minor}*/Makefile; do
+         sed -i $i -e "s|$TMPDIR|/no-such-path|g"
+      done
+
+      # Further get rid of references. https://github.com/NixOS/nixpkgs/issues/51668
+      find $out/lib/python*/config-* -type f -print -exec nuke-refs -e $out '{}' +
+      find $out/lib -name '_sysconfigdata*.py*' -print -exec nuke-refs -e $out '{}' +
+
+      '' + optionalString stripConfig ''
+      rm -R $out/bin/python*-config $out/lib/python*/config-*
+      '' + optionalString stripIdlelib ''
+      # Strip IDLE (and turtledemo, which uses it)
+      rm -R $out/bin/idle* $out/lib/python*/{idlelib,turtledemo}
+      '' + optionalString stripTkinter ''
+      rm -R $out/lib/python*/tkinter
+      '' + optionalString stripTests ''
+      # Strip tests
+      rm -R $out/lib/python*/test $out/lib/python*/**/test{,s}
+      '' + ''
+      # Include a sitecustomize.py file
+      cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
+      '' + optionalString rebuildBytecode ''
+
+      # Determinism: rebuild all bytecode
+      # We exclude lib2to3 because that's Python 2 code which fails
+      # We rebuild three times, once for each optimization level
+      # Python 3.7 implements PEP 552, introducing support for deterministic bytecode.
+      # This is automatically used when `SOURCE_DATE_EPOCH` is set.
+      find $out -name "*.py" | ${pythonForBuildInterpreter}     -m compileall -q -f -x "lib2to3" -i -
+      find $out -name "*.py" | ${pythonForBuildInterpreter} -O  -m compileall -q -f -x "lib2to3" -i -
+      find $out -name "*.py" | ${pythonForBuildInterpreter} -OO -m compileall -q -f -x "lib2to3" -i -
+      '' + optionalString stripBytecode ''
+      find $out -type d -name __pycache__ -print0 | xargs -0 -I {} rm -rf "{}"
+    '';
+
+    preFixup = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+      # Ensure patch-shebangs uses shebangs of host interpreter.
+      export PATH=${stdenv.lib.makeBinPath [ "$out" bash ]}:$PATH
+    '';
+
+    # Enforce that we don't have references to the OpenSSL -dev package, which we
+    # explicitly specify in our configure flags above.
+    disallowedReferences =
+      stdenv.lib.optionals (openssl != null) [ openssl.dev ]
+      ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      # Ensure we don't have references to build-time packages.
+      # These typically end up in shebangs.
+      pythonForBuild buildPackages.bash
+    ];
+
+    inherit passthru;
+
+    enableParallelBuilding = true;
+
+    meta = {
+      homepage = http://python.org;
+      description = "A high-level dynamically-typed programming language";
+      longDescription = ''
+        Python is a remarkably powerful dynamic programming language that
+        is used in a wide variety of application domains. Some of its key
+        distinguishing features include: clear, readable syntax; strong
+        introspection capabilities; intuitive object orientation; natural
+        expression of procedural code; full modularity, supporting
+        hierarchical packages; exception-based error handling; and very
+        high level dynamic data types.
+      '';
+      license = licenses.psfl;
+      platforms = with platforms; linux ++ darwin;
+      maintainers = with maintainers; [ fridh ];
+    };
   };
-}
+
+in self

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -49,7 +49,6 @@ with pkgs;
 in {
 
   python27 = callPackage ./cpython/2.7 {
-    self = python27;
     sourceVersion = {
       major = "2";
       minor = "7";
@@ -62,7 +61,6 @@ in {
   };
 
   python35 = callPackage ./cpython {
-    self = python35;
     sourceVersion = {
       major = "3";
       minor = "5";
@@ -75,7 +73,6 @@ in {
   };
 
   python36 = callPackage ./cpython {
-    self = python36;
     sourceVersion = {
       major = "3";
       minor = "6";
@@ -88,7 +85,6 @@ in {
   };
 
   python37 = callPackage ./cpython {
-    self = python37;
     sourceVersion = {
       major = "3";
       minor = "7";
@@ -101,7 +97,6 @@ in {
   };
 
   python38 = callPackage ./cpython {
-    self = python38;
     sourceVersion = {
       major = "3";
       minor = "8";
@@ -114,7 +109,6 @@ in {
   };
 
   python39 = callPackage ./cpython {
-    self = python39;
     sourceVersion = {
       major = "3";
       minor = "9";
@@ -128,7 +122,6 @@ in {
 
   # Minimal versions of Python (built without optional dependencies)
   python3Minimal = (python37.override {
-    self = python3Minimal;
     pythonForBuild = pkgs.buildPackages.python3Minimal;
     # strip down that python version as much as possible
     openssl = null;
@@ -150,7 +143,6 @@ in {
   });
 
   pypy27 = callPackage ./pypy {
-    self = pypy27;
     sourceVersion = {
       major = "7";
       minor = "1";
@@ -164,7 +156,6 @@ in {
   };
 
   pypy36 = callPackage ./pypy {
-    self = pypy36;
     sourceVersion = {
       major = "7";
       minor = "1";
@@ -178,8 +169,6 @@ in {
   };
 
   pypy27_prebuilt = callPackage ./pypy/prebuilt.nix {
-    # Not included at top-level
-    self = pythonInterpreters.pypy27_prebuilt;
     sourceVersion = {
       major = "7";
       minor = "1";
@@ -192,8 +181,6 @@ in {
   };
 
   pypy36_prebuilt = callPackage ./pypy/prebuilt.nix {
-    # Not included at top-level
-    self = pythonInterpreters.pypy36_prebuilt;
     sourceVersion = {
       major = "7";
       minor = "1";
@@ -206,7 +193,6 @@ in {
   };
 
   graalpython37 = callPackage ./graalpython/default.nix {
-    self = pythonInterpreters.graalpython37;
     inherit passthruFun;
   };
 

--- a/pkgs/development/interpreters/python/graalpython/default.nix
+++ b/pkgs/development/interpreters/python/graalpython/default.nix
@@ -3,7 +3,6 @@
 , graalvm8
 , passthruFun
 , packageOverrides ? (self: super: {})
-, self
 }:
 
 let
@@ -18,4 +17,5 @@ let
     hasDistutilsCxxPatch = false;
     pythonForBuild = pkgs.buildPackages.pythonInterpreters.graalpython37;
   };
-in lib.extendDerivation true passthru graalvm8
+  self = lib.extendDerivation true passthru graalvm8;
+in self

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -1,7 +1,7 @@
 { stdenv, substituteAll, fetchurl
 , zlib ? null, zlibSupport ? true, bzip2, pkgconfig, libffi
 , sqlite, openssl_1_0_2, ncurses, python, expat, tcl, tk, tix, xlibsWrapper, libX11
-, self, gdbm, db, lzma
+, gdbm, db, lzma
 , python-setup-hook
 # For the Python package set
 , packageOverrides ? (self: super: {})
@@ -30,125 +30,127 @@ let
   version = with sourceVersion; "${major}.${minor}.${patch}";
   pythonForPypy = python.withPackages (ppkgs: [ ppkgs.pycparser ]);
 
-in with passthru; stdenv.mkDerivation rec {
-  inherit pname version;
+  self = with passthru; stdenv.mkDerivation rec {
+    inherit pname version;
 
-  src = fetchurl {
-    url = "https://bitbucket.org/pypy/pypy/get/release-pypy${pythonVersion}-v${version}.tar.bz2";
-    inherit sha256;
-  };
+    src = fetchurl {
+      url = "https://bitbucket.org/pypy/pypy/get/release-pypy${pythonVersion}-v${version}.tar.bz2";
+      inherit sha256;
+    };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    bzip2 openssl_1_0_2 pythonForPypy libffi ncurses expat sqlite tk tcl xlibsWrapper libX11 gdbm db
-  ]  ++ optionals isPy3k [
-    lzma
-  ] ++ optionals (stdenv ? cc && stdenv.cc.libc != null) [
-    stdenv.cc.libc
-  ] ++ optionals zlibSupport [
-    zlib
-  ];
-
-  hardeningDisable = optional stdenv.isi686 "pic";
-
-  C_INCLUDE_PATH = makeSearchPathOutput "dev" "include" buildInputs;
-  LIBRARY_PATH = makeLibraryPath buildInputs;
-  LD_LIBRARY_PATH = makeLibraryPath (filter (x : x.outPath != stdenv.cc.libc.outPath or "") buildInputs);
-
-  patches = [
-    (substituteAll {
-      src = ./tk_tcl_paths.patch;
-      inherit tk tcl;
-      tk_dev = tk.dev;
-      tcl_dev = tcl;
-      tk_libprefix = tk.libPrefix;
-      tcl_libprefix = tcl.libPrefix;
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace "lib-python/${if isPy3k then "3/tkinter/tix.py" else "2.7/lib-tk/Tix.py"}" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
-
-    # hint pypy to find nix ncurses
-    substituteInPlace pypy/module/_minimal_curses/fficurses.py \
-      --replace "/usr/include/ncurses/curses.h" "${ncurses.dev}/include/curses.h" \
-      --replace "ncurses/curses.h" "${ncurses.dev}/include/curses.h" \
-      --replace "ncurses/term.h" "${ncurses.dev}/include/term.h" \
-      --replace "libraries=['curses']" "libraries=['ncurses']"
-
-    sed -i "s@libraries=\['sqlite3'\]\$@libraries=['sqlite3'], include_dirs=['${sqlite.dev}/include'], library_dirs=['${sqlite.out}/lib']@" lib_pypy/_sqlite3_build.py
-  '';
-
-  buildPhase = ''
-    ${pythonForPypy.interpreter} rpython/bin/rpython \
-      --make-jobs="$NIX_BUILD_CORES" \
-      -Ojit \
-      --batch pypy/goal/targetpypystandalone.py
-  '';
-
-  setupHook = python-setup-hook sitePackages;
-
-  # TODO: A bunch of tests are failing as of 7.1.1, please feel free to
-  # fix and re-enable if you have the patience and tenacity.
-  doCheck = false;
-  checkPhase = let
-    disabledTests = [
-      # disable shutils because it assumes gid 0 exists
-      "test_shutil"
-      # disable socket because it has two actual network tests that fail
-      "test_socket"
-    ] ++ optionals (!isPy3k) [
-      # disable test_urllib2net, test_urllib2_localnet, and test_urllibnet because they require networking (example.com)
-      "test_urllib2net"
-      "test_urllibnet"
-      "test_urllib2_localnet"
-    ] ++ optionals isPy3k [
-      # disable asyncio due to https://github.com/NixOS/nix/issues/1238
-      "test_asyncio"
-      # disable os due to https://github.com/NixOS/nixpkgs/issues/10496
-      "test_os"
-      # disable pathlib due to https://bitbucket.org/pypy/pypy/pull-requests/594
-      "test_pathlib"
-      # disable tarfile because it assumes gid 0 exists
-      "test_tarfile"
-      # disable __all__ because of spurious imp/importlib warning and
-      # warning-to-error test policy
-      "test___all__"
+    nativeBuildInputs = [ pkgconfig ];
+    buildInputs = [
+      bzip2 openssl_1_0_2 pythonForPypy libffi ncurses expat sqlite tk tcl xlibsWrapper libX11 gdbm db
+    ]  ++ optionals isPy3k [
+      lzma
+    ] ++ optionals (stdenv ? cc && stdenv.cc.libc != null) [
+      stdenv.cc.libc
+    ] ++ optionals zlibSupport [
+      zlib
     ];
-  in ''
-    export TERMINFO="${ncurses.out}/share/terminfo/";
-    export TERM="xterm";
-    export HOME="$TMPDIR";
 
-    ${pythonForPypy.interpreter} ./pypy/test_all.py --pypy=./${executable}-c -k 'not (${concatStringsSep " or " disabledTests})' lib-python
-  '';
+    hardeningDisable = optional stdenv.isi686 "pic";
 
-  installPhase = ''
-    mkdir -p $out/{bin,include,lib,${executable}-c}
+    C_INCLUDE_PATH = makeSearchPathOutput "dev" "include" buildInputs;
+    LIBRARY_PATH = makeLibraryPath buildInputs;
+    LD_LIBRARY_PATH = makeLibraryPath (filter (x : x.outPath != stdenv.cc.libc.outPath or "") buildInputs);
 
-    cp -R {include,lib_pypy,lib-python,${executable}-c} $out/${executable}-c
-    cp lib${executable}-c.so $out/lib/
-    ln -s $out/${executable}-c/${executable}-c $out/bin/${executable}
+    patches = [
+      (substituteAll {
+        src = ./tk_tcl_paths.patch;
+        inherit tk tcl;
+        tk_dev = tk.dev;
+        tcl_dev = tcl;
+        tk_libprefix = tk.libPrefix;
+        tcl_libprefix = tcl.libPrefix;
+      })
+    ];
 
-    # other packages expect to find stuff according to libPrefix
-    ln -s $out/${executable}/include $out/include/${libPrefix}
-    ln -s $out/${executable}-c/lib-python/${if isPy3k then "3" else pythonVersion} $out/lib/${libPrefix}
+    postPatch = ''
+      substituteInPlace "lib-python/${if isPy3k then "3/tkinter/tix.py" else "2.7/lib-tk/Tix.py"}" --replace "os.environ.get('TIX_LIBRARY')" "os.environ.get('TIX_LIBRARY') or '${tix}/lib'"
 
-    # verify cffi modules
-    $out/bin/${executable} -c ${if isPy3k then "'import tkinter;import sqlite3;import curses;import lzma'" else "'import Tkinter;import sqlite3;import curses'"}
+      # hint pypy to find nix ncurses
+      substituteInPlace pypy/module/_minimal_curses/fficurses.py \
+        --replace "/usr/include/ncurses/curses.h" "${ncurses.dev}/include/curses.h" \
+        --replace "ncurses/curses.h" "${ncurses.dev}/include/curses.h" \
+        --replace "ncurses/term.h" "${ncurses.dev}/include/term.h" \
+        --replace "libraries=['curses']" "libraries=['ncurses']"
 
-    # Include a sitecustomize.py file
-    cp ${../sitecustomize.py} $out/lib/${libPrefix}/${sitePackages}/sitecustomize.py
-  '';
+      sed -i "s@libraries=\['sqlite3'\]\$@libraries=['sqlite3'], include_dirs=['${sqlite.dev}/include'], library_dirs=['${sqlite.out}/lib']@" lib_pypy/_sqlite3_build.py
+    '';
 
-  inherit passthru;
-  enableParallelBuilding = true;  # almost no parallelization without STM
+    buildPhase = ''
+      ${pythonForPypy.interpreter} rpython/bin/rpython \
+        --make-jobs="$NIX_BUILD_CORES" \
+        -Ojit \
+        --batch pypy/goal/targetpypystandalone.py
+    '';
 
-  meta = with stdenv.lib; {
-    homepage = http://pypy.org/;
-    description = "Fast, compliant alternative implementation of the Python language (${pythonVersion})";
-    license = licenses.mit;
-    platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
-    maintainers = with maintainers; [ andersk ];
+    setupHook = python-setup-hook sitePackages;
+
+    # TODO: A bunch of tests are failing as of 7.1.1, please feel free to
+    # fix and re-enable if you have the patience and tenacity.
+    doCheck = false;
+    checkPhase = let
+      disabledTests = [
+        # disable shutils because it assumes gid 0 exists
+        "test_shutil"
+        # disable socket because it has two actual network tests that fail
+        "test_socket"
+      ] ++ optionals (!isPy3k) [
+        # disable test_urllib2net, test_urllib2_localnet, and test_urllibnet because they require networking (example.com)
+        "test_urllib2net"
+        "test_urllibnet"
+        "test_urllib2_localnet"
+      ] ++ optionals isPy3k [
+        # disable asyncio due to https://github.com/NixOS/nix/issues/1238
+        "test_asyncio"
+        # disable os due to https://github.com/NixOS/nixpkgs/issues/10496
+        "test_os"
+        # disable pathlib due to https://bitbucket.org/pypy/pypy/pull-requests/594
+        "test_pathlib"
+        # disable tarfile because it assumes gid 0 exists
+        "test_tarfile"
+        # disable __all__ because of spurious imp/importlib warning and
+        # warning-to-error test policy
+        "test___all__"
+      ];
+    in ''
+      export TERMINFO="${ncurses.out}/share/terminfo/";
+      export TERM="xterm";
+      export HOME="$TMPDIR";
+
+      ${pythonForPypy.interpreter} ./pypy/test_all.py --pypy=./${executable}-c -k 'not (${concatStringsSep " or " disabledTests})' lib-python
+    '';
+
+    installPhase = ''
+      mkdir -p $out/{bin,include,lib,${executable}-c}
+
+      cp -R {include,lib_pypy,lib-python,${executable}-c} $out/${executable}-c
+      cp lib${executable}-c.so $out/lib/
+      ln -s $out/${executable}-c/${executable}-c $out/bin/${executable}
+
+      # other packages expect to find stuff according to libPrefix
+      ln -s $out/${executable}/include $out/include/${libPrefix}
+      ln -s $out/${executable}-c/lib-python/${if isPy3k then "3" else pythonVersion} $out/lib/${libPrefix}
+
+      # verify cffi modules
+      $out/bin/${executable} -c ${if isPy3k then "'import tkinter;import sqlite3;import curses;import lzma'" else "'import Tkinter;import sqlite3;import curses'"}
+
+      # Include a sitecustomize.py file
+      cp ${../sitecustomize.py} $out/lib/${libPrefix}/${sitePackages}/sitecustomize.py
+    '';
+
+    inherit passthru;
+    enableParallelBuilding = true;  # almost no parallelization without STM
+
+    meta = with stdenv.lib; {
+      homepage = http://pypy.org/;
+      description = "Fast, compliant alternative implementation of the Python language (${pythonVersion})";
+      license = licenses.mit;
+      platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
+      maintainers = with maintainers; [ andersk ];
+    };
   };
-}
+
+in self

--- a/pkgs/development/interpreters/python/pypy/prebuilt.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt.nix
@@ -1,7 +1,6 @@
 { stdenv
 , fetchurl
 , python-setup-hook
-, self
 , which
 # Dependencies
 , bzip2
@@ -52,75 +51,77 @@ let
     tk
   ];
 
-in with passthru; stdenv.mkDerivation {
-  inherit pname version;
+  self = with passthru; stdenv.mkDerivation {
+    inherit pname version;
 
-  src = fetchurl {
-    url = "https://bitbucket.org/pypy/pypy/downloads/pypy${pythonVersion}-v${version}-linux64.tar.bz2";
-    inherit sha256;
+    src = fetchurl {
+      url = "https://bitbucket.org/pypy/pypy/downloads/pypy${pythonVersion}-v${version}-linux64.tar.bz2";
+      inherit sha256;
+    };
+
+    buildInputs = [ which ];
+
+    installPhase = ''
+      mkdir -p $out/lib
+      echo "Moving files to $out"
+      mv -t $out bin include lib-python lib_pypy site-packages
+
+      mv $out/bin/libpypy*-c.so $out/lib/
+
+      rm $out/bin/*.debug
+
+      echo "Patching binaries"
+      interpreter=$(patchelf --print-interpreter $(readlink -f $(which patchelf)))
+      patchelf --set-interpreter $interpreter \
+               --set-rpath $out/lib \
+               $out/bin/pypy*
+
+      pushd $out
+      find {lib,lib_pypy*} -name "*.so" -exec patchelf --replace-needed "libbz2.so.1.0" "libbz2.so.1" {} \;
+      find {lib,lib_pypy*} -name "*.so" -exec patchelf --set-rpath ${stdenv.lib.makeLibraryPath deps} {} \;
+
+      echo "Removing bytecode"
+      find . -name "__pycache__" -type d -depth -exec rm -rf {} \;
+      popd
+
+      # Include a sitecustomize.py file
+      cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
+
+    '';
+
+    doInstallCheck = true;
+
+    # Check whether importing of (extension) modules functions
+    installCheckPhase = let
+      modules = [
+        "ssl"
+        "sys"
+        "curses"
+      ] ++ optionals (!isPy3k) [
+        "Tkinter"
+      ] ++ optionals isPy3k [
+        "tkinter"
+      ];
+      imports = concatMapStringsSep "; " (x: "import ${x}") modules;
+    in ''
+      echo "Testing whether we can import modules"
+      $out/bin/${executable} -c '${imports}'
+    '';
+
+    setupHook = python-setup-hook sitePackages;
+
+    donPatchElf = true;
+    dontStrip = true;
+
+    inherit passthru;
+
+    meta = with stdenv.lib; {
+      homepage = http://pypy.org/;
+      description = "Fast, compliant alternative implementation of the Python language (${pythonVersion})";
+      license = licenses.mit;
+      platforms = [ "x86_64-linux" ];
+    };
+
   };
 
-  buildInputs = [ which ];
-
-  installPhase = ''
-    mkdir -p $out/lib
-    echo "Moving files to $out"
-    mv -t $out bin include lib-python lib_pypy site-packages
-
-    mv $out/bin/libpypy*-c.so $out/lib/
-
-    rm $out/bin/*.debug
-
-    echo "Patching binaries"
-    interpreter=$(patchelf --print-interpreter $(readlink -f $(which patchelf)))
-    patchelf --set-interpreter $interpreter \
-             --set-rpath $out/lib \
-             $out/bin/pypy*
-
-    pushd $out
-    find {lib,lib_pypy*} -name "*.so" -exec patchelf --replace-needed "libbz2.so.1.0" "libbz2.so.1" {} \;
-    find {lib,lib_pypy*} -name "*.so" -exec patchelf --set-rpath ${stdenv.lib.makeLibraryPath deps} {} \;
-
-    echo "Removing bytecode"
-    find . -name "__pycache__" -type d -depth -exec rm -rf {} \;
-    popd
-
-    # Include a sitecustomize.py file
-    cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
-
-  '';
-
-  doInstallCheck = true;
-
-  # Check whether importing of (extension) modules functions
-  installCheckPhase = let
-    modules = [
-      "ssl"
-      "sys"
-      "curses"
-    ] ++ optionals (!isPy3k) [
-      "Tkinter"
-    ] ++ optionals isPy3k [
-      "tkinter"
-    ];
-    imports = concatMapStringsSep "; " (x: "import ${x}") modules;
-  in ''
-    echo "Testing whether we can import modules"
-    $out/bin/${executable} -c '${imports}'
-  '';
-
-  setupHook = python-setup-hook sitePackages;
-
-  donPatchElf = true;
-  dontStrip = true;
-
-  inherit passthru;
-
-  meta = with stdenv.lib; {
-    homepage = http://pypy.org/;
-    description = "Fast, compliant alternative implementation of the Python language (${pythonVersion})";
-    license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
-  };
-
-}
+in self


### PR DESCRIPTION
###### Motivation for this change

Before this change, `python3.override { ... }.buildEnv` would take the
un-overriden python interpreter as basis for the buildEnv. With this
commit, we compute `self` inside the argument passed to callPackage so the
buildEnv will always reference the python interpreter it belongs to.

As an example where this matters, `python3Full` is defined as
`python3.override { x11Support = true; }`.  `python3Full.buildEnv` didn't get that override:

```
nix-shell -p 'with (import ./. {}); python3Full.buildEnv' --command 'python3 -c "import tkinter"'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File
"/nix/store/s7vw8y02cqzx8bnjxl4bkhlnwvz6ws1s-python3-3.7.6/lib/python3.7/tkinter/__init__.py",
line 36, in <module>
    import _tkinter # If this fails your Python may not be configured
for Tk
ModuleNotFoundError: No module named '_tkinter'
```

With this commit, that example now works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).