### PR TITLE
Upgrade duplicity to 0.8.09.

### DIFF
--- a/pkgs/tools/backup/duplicity/default.nix
+++ b/pkgs/tools/backup/duplicity/default.nix
@@ -1,49 +1,32 @@
-{ stdenv, fetchpatch, fetchurl, python2Packages, librsync, ncftp, gnupg
+{ stdenv, fetchpatch, fetchurl, python3Packages, librsync, ncftp, gnupg
 , gnutar
 , par2cmdline
 , utillinux
 , rsync
 , backblaze-b2, makeWrapper }:
 
-python2Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "duplicity";
-  version = "0.7.19";
+  version = "0.8.09";
 
   src = fetchurl {
     url = "https://code.launchpad.net/duplicity/${stdenv.lib.versions.majorMinor version}-series/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "0ag9dknslxlasslwfjhqgcqbkb1mvzzx93ry7lch2lfzcdd91am6";
+    sha256 = "01fixfn6b4wvkfdi9hh39kks4hk2nqkqnc8zzv4r49f0bkxcc42f";
   };
   patches = [
     ./gnutar-in-test.patch
     ./use-installed-scripts-in-test.patch
-
-    # The following patches improve the performance of installCheckPhase:
-    # Ensure all duplicity output is captured in tests
-    (fetchpatch {
-      extraPrefix = "";
-      sha256 = "07ay3mmnw8p2j3v8yvcpjsx0rf2jqly9ablwjpmry23dz9f0mxsd";
-      url = "https://bazaar.launchpad.net/~duplicity-team/duplicity/0.8-series/diff/1359.2.1";
-    })
-    # Minimize time spent sleeping between backups
-    (fetchpatch {
-      extraPrefix = "";
-      sha256 = "0v99q6mvikb8sf68gh3s0zg12pq8fijs87fv1qrvdnc8zvs4pmfs";
-      url = "https://bazaar.launchpad.net/~duplicity-team/duplicity/0.8-series/diff/1359.2.2";
-    })
-    # Remove unnecessary sleeping after running backups in tests
-    (fetchpatch {
-      extraPrefix = "";
-      sha256 = "1bmgp4ilq2gwz2k73fxrqplf866hj57lbyabaqpkvwxhr0ch1jiq";
-      url = "https://bazaar.launchpad.net/~duplicity-team/duplicity/0.8-series/diff/1359.2.3";
-    })
   ] ++ stdenv.lib.optionals stdenv.isLinux [
     ./linux-disable-timezone-test.patch
   ];
 
-  buildInputs = [ librsync makeWrapper python2Packages.wrapPython ];
-  propagatedBuildInputs = [ backblaze-b2 ] ++ (with python2Packages; [
-    boto cffi cryptography ecdsa enum idna pygobject3 fasteners
-    ipaddress lockfile paramiko pyasn1 pycrypto six pydrive
+  buildInputs = [ librsync makeWrapper python3Packages.wrapPython ];
+  propagatedBuildInputs = [ backblaze-b2 ] ++ (with python3Packages; [
+	  # see requirements.txt in tarball
+	  # basic
+		fasteners future mock requests urllib3 urllib3
+    # backends
+		boto boto3 dropbox gdata pydrive requests_oauthlib
   ]);
   checkInputs = [
     gnupg  # Add 'gpg' to PATH.
@@ -52,7 +35,7 @@ python2Packages.buildPythonApplication rec {
     par2cmdline  # Add 'par2' to PATH.
   ] ++ stdenv.lib.optionals stdenv.isLinux [
     utillinux  # Add 'setsid' to PATH.
-  ] ++ (with python2Packages; [ lockfile mock pexpect ]);
+  ] ++ (with python3Packages; [ coverage lockfile mock pexpect pytest pytestrunner ]);
 
   postInstall = ''
     wrapProgram $out/bin/duplicity \

--- a/pkgs/tools/backup/duplicity/gnutar-in-test.patch
+++ b/pkgs/tools/backup/duplicity/gnutar-in-test.patch
@@ -1,18 +1,18 @@
 --- a/testing/functional/test_restart.py
 +++ b/testing/functional/test_restart.py
-@@ -323,14 +323,7 @@ class RestartTestWithoutEncryption(RestartTest):
+@@ -345,14 +345,7 @@ class RestartTestWithoutEncryption(RestartTest):
          https://launchpad.net/bugs/929067
          """
 
--        if platform.system().startswith('Linux'):
--            tarcmd = "tar"
--        elif platform.system().startswith('Darwin'):
--            tarcmd = "gtar"
--        elif platform.system().endswith('BSD'):
--            tarcmd = "gtar"
+-        if platform.system().startswith(u'Linux'):
+-            tarcmd = u"tar"
+-        elif platform.system().startswith(u'Darwin'):
+-            tarcmd = u"gtar"
+-        elif platform.system().endswith(u'BSD'):
+-            tarcmd = u"gtar"
 -        else:
--            raise Exception("Platform %s not supported by tar/gtar." % platform.platform())
-+        tarcmd = "tar"
+-            raise Exception(u"Platform %s not supported by tar/gtar." % platform.platform())
++        tarcmd = u"tar"
 
          # Intial normal backup
          self.backup("full", "testfiles/blocktartest")

--- a/pkgs/tools/backup/duplicity/use-installed-scripts-in-test.patch
+++ b/pkgs/tools/backup/duplicity/use-installed-scripts-in-test.patch
@@ -1,13 +1,46 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -92,10 +92,6 @@ class TestCommand(test):
+@@ -100,10 +100,6 @@ class TestCommand(test):
                  except Exception:
                      pass
 
--        os.environ['PATH'] = "%s:%s" % (
+-        os.environ[u'PATH'] = u"%s:%s" % (
 -            os.path.abspath(build_scripts_cmd.build_dir),
--            os.environ.get('PATH'))
+-            os.environ.get(u'PATH'))
 -
          test.run(self)
 
      def run_tests(self):
+--- a/testing/functional/__init__.py
++++ b/testing/functional/__init__.py
+@@ -107,7 +107,7 @@
+         if basepython is not None:
+             cmd_list.extend([basepython])
+             cmd_list.extend([u"-m", u"coverage", u"run", u"--source=duplicity", u"-p"])
+-        cmd_list.extend([u"../bin/duplicity"])
++        cmd_list.extend([u"duplicity"])
+         cmd_list.extend(options)
+         cmd_list.extend([u"-v0"])
+         cmd_list.extend([u"--no-print-statistics"])
+--- a/testing/functional/test_log.py
++++ b/testing/functional/test_log.py
+@@ -47,7 +47,7 @@
+         if basepython is not None:
+             os.system(u"%s ../bin/duplicity --log-file=/tmp/duplicity.log >/dev/null 2>&1" % (basepython,))
+         else:
+-            os.system(u"../bin/duplicity --log-file=/tmp/duplicity.log >/dev/null 2>&1")
++            os.system(u"duplicity --log-file=/tmp/duplicity.log >/dev/null 2>&1")
+
+         # The format of the file should be:
+         # """ERROR 2
+--- a/testing/functional/test_rdiffdir.py
++++ b/testing/functional/test_rdiffdir.py
+@@ -38,7 +38,7 @@
+
+     def run_rdiffdir(self, argstring):
+         u"""Run rdiffdir with given arguments"""
+-        self.run_cmd(u"../bin/rdiffdir " + argstring)
++        self.run_cmd(u"rdiffdir " + argstring)
+
+     def run_cycle(self, dirname_list):
+         u"""Run diff/patch cycle on directories in dirname_list"""


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upgrade duplicity to 0.8.09 from 0.7.19.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
