### PR TITLE
pg_checksums: init at 1.0

### DIFF
--- a/pkgs/development/tools/database/pg_checksums/default.nix
+++ b/pkgs/development/tools/database/pg_checksums/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, libxslt, docbook_xsl, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "pg_checksums";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "credativ";
+    repo = pname;
+    rev = version;
+    sha256 = "0xc2bwp55xjnnf45lc60ldxpb5jfyi1bgfkv3nxrymcswh8yfidj";
+  };
+
+  nativeBuildInputs = [ libxslt.bin ];
+
+  buildInputs = [ postgresql ];
+
+  buildFlags = [ "all" "man" ];
+
+  preConfigure = ''
+    substituteInPlace doc/stylesheet-man.xsl \
+      --replace "http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl" "${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl"
+  '';
+
+  installPhase = ''
+    install -Dm755 -t $out/bin pg_checksums
+    install -Dm644 -t $out/share/man/man1 doc/man1/pg_checksums.1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Activate/deactivate/verify checksums in offline PostgreSQL clusters";
+    homepage = "https://github.com/credativ/pg_checksums";
+    maintainers = [ maintainers.marsam ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.postgresql;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5699,6 +5699,8 @@ in
 
   peco = callPackage ../tools/text/peco { };
 
+  pg_checksums = callPackage ../development/tools/database/pg_checksums { };
+
   pg_flame = callPackage ../tools/misc/pg_flame { };
 
   pg_top = callPackage ../tools/misc/pg_top { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/credativ/pg_checksums

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
