### PR TITLE
pythonPackages.runway-python: 0.5.7 -> 0.5.9

### DIFF
--- a/pkgs/development/python-modules/flask-sockets/default.nix
+++ b/pkgs/development/python-modules/flask-sockets/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, flask
+, gevent
+, gevent-websocket
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-Sockets";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "072927da8edca0e81e024f5787e643c87d80b351b714de95d723becb30e0643b";
+  };
+
+  propagatedBuildInputs = [
+    flask
+    gevent
+    gevent-websocket
+  ];
+
+  # upstream doesn't have any tests, single file
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "flask_sockets"
+  ];
+
+  meta = with lib; {
+    description = "Elegant WebSockets for your Flask apps";
+    homepage = "https://github.com/heroku-python/flask-sockets";
+    license = licenses.mit;
+    maintainers = [ maintainers.prusnak ];
+  };
+}

--- a/pkgs/development/python-modules/runway-python/default.nix
+++ b/pkgs/development/python-modules/runway-python/default.nix
@@ -2,28 +2,37 @@
 , buildPythonPackage
 , fetchPypi
 , flask
+, flask-compress
 , flask-cors
+, flask-sockets
 , numpy
+, scipy
 , pillow
 , gevent
 , wget
 , six
 , colorcet
+, unidecode
+, urllib3
 }:
 
 buildPythonPackage rec {
   pname = "runway-python";
-  version = "0.5.7";
+  version = "0.5.9";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "06e0138cc4cf2ddb7304502f5c7b53269ce73679c5784c8d6b423db04d179c18";
+    sha256 = "1d75c44008275213034977c75bc2dc6f419e7f11d087984e3faea1e0cf6da69d";
   };
 
-  propagatedBuildInputs = [ flask flask-cors numpy pillow gevent wget six colorcet ];
+  propagatedBuildInputs = [ flask flask-compress flask-cors flask-sockets numpy scipy pillow gevent wget six colorcet unidecode urllib3 ];
 
   # tests are not packaged in the released tarball
   doCheck = false;
+
+  pythonImportsCheck = [
+    "runway"
+  ];
 
   meta = {
     description = "Helper library for creating Runway models";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3460,6 +3460,8 @@ in {
 
   flask-socketio = callPackage ../development/python-modules/flask-socketio { };
 
+  flask-sockets = callPackage ../development/python-modules/flask-sockets { };
+
   flask_sqlalchemy = callPackage ../development/python-modules/flask-sqlalchemy { };
 
   flask-swagger = callPackage ../development/python-modules/flask-swagger { };


### PR DESCRIPTION
#### Motivation for this change

Update to latest stable. Add new dependency Flask-Sockets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
