### PR TITLE
chromium: enable parallel building

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -110,6 +110,8 @@ let
     inherit packageName buildType buildPath;
 
     src = upstream-info.main;
+    # Enable parallel building
+    enableParallelBuilding = true;
 
     nativeBuildInputs = [
       ninja which python2Packages.python perl pkgconfig


### PR DESCRIPTION
I'd prefer if chromium was built with "parallel building" enabled as this would shorten build time greatly on multi core CPUs.

Sadly I don't currently have a machine with NixOS to test this on without it taking days to compile.
If anyone have any input eg. reasons why this wouldn't build or be a bad idea please let me know.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
