### PR TITLE
pythonPackages.nest-asyncio: build without tests

### DIFF
--- a/pkgs/development/python-modules/nest-asyncio/default.nix
+++ b/pkgs/development/python-modules/nest-asyncio/default.nix
@@ -14,6 +14,11 @@ buildPythonPackage rec {
     sha256 = "7d4d7c1ca2aad0e5c2706d0222c8ff006805abfd05caa97e6127c8811d0f6adc";
   };
 
+  # tests not packaged with source dist as of 1.2.1/1.2.2, and
+  # can't check tests out of GitHub easily without specific commit IDs (no tagged releases)
+  doCheck = false;
+  pythonImportsCheck = [ "nest_asyncio" ];
+
   meta = with stdenv.lib; {
     homepage = https://github.com/erdewit/nest_asyncio;
     description = "Patch asyncio to allow nested event loops";


### PR DESCRIPTION
###### Motivation for this change

Build fails due to tests on v1.2.1 & old v1.2.0.
This disables the tests to allow this package to build.
There doesn't seem to be an easy fix to allow running tests, b/c
the GitHub repo doesn't have release tags.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) **N/A**
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`. **Said "no diff detected, stopping review..."**
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

### Other tests
On master branch: ``nix-build -A pythonPackages.nest-asyncio``: Build fails
On PR branch: same command passes.