### PR TITLE
at-spi2-core: propagate glib and dbus

### DIFF
--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -30,7 +30,9 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection makeWrapper ];
-  buildInputs = [ dbus glib libX11 libXtst libXi ];
+  buildInputs = [ libX11 libXtst libXi ];
+  # In atspi-2.pc dbus-1 glib-2.0
+  propagatedBuildInputs = [ dbus glib ];
 
   doCheck = false; # fails with "AT-SPI: Couldn't connect to accessibility bus. Is at-spi-bus-launcher running?"
 


### PR DESCRIPTION
Both libraries are in the pkgconfig `Requires` field and are needed by
all downstream dependencies of this library.

Fell out of https://github.com/NixOS/nixpkgs/pull/78051