### PR TITLE
chatterino2: use wrapQtAppsHook, unstable-2019-05-11 -> v2.1.7, adopt as maintainer

### DIFF
--- a/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
@@ -32,10 +32,10 @@ mkDerivation rec {
       improved/extended version of the Twitch web chat. Chatterino 2 is
       the second installment of the Twitch chat client series
       "Chatterino".
-  '';
-    homepage = "https://github.com/fourtf/chatterino2";
+    '';
+    homepage = "https://github.com/Chatterino/chatterino2";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ rexim ];
+    maintainers = with maintainers; [ ldesgoui rexim ];
   };
 }

--- a/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pkgconfig, fetchFromGitHub, qtbase, qtsvg, qtmultimedia, qmake, boost, openssl }:
+{ stdenv, pkgconfig, fetchFromGitHub, qtbase, qtsvg, qtmultimedia, qmake, boost, openssl, mkDerivation }:
 
-stdenv.mkDerivation rec {
+mkDerivation rec {
   pname = "chatterino2";
   version = "unstable-2019-05-11";
   src = fetchFromGitHub {
@@ -10,8 +10,20 @@ stdenv.mkDerivation rec {
     sha256 = "0i2385hamhd9i7jdy906cfrd81cybw524j92l87c8pzrkxphignk";
     fetchSubmodules = true;
   };
-  nativeBuildInputs = [ qmake pkgconfig ];
-  buildInputs = [ qtbase qtsvg qtmultimedia boost openssl ];
+
+  nativeBuildInputs = [
+    qmake
+    pkgconfig
+  ];
+
+  buildInputs = [
+    qtbase
+    qtsvg
+    qtmultimedia
+    boost
+    openssl
+  ];
+
   meta = with stdenv.lib; {
     description = "A chat client for Twitch chat";
     longDescription = ''

--- a/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
+++ b/pkgs/applications/networking/instant-messengers/chatterino2/default.nix
@@ -2,12 +2,13 @@
 
 mkDerivation rec {
   pname = "chatterino2";
-  version = "unstable-2019-05-11";
+  version = "2.1.7";
+
   src = fetchFromGitHub {
-    owner = "fourtf";
+    owner = "Chatterino";
     repo = pname;
-    rev = "8c46cbf571dc8fd77287bf3186445ff52b1d1aaf";
-    sha256 = "0i2385hamhd9i7jdy906cfrd81cybw524j92l87c8pzrkxphignk";
+    rev = "v${version}";
+    sha256 = "0bbdzainfa7hlz5p0jfq4y04i3wix7z3i6w193906bi4gr9wilpg";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
The current `chatterino2` derivation does not provide a functioning client because of the breaking changes caused by the addition of `wrapQtAppsHook`.
I have also updated the sources which were out of date as the project moved to a Github organisation.
I have also added myself as a maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) [NA]
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date [NA]
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
