### PR TITLE
nixos/buildkite-agent: set StateDirectory=buildkite-agent, extend vm test

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -243,6 +243,7 @@ in
         serviceConfig =
           { ExecStart = "${cfg.package}/bin/buildkite-agent start --config /var/lib/buildkite-agent/buildkite-agent.cfg";
             User = cfg.user;
+            StateDirectory = "buildkite-agent";
             RestartSec = 5;
             Restart = "on-failure";
             TimeoutSec = 10;

--- a/nixos/tests/buildkite-agent.nix
+++ b/nixos/tests/buildkite-agent.nix
@@ -6,18 +6,39 @@ import ./make-test-python.nix ({ pkgs, ... }:
     maintainers = [ flokli ];
   };
 
-  machine = { pkgs, ... }: {
-    services.buildkite-agent = {
-      enable = true;
-      privateSshKeyPath = (import ./ssh-keys.nix pkgs).snakeOilPrivateKey;
-      tokenPath = (pkgs.writeText "my-token" "5678");
+  nodes = {
+    node1 = { pkgs, ... }: {
+      services.buildkite-agent = {
+        enable = true;
+        privateSshKeyPath = (import ./ssh-keys.nix pkgs).snakeOilPrivateKey;
+        tokenPath = (pkgs.writeText "my-token" "5678");
+      };
+    };
+    # don't configure ssh key, run as a separate user
+    node2 = { pkgs, ...}: {
+      services.buildkite-agent = {
+        enable = true;
+        tokenPath = (pkgs.writeText "my-token" "1234");
+        user = "ci";
+      };
+      users.users."ci" = {
+        createHome = true;
+        home = "/var/lib/ci";
+        useDefaultShell = true;
+      };
     };
   };
 
   testScript = ''
+    start_all()
     # we can't wait on the unit to start up, as we obviously can't connect to buildkite,
     # but we can look whether files are set up correctly
-    machine.wait_for_file("/var/lib/buildkite-agent/buildkite-agent.cfg")
-    machine.wait_for_file("/var/lib/buildkite-agent/.ssh/id_rsa")
+
+    node1.wait_for_file("/var/lib/buildkite-agent/buildkite-agent.cfg")
+    node1.wait_for_file("/var/lib/buildkite-agent/.ssh/id_rsa")
+
+    # node2 should still assemble the config inside /var/lib/buildkite-agent,
+    # even though it's running as a different user
+    node2.wait_for_file("/var/lib/buildkite-agent/buildkite-agent.cfg")
   '';
 })


### PR DESCRIPTION
We run buildkite from inside /var/lib/buildkite-agent, and do some setup
at runtime (as we need to assemble the config file containing secrets at
runtime).

We did rely on rely on users.users."buildkite-agent".createHome to set
up that directory.

However, when configuring another user to run buildkite as
(by services.buildkite-agent.user), this directory doesn't exist
automatically.

Let's not require the user to set it up, instead just use
`StateDirectory=buildkite-agent` unconditionally to create it.

Also, extend the VM test to create a second runner, running as a different user, and having no ssh key configured.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
