### PR TITLE
tsduck: init at 3.19-1520

### DIFF
--- a/pkgs/development/libraries/dtapi/default.nix
+++ b/pkgs/development/libraries/dtapi/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "dtapi";
+  version = "2020.08.0";
+
+  src = fetchurl {
+    url = "https://www.dektec.com/products/SDK/DTAPI/Downloads/LinuxSDK_v${version}.tar.gz";
+    sha256 = "jjO5PWzlDd4gsv1+bpQcawTU1srkJwxXnbscIcwoB2s=";
+  };
+
+  postPatch = ''
+    substituteInPlace DTAPI/Include/DTAPI.h --replace /usr/include/ ""
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cp License $out
+    cd DTAPI
+    cp -r Include/ Lib/ $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Dektec DTAPI for PCI, PCI Express cards and USB devices";
+    homepage = "https://www.dektec.com/downloads/SDK/";
+    license = with licenses; [ unfreeRedistributable ];
+    maintainers = with maintainers; [ Scriptkiddi ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/tools/video/tsduck/default.nix
+++ b/pkgs/tools/video/tsduck/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchFromGitHub, fetchurl, makeWrapper
+, dtapi, curl, linuxHeaders }:
+
+stdenv.mkDerivation rec {
+  pname = "tsduck";
+  version = "3.19-1520";
+
+  src = fetchFromGitHub {
+    owner = "tsduck";
+    repo = "tsduck";
+    rev = "v${version}";
+    sha256 = "1w7qq4hjk144dwqhfrkbf7qgz1i8pf8z8phyk9gwc4yd9i5rx8an";
+  };
+
+  postPatch = ''
+    patchShebangs .
+
+    # Provide patched dtapi
+    mkdir -p dektec/LinuxSDK/DTAPI
+    cp -r ${dtapi}/* dektec/LinuxSDK/DTAPI/
+
+    # Disable automatic downloading or unpacking of dtapi
+    sed -i 's/^dtapi:.*/dtapi:/g' dektec/Makefile
+  '';
+
+  buildInputs = [ curl linuxHeaders ];
+  nativeBuildInputs = [ curl makeWrapper ]; # Makefile calls curl-config
+
+  makeFlags = [
+    # Disable smartcard support, removes pcsc-lite dependency
+    "NOPCSC=1"
+    # Yes, it will not find it otherwise
+    "LDFLAGS_EXTRA=${dtapi}/Lib/GCC5.1_CXX11_ABI1/DTAPI64.o"
+  ];
+
+  installFlags = [ "SYSROOT=$(out)" ];
+
+  postInstall = ''
+    # Some LSB stuff
+    rm -r $out/etc/security
+
+    # /usr
+    mv $out/usr/* $out
+    rmdir $out/usr
+
+    # non-executables in bin
+    mkdir $out/lib
+    mv $out/bin/*.so $out/bin/*.xml $out/bin/*.names $out/lib
+
+    # Wrap to add lib to search path
+    for prog in $out/bin/*; do
+      wrapProgram "$prog" \
+        --prefix LD_LIBRARY_PATH : "$out/lib" \
+        --prefix TSPLUGINS_PATH : "$out/lib"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An extensible toolkit for MPEG/DVB transport streams";
+    homepage = "https://tsduck.io/";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ Scriptkiddi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3427,6 +3427,8 @@ in
 
   buildEmscriptenPackage = callPackage ../development/em-modules/generic { };
 
+  dtapi = callPackage ../development/libraries/dtapi { };
+
   carp = callPackage ../development/compilers/carp { };
 
   cholmod-extra = callPackage ../development/libraries/science/math/cholmod-extra { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3380,6 +3380,8 @@ in
 
   trompeloeil = callPackage ../development/libraries/trompeloeil { };
 
+  tsduck = callPackage ../tools/video/tsduck { };
+
   uudeview = callPackage ../tools/misc/uudeview { };
 
   uutils-coreutils = callPackage ../tools/misc/uutils-coreutils {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Wanted to test video stream
@dasJ 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
