### PR TITLE
zchunk: init at 1.1.5

### DIFF
--- a/pkgs/tools/compression/zchunk/default.nix
+++ b/pkgs/tools/compression/zchunk/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, fetchpatch, meson, ninja, pkgconfig, curl, openssl, zstd, argp-standalone }:
+
+stdenv.mkDerivation rec {
+  pname = "zchunk";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "13sqjslk634mkklnmzdlzk9l9rc6g6migig5rln3irdnjrxvjf69";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/void-linux/void-packages/5aa57003367c31a6ced50a0fa144a2a3bd71b045/srcpkgs/zchunk/patches/001-musl.patch";
+      sha256 = "0dzchagcw67c02ns796savyadbhmc484wfr6kayql1w7b0i25mdz";
+      extraPrefix = "";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/void-linux/void-packages/5aa57003367c31a6ced50a0fa144a2a3bd71b045/srcpkgs/zchunk/patches/002-musl.patch";
+      sha256 = "0f62q0cc144k9jd9lnf0b185szcl153gh9qg6jfximb46x99hvf4";
+      extraPrefix = "";
+    })
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs =  [ curl openssl zstd ]
+    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl argp-standalone;
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.hostPlatform.isMusl "-largp";
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Easy-to-delta, compressed file format";
+    license = licenses.bsd2;
+    homepage = "https://github.com/zchunk/zchunk";
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7534,6 +7534,8 @@ in
 
   zbar = libsForQt5.callPackage ../tools/graphics/zbar { };
 
+  zchunk = callPackage ../tools/compression/zchunk { };
+
   zdelta = callPackage ../tools/compression/zdelta { };
 
   zerotierone = callPackage ../tools/networking/zerotierone { };


### PR DESCRIPTION
###### Motivation for this change

From README.md:
> zchunk is a compressed file format that splits the file into independent chunks.
> This allows you to only download changed chunks when downloading a new version
> of the file, and also makes zchunk files efficient over rsync.
>  
> zchunk files are protected with strong checksums to verify that the file you
downloaded is, in fact, the file you wanted.

Especially neat is what looks like Fedora has adopted this (might still be under testing?)
for more efficient updating.

https://fedoraproject.org/wiki/Changes/Zchunk_Metadata

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).