### PR TITLE
aria2p: init at 0.7.0

### DIFF
--- a/pkgs/development/python-modules/aria2p/default.nix
+++ b/pkgs/development/python-modules/aria2p/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder
+, aria2, poetry, pytest, pytestcov, pytest_xdist, responses
+, asciimatics, loguru, requests, setuptools, websocket_client
+}:
+
+buildPythonPackage rec {
+  pname = "aria2p";
+  version = "0.7.0";
+  format = "pyproject";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "pawamoy";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1inak3y2win58zbzykfzy6xp00f276sqsz69h2nfsd93mpr74wf6";
+  };
+  
+  nativeBuildInputs = [ poetry ];
+
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkInputs = [ aria2 responses pytest pytestcov pytest_xdist ];
+
+  # Tests are not all stable/deterministic,
+  # they rely on actually running an aria2c daemon and communicating with it,
+  # race conditions and deadlocks were observed,
+  # thus the corresponding tests are disabled
+  checkPhase = ''
+    pytest -nauto -k "not test_api and not test_cli and not test_interface"
+  '';
+
+  propagatedBuildInputs = [ asciimatics loguru requests setuptools websocket_client ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/pawamoy/aria2p";
+    description = "Command-line tool and library to interact with an aria2c daemon process with JSON-RPC";
+    license = licenses.isc;
+    maintainers = with maintainers; [ koral ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -187,6 +187,8 @@ in {
 
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
 
+  aria2p = callPackage ../development/python-modules/aria2p { inherit (pkgs) aria2 poetry; };
+
   arviz = callPackage ../development/python-modules/arviz { };
 
   asana = callPackage ../development/python-modules/asana { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Install `aria2p` tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
