### PR TITLE
libieee1284: init at 0.2.11

### DIFF
--- a/pkgs/development/libraries/libieee1284/default.nix
+++ b/pkgs/development/libraries/libieee1284/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, xmlto, docbook_xml_dtd_412, docbook_xsl }:
+
+stdenv.mkDerivation rec {
+  pname = "libieee1284";
+  version = "0.2.11";
+
+  src = fetchFromGitHub {
+    owner = "twaugh";
+    repo = pname;
+    rev = "V${builtins.replaceStrings [ "." ] [ "_" ] version}";
+    sha256 = "0wfv1prmhhpyll9l4g1ij3im7hk9mm96ydw3l9fvhjp3993cdn2x";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    xmlto
+    docbook_xml_dtd_412
+    docbook_xsl
+  ];
+
+  configureFlags = [
+    "--without-python"
+  ];
+
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Parallel port communication library";
+    homepage = "http://cyberelk.net/tim/software/libieee1284/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12608,6 +12608,8 @@ in
 
   libicns = callPackage ../development/libraries/libicns { };
 
+  libieee1284 = callPackage ../development/libraries/libieee1284 { };
+
   libimobiledevice = callPackage ../development/libraries/libimobiledevice { };
 
   libindicator-gtk2 = libindicator.override { gtkVersion = "2"; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this ch

Add [libieee1284](url), a library to query devices connected in parallel port.

It is required for the following backends in `sane-backends-1.0.28`: `canon_pp`, `hpsj5s` and `mustek_pp`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).