### PR TITLE
perl.withPackages: respect $PERL5LIB

### DIFF
--- a/pkgs/development/interpreters/perl/wrapper.nix
+++ b/pkgs/development/interpreters/perl/wrapper.nix
@@ -35,7 +35,7 @@ let
             if [ -f "$prg" ]; then
               rm -f "$out/bin/$prg"
               if [ -x "$prg" ]; then
-                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set PERL5LIB "$out/${perl.libPrefix}"
+                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --suffix PERL5LIB ':' "$out/${perl.libPrefix}"
               fi
             fi
           done


### PR DESCRIPTION
`perl.withPackages` did not allow to add more packages using `$PERL5LIB`

reported by @ljli at https://github.com/NixOS/nixpkgs/pull/77996#issuecomment-575985659