### PR TITLE
pythonPackages.dill: enable tests

### DIFF
--- a/pkgs/development/python-modules/dill/default.nix
+++ b/pkgs/development/python-modules/dill/default.nix
@@ -1,7 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, python
+, isPy27
+, nose
 }:
 
 buildPythonPackage rec {
@@ -13,15 +14,20 @@ buildPythonPackage rec {
     sha256 = "42d8ef819367516592a825746a18073ced42ca169ab1f5f4044134703e7a049c";
   };
 
-  # Messy test suite. Even when running the tests like tox does, it fails
-  doCheck = false;
+  # python2 can't import a test fixture
+  doCheck = !isPy27;
+  checkInputs = [ nose ];
   checkPhase = ''
-    for test in tests/*.py; do
-      ${python.interpreter} $test
-    done
+    PYTHONPATH=$PWD/tests:$PYTHONPATH
+    nosetests \
+      --ignore-files="test_classdef" \
+      --ignore-files="test_objects" \
+      --ignore-files="test_selected" \
+      --exclude="test_the_rest" \
+      --exclude="test_importable"
   '';
-  # Following error without setting checkPhase
-  # TypeError: don't know how to make test from: {'byref': False, 'recurse': False, 'protocol': 3, 'fmode': 0}
+  # Tests seem to fail because of import pathing and referencing items/classes in modules.
+  # Seems to be a Nix/pathing related issue, not the codebase, so disabling failing tests.
 
   meta = {
     description = "Serialize all of python (almost)";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Tests in ``pythonPackages.dill`` were previously disabled. This enables most of the tests. Some tests were disabled, mostly because I tried to track down the errors and didn't have time to figure them out. Seems to maybe be some pathing/import issues from Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
