### PR TITLE
pythonPackages.bravia_tv: init at 1.0.1

### DIFF
--- a/pkgs/development/python-modules/bravia-tv/default.nix
+++ b/pkgs/development/python-modules/bravia-tv/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub, buildPythonPackage, isPy27, requests }:
+
+buildPythonPackage rec {
+  pname = "bravia-tv";
+  version = "1.0.1";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "dcnielsen90";
+    repo = "python-bravia-tv";
+    rev = "v${version}";
+    sha256 = "0jlrin5qw3ny2r961y5divd5xa9giprxhhxdc84rjlq9qdmnsk68";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  # package does not include tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "bravia_tv" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/dcnielsen90/python-bravia-tv";
+    description = "Python library for Sony Bravia TV remote control";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -86,7 +86,7 @@
     "bme680" = ps: with ps; [ ]; # missing inputs: bme680 smbus-cffi
     "bmw_connected_drive" = ps: with ps; [ ]; # missing inputs: bimmer_connected
     "bom" = ps: with ps; [ ]; # missing inputs: bomradarloop
-    "braviatv" = ps: with ps; [ getmac]; # missing inputs: bravia-tv
+    "braviatv" = ps: with ps; [ bravia-tv getmac];
     "broadlink" = ps: with ps; [ broadlink];
     "brother" = ps: with ps; [ ]; # missing inputs: brother
     "brottsplatskartan" = ps: with ps; [ ]; # missing inputs: brottsplatskartan

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -505,6 +505,8 @@ in {
 
   boltons = callPackage ../development/python-modules/boltons { };
 
+  bravia-tv = callPackage ../development/python-modules/bravia-tv { };
+
   braintree = callPackage ../development/python-modules/braintree { };
 
   breezy = callPackage ../development/python-modules/breezy { };


### PR DESCRIPTION
#### Motivation for this change

This introduces `pythonPackages.bravia_tv`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
