### PR TITLE
purescript: 0.13.5 -> 0.13.6 (and add maintainer)

### DIFF
--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -18,19 +18,19 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "purescript";
-  version = "0.13.5";
+  version = "0.13.6";
 
   src =
     if stdenv.isDarwin
     then
     fetchurl {
       url = "https://github.com/${pname}/${pname}/releases/download/v${version}/macos.tar.gz";
-      sha256 = "19bb50m0cd738r353blgy21d842b3yj58xfbplk7bz59jawj9lym";
+      sha256 = "04kwjjrriyizpvhs96jgyx21ppyd1ynblk24i5825ywxlw9hja25";
     }
     else
     fetchurl {
       url = "https://github.com/${pname}/${pname}/releases/download/v${version}/linux64.tar.gz";
-      sha256 = "016wvwypgb4859f0n1lqsqv9a8cca2y8g7d6ffvzx6rncd115gxi";
+      sha256 = "012znrj32aq96qh1g2hscdvhl3flgihhimiz40agk0dykpksblns";
     };
 
 

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -59,7 +59,7 @@ in stdenv.mkDerivation rec {
     description = "A strongly-typed functional programming language that compiles to JavaScript";
     homepage = http://www.purescript.org/;
     license = licenses.bsd3;
-    maintainers = [ maintainers.justinwoo ];
+    maintainers = [ maintainers.justinwoo maintainers.mbbx6spp ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

New purescript 0.13.6 version came out this week. Changelog:
https://github.com/purescript/purescript/releases/tag/v0.13.6

Using following SHA256 from `nix-prefetch-url` for corresponding MacOS binary:

```
$ nix-prefetch-url https://github.com/purescript/purescript/releases/download/v0.13.6/macos.tar.gz
[5.8 MiB DL]
path is '/nix/store/b1i0yhyim0nsfayf9qhkvmpv3fi14xxw-macos.tar.gz'
04kwjjrriyizpvhs96jgyx21ppyd1ynblk24i5825ywxlw9hja25
```

Using following SHA256 from `nix-prefetch-url` for corresponding Linux 64-bit binary:

```
$ nix-prefetch-url https://github.com/purescript/purescript/releases/download/v0.13.6/linux64.tar.gz
[10.0 MiB DL]
path is '/nix/store/k5iz3vmmqla5r2niwygls8j7ghhskf0r-linux64.tar.gz'
012znrj32aq96qh1g2hscdvhl3flgihhimiz40agk0dykpksblns
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
