### PR TITLE
uboot: 2019.10 -> 2020.01

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -112,6 +112,12 @@ in {
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
+  ubootAmx335xEVM = buildUBoot {
+    defconfig = "am335x_evm_defconfig";
+    extraMeta.platforms = ["armv7l-linux"];
+    filesToInstall = ["MLO" "u-boot.img"];
+  };
+
   ubootBananaPi = buildUBoot {
     defconfig = "Bananapi_defconfig";
     extraMeta.platforms = ["armv7l-linux"];
@@ -129,12 +135,6 @@ in {
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
-  };
-
-  ubootBeagleboneBlack = buildUBoot {
-    defconfig = "am335x_boneblack_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["MLO" "u-boot.img"];
   };
 
   # http://git.denx.de/?p=u-boot.git;a=blob;f=board/solidrun/clearfog/README;hb=refs/heads/master

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -6,10 +6,10 @@
 }:
 
 let
-  defaultVersion = "2019.10";
+  defaultVersion = "2020.01";
   defaultSrc = fetchurl {
     url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
-    sha256 = "053hcrwwlacqh2niisn0zas95zkbffw5aw5sdhixs8lmfdq60vcd";
+    sha256 = "1w9ml4jl15q6ixpdqzspxjnl7d3rgxd7f99ms1xv5c8869h3qida";
   };
   buildUBoot = {
     version ? null
@@ -28,19 +28,7 @@ let
 
     src = if src == null then defaultSrc else src;
 
-    patches = [
-      # Submitted upstream: https://patchwork.ozlabs.org/patch/1203693/
-      (fetchpatch {
-        url = https://github.com/dezgeg/u-boot/commit/extlinux-path-length-2018-03.patch;
-        sha256 = "07jafdnxvqv8lz256qy29agjc2k1zj5ad4k28r1w5qkhwj4ixmf8";
-      })
-      # Submitted upstream: https://patchwork.ozlabs.org/patch/1203678/
-      (fetchpatch {
-        name = "rockchip-allow-loading-larger-kernels.patch";
-        url = "https://marc.info/?l=u-boot&m=157537843004298&q=raw";
-        sha256 = "0l3l88cc9xkxkraql82pfgpx6nqn4dj7cvfaagh5pzfwkxyw0n3p";
-      })
-    ] ++ extraPatches;
+    patches = extraPatches;
 
     postPatch = ''
       patchShebangs tools
@@ -53,7 +41,7 @@ let
       dtc
       flex
       openssl
-      (buildPackages.python2.withPackages (p: [ p.libfdt ]))
+      (buildPackages.python3.withPackages (p: [ p.libfdt ]))
       swig
     ];
     depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -442,6 +442,7 @@ mapAliases ({
   transmission_remote_gtk = transmission-remote-gtk; # added 2018-01-06
   truecrypt = veracrypt; # added 2018-10-24
   tshark = wireshark-cli; # added 2018-04-25
+  ubootBeagleboneBlack = ubootAmx335xEVM; # added 2020-01-21
   ucsFonts = ucs-fonts; # added 2016-07-15
   ultrastardx-beta = ultrastardx; # added 2017-08-12
   usb_modeswitch = usb-modeswitch; # added 2016-05-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17084,7 +17084,7 @@ in
     ubootBananaPi
     ubootBananaPim3
     ubootBananaPim64
-    ubootBeagleboneBlack
+    ubootAmx335xEVM
     ubootClearfog
     ubootGuruplug
     ubootJetsonTK1


### PR DESCRIPTION
###### Motivation for this change

Update u-boot!

This update to u-boot got our patches included. We're patch-free for most u-boots! 🎉

There is one platform that was removed *way back*, in January 2019. Made the proper alias. (`ubootBeagleboneBlack -> ubootAmx335xEVM`).

###### Tested

Cross-compilation **will** fail on current unstable. Cross-compilation was tested rebased on current staging.

 * Cross-compiled
      * aarch64-linux
      * armv7l-linux
 * Compiled natively
      * aarch64-linux

```
# cross-compiled aarch64-linux
nix-build --keep-going --no-out-link -A pkgsCross.aarch64-multiplatform.ubootBananaPim64 -A pkgsCross.aarch64-multiplatform.ubootOdroidC2 -A pkgsCross.aarch64-multiplatform.ubootOrangePiZeroPlus2H5 -A pkgsCross.aarch64-multiplatform.ubootPine64 -A pkgsCross.aarch64-multiplatform.ubootPine64LTS -A pkgsCross.aarch64-multiplatform.ubootPinebook -A pkgsCross.aarch64-multiplatform.ubootQemuAarch64 -A pkgsCross.aarch64-multiplatform.ubootRaspberryPi3_64bit -A pkgsCross.aarch64-multiplatform.ubootRock64 -A pkgsCross.aarch64-multiplatform.ubootRockPro64 -A pkgsCross.aarch64-multiplatform.ubootSopine

# cross-compiled armv7l-linux
nix-build --keep-going --no-out-link -A pkgsCross.armv7l-hf-multiplatform.ubootA20OlinuxinoLime -A pkgsCross.armv7l-hf-multiplatform.ubootAmx335xEVM -A pkgsCross.armv7l-hf-multiplatform.ubootBananaPi -A pkgsCross.armv7l-hf-multiplatform.ubootBananaPim3 -A pkgsCross.armv7l-hf-multiplatform.ubootBeagleboneBlack -A pkgsCross.armv7l-hf-multiplatform.ubootClearfog -A pkgsCross.armv7l-hf-multiplatform.ubootJetsonTK1 -A pkgsCross.armv7l-hf-multiplatform.ubootNovena -A pkgsCross.armv7l-hf-multiplatform.ubootOdroidXU3 -A pkgsCross.armv7l-hf-multiplatform.ubootOrangePiPc -A pkgsCross.armv7l-hf-multiplatform.ubootPcduino3Nano -A pkgsCross.armv7l-hf-multiplatform.ubootQemuArm -A pkgsCross.armv7l-hf-multiplatform.ubootRaspberryPi2 -A pkgsCross.armv7l-hf-multiplatform.ubootRaspberryPi3_32bit -A pkgsCross.armv7l-hf-multiplatform.ubootUtilite -A pkgsCross.armv7l-hf-multiplatform.ubootWandboard

# native aarch64-linux
nix-build --keep-going --no-out-link -A ubootBananaPim64 -A ubootOdroidC2 -A ubootOrangePiZeroPlus2H5 -A ubootPine64 -A ubootPine64LTS -A ubootPinebook -A ubootQemuAarch64 -A ubootRaspberryPi3_64bit -A ubootRock64 -A ubootRockPro64 -A ubootSopine
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- (partial) Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- (partial) Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
