### PR TITLE
pythonPackages: add `plexauth`, `plexapi`, `plexwebsocket`

### DIFF
--- a/pkgs/development/python-modules/plexapi/default.nix
+++ b/pkgs/development/python-modules/plexapi/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchFromGitHub, requests
+, tqdm, websocket_client, pytest, pillow, mock, isPy27 }:
+
+buildPythonPackage rec {
+  pname = "PlexAPI";
+  version = "3.2.0";
+
+  src = fetchFromGitHub {
+    owner = "pkkid";
+    repo = "python-plexapi";
+    rev = version;
+    sha256 = "1rzy018zcsws56mcghnphhzwj650pwj7qg6nh9z1kjvgwwjfmghf";
+  };
+
+  propagatedBuildInputs = [ requests tqdm websocket_client ];
+
+  checkInputs = [ pytest pillow ]
+    ++ lib.optionals isPy27 [ mock ];
+
+  meta = with lib; {
+    homepage = "https://github.com/pkkid/python-plexapi";
+    description = "Python bindings for the Plex API";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/development/python-modules/plexauth/default.nix
+++ b/pkgs/development/python-modules/plexauth/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchFromGitHub, aiohttp, isPy27 }:
+
+buildPythonPackage rec {
+  pname = "plexauth";
+  version = "0.0.5";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "jjlawren";
+    repo = "python-plexauth";
+    rev = "v${version}";
+    sha256 = "1wbrn22iywl4ccz64r3w3f17k0r7vi2cqkqd2mrdkx5xqhscn9hz";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  # package does not include tests
+  doCheck = false;
+
+  # at least guarantee the module can be imported
+  pythonImportsCheck = [
+    "plexauth"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/jjlawren/python-plexauth/";
+    description = "Handles the authorization flow to obtain tokens from Plex.tv via external redirection";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/development/python-modules/plexwebsocket/default.nix
+++ b/pkgs/development/python-modules/plexwebsocket/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchFromGitHub, aiohttp, isPy27 }:
+
+buildPythonPackage rec {
+  pname = "plexwebsocket";
+  version = "0.0.6";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "jjlawren";
+    repo = "python-plexwebsocket";
+    rev = "v${version}";
+    sha256 = "1sy9khxksimcmdvghg1ksk65mkiihjvhi7m7ms2kzmy7mrg3s3i7";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  # package does not include tests
+  doCheck = false;
+
+  # at least guarantee the module can be imported
+  pythonImportsCheck = [
+    "plexwebsocket"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/jjlawren/python-plexwebsocket/";
+    description = "Async library to react to events issued over Plex websockets";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2934,6 +2934,8 @@ in {
 
   plexapi = callPackage ../development/python-modules/plexapi { };
 
+  plexauth = callPackage ../development/python-modules/plexauth { };
+
   plotly = callPackage ../development/python-modules/plotly { };
 
   plyfile = callPackage ../development/python-modules/plyfile { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2932,6 +2932,8 @@ in {
 
   plaster-pastedeploy = callPackage ../development/python-modules/plaster-pastedeploy {};
 
+  plexapi = callPackage ../development/python-modules/plexapi { };
+
   plotly = callPackage ../development/python-modules/plotly { };
 
   plyfile = callPackage ../development/python-modules/plyfile { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2936,6 +2936,8 @@ in {
 
   plexauth = callPackage ../development/python-modules/plexauth { };
 
+  plexwebsocket = callPackage ../development/python-modules/plexwebsocket { };
+
   plotly = callPackage ../development/python-modules/plotly { };
 
   plyfile = callPackage ../development/python-modules/plyfile { };


### PR DESCRIPTION
###### Motivation for this change
These are used by `home-assistant` when the `plex` component is used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
