### PR TITLE
pythonPackages.cpplint: init at 1.4.5

### DIFF
--- a/pkgs/development/python-modules/cpplint/default.nix
+++ b/pkgs/development/python-modules/cpplint/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pytestcov
+, pythonOlder
+, pytestrunner
+}:
+
+buildPythonPackage rec {
+  pname = "cpplint";
+  version = "1.4.5";
+  disabled = pythonOlder "3.5";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "08b384606136146ac1d32a2ffb60623a5dc1b20434588eaa0fa12a6e24eb3bf5";
+  };
+  
+  # fixing pytest version is not necessary
+  patchPhase = ''
+    substituteInPlace test-requirements --replace 'pytest>=4.6,<5.0' 'pytest'
+  '';
+  
+  checkInputs = [ pytestrunner pytest pytestcov];
+  
+  meta = with lib; {
+    description = "Automated checker to ensure C++ files follow Google's style guide";
+    homepage = "https://github.com/cpplint/cpplint";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.arnoldfarkas ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -560,6 +560,8 @@ in {
 
   codespell = callPackage ../development/python-modules/codespell { };
 
+  cpplint = callPackage ../development/python-modules/cpplint { };
+
   crc32c = callPackage ../development/python-modules/crc32c { };
 
   curio = callPackage ../development/python-modules/curio { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Adding cpplint to Python packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
