### PR TITLE
sfizz: init at unstable-2020-01-19

### DIFF
--- a/pkgs/applications/audio/sfizz/default.nix
+++ b/pkgs/applications/audio/sfizz/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub , cmake, libjack2, libsndfile }:
+
+stdenv.mkDerivation rec {
+  pname = "sfizz";
+  version = "unstable-2020-01-24";
+
+  src = fetchFromGitHub {
+    owner = "sfztools";
+    repo = pname;
+    rev = "b9c332777853cb35faeeda2ff4bf34ea7121ffb9";
+    sha256 = "0wzgwpcwal5a7ifrm1hx8y6vx832qixk9ilp8wkjnsdxj6i88p2c";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ libjack2 libsndfile ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DSFIZZ_TESTS=ON"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/sfztools/sfizz";
+    description = "SFZ jack client and LV2 plugin";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.all;
+    badPlatforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21260,6 +21260,8 @@ in
 
   setbfree = callPackage ../applications/audio/setbfree { };
 
+  sfizz = callPackage ../applications/audio/sfizz { };
+
   sfxr = callPackage ../applications/audio/sfxr { };
 
   sfxr-qt = libsForQt5.callPackage ../applications/audio/sfxr-qt { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
