### PR TITLE
teleprompter: init at 2.3.4

### DIFF
--- a/pkgs/applications/misc/teleprompter/default.nix
+++ b/pkgs/applications/misc/teleprompter/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchurl, electron, makeDesktopItem, makeWrapper, nodePackages, autoPatchelfHook}:
+
+stdenv.mkDerivation rec {
+  pname = "teleprompter";
+  version = "2.3.4";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/teleprompter-imaginary-films/imaginary-${pname}-${version}-64bit.tar.gz";
+    sha256 = "084ml2l3qg46bsazaapyxdx4zavvxp0j4ycsdpdwk3f94g9xb120";
+  };
+
+  dontBuild = true;
+  dontStrip = true;
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper nodePackages.asar ];
+  installPhase = ''
+    mkdir -p $out/bin $out/opt/teleprompter $out/share/applications
+    asar e resources/app.asar $out/opt/teleprompter/resources/app.asar.unpacked
+    ln -s ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+  postFixup = ''
+    makeWrapper ${electron}/bin/electron $out/bin/teleprompter \
+      --add-flags "$out/opt/teleprompter/resources/app.asar.unpacked --without-update"
+  '';
+
+  desktopItem = makeDesktopItem {
+     name = "teleprompter";
+     exec = "teleprompter";
+     type = "Application";
+     desktopName = "Teleprompter";
+  };
+
+  meta = with lib; {
+    description = "The most complete, free, teleprompter app on the web";
+    license = [ licenses.gpl3 ];
+    homepage = "https://github.com/ImaginarySense/Teleprompter-Core";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Scriptkiddi ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21472,6 +21472,8 @@ in
 
   telepathy-idle = callPackage ../applications/networking/instant-messengers/telepathy/idle {};
 
+  teleprompter = callPackage ../applications/misc/teleprompter {};
+
   tendermint = callPackage ../tools/networking/tendermint {
     buildGoModule = buildGo112Module;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
