### PR TITLE
pythonPackages.flux_led: init at v0.22

### DIFF
--- a/pkgs/development/python-modules/flux-led/default.nix
+++ b/pkgs/development/python-modules/flux-led/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub
+, aiohttp, zigpy
+, pytest, isPy27 }:
+
+buildPythonPackage rec {
+  pname = "flux_led";
+  version = "0.22";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "Danielhiversen";
+    repo = "flux_led";
+    rev = version;
+    sha256 = "1zgajlkhclyrqhkmivna4ha2lyvfpk5929s042gy59p7mzpkvjx7";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A Python library to communicate with the flux_led smart bulbs";
+    homepage = "https://github.com/Danielhiversen/flux_led";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ colemickens ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2583,6 +2583,8 @@ in {
 
   fluent-logger = callPackage ../development/python-modules/fluent-logger {};
 
+  flux-led = callPackage ../development/python-modules/flux-led { };
+
   python-forecastio = callPackage ../development/python-modules/python-forecastio { };
 
   fpdf = callPackage ../development/python-modules/fpdf { };


### PR DESCRIPTION
#### Motivation for this change

This is used by home-assistant when the fluxled/magichome led component is used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
