### PR TITLE
v2ray: 4.22.0 -> 4.22.1

### DIFF
--- a/pkgs/tools/networking/v2ray/default.nix
+++ b/pkgs/tools/networking/v2ray/default.nix
@@ -3,20 +3,20 @@
 , ... } @ args:
 
 callPackage ./generic.nix (rec {
-  version = "4.22.0";
+  version = "4.22.1";
 
   src = fetchFromGitHub {
     owner = "v2ray";
     repo = "v2ray-core";
     rev = "v${version}";
-    sha256 = "1gr4s96ii4dx5bcwpb82rn250pcnncxwzx147p9dbwbyiy0i9nz7";
+    sha256 = "0l4rg9galjcm6dzv7sapnim9a02z7pv354mk5mwqndznii6nkr73";
   };
 
   assets = {
     # MIT licensed
     "geoip.dat" = let
-      geoipRev = "202001010102";
-      geoipSha256 = "16i73c3852f7zmya0q3856cc4gvhqhpln9s98qvr2dr1mpp72c1w";
+      geoipRev = "202001210102";
+      geoipSha256 = "1wxhrhrigjqzpy5w8yj7yd9ib245xwhqys2pf9prdknq71piyziz";
     in fetchurl {
       url = "https://github.com/v2ray/geoip/releases/download/${geoipRev}/geoip.dat";
       sha256 = geoipSha256;
@@ -24,8 +24,8 @@ callPackage ./generic.nix (rec {
 
     # MIT licensed
     "geosite.dat" = let
-      geositeRev = "20191226.1";
-      geositeSha256 = "0b4ji5kj5jpkwri3libxm9yl49dcy91vkl7h1rkhrrhbl17s3qiy";
+      geositeRev = "202001211332";
+      geositeSha256 = "06qlbjxk21lhyh5l3pd8l4m9rdl7sjh2jriz51zihaqx4417f0m7";
     in fetchurl {
       url = "https://github.com/v2ray/domain-list-community/releases/download/${geositeRev}/dlc.dat";
       sha256 = geositeSha256;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update v2ray to 4.22.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
