### PR TITLE
nixos: home-assistant: can dial out

### DIFF
--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -251,6 +251,7 @@ in {
       home = cfg.configDir;
       createHome = true;
       group = "hass";
+      extraGroups = [ "dialout" ];
       uid = config.ids.uids.hass;
     };
 


### PR DESCRIPTION
Add the `home-assistant` user to the `dialout` group so that it may use Zwave and Zigbee adapters.