### PR TITLE
rofi-mpd: 1.1.0 -> 2.0.0

### DIFF
--- a/pkgs/applications/audio/rofi-mpd/default.nix
+++ b/pkgs/applications/audio/rofi-mpd/default.nix
@@ -2,16 +2,16 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "rofi-mpd";
-  version = "1.1.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "JakeStanger";
     repo = "Rofi_MPD";
     rev = "v${version}";
-    sha256 = "0pdra1idgas3yl9z9v7b002igwg2c1mv0yw2ffb8rsbx88x4gbai";
+    sha256 = "0qn2jwvil5csp423r523wjbgwpb781li2bgaz1mby3prscrlz8mg";
   };
 
-  propagatedBuildInputs = with python3Packages; [ mutagen mpd2 ];
+  propagatedBuildInputs = with python3Packages; [ mutagen mpd2 toml appdirs ];
 
   # upstream doesn't contain a test suite
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

New major release of rofi-mpd https://github.com/JakeStanger/Rofi_MPD/releases/tag/v2.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
