### PR TITLE
pythonPackages.pyparsing: improve tests

### DIFF
--- a/pkgs/development/python-modules/pyparsing/default.nix
+++ b/pkgs/development/python-modules/pyparsing/default.nix
@@ -1,19 +1,35 @@
-{ stdenv, buildPythonPackage, fetchPypi }:
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+
+# pythonPackages
+, coverage
+}:
+
 buildPythonPackage rec {
-    pname = "pyparsing";
-    version = "2.4.6";
+  pname = "pyparsing";
+  version = "2.4.6";
 
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f";
-    };
+  src = fetchFromGitHub {
+    owner = "pyparsing";
+    repo = pname;
+    rev = "pyparsing_${version}";
+    sha256 = "1fh7s3cfr274pd6hh6zygl99842rqws98an2nkrrqj2spb9ldxcm";
+  };
 
-    # Not everything necessary to run the tests is included in the distribution
-    doCheck = false;
+  # https://github.com/pyparsing/pyparsing/blob/847af590154743bae61a32c3dc1a6c2a19009f42/tox.ini#L6
+  checkInputs = [ coverage ];
+  checkPhase = ''
+    coverage run --branch simple_unit_tests.py
+    coverage run --branch unitTests.py
+  '';
 
-    meta = with stdenv.lib; {
-      homepage = https://pyparsing.wikispaces.com/;
-      description = "An alternative approach to creating and executing simple grammars, vs. the traditional lex/yacc approach, or the use of regular expressions";
-      license = licenses.mit;
-    };
+  meta = with lib; {
+    homepage = "https://github.com/pyparsing/pyparsing";
+    description = "An alternative approach to creating and executing simple grammars, vs. the traditional lex/yacc approach, or the use of regular expressions";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      kamadorueda
+    ];
+  };
 }


### PR DESCRIPTION
- Fetch pyparsing from GitHub instead of PyPi
- Add tests

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A back-bone of many packages like pyparsing needs to be tested

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
