### PR TITLE
cinnamon.cinnamon-translations: init at 4.4.0

### DIFF
--- a/pkgs/desktops/cinnamon/cinnamon-translations/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-translations/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, fetchFromGitHub
+, gettext
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cinnamon-translations";
+  version = "4.4.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "0hh6shfj7vc1mw814l38cakfmh135ba8j604h1rmx4zwspwgvgzh";
+  };
+
+  nativeBuildInputs = [
+    gettext
+  ];
+
+  installPhase = ''
+    mv usr $out # files get installed like so: msgfmt -o usr/share/locale/$lang/LC_MESSAGES/$dir.mo $file
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/cinnamon-translations";
+    description = "Translations files for the Cinnamon desktop";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -3,6 +3,7 @@
 lib.makeScope pkgs.newScope (self: with self; {
   cinnamon-desktop = callPackage ./cinnamon-desktop { };
   cinnamon-menus = callPackage ./cinnamon-menus { };
+  cinnamon-translations = callPackage ./cinnamon-translations { };
   cjs = callPackage ./cjs { };
   xapps = callPackage ./xapps { };
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Needed for cinnamon port

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
