### PR TITLE
fluidasserts: 20.1.22554 -> 20.1.28253

### DIFF
--- a/pkgs/development/python-modules/fluidasserts/default.nix
+++ b/pkgs/development/python-modules/fluidasserts/default.nix
@@ -57,13 +57,13 @@
 
 buildPythonPackage rec {
   pname = "fluidasserts";
-  version = "20.1.22554";
+  version = "20.1.28253";
   disabled = !isPy37;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    sha256 = "0j7zppwingi9m58z51phy40d69jlskx1vgyz1gj9miqhbjfdymhi";
+    sha256 = "1d2smx9ywd1azsiwgavp69vlixmvwaabshprm192wnmprbghsp6c";
   };
 
   patchPhase = ''
@@ -82,6 +82,7 @@ buildPythonPackage rec {
       --replace "'pymssql==2.1.4'," "" \
       --replace "'pytesseract==0.3.0'," "" \
       --replace "'pywinrm==0.4.1'," "" \
+      --replace "'mitmproxy==5.0.1'," "" \
 
   '';
 
@@ -145,34 +146,13 @@ buildPythonPackage rec {
     rm test/conftest.py
 
     pytest \
-      test/test_cloud_aws_cloudformation_cloudfront.py \
-      test/test_cloud_aws_cloudformation_dynamodb.py \
-      test/test_cloud_aws_cloudformation_ec2.py \
-      test/test_cloud_aws_cloudformation_elb.py \
-      test/test_cloud_aws_cloudformation_elb2.py \
-      test/test_cloud_aws_cloudformation_fsx.py \
-      test/test_cloud_aws_cloudformation_iam.py \
-      test/test_cloud_aws_cloudformation_kms.py \
-      test/test_cloud_aws_cloudformation_rds.py \
-      test/test_cloud_aws_cloudformation_s3.py \
-      test/test_cloud_aws_cloudformation_secretsmanager.py \
-      test/test_format_apk.py \
-      test/test_format_file.py \
-      test/test_format_jks.py \
-      test/test_format_jwt.py \
-      test/test_format_pdf.py \
-      test/test_format_pkcs12.py \
-      test/test_format_string.py \
-      test/test_helper_asynchronous.py \
-      test/test_helper_crypto.py \
-      test/test_lang_core.py \
-      test/test_lang_csharp.py \
-      test/test_lang_docker.py \
-      test/test_lang_dotnetconfig.py \
-      test/test_lang_html.py \
-      test/test_lang_php.py \
-      test/test_lang_python.py \
-      test/test_lang_rpgle.py \
+      test/test_cloud_aws_cloudformation_{cloudfront,dynamodb,ec2,elb,elb2}.py \
+      test/test_cloud_aws_cloudformation_{fsx,iam,kms,rds,s3,secretsmanager}.py \
+      test/test_format_{apk,file,jks,jwt,pdf,pkcs12,string}.py \
+      test/test_helper_{asynchronous,crypto}.py \
+      test/test_lang_{javascript,java}.py \
+      test/test_lang_{core,csharp,docker,dotnetconfig,html,php,python,rpgle}.py \
+      test/test_utils_generic.py
 
   '';
 


### PR DESCRIPTION
- bumps the fluidasserts version to 20.1.28253
- in this version the build process is deterministic and
  reproducible (you'll get the same hash on multiple builds)
- refactored the tests accordingly to a maintainer suggestion in last PR
- added many new tests :)
- see: https://gitlab.com/fluidattacks/asserts/issues/873

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Reproducible builds

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
