### PR TITLE
graphui: init at 1.1.1

### DIFF
--- a/pkgs/applications/graphics/graphui/default.nix
+++ b/pkgs/applications/graphics/graphui/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, vala
+, pkg-config
+, pantheon
+, python3
+, desktop-file-utils
+, glib
+, graphviz
+, gtk3
+, gtksourceview
+, libgee
+, substituteAll
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "graphui";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "artemanufrij";
+    repo = pname;
+    rev = version;
+    sha256 = "19r44rw0chvj7yrqf35rvpg1yziv25d43h392qnwbmifnq1kbfcs";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      graphviz = "${graphviz}/bin/";
+    })
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    vala
+    pkg-config
+    python3
+    desktop-file-utils
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    gtksourceview
+    graphviz
+    libgee
+    pantheon.granite
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  passthru = {
+    updateScript = pantheon.updateScript {
+      attrPath = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Graph visualization based on graphviz";
+    homepage = "https://github.com/artemanufrij/graphui";
+    maintainers = with maintainers; [ kjuvi ] ++ pantheon.maintainers;
+    platforms = platforms.linux;
+    license = licenses.lgpl2Plus;
+  };
+}
+  

--- a/pkgs/applications/graphics/graphui/fix-paths.patch
+++ b/pkgs/applications/graphics/graphui/fix-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Services/GraphViz.vala b/src/Services/GraphViz.vala
+index 213d4e5..192b8dd 100644
+--- a/src/Services/GraphViz.vala
++++ b/src/Services/GraphViz.vala
+@@ -76,7 +76,7 @@ namespace GraphUI.Services {
+             }
+             output_image = GraphUIApp.instance.CACHE_FOLDER + "/output.svg";
+ 
+-            string[] spawn_args = {format, "-T%s".printf (type), "%s".printf (output_txt), "-o", "%s".printf (output_image)};
++            string[] spawn_args = {"@graphviz@" + format, "-T%s".printf (type), "%s".printf (output_txt), "-o", "%s".printf (output_image)};
+             string[] spawn_env = Environ.get ();
+ 
+             string processout = "";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19333,6 +19333,8 @@ in
 
   graphicsmagick-imagemagick-compat = callPackage ../applications/graphics/graphicsmagick/compat.nix { };
 
+  graphui = callPackage ../applications/graphics/graphui/default.nix { };
+
   grisbi = callPackage ../applications/office/grisbi { gtk = gtk3; };
 
   gtkpod = callPackage ../applications/audio/gtkpod { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add more curated apps from Elementary OS app store for Pantheon Desktop.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
