### PR TITLE
cinnamon.cinnamon-settings-daemon: init at 4.4.0

### DIFF
--- a/pkgs/desktops/cinnamon/cinnamon-settings-daemon/csd-backlight-helper-fix.patch
+++ b/pkgs/desktops/cinnamon/cinnamon-settings-daemon/csd-backlight-helper-fix.patch
@@ -1,0 +1,48 @@
+From 6d71bf9764fb81d437678a603826167850bbf453 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Maciej=20Kr=C3=BCger?= <mkg20001@gmail.com>
+Date: Tue, 21 Jan 2020 03:19:28 +0100
+Subject: [PATCH] fix: use an impure path to csd-backlight-helper to fix
+ policy-reload bug
+
+---
+ plugins/power/csd-power-manager.c                             | 4 ++--
+ .../org.cinnamon.settings-daemon.plugins.power.policy.in.in   | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/plugins/power/csd-power-manager.c b/plugins/power/csd-power-manager.c
+index b24c456..212c47e 100755
+--- a/plugins/power/csd-power-manager.c
++++ b/plugins/power/csd-power-manager.c
+@@ -2519,7 +2519,7 @@ backlight_helper_get_value (const gchar *argument, CsdPowerManager* manager,
+ #endif
+
+         /* get the data */
+-        command = g_strdup_printf (LIBEXECDIR "/csd-backlight-helper --%s %s",
++        command = g_strdup_printf ("/run/current-system/sw/bin/cinnamon-settings-daemon/csd-backlight-helper --%s %s",
+                                    argument,
+                                    manager->priv->backlight_helper_preference_args);
+         ret = g_spawn_command_line_sync (command,
+@@ -2609,7 +2609,7 @@ backlight_helper_set_value (const gchar *argument,
+ #endif
+
+         /* get the data */
+-        command = g_strdup_printf ("pkexec " LIBEXECDIR "/csd-backlight-helper --%s %i %s",
++        command = g_strdup_printf ("pkexec " "/run/current-system/sw/bin/cinnamon-settings-daemon/csd-backlight-helper --%s %i %s",
+                                    argument, value,
+                                    manager->priv->backlight_helper_preference_args);
+         ret = g_spawn_command_line_sync (command,
+diff --git a/plugins/power/org.cinnamon.settings-daemon.plugins.power.policy.in.in b/plugins/power/org.cinnamon.settings-daemon.plugins.power.policy.in.in
+index 2c44e62..c0a2348 100755
+--- a/plugins/power/org.cinnamon.settings-daemon.plugins.power.policy.in.in
++++ b/plugins/power/org.cinnamon.settings-daemon.plugins.power.policy.in.in
+@@ -25,7 +25,7 @@
+       <allow_inactive>no</allow_inactive>
+       <allow_active>yes</allow_active>
+     </defaults>
+-    <annotate key="org.freedesktop.policykit.exec.path">@libexecdir@/csd-backlight-helper</annotate>
++    <annotate key="org.freedesktop.policykit.exec.path">/run/current-system/sw/bin/cinnamon-settings-daemon/csd-backlight-helper</annotate>
+   </action>
+
+ </policyconfig>
+--
+2.24.1

--- a/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
+++ b/pkgs/desktops/cinnamon/cinnamon-settings-daemon/default.nix
@@ -1,0 +1,111 @@
+{ fetchFromGitHub
+, autoconf-archive
+, autoreconfHook
+, cinnamon-desktop
+, colord
+, glib
+, gsettings-desktop-schemas
+, gtk3
+, intltool
+, lcms2
+, libcanberra-gtk3
+, libgnomekbd
+, libnotify
+, libxklavier
+, wrapGAppsHook
+, pkgconfig
+, pulseaudio
+, stdenv
+, systemd
+, upower
+, dconf
+, cups
+, polkit
+, librsvg
+, libwacom
+, xf86_input_wacom
+, xorg
+, fontconfig
+, tzdata
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cinnamon-settings-daemon";
+  version = "4.4.0";
+
+  /* csd-power-manager.c:50:10: fatal error: csd-power-proxy.h: No such file or directory
+   #include "csd-power-proxy.h"
+            ^~~~~~~~~~~~~~~~~~~
+  compilation terminated. */
+
+  # but this occurs only sometimes, so disabling parallel building
+  # also see https://github.com/linuxmint/cinnamon-settings-daemon/issues/248
+  enableParallelBuilding = false;
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = pname;
+    rev = version;
+    sha256 = "1h74d68a7hx85vv6ak26b85jq0wr56ps9rzfvqsnxwk81zxw2n7q";
+  };
+
+  patches = [
+    ./csd-backlight-helper-fix.patch
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0"; # TODO: https://github.com/NixOS/nixpkgs/issues/36468
+
+  buildInputs = [
+    cinnamon-desktop
+    colord
+    gtk3
+    glib
+    gsettings-desktop-schemas
+    lcms2
+    libcanberra-gtk3
+    libgnomekbd
+    libnotify
+    libxklavier
+    pulseaudio
+    systemd
+    upower
+    dconf
+    cups
+    polkit
+    librsvg
+    libwacom
+    xf86_input_wacom
+    xorg.libXext
+    xorg.libX11
+    xorg.libXi
+    xorg.libXtst
+    xorg.libXfixes
+    fontconfig
+  ];
+
+  nativeBuildInputs = [
+    autoconf-archive
+    autoreconfHook
+    wrapGAppsHook
+    intltool
+    pkgconfig
+  ];
+
+  postPatch = ''
+    sed "s|/usr/share/zoneinfo|${tzdata}/share/zoneinfo|g" -i plugins/datetime/system-timezone.h
+  '';
+
+  # So the polkit policy can reference /run/current-system/sw/bin/cinnamon-settings-daemon/csd-backlight-helper
+  postFixup = ''
+    mkdir -p $out/bin/cinnamon-settings-daemon
+    ln -s $out/libexec/csd-backlight-helper $out/bin/cinnamon-settings-daemon/csd-backlight-helper
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/linuxmint/cinnamon-settings-daemon";
+    description = "The settings daemon for the Cinnamon desktop";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mkg20001 ];
+  };
+}

--- a/pkgs/desktops/cinnamon/default.nix
+++ b/pkgs/desktops/cinnamon/default.nix
@@ -4,6 +4,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   cinnamon-desktop = callPackage ./cinnamon-desktop { };
   cinnamon-menus = callPackage ./cinnamon-menus { };
   cinnamon-translations = callPackage ./cinnamon-translations { };
+  cinnamon-settings-daemon = callPackage ./cinnamon-settings-daemon { };
   cjs = callPackage ./cjs { };
   xapps = callPackage ./xapps { };
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Cinnamon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
