### PR TITLE
h: init at 1.0.0

### DIFF
--- a/pkgs/tools/misc/h/default.nix
+++ b/pkgs/tools/misc/h/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper, ruby }:
+
 stdenv.mkDerivation rec {
   pname = "h";
   version = "1.0.0";

--- a/pkgs/tools/misc/h/default.nix
+++ b/pkgs/tools/misc/h/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, makeWrapper, ruby }:
+stdenv.mkDerivation rec {
+  pname = "h";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "zimbatm";
+    repo = "h";
+    rev = "v${version}";
+    hash = "sha256-chGrMtvLyyNtlM7PO1olVdkzkvMOk6OibHw+mqwVxIM=";
+  };
+
+  buildInputs = [ ruby ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp h $out/bin/h
+    cp up $out/bin/up
+  '';
+
+  meta = {
+    description = "faster shell navigation of projects";
+    homepage = "https://github.com/zimbatm/h";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.zimbatm ];
+  };
+}

--- a/pkgs/tools/misc/h/default.nix
+++ b/pkgs/tools/misc/h/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     cp up $out/bin/up
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "faster shell navigation of projects";
     homepage = "https://github.com/zimbatm/h";
     license = stdenv.lib.licenses.mit;

--- a/pkgs/tools/misc/h/default.nix
+++ b/pkgs/tools/misc/h/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     description = "faster shell navigation of projects";
     homepage = "https://github.com/zimbatm/h";
     license = licenses.mit;
-    maintainers = [ stdenv.lib.maintainers.zimbatm ];
+    maintainers = [ maintainers.zimbatm ];
   };
 }

--- a/pkgs/tools/misc/h/default.nix
+++ b/pkgs/tools/misc/h/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "faster shell navigation of projects";
     homepage = "https://github.com/zimbatm/h";
-    license = stdenv.lib.licenses.mit;
+    license = licenses.mit;
     maintainers = [ stdenv.lib.maintainers.zimbatm ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1585,6 +1585,8 @@ in
 
   direnv = callPackage ../tools/misc/direnv { };
 
+  h = callPackage ../tools/misc/h { };
+
   discount = callPackage ../tools/text/discount { };
 
   diskscan = callPackage ../tools/misc/diskscan { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

other people are using it: https://twitter.com/grhmc/status/1218711013757014019?s=20

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
