### PR TITLE
nixos/buildkite: add option to configure user, add nix-required packages to runtime, add test

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -52,8 +52,8 @@ in
       };
 
       runtimePackages = mkOption {
-        default = [ pkgs.bash pkgs.nix ];
-        defaultText = "[ pkgs.bash pkgs.nix ]";
+        default = [ pkgs.bash pkgs.gnutar pkgs.gzip pkgs.git pkgs.nix ];
+        defaultText = "[ pkgs.bash pkgs.gnutar pkgs.gzip pkgs.git pkgs.nix ]";
         description = "Add programs to the buildkite-agent environment";
         type = types.listOf types.package;
       };

--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -225,8 +225,8 @@ in
         in
           ''
             mkdir -m 0700 -p "${sshDir}"
-            cp -f "${toString cfg.openssh.privateKeyPath}" "${sshDir}/id_rsa"
-            chmod 600 "${sshDir}"/id_rsa*
+            cp -f "${toString cfg.privateSshKeyPath}" "${sshDir}/id_rsa"
+            chmod 600 "${sshDir}"/id_rsa
 
             cat > "${cfg.dataDir}/buildkite-agent.cfg" <<EOF
             token="$(cat ${toString cfg.tokenPath})"

--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -104,7 +104,8 @@ in
       };
 
       privateSshKeyPath = mkOption {
-        type = types.path;
+        type = types.nullOr types.path;
+        default = null;
         ## maximum care is taken so that secrets (ssh keys and the CI token)
         ## don't end up in the Nix store.
         apply = final: if final == null then null else toString final;
@@ -223,11 +224,11 @@ in
           sshDir = "${cfg.dataDir}/.ssh";
           tagStr = lib.concatStringsSep "," (lib.mapAttrsToList (name: value: "${name}=${value}") cfg.tags);
         in
-          ''
+          optionalString (cfg.privateSshKeyPath != null) ''
             mkdir -m 0700 -p "${sshDir}"
             cp -f "${toString cfg.privateSshKeyPath}" "${sshDir}/id_rsa"
             chmod 600 "${sshDir}"/id_rsa
-
+          '' + ''
             cat > "${cfg.dataDir}/buildkite-agent.cfg" <<EOF
             token="$(cat ${toString cfg.tokenPath})"
             name="${cfg.name}"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -33,6 +33,7 @@ in
   bind = handleTest ./bind.nix {};
   bittorrent = handleTest ./bittorrent.nix {};
   #blivet = handleTest ./blivet.nix {};   # broken since 2017-07024
+  buildkite-agent = handleTest ./buildkite-agent.nix {};
   boot = handleTestOn ["x86_64-linux"] ./boot.nix {}; # syslinux is unsupported on aarch64
   boot-stage1 = handleTest ./boot-stage1.nix {};
   borgbackup = handleTest ./borgbackup.nix {};

--- a/nixos/tests/buildkite-agent.nix
+++ b/nixos/tests/buildkite-agent.nix
@@ -1,0 +1,23 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+{
+  name = "buildkite-agent";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ flokli ];
+  };
+
+  machine = { pkgs, ... }: {
+    services.buildkite-agent = {
+      enable = true;
+      privateSshKeyPath = (import ./ssh-keys.nix pkgs).snakeOilPrivateKey;
+      tokenPath = (pkgs.writeText "my-token" "5678");
+    };
+  };
+
+  testScript = ''
+    # we can't wait on the unit to start up, as we obviously can't connect to buildkite,
+    # but we can look whether files are set up correctly
+    machine.wait_for_file("/var/lib/buildkite-agent/buildkite-agent.cfg")
+    machine.wait_for_file("/var/lib/buildkite-agent/.ssh/id_rsa")
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change
```
commit 933ca9d8216447a82b3bfa60852341cef31b7ce0
Author: Florian Klink <flokli@flokli.de>
Date:   Mon Jan 20 10:28:47 2020 +0100

    nixos/buildkite: make privateSshKeyPath optional
    
    When only cloning public repos, or when the ssh key is provided by
    different means, we don't need to manage it here.

commit a208e6eb994b997542528371ffa483c7deda98fe
Author: Florian Klink <flokli@flokli.de>
Date:   Sun Jan 19 21:50:52 2020 +0100

    nixosTests.buildkite: add test

commit 70308a7daf3e1d555de42f7bb557caa4fdd8b542
Author: Florian Klink <flokli@flokli.de>
Date:   Sun Jan 19 21:49:19 2020 +0100

    nixos/buildkite-agent: add gnutar, gzip and git to runtimePackages
    
    These are required for nix to do builtins.fetchTarball and
    builtins.fetchGit, so most likely we want them to be around.

commit 7838f0082491e1835221419b3adba0467a4446ce
Author: Florian Klink <flokli@flokli.de>
Date:   Sun Jan 19 21:48:59 2020 +0100

    nixos/buildkite: stop using deprecated option

commit 8c6b1c3eaaa8b555bddaced3ab6f02695bef1541
Author: Florian Klink <flokli@flokli.de>
Date:   Sun Jan 19 21:19:35 2020 +0100

    nixos/buildkite-agent: add "user" option
    
    This allows buildkite-agent to run as another user.
    
    It'll still run builds from /var/lib/buildkite-agent and setup things in
    there.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
