### PR TITLE
safety: init at 1.8.5

### DIFF
--- a/pkgs/development/python-modules/dparse/default.nix
+++ b/pkgs/development/python-modules/dparse/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, six
+, pyyaml
+, packaging
+}:
+
+buildPythonPackage rec {
+  pname = "dparse";
+  version = "0.4.1";
+
+  buildInputs = [ six pyyaml packaging ];
+
+  # Inpure integration tests
+  doCheck = false;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06bvn7m3xlfvw0l6ydm3b503ycsvj120sq7kkcayaa86j3xgv980";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A parser for Python dependency files";
+    homepage = "https://github.com/pyupio/dparse";
+    license = licenses.mit;
+    maintainers = [ maintainers.mmahut ];
+  };
+}

--- a/pkgs/tools/security/safety/default.nix
+++ b/pkgs/tools/security/safety/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "safety";
+  version = "1.8.5";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "0y6b4j7wa52xh9q5f8qibc4azgsv801p977a902k6j1nmgzz6nah";
+  };
+
+  # Inpure tests, as they require internet connection
+  doCheck = false;
+
+  propagatedBuildInputs = with python3Packages; [
+    dparse
+    requests
+    click
+    pyyaml
+    setuptools
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Safety checks your installed dependencies for known security vulnerabilities";
+    homepage = "https://pyup.io/safety/";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.mmahut ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6236,6 +6236,8 @@ in
 
   safeeyes = callPackage ../applications/misc/safeeyes { };
 
+  safety = callPackage ../tools/security/safety { };
+
   sahel-fonts = callPackage ../data/fonts/sahel-fonts { };
 
   saldl = callPackage ../tools/networking/saldl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2512,6 +2512,8 @@ in {
 
   dpath = callPackage ../development/python-modules/dpath { };
 
+  dparse = callPackage ../development/python-modules/dparse { };
+
   dpkt = callPackage ../development/python-modules/dpkt {};
 
   urllib3 = callPackage ../development/python-modules/urllib3 {};


### PR DESCRIPTION
###### Motivation for this change

safety: init at 1.8.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
