### PR TITLE
corerad: 0.1.8 -> 0.1.9

### DIFF
--- a/nixos/tests/corerad.nix
+++ b/nixos/tests/corerad.nix
@@ -18,8 +18,7 @@ import ./make-test-python.nix (
               [[interfaces]]
               name = "eth1"
               send_advertisements = true
-                [[interfaces.plugins]]
-                name = "prefix"
+                [[interfaces.prefix]]
                 prefix = "::/64"
             '';
           };

--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "corerad";
-  version = "0.1.8";
+  version = "0.1.9";
 
   goPackagePath = "github.com/mdlayher/corerad";
 
@@ -10,10 +10,10 @@ buildGoModule rec {
     owner = "mdlayher";
     repo = "corerad";
     rev = "v${version}";
-    sha256 = "13js6p3svx2xp20yjpb5w71rnyrhiiqbbvsck45i756j1lndaqxr";
+    sha256 = "1m23f318qr6b8c7hxrhihrm09pmdwab988k3bn4ygfm49z5phy4s";
   };
 
-  modSha256 = "03x7r392bwchmd3jzwwykdfkr9lfdn77phfwh8xfk2avhzq7qs89";
+  modSha256 = "0idlpkn6krs77akn3p6gxsbc8zpj1rnjkhhwmb8ns98x82g6bln0";
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/mdlayher/corerad";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

CoreRAD v0.1.9 introduces a small change to the config format that also necessitates a minor change to the NixOS module test. I wasn't sure if it was preferred to do the dependent change in the same PR, or in a different one. Let me know either way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Both changes have been verified:

```
$ nix-build nixos/tests/corerad.nix
[...]
client: connected to guest root shell
client: (connecting took 0.00 seconds)
(0.17 seconds)
client: waiting for success: ping -c 1 fd00:dead:beef:dead::1
router # [   75.078734] corerad[741]: 2020/01/19 16:25:34 CoreRAD v0.1.9 (ALPHA) starting with configuration file "/nix/store/axjwfhk5iw9mk1dvrg87plivhb4kgrcd-corerad.toml"
router # [   75.167848] corerad[741]: 2020/01/19 16:25:34 eth1: "prefix": ::/64 [on-link, autonomous], preferred: 4h0m0s, valid: 24h0m0s
router # [   75.205786] corerad[741]: 2020/01/19 16:25:34 eth1: "lla": source link-layer address: 52:54:00:12:01:02
router # [   75.234719] corerad[741]: 2020/01/19 16:25:34 eth1: initialized, advertising from fe80::5054:ff:fe12:102
(11.57 seconds)
(91.23 seconds)
Verify SLAAC on client
client: waiting for success: rdisc6 -1 -r 10 eth1
(0.20 seconds)
client: waiting for success: ip -6 addr show dev eth1 | grep -q 'fd00:dead:beef:dead:'
(0.17 seconds)
client: must succeed: ip -6 addr show dev eth1
(0.04 seconds)
(0.41 seconds)
(92.72 seconds)
2 out of 2 tests succeeded
test script finished in 92.92s
cleaning up
killing client (pid 9)
killing router (pid 21)
(0.01 seconds)
/nix/store/raicncj37n0h2w28s4rpdng4if44bfgd-vm-test-run-unnamed
```

/cc @danderson
