### PR TITLE
megacmd: init at 1.1.0

### DIFF
--- a/pkgs/applications/misc/megacmd/default.nix
+++ b/pkgs/applications/misc/megacmd/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, autoconf
+, automake
+, c-ares
+, cryptopp
+, curl
+, fetchFromGitHub
+, ffmpeg
+, freeimage
+, gcc-unwrapped
+, libmediainfo
+, libraw
+, libsodium
+, libtool
+, libuv
+, libzen
+, pcre-cpp
+, pkgconfig
+, readline
+, sqlite
+}:
+
+stdenv.mkDerivation rec {
+  pname = "megacmd";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "meganz";
+    repo = "MEGAcmd";
+    rev = "${version}_Linux";
+    sha256 = "004j8m3xs6slx03g2g6wzr97myl2v3zc09wxnfar5c62a625pd53";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    pkgconfig
+  ];
+
+  buildInputs = [
+    c-ares
+    cryptopp
+    curl
+    ffmpeg
+    freeimage
+    gcc-unwrapped
+    libmediainfo
+    libraw
+    libsodium
+    libtool
+    libuv
+    libzen
+    pcre-cpp
+    readline
+    sqlite
+  ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  configureFlags = [
+    "--disable-curl-checks"
+    "--disable-examples"
+    "--with-cares"
+    "--with-cryptopp"
+    "--with-curl"
+    "--with-ffmpeg"
+    "--with-freeimage"
+    "--with-libmediainfo"
+    "--with-libuv"
+    "--with-libzen"
+    "--with-pcre"
+    "--with-readline"
+    "--with-sodium"
+    "--with-termcap"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "MEGA Command Line Interactive and Scriptable Application";
+    homepage    = https://mega.nz/;
+    license     = licenses.unfree;
+    platforms   = [ "i686-linux" "x86_64-linux" ];
+    maintainers = [ maintainers.wedens ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1928,6 +1928,8 @@ in
 
   megasync = libsForQt5.callPackage ../applications/misc/megasync { };
 
+  megacmd = callPackage ../applications/misc/megacmd { };
+
   meritous = callPackage ../games/meritous { };
 
   opendune = callPackage ../games/opendune { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
