### PR TITLE
nixos/buildkite: drop user option

### DIFF
--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -29,8 +29,6 @@ let
     ${concatStringsSep "\n" (mapAttrsToList mkHookEntry (filterAttrs (n: v: v != null) cfg.hooks))}
   '';
 
-  defaultUser = "buildkite-agent";
-
 in
 
 {
@@ -56,15 +54,6 @@ in
         defaultText = "[ pkgs.bash pkgs.gnutar pkgs.gzip pkgs.git pkgs.nix ]";
         description = "Add programs to the buildkite-agent environment";
         type = types.listOf types.package;
-      };
-
-      user = mkOption {
-        type = types.str;
-        default = defaultUser;
-        description = ''
-          Set this option when you want to run the buildkite agent as something else
-          than the default user "buildkite-agent".
-        '';
       };
 
       tokenPath = mkOption {
@@ -197,7 +186,7 @@ in
   };
 
   config = mkIf config.services.buildkite-agent.enable {
-    users.users.buildkite-agent = mkIf (cfg.user == defaultUser) {
+    users.users.buildkite-agent = {
       name = "buildkite-agent";
       home = cfg.dataDir;
       createHome = true;
@@ -242,7 +231,7 @@ in
 
         serviceConfig =
           { ExecStart = "${cfg.package}/bin/buildkite-agent start --config /var/lib/buildkite-agent/buildkite-agent.cfg";
-            User = cfg.user;
+            User = "buildkite-agent";
             RestartSec = 5;
             Restart = "on-failure";
             TimeoutSec = 10;

--- a/nixos/tests/buildkite-agent.nix
+++ b/nixos/tests/buildkite-agent.nix
@@ -6,18 +6,31 @@ import ./make-test-python.nix ({ pkgs, ... }:
     maintainers = [ flokli ];
   };
 
-  machine = { pkgs, ... }: {
-    services.buildkite-agent = {
-      enable = true;
-      privateSshKeyPath = (import ./ssh-keys.nix pkgs).snakeOilPrivateKey;
-      tokenPath = (pkgs.writeText "my-token" "5678");
+  nodes = {
+    node1 = { pkgs, ... }: {
+      services.buildkite-agent = {
+        enable = true;
+        privateSshKeyPath = (import ./ssh-keys.nix pkgs).snakeOilPrivateKey;
+        tokenPath = (pkgs.writeText "my-token" "5678");
+      };
+    };
+    # don't configure ssh key, run as a separate user
+    node2 = { pkgs, ...}: {
+      services.buildkite-agent = {
+        enable = true;
+        tokenPath = (pkgs.writeText "my-token" "1234");
+      };
     };
   };
 
   testScript = ''
+    start_all()
     # we can't wait on the unit to start up, as we obviously can't connect to buildkite,
     # but we can look whether files are set up correctly
-    machine.wait_for_file("/var/lib/buildkite-agent/buildkite-agent.cfg")
-    machine.wait_for_file("/var/lib/buildkite-agent/.ssh/id_rsa")
+
+    node1.wait_for_file("/var/lib/buildkite-agent/buildkite-agent.cfg")
+    node1.wait_for_file("/var/lib/buildkite-agent/.ssh/id_rsa")
+
+    node2.wait_for_file("/var/lib/buildkite-agent/buildkite-agent.cfg")
   '';
 })


### PR DESCRIPTION
This reverts 8c6b1c3eaaa8b555bddaced3ab6f02695bef1541.
It was never part of the release notes, and only was an additional option
that existed for some days in master.

Turns out, buildkite-agent has logic to write .ssh/known_hosts files and
only really works when $HOME and the user homedir are in sync.

On top of that, we provision ssh keys in /var/lib/buildkite-agent, which
doesn't work if that other users' homedir points elsewhere (we can cheat
by setting $HOME, but then getent and $HOME provide conflicting
results).

So after all, it's better to only run the system-wide buildkite agent as
the "buildkite-agent" user only - if one wants to run buildkite as
different users, systemd user services might be a better fit.

This also extends the vm test to test both deploying a ssh key and not
deploying one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
