### PR TITLE
nixos/transmission: Allow others to read the directory

### DIFF
--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -23,7 +23,8 @@ let
     for DIR in "${homeDir}" "${settingsDir}" "${fullSettings.download-dir}" "${fullSettings.incomplete-dir}"; do
       mkdir -p "$DIR"
     done
-    chmod 700 "${homeDir}" "${settingsDir}"
+    chmod 755 "${homeDir}"
+    chmod 700 "${settingsDir}"
     chmod ${downloadDirPermissions} "${fullSettings.download-dir}" "${fullSettings.incomplete-dir}"
     cp -f ${settingsFile} ${settingsDir}/settings.json
   '';


### PR DESCRIPTION
###### Motivation for this change
Directory mode 755 is standard for running services. Without this,
`downloadDirPermissions` can't work since other users can't even
look inside the main transmission directory

###### Things done
- [x] Checked that this indeed changes the directory permissions and allows e.g. users in the transmission group to access the download directory

Ping @dsg22 @wizeman @Lassulus 