### PR TITLE
rpm: fix helper script paths

### DIFF
--- a/pkgs/tools/package-management/rpm/default.nix
+++ b/pkgs/tools/package-management/rpm/default.nix
@@ -50,6 +50,11 @@ stdenv.mkDerivation rec {
       sed -i $out/lib/rpm/macros -e "s/^%__$tool.*/%__$tool $tool/"
     done
 
+    # Avoid helper scripts pointing to absolute paths
+    for tool in find-provides find-requires; do
+      sed -i $out/lib/rpm/$tool -e "s#/usr/lib/rpm/#$out/lib/rpm/#"
+    done
+
     # symlinks produced by build are incorrect
     ln -sf $out/bin/{rpm,rpmquery}
     ln -sf $out/bin/{rpm,rpmverify}


### PR DESCRIPTION
##### Motivation for this change

This PR replaces a hardcoded reference to `/usr/lib/rpm` that, at least on my machine, appears in the `find-provides` and `find-requires` scripts (e.g. https://github.com/rpm-software-management/rpm/blob/75ec16e660e784d7897b37cac1a2b9b135825f25/scripts/find-provides).

The hardcoded link results in the following error:

```
$ /nix/store/ag4r7xv9kv0bc79y7rlsy07rjadl26xk-rpm-4.14.2.1/lib/rpm/find-provides
/nix/store/ag4r7xv9kv0bc79y7rlsy07rjadl26xk-rpm-4.14.2.1/lib/rpm/find-provides: line 3: /usr/lib/rpm/rpmdeps: No such file or directory
```

There may be a better way of fixing this, so I am open to suggestions.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
