### PR TITLE
b2sdk: Add b2sdk python module.

### DIFF
--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, mock, pyflakes, yapf, nose, arrow, logfury, requests, setuptools, six, tqdm}:
+
+buildPythonPackage rec {
+  pname = "b2sdk";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "143knykrlsdmk0748s4m7blp71r5n2bnk2gbsn72jlhn81zjyh0h";
+  };
+
+	postPatch = ''
+		sed 's/==\([0-9]\.\?\)\+//' -i requirements-test.txt
+	  substituteInPlace requirements-test.txt --replace "liccheck" ""
+  '';
+
+	checkInputs = [ mock pyflakes yapf nose ];
+	propagatedBuildInputs = [ arrow logfury requests setuptools six tqdm yapf ];
+
+  meta = with lib; {
+    homepage = https://github.com/Backblaze/b2-sdk-python;
+    description = "Python library to access B2 cloud storage.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sdier ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -466,6 +466,8 @@ in {
 
   azure-multiapi-storage = callPackage ../development/python-modules/azure-multiapi-storage { };
 
+	b2sdk = callPackage ../development/python-modules/b2sdk {};
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The B2 cli and duplicity applications should be depending on this instead of the current situation where B2 is exporting something like this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
