### PR TITLE
i3-layout-manager: unstable-2019-06-19 -> unstable-2019-12-06

### DIFF
--- a/pkgs/applications/window-managers/i3/layout-manager.nix
+++ b/pkgs/applications/window-managers/i3/layout-manager.nix
@@ -6,13 +6,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "i3-layout-manager";
-  version = "unstable-2019-06-19";
+  version = "unstable-2019-12-06";
 
   src = fetchFromGitHub {
     owner = "klaxalk";
     repo = pname;
-    rev = "80ade872bfd70d9c6039024097ceb8c852a2816a";
-    sha256 = "02xhyd737qwni628mjzr9i5v2kga5cq4k8m77bxm1p6kkj84nlmg";
+    rev = "064e13959413ba2d706185478a394e5852c0dc53";
+    sha256 = "1qm35sp1cfi3xj5j7xwa05dkb3353gwq4xh69ryc6382xx3wszg6";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
