### PR TITLE
coqPackages.CoLoR: 1.4.0 -> 1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3492,6 +3492,12 @@
     github = "jorsn";
     githubId = 4646725;
   };
+  jpas = {
+    name = "Jarrod Pas";
+    email = "jarrod@jarrodpas.com";
+    github = "jpas";
+    githubId = 5689724;
+  };
   jpdoyle = {
     email = "joethedoyle@gmail.com";
     github = "jpdoyle";

--- a/pkgs/development/coq-modules/CoLoR/default.nix
+++ b/pkgs/development/coq-modules/CoLoR/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchurl, coq, bignums }:
+{ stdenv, fetchFromGitHub, coq, bignums }:
 
 stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-CoLoR-1.4.0";
+  name = "coq${coq.coq-version}-CoLoR-1.6.0";
 
-  src = fetchurl {
-    url = https://gforge.inria.fr/frs/download.php/file/37205/color.1.4.0.tar.gz;
-    sha256 = "1jsp9adsh7w59y41ihbwchryjhjpajgs9bhf8rnb4b3hzccqxgag";
+  src = fetchFromGitHub {
+    owner = "fblanqui";
+    repo = "color";
+    rev = "328aa06270584b578edc0d2925e773cced4f14c8";
+    sha256 = "07sy9kw1qlynsqy251adgi8b3hghrc9xxl2rid6c82mxfsp329sd";
   };
 
   buildInputs = [ coq bignums ];
@@ -15,14 +17,14 @@ stdenv.mkDerivation {
     make -f Makefile.coq COQLIB=$out/lib/coq/${coq.coq-version}/ install
   '';
 
-  meta = with stdenv.lib; {
+  meta = with stdenv.lib ; {
     homepage = http://color.inria.fr/;
     description = "CoLoR is a library of formal mathematical definitions and proofs of theorems on rewriting theory and termination whose correctness has been mechanically checked by the Coq proof assistant.";
-    maintainers = with maintainers; [ jwiegley ];
+    maintainers = with maintainers; [ jpas jwiegley ];
     platforms = coq.meta.platforms;
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" ];
+    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" "8.9" ];
   };
 }

--- a/pkgs/development/coq-modules/CoLoR/default.nix
+++ b/pkgs/development/coq-modules/CoLoR/default.nix
@@ -6,6 +6,7 @@ let
     "8.7" = "1.4.0";
     "8.8" = "1.6.0";
     "8.9" = "1.6.0";
+    "8.10" = "1.7.0";
   };
   params = {
     "1.4.0" = {
@@ -17,6 +18,11 @@ let
       version = "1.6.0";
       rev = "328aa06270584b578edc0d2925e773cced4f14c8";
       sha256 = "07sy9kw1qlynsqy251adgi8b3hghrc9xxl2rid6c82mxfsp329sd";
+    };
+    "1.7.0" = {
+      version = "1.7.0";
+      rev = "08b5481ed6ea1a5d2c4c068b62156f5be6d82b40";
+      sha256 = "1w7fmcpf0691gcwq00lm788k4ijlwz3667zj40j5jjc8j8hj7cq3";
     };
   };
   param = params.${coqVersions.${coq.coq-version}};

--- a/pkgs/development/coq-modules/CoLoR/default.nix
+++ b/pkgs/development/coq-modules/CoLoR/default.nix
@@ -1,13 +1,34 @@
 { stdenv, fetchFromGitHub, coq, bignums }:
 
+let
+  coqVersions = {
+    "8.6" = "1.4.0";
+    "8.7" = "1.4.0";
+    "8.8" = "1.6.0";
+    "8.9" = "1.6.0";
+  };
+  params = {
+    "1.4.0" = {
+      version = "1.4.0";
+      rev = "168c6b86c7d3f87ee51791f795a8828b1521589a";
+      sha256 = "1d2whsgs3kcg5wgampd6yaqagcpmzhgb6a0hp6qn4lbimck5dfmm";
+    };
+    "1.6.0" = {
+      version = "1.6.0";
+      rev = "328aa06270584b578edc0d2925e773cced4f14c8";
+      sha256 = "07sy9kw1qlynsqy251adgi8b3hghrc9xxl2rid6c82mxfsp329sd";
+    };
+  };
+  param = params.${coqVersions.${coq.coq-version}};
+in
+
 stdenv.mkDerivation {
-  name = "coq${coq.coq-version}-CoLoR-1.6.0";
+  name = "coq${coq.coq-version}-CoLoR-${param.version}";
 
   src = fetchFromGitHub {
     owner = "fblanqui";
     repo = "color";
-    rev = "328aa06270584b578edc0d2925e773cced4f14c8";
-    sha256 = "07sy9kw1qlynsqy251adgi8b3hghrc9xxl2rid6c82mxfsp329sd";
+    inherit (param) rev sha256;
   };
 
   buildInputs = [ coq bignums ];
@@ -17,7 +38,7 @@ stdenv.mkDerivation {
     make -f Makefile.coq COQLIB=$out/lib/coq/${coq.coq-version}/ install
   '';
 
-  meta = with stdenv.lib ; {
+  meta = with stdenv.lib; {
     homepage = http://color.inria.fr/;
     description = "CoLoR is a library of formal mathematical definitions and proofs of theorems on rewriting theory and termination whose correctness has been mechanically checked by the Coq proof assistant.";
     maintainers = with maintainers; [ jpas jwiegley ];
@@ -25,6 +46,6 @@ stdenv.mkDerivation {
   };
 
   passthru = {
-    compatibleCoqVersions = v: builtins.elem v [ "8.6" "8.7" "8.8" "8.9" ];
+    compatibleCoqVersions = v: builtins.hasAttr v coqVersions;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I'm working on a project that requires this package and it is about a year years out of date and the old version no longer states support for Coq 8.6 and 8.7 which are at least 2 minor versions out of date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
