### PR TITLE
rofimoji: init

### DIFF
--- a/pkgs/applications/misc/rofimoji/default.nix
+++ b/pkgs/applications/misc/rofimoji/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, lib, fetchFromGitHub, rofi, xdotool
+, xsel, python3, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "rofimoji";
+  version = "unstable-2017-10-31";
+
+  src = fetchFromGitHub {
+    owner = "fdw";
+    repo = "rofimoji";
+    rev = "8c2278b29b0f982936027022cab37e67d0811144";
+    sha256 = "18h901i1pqs3n4y3pl3aj5n0j694xlwrxrk742qy0mggh9r4djnc";
+  };
+
+  dontBuild = true;
+
+  buildInputs = [ python3 ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -vD rofimoji.py $out/bin/rofimoji
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/rofimoji \
+      --prefix PATH : ${lib.makeBinPath [ xdotool xsel ]}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/fdw/rofimoji;
+    description = "A simple emoji picker for rofi";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wedens ];
+  };
+}

--- a/pkgs/applications/misc/rofimoji/default.nix
+++ b/pkgs/applications/misc/rofimoji/default.nix
@@ -3,34 +3,35 @@
 
 stdenv.mkDerivation rec {
   pname = "rofimoji";
-  version = "unstable-2017-10-31";
+  version = "unstable-2020-01-12";
 
   src = fetchFromGitHub {
     owner = "fdw";
     repo = "rofimoji";
-    rev = "8c2278b29b0f982936027022cab37e67d0811144";
-    sha256 = "18h901i1pqs3n4y3pl3aj5n0j694xlwrxrk742qy0mggh9r4djnc";
+    rev = "f211333bf90006c8742559a273e5eda26cf437ef";
+    sha256 = "1msx4clnrp9lzp0ap8rsdhhacynhfbi797vpjp93jj62sb08ahnc";
   };
 
   dontBuild = true;
 
-  buildInputs = [ python3 ];
-
-  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [
+    makeWrapper
+    (python3.withPackages (pkgs: with pkgs; [
+      ConfigArgParse
+      pyxdg
+    ]))
+  ];
 
   installPhase = ''
-    install -vD rofimoji.py $out/bin/rofimoji
-  '';
-
-  postInstall = ''
-    wrapProgram $out/bin/rofimoji \
-      --prefix PATH : ${lib.makeBinPath [ xdotool xsel ]}
+    cp . -R $out
+    makeWrapper $out/src/picker/rofimoji.py $out/bin/rofimoji \
+      --prefix PATH : ${lib.makeBinPath [ xdotool xsel rofi ]}
   '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/fdw/rofimoji;
     description = "A simple emoji picker for rofi";
     license = licenses.mit;
-    maintainers = with maintainers; [ wedens ];
+    maintainers = with maintainers; [ siers ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21172,6 +21172,8 @@ in
 
   rofi-menugen = callPackage ../applications/misc/rofi-menugen { };
 
+  rofimoji = callPackage ../applications/misc/rofimoji { };
+
   rofi-systemd = callPackage ../tools/system/rofi-systemd { };
 
   rootlesskit = callPackage ../tools/virtualization/rootlesskit {};


### PR DESCRIPTION
It seems to be working. It's a just couple of python scripts with CSVs inside.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
