### PR TITLE
pythonPackages.fastavro: init at 0.22.9

### DIFF
--- a/pkgs/development/python-modules/fastavro/default.nix
+++ b/pkgs/development/python-modules/fastavro/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, check-manifest
+, coverage
+, codecov
+, cython
+, flake8
+, lz4
+, numpy
+, pytest
+, pytestcov
+, python
+, python-snappy
+, twine
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "fastavro";
+  version = "0.22.9";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fc3a97187d51aea9ad5ebb02bcb7a579a62da6310788ed82fb1e22abcd0ec33b";
+  };
+  
+  nativeBuildInputs = [ cython ];
+  
+  propagatedBuildInputs = [ lz4 python-snappy ];
+  
+  preBuild = ''
+    FASTAVRO_USE_CYTHON=1 ${python.interpreter} setup.py build_ext -i
+  '';
+  
+  checkInputs = [
+    check-manifest
+    codecov
+    coverage
+    flake8
+    numpy
+    pytest
+    pytestcov
+    twine
+    wheel
+  ];
+  
+  # test_compression.py is missing zstandard package
+  checkPhase = ''
+    pytest tests --ignore=tests/test_compression.py
+  '';
+    
+  meta = with lib; {
+    description = "Fast read/write of AVRO files";
+    homepage = "https://github.com/fastavro/fastavro";
+    license = licenses.mit;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3391,6 +3391,8 @@ in {
 
   exifread = callPackage ../development/python-modules/exifread { };
 
+  fastavro =  callPackage ../development/python-modules/fastavro { };
+
   fastimport = callPackage ../development/python-modules/fastimport { };
 
   fastpair = callPackage ../development/python-modules/fastpair { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding fastavro to available Python packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
