### PR TITLE
pythonPackages.pyproj1: Added support for version 1.9.6

### DIFF
--- a/pkgs/development/python-modules/pyproj/1.9.6.nix
+++ b/pkgs/development/python-modules/pyproj/1.9.6.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, nose2
+, cython
+, proj ? null
+}:
+
+buildPythonPackage (rec {
+  pname = "pyproj";
+  version = "1.9.6";
+
+  src = fetchFromGitHub {
+    owner = "pyproj4";
+    repo = "pyproj";
+    rev = "v${version}rel";
+    sha256 = "sha256:18v4h7jx4mcc0x2xy8y7dfjq9bzsyxs8hdb6v67cabvlz2njziqy";
+  };
+
+  buildInputs = [ cython ];
+
+  checkInputs = [ nose2 ];
+
+  checkPhase = ''
+    runHook preCheck
+    pushd unittest  # changing directory should ensure we're importing the global pyproj
+    ${python.interpreter} test.py && ${python.interpreter} -c "import doctest, pyproj, sys; sys.exit(doctest.testmod(pyproj)[0])"
+    popd
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Python interface to PROJ.4 library";
+    homepage = https://github.com/pyproj4/pyproj;
+    license = with lib.licenses; [ isc ];
+  };
+} // (if proj == null then {} else { PROJ_DIR = proj; }))

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4851,6 +4851,8 @@ in {
 
   pyproj = callPackage ../development/python-modules/pyproj { };
 
+  pyproj1 = callPackage ../development/python-modules/pyproj/1.9.6.nix { proj = null;};
+
   pyqrcode = callPackage ../development/python-modules/pyqrcode { };
 
   pyrabbit2 = callPackage ../development/python-modules/pyrabbit2 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Structure for pyproj is very different from pyproj version 2 onwards, Some applications (e. g. Mapproxy) are still using old structure from pyrpoj (1.9.6). So with latest nixpkgs they doesn't work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
@CMCDragonkai @jonringer 