### PR TITLE
morph: add openssh to PATH

### DIFF
--- a/pkgs/tools/package-management/morph/default.nix
+++ b/pkgs/tools/package-management/morph/default.nix
@@ -1,4 +1,4 @@
-{ buildGoPackage, fetchFromGitHub, go-bindata, lib }:
+{ buildGoPackage, fetchFromGitHub, go-bindata, openssh, makeWrapper, lib }:
 
 buildGoPackage rec {
   pname = "morph";
@@ -14,6 +14,7 @@ buildGoPackage rec {
   goPackagePath = "github.com/dbcdk/morph";
   goDeps = ./deps.nix;
 
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ go-bindata ];
 
   buildFlagsArray = ''
@@ -29,6 +30,7 @@ buildGoPackage rec {
   postInstall = ''
     mkdir -p $lib
     cp -v $src/data/*.nix $lib
+    wrapProgram $bin/bin/morph --prefix PATH : ${lib.makeBinPath [ openssh ]};
   '';
 
   outputs = [ "out" "bin" "lib" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes #78106

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
