### PR TITLE
rar2fs: init at 1.28.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3812,6 +3812,12 @@
     githubId = 787421;
     name = "Kevin Quick";
   };
+  kraem = {
+    email = "me@kraem.xyz";
+    github = "kraem";
+    githubId = 26622971;
+    name = "Ronnie Ebrin";
+  };
   kragniz = {
     email = "louis@kragniz.eu";
     github = "kragniz";

--- a/pkgs/tools/archivers/unrar/default.nix
+++ b/pkgs/tools/archivers/unrar/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     make lib
   '';
 
+  outputs = [ "out" "dev" ];
+
   installPhase = ''
     install -Dt "$out/bin" unrar
 
@@ -30,7 +32,8 @@ stdenv.mkDerivation rec {
         $out/share/doc/unrar
 
     install -Dm755 libunrar.so $out/lib/libunrar.so
-    install -D dll.hpp $out/include/unrar/dll.hpp
+
+    install -Dt $dev/include/unrar/ *.hpp
   '';
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/tools/filesystems/rar2fs/default.nix
+++ b/pkgs/tools/filesystems/rar2fs/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, fuse
+, unrar
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rar2fs";
+  version = "1.28.0";
+
+  src = fetchFromGitHub {
+    owner = "hasse69";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0fmdqrs5yvn89ngc26vj5ggnalpwrdm8pdcfszw1wflh78hvd8kb";
+  };
+
+  postPatch = ''
+    substituteInPlace get-version.sh \
+      --replace "which echo" "echo"
+  '';
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ fuse unrar ];
+
+  configureFlags = [
+    "--with-unrar=${unrar.dev}/include/unrar"
+    "--disable-static-unrar"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "FUSE file system for reading RAR archives";
+    homepage = https://hasse69.github.io/rar2fs/;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ kraem ];
+    platforms = with platforms; linux ++ freebsd;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2958,6 +2958,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  rar2fs = callPackage ../tools/filesystems/rar2fs { };
+
   s-tar = callPackage ../tools/archivers/s-tar {};
 
   sonota = callPackage ../tools/misc/sonota { };


### PR DESCRIPTION
###### Motivation for this change
`rar2fs` uses fuse to mount rar archives, or directories containing rar archives, and makes the files available as if they were unrar:ed.

[rar2fs Github](https://github.com/hasse69/rar2fs)
[rar2fs web](https://hasse69.github.io/rar2fs/)

###### Things done
Init package at most recent version 1.28.0

Added the unfree license even though `rar2fs` is licensed using GPLv3.
The source from `RARLAB` is used during compilation though. The license of `RARLAB` is free to distribute if only the `UnRAR` sources are used ([source](https://fedoraproject.org/wiki/Licensing:Unrar)). I'm not sure if anything else is used during the compilation of `rar2fs`. I'm super new to licenses and if anyone has any idea as to what the situation is here they are very welcome to have a say in this :)

###### Other
This is my first package added so added myself to the maintainers-list. I'm more than happy to receive suggestions for improvement too :)

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
