### PR TITLE
pythonPackages.getmac: init at 0.8.2

### DIFF
--- a/pkgs/development/python-modules/getmac/default.nix
+++ b/pkgs/development/python-modules/getmac/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, pytest, pytest-benchmark, pytest-mock }:
+
+buildPythonPackage rec {
+  pname = "getmac";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "GhostofGoes";
+    repo = "getmac";
+    rev = version;
+    sha256 = "08d4iv5bjl1s4i9qhzf3pzjgj1rgbwi0x26qypf3ycgdj0a6gvh2";
+  };
+
+  checkInputs = [ pytest pytest-benchmark pytest-mock ];
+  checkPhase = ''
+    pytest --ignore tests/test_cli.py
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/GhostofGoes/getmac";
+    description = "Pure-Python package to get the MAC address of network interfaces and hosts on the local network.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colemickens ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -690,6 +690,8 @@ in {
 
   geoip2 = callPackage ../development/python-modules/geoip2 { };
 
+  getmac = callPackage ../development/python-modules/getmac { };
+
   gidgethub = callPackage ../development/python-modules/gidgethub { };
 
   gin-config = callPackage ../development/python-modules/gin-config { };


### PR DESCRIPTION
###### Motivation for this change

This is needed by home-assistant when the braviatv component is used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
