### PR TITLE
[RFC]: nixos/opendkim: umask, extraConfig options

### DIFF
--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -10,12 +10,15 @@ let
 
   keyFile = "${cfg.keyPath}/${cfg.selector}.private";
 
+  cfgCts = optionalString (cfg.umask != null) "UMask ${cfg.umask}\n"
+         + optionalString (cfg.extraConfig != null) cfg.extraConfig;
+
   args = [ "-f" "-l"
            "-p" cfg.socket
            "-d" cfg.domains
            "-k" keyFile
            "-s" cfg.selector
-         ] ++ optionals (cfg.configFile != null) [ "-x" cfg.configFile ];
+         ] ++ optionals (cfgCts != "") [ "-x" (pkgs.writeText "opendkim.conf" cfgCts)];
 
 in {
   imports = [
@@ -38,6 +41,12 @@ in {
         type = types.str;
         default = defaultSock;
         description = "Socket which is used for communication with OpenDKIM.";
+      };
+
+      umask = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Umask for socket";
       };
 
       user = mkOption {
@@ -76,8 +85,8 @@ in {
         description = "Selector to use when signing.";
       };
 
-      configFile = mkOption {
-        type = types.nullOr types.path;
+      extraConfig = mkOption {
+        type = types.nullOr types.lines;
         default = null;
         description = "Additional opendkim configuration.";
       };


### PR DESCRIPTION
Motivated by #27260 (by default opendkim creates a socket whose permissions do not allow postfix to talk to it), we add a umask option. Since this would clash with configFile, we change that to an extraConfig string which is merged with the umask option to create the actual config file.
This does not add any new functionality, but I think it is cleaner this way.

This has been running on my mailserver with no problems (indeed, the instantiated configuration of opendkim is the same as it was using configFile).

Obviously there is some debate to be had as to whether we want this patch.
If we do, I have a couple of questions to clear up before merging:
 - This removes the configFile option - does any deprecation need to happen?
 - What type should the umask option have?
