### PR TITLE
Pr scala out dir cleaned

### DIFF
--- a/pkgs/development/compilers/scala/2.11.nix
+++ b/pkgs/development/compilers/scala/2.11.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
     rm "bin/"*.bat
     mv * $out
 
+    # put docs in correct subdirectory
+    mkdir -p $out/share/doc
+    mv $out/doc $out/share/doc/${name}
+    mv $out/man $out/share/man
+
     for p in $(ls $out/bin/) ; do
       wrapProgram $out/bin/$p \
         --prefix PATH ":" ${coreutils}/bin \

--- a/pkgs/development/compilers/scala/2.12.nix
+++ b/pkgs/development/compilers/scala/2.12.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     # put docs in correct subdirectory
     mkdir -p $out/share/doc
     mv $out/doc $out/share/doc/scala
+    mv $out/{LICENSE,NOTICE} $out/share/doc/scala
 
     for p in $(ls $out/bin/) ; do
       wrapProgram $out/bin/$p \

--- a/pkgs/development/compilers/scala/2.13.nix
+++ b/pkgs/development/compilers/scala/2.13.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     # put docs in correct subdirectory
     mkdir -p $out/share/doc
     mv $out/doc $out/share/doc/scala
+    mv $out/{LICENSE,NOTICE} $out/share/doc/scala
 
     for p in $(ls $out/bin/) ; do
       wrapProgram $out/bin/$p \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The changed scala packages put text files like LICENCSE and NOTICE into their root directory.  They should not be there to avoid clashes between packages.

###### Things done

Changed the install phase of scala, scala_2_12, and scala_2_11 to move those files to $out/share/doc/scala. scala_2_10 is unchanged since it has way more files in $out which should not be there imho. And I am not sure where to put them. 

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
