### PR TITLE
sane-backends: 1.0.27 -> 1.0.28

### DIFF
--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -1,11 +1,10 @@
 { callPackage, fetchurl, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "1.0.27";
+  version = "1.0.28";
+
   src = fetchurl {
-    sha256 = "1j9nbqspaj0rlgalafb5z6r606k0i22kz0rcpd744p176yzlfdr9";
-    urls = [
-      "https://alioth-archive.debian.org/releases/sane/sane-backends/${version}/sane-backends-${version}.tar.gz"
-    ];
+    url = "https://gitlab.com/sane-project/backends/uploads/9e718daff347826f4cfe21126c8d5091/sane-backends-${version}.tar.gz";
+    sha256 = "00yy8q9hqdf0zjxxl4d8njr9zf0hhi3a9ib23ikc2anqf8zhy9ii";
   };
 })

--- a/pkgs/applications/graphics/sane/backends/generic.nix
+++ b/pkgs/applications/graphics/sane/backends/generic.nix
@@ -1,6 +1,6 @@
 { stdenv
-, avahi, libjpeg, libusb1, libv4l, net-snmp, libpng
 , gettext, pkgconfig
+, avahi, libgphoto2, libieee1284, libjpeg, libpng, libtiff, libusb1, libv4l, net-snmp
 
 # List of { src name backend } attibute sets - see installFirmware below:
 , extraFirmware ? []
@@ -19,14 +19,29 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "doc" "man" ];
 
+  nativeBuildInputs = [
+    gettext
+    pkgconfig
+  ];
+
+  buildInputs = [
+    avahi
+    libgphoto2
+    libieee1284
+    libjpeg
+    libpng
+    libtiff
+    libusb1
+    libv4l
+    net-snmp
+  ];
+
+  enableParallelBuilding = true;
+
   configureFlags = []
     ++ stdenv.lib.optional (avahi != null)   "--enable-avahi"
-    ++ stdenv.lib.optional (libusb1 != null) "--enable-libusb_1_0"
-    ;
-
-  buildInputs = [ avahi libusb1 libv4l net-snmp libpng ];
-  nativeBuildInputs = [ gettext pkgconfig ];
-  enableParallelBuilding = true;
+    ++ stdenv.lib.optional (libusb1 != null) "--with-usb"
+  ;
 
   postInstall = let
 
@@ -71,7 +86,7 @@ stdenv.mkDerivation {
       video- and still-cameras, frame-grabbers, etc. For a list of supported
       scanners, see http://www.sane-project.org/sane-backends.html.
     '';
-    homepage = http://www.sane-project.org/;
+    homepage = "http://www.sane-project.org/";
     license = licenses.gpl2Plus;
 
     maintainers = with maintainers; [ peti ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to version [1.0.28](https://gitlab.com/sane-project/backends/-/tags/1.0.28)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).