### PR TITLE
python3Packages.ppft: re-enable tests

### DIFF
--- a/pkgs/development/python-modules/ppft/default.nix
+++ b/pkgs/development/python-modules/ppft/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, python
 , six
 }:
 
@@ -15,8 +16,12 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ six ];
 
-  # tests no longer packages on pypi
-  doCheck = false;
+  # darwin seems to hang
+  doCheck = !stdenv.isDarwin;
+  checkPhase = ''
+    cd examples
+    ${python.interpreter} -m ppft.tests
+  '';
 
   meta = with stdenv.lib; {
     description = "Distributed and parallel python";


### PR DESCRIPTION
###### Motivation for this change
closes #78194

They follow a non-standard testing format, although they try to do parallel compute, which isn't a normal python use case

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


```
[6 built, 10 copied (4.0 MiB), 1.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/78209
6 package built:
python27Packages.pathos python27Packages.ppft python37Packages.pathos python37Packages.ppft python38Packages.pathos python38Packages.ppft
```