### PR TITLE
pymetno: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/pymetno/default.nix
+++ b/pkgs/development/python-modules/pymetno/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, aiohttp
+, async-timeout
+, pytz
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "PyMetno";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "Danielhiversen";
+    rev = version;
+    sha256 = "00v2r3nn48svni9rbmbf0a4ylgfcf93gk2wg7qnm1fv1qrkgscvg";
+  };
+
+  propagatedBuildInputs = [ aiohttp async-timeout pytz xmltodict ];
+
+  pythonImportsCheck = [ "metno"];
+
+  meta = with stdenv.lib; {
+    description = "A library to communicate with the met.no api";
+    homepage = https://github.com/Danielhiversen/pyMetno/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ flyfloh ];
+  };
+}

--- a/pkgs/development/python-modules/pymetno/default.nix
+++ b/pkgs/development/python-modules/pymetno/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "A library to communicate with the met.no api";
-    homepage = https://github.com/Danielhiversen/pyMetno/;
+    homepage = "https://github.com/Danielhiversen/pyMetno/";
     license = licenses.mit;
     maintainers = with maintainers; [ flyfloh ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7068,6 +7068,8 @@ in {
 
   pybotvac = callPackage ../development/python-modules/pybotvac { };
 
+  pymetno = callPackage ../development/python-modules/pymetno { };
+
   pytado = callPackage ../development/python-modules/pytado { };
 
   casttube = callPackage ../development/python-modules/casttube { };


### PR DESCRIPTION
Another library used by Home-Assistant. This one is for talking to the met.no service and getting the weather.

It seems the tests for `aiohttp` break when building this for python 3.8, but it works for 3.6 and 3.7.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
