### PR TITLE
digibyte: init at 7.17.2

### DIFF
--- a/pkgs/applications/blockchains/digibyte.nix
+++ b/pkgs/applications/blockchains/digibyte.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, fetchFromGitHub
+, openssl
+, boost
+, libevent
+, autoreconfHook
+, db4
+, pkgconfig
+, protobuf
+, hexdump
+, zeromq
+, withGui
+, qtbase ? null
+, qttools ? null
+, wrapQtAppsHook ? null
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  pname = "digibyte";
+  version = "7.17.2";
+
+  name = pname + toString (optional (!withGui) "d") + "-" + version;
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "04czj7mx3wpbx4832npk686p9pg5zb6qwlcvnmvqf31hm5qylbxj";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    hexdump
+  ] ++ optionals withGui [
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    openssl
+    boost
+    libevent
+    db4
+    zeromq
+  ] ++ optionals withGui [
+    qtbase
+    qttools
+    protobuf
+  ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+      "--with-boost-libdir=${boost.out}/lib"
+  ] ++ optionals withGui [
+      "--with-gui=qt5"
+      "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
+  ];
+
+  meta = {
+    description = "DigiByte (DGB) is a rapidly growing decentralized, global blockchain";
+    homepage = "https://digibyte.io/";
+    license = licenses.mit;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22641,6 +22641,9 @@ in
 
   dero = callPackage ../applications/blockchains/dero.nix { boost = boost165; };
 
+  digibyte = libsForQt5.callPackage ../applications/blockchains/digibyte.nix { withGui = true; };
+  digibyted = callPackage ../applications/blockchains/digibyte.nix { withGui = false; };
+
   dogecoin  = callPackage ../applications/blockchains/dogecoin.nix { boost = boost165; withGui = true; };
   dogecoind = callPackage ../applications/blockchains/dogecoin.nix { boost = boost165; withGui = false; };
 


### PR DESCRIPTION
###### Motivation for this change

digibyte: init at 7.17.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
