### PR TITLE
tailscale: init at 0.94-236.

### DIFF
--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -20,14 +20,14 @@ stdenv.mkDerivation rec {
     libPath = lib.makeLibraryPath [ glibc ];
     ldLinux = "${libPath}/ld-linux-x86-64.so.2";
   in ''
-    mkdir -p $out/usr/sbin
+    mkdir -p $out/sbin
     cd usr/sbin
-    cp * $out/usr/sbin
+    cp * $out/sbin
 
-    patchelf --set-rpath "${libPath}" $out/usr/sbin/relaynode
-    patchelf --set-interpreter "${ldLinux}" $out/usr/sbin/relaynode
-    patchelf --set-rpath "${libPath}" $out/usr/sbin/taillogin
-    patchelf --set-interpreter "${ldLinux}" $out/usr/sbin/taillogin
+    patchelf --set-rpath "${libPath}" $out/sbin/relaynode
+    patchelf --set-interpreter "${ldLinux}" $out/sbin/relaynode
+    patchelf --set-rpath "${libPath}" $out/sbin/taillogin
+    patchelf --set-interpreter "${ldLinux}" $out/sbin/taillogin
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
     description = "A mesh VPN that makes it easy to connect your devices, wherever they are";
     license = licenses.unfree;
     platforms = platforms.linux;
-    architectures = [ "amd64" ];
     maintainers = with maintainers; [ danderson ];
   };
 }

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -1,43 +1,41 @@
 { stdenv, lib, rpmextract, fetchurl, glibc }:
-{
-  tailscale = stdenv.mkDerivation rec {
-    pname = "tailscale";
-    version = "0.94-236";
+stdenv.mkDerivation rec {
+  pname = "tailscale";
+  version = "0.94-236";
 
-    src = fetchurl {
-      url = "https://tailscale.com/files/dist/tailscale-relay-${version}.x86_64.rpm";
-      sha256 = "b8e7505debba715f1a7c444715fbbbca5a6e3dd6515f35756006fa0daab3b9ea";
-    };
+  src = fetchurl {
+    url = "https://tailscale.com/files/dist/tailscale-relay-${version}.x86_64.rpm";
+    sha256 = "b8e7505debba715f1a7c444715fbbbca5a6e3dd6515f35756006fa0daab3b9ea";
+  };
 
-    buildInputs = [ glibc ];
+  buildInputs = [ glibc ];
 
-    nativeBuildInputs = [ rpmextract ];
+  nativeBuildInputs = [ rpmextract ];
 
-    unpackPhase = ''
-      rpmextract $src
-    '';
+  unpackPhase = ''
+    rpmextract $src
+  '';
 
-    installPhase = let
-      libPath = lib.makeLibraryPath [ glibc ];
-      ldLinux = "${libPath}/ld-linux-x86-64.so.2";
-    in ''
-      mkdir -p $out/usr/sbin
-      cd usr/sbin
-      cp * $out/usr/sbin
+  installPhase = let
+    libPath = lib.makeLibraryPath [ glibc ];
+    ldLinux = "${libPath}/ld-linux-x86-64.so.2";
+  in ''
+    mkdir -p $out/usr/sbin
+    cd usr/sbin
+    cp * $out/usr/sbin
 
-      patchelf --set-rpath "${libPath}" $out/usr/sbin/relaynode
-      patchelf --set-interpreter "${ldLinux}" $out/usr/sbin/relaynode
-      patchelf --set-rpath "${libPath}" $out/usr/sbin/taillogin
-      patchelf --set-interpreter "${ldLinux}" $out/usr/sbin/taillogin
-    '';
+    patchelf --set-rpath "${libPath}" $out/usr/sbin/relaynode
+    patchelf --set-interpreter "${ldLinux}" $out/usr/sbin/relaynode
+    patchelf --set-rpath "${libPath}" $out/usr/sbin/taillogin
+    patchelf --set-interpreter "${ldLinux}" $out/usr/sbin/taillogin
+  '';
 
-    meta = with stdenv.lib; {
-      homepage = "https://www.tailscale.com";
-      description = "A mesh VPN that makes it easy to connect your devices, wherever they are";
-      license = licenses.unfree;
-      platforms = platforms.linux;
-      architectures = [ "amd64" ];
-      maintainers = with maintainers; [ danderson ];
-    };
+  meta = with stdenv.lib; {
+    homepage = "https://www.tailscale.com";
+    description = "A mesh VPN that makes it easy to connect your devices, wherever they are";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    architectures = [ "amd64" ];
+    maintainers = with maintainers; [ danderson ];
   };
 }

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.tailscale.com";
     description = "A mesh VPN that makes it easy to connect your devices, wherever they are";
     license = licenses.unfree;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ danderson ];
   };
 }

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, rpmextract, fetchurl, glibc }:
+{
+  tailscale = stdenv.mkDerivation rec {
+    pname = "tailscale";
+    version = "0.94-236";
+
+    src = fetchurl {
+      url = "https://tailscale.com/files/dist/tailscale-relay-${version}.x86_64.rpm";
+      sha256 = "b8e7505debba715f1a7c444715fbbbca5a6e3dd6515f35756006fa0daab3b9ea";
+    };
+
+    buildInputs = [ glibc ];
+
+    nativeBuildInputs = [ rpmextract ];
+
+    unpackPhase = ''
+      rpmextract $src
+    '';
+
+    installPhase = let
+      libPath = lib.makeLibraryPath [ glibc ];
+      ldLinux = "${libPath}/ld-linux-x86-64.so.2";
+    in ''
+      mkdir -p $out/usr/sbin
+      cd usr/sbin
+      cp * $out/usr/sbin
+
+      patchelf --set-rpath "${libPath}" $out/usr/sbin/relaynode
+      patchelf --set-interpreter "${ldLinux}" $out/usr/sbin/relaynode
+      patchelf --set-rpath "${libPath}" $out/usr/sbin/taillogin
+      patchelf --set-interpreter "${ldLinux}" $out/usr/sbin/taillogin
+    '';
+
+    meta = with stdenv.lib; {
+      homepage = "https://www.tailscale.com";
+      description = "A mesh VPN that makes it easy to connect your devices, wherever they are";
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      architectures = [ "amd64" ];
+      maintainers = with maintainers; [ danderson ];
+    };
+  };
+}

--- a/pkgs/servers/tailscale/default.nix
+++ b/pkgs/servers/tailscale/default.nix
@@ -20,9 +20,11 @@ stdenv.mkDerivation rec {
     libPath = lib.makeLibraryPath [ glibc ];
     ldLinux = "${libPath}/ld-linux-x86-64.so.2";
   in ''
-    mkdir -p $out/sbin
+    mkdir -p $out/sbin $out/etc
     cd usr/sbin
     cp * $out/sbin
+    cd ../../etc/tailscale
+    cp acl.json $out/etc/acl.json
 
     patchelf --set-rpath "${libPath}" $out/sbin/relaynode
     patchelf --set-interpreter "${ldLinux}" $out/sbin/relaynode

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6660,6 +6660,8 @@ in
 
   t1utils = callPackage ../tools/misc/t1utils { };
 
+  tailscale = callPackage ../servers/tailscale {};
+
   talkfilters = callPackage ../misc/talkfilters {};
 
   znapzend = callPackage ../tools/backup/znapzend { };


### PR DESCRIPTION
###### Motivation for this change

Tailscale is a mesh VPN service that I want to run on my NixOS machines. This change adds the package derivation. A future change will add a corresponding NixOS module (or I can add it to this change if you prefer).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [n/a] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [n/a] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [n/a] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
