### PR TITLE
sta: init at 2016-01-25

### DIFF
--- a/pkgs/tools/misc/sta/default.nix
+++ b/pkgs/tools/misc/sta/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook }:
+stdenv.mkDerivation {
+  pname = "sta";
+  version = "unstable-2016-01-25";
+
+  src = fetchFromGitHub {
+    owner = "simonccarter";
+    repo = "sta";
+    rev = "2aa2a6035dde88b24978b875e4c45e0e296f77ed";
+    sha256 = "05804f106nb89yvdd0csvpd5skwvnr9x4qr3maqzaw0qr055mrsk";
+  };
+
+  buildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
+    description = "Simple statistics from the command line interface (CLI), fast";
+    longDescription = ''
+      This is a lightweight, fast tool for calculating basic descriptive
+      statistics from the command line. Inspired by
+      https://github.com/nferraz/st, this project differs in that it is written
+      in C++, allowing for faster computation of statistics given larger
+      non-trivial data sets.
+    '';
+    license = licenses.mit;
+    homepage = "https://github.com/simonccarter/sta";
+    maintainers = with maintainers; [ infinisil ];
+    platforms = platforms.all;
+    badPlatforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5103,6 +5103,8 @@ in
 
   multitime = callPackage ../tools/misc/multitime { };
 
+  sta = callPackage ../tools/misc/sta {};
+
   multitran = recurseIntoAttrs (let callPackage = newScope pkgs.multitran; in {
     multitrandata = callPackage ../tools/text/multitran/data { };
 


### PR DESCRIPTION
###### Motivation for this change
Adds [sta](https://github.com/simonccarter/sta), which allows easy calculation of stats with the CLI, e.g.
```
$ cat /dev/random | tr -cd '[:digit:]\n' | head | cut -b-4 | sta
N	min	max	sum	mean	sd	sderr	
9	2	8793	31871	3541.22	3455.11	1151.7
```

###### Things done

- [x] Built and tested on Linux
