### PR TITLE
jetbrains-mono: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/data/fonts/jetbrains-mono/default.nix
+++ b/pkgs/data/fonts/jetbrains-mono/default.nix
@@ -1,18 +1,20 @@
 { lib, fetchzip }:
 
 let
-  version = "1.0.0";
+  version = "1.0.1";
 in
 fetchzip rec {
   name = "JetBrainsMono-${version}";
 
-  url = "https://download.jetbrains.com/fonts/JetBrainsMono-${version}.zip";
+  url = "https://github.com/JetBrains/JetBrainsMono/releases/download/${version}/JetBrainsMono-${version}.zip";
 
-  sha256 = "0mwqi66d56v4ml1w7wjsiidrh153jvh0czafyic47rkvmxhnrrhv";
+  sha256 = "15a8fwyg8ns6krq6nsvgn41iaqbd3lgm3cmv7w370gr6brbn6lxq";
 
   postFetch = ''
     unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/truetype *.ttf
+    install -m444 -Dt $out/share/fonts/truetype ttf/*.ttf
+    install -m444 -Dt $out/share/fonts/woff/ web/woff/*.woff
+    install -m444 -Dt $out/share/fonts/woff2/ web/woff2/*.woff2
   '';
 
   meta = with lib; {


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/JetBrains/JetBrainsMono/releases/tag/1.0.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
