### PR TITLE
librepo: 1.9.2 -> 1.11.2, zchunk

### DIFF
--- a/pkgs/tools/compression/zchunk/default.nix
+++ b/pkgs/tools/compression/zchunk/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, fetchpatch, meson, ninja, pkgconfig, curl, openssl, zstd, argp-standalone }:
+
+stdenv.mkDerivation rec {
+  pname = "zchunk";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "13sqjslk634mkklnmzdlzk9l9rc6g6migig5rln3irdnjrxvjf69";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/void-linux/void-packages/5aa57003367c31a6ced50a0fa144a2a3bd71b045/srcpkgs/zchunk/patches/001-musl.patch";
+      sha256 = "0dzchagcw67c02ns796savyadbhmc484wfr6kayql1w7b0i25mdz";
+      extraPrefix = "";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/void-linux/void-packages/5aa57003367c31a6ced50a0fa144a2a3bd71b045/srcpkgs/zchunk/patches/002-musl.patch";
+      sha256 = "0f62q0cc144k9jd9lnf0b185szcl153gh9qg6jfximb46x99hvf4";
+      extraPrefix = "";
+    })
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs =  [ curl openssl zstd ]
+    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl argp-standalone;
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.hostPlatform.isMusl "-largp";
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Easy-to-delta, compressed file format";
+    license = licenses.bsd2;
+    homepage = "https://github.com/zchunk/zchunk";
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/tools/package-management/librepo/default.nix
+++ b/pkgs/tools/package-management/librepo/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, fetchFromGitHub, cmake, python, pkgconfig, libxml2, glib, openssl, curl, check, gpgme }:
+{ stdenv, fetchFromGitHub, cmake, python, pkgconfig, libxml2, glib, openssl, curl, check, gpgme, zchunk }:
 
 stdenv.mkDerivation rec {
-  version = "1.9.2";
+  version = "1.11.2";
   pname = "librepo";
 
   src = fetchFromGitHub {
     owner  = "rpm-software-management";
     repo   = "librepo";
     rev    = version;
-    sha256 = "0xa9ng9mhpianhjy2a0jnj8ha1zckk2sz91y910daggm1qcv5asx";
+    sha256 = "0f04qky61dlh5h71xdmpngpy98cmlsfyp2pkyj5sbkplvrmh1wzw";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
   cmakeFlags = ["-DPYTHON_DESIRED=${stdenv.lib.substring 0 1 python.pythonVersion}" ];
 
-  buildInputs = [ python libxml2 glib openssl curl check gpgme ];
+  buildInputs = [ python libxml2 glib openssl curl check gpgme zchunk ];
 
   # librepo/fastestmirror.h includes curl/curl.h, and pkg-config specfile refers to others in here
   propagatedBuildInputs = [ curl gpgme libxml2 ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7534,6 +7534,8 @@ in
 
   zbar = libsForQt5.callPackage ../tools/graphics/zbar { };
 
+  zchunk = callPackage ../tools/compression/zchunk { };
+
   zdelta = callPackage ../tools/compression/zdelta { };
 
   zerotierone = callPackage ../tools/networking/zerotierone { };


### PR DESCRIPTION
###### Motivation for this change

Update librepo, now featuring zchunk support
which is packaged in ##78040 as it's expected
(didn't check if required or just optional but default on).

This PR includes commit from zchunk PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).