### PR TITLE
Mullvad VPN module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -642,6 +642,7 @@
   ./services/networking/miredo.nix
   ./services/networking/mstpd.nix
   ./services/networking/mtprotoproxy.nix
+  ./services/networking/mullvad.nix
   ./services/networking/murmur.nix
   ./services/networking/mxisd.nix
   ./services/networking/namecoind.nix

--- a/nixos/modules/services/networking/mullvad.nix
+++ b/nixos/modules/services/networking/mullvad.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.mullvad;
+in
+{
+  options.services.mullvad = {
+    enable = mkEnableOption "the Mullvad VPN daemon";
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.mullvad-vpn ];
+    
+    systemd.services."mullvad-vpn" = {
+      enable = true;
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [ iproute ];
+      environment = 
+        {
+          MULLVAD_SETTINGS_DIR = "/var/lib/mullvad-vpn";
+        };
+      serviceConfig = {
+        StateDirectory = "mullvad-vpn";
+        CacheDirectory = "mullvad-vpn";
+        ExecStart = ''
+          ${pkgs.mullvad-vpn}/bin/mullvad-daemon --disable-log-to-file
+        '';
+      };
+    };
+  };
+}
+ 

--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -1,7 +1,7 @@
 { stdenv, makeWrapper, fetchurl, dpkg
 , alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype
 , gdk-pixbuf, glib, gnome2, pango, nspr, nss, gtk3
-, xorg, autoPatchelfHook, systemd, libnotify
+, xorg, autoPatchelfHook, systemd, libnotify, iproute
 }:
 
 let deps = [
@@ -50,6 +50,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoPatchelfHook
     dpkg
+    makeWrapper
   ];
 
   buildInputs = deps;
@@ -72,7 +73,10 @@ stdenv.mkDerivation rec {
 
     sed -i 's|\/opt\/Mullvad.*VPN|'$out'/bin|g' $out/share/applications/mullvad-vpn.desktop
 
-    ln -s $out/share/mullvad/mullvad-{gui,vpn} $out/bin/
+    wrapProgram $out/share/mullvad/resources/mullvad-daemon \
+        --suffix PATH : ${iproute}/bin
+
+    ln -s $out/share/mullvad/mullvad-vpn $out/bin/mullvad-vpn
     ln -s $out/share/mullvad/resources/mullvad-daemon $out/bin/mullvad-daemon
 
     runHook postInstall


### PR DESCRIPTION
There is already a mullvad package in nixpgks, but it wasn't very well
usable without some changes.  I've also added a pretty simple module
to enable mullvad, without having to wrap the daemon manually.

I've been using this setup on my laptop for a while now.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).