### PR TITLE
pantalaimon: init at 0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7340,6 +7340,12 @@
     github = "valeriangalliat";
     name = "Valérian Galliat";
   };
+  valodim = {
+    email = "look@my.amazin.horse";
+    github = "valodim";
+    githubId = 27813;
+    name = "Vincent Breitmoser";
+  };
   vandenoever = {
     email = "jos@vandenoever.info";
     github = "vandenoever";

--- a/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pantalaimon/default.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv, buildPythonApplication, fetchPypi, pythonOlder,
+  attrs, aiohttp, appdirs, click, keyring, Logbook, peewee, janus,
+  prompt_toolkit, matrix-nio, dbus-python, pydbus, notify2, pygobject3,
+
+  pytest, faker, pytest-aiohttp, aioresponses,
+
+  enableDbusUi ? true
+}:
+
+buildPythonApplication rec {
+  pname = "pantalaimon";
+  version = "0.4";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1canj9w72wh1rcw6fivrvaahpxy13gb6gh1k8nss6bgixalvnq9m";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    appdirs
+    attrs
+    click
+    janus
+    keyring
+    Logbook
+    matrix-nio
+    peewee
+    prompt_toolkit
+  ] ++ lib.optional enableDbusUi [
+      dbus-python
+      notify2
+      pygobject3
+      pydbus
+  ];
+
+  checkInputs = [
+    pytest
+    faker
+    pytest-aiohttp
+    aioresponses
+  ];
+
+  # darwin has difficulty communicating with server, fails some integration tests
+  doCheck = !stdenv.isDarwin;
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "An end-to-end encryption aware Matrix reverse proxy daemon.";
+    homepage = "https://github.com/matrix-org/pantalaimon";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ valodim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20757,6 +20757,8 @@ in
 
   paprefs = callPackage ../applications/audio/paprefs { };
 
+  pantalaimon = python3Packages.callPackage ../applications/networking/instant-messengers/pantalaimon { };
+
   pavucontrol = callPackage ../applications/audio/pavucontrol { };
 
   paraview = libsForQt5.callPackage ../applications/graphics/paraview { };


### PR DESCRIPTION
###### Motivation for this change

Packaging pantalaimon :)

###### Things done

Straightforward packaging, nothing out of the ordinary. All dependencies were available.

One thing of note, though: during nixpkgs-review I received this seemingly unrelated error while testing asynctest with python3.8. Not sure what that is about?:

```
builder for '/nix/store/19rjmv99i3w4n6bsc8v2wmx2g18qqjsn-python3.8-asynctest-0.13.0.drv' failed with exit code 1; last 10 log lines:
    File "/nix/store/r9zas1x2nv9bn505hq6323171f5ik5ad-python3-3.8.1/lib/python3.8/asyncio/base_events.py", line 612, in run_until_complete
      return future.result()
    File "/build/asynctest-0.13.0/test/test_mock.py", line 1934, in tester
      self.assertFalse(fut.result())
  AssertionError: True is not false
  
  ----------------------------------------------------------------------
  Ran 219 tests in 0.530s
  
  FAILED (failures=6)
```

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` **failed for python3.8, see above** 
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).