### PR TITLE
jetbrains-mono: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -828,6 +828,12 @@
     githubId = 24027;
     name = "Bruno Bigras";
   };
+  bbuscarino = {
+    email = "foss@busc.dev";
+    github = "bbuscarino";
+    githubId = 2858049;
+    name = "Ben Buscarino";
+  };
   bcarrell = {
     email = "brandoncarrell@gmail.com";
     github = "bcarrell";

--- a/pkgs/data/fonts/jetbrains-mono/default.nix
+++ b/pkgs/data/fonts/jetbrains-mono/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchzip }:
+
+let version = "1.0.0";
+in fetchzip {
+  name = "jetbrains-mono";
+  url = "https://download.jetbrains.com/fonts/JetBrainsMono-${version}.zip";
+  sha256 = "1znw1xihk4139bi1gacdpx5a3l3rpvhcmg3c2vwaj1g3kvhnyhnp";
+  stripRoot = false;
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A monospace typeface for developers";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bbuscarino ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/fonts/jetbrains-mono/default.nix
+++ b/pkgs/data/fonts/jetbrains-mono/default.nix
@@ -4,7 +4,7 @@ let version = "1.0.0";
 in fetchzip {
   name = "jetbrains-mono";
   url = "https://download.jetbrains.com/fonts/JetBrainsMono-${version}.zip";
-  sha256 = "1znw1xihk4139bi1gacdpx5a3l3rpvhcmg3c2vwaj1g3kvhnyhnp";
+  sha256 = "0mwqi66d56v4ml1w7wjsiidrh153jvh0czafyic47rkvmxhnrrhv";
   stripRoot = false;
 
   postFetch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17477,6 +17477,8 @@ in
 
   iwona = callPackage ../data/fonts/iwona { };
 
+  jetbrains-mono = callPackage ../data/fonts/jetbrains-mono { };
+
   jost = callPackage ../data/fonts/jost { };
 
   joypixels = callPackage ../data/fonts/joypixels { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Introduce JetBrains Mono font.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
