### PR TITLE
home-assistant: add icloud support

### DIFF
--- a/pkgs/development/python-modules/pyicloud/default.nix
+++ b/pkgs/development/python-modules/pyicloud/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, keyring
+, keyrings-alt
+, click
+, six
+, tzlocal
+, certifi
+, bitstring
+, unittest2
+}:
+
+buildPythonPackage rec {
+  pname = "pyicloud";
+  version = "0.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "580b52e95f67a41ed86c56a514aa2b362f53fbaf23f16c69fb24e0d19fd373ee";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    keyring
+    keyrings-alt
+    click
+    six
+    tzlocal
+    certifi
+    bitstring
+  ];
+
+  checkInputs = [ unittest2 ];
+
+  postPatch = ''
+    sed -i \
+      -e 's!click>=6.0,<7.0!click!' \
+      -e 's!keyring>=8.0,<9.0!keyring!' \
+      -e 's!keyrings.alt>=1.0,<2.0!keyrings.alt!' \
+      requirements.txt
+  '';
+
+  meta = with lib; {
+    description = "PyiCloud is a module which allows pythonistas to interact with iCloud webservices";
+    homepage = https://github.com/picklepete/pyicloud;
+    license = licenses.mit;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/development/python-modules/snitun/default.nix
+++ b/pkgs/development/python-modules/snitun/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, python, fetchFromGitHub, attrs, cryptography, async-timeout, pytest-aiohttp, pytest }:
+{ lib, stdenv, buildPythonPackage, python, fetchFromGitHub, attrs, cryptography, async-timeout, pytest-aiohttp, pytest }:
 
 buildPythonPackage rec {
   pname = "snitun";
@@ -16,7 +16,8 @@ buildPythonPackage rec {
   checkInputs = [ pytest pytest-aiohttp ];
 
   checkPhase = ''
-    pytest tests/
+    # https://github.com/NabuCasa/snitun/issues/61
+    pytest ${lib.optionalString stdenv.isDarwin "-k 'not test_multiplexer_data_channel_abort_full'"} tests/
   '';
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -339,7 +339,7 @@
     "hyperion" = ps: with ps; [  ];
     "ialarm" = ps: with ps; [  ];
     "iaqualink" = ps: with ps; [  ];
-    "icloud" = ps: with ps; [  ];
+    "icloud" = ps: with ps; [ pyicloud ];
     "idteck_prox" = ps: with ps; [  ];
     "ifttt" = ps: with ps; [ aiohttp-cors pyfttt ];
     "iglo" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -944,6 +944,8 @@ in {
 
   pdfx = callPackage ../development/python-modules/pdfx { };
 
+  pyicloud = callPackage ../development/python-modules/pyicloud { };
+
   pyperf = callPackage ../development/python-modules/pyperf { };
 
   pefile = callPackage ../development/python-modules/pefile { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
