### PR TITLE
lispPackages: add serapeum

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-extras.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-extras.nix
@@ -1,0 +1,39 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''fare-quasiquote-extras'';
+  version = ''fare-quasiquote-20190521-git'';
+
+  description = ''fare-quasiquote plus extras'';
+
+  deps = [ args."alexandria" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."named-readtables" args."optima" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/fare-quasiquote/2019-05-21/fare-quasiquote-20190521-git.tgz'';
+    sha256 = ''1skrj68dnmihckip1vyc31xysbdsw9ihb7imks73cickkvv6yjfj'';
+  };
+
+  packageName = "fare-quasiquote-extras";
+
+  asdFilesToKeep = ["fare-quasiquote-extras.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM fare-quasiquote-extras DESCRIPTION fare-quasiquote plus extras
+    SHA256 1skrj68dnmihckip1vyc31xysbdsw9ihb7imks73cickkvv6yjfj URL
+    http://beta.quicklisp.org/archive/fare-quasiquote/2019-05-21/fare-quasiquote-20190521-git.tgz
+    MD5 e08c24d35a485a74642bd0c7c06662d6 NAME fare-quasiquote-extras FILENAME
+    fare-quasiquote-extras DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME fare-quasiquote FILENAME fare-quasiquote)
+     (NAME fare-quasiquote-optima FILENAME fare-quasiquote-optima)
+     (NAME fare-quasiquote-readtable FILENAME fare-quasiquote-readtable)
+     (NAME fare-utils FILENAME fare-utils)
+     (NAME named-readtables FILENAME named-readtables)
+     (NAME optima FILENAME optima))
+    DEPENDENCIES
+    (alexandria closer-mop fare-quasiquote fare-quasiquote-optima
+     fare-quasiquote-readtable fare-utils named-readtables optima)
+    VERSION fare-quasiquote-20190521-git SIBLINGS
+    (fare-quasiquote-optima fare-quasiquote-readtable fare-quasiquote-test
+     fare-quasiquote)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-optima.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-optima.nix
@@ -1,0 +1,34 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''fare-quasiquote-optima'';
+  version = ''fare-quasiquote-20190521-git'';
+
+  description = ''fare-quasiquote extension for optima'';
+
+  deps = [ args."alexandria" args."closer-mop" args."fare-quasiquote" args."fare-utils" args."optima" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/fare-quasiquote/2019-05-21/fare-quasiquote-20190521-git.tgz'';
+    sha256 = ''1skrj68dnmihckip1vyc31xysbdsw9ihb7imks73cickkvv6yjfj'';
+  };
+
+  packageName = "fare-quasiquote-optima";
+
+  asdFilesToKeep = ["fare-quasiquote-optima.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM fare-quasiquote-optima DESCRIPTION
+    fare-quasiquote extension for optima SHA256
+    1skrj68dnmihckip1vyc31xysbdsw9ihb7imks73cickkvv6yjfj URL
+    http://beta.quicklisp.org/archive/fare-quasiquote/2019-05-21/fare-quasiquote-20190521-git.tgz
+    MD5 e08c24d35a485a74642bd0c7c06662d6 NAME fare-quasiquote-optima FILENAME
+    fare-quasiquote-optima DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME fare-quasiquote FILENAME fare-quasiquote)
+     (NAME fare-utils FILENAME fare-utils) (NAME optima FILENAME optima))
+    DEPENDENCIES (alexandria closer-mop fare-quasiquote fare-utils optima)
+    VERSION fare-quasiquote-20190521-git SIBLINGS
+    (fare-quasiquote-extras fare-quasiquote-readtable fare-quasiquote-test
+     fare-quasiquote)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-readtable.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote-readtable.nix
@@ -1,0 +1,33 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''fare-quasiquote-readtable'';
+  version = ''fare-quasiquote-20190521-git'';
+
+  description = ''Using fare-quasiquote with named-readtable'';
+
+  deps = [ args."fare-quasiquote" args."fare-utils" args."named-readtables" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/fare-quasiquote/2019-05-21/fare-quasiquote-20190521-git.tgz'';
+    sha256 = ''1skrj68dnmihckip1vyc31xysbdsw9ihb7imks73cickkvv6yjfj'';
+  };
+
+  packageName = "fare-quasiquote-readtable";
+
+  asdFilesToKeep = ["fare-quasiquote-readtable.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM fare-quasiquote-readtable DESCRIPTION
+    Using fare-quasiquote with named-readtable SHA256
+    1skrj68dnmihckip1vyc31xysbdsw9ihb7imks73cickkvv6yjfj URL
+    http://beta.quicklisp.org/archive/fare-quasiquote/2019-05-21/fare-quasiquote-20190521-git.tgz
+    MD5 e08c24d35a485a74642bd0c7c06662d6 NAME fare-quasiquote-readtable
+    FILENAME fare-quasiquote-readtable DEPS
+    ((NAME fare-quasiquote FILENAME fare-quasiquote)
+     (NAME fare-utils FILENAME fare-utils)
+     (NAME named-readtables FILENAME named-readtables))
+    DEPENDENCIES (fare-quasiquote fare-utils named-readtables) VERSION
+    fare-quasiquote-20190521-git SIBLINGS
+    (fare-quasiquote-extras fare-quasiquote-optima fare-quasiquote-test
+     fare-quasiquote)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-quasiquote.nix
@@ -1,0 +1,29 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''fare-quasiquote'';
+  version = ''20190521-git'';
+
+  description = ''Portable, matchable implementation of quasiquote'';
+
+  deps = [ args."fare-utils" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/fare-quasiquote/2019-05-21/fare-quasiquote-20190521-git.tgz'';
+    sha256 = ''1skrj68dnmihckip1vyc31xysbdsw9ihb7imks73cickkvv6yjfj'';
+  };
+
+  packageName = "fare-quasiquote";
+
+  asdFilesToKeep = ["fare-quasiquote.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM fare-quasiquote DESCRIPTION
+    Portable, matchable implementation of quasiquote SHA256
+    1skrj68dnmihckip1vyc31xysbdsw9ihb7imks73cickkvv6yjfj URL
+    http://beta.quicklisp.org/archive/fare-quasiquote/2019-05-21/fare-quasiquote-20190521-git.tgz
+    MD5 e08c24d35a485a74642bd0c7c06662d6 NAME fare-quasiquote FILENAME
+    fare-quasiquote DEPS ((NAME fare-utils FILENAME fare-utils)) DEPENDENCIES
+    (fare-utils) VERSION 20190521-git SIBLINGS
+    (fare-quasiquote-extras fare-quasiquote-optima fare-quasiquote-readtable
+     fare-quasiquote-test)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-utils.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/fare-utils.nix
@@ -1,0 +1,26 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''fare-utils'';
+  version = ''20170124-git'';
+
+  description = ''Basic functions and macros, interfaces, pure and stateful datastructures'';
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/fare-utils/2017-01-24/fare-utils-20170124-git.tgz'';
+    sha256 = ''0jhb018ccn3spkgjywgd0524m5qacn8x15fdiban4zz3amj9dapq'';
+  };
+
+  packageName = "fare-utils";
+
+  asdFilesToKeep = ["fare-utils.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM fare-utils DESCRIPTION
+    Basic functions and macros, interfaces, pure and stateful datastructures
+    SHA256 0jhb018ccn3spkgjywgd0524m5qacn8x15fdiban4zz3amj9dapq URL
+    http://beta.quicklisp.org/archive/fare-utils/2017-01-24/fare-utils-20170124-git.tgz
+    MD5 6752362d0c7c03df6576ab2dbe807ee2 NAME fare-utils FILENAME fare-utils
+    DEPS NIL DEPENDENCIES NIL VERSION 20170124-git SIBLINGS (fare-utils-test)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/global-vars.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/global-vars.nix
@@ -1,0 +1,25 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''global-vars'';
+  version = ''20141106-git'';
+
+  description = ''Define efficient global variables.'';
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/global-vars/2014-11-06/global-vars-20141106-git.tgz'';
+    sha256 = ''0bjgmsifs9vrq409rfrsgrhlxwklvls1dpvh2d706i0incxq957j'';
+  };
+
+  packageName = "global-vars";
+
+  asdFilesToKeep = ["global-vars.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM global-vars DESCRIPTION Define efficient global variables. SHA256
+    0bjgmsifs9vrq409rfrsgrhlxwklvls1dpvh2d706i0incxq957j URL
+    http://beta.quicklisp.org/archive/global-vars/2014-11-06/global-vars-20141106-git.tgz
+    MD5 dd3153ee75c972a80450aa00644b2200 NAME global-vars FILENAME global-vars
+    DEPS NIL DEPENDENCIES NIL VERSION 20141106-git SIBLINGS (global-vars-test)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/parse-declarations-1_dot_0.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/parse-declarations-1_dot_0.nix
@@ -1,0 +1,26 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''parse-declarations-1_dot_0'';
+  version = ''parse-declarations-20101006-darcs'';
+
+  description = ''Library to parse and rebuild declarations.'';
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/parse-declarations/2010-10-06/parse-declarations-20101006-darcs.tgz'';
+    sha256 = ''0r85b0jfacd28kr65kw9c13dx4i6id1dpmby68zjy63mqbnyawrd'';
+  };
+
+  packageName = "parse-declarations-1.0";
+
+  asdFilesToKeep = ["parse-declarations-1.0.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM parse-declarations-1.0 DESCRIPTION
+    Library to parse and rebuild declarations. SHA256
+    0r85b0jfacd28kr65kw9c13dx4i6id1dpmby68zjy63mqbnyawrd URL
+    http://beta.quicklisp.org/archive/parse-declarations/2010-10-06/parse-declarations-20101006-darcs.tgz
+    MD5 e49222003e5b59c5c2a0cf58b86cfdcd NAME parse-declarations-1.0 FILENAME
+    parse-declarations-1_dot_0 DEPS NIL DEPENDENCIES NIL VERSION
+    parse-declarations-20101006-darcs SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/serapeum.nix
@@ -1,0 +1,61 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''serapeum'';
+  version = ''20190710-git'';
+
+  description = ''Utilities beyond Alexandria.'';
+
+  deps = [ args."alexandria" args."bordeaux-threads" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-extras" args."fare-quasiquote-optima" args."fare-quasiquote-readtable" args."fare-utils" args."global-vars" args."introspect-environment" args."iterate" args."lisp-namespace" args."named-readtables" args."optima" args."parse-declarations-1_dot_0" args."parse-number" args."split-sequence" args."string-case" args."trivia" args."trivia_dot_balland2006" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_quasiquote" args."trivia_dot_trivial" args."trivial-cltl2" args."trivial-file-size" args."trivial-garbage" args."trivial-macroexpand-all" args."type-i" args."uiop" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/serapeum/2019-07-10/serapeum-20190710-git.tgz'';
+    sha256 = ''1yvpv8808q24r4fbi2apks12b94az41if2ny1i1ddv9h00vzvpy5'';
+  };
+
+  packageName = "serapeum";
+
+  asdFilesToKeep = ["serapeum.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM serapeum DESCRIPTION Utilities beyond Alexandria. SHA256
+    1yvpv8808q24r4fbi2apks12b94az41if2ny1i1ddv9h00vzvpy5 URL
+    http://beta.quicklisp.org/archive/serapeum/2019-07-10/serapeum-20190710-git.tgz
+    MD5 60e2073fccc750d5b56a7e0814756e1c NAME serapeum FILENAME serapeum DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME fare-quasiquote FILENAME fare-quasiquote)
+     (NAME fare-quasiquote-extras FILENAME fare-quasiquote-extras)
+     (NAME fare-quasiquote-optima FILENAME fare-quasiquote-optima)
+     (NAME fare-quasiquote-readtable FILENAME fare-quasiquote-readtable)
+     (NAME fare-utils FILENAME fare-utils)
+     (NAME global-vars FILENAME global-vars)
+     (NAME introspect-environment FILENAME introspect-environment)
+     (NAME iterate FILENAME iterate)
+     (NAME lisp-namespace FILENAME lisp-namespace)
+     (NAME named-readtables FILENAME named-readtables)
+     (NAME optima FILENAME optima)
+     (NAME parse-declarations-1.0 FILENAME parse-declarations-1_dot_0)
+     (NAME parse-number FILENAME parse-number)
+     (NAME split-sequence FILENAME split-sequence)
+     (NAME string-case FILENAME string-case) (NAME trivia FILENAME trivia)
+     (NAME trivia.balland2006 FILENAME trivia_dot_balland2006)
+     (NAME trivia.level0 FILENAME trivia_dot_level0)
+     (NAME trivia.level1 FILENAME trivia_dot_level1)
+     (NAME trivia.level2 FILENAME trivia_dot_level2)
+     (NAME trivia.quasiquote FILENAME trivia_dot_quasiquote)
+     (NAME trivia.trivial FILENAME trivia_dot_trivial)
+     (NAME trivial-cltl2 FILENAME trivial-cltl2)
+     (NAME trivial-file-size FILENAME trivial-file-size)
+     (NAME trivial-garbage FILENAME trivial-garbage)
+     (NAME trivial-macroexpand-all FILENAME trivial-macroexpand-all)
+     (NAME type-i FILENAME type-i) (NAME uiop FILENAME uiop))
+    DEPENDENCIES
+    (alexandria bordeaux-threads closer-mop fare-quasiquote
+     fare-quasiquote-extras fare-quasiquote-optima fare-quasiquote-readtable
+     fare-utils global-vars introspect-environment iterate lisp-namespace
+     named-readtables optima parse-declarations-1.0 parse-number split-sequence
+     string-case trivia trivia.balland2006 trivia.level0 trivia.level1
+     trivia.level2 trivia.quasiquote trivia.trivial trivial-cltl2
+     trivial-file-size trivial-garbage trivial-macroexpand-all type-i uiop)
+    VERSION 20190710-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_quasiquote.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivia_dot_quasiquote.nix
@@ -1,0 +1,44 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''trivia_dot_quasiquote'';
+  version = ''trivia-20190710-git'';
+
+  description = ''fare-quasiquote extension for trivia'';
+
+  deps = [ args."alexandria" args."closer-mop" args."fare-quasiquote" args."fare-quasiquote-readtable" args."fare-utils" args."lisp-namespace" args."named-readtables" args."trivia_dot_level0" args."trivia_dot_level1" args."trivia_dot_level2" args."trivia_dot_trivial" args."trivial-cltl2" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz'';
+    sha256 = ''0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic'';
+  };
+
+  packageName = "trivia.quasiquote";
+
+  asdFilesToKeep = ["trivia.quasiquote.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM trivia.quasiquote DESCRIPTION fare-quasiquote extension for trivia
+    SHA256 0601gms5n60c6cgkh78a50a3m1n3mb1a39p5k4hb69yx1vnmz6ic URL
+    http://beta.quicklisp.org/archive/trivia/2019-07-10/trivia-20190710-git.tgz
+    MD5 f17ca476901eaff8d3e5d32de23b7447 NAME trivia.quasiquote FILENAME
+    trivia_dot_quasiquote DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME closer-mop FILENAME closer-mop)
+     (NAME fare-quasiquote FILENAME fare-quasiquote)
+     (NAME fare-quasiquote-readtable FILENAME fare-quasiquote-readtable)
+     (NAME fare-utils FILENAME fare-utils)
+     (NAME lisp-namespace FILENAME lisp-namespace)
+     (NAME named-readtables FILENAME named-readtables)
+     (NAME trivia.level0 FILENAME trivia_dot_level0)
+     (NAME trivia.level1 FILENAME trivia_dot_level1)
+     (NAME trivia.level2 FILENAME trivia_dot_level2)
+     (NAME trivia.trivial FILENAME trivia_dot_trivial)
+     (NAME trivial-cltl2 FILENAME trivial-cltl2))
+    DEPENDENCIES
+    (alexandria closer-mop fare-quasiquote fare-quasiquote-readtable fare-utils
+     lisp-namespace named-readtables trivia.level0 trivia.level1 trivia.level2
+     trivia.trivial trivial-cltl2)
+    VERSION trivia-20190710-git SIBLINGS
+    (trivia trivia.balland2006 trivia.benchmark trivia.cffi trivia.level0
+     trivia.level1 trivia.level2 trivia.ppcre trivia.test trivia.trivial)
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-file-size.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-file-size.nix
@@ -1,0 +1,29 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''trivial-file-size'';
+  version = ''20180131-git'';
+
+  parasites = [ "trivial-file-size/tests" ];
+
+  description = ''Stat a file's size.'';
+
+  deps = [ args."fiveam" args."uiop" ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/trivial-file-size/2018-01-31/trivial-file-size-20180131-git.tgz'';
+    sha256 = ''1dhbj764rxw8ndr2l06g5lszzvxis8fjbp71i3l2y9zmdm0k5zrd'';
+  };
+
+  packageName = "trivial-file-size";
+
+  asdFilesToKeep = ["trivial-file-size.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM trivial-file-size DESCRIPTION Stat a file's size. SHA256
+    1dhbj764rxw8ndr2l06g5lszzvxis8fjbp71i3l2y9zmdm0k5zrd URL
+    http://beta.quicklisp.org/archive/trivial-file-size/2018-01-31/trivial-file-size-20180131-git.tgz
+    MD5 ac921679334dd8bd12f927f0bd806f4b NAME trivial-file-size FILENAME
+    trivial-file-size DEPS
+    ((NAME fiveam FILENAME fiveam) (NAME uiop FILENAME uiop)) DEPENDENCIES
+    (fiveam uiop) VERSION 20180131-git SIBLINGS NIL PARASITES
+    (trivial-file-size/tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-macroexpand-all.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/trivial-macroexpand-all.nix
@@ -1,0 +1,26 @@
+args @ { fetchurl, ... }:
+rec {
+  baseName = ''trivial-macroexpand-all'';
+  version = ''20171023-git'';
+
+  description = ''Call each implementation's macroexpand-all equivalent'';
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = ''http://beta.quicklisp.org/archive/trivial-macroexpand-all/2017-10-23/trivial-macroexpand-all-20171023-git.tgz'';
+    sha256 = ''0h5h9zn32pn26x7ll9h08g0csr2f5hvk1wgbr7kdhx5zbrszd7zm'';
+  };
+
+  packageName = "trivial-macroexpand-all";
+
+  asdFilesToKeep = ["trivial-macroexpand-all.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM trivial-macroexpand-all DESCRIPTION
+    Call each implementation's macroexpand-all equivalent SHA256
+    0h5h9zn32pn26x7ll9h08g0csr2f5hvk1wgbr7kdhx5zbrszd7zm URL
+    http://beta.quicklisp.org/archive/trivial-macroexpand-all/2017-10-23/trivial-macroexpand-all-20171023-git.tgz
+    MD5 9cec494869344eb64ebce802c01928c5 NAME trivial-macroexpand-all FILENAME
+    trivial-macroexpand-all DEPS NIL DEPENDENCIES NIL VERSION 20171023-git
+    SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -105,6 +105,18 @@ $out/lib/common-lisp/query-fs"
       '';
     };
   };
+  serapeum = x: {
+    overrides = y: (x.overrides y) //{
+      # Override src until quicklisp catches up to 65837f8 (see serapeum
+      # issue #42)
+      src = pkgs.fetchFromGitHub {
+        owner = "ruricolist";
+        repo = "serapeum";
+        rev = "65837f8a0d65b36369ec8d000fff5c29a395b5fe";
+        sha256 = "0clwf81r2lvk1rbfvk91s9zmbkas9imf57ilqclw12mxaxlfsnbw";
+      };
+    };
+  };
   sqlite = x: {
     propagatedBuildInputs = [pkgs.sqlite];
     overrides = y: (x.overrides y) // {

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -120,6 +120,7 @@ prove-asdf
 query-fs
 quri
 salza2
+serapeum
 simple-date
 smart-buffer
 split-sequence

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -34,6 +34,24 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "trivial-macroexpand-all" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."trivial-macroexpand-all" or (x: {}))
+       (import ./quicklisp-to-nix-output/trivial-macroexpand-all.nix {
+         inherit fetchurl;
+       }));
+
+
+  "trivial-file-size" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."trivial-file-size" or (x: {}))
+       (import ./quicklisp-to-nix-output/trivial-file-size.nix {
+         inherit fetchurl;
+           "fiveam" = quicklisp-to-nix-packages."fiveam";
+           "uiop" = quicklisp-to-nix-packages."uiop";
+       }));
+
+
   "trivial-cltl2" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."trivial-cltl2" or (x: {}))
@@ -53,6 +71,26 @@ let quicklisp-to-nix-packages = rec {
            "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
            "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
            "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
+           "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+       }));
+
+
+  "trivia_dot_quasiquote" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."trivia_dot_quasiquote" or (x: {}))
+       (import ./quicklisp-to-nix-output/trivia_dot_quasiquote.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
+           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
+           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+           "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
+           "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
+           "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
+           "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
            "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
        }));
 
@@ -109,11 +147,84 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "parse-declarations-1_dot_0" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."parse-declarations-1_dot_0" or (x: {}))
+       (import ./quicklisp-to-nix-output/parse-declarations-1_dot_0.nix {
+         inherit fetchurl;
+       }));
+
+
   "introspect-environment" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."introspect-environment" or (x: {}))
        (import ./quicklisp-to-nix-output/introspect-environment.nix {
          inherit fetchurl;
+       }));
+
+
+  "global-vars" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."global-vars" or (x: {}))
+       (import ./quicklisp-to-nix-output/global-vars.nix {
+         inherit fetchurl;
+       }));
+
+
+  "fare-utils" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."fare-utils" or (x: {}))
+       (import ./quicklisp-to-nix-output/fare-utils.nix {
+         inherit fetchurl;
+       }));
+
+
+  "fare-quasiquote-readtable" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."fare-quasiquote-readtable" or (x: {}))
+       (import ./quicklisp-to-nix-output/fare-quasiquote-readtable.nix {
+         inherit fetchurl;
+           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+       }));
+
+
+  "fare-quasiquote-optima" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."fare-quasiquote-optima" or (x: {}))
+       (import ./quicklisp-to-nix-output/fare-quasiquote-optima.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "optima" = quicklisp-to-nix-packages."optima";
+       }));
+
+
+  "fare-quasiquote-extras" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."fare-quasiquote-extras" or (x: {}))
+       (import ./quicklisp-to-nix-output/fare-quasiquote-extras.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
+           "fare-quasiquote-optima" = quicklisp-to-nix-packages."fare-quasiquote-optima";
+           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+           "optima" = quicklisp-to-nix-packages."optima";
+       }));
+
+
+  "fare-quasiquote" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."fare-quasiquote" or (x: {}))
+       (import ./quicklisp-to-nix-output/fare-quasiquote.nix {
+         inherit fetchurl;
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
        }));
 
 
@@ -1264,6 +1375,45 @@ let quicklisp-to-nix-packages = rec {
            "fiveam" = quicklisp-to-nix-packages."fiveam";
            "md5" = quicklisp-to-nix-packages."md5";
            "usocket" = quicklisp-to-nix-packages."usocket";
+       }));
+
+
+  "serapeum" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."serapeum" or (x: {}))
+       (import ./quicklisp-to-nix-output/serapeum.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "fare-quasiquote" = quicklisp-to-nix-packages."fare-quasiquote";
+           "fare-quasiquote-extras" = quicklisp-to-nix-packages."fare-quasiquote-extras";
+           "fare-quasiquote-optima" = quicklisp-to-nix-packages."fare-quasiquote-optima";
+           "fare-quasiquote-readtable" = quicklisp-to-nix-packages."fare-quasiquote-readtable";
+           "fare-utils" = quicklisp-to-nix-packages."fare-utils";
+           "global-vars" = quicklisp-to-nix-packages."global-vars";
+           "introspect-environment" = quicklisp-to-nix-packages."introspect-environment";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "lisp-namespace" = quicklisp-to-nix-packages."lisp-namespace";
+           "named-readtables" = quicklisp-to-nix-packages."named-readtables";
+           "optima" = quicklisp-to-nix-packages."optima";
+           "parse-declarations-1_dot_0" = quicklisp-to-nix-packages."parse-declarations-1_dot_0";
+           "parse-number" = quicklisp-to-nix-packages."parse-number";
+           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
+           "string-case" = quicklisp-to-nix-packages."string-case";
+           "trivia" = quicklisp-to-nix-packages."trivia";
+           "trivia_dot_balland2006" = quicklisp-to-nix-packages."trivia_dot_balland2006";
+           "trivia_dot_level0" = quicklisp-to-nix-packages."trivia_dot_level0";
+           "trivia_dot_level1" = quicklisp-to-nix-packages."trivia_dot_level1";
+           "trivia_dot_level2" = quicklisp-to-nix-packages."trivia_dot_level2";
+           "trivia_dot_quasiquote" = quicklisp-to-nix-packages."trivia_dot_quasiquote";
+           "trivia_dot_trivial" = quicklisp-to-nix-packages."trivia_dot_trivial";
+           "trivial-cltl2" = quicklisp-to-nix-packages."trivial-cltl2";
+           "trivial-file-size" = quicklisp-to-nix-packages."trivial-file-size";
+           "trivial-garbage" = quicklisp-to-nix-packages."trivial-garbage";
+           "trivial-macroexpand-all" = quicklisp-to-nix-packages."trivial-macroexpand-all";
+           "type-i" = quicklisp-to-nix-packages."type-i";
+           "uiop" = quicklisp-to-nix-packages."uiop";
        }));
 
 


### PR DESCRIPTION
Adds common-lisp package serapeum (a dependency for Next browser as of
Next v1.4.0), using the quicklisp-to-nix mechanism.

src is overridden and pinned to 65837f8 to deal with
https://github.com/ruricolist/serapeum/issues/42

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Permits updating `nixpkgs.next` to >= v1.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
