### PR TITLE
gavrasm: init at 4.5

### DIFF
--- a/pkgs/development/compilers/gavrasm/default.nix
+++ b/pkgs/development/compilers/gavrasm/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchzip, fpc , lang ? "en" } :
+assert stdenv.lib.assertOneOf "lang" lang ["cn" "de" "en" "fr" "tr"];
+stdenv.mkDerivation rec {
+  pname = "gavrasm";
+  version = "4.5";
+
+  src = fetchzip {
+    url ="http://www.avr-asm-tutorial.net/gavrasm/v45/gavrasm_sources_lin_45.zip";
+    sha256 = "1f5g5ran74pznwj4g7vfqh2qhymaj3p26f2lvzbmlwq447iid52c";
+    stripRoot=false;
+  };
+
+  nativeBuildInputs = [ fpc ];
+
+  configurePhase = ''
+    cp gavrlang_${lang}.pas gavrlang.pas
+  '';
+
+  buildPhase = ''
+    fpc gavrasm.pas
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp gavrasm $out/bin
+    mkdir -p $out/doc
+    cp instr.asm $out/doc
+    cp ReadMe.Txt $out/doc
+    cp LiesMich.Txt $out/doc
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.avr-asm-tutorial.net/gavrasm;
+    description = "AVR Assembler for ATMEL AVR-Processors";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ mafo ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19211,6 +19211,8 @@ in
 
   game-music-emu = callPackage ../applications/audio/game-music-emu { };
 
+  gavrasm = callPackage ../development/compilers/gavrasm { };
+
   gcalcli = callPackage ../applications/misc/gcalcli { };
 
   vcal = callPackage ../applications/misc/vcal { };


### PR DESCRIPTION
###### Motivation for this change
This PR adds the `gavrasm` AVR assembler to nixpkgs.
This assembler is used in several AVR projects and tutorials.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
