### PR TITLE
cinnamon.nemo: init at 4.4.1

### DIFF
--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -3,5 +3,6 @@
 lib.makeScope pkgs.newScope (self: with self; {
   cinnamon-desktop = callPackage ./cinnamon-desktop { };
   cjs = callPackage ./cjs { };
+  nemo = callPackage ./nemo { };
   xapps = callPackage ./xapps { };
 })

--- a/pkgs/desktops/cinnamon/nemo/default.nix
+++ b/pkgs/desktops/cinnamon/nemo/default.nix
@@ -1,0 +1,76 @@
+{ fetchFromGitHub
+, fetchpatch
+, glib
+, gobject-introspection
+, meson
+, ninja
+, pkgconfig
+, stdenv
+, wrapGAppsHook
+, libxml2
+, gtk3
+, libnotify
+, cinnamon-desktop
+, xapps
+, libexif
+, exempi
+, intltool
+, shared-mime-info
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nemo";
+  version = "4.4.1";
+
+  # TODO: add plugins support (see https://github.com/NixOS/nixpkgs/issues/78327)
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "0sskq0rssxvna937md446x1489hkhxys1zq03hvl8asjqa259w2q";
+  };
+
+  patches = [
+    (fetchpatch { # details see https://github.com/linuxmint/nemo/pull/2303
+      url = "https://github.com/linuxmint/nemo/pull/2303/commits/9c1ec7812abe712419317df07d6b64623e8f639d.patch";
+      sha256 = "09dz7lq3i47rbvycawrxwgjmd9g1mhb76ibx2vq85wck6r08arml";
+    })
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libnotify
+    cinnamon-desktop
+    libxml2
+    xapps
+    libexif
+    exempi
+    gobject-introspection
+  ];
+
+  nativeBuildInputs = [
+    meson
+    pkgconfig
+    ninja
+    wrapGAppsHook
+    intltool
+    shared-mime-info
+  ];
+
+  mesonFlags = [
+    # TODO: https://github.com/NixOS/nixpkgs/issues/36468
+    "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/nemo";
+    description = "File browser for Cinnamon";
+    license = [ licenses.gpl2 licenses.lgpl2 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Needed for cinnamon porting

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
