### PR TITLE
vertcoin: init at 0.14.0

### DIFF
--- a/pkgs/applications/blockchains/vertcoin.nix
+++ b/pkgs/applications/blockchains/vertcoin.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, fetchFromGitHub
+, openssl
+, boost
+, libevent
+, autoreconfHook
+, db4
+, pkgconfig
+, protobuf
+, hexdump
+, zeromq
+, withGui
+, qtbase ? null
+, qttools ? null
+, wrapQtAppsHook ? null
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  pname = "vertcoin";
+  version = "0.14.0";
+
+  name = pname + toString (optional (!withGui) "d") + "-" + version;
+
+  src = fetchFromGitHub {
+    owner = pname + "-project";
+    repo = pname + "-core";
+    rev = version;
+    sha256 = "00vnmrhn5mad58dyiz8rxgsrn0663ii6fdbcqm20mv1l313k4882";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    hexdump
+  ] ++ optionals withGui [
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    openssl
+    boost
+    libevent
+    db4
+    zeromq
+  ] ++ optionals withGui [
+    qtbase
+    qttools
+    protobuf
+  ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+      "--with-boost-libdir=${boost.out}/lib"
+  ] ++ optionals withGui [
+      "--with-gui=qt5"
+      "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
+  ];
+
+  meta = {
+    description = "A digital currency with mining decentralisation and ASIC resistance as a key focus";
+    homepage = "https://vertcoin.org/";
+    license = licenses.mit;
+    maintainers = [ maintainers.mmahut ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22692,6 +22692,9 @@ in
 
   sumokoin = callPackage ../applications/blockchains/sumokoin.nix { boost = boost165; };
 
+  vertcoin  = libsForQt5.callPackage ../applications/blockchains/vertcoin.nix { boost = boost165; withGui = true; };
+  vertcoind = callPackage ../applications/blockchains/vertcoin.nix { boost = boost165; withGui = false; };
+
   wasabiwallet = callPackage ../applications/blockchains/wasabiwallet { };
 
   wownero = callPackage ../applications/blockchains/wownero.nix {};


### PR DESCRIPTION
###### Motivation for this change

vertcoin: init at 0.14.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
