### PR TITLE
glirc: 2.33.1 -> 2.34

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1337,7 +1337,15 @@ self: super: {
 
   # 2019-12-19 - glirc wants regex-tdfa >=1.3 which results in errors with regex-base which errors more
   # hoping to make a proper derivation with plugins enabled and more reliable building -- kiwi
-  glirc = doJailbreak super.glirc;
+  # 2020-01-17 - as of recently the basic doJailbreak is not enough and have to override regex-tdfa which needs an override for regex-base
+
+  glirc = doJailbreak (super.glirc.override {
+    regex-tdfa = self.regex-tdfa_1_3_1_0;
+  });
+
+  regex-tdfa_1_3_1_0 = doJailbreak (super.regex-tdfa_1_3_1_0.override {
+    regex-base = self.regex-base_0_94_0_0;
+  });
 
   # apply patches from https://github.com/snapframework/snap-server/pull/126
   # manually until they are accepted upstream


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
glirc update needed fixed. which needed a fix for regex-tdfa_1_3_1_0

###### Things done
fixed glirc build and that regex-tdfa version

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
