### PR TITLE
michabo: mark as broken as it's abandoned by upstream

### DIFF
--- a/pkgs/applications/misc/michabo/default.nix
+++ b/pkgs/applications/misc/michabo/default.nix
@@ -48,6 +48,7 @@ in mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
+    broken = true; # has been abandoned upstream: https://socially.whimsic.al/objects/56db0963-ca22-4bf0-be50-88f7e4d4c7ed
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change

Michabo has been abandoned upstream as the maintainer is moving away from Fediverse development, see [this thread](https://socially.whimsic.al/objects/56db0963-ca22-4bf0-be50-88f7e4d4c7ed).

@fgaz Any ideas on how to keep this updated in the future? Otherwise I suggest to mark it as broken and later remove it from nixpkgs. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
