### PR TITLE
pythonPackages.djangorestframework-simplejwt: init at 4.4.0

### DIFF
--- a/pkgs/development/python-modules/djangorestframework-simplejwt/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-simplejwt/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, django, djangorestframework, pyjwt }:
+
+buildPythonPackage rec {
+  pname = "djangorestframework_simplejwt";
+  version = "4.4.0";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c315be70aa12a5f5790c0ab9acd426c3a58eebea65a77d0893248c5144a5080c";
+  };
+  
+  propagatedBuildInputs = [ django djangorestframework pyjwt ];
+  
+  # Test raises django.core.exceptions.ImproperlyConfigured
+  doCheck = false;
+  
+  meta = with lib; {
+    description = "A minimal JSON Web Token authentication plugin for Django REST Framework";
+    homepage = "https://github.com/davesque/django-rest-framework-simplejwt";
+    license = licenses.mit;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3324,6 +3324,8 @@ in {
 
   djangorestframework-jwt = callPackage ../development/python-modules/djangorestframework-jwt { };
 
+  djangorestframework-simplejwt = callPackage ../development/python-modules/djangorestframework-simplejwt { };
+
   django-raster = callPackage ../development/python-modules/django-raster { };
 
   django_redis = callPackage ../development/python-modules/django_redis { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding djangorestframework-simplejwt to Python packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
