### PR TITLE
nixos/lib: Inherit type for doRename options

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -764,12 +764,15 @@ rec {
       fromOpt = getAttrFromPath from options;
       toOf = attrByPath to
         (abort "Renaming error: option `${showOption to}' does not exist.");
+      toType = let opt = attrByPath to {} options; in opt.type or null;
     in
     {
       options = setAttrByPath from (mkOption {
         inherit visible;
         description = "Alias of <option>${showOption to}</option>.";
         apply = x: use (toOf config);
+      } // optionalAttrs (toType != null) {
+        type = toType;
       });
       config = mkMerge [
         {


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/76670 with my suggestion

Ping @dasJ 

###### Things done

- [x] Checked that the manual builds and displays all renamed options with their appropriate type