### PR TITLE
nudoku: init at 2.0.0

### DIFF
--- a/pkgs/games/nudoku/default.nix
+++ b/pkgs/games/nudoku/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gettext, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "nudoku";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "jubalh";
+    repo = pname;
+    rev = version;
+    sha256 = "0rj8ajni7gssj0qbf1jn51699sadxwsr6ca2718w74psv7acda8h";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig gettext ];
+  buildInputs = [ ncurses ];
+
+  meta = with stdenv.lib; {
+    description = "An ncurses based sudoku game";
+    homepage = "http://jubalh.github.io/nudoku/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}
+

--- a/pkgs/games/nudoku/default.nix
+++ b/pkgs/games/nudoku/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "0rj8ajni7gssj0qbf1jn51699sadxwsr6ca2718w74psv7acda8h";
   };
 
+  # Allow gettext 0.20
+  postPatch = ''
+    substituteInPlace configure.ac --replace 0.19 0.20
+  '';
+
   nativeBuildInputs = [ autoreconfHook pkgconfig gettext ];
   buildInputs = [ ncurses ];
 

--- a/pkgs/games/nudoku/default.nix
+++ b/pkgs/games/nudoku/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig gettext ];
   buildInputs = [ ncurses ];
 
+  configureFlags = stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-nls";
+
   meta = with stdenv.lib; {
     description = "An ncurses based sudoku game";
     homepage = "http://jubalh.github.io/nudoku/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23141,6 +23141,8 @@ in
 
   newtonwars = callPackage ../games/newtonwars { };
 
+  nudoku = callPackage ../games/nudoku { };
+
   nxengine-evo = callPackage ../games/nxengine-evo { };
 
   odamex = callPackage ../games/odamex { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Ncurses-based sudoku game :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).