### PR TITLE
binutils: 2.31.1 -> 2.33.1

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -16,7 +16,7 @@ let
   # Remove gold-symbol-visibility patch when updating, the proper fix
   # is now upstream.
   # https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commitdiff;h=330b90b5ffbbc20c5de6ae6c7f60c40fab2e7a4f;hp=99181ccac0fc7d82e7dabb05dc7466e91f1645d3
-  version = "2.31.1";
+  version = "2.33.1";
   basename = "binutils";
   # The targetPrefix prepended to binary names to allow multiple binuntils on the
   # PATH to both be usable.
@@ -31,7 +31,7 @@ let
   # HACK to ensure that we preserve source from bootstrap binutils to not rebuild LLVM
   normal-src = stdenv.__bootPackages.binutils-unwrapped.src or (fetchurl {
     url = "mirror://gnu/binutils/${basename}-${version}.tar.bz2";
-    sha256 = "1l34hn1zkmhr1wcrgf0d4z7r3najxnw3cx2y2fk7v55zjlk3ik7z";
+    sha256 = "1cmd0riv37bqy9mwbg6n3523qgr8b3bbm5kwj19sjrasl4yq9d0c";
   });
 in
 
@@ -68,12 +68,6 @@ stdenv.mkDerivation {
   [
     # https://sourceware.org/bugzilla/show_bug.cgi?id=22868
     ./gold-symbol-visibility.patch
-
-    # https://sourceware.org/bugzilla/show_bug.cgi?id=23428
-    # un-break features so linking against musl doesn't produce crash-only binaries
-    ./0001-x86-Add-a-GNU_PROPERTY_X86_ISA_1_USED-note-if-needed.patch
-    ./0001-x86-Properly-merge-GNU_PROPERTY_X86_ISA_1_USED.patch
-    ./0001-x86-Properly-add-X86_ISA_1_NEEDED-property.patch
   ] ++ lib.optional stdenv.targetPlatform.isiOS ./support-ios.patch;
 
   outputs = [ "out" "info" "man" ];

--- a/pkgs/development/tools/misc/binutils/no-plugins.patch
+++ b/pkgs/development/tools/misc/binutils/no-plugins.patch
@@ -1,19 +1,21 @@
-diff -ru binutils-2.27-orig/bfd/plugin.c binutils-2.27/bfd/plugin.c
---- binutils-2.27-orig/bfd/plugin.c	2016-10-14 17:46:30.791315555 +0200
-+++ binutils-2.27/bfd/plugin.c	2016-10-14 17:46:38.583298765 +0200
-@@ -333,6 +333,7 @@
+diff --git a/bfd/plugin.c b/bfd/plugin.c
+index 537ab60311..bfe7957f96 100644
+--- a/bfd/plugin.c
++++ b/bfd/plugin.c
+@@ -386,6 +386,7 @@ load_plugin (bfd *abfd)
    if (plugin_program_name == NULL)
      return found;
  
 +#if 0
-   plugin_dir = concat (BINDIR, "/../lib/bfd-plugins", NULL);
-   p = make_relative_prefix (plugin_program_name,
- 			    BINDIR,
-@@ -364,6 +365,7 @@
-   free (p);
-   if (d)
-     closedir (d);
+   /* Try not to search the same dir twice, by looking at st_dev and
+      st_ino for the dir.  If we are on a file system that always sets
+      st_ino to zero or the actual st_ino is zero we might waste some
+@@ -437,7 +438,7 @@ load_plugin (bfd *abfd)
+       if (found)
+ 	break;
+     }
+-
 +#endif
- 
    return found;
  }
+ 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bump of `binutils` to a more recent version. It closes #78197 . Please review with care because I have NO idea what I'm doing. This will trigger a mass rebuild and mostly everything in nixpkgs depend on this.

I'm opening this PR as a proof of motivation to work on this issue, but really, feel free to tell me that I totally missed something and that binutils is stuck at 2.31.1 on nixpkgs for good reasons.

###### Things done

I bumped the package and ensured patchs applies. This is a mass rebuild, so I did not even tried to wait for the end of the build on my laptop. At least, patches are correctly applied (after fixup) and the build is running.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
