### PR TITLE
cockatrice: 2017-08-31 -> 2019-08-31

### DIFF
--- a/pkgs/games/cockatrice/default.nix
+++ b/pkgs/games/cockatrice/default.nix
@@ -1,25 +1,29 @@
-{ stdenv, fetchurl, cmake, qtbase, qtmultimedia, protobuf, qttools
+{ stdenv, fetchFromGitHub, mkDerivation, cmake, protobuf
+, qtbase, qtmultimedia, qttools, qtwebsockets, wrapQtAppsHook
 }:
 
-stdenv.mkDerivation rec {
-    name = "${pname}-unstable-${version}";
-    pname = "cockatrice";
-    version = "2017-01-20";
+mkDerivation rec {
+  pname = "cockatrice";
+  version = "2019-08-31-Release-2.7.2";
 
-    src = fetchurl {
-        url = "https://github.com/Cockatrice/Cockatrice/archive/${version}-Release.tar.gz";
-        sha256 = "1gbcn8vffqdagidlamx670jxymhzaw28r4c6aqg3pq0s6by1l65f";
-    };
+  src = fetchFromGitHub {
+    owner = "Cockatrice";
+    repo = "Cockatrice";
+    rev = "${version}";
+    sha256 = "17nfz4z6zfkiwcrq1rpm8bc7zh4gvcmb3fis9gdjjbji20dvcfxp";
+  };
 
-    buildInputs = [
-        cmake qtbase qtmultimedia protobuf qttools
-    ];
+  buildInputs = [
+    cmake qtbase qtmultimedia protobuf qttools qtwebsockets
+  ];
 
-    meta = {
-        repositories.git = git://github.com/Cockatrice/Cockatrice.git;
-        description = "A cross-platform virtual tabletop for multiplayer card games";
-        license = stdenv.lib.licenses.gpl2;
-        maintainers = with stdenv.lib.maintainers; [ spencerjanssen ];
-      platforms = with stdenv.lib.platforms; linux;
-    };
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
+  meta = {
+    homepage = "https://github.com/Cockatrice/Cockatrice";
+    description = "A cross-platform virtual tabletop for multiplayer card games";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ spencerjanssen ];
+    platforms = with stdenv.lib.platforms; linux;
+  };
 }

--- a/pkgs/games/cockatrice/default.nix
+++ b/pkgs/games/cockatrice/default.nix
@@ -23,7 +23,7 @@ mkDerivation rec {
     homepage = "https://github.com/Cockatrice/Cockatrice";
     description = "A cross-platform virtual tabletop for multiplayer card games";
     license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = with stdenv.lib.maintainers; [ evanjs ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/games/cockatrice/default.nix
+++ b/pkgs/games/cockatrice/default.nix
@@ -23,7 +23,7 @@ mkDerivation rec {
     homepage = "https://github.com/Cockatrice/Cockatrice";
     description = "A cross-platform virtual tabletop for multiplayer card games";
     license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ spencerjanssen ];
+    maintainers = with stdenv.lib.maintainers; [ ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Somebody expressed some interest for this on IRC but couldn't get the package working.
Ended up basically updating the whole thing so why not make a PR.

Figured I'd use the latest stable version, as the newest beta is only a month ahead of it.

App runs and initializes card database and etc fine, and I can browse through the cards after that.
###### Things done
- formatting
- add `wrapQtAppsHook`
- use `fetchFromGitHub` instead of `fetchurl`
- don't construct name manually
- add homepage to meta
- remove repositories.get from meta
- use `mkDerivation` instead of `stdenv.mkDerivation` (per the Qt section of the [manual](https://nixos.org/nixpkgs/manual/#qt-default-nix-co-2))
___

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
