### PR TITLE
nixos/snapper: automatically create the .snapshots subvolume with correct permissions

### DIFF
--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -42,7 +42,7 @@ in
     };
 
     configs = mkOption {
-      default = { };
+      default = {};
       example = literalExample {
         home = {
           subvolume = "/home";
@@ -56,97 +56,109 @@ in
         Subvolume configuration
       '';
 
-      type = types.attrsOf (types.submodule {
-        options = {
-          subvolume = mkOption {
-            type = types.path;
-            description = ''
-              Path of the subvolume or mount point.
-              This path is a subvolume and has to contain a subvolume named
-              .snapshots.
-              See also man:snapper(8) section PERMISSIONS.
-            '';
-          };
+      type = types.attrsOf (
+        types.submodule {
+          options = {
+            subvolume = mkOption {
+              type = types.path;
+              description = ''
+                Path of the subvolume or mount point.
+                This path is a subvolume and has to contain a subvolume named
+                .snapshots.
+                See also man:snapper(8) section PERMISSIONS.
+              '';
+            };
 
-          fstype = mkOption {
-            type = types.enum [ "btrfs" ];
-            default = "btrfs";
-            description = ''
-              Filesystem type. Only btrfs is stable and tested.
-            '';
-          };
+            fstype = mkOption {
+              type = types.enum [ "btrfs" ];
+              default = "btrfs";
+              description = ''
+                Filesystem type. Only btrfs is stable and tested.
+              '';
+            };
 
-          extraConfig = mkOption {
-            type = types.lines;
-            default = "";
-            description = ''
-              Additional configuration next to SUBVOLUME and FSTYPE.
-              See man:snapper-configs(5).
-            '';
+            extraConfig = mkOption {
+              type = types.lines;
+              default = "";
+              description = ''
+                Additional configuration next to SUBVOLUME and FSTYPE.
+                See man:snapper-configs(5).
+              '';
+            };
           };
-        };
-      });
+        }
+      );
     };
   };
 
-  config = mkIf (cfg.configs != {}) (let
-    documentation = [ "man:snapper(8)" "man:snapper-configs(5)" ];
-  in {
+  config = mkIf (cfg.configs != {}) (
+    let
+      documentation = [ "man:snapper(8)" "man:snapper-configs(5)" ];
+    in
+      {
 
-    environment = {
+        environment = {
 
-      systemPackages = [ pkgs.snapper ];
+          systemPackages = [ pkgs.snapper ];
 
-      # Note: snapper/config-templates/default is only needed for create-config
-      #       which is not the NixOS way to configure.
-      etc = {
+          # Note: snapper/config-templates/default is only needed for create-config
+          #       which is not the NixOS way to configure.
+          etc = {
 
-        "sysconfig/snapper".text = ''
-          SNAPPER_CONFIGS="${lib.concatStringsSep " " (builtins.attrNames cfg.configs)}"
-        '';
+            "sysconfig/snapper".text = ''
+              SNAPPER_CONFIGS="${lib.concatStringsSep " " (builtins.attrNames cfg.configs)}"
+            '';
 
+          }
+          // (
+            mapAttrs' (
+              name: subvolume: nameValuePair "snapper/configs/${name}" (
+                {
+                  text = ''
+                    ${subvolume.extraConfig}
+                    FSTYPE="${subvolume.fstype}"
+                    SUBVOLUME="${subvolume.subvolume}"
+                  '';
+                }
+              )
+            ) cfg.configs
+          )
+          // (
+            lib.optionalAttrs (cfg.filters != null) {
+              "snapper/filters/default.txt".text = cfg.filters;
+            }
+          );
+
+        };
+
+        services.dbus.packages = [ pkgs.snapper ];
+
+        systemd.services.snapper-timeline = {
+          description = "Timeline of Snapper Snapshots";
+          inherit documentation;
+          serviceConfig.ExecStart = "${pkgs.snapper}/lib/snapper/systemd-helper --timeline";
+        };
+
+        systemd.timers.snapper-timeline = {
+          description = "Timeline of Snapper Snapshots";
+          inherit documentation;
+          wantedBy = [ "basic.target" ];
+          timerConfig.OnCalendar = cfg.snapshotInterval;
+        };
+
+        systemd.services.snapper-cleanup = {
+          description = "Cleanup of Snapper Snapshots";
+          inherit documentation;
+          serviceConfig.ExecStart = "${pkgs.snapper}/lib/snapper/systemd-helper --cleanup";
+        };
+
+        systemd.timers.snapper-cleanup = {
+          description = "Cleanup of Snapper Snapshots";
+          inherit documentation;
+          wantedBy = [ "basic.target" ];
+          timerConfig.OnBootSec = "10m";
+          timerConfig.OnUnitActiveSec = cfg.cleanupInterval;
+        };
       }
-      // (mapAttrs' (name: subvolume: nameValuePair "snapper/configs/${name}" ({
-        text = ''
-          ${subvolume.extraConfig}
-          FSTYPE="${subvolume.fstype}"
-          SUBVOLUME="${subvolume.subvolume}"
-        '';
-      })) cfg.configs)
-      // (lib.optionalAttrs (cfg.filters != null) {
-        "snapper/filters/default.txt".text = cfg.filters;
-      });
-
-    };
-
-    services.dbus.packages = [ pkgs.snapper ];
-
-    systemd.services.snapper-timeline = {
-      description = "Timeline of Snapper Snapshots";
-      inherit documentation;
-      serviceConfig.ExecStart = "${pkgs.snapper}/lib/snapper/systemd-helper --timeline";
-    };
-
-    systemd.timers.snapper-timeline = {
-      description = "Timeline of Snapper Snapshots";
-      inherit documentation;
-      wantedBy = [ "basic.target" ];
-      timerConfig.OnCalendar = cfg.snapshotInterval;
-    };
-
-    systemd.services.snapper-cleanup = {
-      description = "Cleanup of Snapper Snapshots";
-      inherit documentation;
-      serviceConfig.ExecStart = "${pkgs.snapper}/lib/snapper/systemd-helper --cleanup";
-    };
-
-    systemd.timers.snapper-cleanup = {
-      description = "Cleanup of Snapper Snapshots";
-      inherit documentation;
-      wantedBy = [ "basic.target" ];
-      timerConfig.OnBootSec = "10m";
-      timerConfig.OnUnitActiveSec = cfg.cleanupInterval;
-    };
-  });
+  );
 }
-

--- a/nixos/modules/services/misc/snapper.nix
+++ b/nixos/modules/services/misc/snapper.nix
@@ -63,9 +63,8 @@ in
               type = types.path;
               description = ''
                 Path of the subvolume or mount point.
-                This path is a subvolume and has to contain a subvolume named
-                .snapshots.
-                See also man:snapper(8) section PERMISSIONS.
+                A child subvolume with required permissions will be created at .snapshots
+                if it does not exist yet.
               '';
             };
 
@@ -77,11 +76,32 @@ in
               '';
             };
 
+            allowUsers = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              description = ''
+                List of users allowed to operate the configuration. root is always
+                implicitely contained in this list.
+                These users must have permissions to traverse directories up
+                to the specified subvolume.
+              '';
+            };
+
+            allowGroups = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              description = ''
+                List of groups allowed to operate the configuration.
+                These groups must have permissions to traverse directories up
+                to the specified subvolume.
+              '';
+            };
+
             extraConfig = mkOption {
               type = types.lines;
               default = "";
               description = ''
-                Additional configuration next to SUBVOLUME and FSTYPE.
+                Additional configuration next to SUBVOLUME, ALLOW_USERS, ALLOW_GROUPS, and FSTYPE.
                 See man:snapper-configs(5).
               '';
             };
@@ -118,6 +138,8 @@ in
                     ${subvolume.extraConfig}
                     FSTYPE="${subvolume.fstype}"
                     SUBVOLUME="${subvolume.subvolume}"
+                    ALLOW_USERS=${lib.concatStringsSep " " subvolume.allowUsers}
+                    ALLOW_GROUPS=${lib.concatStringsSep " " subvolume.allowGroups}
                   '';
                 }
               )
@@ -129,6 +151,22 @@ in
             }
           );
 
+        };
+
+        systemd.services.snapper-subvolume-setup = {
+          description = "Creates .snapshots subvolumes for Snapper Snapshots";
+          inherit documentation;
+          script = let
+            config = cfg: "v /.snapshots 0770 root root\n" + (
+              let
+                acl = lib.concatMapStringsSep "," (x: "${x}:r-x") ((map (u: "u:${u}") cfg.allowUsers) ++ (map (g: "g:${g}") cfg.allowGroups));
+              in
+                optionalString (acl != "") "a /.snapshots - - - - ${acl}"
+            );
+            cmd = cfg: "systemd-tmpfiles --create --root ${cfg.subvolume} ${builtins.toFile "snapper-subvolume-setup.conf" (config cfg)}";
+          in
+          lib.concatStringsSep "\n" (lib.mapAttrsToList (name: cfg: cmd cfg) cfg.configs);
+          wantedBy = [ "multi-user.target" ];
         };
 
         services.dbus.packages = [ pkgs.snapper ];


### PR DESCRIPTION
###### Motivation for this change

The configuration is declarative but still requires manual intervention to create `.snapshots`.

Only the second commit is interesting, the first one only runs nixpkgs-fmt.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
