### PR TITLE
mc: 4.8.23 -> 4.8.24

### DIFF
--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -60,11 +60,11 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "File Manager and User Shell for the GNU Project";
     downloadPage = "https://www.midnight-commander.org/downloads/";
-    homepage = https://www.midnight-commander.org;
+    homepage = "https://www.midnight-commander.org";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ sander ];
     platforms = with platforms; linux ++ darwin;
-    repositories.git = git://github.com/MidnightCommander/mc.git;
+    repositories.git = "https://github.com/MidnightCommander/mc.git";
     updateWalker = true;
   };
 }

--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -19,12 +19,22 @@
 
 stdenv.mkDerivation rec {
   pname = "mc";
-  version = "4.8.23";
+  version = "4.8.24";
 
   src = fetchurl {
-    url = "http://www.midnight-commander.org/downloads/${pname}-${version}.tar.xz";
-    sha256 = "077z7phzq3m1sxyz7li77lyzv4rjmmh3wp2vy86pnc4387kpqzyx";
+    url = "https://www.midnight-commander.org/downloads/${pname}-${version}.tar.xz";
+    sha256 = "0ikd2yql44p7nagmb08dmjqdwadclnvgr7ri9pmzc2s5f301r7w5";
   };
+
+  preConfigure = ''
+    for f in \
+      ./configure \
+      ./config/ltmain.sh \
+      ./m4/libtool.m4 \
+      ; do
+      substituteInPlace $f --replace /usr/bin/file ${file}/bin/file
+    done
+  '';
 
   nativeBuildInputs = [ pkgconfig ];
 
@@ -58,8 +68,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "File Manager and User Shell for the GNU Project";
-    downloadPage = "http://www.midnight-commander.org/downloads/";
-    homepage = "http://www.midnight-commander.org";
+    downloadPage = "https://www.midnight-commander.org/downloads/";
+    homepage = https://www.midnight-commander.org;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ sander ];
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -15,6 +15,7 @@
 , libssh2
 , openssl
 , coreutils
+, autoreconfHook
 }:
 
 stdenv.mkDerivation rec {
@@ -26,17 +27,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ikd2yql44p7nagmb08dmjqdwadclnvgr7ri9pmzc2s5f301r7w5";
   };
 
-  preConfigure = ''
-    for f in \
-      ./configure \
-      ./config/ltmain.sh \
-      ./m4/libtool.m4 \
-      ; do
-      substituteInPlace $f --replace /usr/bin/file ${file}/bin/file
-    done
-  '';
-
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
 
   buildInputs = [
     file


### PR DESCRIPTION
###### Motivation for this change
Updated to version 4.8.24

Fixed warning
```./configure: line 10014: /usr/bin/file: No such file or directory```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
