### PR TITLE
platformio: 4.0.3 -> 4.1.0

### DIFF
--- a/pkgs/data/misc/spdx-license-list-data/default.nix
+++ b/pkgs/data/misc/spdx-license-list-data/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "spdx-license-list-data";
+  version = "3.7";
+
+  src = fetchFromGitHub {
+    owner = "spdx";
+    repo = "license-list-data";
+    rev = "v${version}";
+    sha256 = "1zll1d4apqh762iplzcm90v3yp3b36whc3vqx1vlmjgdrfss9jhn";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    install -vDt $out/json json/licenses.json
+  '';
+
+  meta = {
+    description = "Various data formats for the SPDX License List";
+    homepage = "https://github.com/spdx/license-list-data";
+    license = lib.licenses.cc0;
+  };
+}

--- a/pkgs/development/arduino/platformio/fix-searchpath.patch
+++ b/pkgs/development/arduino/platformio/fix-searchpath.patch
@@ -1,11 +1,13 @@
---- ./platformio/proc.py-old	2017-09-29 01:20:08.174548250 +0200
-+++ ./platformio/proc.py	2017-09-29 01:19:48.410485308 +0200
-@@ -164,7 +164,7 @@
-                 isdir(join(p, "click")) or isdir(join(p, "platformio")))
+diff --git a/platformio/proc.py b/platformio/proc.py
+index 80e50201..15cee5a5 100644
+--- a/platformio/proc.py
++++ b/platformio/proc.py
+@@ -167,7 +167,7 @@ def copy_pythonpath_to_osenv():
+             conditions.append(isdir(join(p, "click")) or isdir(join(p, "platformio")))
          if all(conditions):
              _PYTHONPATH.append(p)
--    os.environ['PYTHONPATH'] = os.pathsep.join(_PYTHONPATH)
-+    os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
+-    os.environ["PYTHONPATH"] = os.pathsep.join(_PYTHONPATH)
++    os.environ["PYTHONPATH"] = os.pathsep.join(sys.path)
  
  
- def get_serialports(filter_hwid=False):
+ def where_is_program(program, envpath=None):

--- a/pkgs/development/arduino/platformio/use-local-spdx-license-list.patch
+++ b/pkgs/development/arduino/platformio/use-local-spdx-license-list.patch
@@ -1,0 +1,16 @@
+diff --git a/platformio/package/manifest/schema.py b/platformio/package/manifest/schema.py
+index f1d68e08..9b7b1da8 100644
+--- a/platformio/package/manifest/schema.py
++++ b/platformio/package/manifest/schema.py
+@@ -174,9 +174,5 @@ class ManifestSchema(Schema):
+     @staticmethod
+     @memoized(expire="1h")
+     def load_spdx_licenses():
+-        r = requests.get(
+-            "https://raw.githubusercontent.com/spdx/license-list-data"
+-            "/v3.7/json/licenses.json"
+-        )
+-        r.raise_for_status()
+-        return r.json()
++        import json
++        return json.load(open("@SPDX_LICENSE_LIST_DATA@/json/licenses.json"))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17854,6 +17854,8 @@ in
 
   soundfont-fluid = callPackage ../data/soundfonts/fluid { };
 
+  spdx-license-list-data = callPackage ../data/misc/spdx-license-list-data { };
+
   stdmanpages = callPackage ../data/documentation/std-man-pages { };
 
   starship = callPackage ../tools/misc/starship {


### PR DESCRIPTION
###### Things done

- [x] Tested with esphome: Built some images and deployed to some ESPs.
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
