### PR TITLE
xss-lock: add patch to allow setting session

### DIFF
--- a/pkgs/misc/screensavers/xss-lock/default.nix
+++ b/pkgs/misc/screensavers/xss-lock/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchgit, cmake, docutils, pkgconfig, glib, libpthreadstubs
+{ stdenv, fetchFromGitHub, cmake, docutils, pkgconfig, glib, libpthreadstubs
 , libXau, libXdmcp, xcbutil }:
 
 stdenv.mkDerivation {
-  name = "xss-lock-git-2014-03-02";
+  name = "xss-lock-git-2018-05-31";
 
-  src = fetchgit {
-    url = https://bitbucket.org/raymonad/xss-lock.git;
-    rev = "1e158fb20108058dbd62bd51d8e8c003c0a48717";
-    sha256 = "10hx7k7ga8g08akwz8qrsvj8iqr5nd4siiva6sjx789jvf0sak7r";
+  src = fetchFromGitHub {
+    owner = "xdbob";
+    repo = "xss-lock";
+    rev = "cd0b89df9bac1880ea6ea830251c6b4492d505a5";
+    sha256 = "040nqgfh564frvqkrkmak3x3h0yadz6kzk81jkfvd9vd20a9drh7";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -17,7 +18,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "Use external locker (such as i3lock) as X screen saver";
     license = licenses.mit;
-    maintainers = with maintainers; [ malyn ];
+    maintainers = with maintainers; [ malyn offline ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

xss-lock uses current session that cannot be overriden. This prevents starting
xss-lock as systemd user service, as described here:
https://bitbucket.org/raymonad/xss-lock/issues/13/allow-operation-as-systemd-user-unit

This change adds additional patch that adds `--session` parameter. I decided not to use `fetchPatch`, as we do not want to depend on unofficial repos.

Thanks @xdbob for initial implementation here: https://github.com/xdbob/xss-lock

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
