### PR TITLE
pam_gnupg: init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5893,6 +5893,12 @@
     githubId = 2176611;
     name = "Marko Poikonen";
   };
+  mtreca = {
+    email = "maxime@treca.dev";
+    name = "Maxime Tréca";
+    github = "mtreca";
+    githubId = 16440823;
+  };
   mtreskin = {
     email = "zerthurd@gmail.com";
     github = "Zert";

--- a/pkgs/os-specific/linux/pam_gnupg/default.nix
+++ b/pkgs/os-specific/linux/pam_gnupg/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pam, gnupg }:
+
+stdenv.mkDerivation rec {
+  pname = "pam_gnupg";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "cruegge";
+    repo = "pam-gnupg";
+    rev = "v${version}";
+    sha256 = "0b70mazyvcbg6xyqllm62rwhbz0y94pcy202db1qyy4w8466bhsw";
+  };
+
+  configureFlags = [
+    "--with-moduledir=${placeholder "out"}/lib/security"
+  ];
+
+  buildInputs = [ pam gnupg ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    description = "Unlock GnuPG keys on login";
+    longDescription = ''
+      A PAM module that hands over your login password to gpg-agent. This can
+      be useful if you are using a GnuPG-based password manager like pass.
+    '';
+    homepage = "https://github.com/cruegge/pam-gnupg";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ mtreca ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18226,6 +18226,8 @@ in
 
   pam_ccreds = callPackage ../os-specific/linux/pam_ccreds { };
 
+  pam_gnupg = callPackage ../os-specific/linux/pam_gnupg { };
+
   pam_krb5 = callPackage ../os-specific/linux/pam_krb5 { };
 
   pam_ldap = callPackage ../os-specific/linux/pam_ldap { };


### PR DESCRIPTION
###### Motivation for this change

Add the pam_gnupg module that unlocks gnupg keys on login.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
