### PR TITLE
home-assistant: v0.103.1 -> 0.104.3

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.103.6";
+  version = "0.104.3";
   components = {
     "abode" = ps: with ps; [  ];
     "acer_projector" = ps: with ps; [ pyserial ];
@@ -22,7 +22,7 @@
     "almond" = ps: with ps; [ aiohttp-cors ];
     "alpha_vantage" = ps: with ps; [  ];
     "amazon_polly" = ps: with ps; [ boto3 ];
-    "ambiclimate" = ps: with ps; [  ];
+    "ambiclimate" = ps: with ps; [ aiohttp-cors ];
     "ambient_station" = ps: with ps; [  ];
     "amcrest" = ps: with ps; [ ha-ffmpeg ];
     "ampio" = ps: with ps; [  ];
@@ -87,6 +87,7 @@
     "bom" = ps: with ps; [  ];
     "braviatv" = ps: with ps; [  ];
     "broadlink" = ps: with ps; [ broadlink ];
+    "brother" = ps: with ps; [  ];
     "brottsplatskartan" = ps: with ps; [  ];
     "browser" = ps: with ps; [  ];
     "brunt" = ps: with ps; [  ];
@@ -164,7 +165,7 @@
     "dnsip" = ps: with ps; [ aiodns ];
     "dominos" = ps: with ps; [ aiohttp-cors ];
     "doods" = ps: with ps; [ pillow ];
-    "doorbird" = ps: with ps; [  ];
+    "doorbird" = ps: with ps; [ aiohttp-cors ];
     "dovado" = ps: with ps; [  ];
     "downloader" = ps: with ps; [  ];
     "dsmr" = ps: with ps; [  ];
@@ -189,6 +190,7 @@
     "efergy" = ps: with ps; [  ];
     "egardia" = ps: with ps; [  ];
     "eight_sleep" = ps: with ps; [  ];
+    "elgato" = ps: with ps; [  ];
     "eliqonline" = ps: with ps; [  ];
     "elkm1" = ps: with ps; [  ];
     "elv" = ps: with ps; [  ];
@@ -228,7 +230,7 @@
     "fido" = ps: with ps; [  ];
     "file" = ps: with ps; [  ];
     "filesize" = ps: with ps; [  ];
-    "filter" = ps: with ps; [  ];
+    "filter" = ps: with ps; [ aiohttp-cors sqlalchemy ];
     "fints" = ps: with ps; [ fints ];
     "fitbit" = ps: with ps; [ aiohttp-cors fitbit ];
     "fixer" = ps: with ps; [  ];
@@ -272,6 +274,7 @@
     "geofency" = ps: with ps; [ aiohttp-cors ];
     "geonetnz_quakes" = ps: with ps; [  ];
     "geonetnz_volcano" = ps: with ps; [  ];
+    "gios" = ps: with ps; [  ];
     "github" = ps: with ps; [ PyGithub ];
     "gitlab_ci" = ps: with ps; [ python-gitlab ];
     "gitter" = ps: with ps; [  ];
@@ -359,6 +362,7 @@
     "integration" = ps: with ps; [  ];
     "intent" = ps: with ps; [ aiohttp-cors ];
     "intent_script" = ps: with ps; [  ];
+    "intesishome" = ps: with ps; [  ];
     "ios" = ps: with ps; [ aiohttp-cors zeroconf ];
     "iota" = ps: with ps; [  ];
     "iperf3" = ps: with ps; [  ];
@@ -378,6 +382,7 @@
     "kankun" = ps: with ps; [  ];
     "keba" = ps: with ps; [  ];
     "keenetic_ndms2" = ps: with ps; [  ];
+    "kef" = ps: with ps; [  ];
     "keyboard" = ps: with ps; [  ];
     "keyboard_remote" = ps: with ps; [ evdev ];
     "kira" = ps: with ps; [  ];
@@ -410,13 +415,14 @@
     "liveboxplaytv" = ps: with ps; [  ];
     "llamalab_automate" = ps: with ps; [  ];
     "local_file" = ps: with ps; [  ];
+    "local_ip" = ps: with ps; [  ];
     "locative" = ps: with ps; [ aiohttp-cors ];
     "lock" = ps: with ps; [  ];
     "lockitron" = ps: with ps; [  ];
     "logbook" = ps: with ps; [ aiohttp-cors sqlalchemy ];
     "logentries" = ps: with ps; [  ];
     "logger" = ps: with ps; [  ];
-    "logi_circle" = ps: with ps; [ ha-ffmpeg ];
+    "logi_circle" = ps: with ps; [ aiohttp-cors ha-ffmpeg ];
     "london_air" = ps: with ps; [  ];
     "london_underground" = ps: with ps; [  ];
     "loopenergy" = ps: with ps; [  ];
@@ -601,7 +607,7 @@
     "qrcode" = ps: with ps; [ pillow ];
     "quantum_gateway" = ps: with ps; [  ];
     "qwikswitch" = ps: with ps; [  ];
-    "rachio" = ps: with ps; [  ];
+    "rachio" = ps: with ps; [ aiohttp-cors ];
     "radarr" = ps: with ps; [  ];
     "radiotherm" = ps: with ps; [  ];
     "rainbird" = ps: with ps; [  ];
@@ -655,6 +661,7 @@
     "sensehat" = ps: with ps; [  ];
     "sensibo" = ps: with ps; [  ];
     "sensor" = ps: with ps; [  ];
+    "sentry" = ps: with ps; [ sentry-sdk ];
     "serial" = ps: with ps; [ pyserial-asyncio ];
     "serial_pm" = ps: with ps; [  ];
     "sesame" = ps: with ps; [  ];
@@ -666,6 +673,7 @@
     "shopping_list" = ps: with ps; [ aiohttp-cors ];
     "sht31" = ps: with ps; [  ];
     "sigfox" = ps: with ps; [  ];
+    "signal_messenger" = ps: with ps; [  ];
     "simplepush" = ps: with ps; [  ];
     "simplisafe" = ps: with ps; [  ];
     "simulated" = ps: with ps; [  ];
@@ -718,6 +726,7 @@
     "statsd" = ps: with ps; [ statsd ];
     "steam_online" = ps: with ps; [  ];
     "stiebel_eltron" = ps: with ps; [  ];
+    "stookalert" = ps: with ps; [  ];
     "stream" = ps: with ps; [ aiohttp-cors av ];
     "streamlabswater" = ps: with ps; [  ];
     "stt" = ps: with ps; [ aiohttp-cors ];
@@ -725,6 +734,7 @@
     "sun" = ps: with ps; [  ];
     "supervisord" = ps: with ps; [  ];
     "supla" = ps: with ps; [  ];
+    "surepetcare" = ps: with ps; [  ];
     "swiss_hydrological_data" = ps: with ps; [  ];
     "swiss_public_transport" = ps: with ps; [  ];
     "swisscom" = ps: with ps; [  ];
@@ -770,6 +780,7 @@
     "tile" = ps: with ps; [  ];
     "time_date" = ps: with ps; [  ];
     "timer" = ps: with ps; [  ];
+    "tmb" = ps: with ps; [  ];
     "tod" = ps: with ps; [  ];
     "todoist" = ps: with ps; [ todoist ];
     "tof" = ps: with ps; [  ];
@@ -848,11 +859,11 @@
     "weather" = ps: with ps; [  ];
     "webhook" = ps: with ps; [ aiohttp-cors ];
     "weblink" = ps: with ps; [  ];
-    "webostv" = ps: with ps; [ websockets ];
+    "webostv" = ps: with ps; [  ];
     "websocket_api" = ps: with ps; [ aiohttp-cors ];
     "wemo" = ps: with ps; [  ];
     "whois" = ps: with ps; [  ];
-    "wink" = ps: with ps; [  ];
+    "wink" = ps: with ps; [ aiohttp-cors ];
     "wirelesstag" = ps: with ps; [  ];
     "withings" = ps: with ps; [ aiohttp-cors ];
     "wled" = ps: with ps; [  ];
@@ -870,12 +881,12 @@
     "xfinity" = ps: with ps; [  ];
     "xiaomi" = ps: with ps; [ ha-ffmpeg ];
     "xiaomi_aqara" = ps: with ps; [  ];
-    "xiaomi_miio" = ps: with ps; [ construct ];
+    "xiaomi_miio" = ps: with ps; [ construct python-miio ];
     "xiaomi_tv" = ps: with ps; [  ];
     "xmpp" = ps: with ps; [ slixmpp ];
     "xs1" = ps: with ps; [  ];
     "yale_smart_alarm" = ps: with ps; [  ];
-    "yamaha" = ps: with ps; [  ];
+    "yamaha" = ps: with ps; [ rxv ];
     "yamaha_musiccast" = ps: with ps; [  ];
     "yandex_transport" = ps: with ps; [  ];
     "yandextts" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -27,9 +27,6 @@ let
     (mkOverride "colorlog" "4.0.2"
       "3cf31b25cbc8f86ec01fef582ef3b840950dea414084ed19ab922c8b493f9b42")
 
-    (mkOverride "pyyaml" "5.1.2"
-      "1r5faspz73477hlbjgilw05xsms0glmsa371yqdd26znqsvg1b81")
-
     # required by aioesphomeapi
     (self: super: {
       protobuf = super.protobuf.override {
@@ -70,7 +67,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.103.6";
+  hassVersion = "0.104.3";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -85,7 +82,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "1492q4icyhvz30fw5ysrwlnsls4iy5pv62ay3vq1ygcfnlapkqhl";
+    sha256 = "06bh9qrpa1d370pvw6in0isg3yw4p7gh9rpy4hm96p0mf53vxfdp";
   };
 
   propagatedBuildInputs = [
@@ -99,14 +96,6 @@ in with py.pkgs; buildPythonApplication rec {
 
   checkInputs = [
     asynctest pytest pytest-aiohttp requests-mock pydispatcher aiohue netdisco hass-nabucasa
-  ];
-
-  patches = [
-    # newer importlib-metadata version
-    (fetchpatch {
-      url = "https://github.com/home-assistant/home-assistant/commit/63c6b803dc2d835d57b97ed833ee5cd8318bf7ae.patch";
-      sha256 = "16q3qdnmgsw5415f70zvsv1z63dljp3c9glv06cyj4s6qsl13xdc";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Upgrade `home-assistant` from 0.103.1 -> 0.104.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
