### PR TITLE
cargo-about: init at 0.1.1

### DIFF
--- a/pkgs/tools/package-management/cargo-about/default.nix
+++ b/pkgs/tools/package-management/cargo-about/default.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-about";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "EmbarkStudios";
+    repo = "cargo-about";
+    rev = "${version}";
+    sha256 = "1n9274np1ibz1s35q1qqajnwj7w4l695js9xdbga5wim18ly622m";
+  };
+
+  cargoSha256 = "0zjvvqw68y6zmjzmd22hh246422x2kxljj73vxywkl18crkakd7k";
+
+  meta = with lib; {
+    description = "Cargo plugin to generate list of all licenses for a crate";
+    homepage = "https://github.com/EmbarkStudios/cargo-about";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = with maintainers; [ evanjs ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8780,6 +8780,7 @@ in
 
   defaultCrateOverrides = callPackage ../build-support/rust/default-crate-overrides.nix { };
 
+  cargo-about = callPackage ../tools/package-management/cargo-about { };
   cargo-audit = callPackage ../tools/package-management/cargo-audit {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/EmbarkStudios/cargo-about/tree/master#generate-license-information-for-your-own-project
:D 

This project is similar to [cargo-license](https://github.com/onur/cargo-license), but allows you to e.g. generate a list of licenses used in your Rust project that you can then include in your production application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).