### PR TITLE
pythonPackages.doxypypy: init at 0.8.8.6

### DIFF
--- a/pkgs/development/python-modules/doxypypy/default.nix
+++ b/pkgs/development/python-modules/doxypypy/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi}:
+
+buildPythonPackage rec {
+  pname = "doxypypy";
+  version = "0.8.8.6";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "627571455c537eb91d6998d95b32efc3c53562b2dbadafcb17e49593e0dae01b";
+  };
+    
+  meta = with lib; {
+    description = "Doxygen filter for Python";
+    homepage = "https://github.com/Feneric/doxypypy";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -608,6 +608,8 @@ in {
     inherit (pkgs) substituteAll dotnet-sdk;
   };
 
+  doxypypy = callPackage ../development/python-modules/doxypypy { };
+
   emcee = callPackage ../development/python-modules/emcee { };
 
   emailthreads = callPackage ../development/python-modules/emailthreads { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding doxypypy to Python packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
