### PR TITLE
pythonPackages.pycurl: Disable tests

### DIFF
--- a/pkgs/development/python-modules/pycurl/default.nix
+++ b/pkgs/development/python-modules/pycurl/default.nix
@@ -28,6 +28,10 @@ buildPythonPackage rec {
     curl
   ];
 
+  # Tests are very flakey, occasionally failing
+  # See https://github.com/NixOS/nixpkgs/issues/77304
+  doCheck = false;
+
   checkInputs = [
     bottle
     pytest


### PR DESCRIPTION
###### Motivation for this change
Tests are very flakey, disable them for now, fixes https://github.com/NixOS/nixpkgs/issues/77304

Ping @FRidh @costrouc 

###### Things done

- [x] Built `python{2,3}Packages.pycurl` successfully on NixOS