### PR TITLE
pythonPackages.denonavr: init at 0.7.10

### DIFF
--- a/pkgs/development/python-modules/denonavr/default.nix
+++ b/pkgs/development/python-modules/denonavr/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchFromGitHub, isPy27, requests
+, pytest, testtools, requests-mock }:
+
+buildPythonPackage rec {
+  pname = "denonavr";
+  version = "0.7.10";
+
+  src = fetchFromGitHub {
+    owner = "scarface-4711";
+    repo = "denonavr";
+    rev = version;
+    sha256 = "078nhr69f68nfazhmkf2sl7wiadqx96a5ry3ziggiy1xs04vflj7";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  doCheck = !isPy27;
+  checkInputs = [ pytest testtools requests-mock ];
+  checkPhase = ''
+    pytest tests
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/scarface-4711/denonavr";
+    description = "Automation Library for Denon AVR receivers.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -560,6 +560,8 @@ in {
 
   dendropy = callPackage ../development/python-modules/dendropy { };
 
+  denonavr = callPackage ../development/python-modules/denonavr { };
+
   dependency-injector = callPackage ../development/python-modules/dependency-injector { };
 
   btchip = callPackage ../development/python-modules/btchip { };


### PR DESCRIPTION
#### Motivation for this change
This is used by home-assistant when one of the denon components is used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
